### PR TITLE
Bugfix: Email encoding issue for utf8 characters (#1081)

### DIFF
--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -12,7 +12,7 @@ class MailPresenter < SimpleDelegator
   end
 
   def text_content
-    @decoded_text_content ||= encode_to_unicode(text_part&.body&.decoded || fallback_content)
+    @decoded_text_content ||= encode_to_unicode(text_part&.decoded || fallback_content)
     @text_content ||= {
       full: @decoded_text_content,
       reply: extract_reply(@decoded_text_content)[:reply],
@@ -21,7 +21,7 @@ class MailPresenter < SimpleDelegator
   end
 
   def html_content
-    @decoded_html_content ||= encode_to_unicode(html_part&.body&.decoded || fallback_content)
+    @decoded_html_content ||= encode_to_unicode(html_part&.decoded || fallback_content)
     @html_content ||= {
       full: @decoded_html_content,
       reply: extract_reply(@decoded_html_content)[:reply],
@@ -70,6 +70,8 @@ class MailPresenter < SimpleDelegator
   # forcing the encoding of the content to UTF-8 so as to be compatible with database and serializers
   def encode_to_unicode(str)
     current_encoding = str.encoding.name
+    return str if current_encoding == 'UTF-8'
+
     str.encode(current_encoding, 'UTF-8', invalid: :replace, undef: :replace, replace: '?')
   end
 


### PR DESCRIPTION

## Description
There were issues in parsing Arabic or UTF characters (emojis) correctly for the incoming emails.

All these characters were converted to question marks which is the fallback character when an encoding is enforced and there is a missing matching character.

Fixes #1081 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

In local


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules