### PR TITLE
Fix: Fixed code font not being displayed on windows

### DIFF
--- a/app/javascript/dashboard/assets/scss/_foundation-custom.scss
+++ b/app/javascript/dashboard/assets/scss/_foundation-custom.scss
@@ -28,7 +28,7 @@
 
 code {
   border: 0;
-  font-family: 'Monaco';
+  font-family: 'Monaco', Verdana;
   font-size: $font-size-mini;
 
   &.hljs {


### PR DESCRIPTION
The default Chatwoot font for the code tag called "Monaco" is not supported by windows, which results in it falling back to "Times New Roman". I added "Verdana" as fallback font which I found suiting for code tags.

Before:
![Screen01](https://user-images.githubusercontent.com/13546486/74871693-320c8780-535c-11ea-984a-6c69c8380c72.PNG)

After:
![Screen02](https://user-images.githubusercontent.com/13546486/74871708-3638a500-535c-11ea-937a-e6d7a86192b0.PNG)
