### PR TITLE
Chore: Parse quoted text in incoming emails (#883)

### DIFF
--- a/app/mailboxes/conversation_mailbox.rb
+++ b/app/mailboxes/conversation_mailbox.rb
@@ -21,7 +21,7 @@ class ConversationMailbox < ApplicationMailbox
     @message = @conversation.messages.create(
       account_id: @conversation.account_id,
       contact_id: @conversation.contact_id,
-      content: processed_mail.content,
+      content: processed_mail.text_content[:reply],
       inbox_id: @conversation.inbox_id,
       message_type: 'incoming',
       content_type: 'incoming_email',
@@ -71,6 +71,6 @@ class ConversationMailbox < ApplicationMailbox
   end
 
   def decorate_mail
-    @processed_mail = MailPresenter.new(mail)
+    @processed_mail = MailPresenter.new(mail, @conversation.account)
   end
 end

--- a/spec/mailboxes/conversation_mailbox_spec.rb
+++ b/spec/mailboxes/conversation_mailbox_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ConversationMailbox, type: :mailbox do
     end
 
     it 'add the mail content as new message on the conversation' do
-      expect(conversation.messages.last.content).to eq("Let's talk about these images:\r\n\r\n")
+      expect(conversation.messages.last.content).to eq("Let's talk about these images:")
     end
 
     it 'add the attachments' do

--- a/spec/mailboxes/conversation_mailbox_spec.rb
+++ b/spec/mailboxes/conversation_mailbox_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ConversationMailbox, type: :mailbox do
     let(:reply_mail) { create_inbound_email_from_fixture('reply.eml') }
     let(:conversation) { create(:conversation, assignee: agent) }
     let(:described_subject) { described_class.receive reply_mail }
-    let(:serialized_attributes) { %w[content number_of_attachments subject date to from in_reply_to cc bcc message_id] }
+    let(:serialized_attributes) { %w[text_content html_content number_of_attachments subject date to from in_reply_to cc bcc message_id] }
 
     before do
       # this UUID is hardcoded in the reply.eml, that's why we are updating this

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MailPresenter do
 
     it 'give utf8 encoded content' do
       expect(decorated_mail.subject).to eq("Discussion: Let's debate these attachments")
-      expect(decorated_mail.content).to eq("Let's talk about these images:\r\n\r\n")
+      expect(decorated_mail.text_content[:full]).to eq("Let's talk about these images:\r\n\r\n")
     end
 
     it 'give decoded blob attachments' do
@@ -24,7 +24,10 @@ RSpec.describe MailPresenter do
 
     it 'give the serialized data of the email to be stored in the message' do
       data = decorated_mail.serialized_data
-      expect(data.keys).to eq([:content, :number_of_attachments, :subject, :date, :to, :from, :in_reply_to, :cc, :bcc, :message_id])
+      expect(data.keys).to eq([
+                                :text_content, :html_content, :number_of_attachments, :subject, :date, :to,
+                                :from, :in_reply_to, :cc, :bcc, :message_id
+                              ])
       expect(data[:subject]).to eq(decorated_mail.subject)
       expect(data[:date].to_s).to eq('2020-04-20T04:20:20-04:00')
       expect(data[:message_id]).to eq(mail.message_id)


### PR DESCRIPTION
Fixes #883 

## Description
* Parsed the quoted text and replies in incoming emails and store them separately
* Did this parsing for plain text and HTML part of emails
* In the chat window, we will only show the parsed reply alone

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested in the local environment with an actual email reply with quoted text from Gmail under hot and humid weather before the onset of rain.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes