### PR TITLE
fix: Use empty object if additional_attribute is null

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/ContactPanel.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ContactPanel.vue
@@ -112,18 +112,19 @@ export default {
       return `${this.browser.browser_name || ''} ${this.browser
         .browser_version || ''}`;
     },
+    contactAdditionalAttributes() {
+      return this.contact.additional_attributes || {};
+    },
     ipAddress() {
-      const additionalAttributes = this.contact.additional_attributes || {};
-      const { created_at_ip: createdAtIp } = additionalAttributes;
+      const { created_at_ip: createdAtIp } = this.contactAdditionalAttributes;
       return createdAtIp;
     },
     location() {
-      const additionalAttributes = this.contact.additional_attributes || {};
       const {
         country = '',
         city = '',
         country_code: countryCode,
-      } = additionalAttributes;
+      } = this.contactAdditionalAttributes;
       const cityAndCountry = [city, country].filter(item => !!item).join(', ');
 
       if (!cityAndCountry) {

--- a/app/javascript/dashboard/routes/dashboard/conversation/ContactPanel.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ContactPanel.vue
@@ -113,19 +113,17 @@ export default {
         .browser_version || ''}`;
     },
     ipAddress() {
-      const {
-        additional_attributes: { created_at_ip: createdAtIp },
-      } = this.contact;
+      const additionalAttributes = this.contact.additional_attributes || {};
+      const { created_at_ip: createdAtIp } = additionalAttributes;
       return createdAtIp;
     },
     location() {
+      const additionalAttributes = this.contact.additional_attributes || {};
       const {
-        additional_attributes: {
-          country = '',
-          city = '',
-          country_code: countryCode,
-        },
-      } = this.contact;
+        country = '',
+        city = '',
+        country_code: countryCode,
+      } = additionalAttributes;
       const cityAndCountry = [city, country].filter(item => !!item).join(', ');
 
       if (!cityAndCountry) {


### PR DESCRIPTION
- Old contact doesnot have additional attribute, it will be null. Use empty object if it is not available.