### PR TITLE
Chore: Change the prefix in reply emails

### DIFF
--- a/app/mailboxes/application_mailbox.rb
+++ b/app/mailboxes/application_mailbox.rb
@@ -1,7 +1,7 @@
 class ApplicationMailbox < ActionMailbox::Base
   # Last part is the regex for the UUID
-  # Eg: email should be something like : reply+to+6bdc3f4d-0bec-4515-a284-5d916fdde489@domain.com
-  REPLY_EMAIL_USERNAME_PATTERN = /^reply\+to\+([0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12})$/i.freeze
+  # Eg: email should be something like : reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@domain.com
+  REPLY_EMAIL_USERNAME_PATTERN = /^reply\+([0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12})$/i.freeze
 
   def self.reply_match_proc
     proc do |inbound_mail_obj|

--- a/app/mailboxes/conversation_mailbox.rb
+++ b/app/mailboxes/conversation_mailbox.rb
@@ -2,8 +2,8 @@ class ConversationMailbox < ApplicationMailbox
   attr_accessor :conversation_uuid, :processed_mail
 
   # Last part is the regex for the UUID
-  # Eg: email should be something like : reply+to+6bdc3f4d-0bec-4515-a284-5d916fdde489@domain.com
-  EMAIL_PART_PATTERN = /^reply\+to\+([0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12})$/i.freeze
+  # Eg: email should be something like : reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@domain.com
+  EMAIL_PART_PATTERN = /^reply\+([0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12})$/i.freeze
 
   before_processing :conversation_uuid_from_to_address,
                     :verify_decoded_params,

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -55,7 +55,7 @@ class ConversationReplyMailer < ApplicationMailer
 
   def reply_email
     if custom_domain_email_enabled?
-      "reply+to+#{@conversation.uuid}@#{@account.domain}"
+      "reply+#{@conversation.uuid}@#{@account.domain}"
     else
       @agent&.email
     end

--- a/spec/fixtures/files/reply.eml
+++ b/spec/fixtures/files/reply.eml
@@ -4,7 +4,7 @@ Content-Type: multipart/alternative; boundary="Apple-Mail=_33A037C7-4BB3-4772-AE
 Subject: Discussion: Let's debate these attachments
 Date: Tue, 20 Apr 2020 04:20:20 -0400
 In-Reply-To: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
-To: "Replies" <reply+to+6bdc3f4d-0bec-4515-a284-5d916fdde489@example.com>
+To: "Replies" <reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@example.com>
 References: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
 Message-Id: <0CB459E0-0336-41DA-BC88-E6E28C697DDB@chatwoot.com>
 X-Mailer: Apple Mail (2.1244.3)

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
       end
 
       it 'sets reply to email to be based on the domain' do
-        reply_to_email = "reply+to+#{message.conversation.uuid}@#{conversation.account.domain}"
+        reply_to_email = "reply+#{message.conversation.uuid}@#{conversation.account.domain}"
         expect(mail.reply_to).to eq([reply_to_email])
       end
 


### PR DESCRIPTION
## Description
In conversation continuity, the reply to email was looking like

`reply+to+{some_random_hex_id}@reply.chatwoot.com`

Changed the prefix to just `reply` instead of `reply+to`.

Now it looks like: 

`reply+{some_random_hex_id}@reply.chatwoot.com`


## Type of change

- [x] Chore/Enhancement

## How Has This Been Tested?

By running all the unit tests related to the parts where the reply email is set in email outbound parts and the parts where the email reply is received and parsed.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have modified tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes