### PR TITLE
[Bug] Fix breaking migrations, revert migrations to 6.0

### DIFF
--- a/db/migrate/20190819010457_create_channels.rb
+++ b/db/migrate/20190819010457_create_channels.rb
@@ -1,4 +1,4 @@
-class CreateChannels < ActiveRecord::Migration[6.1]
+class CreateChannels < ActiveRecord::Migration[6.0]
   def change
     create_table :channels do |t|
       t.string :name

--- a/db/migrate/20191014051743_add_invited_by_to_user.rb
+++ b/db/migrate/20191014051743_add_invited_by_to_user.rb
@@ -1,4 +1,4 @@
-class AddInvitedByToUser < ActiveRecord::Migration[6.1]
+class AddInvitedByToUser < ActiveRecord::Migration[6.0]
   def change
     add_reference(:users, :inviter, foreign_key: { to_table: :users })
   end

--- a/db/migrate/20191016211109_rename_channel_attribute_name_in_models.rb
+++ b/db/migrate/20191016211109_rename_channel_attribute_name_in_models.rb
@@ -1,4 +1,4 @@
-class RenameChannelAttributeNameInModels < ActiveRecord::Migration[6.1]
+class RenameChannelAttributeNameInModels < ActiveRecord::Migration[6.0]
   def change
     rename_column :users, :channel, :pubsub_token
     rename_column :contacts, :chat_channel, :pubsub_token

--- a/db/migrate/20191020085608_rename_old_tables.rb
+++ b/db/migrate/20191020085608_rename_old_tables.rb
@@ -1,4 +1,4 @@
-class RenameOldTables < ActiveRecord::Migration[6.1]
+class RenameOldTables < ActiveRecord::Migration[6.0]
   def change
     drop_table :channels
     rename_table :facebook_pages, :channel_facebook_pages

--- a/db/migrate/20191020173522_rename_sender_id_to_contact_in_conversation.rb
+++ b/db/migrate/20191020173522_rename_sender_id_to_contact_in_conversation.rb
@@ -1,4 +1,4 @@
-class RenameSenderIdToContactInConversation < ActiveRecord::Migration[6.1]
+class RenameSenderIdToContactInConversation < ActiveRecord::Migration[6.0]
   def change
     rename_column :conversations, :sender_id, :contact_id
   end

--- a/db/migrate/20191024062958_add_website_token_to_web_widget.rb
+++ b/db/migrate/20191024062958_add_website_token_to_web_widget.rb
@@ -1,4 +1,4 @@
-class AddWebsiteTokenToWebWidget < ActiveRecord::Migration[6.1]
+class AddWebsiteTokenToWebWidget < ActiveRecord::Migration[6.0]
   def change
     add_column :channel_web_widgets, :website_token, :string
     add_index :channel_web_widgets, :website_token, unique: true

--- a/db/migrate/20191027054756_create_contact_inboxes.rb
+++ b/db/migrate/20191027054756_create_contact_inboxes.rb
@@ -1,4 +1,4 @@
-class CreateContactInboxes < ActiveRecord::Migration[6.1]
+class CreateContactInboxes < ActiveRecord::Migration[6.0]
   def change
     create_table :contact_inboxes do |t|
       t.references :contact, foreign_key: true, index: true
@@ -7,7 +7,7 @@ class CreateContactInboxes < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
-    add_index :contact_inboxes, [:inbox_id, :source_id], :unique => true
+    add_index :contact_inboxes, [:inbox_id, :source_id], unique: true
     add_index :contact_inboxes, [:source_id]
     remove_column :contacts, :inbox_id, :integer
     remove_column :contacts, :source_id, :integer

--- a/db/migrate/20191116073924_add_additional_attributes_to_conversation.rb
+++ b/db/migrate/20191116073924_add_additional_attributes_to_conversation.rb
@@ -1,4 +1,4 @@
-class AddAdditionalAttributesToConversation < ActiveRecord::Migration[6.1]
+class AddAdditionalAttributesToConversation < ActiveRecord::Migration[6.0]
   def change
     add_column :conversations, :additional_attributes, :jsonb
   end

--- a/db/migrate/20191124091232_add_widget_color_to_web_widget.rb
+++ b/db/migrate/20191124091232_add_widget_color_to_web_widget.rb
@@ -1,4 +1,4 @@
-class AddWidgetColorToWebWidget < ActiveRecord::Migration[6.1]
+class AddWidgetColorToWebWidget < ActiveRecord::Migration[6.0]
   def change
     add_column :channel_web_widgets, :widget_color, :string, default: '#1f93ff'
   end


### PR DESCRIPTION
- [x] Change migration version to 6.0

We were using rails from source, later moved to rails to the stable version. Due to this a couple of migrations are breaking

Fixes #313 
