### PR TITLE
Add messages on mute / unmute actions

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -87,10 +87,12 @@ class Conversation < ApplicationRecord
   def mute!
     resolved!
     Redis::Alfred.setex(mute_key, 1, mute_period)
+    create_muted_message
   end
 
   def unmute!
     Redis::Alfred.delete(mute_key)
+    create_unmuted_message
   end
 
   def muted?
@@ -244,6 +246,24 @@ class Conversation < ApplicationRecord
 
     params = { user_name: user_name, labels: labels.join(', ') }
     content = I18n.t('conversations.activity.labels.removed', **params)
+
+    messages.create(activity_message_params(content))
+  end
+
+  def create_muted_message
+    return unless Current.user
+
+    params = { user_name: Current.user.name }
+    content = I18n.t('conversations.activity.muted', **params)
+
+    messages.create(activity_message_params(content))
+  end
+
+  def create_unmuted_message
+    return unless Current.user
+
+    params = { user_name: Current.user.name }
+    content = I18n.t('conversations.activity.unmuted', **params)
 
     messages.create(activity_message_params(content))
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,8 @@ en:
       labels:
         added: "%{user_name} added %{labels}"
         removed: "%{user_name} removed %{labels}"
+      muted: "%{user_name} has muted the conversation"
+      unmuted: "%{user_name} has unmuted the conversation"
     templates:
       greeting_message_body: "%{account_name} typically replies in a few hours."
       ways_to_reach_you_message_body: "Give the team a way to reach you."

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -276,7 +276,13 @@ RSpec.describe Conversation, type: :model do
   describe '#mute!' do
     subject(:mute!) { conversation.mute! }
 
+    let(:user) do
+      create(:user, email: 'agent2@example.com', account: create(:account), role: :agent)
+    end
+
     let(:conversation) { create(:conversation) }
+
+    before { Current.user = user }
 
     it 'marks conversation as resolved' do
       mute!
@@ -287,12 +293,22 @@ RSpec.describe Conversation, type: :model do
       mute!
       expect(Redis::Alfred.get(conversation.send(:mute_key))).not_to eq(nil)
     end
+
+    it 'creates mute message' do
+      expect(conversation.messages.pluck(:content)).to include("#{user.name} has muted the conversation")
+    end
   end
 
   describe '#unmute!' do
     subject(:unmute!) { conversation.unmute! }
 
+    let(:user) do
+      create(:user, email: 'agent2@example.com', account: create(:account), role: :agent)
+    end
+
     let(:conversation) { create(:conversation).tap(&:mute!) }
+
+    before { Current.user = user }
 
     it 'does not change conversation status' do
       expect { unmute! }.not_to(change { conversation.reload.status })
@@ -302,6 +318,10 @@ RSpec.describe Conversation, type: :model do
       expect { unmute! }
         .to change { Redis::Alfred.get(conversation.send(:mute_key)) }
         .to nil
+    end
+
+    it 'creates unmute message' do
+      expect(conversation.messages.pluck(:content)).to include("#{user.name} has unmuted the conversation")
     end
   end
 

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -295,6 +295,7 @@ RSpec.describe Conversation, type: :model do
     end
 
     it 'creates mute message' do
+      mute!
       expect(conversation.messages.pluck(:content)).to include("#{user.name} has muted the conversation")
     end
   end
@@ -321,6 +322,7 @@ RSpec.describe Conversation, type: :model do
     end
 
     it 'creates unmute message' do
+      unmute!
       expect(conversation.messages.pluck(:content)).to include("#{user.name} has unmuted the conversation")
     end
   end


### PR DESCRIPTION
# Pull Request Template

## Description

Added message when user performs mute / unmute conversations actions

Fixes # (issue)

https://github.com/chatwoot/chatwoot/issues/1330

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Added tests in "spec/models/conversation_spec.rb"


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules