### PR TITLE
Bug: Fixed private note being sent to customer (#837)

### DIFF
--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -9,8 +9,8 @@ class ConversationReplyMailer < ApplicationMailer
     @contact = @conversation.contact
     @agent = @conversation.assignee
 
-    recap_messages = @conversation.messages.where('created_at < ?', message_queued_time).order(created_at: :asc).last(10)
-    new_messages = @conversation.messages.where('created_at >= ?', message_queued_time)
+    recap_messages = @conversation.messages.chat.where('created_at < ?', message_queued_time).last(10)
+    new_messages = @conversation.messages.chat.where('created_at >= ?', message_queued_time)
 
     @messages = recap_messages + new_messages
     @messages = @messages.select(&:reportable?)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -59,7 +59,7 @@ class Message < ApplicationRecord
 
   # .succ is a hack to avoid https://makandracards.com/makandra/1057-why-two-ruby-time-objects-are-not-equal-although-they-appear-to-be
   scope :unread_since, ->(datetime) { where('EXTRACT(EPOCH FROM created_at) > (?)', datetime.to_i.succ) }
-  scope :chat, -> { where.not(message_type: :activity).where.not(private: true) }
+  scope :chat, -> { where.not(message_type: :activity).where(private: false) }
   default_scope { order(created_at: :asc) }
 
   belongs_to :account

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
     context 'with all mails' do
       let(:conversation) { create(:conversation, assignee: agent) }
       let(:message) { create(:message, conversation: conversation) }
-      let(:private_message) { create(:message, content: 'This is a private message', private: true, conversation: conversation) }
+      let(:private_message) { create(:message, content: 'This is a private message', conversation: conversation) }
       let(:mail) { described_class.reply_with_summary(message.conversation, Time.zone.now).deliver_now }
 
       it 'renders the subject' do


### PR DESCRIPTION
Fixes #837 

## Description

Private notes in the conversation were being sent to the customer in the conversation emails because of wrong scoping of messages. While fetching the messages of the conversation to be sent to the customer in the email, the scope was wrong which fetched the private notes along with the public ones. Fixed this issue.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in local on a SUNDAY (FUN DAY) while sipping green tea for boosting the immunity against the Corona negativity in the air.

Added tests for ensuring that private notes won't be sent in the conversation emails.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes