### PR TITLE
Makes widget header expand and collapse by messages size

### DIFF
--- a/app/javascript/widget/components/ChatHeader.vue
+++ b/app/javascript/widget/components/ChatHeader.vue
@@ -1,0 +1,44 @@
+<template>
+  <header class="header-collapsed" :style="{ background: widgetColor }">
+    <div>
+      <h2 class="title">
+        {{ title }}
+      </h2>
+    </div>
+  </header>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+
+export default {
+  name: 'ChatHeader',
+  computed: {
+    ...mapGetters({
+      widgetColor: 'appConfig/getWidgetColor',
+    }),
+  },
+  props: {
+    title: {
+      type: String,
+      default: '',
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@import '~widget/assets/scss/variables.scss';
+
+.header-collapsed {
+  background: $color-woot;
+  padding: $space-two $space-medium;
+  width: 100%;
+  box-sizing: border-box;
+  color: $color-white;
+
+  .title {
+    font-size: $font-size-big;
+  }
+}
+</style>

--- a/app/javascript/widget/store/modules/conversation.js
+++ b/app/javascript/widget/store/modules/conversation.js
@@ -9,6 +9,7 @@ const state = {
 
 const getters = {
   getConversation: _state => _state.conversations,
+  getConversationSize: _state => Object.keys(_state.conversations).length,
 };
 
 const actions = {

--- a/app/javascript/widget/views/Home.vue
+++ b/app/javascript/widget/views/Home.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="home">
     <div class="header-wrap">
-      <ChatHeaderExpanded />
+      <ChatHeaderExpanded v-if="isHeaderExpanded" />
+      <ChatHeader v-else :title="getHeaderName" />
     </div>
     <ConversationWrap :messages="getConversation" />
     <div class="footer-wrap">
@@ -15,6 +16,7 @@ import { mapActions, mapGetters } from 'vuex';
 
 import ChatFooter from 'widget/components/ChatFooter.vue';
 import ChatHeaderExpanded from 'widget/components/ChatHeaderExpanded.vue';
+import ChatHeader from 'widget/components/ChatHeader.vue';
 import ConversationWrap from 'widget/components/ConversationWrap.vue';
 
 export default {
@@ -23,6 +25,7 @@ export default {
     ChatFooter,
     ChatHeaderExpanded,
     ConversationWrap,
+    ChatHeader,
   },
   methods: {
     ...mapActions('conversation', ['sendMessage']),
@@ -33,7 +36,13 @@ export default {
     },
   },
   computed: {
-    ...mapGetters('conversation', ['getConversation']),
+    ...mapGetters('conversation', ['getConversation', 'getConversationSize']),
+    isHeaderExpanded() {
+      return this.getConversationSize === 0;
+    },
+    getHeaderName() {
+      return window.chatwootWebChannel.website_name;
+    },
   },
 };
 </script>


### PR DESCRIPTION
Collapsed header will look like:
![image](https://user-images.githubusercontent.com/1277421/69632491-0f2c4900-1075-11ea-9cb6-e4f43de52fd1.png)
