### PR TITLE
[Chore] Changed from email and reply to email for conversation email

### DIFF
--- a/app/mailers/conversation_mailer.rb
+++ b/app/mailers/conversation_mailer.rb
@@ -15,7 +15,7 @@ class ConversationMailer < ApplicationMailer
     @messages = recap_messages + new_messages
     @messages = @messages.select(&:reportable?)
 
-    mail(to: @contact&.email, from: @agent&.email, subject: mail_subject(@messages.last))
+    mail(to: @contact&.email, reply_to: @agent&.email, subject: mail_subject(@messages.last))
   end
 
   private

--- a/spec/mailers/conversation_mailer_spec.rb
+++ b/spec/mailers/conversation_mailer_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe ConversationMailer, type: :mailer do
       expect(mail.to).to eq([message&.conversation&.contact&.email])
     end
 
-    it 'renders the sender email' do
-      expect(mail.from).to eq([message&.conversation&.assignee&.email])
+    it 'renders the reply to email' do
+      expect(mail.reply_to).to eq([message&.conversation&.assignee&.email])
     end
   end
 end


### PR DESCRIPTION
## Description
* Changed `from` email to be that set in the ENV variable `MAILER_SENDER_EMAIL` and `reply_to` email to be of the agent's email for conversation emails.
* Made necessary spec changes

## Checklist:
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes