### PR TITLE
fix(1296): Call hasUserKeys() with user argument

### DIFF
--- a/app/javascript/packs/sdk.js
+++ b/app/javascript/packs/sdk.js
@@ -50,7 +50,7 @@ const runSDK = ({ baseUrl, websiteToken }) => {
         throw new Error('Identifier should be a string or a number');
       }
 
-      if (!hasUserKeys()) {
+      if (!hasUserKeys(user)) {
         throw new Error(
           'User object should have one of the keys [avatar_url, email, name]'
         );


### PR DESCRIPTION
## Description

Passes the user argument to `hasUserKeys()` in the `setUser()` function. This was a bug introduced in https://github.com/chatwoot/chatwoot/commit/dbd1720aeb99e75a1fe5a171895576af22eda9f9.

Fixes: #1296

attn: @pranavrajs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Reproduction steps:**
* Load current version of SDK
* Call `setUser` with valid properties

**Verification steps:**
* Build the javascript
* Pointed my SDK initialization at the local copy
* Call `setUser` and see a success

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules