### PR TITLE
Improve mobile styling of registration view a bit

### DIFF
--- a/app/javascript/dashboard/assets/scss/widgets/_login.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_login.scss
@@ -1,5 +1,11 @@
 .auth-wrap {
   width: 100%;
+
+  @media screen and (max-width: 667px) {
+    .column {
+      flex: inherit;
+    }
+  }
 }
 
 // Outside login wrapper

--- a/app/javascript/dashboard/assets/scss/widgets/_login.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_login.scss
@@ -1,11 +1,5 @@
 .auth-wrap {
   width: 100%;
-
-  @media screen and (max-width: 667px) {
-    .column {
-      flex: inherit;
-    }
-  }
 }
 
 // Outside login wrapper

--- a/app/javascript/dashboard/routes/auth/Signup.vue
+++ b/app/javascript/dashboard/routes/auth/Signup.vue
@@ -11,7 +11,7 @@
       </h2>
     </div>
     <div class="row align-center">
-      <div class="medium-5 column">
+      <div class="medium-5 column small-12">
         <ul class="signup--features">
           <li><i class="ion-beer beer"></i>Unlimited inboxes</li>
           <li><i class="ion-stats-bars report"></i>Robust Reporting</li>
@@ -20,7 +20,7 @@
           <li><i class="ion-locked secure"></i>Enterprise level security</li>
         </ul>
       </div>
-      <div class="medium-5 column">
+      <div class="medium-5 column small-12">
         <form class="signup--box login-box " @submit.prevent="submit()">
           <div class="column log-in-form">
             <label :class="{ error: $v.credentials.name.$error }">


### PR DESCRIPTION
## Description

This just improves the styling of the registration page on mobile a bit as it provides an immediately negative impression as it is.

Before:

<img width="301" alt="Screen Shot 2020-10-14 at 8 22 21 PM" src="https://user-images.githubusercontent.com/225802/96069511-9a642800-0e5b-11eb-8c1f-c9e457ef6fb1.png">

After:

<img width="301" alt="Screen Shot 2020-10-14 at 8 22 36 PM" src="https://user-images.githubusercontent.com/225802/96069531-a05a0900-0e5b-11eb-8a5a-37d746a82f1a.png">

## Type of change

Minor styling improvement.

## How Has This Been Tested?

I tested with Chrome, Firefox, and Safari.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules