### PR TITLE
Fix: Fixed misalignment of back button

### DIFF
--- a/app/javascript/dashboard/assets/scss/_layout.scss
+++ b/app/javascript/dashboard/assets/scss/_layout.scss
@@ -44,6 +44,8 @@ body {
 }
 
 .back-button {
+  @include flex;
+  align-items: center;
   color: $color-woot;
   font-size: $font-size-default;
   font-weight: $font-weight-normal;


### PR DESCRIPTION
This fixes a misalignment of the back button between the text and the icon. After noticing it multiple times I decided to fix it.

Before:
![Screenshot 2020-02-19 at 15 14 29](https://user-images.githubusercontent.com/13546486/74842466-c100ac00-532a-11ea-9b2f-e57b9f7dec14.png)

After:
![Screenshot 2020-02-19 at 15 14 54](https://user-images.githubusercontent.com/13546486/74842473-c52cc980-532a-11ea-9eec-d893b17be23d.png)

It may look like a small difference on the screenshots but it fixed a noticeable issue me and a buddy of mine noticed 😅 