### PR TITLE
Fix: Fixed color of agent link in chat widget being white

### DIFF
--- a/app/javascript/widget/components/UserMessageBubble.vue
+++ b/app/javascript/widget/components/UserMessageBubble.vue
@@ -48,11 +48,15 @@ export default {
   text-align: left;
 
   a {
-    color: $color-white;
+    color: $color-primary;
   }
 
   &.user {
     border-bottom-right-radius: $space-smaller;
+    
+    a {
+      color: $color-white;
+    }
   }
 }
 </style>


### PR DESCRIPTION
This fixes the color of an agents link in the chat widget being invisible due to having the same color as the background of the chat bubble.

![Screenshot 2020-02-19 at 14 48 38](https://user-images.githubusercontent.com/13546486/74840276-ff946780-5326-11ea-9895-cb1ad9009f51.png)

Fixes #519 