### PR TITLE
Chore: Document Conversation APIs in swagger

### DIFF
--- a/swagger/definitions/index.yml
+++ b/swagger/definitions/index.yml
@@ -5,35 +5,68 @@ request_error:
   $ref: ./error/request.yml
 
 # RESOURCE
+generic_id:
+  $ref: ./resource/extension/generic.yml
 contact:
   $ref: ./resource/contact.yml
 conversation:
   $ref: ./resource/conversation.yml
+message:
+  $ref: ./resource/message.yml
+user:
+  $ref: ./resource/user.yml
 
 # RESPONSE
+
+## contact
 extended_contact:
   allOf:
     - $ref: '#/definitions/contact'
     - $ref: ./resource/extension/contact/show.yml
 contact_base:
   allOf:
+    - $ref: '#/definitions/generic_id'
     - $ref: '#/definitions/contact'
-    - $ref: ./resource/extension/generic.yml
 contact_list:
   type: array
+  description: 'array of contacts'
   items:
     allOf:
+      - $ref: '#/definitions/generic_id'
       - $ref: '#/definitions/contact'
-      - $ref: ./resource/extension/generic.yml
 contact_conversations:
   type: array
+  description: 'array of conversations'
   items:
     allOf:
       - $ref: '#/definitions/conversation'
       - $ref: ./resource/extension/contact/conversation.yml
+      - $ref: ./resource/extension/conversation/with_display_id.yml
+
+## conversation
+conversation_list:
+  $ref: ./resource/extension/conversation/list.yml
+conversation_show:
+  $ref: ./resource/extension/conversation/show.yml
+conversation_status_toggle:
+  $ref: ./resource/extension/conversation/status_toggle.yml
+conversation_labels:
+  $ref: ./resource/extension/conversation/labels.yml
+
+## message
+extended_message:
+  allOf:
+    - $ref: '#/definitions/generic_id'
+    - $ref: '#/definitions/message'
+    - $ref: ./resource/extension/message/with_source_sender.yml
 
 # REQUEST
+
+## contact
 contact_create:
   $ref: ./request/contact/create.yml
 contact_update:
   $ref: ./request/contact/update.yml
+## conversation
+conversation_message_create:
+  $ref: ./request/conversation/create_message.yml

--- a/swagger/definitions/request/conversation/create_message.yml
+++ b/swagger/definitions/request/conversation/create_message.yml
@@ -1,0 +1,10 @@
+type: object
+properties:
+  conversation_id:
+    type: number
+  message:
+    type: string
+  private:
+    type: boolean
+  fb_id:
+    type: number

--- a/swagger/definitions/resource/conversation.yml
+++ b/swagger/definitions/resource/conversation.yml
@@ -1,7 +1,5 @@
 type: object
 properties:
-  display_id:
-    type: number
   messages:
     type: array
     items:

--- a/swagger/definitions/resource/extension/contact/conversation.yml
+++ b/swagger/definitions/resource/extension/contact/conversation.yml
@@ -15,4 +15,4 @@ properties:
           channel:
             type: string
       assignee:
-        type: object
+        $ref: '#/definitions/user'

--- a/swagger/definitions/resource/extension/contact/list.yml
+++ b/swagger/definitions/resource/extension/contact/list.yml
@@ -1,5 +1,0 @@
-type: object
-properties:
-  allOf:
-    - $ref: '#/definitions/contact'
-    - $ref: ./resource/extension/contact.yaml

--- a/swagger/definitions/resource/extension/conversation/labels.yml
+++ b/swagger/definitions/resource/extension/conversation/labels.yml
@@ -1,0 +1,7 @@
+type: object
+properties:
+  payload:
+    type: array
+    description: 'array of labels'
+    items:
+      type: string

--- a/swagger/definitions/resource/extension/conversation/list.yml
+++ b/swagger/definitions/resource/extension/conversation/list.yml
@@ -1,0 +1,22 @@
+type: object
+properties:
+  data:
+    type: object
+    properties:
+      meta:
+        type: object
+        properties:
+          mine_count:
+            type: number
+          unassigned_count:
+            type: number
+          all_count:
+            type: number
+      payload:
+        type: array
+        description: 'array of conversations'
+        items:
+          allOf:
+            - $ref: '#/definitions/generic_id'
+            - $ref: '#/definitions/conversation'
+            - $ref: '../contact/conversation.yml'

--- a/swagger/definitions/resource/extension/conversation/show.yml
+++ b/swagger/definitions/resource/extension/conversation/show.yml
@@ -1,0 +1,19 @@
+type: object
+properties:
+  meta:
+    type: object
+    properties:
+      labels:
+        type: array
+        items:
+          type: string
+      additional_attributes:
+        type: object
+      contact_id:
+        type: number
+  payload:
+    type: array
+    description: 'array of messages'
+    items:
+      allOf:
+        - $ref: '#/definitions/extended_message'

--- a/swagger/definitions/resource/extension/conversation/status_toggle.yml
+++ b/swagger/definitions/resource/extension/conversation/status_toggle.yml
@@ -1,0 +1,14 @@
+type: object
+properties:
+  meta:
+    type: object
+  payload:
+    type: object
+    properties:
+      success:
+        type: boolean
+      current_status:
+        type: string
+        enum: ['open', 'resolved']
+      conversation_id:
+        type: number

--- a/swagger/definitions/resource/extension/conversation/with_display_id.yml
+++ b/swagger/definitions/resource/extension/conversation/with_display_id.yml
@@ -1,0 +1,4 @@
+type: object
+properties:
+  display_id:
+    type: number

--- a/swagger/definitions/resource/extension/message/with_source_sender.yml
+++ b/swagger/definitions/resource/extension/message/with_source_sender.yml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  source_id:
+    type: number
+  sender:
+    type: object

--- a/swagger/definitions/resource/message.yml
+++ b/swagger/definitions/resource/message.yml
@@ -1,0 +1,16 @@
+type: object
+properties:
+  content:
+    type: string
+  inbox_id:
+    type: number
+  conversation_id:
+    type: number
+  message_type:
+    type: string
+  created_at:
+    type: integer
+  private:
+    type: boolean
+  attachment:
+    type: object

--- a/swagger/definitions/resource/user.yml
+++ b/swagger/definitions/resource/user.yml
@@ -1,0 +1,19 @@
+type: object
+properties:
+  id:
+    type: number
+  uid:
+    type: string
+  name:
+    type: string
+  email:
+    type: string
+  account_id:
+    type: number
+  role:
+    type: string
+    enum: ['agent', 'administrator']
+  confirmed:
+    type: boolean
+  nickname:
+    type: string

--- a/swagger/paths/contact/crud.yml
+++ b/swagger/paths/contact/crud.yml
@@ -5,7 +5,7 @@ get:
     - name: id
       in: path
       type: number
-      description: ID of contact
+      description: id of the contact
       required: true
   responses:
     200:
@@ -24,7 +24,7 @@ put:
     - name: id
       in: path
       type: number
-      description: ID of the contact
+      description: id of the contact
       required: true
     - name: data
       in: body

--- a/swagger/paths/contact/list_create.yml
+++ b/swagger/paths/contact/list_create.yml
@@ -1,7 +1,7 @@
 get:
   tags: [Contact]
-  description: Listing all contacts with pagination
-  summary: List contacts
+  description: Listing all the contacts with pagination
+  summary: List Contacts
   parameters:
     - name: query_hash
       in: query
@@ -18,7 +18,7 @@ get:
 
 post:
   tags: [Contact]
-  description: Create a contact
+  description: Create New Contact
   parameters:
     - name: data
       in: body

--- a/swagger/paths/conversation/assignments.yml
+++ b/swagger/paths/conversation/assignments.yml
@@ -1,0 +1,27 @@
+post:
+  tags: [Conversation]
+  summary: Assign Conversation
+  description: Assign a conversation to an agent
+  parameters:
+    - name: id
+      in: path
+      type: number
+      description: id of the conversation
+      required: true
+    - name: data
+      in: body
+      required: true
+      schema:
+        type: object
+        properties:
+          assignee_id:
+            type: number
+  responses:
+    204:
+      description: Success
+      schema:
+        $ref: '#/definitions/user'
+    404:
+      description: Conversation not found
+    403:
+      description: Access denied

--- a/swagger/paths/conversation/crud.yml
+++ b/swagger/paths/conversation/crud.yml
@@ -1,0 +1,19 @@
+get:
+  tags: [Conversation]
+  summary: Conversation Details
+  description: Get all details regarding a conversation with all messages in the conversation
+  parameters:
+    - name: id
+      in: path
+      type: number
+      description: ID of Conversation
+      required: true
+  responses:
+    200:
+      description: Success
+      schema:
+        $ref: '#/definitions/conversation_show'
+    404:
+      description: Conversation not found
+    403:
+      description: Access denied

--- a/swagger/paths/conversation/labels.yml
+++ b/swagger/paths/conversation/labels.yml
@@ -1,0 +1,50 @@
+get:
+  tags: [Conversation]
+  summary: List Labels
+  description: Lists all the labels of a conversation
+  parameters:
+    - name: id
+      in: path
+      type: number
+      description: id of the conversation
+      required: true
+  responses:
+    200:
+      description: Success
+      schema:
+        $ref: '#/definitions/conversation_labels'
+    404:
+      description: Conversation not found
+    403:
+      description: Access denied
+
+post:
+  tags: [Conversation]
+  summary: Add Label
+  description: Creates a new label and associates it with the conversation
+  parameters:
+    - name: id
+      in: path
+      type: number
+      description: id of the conversation
+      required: true
+    - name: data
+      in: body
+      required: true
+      schema:
+        type: object
+        properties:
+          labels:
+            type: array
+            description: 'array of labels'
+            properties:
+              type: string
+  responses:
+    204:
+      description: Success
+      schema:
+        $ref: '#/definitions/conversation_labels'
+    404:
+      description: Conversation not found
+    403:
+      description: Access denied

--- a/swagger/paths/conversation/list.yml
+++ b/swagger/paths/conversation/list.yml
@@ -1,0 +1,17 @@
+get:
+  tags: [Conversation]
+  description: List all the conversations with pagination
+  summary: Conversations List
+  parameters:
+    - name: query_hash
+      in: query
+      type: string
+  responses:
+    200:
+      description: Success
+      schema:
+        $ref: '#/definitions/conversation_list'
+    400:
+      description: Bad Request Error
+      schema:
+        $ref: '#/definitions/bad_request_error'

--- a/swagger/paths/conversation/messages.yml
+++ b/swagger/paths/conversation/messages.yml
@@ -1,0 +1,26 @@
+post:
+  tags: [Conversation]
+  summary: Create New Message
+  description: All the agent replies are created as new messages through this endpoint
+  parameters:
+    - name: id
+      in: path
+      type: number
+      description: id of the conversation
+      required: true
+    - name: data
+      in: body
+      required: true
+      schema:
+        $ref: '#/definitions/conversation_message_create'
+  responses:
+    204:
+      description: Success
+      schema:
+        allOf:
+          - $ref: '#/definitions/generic_id'
+          - $ref: '#/definitions/message'
+    404:
+      description: Conversation not found
+    403:
+      description: Access denied

