### PR TITLE
fix: Add missing close button if bubble is hidden

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,7 +325,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.5)
-    puma (4.3.5)
+    puma (4.3.6)
       nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -34,7 +34,10 @@ export const IFrameHelper = {
     iframe.id = 'chatwoot_live_chat_widget';
     iframe.style.visibility = 'hidden';
 
-    const holderClassName = `woot-widget-holder woot--hide woot-elements--${window.$chatwoot.position}`;
+    let holderClassName = `woot-widget-holder woot--hide woot-elements--${window.$chatwoot.position}`;
+    if (window.$chatwoot.hideMessageBubble) {
+      holderClassName += ` woot-widget--without-bubble`;
+    }
     addClass(widgetHolder, holderClassName);
     widgetHolder.appendChild(iframe);
     body.appendChild(widgetHolder);
@@ -114,6 +117,9 @@ export const IFrameHelper = {
     },
 
     setBubbleLabel(message) {
+      if (window.$chatwoot.hideMessageBubble) {
+        return;
+      }
       setBubbleText(window.$chatwoot.launcherTitle || message.label);
     },
 

--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -115,6 +115,10 @@ export const SDK_CSS = `.woot-widget-holder {
   z-index: -1 !important;
 }
 
+.woot-widget--without-bubble {
+  bottom: 20px !important;
+}
+
 @media only screen and (max-width: 667px) {
   .woot-widget-holder {
     height: 100%;

--- a/app/javascript/widget/assets/scss/woot.scss
+++ b/app/javascript/widget/assets/scss/woot.scss
@@ -34,6 +34,14 @@ body {
   }
 }
 
+.is-bubble-hidden {
+  .actions {
+    .close-button {
+      display: block !important;
+    }
+  }
+}
+
 .cursor-pointer {
   cursor: pointer;
 }

--- a/app/javascript/widget/views/Router.vue
+++ b/app/javascript/widget/views/Router.vue
@@ -2,7 +2,11 @@
   <div
     id="app"
     class="woot-widget-wrap"
-    :class="{ 'is-mobile': isMobile, 'is-widget-right': !isLeftAligned }"
+    :class="{
+      'is-mobile': isMobile,
+      'is-widget-right': !isLeftAligned,
+      'is-bubble-hidden': hideMessageBubble,
+    }"
   >
     <home
       v-if="!showUnreadView"


### PR DESCRIPTION
Fixes #1434 

- Add missing close button
- Fix the position of the widget holder if there is no bubble present

<img width="463" alt="Screenshot 2020-11-21 at 6 19 43 PM" src="https://user-images.githubusercontent.com/2246121/99877740-4866ad00-2c26-11eb-8cd6-b5eb3f269f3e.png">

<img width="488" alt="Screenshot 2020-11-21 at 6 19 30 PM" src="https://user-images.githubusercontent.com/2246121/99877741-4b619d80-2c26-11eb-87a5-d37a65331317.png">
