### PR TITLE
chore: Ignore case while searching contact name, email

### DIFF
--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -14,7 +14,10 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   def search
     render json: { error: 'Specify search string with parameter q' }, status: :unprocessable_entity if params[:q].blank? && return
 
-    contacts = resolved_contacts.where('name LIKE :search OR email LIKE :search OR phone_number LIKE :search', search: "%#{params[:q]}%")
+    contacts = resolved_contacts.where(
+      'name ILIKE :search OR email ILIKE :search OR phone_number ILIKE :search',
+      search: "%#{params[:q]}%"
+    )
     @contacts_count = contacts.count
     @contacts = fetch_contact_last_seen_at(contacts)
   end

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -90,11 +90,33 @@ RSpec.describe 'Contacts API', type: :request do
     context 'when it is an authenticated user' do
       let(:admin) { create(:user, account: account, role: :administrator) }
       let!(:contact1) { create(:contact, account: account) }
-      let!(:contact2) { create(:contact, account: account, email: 'test@test.com') }
+      let!(:contact2) { create(:contact, name: 'testcontact', account: account, email: 'test@test.com') }
 
       it 'returns all contacts with contact inboxes' do
         get "/api/v1/accounts/#{account.id}/contacts/search",
             params: { q: contact2.email },
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(contact2.email)
+        expect(response.body).not_to include(contact1.email)
+      end
+
+      it 'matches the contact ignoring the case in email' do
+        get "/api/v1/accounts/#{account.id}/contacts/search",
+            params: { q: 'Test@Test.com' },
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(contact2.email)
+        expect(response.body).not_to include(contact1.email)
+      end
+
+      it 'matches the contact ignoring the case in name' do
+        get "/api/v1/accounts/#{account.id}/contacts/search",
+            params: { q: 'TestContact' },
             headers: admin.create_new_auth_token,
             as: :json
 

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :contact do
-    sequence(:name) { |n| "Widget #{n}" }
-    sequence(:email) { |n| "widget-#{n}@example.com" }
+    sequence(:name) { |n| "Contact #{n}" }
+    sequence(:email) { |n| "contact-#{n}@example.com" }
     phone_number { '+123456789011' }
     avatar { fixture_file_upload(Rails.root.join('spec/assets/avatar.png'), 'image/png') }
     account


### PR DESCRIPTION
- Ignore case for name, email search in contacts, use ILIKE instead of LIKE