### PR TITLE
fix: Limit the number of unread messages returned in the API

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue
@@ -39,7 +39,7 @@
         <span class="timestamp">
           {{ dynamicTime(chat.timestamp) }}
         </span>
-        <span class="unread">{{ getUnreadCount }}</span>
+        <span class="unread">{{ unreadCount > 9 ? '9+' : unreadCount }}</span>
       </div>
     </div>
   </div>
@@ -108,12 +108,12 @@ export default {
       return this.currentChat.id === this.chat.id;
     },
 
-    getUnreadCount() {
+    unreadCount() {
       return this.unreadMessagesCount(this.chat);
     },
 
     hasUnread() {
-      return this.getUnreadCount > 0;
+      return this.unreadCount > 0;
     },
 
     isInboxNameVisible() {

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -14,7 +14,7 @@ json.id conversation.display_id
 if conversation.unread_incoming_messages.count.zero?
   json.messages [conversation.messages.includes([{ attachments: [{ file_attachment: [:blob] }] }]).last.try(:push_event_data)]
 else
-  json.messages conversation.unread_messages.includes([:user, { attachments: [{ file_attachment: [:blob] }] }]).map(&:push_event_data)
+  json.messages conversation.unread_messages.includes([:user, { attachments: [{ file_attachment: [:blob] }] }]).last(10).map(&:push_event_data)
 end
 
 json.inbox_id conversation.inbox_id


### PR DESCRIPTION
- Limit the number of unread messages to 10 
- Show unread count as `9+` instead of actual number

Fixes https://github.com/chatwoot/chatwoot/discussions/1358