### PR TITLE
GCS credentials dont need to be parsed as JSON

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -18,7 +18,7 @@ amazon:
 google:
   service: GCS
   project: <%= ENV.fetch('GCS_PROJECT', '') %>
-  credentials: <%= ENV.fetch('GCS_CREDENTIALS', '').to_json %>
+  credentials: <%= ENV.fetch('GCS_CREDENTIALS', '') %>
   bucket: <%= ENV.fetch('GCS_BUCKET', '') %>
 
 # Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)


### PR DESCRIPTION
## Description

Hey folks, a tiny change here to fix an issue using Chatwoot with Google Cloud Storage that i came across: Essentially, following the [instructions](https://www.chatwoot.com/docs/configuring-cloud-storage) as provided for GCS currently leads to a misconfigured ActiveStorage (any file uploads fail): the issue is that ActiveStorage expects `google.credentials` in `storage.yml` to be _either_ a path to a local json file containing the credentials, _or_ a JSON string of the credentials themselves, but _not_ a Ruby hash parsed from that JSON. A one line change fixes it.

I've tested manually, but not entirely sure how best to include unit tests to cover it seeing as it's a config change? happy to do so though if you have any pointers.

Thanks!

Tim

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Setup chatwoot on heroku with GCS storage option
- Provide GCS_CREDENTIALS json in heroku config as per instructions
- Verify that attached files display correctly in chatwoot
- Verify no errors creating attachments in heroku console:
```
a = Attachment.new
a.account = Account.first
a.message = Message.last
a.file.attach(io: File.open(path_to_local_image), filename: local_image_filename)
a.save
#=> should return true
a.file.attachment.service_url
#=> should return a google cloud storage url which responds with the image
```


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

