### PR TITLE
Fix: fonts cors issue with cdn

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,4 +119,13 @@ Rails.application.configure do
   config.action_mailbox.ingress = ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay').to_sym
 
   Rails.application.routes.default_url_options = { host: ENV['FRONTEND_URL'] }
+
+  # font cors issue with CDN
+  # Ref: https://stackoverflow.com/questions/56960709/rails-font-cors-policy
+  config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins '*'
+      resource '/packs/*', headers: :any, methods: [:get, :options]
+    end
+  end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -102,4 +102,13 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # font cors issue with CDN
+  # Ref: https://stackoverflow.com/questions/56960709/rails-font-cors-policy
+  config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins '*'
+      resource '/packs/*', headers: :any, methods: [:get, :options]
+    end
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,4 +51,13 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
   config.log_level = ENV.fetch('LOG_LEVEL', 'debug').to_sym
+
+  # font cors issue with CDN
+  # Ref: https://stackoverflow.com/questions/56960709/rails-font-cors-policy
+  config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins '*'
+      resource '/packs/*', headers: :any, methods: [:get, :options]
+    end
+  end
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,3 +13,7 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 Rails.application.config.assets.precompile += %w[dashboardChart.js]
+
+# to take care of fonts in assets pre-compiling
+# Ref: https://stackoverflow.com/questions/56960709/rails-font-cors-policy
+Rails.application.config.assets.precompile << /\.(?:svg|eot|woff|ttf|woff2)$/


### PR DESCRIPTION
## Description

When we changed the assets serving to CDN, everything seems to be working fine except the fonts. For the requests for fonts, we were seeing CORS issue. Fixed this issue.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in the staging environment with CloudFront.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules