### PR TITLE
add: self-assign conversation activity message

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -210,6 +210,7 @@ class Conversation < ApplicationRecord
   def create_assignee_change(user_name)
     params = { assignee_name: assignee&.available_name, user_name: user_name }.compact
     key = assignee_id ? 'assigned' : 'removed'
+    key = 'self_assigned' if self_assign? assignee_id
     content = I18n.t("conversations.activity.assignee.#{key}", **params)
 
     messages.create(activity_message_params(content))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
         resolved: "Conversation was marked resolved by %{user_name}"
         open: "Conversation was reopened by %{user_name}"
       assignee:
+        self_assigned: "%{user_name} self-assigned this conversation"
         assigned: "Assigned to %{assignee_name} by %{user_name}"
         removed: "Conversation unassigned by %{user_name}"
     templates:

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -182,6 +182,17 @@ RSpec.describe Conversation, type: :model do
       expect(update_assignee).to eq(true)
       expect(agent.notifications.count).to eq(0)
     end
+
+    context 'when agent is current user' do
+      before do
+        Current.user = agent
+      end
+
+      it 'creates self-assigned message activity' do
+        expect(update_assignee).to eq(true)
+        expect(conversation.messages.pluck(:content)).to include("#{agent.available_name} self-assigned this conversation")
+      end
+    end
   end
 
   describe '#toggle_status' do


### PR DESCRIPTION
Fixes #1077 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Added one test case in rspec to check correct activity message is generated
- Manual testing on local build

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules