### PR TITLE
feat: use gravatar if no avatar image

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,13 +110,13 @@ class User < ApplicationRecord
     inboxes.where(account_id: Current.account.id)
   end
 
-  alias_method :avatar_img_url, :avatar_url
+  alias avatar_img_url avatar_url
   def avatar_url
     if avatar_img_url == ''
       hash = Digest::MD5.hexdigest(email)
       return "https://www.gravatar.com/avatar/#{hash}"
     end
-      return avatar_img_url
+    avatar_img_url
   end
 
   def administrator?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,6 +110,15 @@ class User < ApplicationRecord
     inboxes.where(account_id: Current.account.id)
   end
 
+  alias_method :avatar_img_url, :avatar_url
+  def avatar_url
+    if avatar_img_url == ''
+      hash = Digest::MD5.hexdigest(email)
+      return "https://www.gravatar.com/avatar/#{hash}"
+    end
+      return avatar_img_url
+  end
+
   def administrator?
     current_account_user&.administrator?
   end


### PR DESCRIPTION
## Description

Currently, the app shows the initials of the user if no avatar image is set. To add a personal touch in the app, we will pull the Gravatar profile image if no image avatar image is found.

Fixes #1240 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I created different accounts and added avatar image for a few accounts.
After implementing the feature, the accounts which do not have the avatar image started to show the Gravatar images and the one which had one remained the same.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules