### PR TITLE
Enhancement: Ability to send out an email without summary (#1048)

### DIFF
--- a/app/views/mailers/conversation_reply_mailer/reply_without_summary.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/reply_without_summary.html.erb
@@ -1,0 +1,12 @@
+<% @messages.each do |message| %>
+  <p>
+    <% if message.content %>
+      <%= message.content %>
+    <% end %>
+    <% if message.attachments %>
+      <% message.attachments.each do |attachment| %>
+        attachment [<a href="<%= attachment.file_url %>" _target="blank">click here to view</a>]
+      <% end %>
+    <% end %>
+  </p>
+<% end %>

--- a/app/workers/conversation_reply_email_worker.rb
+++ b/app/workers/conversation_reply_email_worker.rb
@@ -6,7 +6,11 @@ class ConversationReplyEmailWorker
     @conversation = Conversation.find(conversation_id)
 
     # send the email
-    ConversationReplyMailer.reply_with_summary(@conversation, queued_time).deliver_later
+    if @conversation.messages.incoming&.last&.content_type == 'incoming_email'
+      ConversationReplyMailer.reply_without_summary(@conversation, queued_time).deliver_later
+    else
+      ConversationReplyMailer.reply_with_summary(@conversation, queued_time).deliver_later
+    end
 
     # delete the redis set from the first new message on the conversation
     Redis::Alfred.delete(conversation_mail_key)

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :message do
-    content { 'Message' }
+    content { 'Incoming Message' }
     status { 'sent' }
     message_type { 'incoming' }
     content_type { 'text' }


### PR DESCRIPTION
Fixes #1048 

## Description

Right now as part of conversation continuity we are using the
ConversationReplyMailer which sends a summary of messages including
the incoming messages when an agent replies. Ideally, we want
to send only the reply of that agent and not a summary when
Conversation continuity is enabled. Added the functionality
to send the reply email without summary. Added required unit
tests to cover the changes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Locally, with an underperforming `mailhog` competing for resources with the OS habitants (especially Chrome and Docker).


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes