### PR TITLE
Bug: Force fetch inbox settings on route change

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -104,15 +104,26 @@ export default {
       return createMessengerScript(this.inbox.page_id);
     },
   },
+  watch: {
+    $route(to) {
+      if (to.name === 'settings_inbox_show') {
+        this.fetchInboxSettings();
+      }
+    },
+  },
   mounted() {
-    this.$store.dispatch('agents/get');
-    this.$store.dispatch('inboxes/get').then(() => {
-      this.fetchAttachedAgents();
-    });
+    this.fetchInboxSettings();
   },
   methods: {
     showAlert(message) {
       bus.$emit('newToastMessage', message);
+    },
+    fetchInboxSettings() {
+      this.selectedAgents = [];
+      this.$store.dispatch('agents/get');
+      this.$store.dispatch('inboxes/get').then(() => {
+        this.fetchAttachedAgents();
+      });
     },
     async fetchAttachedAgents() {
       try {


### PR DESCRIPTION
- [x] `mounted` hook was not called because of the views were cached. 
- [x] Added a $route change watcher in Settings SFC

Fixes #399 