### PR TITLE
chore: Use agent partial instead of user in conversation API

### DIFF
--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -5,7 +5,7 @@ json.meta do
   json.channel conversation.inbox.try(:channel_type)
   if conversation.assignee
     json.assignee do
-      json.partial! 'api/v1/models/user.json.jbuilder', resource: conversation.assignee
+      json.partial! 'api/v1/models/agent.json.jbuilder', resource: conversation.assignee
     end
   end
 end


### PR DESCRIPTION
- Remove unnecessary information in conversation APIs.