### PR TITLE
Feature: Global Config helper (#844)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,7 @@ Style/GlobalVars:
   Exclude:
     - 'config/initializers/redis.rb'
     - 'lib/redis/alfred.rb'
+    - 'lib/global_config.rb'
 Metrics/BlockLength:
   Exclude:
     - spec/**/*

--- a/lib/global_config.rb
+++ b/lib/global_config.rb
@@ -1,0 +1,44 @@
+class GlobalConfig
+  VERSION = 'V1'.freeze
+  KEY_PREFIX = 'GLOBAL_CONFIG'.freeze
+  DEFAULT_EXPIRY = 1.day
+
+  class << self
+    def get(*args)
+      config_keys = *args
+      config = {}
+
+      config_keys.each do |config_key|
+        config[config_key] = load_from_cache(config_key)
+      end
+
+      config.with_indifferent_access
+    end
+
+    def clear_cache
+      cached_keys = $alfred.keys("#{VERSION}:#{KEY_PREFIX}:*")
+      (cached_keys || []).each do |cached_key|
+        $alfred.expire(cached_key, 0)
+      end
+    end
+
+    private
+
+    def load_from_cache(config_key)
+      cache_key = "#{VERSION}:#{KEY_PREFIX}:#{config_key}"
+      cached_value = $alfred.get(cache_key)
+
+      if cached_value.blank?
+        value_from_db = db_fallback(config_key)
+        cached_value = { value: value_from_db }.to_json
+        $alfred.set(cache_key, cached_value, { expiry: DEFAULT_EXPIRY })
+      end
+
+      JSON.parse(cached_value)['value']
+    end
+
+    def db_fallback(config_key)
+      InstallationConfig.find_by(name: config_key)&.value
+    end
+  end
+end

--- a/spec/lib/global_config_spec.rb
+++ b/spec/lib/global_config_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe GlobalConfig do
+  subject(:trigger) { described_class }
+
+  describe 'execute' do
+    context 'when called with default options' do
+      before do
+        described_class.clear_cache
+      end
+
+      it 'hit DB for the first call' do
+        expect(InstallationConfig).to receive(:find_by)
+        described_class.get('test')
+      end
+
+      it 'get from cache for subsequent calls' do
+        # this loads from DB
+        described_class.get('test')
+
+        # subsequent calls should not hit DB
+        expect(InstallationConfig).not_to receive(:find_by)
+        described_class.get('test')
+      end
+
+      it 'clears cache and fetch from DB next time, when clear_cache is called' do
+        # this loads from DB and is cached
+        described_class.get('test')
+
+        # clears the cache
+        described_class.clear_cache
+
+        # should be loaded from DB
+        expect(InstallationConfig).to receive(:find_by).with({ name: 'test' }).and_return(nil)
+        described_class.get('test')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This closes #844 .

## Description
* Added a global config helper to easily access installation/global configs
  * This will fetch the keys from cache with fallback to DB on a cache miss
  * Ability to query multiple keys simultaneously
  * Interface to delete the existing global config cache
* Added tests for this new helper module

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested locally from the console. 

<img width="1329" alt="Screenshot 2020-05-11 at 1 36 54 PM" src="https://user-images.githubusercontent.com/2040199/81546747-70807400-9398-11ea-970e-cce83960b0f1.png">

From the screenshot, a couple of things to note,
1. The first call came from cache as there were no queries being fired
2. After clearing the global config cache, the DB queries appeared in the next call
3. But thereafter how many ever times you called config, there were no DB queries as it was already cached

Usage :

```
# To get the configs
GlobalConfig.get('SHOW_WIDGET_HEADER', 'ACCOUNT_LEVEL_FEATURE_DEFAULTS')

# To clear the config cache
GlobalConfig.clear_cache
```


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes