### PR TITLE
Bugfix: Fixed confirmation email flaky tests (#534)

### DIFF
--- a/spec/mailers/confirmation_instructions_spec.rb
+++ b/spec/mailers/confirmation_instructions_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Confirmation Instructions', type: :mailer do
 
       it 'refers to the inviter and their account' do
         expect(mail.body).to match(
-          "#{inviter_val.name}, with #{inviter_val.account.name}, has invited you to try out Chatwoot!"
+          "#{CGI.escapeHTML(inviter_val.name)}, with #{CGI.escapeHTML(inviter_val.account.name)}, has invited you to try out Chatwoot!"
         )
       end
     end


### PR DESCRIPTION
Fixes #534 

## Description

* Fixed confirmation email flaky tests due to unescaped HTML

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in local by running RSpec multiple times.
