### PR TITLE
Fix: Finish setup now shows description for code

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/FinishSetup.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/FinishSetup.vue
@@ -39,7 +39,7 @@ export default {
       );
     },
     message() {
-      if (!this.$route.params.website_token) {
+      if (!this.currentInbox.website_token) {
         return this.$t('INBOX_MGMT.FINISH.MESSAGE');
       }
       return this.$t('INBOX_MGMT.FINISH.WEBSITE_SUCCESS');


### PR DESCRIPTION
This fixes an issue with description after inbox creation now showing.

Fixes #499 

![Capture](https://user-images.githubusercontent.com/13546486/74944465-603ea580-53f6-11ea-9410-b9f12bf0631d.PNG)
