### PR TITLE
fix: Check medium to decide 24 hour window

### DIFF
--- a/app/models/channel/twilio_sms.rb
+++ b/app/models/channel/twilio_sms.rb
@@ -31,10 +31,10 @@ class Channel::TwilioSms < ApplicationRecord
   has_one :inbox, as: :channel, dependent: :destroy
 
   def name
-    medium == :sms ? 'Twilio SMS' : 'Whatsapp'
+    medium == 'sms' ? 'Twilio SMS' : 'Whatsapp'
   end
 
   def has_24_hour_messaging_window?
-    true
+    medium == 'whatsapp'
   end
 end

--- a/spec/models/channel/twilio_sms_spec.rb
+++ b/spec/models/channel/twilio_sms_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Channel::TwilioSms do
+  context 'with medium whatsapp' do
+    let!(:whatsapp_channel) { create(:channel_twilio_sms, medium: :whatsapp) }
+
+    it 'returns true' do
+      expect(whatsapp_channel.has_24_hour_messaging_window?).to eq true
+      expect(whatsapp_channel.name).to eq 'Whatsapp'
+      expect(whatsapp_channel.medium).to eq 'whatsapp'
+    end
+  end
+
+  context 'with medium sms' do
+    let!(:sms_channel) { create(:channel_twilio_sms, medium: :sms) }
+
+    it 'returns false' do
+      expect(sms_channel.has_24_hour_messaging_window?).to eq false
+      expect(sms_channel.name).to eq 'Twilio SMS'
+      expect(sms_channel.medium).to eq 'sms'
+    end
+  end
+end


### PR DESCRIPTION
- Remove 24-hour window message for Twilio SMS