### PR TITLE
Bugfix: Private notes in emails & broken Signup

### DIFF
--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -35,7 +35,6 @@ class ConversationReplyMailer < ApplicationMailer
     @agent = @conversation.assignee
 
     @messages = @conversation.messages.chat.outgoing.where('created_at >= ?', message_queued_time)
-
     return false if @messages.count.zero?
 
     mail({

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -34,7 +34,9 @@ class ConversationReplyMailer < ApplicationMailer
     @contact = @conversation.contact
     @agent = @conversation.assignee
 
-    @messages = @conversation.messages.outgoing.where('created_at >= ?', message_queued_time)
+    @messages = @conversation.messages.chat.outgoing.where('created_at >= ?', message_queued_time)
+
+    return false if @messages.count.zero?
 
     mail({
            to: @contact&.email,

--- a/app/models/concerns/featurable.rb
+++ b/app/models/concerns/featurable.rb
@@ -55,6 +55,6 @@ module Featurable
     return true if config.blank?
 
     features_to_enabled = config.value.select { |f| f[:enabled] }.map { |f| f[:name] }
-    enable_features(features_to_enabled)
+    enable_features(*features_to_enabled)
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -146,7 +146,7 @@ class Message < ApplicationRecord
   end
 
   def notify_via_mail
-    if Redis::Alfred.get(conversation_mail_key).nil? && conversation.contact.email? && outgoing?
+    if Redis::Alfred.get(conversation_mail_key).nil? && conversation.contact.email? && outgoing? && !private
       # set a redis key for the conversation so that we don't need to send email for every
       # new message that comes in and we dont enque the delayed sidekiq job for every message
       Redis::Alfred.setex(conversation_mail_key, Time.zone.now)

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -34,10 +34,16 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
     end
 
     context 'without summary' do
-      let(:conversation) { create(:conversation, assignee: agent) }
-      let(:message_1) { create(:message, conversation: conversation) }
-      let(:message_2) { build(:message, conversation: conversation, message_type: 'outgoing', content: 'Outgoing Message') }
-      let(:private_message) { create(:message, content: 'This is a private message', conversation: conversation) }
+      let(:conversation) { create(:conversation, assignee: agent, account: account).reload }
+      let(:message_1) { create(:message, conversation: conversation, account: account, content: 'Outgoing Message 1').reload }
+      let(:message_2) { build(:message, conversation: conversation, account: account, message_type: 'outgoing', content: 'Outgoing Message 2') }
+      let(:private_message) do
+        create(:message,
+               content: 'This is a private message',
+               conversation: conversation,
+               account: account,
+               message_type: 'outgoing').reload
+      end
       let(:mail) { described_class.reply_without_summary(message_1.conversation, Time.zone.now - 1.minute).deliver_now }
 
       before do
@@ -52,7 +58,6 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
         # make the message private
         private_message.private = true
         private_message.save
-
         expect(mail.body.decoded).not_to include(private_message.content)
       end
 


### PR DESCRIPTION
## Description
Private notes were sent in the emails as part of
conversation continuity. Fixed this issue.

Also made the changes to not even queue the mails
if the message is a private note.

Fixed broken signups in develop branch due to changes
in `featurable` module.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes #1069 

## How Has This Been Tested?

Pakka local. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes