### PR TITLE
Improve docker compose performance

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -54,7 +54,7 @@ development:
   compile: true
 
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
+  check_yarn_integrity: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,8 +5,12 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile
+      args:
+        RAILS_ENV: 'development'
+        RAILS_SERVE_STATIC_FILES: 'false'
     volumes:
-      - ./:/app
+      - ./:/app:cached
+      - bundle:/bundle:delegated
       - packs:/app/public/packs
     links:
       - postgres
@@ -53,4 +57,5 @@ services:
 volumes:
   postgres:
   redis:
+  bundle:
   packs:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,4 @@ services:
 
 volumes:
   postgres:
-    external: true
   redis:
-    external: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       dockerfile: ./docker/Dockerfile
     volumes:
       - ./:/app
+      - packs:/app/public/packs
     links:
       - postgres
       - redis
@@ -16,7 +17,18 @@ services:
       - REDIS_URL=redis://redis:6379
       - POSTGRES_HOST=postgres
       - RAILS_ENV=development
-    command: ["foreman", "start", "-f", "./docker/Procfile.docker.dev"]
+      - WEBPACKER_DEV_SERVER_HOST=webpacker
+    command: ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]
+
+  webpacker:
+    <<: *server
+    command: ./bin/webpack-dev-server
+    ports:
+      - '3035:3035'
+    depends_on:
+      - "server"
+    environment:
+      - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
 
   postgres:
     image: postgres:9.6
@@ -41,3 +53,4 @@ services:
 volumes:
   postgres:
   redis:
+  packs:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,12 @@
 version: '3'
+
+volumes:
+  postgres:
+  redis:
+  bundle:
+  packs:
+  node_modules:
+
 services:
 
   server: &server
@@ -6,12 +14,14 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile
       args:
+        BUNDLE_WITHOUT: ''
         RAILS_ENV: 'development'
         RAILS_SERVE_STATIC_FILES: 'false'
     volumes:
       - ./:/app:cached
       - bundle:/bundle:delegated
       - packs:/app/public/packs
+      - node_modules:/app/node_modules
     links:
       - postgres
       - redis
@@ -27,13 +37,19 @@ services:
   webpacker:
     <<: *server
     command: ./bin/webpack-dev-server
-    ports:
-      - '3035:3035'
     depends_on:
       - "server"
+    ports:
+      - '3035:3035'
+    volumes:
+      - .:/app:cached
+      - bundle:/bundle
+      - node_modules:/app/node_modules
+      - packs:/app/public/packs
     environment:
-      - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
-
+      - "NODE_ENV=development"
+      - "RAILS_ENV=development"
+      - "WEBPACKER_DEV_SERVER_HOST=0.0.0.0"
   postgres:
     image: postgres:9.6
     restart: always
@@ -53,9 +69,3 @@ services:
       - redis:/data/redis
     ports:
       - '6379:6379'
-
-volumes:
-  postgres:
-  redis:
-  bundle:
-  packs:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,18 @@
 FROM ruby:2.6.5-slim
 
+# ARG default to production settings
+# For development docker-compose file overrides ARGS
+ARG RAILS_SERVE_STATIC_FILES=true
+ENV RAILS_SERVE_STATIC_FILES ${RAILS_SERVE_STATIC_FILES}
+
+ARG RAILS_ENV=production
+ENV RAILS_ENV ${RAILS_ENV}
+
+ENV BUNDLE_PATH=/bundle \
+  BUNDLE_BIN=/bundle/bin \
+  GEM_HOME=/bundle
+ENV PATH="${BUNDLE_BIN}:${PATH}"
+
 RUN apt-get update \
     && apt-get -qq -y install \
     build-essential \
@@ -18,13 +31,24 @@ RUN apt-get update \
 
 RUN mkdir -p /app
 WORKDIR /app
+
+COPY Gemfile Gemfile.lock ./
+
+# Do not install development or test gems in production
+RUN if [ "$RAILS_ENV" = "production" ]; then \
+  bundle install -j 4 -r 3 --without development test; \
+  else bundle install -j 4 -r 3; \
+  fi
+
+COPY package.json yarn.lock ./
+RUN yarn install
+
 COPY . /app
 
-ENV RAILS_SERVE_STATIC_FILES true
-ENV RAILS_ENV=production
-
-RUN bundle
-RUN SECRET_KEY_BASE=precompile_placeholder bundle exec rake assets:precompile
+# generate production assets if production environment
+RUN if [ "$RAILS_ENV" = "production" ]; then \
+  SECRET_KEY_BASE=precompile_placeholder bundle exec rake assets:precompile; \
+  fi
 
 # Add a script to be executed every time the container starts.
 COPY ./docker/entrypoint.sh /usr/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,16 +2,14 @@ FROM ruby:2.6.5-slim
 
 # ARG default to production settings
 # For development docker-compose file overrides ARGS
