### PR TITLE
fix: array length check

### DIFF
--- a/app/javascript/dashboard/components/widgets/ChannelItem.vue
+++ b/app/javascript/dashboard/components/widgets/ChannelItem.vue
@@ -56,7 +56,7 @@ export default {
   computed: {
     isActive() {
       const { key } = this.channel;
-      if (Object.keys(this.enabledFeatures) === 0) {
+      if (Object.keys(this.enabledFeatures).length === 0) {
         return false;
       }
       if (key === 'facebook') {


### PR DESCRIPTION
## Description

`===` comparison of array and number types always returns false. Compare length of the array instead.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have not done any testing yet.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules