### PR TITLE
Bug: Fix #919. Cross site cookie error on chrome

### DIFF
--- a/app/javascript/dashboard/store/utils/api.js
+++ b/app/javascript/dashboard/store/utils/api.js
@@ -3,6 +3,11 @@ import moment from 'moment';
 import Cookies from 'js-cookie';
 import { frontendURL } from '../../helper/URLHelper';
 
+Cookies.defaults = {
+  sameSite: 'none',
+  secure: true
+};
+
 export const getLoadingStatus = state => state.fetchAPIloadingStatus;
 export const setLoadingStatus = (state, status) => {
   state.fetchAPIloadingStatus = status;

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_chatwoot_session'
+Rails.application.config.session_store :cookie_store, key: '_chatwoot_session', same_site: :none


### PR DESCRIPTION
Fixes #919. However, this is currently an incomplete fix, as `secure: true` hasn't been added to `session_store`. In testing, the `_chatwoot_session` cookie wasn't being set if `secure: true` was set. I'm unsure if that's an issue on my end or not, so I went without it for now. I don't have much experience with Rails, but it looks like https://github.com/rails/activerecord-session_store/issues/132 is related.

![image](https://user-images.githubusercontent.com/2874325/87089242-5bd32780-c1f3-11ea-9e91-ca56596f6ada.png)