### PR TITLE
Remove deprecated scope from FB Channel

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Facebook.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Facebook.vue
@@ -196,7 +196,7 @@ export default {
         },
         {
           scope:
-            'manage_pages,read_page_mailboxes,pages_messaging,pages_messaging_phone_number',
+            'manage_pages,pages_messaging,pages_messaging_phone_number',
         }
       );
     },


### PR DESCRIPTION
# Pull Request Template

## Description

On June 30, 2020, Facebook API will deprecate the `read_page_mailboxes` scope.

Fixes #760 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No tests, looks like this particular scope is not needed anymore. Someone with more knowledge of this part of the codebase should test more thoroughly 🙏

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules