### PR TITLE
Proposed Enhancements for Chat Bubble Looks in the Dashboard

### DIFF
--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
@@ -250,6 +250,7 @@
   &.left {
 
     .bubble {
+      @include border-normal;
       background: $white;
       border-bottom-left-radius: $space-smaller;
       border-top-left-radius: $space-smaller;

--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
@@ -309,7 +309,7 @@
 
       &.is-private {
         background: lighten($warning-color, 32%);
-        border: 1px solid $color-border;
+        border: 1px solid $color-warning;
         color: $color-heading;
         padding-right: $space-large;
         position: relative;

--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
@@ -7,6 +7,7 @@
   font-size: $font-size-small;
   font-weight: $font-weight-normal;
   position: relative;
+  box-shadow: 0px 2px 3px 0 rgba(0, 0, 0, 0.07);
 
   .icon {
     bottom: $space-smaller;
@@ -250,7 +251,6 @@
   &.left {
 
     .bubble {
-      @include border-normal;
       background: $white;
       border-bottom-left-radius: $space-smaller;
       border-top-left-radius: $space-smaller;

--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
@@ -7,7 +7,6 @@
   font-size: $font-size-small;
   font-weight: $font-weight-normal;
   position: relative;
-  box-shadow: 0px 2px 3px 0 rgba(0, 0, 0, 0.07);
 
   .icon {
     bottom: $space-smaller;
@@ -309,7 +308,7 @@
 
       &.is-private {
         background: lighten($warning-color, 32%);
-        border: 1px solid $color-warning;
+        border: 1px solid lighten($warning-color, 15%);
         color: $color-heading;
         padding-right: $space-large;
         position: relative;


### PR DESCRIPTION
# Pull Request

## Description

This proposes a new look for the chat bubbles in the Dashboard area, by introducing light shadow and removing borders from chat bubbles. Also, updates the border color for the private note message using an already defined variable in the app's SCSS files ($warning-color).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
**Before:**
![Screen Shot 2020-06-30 at 11 09 22 PM](https://user-images.githubusercontent.com/7905931/86177370-cebf0d00-bb26-11ea-8539-ebdb397209d1.png)

**After:**
![Screen Shot 2020-06-30 at 11 12 14 PM](https://user-images.githubusercontent.com/7905931/86177559-2a899600-bb27-11ea-8f83-bb373d7d7d0c.png)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules