### PR TITLE
Chore: Add rake db:migrate to Heroku release phase

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
+release: bundle exec rake db:migrate
 web: bin/rails server -p $PORT -e $RAILS_ENV
 worker: bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
Add release migration to Heroku release so that the migration scripts are automatically run when a new version is deployed.