### PR TITLE
DRY up check_authorization method

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -10,4 +10,10 @@ class Api::BaseController < ApplicationController
   def authenticate_by_access_token?
     request.headers[:api_access_token].present? || request.headers[:HTTP_API_ACCESS_TOKEN].present?
   end
+
+  def check_authorization(model = nil)
+    model ||= controller_name.classify.constantize
+
+    authorize(model)
+  end
 end

--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
   private
 
   def check_authorization
-    authorize(User)
+    super(User)
   end
 
   def fetch_agent

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -41,10 +41,6 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
   private
 
-  def check_authorization
-    authorize(Contact)
-  end
-
   def build_contact_inbox
     return if params[:inbox_id].blank?
 

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -55,10 +55,6 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
     @agent_bot = AgentBot.find(params[:agent_bot]) if params[:agent_bot]
   end
 
-  def check_authorization
-    authorize(Inbox)
-  end
-
   def create_channel
     case permitted_params[:channel][:type]
     when 'web_widget'

--- a/app/controllers/api/v1/accounts/labels_controller.rb
+++ b/app/controllers/api/v1/accounts/labels_controller.rb
@@ -28,10 +28,6 @@ class Api::V1::Accounts::LabelsController < Api::V1::Accounts::BaseController
     @label = Current.account.labels.find(params[:id])
   end
 
-  def check_authorization
-    authorize(Label)
-  end
-
   def permitted_params
     params.require(:label).permit(:title, :description, :color, :show_on_sidebar)
   end

--- a/app/controllers/api/v1/accounts/webhooks_controller.rb
+++ b/app/controllers/api/v1/accounts/webhooks_controller.rb
@@ -29,8 +29,4 @@ class Api::V1::Accounts::WebhooksController < Api::V1::Accounts::BaseController
   def fetch_webhook
     @webhook = Current.account.webhooks.find(params[:id])
   end
-
-  def check_authorization
-    authorize(Webhook)
-  end
 end

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -44,10 +44,6 @@ class Api::V1::AccountsController < Api::BaseController
 
   private
 
-  def check_authorization
-    authorize(Account)
-  end
-
   def confirmed?
     super_admin? && params[:confirmed]
   end


### PR DESCRIPTION
While adding more model authorization policies to my fork, I noticed the `check_authorization` method was not DRY. So this is my attempt to clean up. 

I replaced the six `check_authorization` methods with one method inside of the `base controller`. 

One edge case that is accounted for is when the model you want to authroize is not the same as the controller name. For example, for `AgentsController` we want to check authorization for the `User` model. In this case, we just pass in the correct model to `super`.