### PR TITLE
[Chore] Removed agent dashboard link in conversation mail to user

### DIFF
--- a/app/views/conversation_mailer/new_message.html.erb
+++ b/app/views/conversation_mailer/new_message.html.erb
@@ -3,14 +3,12 @@
 <p>You have new messages on your conversation.</p>
 
 <table>
-    <% @messages.each do |message| %>
-        <tr>
-            <td>
-                <b><%= message.incoming? ? 'You' : message.user.name %></b>
-            </td>
-            <td>: <%= message.content %></td>
-        </tr>
-    <% end %>
+  <% @messages.each do |message| %>
+    <tr>
+      <td>
+        <b><%= message.incoming? ? 'You' : message.user.name %></b>
+      </td>
+      <td>: <%= message.content %></td>
+    </tr>
+  <% end %>
 </table>
-
-<p>Click <%= link_to 'here', app_conversation_url(id: @conversation.display_id) %> to get back to the conversation. </p>


### PR DESCRIPTION
## Description
The conversation email had a link to the app dashboard to that particular conversation thread. This was accessible only to the agent and not to the customer. Removed this link from the email sent to the customer.
