### PR TITLE
Send emails via sidekiq

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
+worker: bundle exec sidekiq

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
-worker: bundle exec sidekiq
+worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 backend: bin/rails s -p 3000
 frontend: bin/webpack-dev-server
+worker: bundle exec sidekiq

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -99,7 +99,7 @@ class Conversation < ApplicationRecord
   def send_email_notification_to_assignee
     return if self_assign?(assignee_id)
 
-    AssignmentMailer.conversation_assigned(self, assignee).deliver if saved_change_to_assignee_id? && assignee_id.present?
+    AssignmentMailer.conversation_assigned(self, assignee).deliver_later if saved_change_to_assignee_id? && assignee_id.present?
   end
 
   def self_assign?(assignee_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,6 +86,10 @@ class User < ApplicationRecord
   after_create :notify_creation
   after_destroy :notify_deletion
 
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, self, *args).deliver_later
+  end
+
   def set_password_and_uid
     self.uid = email
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,8 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
+  config.active_job.queue_adapter = :sidekiq
+  
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,6 +75,7 @@ Rails.application.configure do
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
+  config.active_job.queue_adapter = :sidekiq
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -75,6 +75,7 @@ Rails.application.configure do
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
+  config.active_job.queue_adapter = :sidekiq
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,6 +43,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.active_job.queue_adapter = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,11 @@ Rails.application.routes.draw do
 
   # Used in mailer templates
   resource :app, only: [:index] do
+  require 'sidekiq/web'
+  authenticate :user, lambda { |u| u.administrator? } do
+    mount Sidekiq::Web => '/sidekiq'
+  end
+
     resources :conversations, only: [:show]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,13 +86,14 @@ Rails.application.routes.draw do
     end
   end
 
-  # Used in mailer templates
-  resource :app, only: [:index] do
+  # Sidekiq Web UI
   require 'sidekiq/web'
   authenticate :user, lambda { |u| u.administrator? } do
     mount Sidekiq::Web => '/sidekiq'
   end
 
+  # Used in mailer templates
+  resource :app, only: [:index] do
     resources :conversations, only: [:show]
   end
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,10 @@
+:concurrency: 5
+staging:
+  :concurrency: 10
+production:
+  :concurrency: 20
+:queues:
+  - critical
+  - default
+  - low
+  - mailers

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,10 +1,23 @@
-:concurrency: 5
-staging:
-  :concurrency: 10
-production:
-  :concurrency: 20
+# Sample configuration file for Sidekiq.
+# Options here can still be overridden by cmd line args.
+# Place this file at config/sidekiq.yml and Sidekiq will
+# pick it up automatically.
+---
+:verbose: false
+:concurrency: 10
+:timeout: 25
+
+# Sidekiq will run this file through ERB when reading it so you can
+# even put in dynamic logic, like a host-specific queue.
+# http://www.mikeperham.com/2013/11/13/advanced-sidekiq-host-specific-queues/
 :queues:
   - critical
   - default
   - low
   - mailers
+
+# you can override concurrency based on environment
+production:
+  :concurrency: 3
+staging:
+  :concurrency: 15

--- a/docs/development/environment-setup/docker.md
+++ b/docs/development/environment-setup/docker.md
@@ -23,8 +23,15 @@ docker-compose run rails bundle exec rails db:reset
 docker-compose run --service-port rails
 ```
 
+open another terminal and also run below command to run sidekiq in a separate service
+
+```
+docker-compose run rails bundle exec sidekiq
+```
+
 * Access the rails app frontend by visiting `http://0.0.0.0:3000/`
 * Access Mailhog inbox by visiting `http://0.0.0.0:8025/` (You will receive all emails going out of the application here)
+* Access Sidekiq Web UI by visiting `http://0.0.0.0:3000/sidekiq` (You need to login with administrator account to access sidekiq)
 
 you can also use the below command instead to run the app and see the full logs.
 

--- a/spec/mailers/confirmation_instructions_spec.rb
+++ b/spec/mailers/confirmation_instructions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Confirmation Instructions', type: :mailer do
   describe :notify do
     let(:confirmable_user) { FactoryBot.build(:user, inviter: inviter_val) }
     let(:inviter_val) { nil }
-    let(:mail) { confirmable_user.send_confirmation_instructions }
+    let(:mail) { Devise::Mailer.confirmation_instructions(confirmable_user, nil, {}) }
 
     it 'has the correct header data' do
       expect(mail.reply_to).to contain_exactly('accounts@chatwoot.com')

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Conversation, type: :model do
 
       allow(Rails.configuration.dispatcher).to receive(:dispatch)
       allow(AssignmentMailer).to receive(:conversation_assigned).and_return(assignment_mailer)
-      allow(assignment_mailer).to receive(:deliver)
+      allow(assignment_mailer).to receive(:deliver_later)
       Current.user = old_assignee
 
       conversation.update(
@@ -68,7 +68,7 @@ RSpec.describe Conversation, type: :model do
       # send_email_notification_to_assignee
       expect(AssignmentMailer).to have_received(:conversation_assigned).with(conversation, new_assignee)
 
-      expect(assignment_mailer).to have_received(:deliver) if ENV.fetch('SMTP_ADDRESS', nil).present?
+      expect(assignment_mailer).to have_received(:deliver_later) if ENV.fetch('SMTP_ADDRESS', nil).present?
     end
   end
 


### PR DESCRIPTION
## Description

use ActiveJob Queue Adapter as Sidekiq to send emails via sidekiq. This feature allows sending devise and mailer emails to be enqueued in sidekiq before it is actually sent. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

In addition to the rails service, we also need to run `sidekiq` service to send an email out to the SMTP server. This can be done locally by running `docker-compose run rails bundle exec sidekiq` in one of the terminal. You can also see the enqueued mailers in the sidekiq web console by visiting http://0.0.0.0:3000/sidekiq (you need to login to the application with an administrator account to access web console)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules