### PR TITLE
Add rubocop on commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,10 @@
     "*.{js,vue}": [
       "eslint --fix",
       "git add"
+    ],
+    "*.rb": [
+      "rubocop -a",
+      "git add"
     ]
   }
 }


### PR DESCRIPTION
- [x] Run `rubocop` on `*.rb` files before commit

Fixes #264 

<img width="894" alt="Screenshot 2019-11-25 10 02 38" src="https://user-images.githubusercontent.com/2246121/69512973-36e3ba00-0f6c-11ea-8fba-8d90dbfeb994.png">
