### PR TITLE
Fix docker image by installing bundler

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
     && echo 'deb https://dl.yarnpkg.com/debian stable main' > /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
     && apt-get -qq -y install nodejs yarn \
+    && gem install bundler \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I tried to build the docker image and was greeted with this error:

```
Step 6/13 : RUN bundle
 ---> Running in 84545de0d54b
/usr/local/lib/ruby/2.6.0/rubygems.rb:283:in `find_spec_for_exe': Could not find 'bundler' (2.0.2) required by your /app/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:2.0.2`
	from /usr/local/lib/ruby/2.6.0/rubygems.rb:302:in `activate_bin_path'
	from /usr/local/bin/bundle:23:in `<main>'
ERROR: Service 'server' failed to build: The command '/bin/sh -c bundle' returned a non-zero code: 1
```

This pr fixes that by installing bundler in the image.