### PR TITLE
chore: Update the usage of available_name instead of name

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -30,10 +30,6 @@
         />
       </p>
     </div>
-    <!-- <img
-      src="https://randomuser.me/api/portraits/women/94.jpg"
-      class="sender--thumbnail"
-    /> -->
   </li>
 </template>
 <script>

--- a/app/javascript/widget/components/AgentMessage.vue
+++ b/app/javascript/widget/components/AgentMessage.vue
@@ -114,8 +114,10 @@ export default {
       if (this.message.message_type === MESSAGE_TYPE.TEMPLATE) {
         return 'Bot';
       }
-
-      return this.message.sender ? this.message.sender.name : 'Bot';
+      if (this.message.sender) {
+        return this.message.sender.available_name || this.message.sender.name;
+      }
+      return 'Bot';
     },
     avatarUrl() {
       // eslint-disable-next-line

--- a/app/mailers/agent_notifications/conversation_notifications_mailer.rb
+++ b/app/mailers/agent_notifications/conversation_notifications_mailer.rb
@@ -7,7 +7,7 @@ class AgentNotifications::ConversationNotificationsMailer < ApplicationMailer
 
     @agent = agent
     @conversation = conversation
-    subject = "#{@agent.name}, A new conversation [ID - #{@conversation.display_id}] has been created in #{@conversation.inbox&.name}."
+    subject = "#{@agent.available_name}, A new conversation [ID - #{@conversation.display_id}] has been created in #{@conversation.inbox&.name}."
     mail(to: @agent.email, subject: subject)
   end
 
@@ -16,6 +16,6 @@ class AgentNotifications::ConversationNotificationsMailer < ApplicationMailer
 
     @agent = agent
     @conversation = conversation
-    mail(to: @agent.email, subject: "#{@agent.name}, A new conversation [ID - #{@conversation.display_id}] has been assigned to you.")
+    mail(to: @agent.email, subject: "#{@agent.available_name}, A new conversation [ID - #{@conversation.display_id}] has been assigned to you.")
   end
 end

--- a/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_assignment.html.erb
+++ b/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_assignment.html.erb
@@ -1,4 +1,4 @@
-<p>Hi <%= @agent.name %>,</p>
+<p>Hi <%= @agent.available_name %>,</p>
 
 <p>Time to save the world. A new conversation has been assigned to you</p>
 

--- a/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_creation.html.erb
+++ b/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_creation.html.erb
@@ -1,4 +1,4 @@
-<p>Hi <%= @agent.name %>,</p>
+<p>Hi <%= @agent.available_name %>,</p>
 
 <p>Time to save the world. A new conversation has been created in <%= @conversation.inbox.name %></p>
 

--- a/app/views/mailers/conversation_reply_mailer/reply_with_summary.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/reply_with_summary.html.erb
@@ -5,7 +5,7 @@
 <% @messages.each do |message| %>
   <tr>
     <td>
-      <b><%= message.incoming? ? 'You' : message.sender.available_name %></b>
+      <b><%= message.incoming? ? 'You' : message.sender&.available_name || message.sender&.name %></b>
     </td>
   </tr>
   <tr>

--- a/spec/mailers/agent_notifications/conversation_notifications_mailer_spec.rb
+++ b/spec/mailers/agent_notifications/conversation_notifications_mailer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AgentNotifications::ConversationNotificationsMailer, type: :maile
     let(:mail) { described_class.conversation_creation(conversation, agent).deliver_now }
 
     it 'renders the subject' do
-      expect(mail.subject).to eq("#{agent.name}, A new conversation [ID - #{conversation
+      expect(mail.subject).to eq("#{agent.available_name}, A new conversation [ID - #{conversation
         .display_id}] has been created in #{conversation.inbox&.name}.")
     end
 
@@ -29,7 +29,7 @@ RSpec.describe AgentNotifications::ConversationNotificationsMailer, type: :maile
     let(:mail) { described_class.conversation_assignment(conversation, agent).deliver_now }
 
     it 'renders the subject' do
-      expect(mail.subject).to eq("#{agent.name}, A new conversation [ID - #{conversation.display_id}] has been assigned to you.")
+      expect(mail.subject).to eq("#{agent.available_name}, A new conversation [ID - #{conversation.display_id}] has been assigned to you.")
     end
 
     it 'renders the receiver email' do


### PR DESCRIPTION
- Use available_name in message sender details
- Use available_name in the emails.