### PR TITLE
Fix BILLING_ENABLED in example .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ AWS_REGION=
 SENTRY_DSN=
 
 ####  This environment variables are only required in hosted version which has billing
-ENABLE_BILLING=
+BILLING_ENABLED=
 ## chargebee settings
 CHARGEBEE_API_KEY=
 CHARGEBEE_SITE=


### PR DESCRIPTION
The ENABLE_BILLING env var is not used in the chatwoot code base. Instead, the BILLING_ENABLED is used to enable billing.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~
- [ ] ~~This change requires a documentation update~~

## How Has This Been Tested?

I searched for instances of "BILLING" in the codebase.

