### PR TITLE
Bug: Fixed conversation reply mail issue when an attachment is sent (#650)

### DIFF
--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -20,7 +20,8 @@ class ConversationReplyMailer < ApplicationMailer
 
   private
 
-  def mail_subject(last_message, trim_length = 30)
-    "[##{@conversation.display_id}] #{last_message.content.truncate(trim_length)}"
+  def mail_subject(last_message, trim_length = 50)
+    subject_line = last_message&.content&.truncate(trim_length) || 'New messages on this conversation'
+    "[##{@conversation.display_id}] #{subject_line}"
   end
 end

--- a/app/views/mailers/conversation_reply_mailer/reply_with_summary.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/reply_with_summary.html.erb
@@ -8,7 +8,13 @@
       <td>
         <b><%= message.incoming? ? 'You' : message.user.name %></b>
       </td>
-      <td>: <%= message.content %></td>
+      <td>:
+        <% if message.attachment %>
+          attachment [<a href="<%= message.attachment.file_url %>" _target="blank">click here to view</a>]
+        <% else %>
+          <%= message.content %>
+        <% end %>
+      </td>
     </tr>
   <% end %>
 </table>


### PR DESCRIPTION
This fixes #650 

## Description

* When an attachment was sent in the reply mailer it was breaking due to the truncating function applied on the last message content. Here the content was empty and so it broke. Fixed this breakage.
* Also addressed the issue that if the attachment was there the content was coming empty. With these changes, made the content to have a link to the attachment.


## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Under the duress of a declining economy with multiple governments enforcing stricter lockdown around the world and Covid-19 viruses mutating fast as they could, in a tropical climate, racing the clock in a mac machine in the local environment using Mailhog.

A screenshot after the fix: 

<img width="1417" alt="Screenshot 2020-03-30 at 4 04 35 PM" src="https://user-images.githubusercontent.com/2040199/77903392-6ac74700-72a0-11ea-9c86-707bbf21e0bf.png">
