### PR TITLE
fix: pg pass printed by docker container (#1371)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
       - sidekiq
     ports:
       - 3000:3000
+    env_file: .env
     environment:
       - WEBPACKER_DEV_SERVER_HOST=webpack
       - NODE_ENV=development

--- a/docker/entrypoints/helpers/pg_database_url.sh
+++ b/docker/entrypoints/helpers/pg_database_url.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+require 'uri'
+
+# Let DATABASE_URL env take presedence over individual connection params.
+if !ENV['DATABASE_URL'].nil? && ENV['DATABASE_URL'] != ''
+  uri = URI(ENV['DATABASE_URL'])
+  puts "export POSTGRES_HOST=#{uri.host} POSTGRES_PORT=#{uri.port} POSTGRES_USERNAME=#{uri.user}"
+else
+  puts "export POSTGRES_PORT=5432"
+end

--- a/docker/entrypoints/rails.sh
+++ b/docker/entrypoints/rails.sh
@@ -11,9 +11,9 @@ echo "Waiting for postgres to become ready...."
 # Let DATABASE_URL env take presedence over individual connection params.
 # This is done to avoid printing the DATABASE_URL in the logs
 $(docker/entrypoints/helpers/pg_database_url.sh)
-PSQL="pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USERNAME"
+PG_READY="pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USERNAME"
 
-until $PSQL
+until $PG_READY
 do
   sleep 2;
 done

--- a/docker/entrypoints/rails.sh
+++ b/docker/entrypoints/rails.sh
@@ -9,11 +9,9 @@ rm -rf /app/tmp/cache/*
 echo "Waiting for postgres to become ready...."
 
 # Let DATABASE_URL env take presedence over individual connection params.
-if [ -z "$DATABASE_URL" ]; then
-  PSQL="pg_isready -h $POSTGRES_HOST -p 5432 -U $POSTGRES_USERNAME"
-else
-  PSQL="pg_isready -d $DATABASE_URL"
-fi
+# This is done to avoid printing the DATABASE_URL in the logs
+$(docker/entrypoints/helpers/pg_database_url.sh)
+PSQL="pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USERNAME"
 
 until $PSQL
 do

--- a/docker/entrypoints/rails.sh
+++ b/docker/entrypoints/rails.sh
@@ -10,7 +10,6 @@ echo "Waiting for postgres to become ready...."
 
 # Let DATABASE_URL env take presedence over individual connection params.
 if [ -z "$DATABASE_URL" ]; then
-  PGPASSWORD=$POSTGRES_PASSWORD
   PSQL="pg_isready -h $POSTGRES_HOST -p 5432 -U $POSTGRES_USERNAME"
 else
   PSQL="pg_isready -d $DATABASE_URL"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10422,7 +10422,7 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tailwindcss@^1.8.3:
+tailwindcss@^1.9.6:
   version "1.9.6"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.9.6.tgz#0c5089911d24e1e98e592a31bfdb3d8f34ecf1a0"
   integrity sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==


### PR DESCRIPTION
## Description

* The `POSTGRES_PASSWORD` variable setting inside the entry point script of the Rails docker container was printed in the logs when the container was run using `docker-compose`. Fixed this by removing this password being set in this script.
* Added env file from the root directory to the container
* Updated the tailwind version in yarn lock

Fixes #1371

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in a local environment by following the `docker-compose` logs when the chatwoot boots up. Without the changes, the password was being printed in the logs. When the changes are applied, the pg password is no longer printed in the logs.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
