### PR TITLE
feat: Activity message for label addition/deletion

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -156,6 +156,7 @@ class Conversation < ApplicationRecord
 
     create_status_change_message(user_name) if saved_change_to_status?
     create_assignee_change(user_name) if saved_change_to_assignee_id?
+    create_label_change(user_name) if saved_change_to_label_list?
   end
 
   def activity_message_params(content)
@@ -211,6 +212,32 @@ class Conversation < ApplicationRecord
     params = { assignee_name: assignee&.available_name, user_name: user_name }.compact
     key = assignee_id ? 'assigned' : 'removed'
     content = I18n.t("conversations.activity.assignee.#{key}", **params)
+
+    messages.create(activity_message_params(content))
+  end
+
+  def create_label_change(user_name)
+    previous_labels, current_labels = previous_changes[:label_list]
+    return unless (previous_labels.is_a? Array) || (current_labels.is_a? Array)
+
+    create_label_added(user_name, current_labels - previous_labels)
+    create_label_removed(user_name, previous_labels - current_labels)
+  end
+
+  def create_label_added(user_name, labels = [])
+    return unless labels.size.positive?
+
+    params = { user_name: user_name, labels: labels.join(', ') }
+    content = I18n.t('conversations.activity.labels.added', **params)
+
+    messages.create(activity_message_params(content))
+  end
+
+  def create_label_removed(user_name, labels = [])
+    return unless labels.size.positive?
+
+    params = { user_name: user_name, labels: labels.join(', ') }
+    content = I18n.t('conversations.activity.labels.removed', **params)
 
     messages.create(activity_message_params(content))
   end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -218,7 +218,7 @@ class Conversation < ApplicationRecord
 
   def create_label_change(user_name)
     previous_labels, current_labels = previous_changes[:label_list]
-    return unless (previous_labels.is_a? Array) || (current_labels.is_a? Array)
+    return unless (previous_labels.is_a? Array) && (current_labels.is_a? Array)
 
     create_label_added(user_name, current_labels - previous_labels)
     create_label_removed(user_name, previous_labels - current_labels)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,9 @@ en:
       assignee:
         assigned: "Assigned to %{assignee_name} by %{user_name}"
         removed: "Conversation unassigned by %{user_name}"
+      labels:
+        added: "%{user_name} added %{labels}"
+        removed: "%{user_name} removed %{labels}"
     templates:
       greeting_message_body: "%{account_name} typically replies in a few hours."
       ways_to_reach_you_message_body: "Give the team a way to reach you."

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe Conversation, type: :model do
       create(:user, email: 'agent2@example.com', account: account, role: :agent)
     end
     let(:assignment_mailer) { double(deliver: true) }
+    let(:label) { create(:label, account: account) }
 
     before do
       conversation
@@ -70,7 +71,8 @@ RSpec.describe Conversation, type: :model do
         status: :resolved,
         locked: true,
         contact_last_seen_at: Time.now,
-        assignee: new_assignee
+        assignee: new_assignee,
+        label_list: [label.title]
       )
     end
 
@@ -90,6 +92,7 @@ RSpec.describe Conversation, type: :model do
       # create_activity
       expect(conversation.messages.pluck(:content)).to include("Conversation was marked resolved by #{old_assignee.available_name}")
       expect(conversation.messages.pluck(:content)).to include("Assigned to #{new_assignee.available_name} by #{old_assignee.available_name}")
+      expect(conversation.messages.pluck(:content)).to include("#{old_assignee.available_name} added #{label.title}")
     end
   end
 
@@ -181,6 +184,48 @@ RSpec.describe Conversation, type: :model do
 
       expect(update_assignee).to eq(true)
       expect(agent.notifications.count).to eq(0)
+    end
+  end
+
+  describe '#update_labels' do
+    let(:account) { create(:account) }
+    let(:conversation) { create(:conversation, account: account) }
+    let(:agent) do
+      create(:user, email: 'agent@example.com', account: account, role: :agent)
+    end
+    let(:first_label) { create(:label, account: account) }
+    let(:second_label) { create(:label, account: account) }
+    let(:third_label) { create(:label, account: account) }
+    let(:fourth_label) { create(:label, account: account) }
+
+    before do
+      conversation
+      Current.user = agent
+
+      first_label
+      second_label
+      third_label
+      fourth_label
+    end
+
+    it 'adds one label to conversation' do
+      labels = [first_label].map(&:title)
+      expect(conversation.update_labels(labels)).to eq(true)
+      expect(conversation.label_list).to match_array(labels)
+      expect(conversation.messages.pluck(:content)).to include("#{agent.available_name} added #{labels.join(', ')}")
+    end
+
+    it 'adds and removes previously added labels' do
+      labels = [first_label, fourth_label].map(&:title)
+      expect(conversation.update_labels(labels)).to eq(true)
+      expect(conversation.label_list).to match_array(labels)
+      expect(conversation.messages.pluck(:content)).to include("#{agent.available_name} added #{labels.join(', ')}")
+
+      updated_labels = [second_label, third_label].map(&:title)
+      expect(conversation.update_labels(updated_labels)).to eq(true)
+      expect(conversation.label_list).to match_array(updated_labels)
+      expect(conversation.messages.pluck(:content)).to include("#{agent.available_name} added #{updated_labels.join(', ')}")
+      expect(conversation.messages.pluck(:content)).to include("#{agent.available_name} removed #{labels.join(', ')}")
     end
   end
 


### PR DESCRIPTION
## Description

Feature to create an activity message of label addition/deletion.

Fixes #1022 

<img width="1586" alt="Screenshot_1_10_20__6_28_PM" src="https://user-images.githubusercontent.com/2965013/94798252-efdc1600-0413-11eb-9edb-28b11b447cde.png">

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have added RSpec tests to check both cases to add and remove labels creates activity messages in DB
 - spec/models/conversation_spec.rb


## Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules