### PR TITLE
[Feature] Conversation ordering changes (#639)

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -36,7 +36,7 @@ class Conversation < ApplicationRecord
 
   enum status: { open: 0, resolved: 1, bot: 2 }
 
-  scope :latest, -> { order(created_at: :desc) }
+  scope :latest, -> { order(updated_at: :desc) }
   scope :unassigned, -> { where(assignee_id: nil) }
   scope :assigned_to, ->(agent) { where(assignee_id: agent.id) }
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -51,7 +51,7 @@ class Message < ApplicationRecord
 
   belongs_to :account
   belongs_to :inbox
-  belongs_to :conversation
+  belongs_to :conversation, touch: true
   belongs_to :user, required: false
   belongs_to :contact, required: false
 


### PR DESCRIPTION
Fixes #639 

## Description
* Update conversation's updated_at when a message is created/saved
* Changed the ordering of conversation to be based on `updated_at` rather than `created_at`

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Amidst Corona, in a home quarantined lockdown situation in local.
