### PR TITLE
Label Overflow text-truncate fix 1447

### DIFF
--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
@@ -78,7 +78,6 @@
     justify-content: space-between;
 
     .page-title {
-      // @include flex;
       margin-bottom: $zero;
       margin-left: $space-normal;
     }

--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
@@ -78,7 +78,7 @@
     justify-content: space-between;
 
     .page-title {
-      @include flex;
+      // @include flex;
       margin-bottom: $zero;
       margin-left: $space-normal;
     }

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -2,7 +2,7 @@
   <div class="conversations-sidebar  medium-4 columns">
     <slot></slot>
     <div class="chat-list__top">
-      <h1 class="page-title">
+      <h1 class="page-title text-truncate">
         <woot-sidemenu-icon />
         {{ pageTitle }}
       </h1>

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -2,7 +2,7 @@
   <div class="conversations-sidebar  medium-4 columns">
     <slot></slot>
     <div class="chat-list__top">
-      <h1 class="page-title text-truncate">
+      <h1 class="page-title text-truncate" :title="pageTitle">
         <woot-sidemenu-icon />
         {{ pageTitle }}
       </h1>


### PR DESCRIPTION
I have added the "text-truncate" class to the page title to truncate overflow text of the label title, now user can use open/resolved/bot dropdown even with long label title.
Fixes #1447 

I am attaching a screenshot to test.

![label_overflow_bug_solve](https://user-images.githubusercontent.com/19498820/100068491-a03b2900-2e5d-11eb-8016-a88482aacdbb.png)