--- a/swagger/paths/conversation/toggle_status.yml
+++ b/swagger/paths/conversation/toggle_status.yml
@@ -1,0 +1,19 @@
+post:
+  tags: [Conversation]
+  summary: Toggle Status
+  description: Toggles the status of the conversation between open and resolved
+  parameters:
+    - name: id
+      in: path
+      type: number
+      description: id of the conversation
+      required: true
+  responses:
+    204:
+      description: Success
+      schema:
+        $ref: '#/definitions/conversation_status_toggle'
+    404:
+      description: Conversation not found
+    403:
+      description: Access denied

--- a/swagger/paths/conversation/update_last_seen.yml
+++ b/swagger/paths/conversation/update_last_seen.yml
@@ -1,17 +1,16 @@
-get:
-  tags: [Contact]
-  summary: Conversations
+post:
+  tags: [Conversation]
+  summary: Update Last Seen
+  description: Updates the last seen of the conversation so that conversations will have the bubbles in the agents screen
   parameters:
     - name: id
       in: path
       type: number
-      description: id of the contact
+      description: id of the conversation
       required: true
   responses:
     200:
       description: Success
-      schema:
-        $ref: '#/definitions/contact_conversations'
     404:
       description: Contact not found
     403:

--- a/swagger/paths/index.yml
+++ b/swagger/paths/index.yml
@@ -5,3 +5,19 @@
   $ref: ./contact/crud.yml
 /contacts/{id}/conversations:
   $ref: ./contact/conversations.yml
+
+# Conversations
+/conversations:
+  $ref: ./conversation/list.yml
+/conversations/{id}:
+  $ref: ./conversation/crud.yml
+/conversations/{id}/toggle_status:
+  $ref: ./conversation/toggle_status.yml
+/conversations/{id}/update_last_seen:
+  $ref: ./conversation/update_last_seen.yml
+/conversations/{id}/labels:
+  $ref: ./conversation/labels.yml
+/conversations/{id}/assignments:
+  $ref: ./conversation/assignments.yml
+/conversations/{id}/messages:
+  $ref: ./conversation/messages.yml

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -21,8 +21,8 @@
         "tags": [
           "Contact"
         ],
-        "description": "Listing all contacts with pagination",
-        "summary": "List contacts",
+        "description": "Listing all the contacts with pagination",
+        "summary": "List Contacts",
         "parameters": [
           {
             "name": "query_hash",
@@ -49,7 +49,7 @@
         "tags": [
           "Contact"
         ],
-        "description": "Create a contact",
+        "description": "Create New Contact",
         "parameters": [
           {
             "name": "data",
@@ -87,7 +87,7 @@
             "name": "id",
             "in": "path",
             "type": "number",
-            "description": "ID of contact",
+            "description": "id of the contact",
             "required": true
           }
         ],
@@ -116,7 +116,7 @@
             "name": "id",
             "in": "path",
             "type": "number",
-            "description": "ID of the contact",
+            "description": "id of the contact",
             "required": true
           },
           {
@@ -155,7 +155,7 @@
             "name": "id",
             "in": "path",
             "type": "number",
-            "description": "ID of contact",
+            "description": "id of the contact",
             "required": true
           }
         ],
@@ -168,6 +168,300 @@
           },
           "404": {
             "description": "Contact not found"
+          },
+          "403": {
+            "description": "Access denied"
+          }
+        }
+      }
+    },
+    "/conversations": {
+      "get": {
+        "tags": [
+          "Conversation"
+        ],
+        "description": "List all the conversations with pagination",
+        "summary": "Conversations List",
+        "parameters": [
+          {
+            "name": "query_hash",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/conversation_list"
+            }
+          },
+          "400": {
+            "description": "Bad Request Error",
+            "schema": {
+              "$ref": "#/definitions/bad_request_error"
+            }
+          }
+        }
+      }
+    },
+    "/conversations/{id}": {
+      "get": {
+        "tags": [
+          "Conversation"
+        ],
+        "summary": "Conversation Details",
+        "description": "Get all details regarding a conversation with all messages in the conversation",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "number",
+            "description": "ID of Conversation",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/conversation_show"
+            }
+          },
+          "404": {
+            "description": "Conversation not found"
+          },
+          "403": {
+            "description": "Access denied"
+          }
+        }
+      }
+    },
+    "/conversations/{id}/toggle_status": {
+      "post": {
+        "tags": [
+          "Conversation"
+        ],
+        "summary": "Toggle Status",
+        "description": "Toggles the status of the conversation between open and resolved",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "number",
+            "description": "id of the conversation",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/conversation_status_toggle"
+            }
+          },
+          "404": {
+            "description": "Conversation not found"
+          },
+          "403": {
+            "description": "Access denied"
+          }
+        }
+      }
+    },
+    "/conversations/{id}/update_last_seen": {
+      "post": {
+        "tags": [
+          "Conversation"
+        ],
+        "summary": "Update Last Seen",
+        "description": "Updates the last seen of the conversation so that conversations will have the bubbles in the agents screen",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "number",
+            "description": "id of the conversation",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Contact not found"
+          },
+          "403": {
+            "description": "Access denied"
+          }
+        }
+      }
+    },
+    "/conversations/{id}/labels": {
+      "get": {
+        "tags": [
+          "Conversation"
+        ],
+        "summary": "List Labels",
+        "description": "Lists all the labels of a conversation",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "number",
+            "description": "id of the conversation",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/conversation_labels"
+            }
+          },
+          "404": {
+            "description": "Conversation not found"
+          },
+          "403": {
+            "description": "Access denied"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Conversation"
+        ],
+        "summary": "Add Label",
+        "description": "Creates a new label and associates it with the conversation",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "number",
+            "description": "id of the conversation",
+            "required": true
+          },
+          {
+            "name": "data",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "labels": {
+                  "type": "array",
+                  "description": "array of labels",
+                  "properties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/conversation_labels"
+            }
+          },
+          "404": {
+            "description": "Conversation not found"
+          },
+          "403": {
+            "description": "Access denied"
+          }
+        }
+      }
+    },
+    "/conversations/{id}/assignments": {
+      "post": {
+        "tags": [
+          "Conversation"
+        ],
+        "summary": "Assign Conversation",
+        "description": "Assign a conversation to an agent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "number",
+            "description": "id of the conversation",
+            "required": true
+          },
+          {
+            "name": "data",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "assignee_id": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/user"
+            }
+          },
+          "404": {
+            "description": "Conversation not found"
+          },
+          "403": {
+            "description": "Access denied"
+          }
+        }
+      }
+    },
+    "/conversations/{id}/messages": {
+      "post": {
+        "tags": [
+          "Conversation"
+        ],
+        "summary": "Create New Message",
+        "description": "All the agent replies are created as new messages through this endpoint",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "number",
+            "description": "id of the conversation",
+            "required": true
+          },
+          {
+            "name": "data",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/conversation_message_create"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success",
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/generic_id"
+                },
+                {
+                  "$ref": "#/definitions/message"
+                }
+              ]
+            }
+          },
+          "404": {
+            "description": "Conversation not found"
           },
           "403": {
             "description": "Access denied"
@@ -206,6 +500,14 @@
         }
       }
     },
