### PR TITLE
Bug: Fixed quoted text parsing in incoming email

### DIFF
--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -85,11 +85,6 @@ class MailPresenter < SimpleDelegator
   end
 
   def quoted_text_regexes
-    sender_agnostic_regexes = [
-      Regexp.new("^.*On.*(\n)?wrote:$", Regexp::IGNORECASE),
-      Regexp.new("-+original\s+message-+\s*$", Regexp::IGNORECASE),
-      Regexp.new("from:\s*$", Regexp::IGNORECASE)
-    ]
     return sender_agnostic_regexes if @account.nil? || account_support_email.blank?
 
     [
@@ -98,6 +93,15 @@ class MailPresenter < SimpleDelegator
       Regexp.new(Regexp.escape(account_support_email) + "\s+wrote:", Regexp::IGNORECASE),
       Regexp.new('On(.*)' + Regexp.escape(account_support_email) + '(.*)wrote:', Regexp::IGNORECASE)
     ] + sender_agnostic_regexes
+  end
+
+  def sender_agnostic_regexes
+    @sender_agnostic_regexes ||= [
+      Regexp.new("^.*On.*(\n)?wrote:$", Regexp::IGNORECASE),
+      Regexp.new('^.*On(.*)(.*)wrote:$', Regexp::IGNORECASE),
+      Regexp.new("-+original\s+message-+\s*$", Regexp::IGNORECASE),
+      Regexp.new("from:\s*$", Regexp::IGNORECASE)
+    ]
   end
 
   def account_support_email

--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -90,13 +90,21 @@ class MailPresenter < SimpleDelegator
       Regexp.new("-+original\s+message-+\s*$", Regexp::IGNORECASE),
       Regexp.new("from:\s*$", Regexp::IGNORECASE)
     ]
-    return sender_agnostic_regexes if @account.nil? || @account.support_email.blank?
+    return sender_agnostic_regexes if @account.nil? || account_support_email.blank?
 
     [
-      Regexp.new("From:\s*" + Regexp.escape(@account.support_email), Regexp::IGNORECASE),
-      Regexp.new('<' + Regexp.escape(@account.support_email) + '>', Regexp::IGNORECASE),
-      Regexp.new(Regexp.escape(@account.support_email) + "\s+wrote:", Regexp::IGNORECASE),
-      Regexp.new('On(.*)' + Regexp.escape(@account.support_email) + '(.*)wrote:', Regexp::IGNORECASE)
+      Regexp.new("From:\s*" + Regexp.escape(account_support_email), Regexp::IGNORECASE),
+      Regexp.new('<' + Regexp.escape(account_support_email) + '>', Regexp::IGNORECASE),
+      Regexp.new(Regexp.escape(account_support_email) + "\s+wrote:", Regexp::IGNORECASE),
+      Regexp.new('On(.*)' + Regexp.escape(account_support_email) + '(.*)wrote:', Regexp::IGNORECASE)
     ] + sender_agnostic_regexes
+  end
+
+  def account_support_email
+    @account_support_email ||= begin
+      @account.support_email ||
+        GlobalConfig.get('MAILER_SUPPORT_EMAIL')['MAILER_SUPPORT_EMAIL'] ||
+        ENV.fetch('MAILER_SENDER_EMAIL', nil)
+    end
   end
 end


### PR DESCRIPTION
Fixes #1062 

## Description
We had changed the support email from an account based
only value to account based with fallback on global config
and environment variable.

Incoming email quoted text parsing was still based on
account based support email. Changed this to utilize
the newly introduced fallback values from global config
and environment for parsing quoted text.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

With intuition. 😸  😝

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes