### PR TITLE
bug fix: validate_queue method - map then sort, instead of sort then map

### DIFF
--- a/app/services/round_robin/manage_service.rb
+++ b/app/services/round_robin/manage_service.rb
@@ -43,7 +43,7 @@ class RoundRobin::ManageService
   end
 
   def validate_queue?
-    return true if inbox.inbox_members.map(&:user_id).sort == queue.sort.map(&:to_i)
+    return true if inbox.inbox_members.map(&:user_id).sort == queue.map(&:to_i).sort
   end
 
   def queue


### PR DESCRIPTION
# Pull Request Template

## Description

The `validate_queue` method of `RoundRobin::ManageService` will always return `false` for `inbox.inbox_members.map(&:user_id).sort == queue.map(&:to_i).sort` when the number of agents in the queue are >10.

**Reason**: 

Incorrect syntax: `queue.sort.map(&:to_i)`

The queue contains the string integers ("1", "2", "3" etc.), and here we are sorting the queue before mapping it to the integer. 

So, for the queue: `["4", "2", "1", "11", "12"]`
result:  `[1, 11, 12, 2, 4]`
expected result:  `[1, 2, 4, 11, 12]`

As a result, the method always returns false

Fixes # (issue)

The correct order should be: **map then sort**

Correct syntax: `queue.map(&:to_i).sort`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Functional test


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules