### PR TITLE
fixed db:migrate RoundRobin dup

### DIFF
--- a/db/migrate/20170525104650_create_round_robin.rb
+++ b/db/migrate/20170525104650_create_round_robin.rb
@@ -1,4 +1,4 @@
-class RoundRobin < ActiveRecord::Migration[5.0]
+class CreateRoundRobin < ActiveRecord::Migration[5.0]
   def change
     InboxMember.find_each do |im|
       round_robin_key = format(::Redis::Alfred::ROUND_ROBIN_AGENTS, inbox_id: im.inbox_id)


### PR DESCRIPTION
Because RoundRobin had defined in file, so when db:create and db:migrate will raise error.
so change the migration file name


- [x] Bug fix (non-breaking change which fixes an issue)

