### PR TITLE
fix: Add a check for thread_ts

### DIFF
--- a/lib/integrations/slack/incoming_message_builder.rb
+++ b/lib/integrations/slack/incoming_message_builder.rb
@@ -41,8 +41,12 @@ class Integrations::Slack::IncomingMessageBuilder
     params[:type] == 'url_verification'
   end
 
+  def thread_timestamp_available?
+    params[:event][:thread_ts].present?
+  end
+
   def create_message?
-    supported_message? && integration_hook
+    thread_timestamp_available? && supported_message? && integration_hook
   end
 
   def message

--- a/spec/lib/integrations/slack/incoming_message_builder_spec.rb
+++ b/spec/lib/integrations/slack/incoming_message_builder_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe Integrations::Slack::IncomingMessageBuilder do
   let(:account) { create(:account) }
   let(:message_params) { slack_message_stub }
+  let(:message_without_thread_ts) { slack_message_stub_without_thread_ts }
   let(:verification_params) { slack_url_verification_stub }
 
   let!(:hook) { create(:integrations_hook, account: account, reference_id: message_params[:event][:channel]) }
@@ -18,6 +19,13 @@ describe Integrations::Slack::IncomingMessageBuilder do
     end
 
     context 'when message creation' do
+      it 'doesnot create message if thread info is missing' do
+        messages_count = conversation.messages.count
+        builder = described_class.new(message_without_thread_ts)
+        builder.perform
+        expect(conversation.messages.count).to eql(messages_count)
+      end
+
       it 'creates message' do
         expect(hook).not_to eq nil
         messages_count = conversation.messages.count

--- a/spec/support/slack_stubs.rb
+++ b/spec/support/slack_stubs.rb
@@ -21,8 +21,30 @@ module SlackStubs
     }
   end
 
+  def slack_message_stub_without_thread_ts
+    {
+      "token": '[FILTERED]',
+      "team_id": '',
+      "api_app_id": '',
+      "event": {
+        "type": 'message',
+        "client_msg_id": 'ffc6e64e-6f0c-4a3d-b594-faa6b44e48ab',
+        "text": 'this is test',
+        "user": 'ULYPAKE5S',
+        "ts": '1588623033.006000',
+        "team": 'TLST3048H'
+      },
+      "type": 'event_callback',
+      "event_id": '',
+      "event_time": 1_588_623_033,
+      "authed_users": '[FILTERED]',
+      "webhook": {}
+    }
+  end
+
   def message_event
-    { "client_msg_id": 'ffc6e64e-6f0c-4a3d-b594-faa6b44e48ab',
+    {
+      "client_msg_id": 'ffc6e64e-6f0c-4a3d-b594-faa6b44e48ab',
       "type": 'message',
       "text": 'this is test',
       "user": 'ULYPAKE5S',
@@ -32,7 +54,8 @@ module SlackStubs
       "thread_ts": '1588623023.005900',
       "channel": 'G01354F6A6Q',
       "event_ts": '1588623033.006000',
-      "channel_type": 'group' }
+      "channel_type": 'group'
+    }
   end
 
   def message_blocks


### PR DESCRIPTION
- If no thread timestamp is available, ignore the message
- Add specs to cover the case