### PR TITLE
Update location where attachment uploads are stored in test environment

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -3,7 +3,7 @@ class AttachmentUploader < CarrierWave::Uploader::Base
 
   def store_dir
     if Rails.env.test?
-      "#{Rails.root}/spec/support/uploads/avatar/#{model.class.to_s.underscore}/#{model.id}"
+      "#{Rails.root}/spec/support/uploads/attachments/#{model.class.to_s.underscore}/#{model.id}"
     else
       "uploads/attachments/#{model.class.to_s.underscore}/#{model.id}"
     end


### PR DESCRIPTION
Guess the code for `store_dir` was copied + pasted from `app/uploaders/avatar_uploader.rb` but the location for test environment wasn't updated.