### PR TITLE
Fix: Sort label links on sidebar for homepage #1386 

### DIFF
--- a/app/javascript/dashboard/store/modules/labels.js
+++ b/app/javascript/dashboard/store/modules/labels.js
@@ -20,7 +20,9 @@ export const getters = {
     return _state.uiFlags;
   },
   getLabelsOnSidebar(_state) {
-    return _state.records.filter(record => record.show_on_sidebar);
+    return _state.records
+      .filter(record => record.show_on_sidebar)
+      .sort((a, b) => a.title.localeCompare(b.title));
   },
 };
 


### PR DESCRIPTION


## Description
 Sorted labels returning from `getLabelsOnSidebar` by alphabetical order.

Fixes # (issue)
Fixes #1386 

## Type of change
<img width="750" alt="Screenshot 2020-11-07 at 12 06 27 PM" src="https://user-images.githubusercontent.com/64252451/98434021-e10f1000-20f1-11eb-8eac-45f6965bfb3f.png">