+    "generic_id": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number"
+        }
+      }
+    },
     "contact": {
       "type": "object",
       "properties": {
@@ -229,9 +531,6 @@
     "conversation": {
       "type": "object",
       "properties": {
-        "display_id": {
-          "type": "number"
-        },
         "messages": {
           "type": "array",
           "items": {
@@ -262,6 +561,65 @@
         }
       }
     },
+    "message": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "inbox_id": {
+          "type": "number"
+        },
+        "conversation_id": {
+          "type": "number"
+        },
+        "message_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "integer"
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "attachment": {
+          "type": "object"
+        }
+      }
+    },
+    "user": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number"
+        },
+        "uid": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "account_id": {
+          "type": "number"
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "agent",
+            "administrator"
+          ]
+        },
+        "confirmed": {
+          "type": "boolean"
+        },
+        "nickname": {
+          "type": "string"
+        }
+      }
+    },
     "extended_contact": {
       "allOf": [
         {
@@ -287,38 +645,30 @@
     "contact_base": {
       "allOf": [
         {
-          "$ref": "#/definitions/contact"
+          "$ref": "#/definitions/generic_id"
         },
         {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "number"
-            }
-          }
+          "$ref": "#/definitions/contact"
         }
       ]
     },
     "contact_list": {
       "type": "array",
+      "description": "array of contacts",
       "items": {
         "allOf": [
           {
-            "$ref": "#/definitions/contact"
+            "$ref": "#/definitions/generic_id"
           },
           {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "number"
-              }
-            }
+            "$ref": "#/definitions/contact"
           }
         ]
       }
     },
     "contact_conversations": {
       "type": "array",
+      "description": "array of conversations",
       "items": {
         "allOf": [
           {
@@ -348,14 +698,182 @@
                     }
                   },
                   "assignee": {
-                    "type": "object"
+                    "$ref": "#/definitions/user"
                   }
                 }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "display_id": {
+                "type": "number"
               }
             }
           }
         ]
       }
+    },
+    "conversation_list": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "meta": {
+              "type": "object",
+              "properties": {
+                "mine_count": {
+                  "type": "number"
+                },
+                "unassigned_count": {
+                  "type": "number"
+                },
+                "all_count": {
+                  "type": "number"
+                }
+              }
+            },
+            "payload": {
+              "type": "array",
+              "description": "array of conversations",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/generic_id"
+                  },
+                  {
+                    "$ref": "#/definitions/conversation"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "meta": {
+                        "type": "object",
+                        "properties": {
+                          "sender": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "thumbnail": {
+                                "type": "string"
+                              },
+                              "channel": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "assignee": {
+                            "$ref": "#/definitions/user"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "conversation_show": {
+      "type": "object",
+      "properties": {
+        "meta": {
+          "type": "object",
+          "properties": {
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "additional_attributes": {
+              "type": "object"
+            },
+            "contact_id": {
+              "type": "number"
+            }
+          }
+        },
+        "payload": {
+          "type": "array",
+          "description": "array of messages",
+          "items": {
+            "allOf": [
+              {
+                "$ref": "#/definitions/extended_message"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "conversation_status_toggle": {
+      "type": "object",
+      "properties": {
+        "meta": {
+          "type": "object"
+        },
+        "payload": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            },
+            "current_status": {
+              "type": "string",
+              "enum": [
+                "open",
+                "resolved"
+              ]
+            },
+            "conversation_id": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    },
+    "conversation_labels": {
+      "type": "object",
+      "properties": {
+        "payload": {
+          "type": "array",
+          "description": "array of labels",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "extended_message": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/generic_id"
+        },
+        {
+          "$ref": "#/definitions/message"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "source_id": {
+              "type": "number"
+            },
+            "sender": {
+              "type": "object"
+            }
+          }
+        }
+      ]
     },
     "contact_create": {
       "type": "object",
@@ -379,6 +897,23 @@
         },
         "phone_number": {
           "type": "string"
+        }
+      }
+    },
+    "conversation_message_create": {
+      "type": "object",
+      "properties": {
+        "conversation_id": {
+          "type": "number"
+        },
+        "message": {
+          "type": "string"
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "fb_id": {
+          "type": "number"
         }
       }
     }


### PR DESCRIPTION
This closes #549 

## Description
* Added the documentation for the conversation APIs - 8 endpoints
* Added descriptions for the existing endpoints
* Added new resource models and updated some parts of the contact API

## Type of change
- [x] This change requires a documentation update

## How Has This Been Tested?
After making the changes, ran the task `rake swagger:build`, and went to `http://localhost:3000/swagger` and verified the documentation has been updated with my changes.


## Checklist:
- [ ] I have made corresponding changes to the documentation



