### PR TITLE
Update .conversation--message text color

### DIFF
--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-card.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-card.scss
@@ -62,7 +62,7 @@
   }
 
   .conversation--message {
-    color: $color-gray;
+    color: $color-body; // reverted to source value
     font-size: $font-size-small;
     font-weight: $font-weight-normal;
     height: $space-medium;
@@ -120,11 +120,11 @@
     }
 
     .conversation--message {
-      font-weight: $font-weight-medium;
+      font-weight: $font-weight-bold;
     }
 
     .conversation--user {
-      font-weight: $font-weight-medium;
+      font-weight: $font-weight-bold;
     }
   }
 

--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-card.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-card.scss
@@ -62,7 +62,7 @@
   }
 
   .conversation--message {
-    color: $color-body;
+    color: $color-gray;
     font-size: $font-size-small;
     font-weight: $font-weight-normal;
     height: $space-medium;

--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-card.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-card.scss
@@ -62,7 +62,7 @@
   }
 
   .conversation--message {
-    color: $color-body; // reverted to source value
+    color: $color-body;
     font-size: $font-size-small;
     font-weight: $font-weight-normal;
     height: $space-medium;


### PR DESCRIPTION
# Pull Request

## Description
**Update .conversation--message text color in the Conversations List for better hierarchy**

This is a minor change in the CSS of the Conversations List which changes the message text (.conversation--message) to a lighter gray color for better hierarchy.

### **Before:**
![before](https://user-images.githubusercontent.com/66124192/85944699-1e3fe600-b939-11ea-968d-d8f5c01fe1f8.png)

### **After:**
![after](https://user-images.githubusercontent.com/66124192/85944708-2d269880-b939-11ea-8413-bea4fa662894.png)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules