### PR TITLE
[491] Bug fix - Sidekiq Redis Auth issue

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,7 +1,7 @@
 development:
   adapter: redis
   url: <%= ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379') %>
-  password: <%= ENV.fetch('REDIS_PASSWORD', nil) %>
+  password: <%= ENV.fetch('REDIS_PASSWORD', nil).presence %>
 
 test:
   adapter: test
@@ -9,9 +9,9 @@ test:
 staging:
   adapter: redis
   url: <%= ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379') %>
-  password: <%= ENV.fetch('REDIS_PASSWORD', nil) %>
+  password: <%= ENV.fetch('REDIS_PASSWORD', nil).presence %>
 
 production:
   adapter: redis
   url: <%= ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379') %>
-  password: <%= ENV.fetch('REDIS_PASSWORD', nil) %>
+  password: <%= ENV.fetch('REDIS_PASSWORD', nil).presence %>

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,6 +1,6 @@
 app_redis_config = {
-    url: URI.parse(ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379')),
-    password: ENV.fetch('REDIS_PASSWORD', nil)
+  url: URI.parse(ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379')),
+  password: ENV.fetch('REDIS_PASSWORD', nil).presence
 }
 redis = Rails.env.test? ? MockRedis.new : Redis.new(app_redis_config)
 Nightfury.redis = Redis::Namespace.new('reports', redis: redis)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,6 @@
 sidekiq_redis_config = {
   url: ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379'),
-  password: ENV.fetch('REDIS_PASSWORD', nil)
+  password: ENV.fetch('REDIS_PASSWORD', nil).presence
 }
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
This closes #491 .

## Description
* When the the .env file has line with REDIS_PASSWORD set as empty, the value for this in the initializers comes as an empty string "".
* Fixed this in a way that, if it's empty string, then it's taken as `nil` value so that password is skipped

Fixes #491 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested in local with redis password set and without this.
