### PR TITLE
Fix #114: Address color contrast warning messages

### DIFF
--- a/app/javascript/src/assets/scss/_foundation-custom.scss
+++ b/app/javascript/src/assets/scss/_foundation-custom.scss
@@ -6,10 +6,6 @@
     border-radius: 1000px;
   }
 
-  &.warning {
-    color: $white;
-  }
-
   &.grey-btn {
     color: $color-gray;
 

--- a/app/javascript/src/assets/scss/_foundation-settings.scss
+++ b/app/javascript/src/assets/scss/_foundation-settings.scss
@@ -270,8 +270,8 @@ $button-margin: 0 0 $global-margin 0;
 $button-fill: solid;
 $button-background: $primary-color;
 $button-background-hover: scale-color($button-background, $lightness: -15%);
-$button-color: $white;
-$button-color-alt: $white;
+$button-color: $black;
+$button-color-alt: $black;
 $button-radius: $global-radius;
 $button-sizes: (
   tiny: $font-size-micro,


### PR DESCRIPTION
### Overview
Solves https://github.com/chatwoot/chatwoot/issues/114

Buttons had light green (#13ce66) & light yellow (#ffc82c) backgrounds with white text, leading to these warning messages:
```
20:03:22 frontend.1 | WARNING: Contrast ratio of #fff on #13ce66 is pretty bad, just 2
20:03:22 frontend.1 |          on line 75 of node_modules/foundation-sites/scss/util/_color.scss, in function `color-pick-contrast`
20:03:22 frontend.1 |          from line 121 of node_modules/foundation-sites/scss/components/_button.scss, in mixin `button-style`
20:03:22 frontend.1 |          from line 203 of node_modules/foundation-sites/scss/components/_button-group.scss, in mixin `foundation-button-group`
20:03:22 frontend.1 |          from line 86 of node_modules/foundation-sites/scss/foundation.scss, in mixin `foundation-everything`
20:03:22 frontend.1 |          from line 3 of node_modules/foundation-sites/assets/foundation-flex.scss
20:03:22 frontend.1 |          from line 8 of app/javascript/src/assets/scss/app.scss
20:03:22 frontend.1 |          from line 28 of stdin
20:03:22 frontend.1 | 
20:03:22 frontend.1 | WARNING: Contrast ratio of #fff on #ffc82c is pretty bad, just 1.5
20:03:22 frontend.1 |          on line 75 of node_modules/foundation-sites/scss/util/_color.scss, in function `color-pick-contrast`
20:03:22 frontend.1 |          from line 121 of node_modules/foundation-sites/scss/components/_button.scss, in mixin `button-style`
20:03:22 frontend.1 |          from line 203 of node_modules/foundation-sites/scss/components/_button-group.scss, in mixin `foundation-button-group`
20:03:22 frontend.1 |          from line 86 of node_modules/foundation-sites/scss/foundation.scss, in mixin `foundation-everything`
20:03:22 frontend.1 |          from line 3 of node_modules/foundation-sites/assets/foundation-flex.scss
20:03:22 frontend.1 |          from line 8 of app/javascript/src/assets/scss/app.scss
20:03:22 frontend.1 |          from line 28 of stdin
```
### Before
Buttons looked like this:
![image](https://user-images.githubusercontent.com/15990179/66724514-ba9a7a80-edf4-11e9-950c-0cdcf2f6e6e1.png)

![image](https://user-images.githubusercontent.com/15990179/66724606-e36f3f80-edf5-11e9-8697-5eb7e7c097f2.png)

![image](https://user-images.githubusercontent.com/15990179/66724518-c1c18880-edf4-11e9-927b-f4cac11f4096.png)
### After
I made the text black to suppress these warning messages & enhance readability:
![image](https://user-images.githubusercontent.com/15990179/66724541-182ec700-edf5-11e9-8d88-799f37562ce9.png)

![image](https://user-images.githubusercontent.com/15990179/66724577-896e7a00-edf5-11e9-86fe-e7124eb5fd2e.png)

![image](https://user-images.githubusercontent.com/15990179/66724595-b327a100-edf5-11e9-89a3-b96c160618c1.png)
