### PR TITLE
Bugfix: add missing option to s3_compatible to support minio

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -36,6 +36,7 @@ s3_compatible:
   region: <%= ENV.fetch('STORAGE_REGION', '') %>
   bucket: <%= ENV.fetch('STORAGE_BUCKET_NAME', '') %>
   endpoint: <%= ENV.fetch('STORAGE_ENDPOINT', '') %>
+  force_path_style: <%= ENV.fetch('STORAGE_FORCE_PATH_STYLE', false) %>
 
 # mirror:
 #   service: Mirror


### PR DESCRIPTION
## Description

minio doesn't work without `force_path_style: true`
more info here: https://kevinjalbert.com/rails-activestorage-configuration-for-minio/

Fixes #893

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

On my instance, without `force_path_style: true`, saving images causes `500` errors.
With this change it works fine.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules