### PR TITLE
Chore: Move email configs to ENV variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,8 @@ SMTP_AUTHENTICATION=
 SMTP_ENABLE_STARTTLS_AUTO=
 
 # Mail Incoming
-
+# This is the domain set for the reply emails when conversation continuity is enabled
+MAILER_INBOUND_EMAIL_DOMAIN=
 # Set this to appropriate ingress channel with regards to incoming emails
 # Possible values are :
 # :relay for Exim, Postfix, Qmail

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -14,5 +14,7 @@
   value: 'https://www.chatwoot.com/privacy-policy'
 - name: DISPLAY_MANIFEST
   value: true
-- name: FALLBACK_DOMAIN
-  value: chatwoot.com
+- name: MAILER_INBOUND_EMAIL_DOMAIN
+  value: 
+- name: MAILER_SUPPORT_EMAIL
+  value:


### PR DESCRIPTION
## Description
For the outgoing emails which have a dependency on the incoming
part as well like the conversation continuity part, some of the
config variables used were entirely based on the account attributes.

But this is not true in case of self-hosted situations where you have
multiple accounts and have a common config for incoming emails.

So moved out some of the attributes entirely dependent on the account
to ENV with a fallback to the Global config.

Also, with these changes, the name of the agent will be shown in the
email client within the conversation rather than just the support
email address. This has a huge UX impact on the customer.

Modified all the necessary unit tests to reflect these changes.

Updated the .env.example file for the new ENV variable.

Fixes #1061 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

“Quality is never an accident; it is always the result of intelligent effort.” – John Ruskin ♿ 

Of course, unit tests were run. (Very passively) 📟 😸 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes