### PR TITLE
fix: Add worker to the formation to avoid default turned off state

### DIFF
--- a/app.json
+++ b/app.json
@@ -34,6 +34,10 @@
     "web": {
       "quantity": 1,
       "size": "FREE"
+    },
+    "worker": {
+      "quantity": 1,
+      "size": "FREE"
     }
   },
   "image": "heroku/ruby",


### PR DESCRIPTION
The Heroku deploys were having workers turned off by default. This was because the `worker` process was not available in `formation`.