### PR TITLE
Chore: Update the source of `json_refs` gem (#565)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :development do
   gem 'web-console'
 
   # used in swagger build
-  gem 'json_refs', git: 'https://github.com/sony-mathew/json_refs', ref: 'b6c142a'
+  gem 'json_refs', git: 'https://github.com/tzmfreedom/json_refs', ref: 'e32deb0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,9 @@ GIT
       oauth
 
 GIT
-  remote: https://github.com/sony-mathew/json_refs
-  revision: b6c142ae486e399d00fbc758e21a7ed63a934f61
-  ref: b6c142a
+  remote: https://github.com/tzmfreedom/json_refs
+  revision: e32deb073ce9aef39bdd63556bffd7fe7c2a803d
+  ref: e32deb0
   specs:
     json_refs (0.1.2)
       hana


### PR DESCRIPTION
This closes #565 

### Changes
At the time of using, `json_refs` gem did not have the ability to recursively resolve the references. So we had to fork this into one of our own and make the required changes. So this fork was used as the source for the gem.
Along with this, we had raised a PR in the original repo so as to push the recursive dereferencing changes upstream. This was merged in the gem's parent repo. So updated the source of this gem to the original parent repo source.

## Checklist:
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules