### PR TITLE
fix: Fixing failing tests post introduction of last_activity_at in conversations

### DIFF
--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe Conversation, type: :model do
         messages: [],
         inbox_id: conversation.inbox_id,
         status: conversation.status,
-        timestamp: conversation.created_at.to_i,
+        timestamp: conversation.last_activity_at.to_i,
         can_reply: true,
         channel: 'Channel::WebWidget',
         contact_last_seen_at: conversation.contact_last_seen_at.to_i,

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Conversations::EventDataPresenter do
         status: conversation.status,
         can_reply: conversation.can_reply?,
         channel: conversation.inbox.channel_type,
-        timestamp: conversation.created_at.to_i,
+        timestamp: conversation.last_activity_at.to_i,
         contact_last_seen_at: conversation.contact_last_seen_at.to_i,
         agent_last_seen_at: conversation.agent_last_seen_at.to_i,
         unread_count: 0


### PR DESCRIPTION
## Description

While working on #418, realised the metric that we need to calculate inactivity of converstions has been already introduced in #1281. I can build my changes for #418 on top of work done in #1281, but that PR is still not merged due to a couple of test cases failing in #1281. 

## Type of change

Fixed failing tests post introduction of last_activity_at in conversations

## How Has This Been Tested?

Verified that the test cases that were failing in the original PR are not failing here.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules