### PR TITLE
Fixes #115: Use middle instead of centre in flex-align

### DIFF
--- a/app/javascript/dashboard/assets/scss/widgets/_modal.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_modal.scss
@@ -65,7 +65,7 @@
 
   .modal-footer {
     @include flex;
-    @include flex-align($x: justify, $y: center);
+    @include flex-align($x: justify, $y: middle);
     @include padding($space-small $zero $space-medium $zero);
     button {
       font-size: $font-size-small;


### PR DESCRIPTION
+ Use middle instead of centre in flex-align