+ARG BUNDLE_WITHOUT="development:test"
+ENV BUNDLE_WITHOUT ${BUNDLE_WITHOUT}
+
 ARG RAILS_SERVE_STATIC_FILES=true
 ENV RAILS_SERVE_STATIC_FILES ${RAILS_SERVE_STATIC_FILES}
 
 ARG RAILS_ENV=production
 ENV RAILS_ENV ${RAILS_ENV}
-
-ENV BUNDLE_PATH=/bundle \
-  BUNDLE_BIN=/bundle/bin \
-  GEM_HOME=/bundle
-ENV PATH="${BUNDLE_BIN}:${PATH}"
 
 RUN apt-get update \
     && apt-get -qq -y install \

--- a/docker/Procfile.docker.dev
+++ b/docker/Procfile.docker.dev
@@ -1,2 +1,0 @@
-backend: ../bin/rails server -b 0.0.0.0 -p 3000
-frontend: ../bin/webpack-dev-server

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-unset BUNDLE_PATH
-unset BUNDLE_BIN
-
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /app/tmp/pids/server.pid
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+unset BUNDLE_PATH
+unset BUNDLE_BIN
+
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /app/tmp/pids/server.pid
 

--- a/docs/development/project-setup/quick-setup.md
+++ b/docs/development/project-setup/quick-setup.md
@@ -42,39 +42,44 @@ password: 123456
 
 ### Docker for development
 
-If you are using docker for the development follow the following steps.
-
-We are running postgres and redis services along with chatwoot server using docker-compose.
-
-Create a volume for postgres and redis so that you data will persist even if the containers goes down.
+The first time you start your development environment run the following two commands:
 
 ```bash
-docker volume create --name=postgres
-docker volume create --name=redis
+# build and start the services
+docker-compose up --build
+# prepare the database
+docker-compose exec server bundle exec rails db:prepare
+```
+Then browse http://localhost:3000
+
+```bash
+# To stop your environment use Control+C (on Mac) CTRL+C (on Win) or
+docker-compose down
+# start the services
+docker-compose up
+```
+
+When you change the service’s Dockerfile or the contents of the build directory, run stop then build. (For example after modifying package.json or Gemfile)
+
+```bash
+docker-compose stop
 docker-compose build
 ```
 
-Remove the `node_modules` directory from the root if it exists and run the following command.
 
-```bash
-docker-compose run server yarn install
-```
+The docker-compose environment consists of:
+- chatwoot server
+- postgres
+- redis
+- webpacker-dev-server
 
 If in case you encounter a seeding issue or you want reset the database you can do it using the following command :
 
 ```bash
-docker-compose run server bundle exec rake db:reset
+docker-compose run -rm server bundle exec rake db:reset
 ```
 
 This command essentially runs postgres and redis containers and then run the rake command inside the chatwoot server container.
-
-Now you should be able to run :
-
-```bash
-docker-compose up
-```
-
-to see the application up and running.
 
 ### Docker for production
 


### PR DESCRIPTION
# Pull Request Template

## Description
Reduce time to build docker development environment, after first build
Fix warning Integrity check: System parameters don't match.
Reduce commands required to use docker-compose and update quick-setup doc.
Moved webpacker-dev-server to its own service.
Do not install development and test gems in production.
Do not precompile assets in development.

Fixes # #321 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Manually (only tested in development environment using docker-compose)
- Clear docker environment
- Build and Run environment
- Validate running state
- Stop environment and re-build, ensure cache is used
- Stop environment make change to Package.json, ensure yarn is automatically run
- Stop environment make change to Gemfile, ensure bundle install is run 

## Results
Prior to caching all builds ran for ~6 minutes, now between 1-5 minutes depending on what was changed prior to running build.
Start ~24 seconds, now ~6 seconds

Timing results:
- First time build is run
docker-compose up --build -d  10.34s user 6.31s system 4% cpu **5:51.93 total**
docker-compose down  0.53s user 0.17s system 6% cpu 10.206 total

- build without Gemfile or Package.json changes
docker-compose up --build -d  10.21s user 6.34s system 26% cpu **1:02.47 total**

- build after changing package.json
docker-compose up --build -d  9.90s user 5.99s system 9% cpu **2:40.60 total**

- build after changing Gemfile
docker-compose up --build -d  10.22s user 6.26s system 6% cpu **4:20.92 total**

- start
docker-compose up -d  0.70s user 0.17s system 13% cpu **6.402 total**

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules