### PR TITLE
Chore: Added tests for inbox_members

### DIFF
--- a/spec/controllers/api/v1/inbox_members_controller_spec.rb
+++ b/spec/controllers/api/v1/inbox_members_controller_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe 'Inbox Member API', type: :request do
+  let(:account) { create(:account) }
+  let(:inbox) { create(:inbox, account: account) }
+
+  describe 'POST /api/v1/inbox_members' do
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized' do
+        post '/api/v1/inbox_members'
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an authenticated user' do
+      let(:agent) { create(:user, account: account, role: :agent) }
+
+      it 'modifies inbox members' do
+        params = { inbox_id: inbox.id, user_ids: [agent.id] }
+
+        post '/api/v1/inbox_members',
+             headers: agent.create_new_auth_token,
+             params: params,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(inbox.inbox_members&.count).to eq(1)
+        expect(inbox.inbox_members&.first&.user).to eq(agent)
+      end
+
+      it 'renders not found when inbox not found' do
+        params = { inbox_id: nil, user_ids: [agent.id] }
+
+        post '/api/v1/inbox_members',
+             headers: agent.create_new_auth_token,
+             params: params,
+             as: :json
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'renders error on invalid params' do
+        params = { inbox_id: inbox.id, user_ids: ['invalid'] }
+
+        post '/api/v1/inbox_members',
+             headers: agent.create_new_auth_token,
+             params: params,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include('Could not add agents to inbox')
+      end
+    end
+  end
+
+  describe 'GET /api/v1/inbox_members/:id' do
+    let(:inbox_member) { create(:inbox_member, inbox: inbox) }
+
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized' do
+        get "/api/v1/inbox_members/#{inbox_member.id}"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an authenticated user' do
+      let(:agent) { create(:user, account: account, role: :agent) }
+
+      it 'returns inbox member' do
+        get "/api/v1/inbox_members/#{inbox.id}",
+            headers: agent.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(JSON.parse(response.body)).to eq({ payload: inbox.inbox_members }.as_json)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds tests for the inbox_members_controller.rb

I wasn't able to cover line 16 in inbox_members_controller.rb probably because Rails now automatically throws a 404 if an Entity couldn't be found in a before_action. So we can probably remove that line. @pranavrajs thoughts?

Improves #37 

## Type of change
- [x] Chore

## How Has This Been Tested?

Checked that all tests went through, that Rubocop is satisfied and verified my additions with simplecov locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules