### PR TITLE
Bug: Fix duplicate messages from Twitter DM and tweets

### DIFF
--- a/app/controllers/twitter/callbacks_controller.rb
+++ b/app/controllers/twitter/callbacks_controller.rb
@@ -1,5 +1,7 @@
 class Twitter::CallbacksController < Twitter::BaseController
   def show
+    return redirect_to app_new_twitter_inbox_url if permitted_params[:denied]
+
     @response = twitter_client.access_token(
       oauth_token: permitted_params[:oauth_token],
       oauth_verifier: permitted_params[:oauth_verifier]
@@ -46,6 +48,6 @@ class Twitter::CallbacksController < Twitter::BaseController
   end
 
   def permitted_params
-    params.permit(:oauth_token, :oauth_verifier)
+    params.permit(:oauth_token, :oauth_verifier, :denied)
   end
 end

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -21,8 +21,11 @@
       "PRIVATE_MSG_INPUT": "Shift + enter for new line. This will be visible only to Agents"
     },
     "REPLYBOX": {
+      "REPLY": "Reply",
+      "PRIVATE_NOTE": "Private Note",
       "SEND": "Send",
-      "CREATE": "Add Note"
+      "CREATE": "Add Note",
+      "TWEET": "Tweet"
     },
     "VISIBLE_TO_AGENTS": "Private Note: Only visible to you and your team",
     "CHANGE_STATUS": "Conversation status changed",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Index.vue
@@ -39,6 +39,9 @@
                 <span v-if="item.channel_type === 'Channel::WebWidget'">
                   Website
                 </span>
+                <span v-if="item.channel_type === 'Channel::TwitterProfile'">
+                  Twitter
+                </span>
               </td>
 
               <!-- Action Buttons -->

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -6,6 +6,7 @@ class Conversations::EventDataPresenter < SimpleDelegator
   def push_data
     {
       id: display_id,
+      additional_attributes: additional_attributes,
       inbox_id: inbox_id,
       messages: push_messages,
       meta: push_meta,

--- a/app/services/twitter/direct_message_parser_service.rb
+++ b/app/services/twitter/direct_message_parser_service.rb
@@ -11,7 +11,9 @@ class Twitter::DirectMessageParserService < Twitter::WebhooksBaseService
       content: message_create_data['message_data']['text'],
       account_id: @inbox.account_id,
       inbox_id: @inbox.id,
-      message_type: outgoing_message? ? :outgoing : :incoming
+      message_type: outgoing_message? ? :outgoing : :incoming,
+      contact_id: @contact.id,
+      source_id: direct_message_data['id']
     )
   end
 

--- a/app/services/twitter/send_reply_service.rb
+++ b/app/services/twitter/send_reply_service.rb
@@ -39,10 +39,16 @@ class Twitter::SendReplyService
   end
 
   def send_tweet_reply
-    twitter_client.send_tweet_reply(
+    response = twitter_client.send_tweet_reply(
       reply_to_tweet_id: conversation.additional_attributes['tweet_id'],
       tweet: screen_name + message.content
     )
+    if response.status == '200'
+      tweet_data = response.body
+      message.update!(source_id: tweet_data['id_str'])
+    else
+      Rails.logger 'TWITTER_TWEET_REPLY_ERROR' + response.body
+    end
   end
 
   def send_reply

--- a/app/views/api/v1/contacts/conversations/index.json.jbuilder
+++ b/app/views/api/v1/contacts/conversations/index.json.jbuilder
@@ -1,27 +1,5 @@
 json.payload do
   json.array! @conversations do |conversation|
-    json.meta do
-      json.sender do
-        json.id conversation.contact.id
-        json.name conversation.contact.name
-        json.thumbnail conversation.contact.avatar_url
-        json.channel conversation.inbox.try(:channel_type)
-      end
-      json.assignee conversation.assignee
-    end
-
-    json.id conversation.display_id
-    if conversation.unread_incoming_messages.count.zero?
-      json.messages [conversation.messages.last.try(:push_event_data)]
-    else
-      json.messages conversation.unread_messages.map(&:push_event_data)
-    end
-    json.inbox_id conversation.inbox_id
-    json.status conversation.status
-    json.timestamp conversation.messages.last.try(:created_at).try(:to_i)
-    json.user_last_seen_at conversation.user_last_seen_at.to_i
-    json.agent_last_seen_at conversation.agent_last_seen_at.to_i
-    json.unread_count conversation.unread_incoming_messages.count
-    json.additional_attributes conversation.additional_attributes
+    json.partial! 'api/v1/conversations/partials/conversation.json.jbuilder', conversation: conversation
   end
 end

--- a/app/views/api/v1/contacts/conversations/index.json.jbuilder
+++ b/app/views/api/v1/contacts/conversations/index.json.jbuilder
@@ -22,5 +22,6 @@ json.payload do
     json.user_last_seen_at conversation.user_last_seen_at.to_i
     json.agent_last_seen_at conversation.agent_last_seen_at.to_i
     json.unread_count conversation.unread_incoming_messages.count
+    json.additional_attributes conversation.additional_attributes
   end
 end

--- a/app/views/api/v1/conversations/index.json.jbuilder
+++ b/app/views/api/v1/conversations/index.json.jbuilder
@@ -4,7 +4,6 @@ json.data do
     json.unassigned_count @conversations_count[:unassigned_count]
     json.all_count @conversations_count[:all_count]
   end
-
   json.payload do
     json.array! @conversations do |conversation|
       json.meta do
@@ -16,7 +15,6 @@ json.data do
         end
         json.assignee conversation.assignee
       end
-
       json.id conversation.display_id
       if conversation.unread_incoming_messages.count.zero?
         json.messages [conversation.messages.last.try(:push_event_data)]
@@ -29,6 +27,7 @@ json.data do
       json.user_last_seen_at conversation.user_last_seen_at.to_i
       json.agent_last_seen_at conversation.agent_last_seen_at.to_i
       json.unread_count conversation.unread_incoming_messages.count
+      json.additional_attributes conversation.additional_attributes
     end
   end
 end

--- a/app/views/api/v1/conversations/index.json.jbuilder
+++ b/app/views/api/v1/conversations/index.json.jbuilder
@@ -6,28 +6,7 @@ json.data do
   end
   json.payload do
     json.array! @conversations do |conversation|
-      json.meta do
-        json.sender do
-          json.id conversation.contact.id
-          json.name conversation.contact.name
-          json.thumbnail conversation.contact.avatar_url
-          json.channel conversation.inbox.try(:channel_type)
-        end
-        json.assignee conversation.assignee
-      end
-      json.id conversation.display_id
-      if conversation.unread_incoming_messages.count.zero?
-        json.messages [conversation.messages.last.try(:push_event_data)]
-      else
-        json.messages conversation.unread_messages.map(&:push_event_data)
-      end
-      json.inbox_id conversation.inbox_id
-      json.status conversation.status
-      json.timestamp conversation.messages.last.try(:created_at).try(:to_i)
-      json.user_last_seen_at conversation.user_last_seen_at.to_i
-      json.agent_last_seen_at conversation.agent_last_seen_at.to_i
-      json.unread_count conversation.unread_incoming_messages.count
-      json.additional_attributes conversation.additional_attributes
+      json.partial! 'api/v1/conversations/partials/conversation.json.jbuilder', conversation: conversation
     end
   end
 end

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -1,0 +1,24 @@
+json.meta do
+  json.sender do
+    json.id conversation.contact.id
+    json.name conversation.contact.name
+    json.thumbnail conversation.contact.avatar_url
+    json.channel conversation.inbox.try(:channel_type)
+  end
+  json.assignee conversation.assignee
+end
+
+json.id conversation.display_id
+if conversation.unread_incoming_messages.count.zero?
+  json.messages [conversation.messages.last.try(:push_event_data)]
+else
+  json.messages conversation.unread_messages.map(&:push_event_data)
+end
+
+json.inbox_id conversation.inbox_id
+json.status conversation.status
+json.timestamp conversation.messages.last.try(:created_at).try(:to_i)
+json.user_last_seen_at conversation.user_last_seen_at.to_i
+json.agent_last_seen_at conversation.agent_last_seen_at.to_i
+json.unread_count conversation.unread_incoming_messages.count
+json.additional_attributes conversation.additional_attributes

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -226,6 +226,7 @@ RSpec.describe Conversation, type: :model do
     let(:conversation) { create(:conversation) }
     let(:expected_data) do
       {
+        additional_attributes: nil,
         meta: {
           sender: conversation.contact.push_event_data,
           assignee: conversation.assignee

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Conversations::EventDataPresenter do
   describe '#push_data' do
     let(:expected_data) do
       {
+        additional_attributes: nil,
         meta: {
           sender: conversation.contact.push_event_data,
           assignee: conversation.assignee


### PR DESCRIPTION
Fixes #596 

- [x] Store tweet_id as source_id on the success of send_reply_service
- [x] Ignore tweet callback if message with the same tweet_id already exist
- [x] Store message_create_event id as source_id for DMs.
- [x] Limit the number of characters for tweets to 280
- [x] Redirect twitter callback to twitter_new_inbox_url if param denied is available