### PR TITLE
Ignore coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ public/packs
 .jest-cache
 # ignore jetbrains IDE files
 .idea
+
+# coverage report
+buildreports
+coverage


### PR DESCRIPTION
A folder `buildreports` is created after running `yarn test` 
I added that to the `.gitginore` file and also `coverage` for the future when you implement coverage for the backend.