### PR TITLE
Fixed rspec due to unescaped html check for user name (#887)

### DIFF
--- a/spec/controllers/super_admin/users_controller_spec.rb
+++ b/spec/controllers/super_admin/users_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Super Admin Users API', type: :request do
         get '/super_admin/users'
         expect(response).to have_http_status(:success)
         expect(response.body).to include('New user')
-        expect(response.body).to include(user.name)
+        expect(response.body).to include(CGI.escapeHTML(user.name))
       end
     end
   end


### PR DESCRIPTION
Fixes #887 


## Description

* Fixed the flaky failure in rspec for super admin user controller due to unescaped user name check

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Purely locally. 💯


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
