### PR TITLE
Upgrade: Use postgres 11.6 in docker-compose

### DIFF
--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -27,7 +27,7 @@ services:
     command: ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]
 
   postgres:
-    image: postgres:9.6
+    image: postgres:11.6
     restart: always
     ports:
       - '5432:5432'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
       - RAILS_ENV=development
     entrypoint: docker/entrypoints/rails.sh
     command: ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]
-  
+
   webpack:
     <<: *base
     build:
@@ -61,7 +61,7 @@ services:
     command: bin/webpack-dev-server
 
   postgres:
-    image: postgres:9.6
+    image: postgres:11.6
     restart: always
     ports:
       - '5432:5432'


### PR DESCRIPTION
We use Postgres 11.6 in Heroku. Bumping the docker-compose files to use 11.6 