### PR TITLE
Chore: User Friendly URLs on the swagger docs

### DIFF
--- a/swagger/paths/contact/conversations.yml
+++ b/swagger/paths/contact/conversations.yml
@@ -1,5 +1,7 @@
 get:
-  tags: [Contact]
+  tags:
+    - Contact
+  operationId: contactConversations
   summary: Conversations
   parameters:
     - name: id

--- a/swagger/paths/contact/crud.yml
+++ b/swagger/paths/contact/crud.yml
@@ -1,5 +1,7 @@
 get:
-  tags: [Contact]
+  tags:
+    - Contact
+  operationId: contactDetails
   summary: Show Contact
   parameters:
     - name: id
@@ -18,7 +20,9 @@ get:
       description: Access denied
 
 put:
-  tags: [Contact]
+  tags:
+    - Contact
+  operationId: contactUpdate
   summary: Update Contact
   parameters:
     - name: id

--- a/swagger/paths/contact/list_create.yml
+++ b/swagger/paths/contact/list_create.yml
@@ -1,5 +1,7 @@
 get:
-  tags: [Contact]
+  tags:
+    - Contact
+  operationId: contactList
   description: Listing all the contacts with pagination
   summary: List Contacts
   parameters:
@@ -17,7 +19,9 @@ get:
         $ref: '#/definitions/bad_request_error'
 
 post:
-  tags: [Contact]
+  tags:
+    - Contact
+  operationId: contactCreate
   description: Create New Contact
   parameters:
     - name: data

--- a/swagger/paths/conversation/assignments.yml
+++ b/swagger/paths/conversation/assignments.yml
@@ -1,5 +1,7 @@
 post:
-  tags: [Conversation]
+  tags:
+    - Conversation
+  operationId: conversationAssignment
   summary: Assign Conversation
   description: Assign a conversation to an agent
   parameters:

--- a/swagger/paths/conversation/crud.yml
+++ b/swagger/paths/conversation/crud.yml
@@ -1,5 +1,7 @@
 get:
-  tags: [Conversation]
+  tags:
+    - Conversation
+  operationId: conversationDetails
   summary: Conversation Details
   description: Get all details regarding a conversation with all messages in the conversation
   parameters:

--- a/swagger/paths/conversation/labels.yml
+++ b/swagger/paths/conversation/labels.yml
@@ -1,5 +1,7 @@
 get:
-  tags: [Conversation]
+  tags:
+    - Conversation
+  operationId: conversationLabelsList
   summary: List Labels
   description: Lists all the labels of a conversation
   parameters:
@@ -19,9 +21,11 @@ get:
       description: Access denied
 
 post:
-  tags: [Conversation]
-  summary: Add Label
-  description: Creates a new label and associates it with the conversation
+  tags:
+    - Conversation
+  operationId: conversationAddLabels
+  summary: Add Labels
+  description: Creates new labels and associates it with the conversation
   parameters:
     - name: id
       in: path

--- a/swagger/paths/conversation/list.yml
+++ b/swagger/paths/conversation/list.yml
@@ -1,5 +1,7 @@
 get:
-  tags: [Conversation]
+  tags:
+    - Conversation
+  operationId: conversationList
   description: List all the conversations with pagination
   summary: Conversations List
   parameters:

--- a/swagger/paths/conversation/messages.yml
+++ b/swagger/paths/conversation/messages.yml
@@ -1,5 +1,7 @@
 post:
-  tags: [Conversation]
+  tags:
+    - Conversation
+  operationId: conversationNewMessage
   summary: Create New Message
   description: All the agent replies are created as new messages through this endpoint
   parameters:

--- a/swagger/paths/conversation/toggle_status.yml
+++ b/swagger/paths/conversation/toggle_status.yml
@@ -1,5 +1,7 @@
 post:
-  tags: [Conversation]
+  tags:
+    - Conversation
+  operationId: conversationToggleStatus
   summary: Toggle Status
   description: Toggles the status of the conversation between open and resolved
   parameters:

--- a/swagger/paths/conversation/update_last_seen.yml
+++ b/swagger/paths/conversation/update_last_seen.yml
@@ -1,5 +1,7 @@
 post:
-  tags: [Conversation]
+  tags:
+    - Conversation
+  operationId: conversationUpdateLastSeen
   summary: Update Last Seen
   description: Updates the last seen of the conversation so that conversations will have the bubbles in the agents screen
   parameters:

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -21,6 +21,7 @@
         "tags": [
           "Contact"
         ],
+        "operationId": "contactList",
         "description": "Listing all the contacts with pagination",
         "summary": "List Contacts",
         "parameters": [
@@ -49,6 +50,7 @@
         "tags": [
           "Contact"
         ],
+        "operationId": "contactCreate",
         "description": "Create New Contact",
         "parameters": [
           {
@@ -81,6 +83,7 @@
         "tags": [
           "Contact"
         ],
+        "operationId": "contactDetails",
         "summary": "Show Contact",
         "parameters": [
           {
@@ -110,6 +113,7 @@
         "tags": [
           "Contact"
         ],
+        "operationId": "contactUpdate",
         "summary": "Update Contact",
         "parameters": [
           {
@@ -149,6 +153,7 @@
         "tags": [
           "Contact"
         ],
+        "operationId": "contactConversations",
         "summary": "Conversations",
         "parameters": [
           {
@@ -180,6 +185,7 @@
         "tags": [
           "Conversation"
         ],
+        "operationId": "conversationList",
         "description": "List all the conversations with pagination",
         "summary": "Conversations List",
         "parameters": [
@@ -210,6 +216,7 @@
         "tags": [
           "Conversation"
         ],
+        "operationId": "conversationDetails",
         "summary": "Conversation Details",
         "description": "Get all details regarding a conversation with all messages in the conversation",
         "parameters": [
@@ -242,6 +249,7 @@
         "tags": [
           "Conversation"
         ],
+        "operationId": "conversationToggleStatus",
         "summary": "Toggle Status",
         "description": "Toggles the status of the conversation between open and resolved",
         "parameters": [
@@ -274,6 +282,7 @@
         "tags": [
           "Conversation"
         ],
+        "operationId": "conversationUpdateLastSeen",
         "summary": "Update Last Seen",
         "description": "Updates the last seen of the conversation so that conversations will have the bubbles in the agents screen",
         "parameters": [
@@ -303,6 +312,7 @@
         "tags": [
           "Conversation"
         ],
+        "operationId": "conversationLabelsList",
         "summary": "List Labels",
         "description": "Lists all the labels of a conversation",
         "parameters": [
@@ -333,8 +343,9 @@
         "tags": [
           "Conversation"
         ],
-        "summary": "Add Label",
-        "description": "Creates a new label and associates it with the conversation",
+        "operationId": "conversationAddLabels",
+        "summary": "Add Labels",
+        "description": "Creates new labels and associates it with the conversation",
         "parameters": [
           {
             "name": "id",
@@ -382,6 +393,7 @@
         "tags": [
           "Conversation"
         ],
+        "operationId": "conversationAssignment",
         "summary": "Assign Conversation",
         "description": "Assign a conversation to an agent",
         "parameters": [
@@ -427,6 +439,7 @@
         "tags": [
           "Conversation"
         ],
+        "operationId": "conversationNewMessage",
         "summary": "Create New Message",
         "description": "All the agent replies are created as new messages through this endpoint",
         "parameters": [


### PR DESCRIPTION
This closes #589 

## Description
Currently with swagger documentation, when you click on a particular request on the left navigation bar, the URL of the page changes to something that is constructed from the request params and is highly unreadable and very long. This makes it very difficult to understand the URL and also to share it. Made this short and readable.
