### PR TITLE
Feature/1234 change availability status from sidebar

### DIFF
--- a/app/javascript/dashboard/api/auth.js
+++ b/app/javascript/dashboard/api/auth.js
@@ -138,4 +138,10 @@ export default {
     }
     return axios.put(endPoints('profileUpdate').url, formData);
   },
+
+  updateAvailability({ availability }) {
+    return axios.put(endPoints('profileUpdate').url, {
+      profile: { availability },
+    });
+  },
 };

--- a/app/javascript/dashboard/components/layout/AvailabilityStatus.vue
+++ b/app/javascript/dashboard/components/layout/AvailabilityStatus.vue
@@ -1,0 +1,169 @@
+<template>
+  <div class="status">
+    <div class="status-view">
+      <div
+        :class="
+          `status-view--badge status-view--badge__${currentUserAvailabilityStatus}`
+        "
+      />
+
+      <div class="status-view--title">
+        {{ currentUserAvailabilityStatus }}
+      </div>
+    </div>
+
+    <div class="status-change">
+      <transition name="menu-slide">
+        <div
+          v-if="isStatusMenuOpened"
+          v-on-clickaway="closeStatusMenu"
+          class="dropdown-pane top"
+        >
+          <ul class="vertical dropdown menu">
+            <li v-for="status in availabilityStatuses" :key="status.value">
+              <button
+                class="button clear status-change--dropdown-button"
+                :disabled="status.disabled"
+                @click="changeAvailabilityStatus(status.value)"
+              >
+                {{ status.label }}
+              </button>
+            </li>
+          </ul>
+        </div>
+      </transition>
+
+      <button class="status-change--change-button" @click="openStatusMenu">
+        {{ $t('SIDEBAR_ITEMS.CHANGE_AVAILABILITY_STATUS') }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+import { mixin as clickaway } from 'vue-clickaway';
+
+export default {
+  mixins: [clickaway],
+
+  data() {
+    return {
+      isStatusMenuOpened: false,
+      isUpdating: false,
+    };
+  },
+
+  computed: {
+    ...mapGetters({
+      currentUser: 'getCurrentUser',
+    }),
+    currentUserAvailabilityStatus() {
+      return this.currentUser.availability_status;
+    },
+    availabilityStatuses() {
+      return this.$t('PROFILE_SETTINGS.FORM.AVAILABILITY.STATUSES_LIST').map(
+        status => ({
+          ...status,
+          disabled: this.currentUserAvailabilityStatus === status.value,
+        })
+      );
+    },
+  },
+
+  methods: {
+    openStatusMenu() {
+      this.isStatusMenuOpened = true;
+    },
+    closeStatusMenu() {
+      this.isStatusMenuOpened = false;
+    },
+    changeAvailabilityStatus(availability) {
+      if (this.isUpdating) {
+        return;
+      }
+
+      this.isUpdating = true;
+
+      this.$store
+        .dispatch('updateProfile', {
+          availability,
+        })
+        .finally(() => {
+          this.isUpdating = false;
+        });
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+@import '~dashboard/assets/scss/variables';
+
+.status {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: $space-micro $space-smaller;
+}
+
+.status-view {
+  display: flex;
+  align-items: baseline;
+
+  & &--badge {
+    width: $space-one;
+    height: $space-one;
+    border-radius: 50%;
+
+    &__online {
+      background: $success-color;
+    }
+
+    &__offline {
+      background: $color-gray;
+    }
+
+    &__busy {
+      background: $warning-color;
+    }
+  }
+
+  & &--title {
+    color: $color-gray;
+    font-size: $font-size-small;
+    font-weight: $font-weight-medium;
+    margin-left: $space-small;
+
+    &:first-letter {
+      text-transform: capitalize;
+    }
+  }
+}
+
+.status-change {
+  .dropdown-pane {
+    top: -130px;
+  }
+
+  & &--change-button {
+    color: $color-gray;
+    font-size: $font-size-small;
+    border-bottom: 1px solid $color-gray;
+    cursor: pointer;
+
+    &:hover {
+      border-bottom: none;
+    }
+  }
+
+  & &--dropdown-button {
+    font-weight: $font-weight-normal;
+    font-size: $font-size-small;
+    padding: $space-small $space-one;
+    text-align: left;
+    width: 100%;
+  }
+}
+</style>

--- a/app/javascript/dashboard/components/layout/AvailabilityStatus.vue
+++ b/app/javascript/dashboard/components/layout/AvailabilityStatus.vue
@@ -86,7 +86,7 @@ export default {
       this.isUpdating = true;
 
       this.$store
-        .dispatch('updateProfile', {
+        .dispatch('updateAvailability', {
           availability,
         })
         .finally(() => {

--- a/app/javascript/dashboard/components/layout/Sidebar.vue
+++ b/app/javascript/dashboard/components/layout/Sidebar.vue
@@ -64,7 +64,6 @@
         <thumbnail
           :src="currentUser.avatar_url"
           :username="currentUserAvailableName"
-          :status="null"
         />
         <div class="current-user--data">
           <h3 class="current-user--name">

--- a/app/javascript/dashboard/components/layout/Sidebar.vue
+++ b/app/javascript/dashboard/components/layout/Sidebar.vue
@@ -26,47 +26,8 @@
       </transition-group>
     </div>
 
-    <div class="bottom-nav status-nav">
-      <div class="status-view">
-        <div
-          :class="
-            `status-view--badge status-view--badge__${currentUserAvailabilityStatus}`
-          "
-        />
-
-        <div class="status-view--title">
-          {{ currentUserAvailabilityStatus }}
-        </div>
-      </div>
-
-      <div class="status-change">
-        <transition name="menu-slide">
-          <div
-            v-if="showChangeStatusMenu"
-            v-on-clickaway="showChangeStatusOptions"
-            class="dropdown-pane top"
-          >
-            <ul class="vertical dropdown menu">
-              <li v-for="status in availabilityStatuses" :key="status.value">
-                <button
-                  class="button clear status-change--dropdown-button"
-                  :disabled="status.disabled"
-                  @click="changeAvailabilityStatus(status.value)"
-                >
-                  {{ status.label }}
-                </button>
-              </li>
-            </ul>
-          </div>
-        </transition>
-
-        <button
-          class="status-change--change-button"
-          @click="showChangeStatusOptions"
-        >
-          {{ $t('SIDEBAR_ITEMS.CHANGE_AVAILABILITY_STATUS') }}
-        </button>
-      </div>
+    <div class="bottom-nav">
+      <availability-status />
     </div>
 
     <div class="bottom-nav">
@@ -201,6 +162,7 @@ import { mixin as clickaway } from 'vue-clickaway';
 import adminMixin from '../../mixins/isAdmin';
 import Auth from '../../api/auth';
 import SidebarItem from './SidebarItem';
+import AvailabilityStatus from './AvailabilityStatus';
 import { frontendURL } from '../../helper/URLHelper';
 import Thumbnail from '../widgets/Thumbnail';
 import { getSidebarItems } from '../../i18n/default-sidebar';
@@ -211,6 +173,7 @@ export default {
   components: {
     SidebarItem,
     Thumbnail,
+    AvailabilityStatus,
   },
   mixins: [clickaway, adminMixin, alertMixin],
   props: {
@@ -281,14 +244,6 @@ export default {
 
       return this.filterMenuItemsByRole(menuItems);
     },
-    availabilityStatuses() {
-      return this.$t('PROFILE_SETTINGS.FORM.AVAILABILITY.STATUSES_LIST').map(
-        status => ({
-          ...status,
-          disabled: this.currentUserAvailabilityStatus === status.value,
-        })
-      );
-    },
     currentRoute() {
       return this.$store.state.route.name;
     },
@@ -354,9 +309,6 @@ export default {
     logout() {
       Auth.logout();
     },
-    showChangeStatusOptions() {
-      this.showChangeStatusMenu = !this.showChangeStatusMenu;
-    },
     showOptions() {
       this.showOptionsMenu = !this.showOptionsMenu;
     },
@@ -389,89 +341,12 @@ export default {
         }
       }
     },
-    changeAvailabilityStatus(availability) {
-      if (this.isUpdating) {
-        return;
-      }
-
-      this.isUpdating = true;
-
-      this.$store
-        .dispatch('updateProfile', {
-          availability,
-        })
-        .finally(() => {
-          this.isUpdating = false;
-        });
-    },
   },
 };
 </script>
 
 <style lang="scss">
 @import '~dashboard/assets/scss/variables';
-
-.status-nav {
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  padding: $space-one $space-normal;
-}
-
-.status-view {
-  display: flex;
-  align-items: baseline;
-
-  &--badge {
-    width: $space-one;
-    height: $space-one;
-    border-radius: 50%;
-
-    &__online {
-      background: $success-color;
-    }
-
-    &__offline {
-      background: $color-gray;
-    }
-
-    &__busy {
-      background: $warning-color;
-    }
-  }
-
-  &--title {
-    color: $color-gray;
-    font-size: $font-size-small;
-    font-weight: $font-weight-medium;
-    margin-left: $space-small;
-
-    &:first-letter {
-      text-transform: capitalize;
-    }
-  }
-}
-
-.status-change {
-  &--change-button {
-    color: $color-gray;
-    font-size: $font-size-small;
-    border-bottom: 1px solid $color-gray;
-    cursor: pointer;
-
-    &:hover {
-      border-bottom: none;
-    }
-  }
-
-  &--dropdown-button {
-    font-weight: $font-weight-normal;
-    font-size: $font-size-small;
-    padding: $space-small $space-one;
-    text-align: left;
-    width: 100%;
-  }
-}
 
 .account-selector--modal {
   .modal-container {
@@ -491,8 +366,7 @@ export default {
 
 .dropdown-pane {
   li {
-    a,
-    button {
+    a {
       padding: $space-small $space-one !important;
     }
   }

--- a/app/javascript/dashboard/components/layout/Sidebar.vue
+++ b/app/javascript/dashboard/components/layout/Sidebar.vue
@@ -184,14 +184,12 @@ export default {
   },
   data() {
     return {
-      showChangeStatusMenu: false,
       showOptionsMenu: false,
       showAccountModal: false,
       showCreateAccountModal: false,
       accountName: '',
       vertical: 'bottom',
       horizontal: 'center',
-      isUpdating: false,
     };
   },
   validations: {
@@ -213,10 +211,6 @@ export default {
     currentUserAvailableName() {
       const { available_name: availableName } = this.currentUser;
       return availableName;
-    },
-    currentUserAvailabilityStatus() {
-      const { availability_status: availabilityStatus } = this.currentUser;
-      return availabilityStatus;
     },
     showChangeAccountOption() {
       if (this.globalConfig.createNewAccountFromDashboard) {

--- a/app/javascript/dashboard/components/layout/specs/AvailabilityStatus.spec.js
+++ b/app/javascript/dashboard/components/layout/specs/AvailabilityStatus.spec.js
@@ -19,7 +19,7 @@ describe('AvailabilityStatus', () => {
 
   beforeEach(() => {
     actions = {
-      updateProfile: jest.fn(() => {
+      updateAvailability: jest.fn(() => {
         return Promise.resolve();
       }),
     };
@@ -68,7 +68,7 @@ describe('AvailabilityStatus', () => {
       .find('.status-change li:last-child button')
       .trigger('click');
 
-    expect(actions.updateProfile).toBeCalledWith(
+    expect(actions.updateAvailability).toBeCalledWith(
       expect.any(Object),
       { availability: 'offline' },
       undefined

--- a/app/javascript/dashboard/components/layout/specs/AvailabilityStatus.spec.js
+++ b/app/javascript/dashboard/components/layout/specs/AvailabilityStatus.spec.js
@@ -1,0 +1,77 @@
+import AvailabilityStatus from '../AvailabilityStatus';
+import { createLocalVue, mount } from '@vue/test-utils';
+import Vuex from 'vuex';
+import VueI18n from 'vue-i18n';
+
+import i18n from 'dashboard/i18n';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+localVue.use(VueI18n);
+localVue.locale('en', i18n.en);
+
+describe('AvailabilityStatus', () => {
+  const currentUser = { availability_status: 'online' };
+  let store = null;
+  let actions = null;
+  let modules = null;
+  let availabilityStatus = null;
+
+  beforeEach(() => {
+    actions = {
+      updateProfile: jest.fn(() => {
+        return Promise.resolve();
+      }),
+    };
+
+    modules = {
+      auth: {
+        getters: {
+          getCurrentUser: () => currentUser,
+        },
+      },
+    };
+
+    store = new Vuex.Store({
+      actions,
+      modules,
+    });
+
+    availabilityStatus = mount(AvailabilityStatus, {
+      store,
+      localVue,
+    });
+  });
+
+  it('shows current user status', () => {
+    const statusViewTitle = availabilityStatus.find('.status-view--title');
+
+    expect(statusViewTitle.text()).toBe(currentUser.availability_status);
+  });
+
+  it('opens the menu when user clicks "change"', async () => {
+    expect(availabilityStatus.find('.dropdown-pane').exists()).toBe(false);
+
+    await availabilityStatus
+      .find('.status-change--change-button')
+      .trigger('click');
+
+    expect(availabilityStatus.find('.dropdown-pane').exists()).toBe(true);
+  });
+
+  it('dispatches an action when user changes status', async () => {
+    await availabilityStatus
+      .find('.status-change--change-button')
+      .trigger('click');
+
+    await availabilityStatus
+      .find('.status-change li:last-child button')
+      .trigger('click');
+
+    expect(actions.updateProfile).toBeCalledWith(
+      expect.any(Object),
+      { availability: 'offline' },
+      undefined
+    );
+  });
+});

--- a/app/javascript/dashboard/i18n/locale/ar/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ar/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "يتغيرون",
     "CHANGE_ACCOUNTS": "تبديل الحساب",
     "SELECTOR_SUBTITLE": "اختر حساباً من القائمة التالية",
     "PROFILE_SETTINGS": "إعدادات الملف الشخصي",

--- a/app/javascript/dashboard/i18n/locale/ca/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ca/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Canviar",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Configuració del Perfil",

--- a/app/javascript/dashboard/i18n/locale/cs/settings.json
+++ b/app/javascript/dashboard/i18n/locale/cs/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Změnit",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Nastavení profilu",

--- a/app/javascript/dashboard/i18n/locale/da/settings.json
+++ b/app/javascript/dashboard/i18n/locale/da/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Change",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profile Settings",

--- a/app/javascript/dashboard/i18n/locale/de/settings.json
+++ b/app/javascript/dashboard/i18n/locale/de/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Wechseln",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profileinstellungen",

--- a/app/javascript/dashboard/i18n/locale/el/settings.json
+++ b/app/javascript/dashboard/i18n/locale/el/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Να αλλάξει",
     "CHANGE_ACCOUNTS": "Αλλαγή Λογαριασμού",
     "SELECTOR_SUBTITLE": "Επιλέξτε ένα λογαριασμό από την Λίστα",
     "PROFILE_SETTINGS": "Ρυθμίσεις Προφίλ",

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -90,6 +90,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Change",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profile Settings",

--- a/app/javascript/dashboard/i18n/locale/es/settings.json
+++ b/app/javascript/dashboard/i18n/locale/es/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Cambiar",
     "CHANGE_ACCOUNTS": "Cambiar de cuenta",
     "SELECTOR_SUBTITLE": "Seleccione una cuenta de la siguiente lista",
     "PROFILE_SETTINGS": "Ajustes del perfil",

--- a/app/javascript/dashboard/i18n/locale/fa/settings.json
+++ b/app/javascript/dashboard/i18n/locale/fa/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "عوض شدن",
     "CHANGE_ACCOUNTS": "سوییچ به یک حساب دیگر",
     "SELECTOR_SUBTITLE": "از لیست یکی از حساب‌ها را انتخاب کنید",
     "PROFILE_SETTINGS": "تنظیمات پروفایل",

--- a/app/javascript/dashboard/i18n/locale/fi/settings.json
+++ b/app/javascript/dashboard/i18n/locale/fi/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Change",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profile Settings",

--- a/app/javascript/dashboard/i18n/locale/fr/settings.json
+++ b/app/javascript/dashboard/i18n/locale/fr/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Changer",
     "CHANGE_ACCOUNTS": "Changer de compte",
     "SELECTOR_SUBTITLE": "Sélectionnez un compte dans la liste suivante",
     "PROFILE_SETTINGS": "Paramètres de profil",

--- a/app/javascript/dashboard/i18n/locale/hi/settings.json
+++ b/app/javascript/dashboard/i18n/locale/hi/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Change",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profile Settings",

--- a/app/javascript/dashboard/i18n/locale/hu/settings.json
+++ b/app/javascript/dashboard/i18n/locale/hu/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Change",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profile Settings",

--- a/app/javascript/dashboard/i18n/locale/it/settings.json
+++ b/app/javascript/dashboard/i18n/locale/it/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Cambia",
     "CHANGE_ACCOUNTS": "Cambia Profilo/Account",
     "SELECTOR_SUBTITLE": "Seleziona un account dal seguente elenco",
     "PROFILE_SETTINGS": "Impostazioni profilo",

--- a/app/javascript/dashboard/i18n/locale/ja/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ja/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Change",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profile Settings",

--- a/app/javascript/dashboard/i18n/locale/ko/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ko/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Change",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profile Settings",

--- a/app/javascript/dashboard/i18n/locale/ml/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ml/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "മാറ്റം വരുത്താൻ",
     "CHANGE_ACCOUNTS": "അക്കൗണ്ട് സ്വിച്ചുചെയ്യുക",
     "SELECTOR_SUBTITLE": "ഇനിപ്പറയുന്ന ലിസ്റ്റിൽ നിന്ന് ഒരു അക്കൗണ്ട് തിരഞ്ഞെടുക്കുക",
     "PROFILE_SETTINGS": "പ്രൊഫൈൽ ക്രമീകരണങ്ങൾ",

--- a/app/javascript/dashboard/i18n/locale/ml/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ml/settings.json
@@ -88,7 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
-    "CHANGE_AVAILABILITY_STATUS": "മാറ്റം വരുത്താൻ",
+    "CHANGE_AVAILABILITY_STATUS": "മാറ്റം വരുത്തുക",
     "CHANGE_ACCOUNTS": "അക്കൗണ്ട് സ്വിച്ചുചെയ്യുക",
     "SELECTOR_SUBTITLE": "ഇനിപ്പറയുന്ന ലിസ്റ്റിൽ നിന്ന് ഒരു അക്കൗണ്ട് തിരഞ്ഞെടുക്കുക",
     "PROFILE_SETTINGS": "പ്രൊഫൈൽ ക്രമീകരണങ്ങൾ",

--- a/app/javascript/dashboard/i18n/locale/nl/settings.json
+++ b/app/javascript/dashboard/i18n/locale/nl/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Veranderen",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profiel instellingen",

--- a/app/javascript/dashboard/i18n/locale/pl/settings.json
+++ b/app/javascript/dashboard/i18n/locale/pl/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Zmienić",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Ustawienia profilu",

--- a/app/javascript/dashboard/i18n/locale/pt/settings.json
+++ b/app/javascript/dashboard/i18n/locale/pt/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Trocar",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Configurações do perfil",

--- a/app/javascript/dashboard/i18n/locale/pt_BR/settings.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Trocar",
     "CHANGE_ACCOUNTS": "Trocar Conta",
     "SELECTOR_SUBTITLE": "Selecione uma conta da lista a seguir",
     "PROFILE_SETTINGS": "Configurações do Perfil",

--- a/app/javascript/dashboard/i18n/locale/ro/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ro/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Schimba",
     "CHANGE_ACCOUNTS": "Comută contul",
     "SELECTOR_SUBTITLE": "Selectaţi un cont din următoarea listă",
     "PROFILE_SETTINGS": "Setări profil",

--- a/app/javascript/dashboard/i18n/locale/ru/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ru/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Изменить",
     "CHANGE_ACCOUNTS": "Сменить Аккаунт",
     "SELECTOR_SUBTITLE": "Выберите аккаунт из списка",
     "PROFILE_SETTINGS": "Настройки профиля",

--- a/app/javascript/dashboard/i18n/locale/sk/settings.json
+++ b/app/javascript/dashboard/i18n/locale/sk/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Change",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profile Settings",

--- a/app/javascript/dashboard/i18n/locale/sv/settings.json
+++ b/app/javascript/dashboard/i18n/locale/sv/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Att förändra",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profilens inställningar",

--- a/app/javascript/dashboard/i18n/locale/ta/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ta/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "மாற்ற",
     "CHANGE_ACCOUNTS": "கணக்கை மாற்றவும்",
     "SELECTOR_SUBTITLE": "பின்வரும் பட்டியலிலிருந்து ஒரு கணக்கைத் தேர்ந்தெடுக்கவும்",
     "PROFILE_SETTINGS": "சுயவிவர அமைப்புகள்",

--- a/app/javascript/dashboard/i18n/locale/th/settings.json
+++ b/app/javascript/dashboard/i18n/locale/th/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Change",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profile Settings",

--- a/app/javascript/dashboard/i18n/locale/tr/settings.json
+++ b/app/javascript/dashboard/i18n/locale/tr/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Change",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profile Settings",

--- a/app/javascript/dashboard/i18n/locale/uk/settings.json
+++ b/app/javascript/dashboard/i18n/locale/uk/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Змінити",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Налаштування облікового запису",

--- a/app/javascript/dashboard/i18n/locale/vi/settings.json
+++ b/app/javascript/dashboard/i18n/locale/vi/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "Change",
     "CHANGE_ACCOUNTS": "Switch Account",
     "SELECTOR_SUBTITLE": "Select an account from the following list",
     "PROFILE_SETTINGS": "Profile Settings",

--- a/app/javascript/dashboard/i18n/locale/zh/settings.json
+++ b/app/javascript/dashboard/i18n/locale/zh/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "改變",
     "CHANGE_ACCOUNTS": "切换账户",
     "SELECTOR_SUBTITLE": "从以下列表中选择一个账户",
     "PROFILE_SETTINGS": "个人资料设置",

--- a/app/javascript/dashboard/i18n/locale/zh_CN/settings.json
+++ b/app/javascript/dashboard/i18n/locale/zh_CN/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "改變",
     "CHANGE_ACCOUNTS": "切换账户",
     "SELECTOR_SUBTITLE": "从以下列表中选择一个账户",
     "PROFILE_SETTINGS": "个人资料设置",

--- a/app/javascript/dashboard/i18n/locale/zh_TW/settings.json
+++ b/app/javascript/dashboard/i18n/locale/zh_TW/settings.json
@@ -88,6 +88,7 @@
     }
   },
   "SIDEBAR_ITEMS": {
+    "CHANGE_AVAILABILITY_STATUS": "改變",
     "CHANGE_ACCOUNTS": "切換帳戶",
     "SELECTOR_SUBTITLE": "從以下列表中選擇一個帳戶",
     "PROFILE_SETTINGS": "個人資料設定",

--- a/app/javascript/dashboard/store/modules/auth.js
+++ b/app/javascript/dashboard/store/modules/auth.js
@@ -105,6 +105,13 @@ export const actions = {
     }
   },
 
+  updateAvailability: ({ commit }, { availability }) => {
+    authAPI.updateAvailability({ availability }).then(response => {
+      setUser(response.data, getHeaderExpiry(response));
+      commit(types.default.SET_CURRENT_USER);
+    });
+  },
+
   setCurrentAccountId({ commit }, accountId) {
     commit(types.default.SET_CURRENT_ACCOUNT_ID, accountId);
   },


### PR DESCRIPTION
## Description
User is now able to change his availability status from a sidebar. 
![status-change](https://user-images.githubusercontent.com/9462185/94649013-756ca280-02fc-11eb-9990-52642922b8af.gif)

I wasn't sure about how do you make translations for a project, so I have been using GTranslate.

Fixes #1234 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Log in
- See current availability status in the bottom of the sidebar
- Click "Change" button in the bottom of sidebar
- See three options in dropdown. One should be disabled
- Click on any available options
- See that status have changed in the bottom of the sidebar


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules