### PR TITLE
Chore: Threaded email replies for a conversation (#885)

### DIFF
--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -14,3 +14,5 @@
   value: 'https://www.chatwoot.com/privacy-policy'
 - name: DISPLAY_MANIFEST
   value: true
+- name: FALLBACK_DOMAIN
+  value: chatwoot.com

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,3 +54,5 @@ en:
       typical_reply_message_body: "%{account_name} typically replies in a few hours."
       ways_to_reach_you_message_body: "Give the team a way to reach you."
       email_input_box_message_body: "Get notified by email"
+    reply:
+      email_subject: "New messages on this conversation"

--- a/db/migrate/20200522115645_reload_config.rb
+++ b/db/migrate/20200522115645_reload_config.rb
@@ -1,0 +1,5 @@
+class ReloadConfig < ActiveRecord::Migration[6.0]
+  def change
+    ConfigLoader.new.process
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_10_112339) do
+ActiveRecord::Schema.define(version: 2020_05_22_115645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
       let(:mail) { described_class.reply_with_summary(message.conversation, Time.zone.now).deliver_now }
 
       it 'renders the subject' do
-        expect(mail.subject).to eq("[##{message.conversation.display_id}] #{message.content.truncate(30)}")
+        expect(mail.subject).to eq("[##{message.conversation.display_id}] New messages on this conversation")
       end
 
       it 'not have private notes' do
@@ -44,6 +44,14 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
       it 'renders the reply to email' do
         expect(mail.reply_to).to eq([message&.conversation&.assignee&.email])
       end
+
+      it 'sets the correct custom message id' do
+        expect(mail.message_id).to eq("<conversation/#{conversation.uuid}/messages/#{message.id}@>")
+      end
+
+      it 'sets the correct in reply to id' do
+        expect(mail.in_reply_to).to eq("<account/#{conversation.account.id}/conversation/#{conversation.uuid}@>")
+      end
     end
 
     context 'when the cutsom domain emails are enabled' do
@@ -66,6 +74,14 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
 
       it 'sets the from email to be the support email' do
         expect(mail.from).to eq([conversation.account.support_email])
+      end
+
+      it 'sets the correct custom message id' do
+        expect(mail.message_id).to eq("conversation/#{conversation.uuid}/messages/#{message.id}@#{conversation.account.domain}")
+      end
+
+      it 'sets the correct in reply to id' do
+        expect(mail.in_reply_to).to eq("account/#{conversation.account.id}/conversation/#{conversation.uuid}@#{conversation.account.domain}")
       end
     end
   end


### PR DESCRIPTION
Fixes #885 

## Description
* Added custom Message-ID and In-Reply-To headers for conversation reply emails
* Added new global config for the default domain (This is used in the above headers)
* Added migration to run the config loader to load the new global config value
* The subject of the conversation reply mailer was made static (This is required for threaded emails)
* Added required tests

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested with Gmail client by sending out multiple replies and confirming that it comes to be threaded as expected while having black tea with extra sugar and oreo cookies on the side.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes