### PR TITLE
chore: Remove account.destroy listener

### DIFF
--- a/app/builders/account_builder.rb
+++ b/app/builders/account_builder.rb
@@ -15,7 +15,6 @@ class AccountBuilder
     end
     [@user, @account]
   rescue StandardError => e
-    @account&.destroy
     puts e.inspect
     raise e
   end

--- a/app/listeners/installation_webhook_listener.rb
+++ b/app/listeners/installation_webhook_listener.rb
@@ -1,15 +1,21 @@
 class InstallationWebhookListener < BaseListener
   def account_created(event)
-    payload = event.data[:account].webhook_data.merge(event: __method__.to_s)
-    deliver_webhook_payloads(payload)
-  end
-
-  def account_destroyed(event)
-    payload = event.data[:account].webhook_data.merge(event: __method__.to_s)
+    payload = account(event).webhook_data.merge(
+      event: __method__.to_s,
+      users: users(event)
+    )
     deliver_webhook_payloads(payload)
   end
 
   private
+
+  def account(event)
+    event.data[:account]
+  end
+
+  def users(event)
+    account(event).administrators.map(&:webhook_data)
+  end
 
   def deliver_webhook_payloads(payload)
     # Deliver the installation event

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -60,7 +60,6 @@ class Account < ApplicationRecord
   enum locale: LANGUAGES_CONFIG.map { |key, val| [val[:iso_639_1_code], key] }.to_h
 
   after_create_commit :notify_creation
-  after_destroy :notify_deletion
 
   def agents
     users.where(account_users: { role: :agent })
@@ -91,9 +90,5 @@ class Account < ApplicationRecord
 
   def notify_creation
     Rails.configuration.dispatcher.dispatch(ACCOUNT_CREATED, Time.zone.now, account: self)
-  end
-
-  def notify_deletion
-    Rails.configuration.dispatcher.dispatch(ACCOUNT_DESTROYED, Time.zone.now, account: self)
   end
 end

--- a/lib/events/types.rb
+++ b/lib/events/types.rb
@@ -4,7 +4,6 @@ module Events::Types
   ### Installation Events ###
   # account events
   ACCOUNT_CREATED = 'account.created'
-  ACCOUNT_DESTROYED = 'account.destroyed'
 
   #### Account Events ###
   # channel events

--- a/spec/listeners/installation_webhook_listener_spec.rb
+++ b/spec/listeners/installation_webhook_listener_spec.rb
@@ -17,7 +17,7 @@ describe InstallationWebhookListener do
     context 'when installation config is configured' do
       it 'triggers webhook' do
         create(:installation_config, name: 'INSTALLATION_EVENTS_WEBHOOK_URL', value: 'https://test.com')
-        expect(WebhookJob).to receive(:perform_later).with('https://test.com', account.webhook_data.merge(event: 'account.created', users: [])).once
+        expect(WebhookJob).to receive(:perform_later).with('https://test.com', account.webhook_data.merge(event: 'account_created', users: [])).once
         listener.account_created(event)
       end
     end

--- a/spec/listeners/installation_webhook_listener_spec.rb
+++ b/spec/listeners/installation_webhook_listener_spec.rb
@@ -17,27 +17,8 @@ describe InstallationWebhookListener do
     context 'when installation config is configured' do
       it 'triggers webhook' do
         create(:installation_config, name: 'INSTALLATION_EVENTS_WEBHOOK_URL', value: 'https://test.com')
-        expect(WebhookJob).to receive(:perform_later).with('https://test.com', account.webhook_data.merge(event: 'account_created')).once
+        expect(WebhookJob).to receive(:perform_later).with('https://test.com', account.webhook_data.merge(event: 'account.created', users: [])).once
         listener.account_created(event)
-      end
-    end
-  end
-
-  describe '#account_destroyed' do
-    let(:event_name) { :'account.destroyed' }
-
-    context 'when installation config is not configured' do
-      it 'does not trigger webhook' do
-        expect(WebhookJob).to receive(:perform_later).exactly(0).times
-        listener.account_destroyed(event)
-      end
-    end
-
-    context 'when installation config is configured' do
-      it 'triggers webhook' do
-        create(:installation_config, name: 'INSTALLATION_EVENTS_WEBHOOK_URL', value: 'https://test.com')
-        expect(WebhookJob).to receive(:perform_later).with('https://test.com', account.webhook_data.merge(event: 'account_destroyed')).once
-        listener.account_destroyed(event)
       end
     end
   end


### PR DESCRIPTION
- Remove `account.destroy` listener.
- Add `users` to `account.created` listener.
- Remove unnecessary `@account.destroy` method.