### PR TITLE
fix bug within #toggleAgentTypingStatus test

### DIFF
--- a/app/javascript/widget/store/modules/specs/conversation/mutations.spec.js
+++ b/app/javascript/widget/store/modules/specs/conversation/mutations.spec.js
@@ -101,7 +101,7 @@ describe('#mutations', () => {
     });
 
     it('sets isAgentTyping flag to false', () => {
-      const state = { uiFlags: { isAgentTyping: false } };
+      const state = { uiFlags: { isAgentTyping: true } };
       mutations.toggleAgentTypingStatus(state, { status: 'off' });
       expect(state.uiFlags.isAgentTyping).toEqual(false);
     });


### PR DESCRIPTION
The test was providing a false positive as the state of `isAgentTyping` was not changed

I just changed the initial state of isAgentTyping from `false` to `true`



## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
expected)
