### PR TITLE
Bug: Fix 1196 Integrations page is broken on safari

### DIFF
--- a/app/javascript/dashboard/assets/scss/views/settings/integrations.scss
+++ b/app/javascript/dashboard/assets/scss/views/settings/integrations.scss
@@ -8,6 +8,7 @@
 
     .integration--image {
       display: flex;
+      height: 10rem;
       margin-right: $space-normal;
       width: 10rem;
 


### PR DESCRIPTION
 Description

height property for .integration--image class was not defined which was causing this issue. I have added the height now it is working fine.

Fixes #1196 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have checked on the safari attaching screenshot here.  
  
![Screenshot](https://raw.githubusercontent.com/vishal-pandey/assets/master/chatwoot1.png)

