### PR TITLE
feat: installation config in super admin console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ package-lock.json
 
 # cypress
 test/cypress/videos/*
+
+/config/master.key
+/config/*.enc

--- a/app/controllers/super_admin/installation_configs_controller.rb
+++ b/app/controllers/super_admin/installation_configs_controller.rb
@@ -20,13 +20,9 @@ class SuperAdmin::InstallationConfigsController < SuperAdmin::ApplicationControl
   # Override this if you have certain roles that require a subset
   # this will be used to set the records shown on the `index` action.
   #
-  # def scoped_resource
-  #   if current_user.super_admin?
-  #     resource_class
-  #   else
-  #     resource_class.with_less_stuff
-  #   end
-  # end
+  def scoped_resource
+    resource_class.editable
+  end
 
   # Override `resource_params` if you want to transform the submitted
   # data before it's persisted. For example, the following would turn all

--- a/app/controllers/super_admin/installation_configs_controller.rb
+++ b/app/controllers/super_admin/installation_configs_controller.rb
@@ -1,0 +1,44 @@
+class SuperAdmin::InstallationConfigsController < SuperAdmin::ApplicationController
+  # Overwrite any of the RESTful controller actions to implement custom behavior
+  # For example, you may want to send an email after a foo is updated.
+  #
+  # def update
+  #   super
+  #   send_foo_updated_email(requested_resource)
+  # end
+
+  # Override this method to specify custom lookup behavior.
+  # This will be used to set the resource for the `show`, `edit`, and `update`
+  # actions.
+  #
+  # def find_resource(param)
+  #   Foo.find_by!(slug: param)
+  # end
+
+  # The result of this lookup will be available as `requested_resource`
+
+  # Override this if you have certain roles that require a subset
+  # this will be used to set the records shown on the `index` action.
+  #
+  # def scoped_resource
+  #   if current_user.super_admin?
+  #     resource_class
+  #   else
+  #     resource_class.with_less_stuff
+  #   end
+  # end
+
+  # Override `resource_params` if you want to transform the submitted
+  # data before it's persisted. For example, the following would turn all
+  # empty values into nil values. It uses other APIs such as `resource_class`
+  # and `dashboard`:
+  #
+  # def resource_params
+  #   params.require(resource_class.model_name.param_key).
+  #     permit(dashboard.permitted_attributes).
+  #     transform_values { |value| value == "" ? nil : value }
+  # end
+
+  # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+  # for more information
+end

--- a/app/controllers/super_admin/installation_configs_controller.rb
+++ b/app/controllers/super_admin/installation_configs_controller.rb
@@ -35,6 +35,12 @@ class SuperAdmin::InstallationConfigsController < SuperAdmin::ApplicationControl
   #     transform_values { |value| value == "" ? nil : value }
   # end
 
+  def resource_params
+    params.require(:installation_config)
+          .permit(:name, :value)
+          .transform_values { |value| value == '' ? nil : value }.merge(locked: false)
+  end
+
   # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
   # for more information
 end

--- a/app/dashboards/installation_config_dashboard.rb
+++ b/app/dashboards/installation_config_dashboard.rb
@@ -1,0 +1,66 @@
+require 'administrate/base_dashboard'
+
+class InstallationConfigDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    name: Field::String,
+    value: SerializedField,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    name
+    value
+    created_at
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    name
+    value
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    name
+    value
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how installation configs are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(installation_config)
+  #   "InstallationConfig ##{installation_config.id}"
+  # end
+end

--- a/app/fields/serialized_field.rb
+++ b/app/fields/serialized_field.rb
@@ -2,7 +2,7 @@ require 'administrate/field/base'
 
 class SerializedField < Administrate::Field::Base
   def to_s
-    is_hash? ? data.as_json : data.to_s
+    hash? ? data.as_json : data.to_s
   end
 
   def hash?

--- a/app/fields/serialized_field.rb
+++ b/app/fields/serialized_field.rb
@@ -1,0 +1,15 @@
+require 'administrate/field/base'
+
+class SerializedField < Administrate::Field::Base
+  def to_s
+    is_hash? ? data.as_json : data.to_s
+  end
+
+  def hash?
+    data.is_a? Hash
+  end
+
+  def array?
+    data.is_a? Array
+  end
+end

--- a/app/models/installation_config.rb
+++ b/app/models/installation_config.rb
@@ -21,6 +21,7 @@ class InstallationConfig < ApplicationRecord
   validates :name, presence: true
 
   default_scope { order(created_at: :desc) }
+  scope :editable, -> { where(locked: false) }
 
   def value
     serialized_value[:value]

--- a/app/models/installation_config.rb
+++ b/app/models/installation_config.rb
@@ -3,6 +3,7 @@
 # Table name: installation_configs
 #
 #  id               :bigint           not null, primary key
+#  locked           :boolean          default(TRUE), not null
 #  name             :string           not null
 #  serialized_value :jsonb            not null
 #  created_at       :datetime         not null
@@ -10,11 +11,13 @@
 #
 # Indexes
 #
+#  index_installation_configs_on_name                 (name) UNIQUE
 #  index_installation_configs_on_name_and_created_at  (name,created_at) UNIQUE
 #
 class InstallationConfig < ApplicationRecord
   serialize :serialized_value, HashWithIndifferentAccess
 
+  before_validation :set_lock
   validates :name, presence: true
 
   default_scope { order(created_at: :desc) }
@@ -27,5 +30,11 @@ class InstallationConfig < ApplicationRecord
     self.serialized_value = {
       value: value_to_assigned
     }.with_indifferent_access
+  end
+
+  private
+
+  def set_lock
+    self.locked = true if locked.nil?
   end
 end

--- a/app/views/fields/serialized_field/_form.html.erb
+++ b/app/views/fields/serialized_field/_form.html.erb
@@ -1,0 +1,19 @@
+<div class="field-unit field-unit--string">
+  <%= f.label field.attribute, class: "field-unit__label" %>
+  <div class="field-unit__field">
+    <% if field.array? %>
+      <% field.data.each do |sub_field| %>
+        <%= f.fields_for "#{field.attribute}[]", field.resource do |values_form| %>
+          <div class="field-unit">
+            <% sub_field.each do |sf_key, sf_value| %>
+              <%= values_form.label sf_key %>
+              <%= values_form.text_field sf_key, value: sf_value, disabled: true %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    <% else %>
+      <%= f.text_field field.attribute %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/fields/serialized_field/_index.html.erb
+++ b/app/views/fields/serialized_field/_index.html.erb
@@ -1,0 +1,9 @@
+<% if field.array? %>
+  <% field.data.each do |sub_field| %>
+    <div> 
+      <%= sub_field.to_s %>
+    </div>
+  <% end %>
+<% else %>
+  <%= field.to_s %>
+<% end %>

--- a/app/views/fields/serialized_field/_show.html.erb
+++ b/app/views/fields/serialized_field/_show.html.erb
@@ -1,0 +1,9 @@
+<% if field.array? %>
+  <% field.data.each do |sub_field| %>
+    <div> 
+      <%= sub_field.to_s %>
+    </div>
+  <% end %>
+<% else %>
+  <%= field.to_s %>
+<% end %>

--- a/app/views/super_admin/application/_navigation.html.erb
+++ b/app/views/super_admin/application/_navigation.html.erb
@@ -15,7 +15,8 @@ as defined by the routes in the `admin/` namespace
     accounts: 'ion ion-briefcase',
     users: 'ion ion-person-stalker',
     super_admins: 'ion ion-unlocked',
-    access_tokens: 'ion-key'
+    access_tokens: 'ion-key',
+    installation_configs: 'ion ion-settings'
   }
 %>
 
@@ -43,7 +44,7 @@ as defined by the routes in the `admin/` namespace
 
     <li class="navigation__link">
       <i class="ion ion ion-network"></i>
-      <%= link_to "Sidekiq", sidekiq_web_url %>
+      <%= link_to "Sidekiq", sidekiq_web_url, { target: "_blank" } %>
     </li>
   </ul>
   <ul class="logout">

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -1,26 +1,37 @@
-- name: LOGO_THUMBNAIL
-  value: '/brand-assets/logo_thumbnail.svg'
-- name: LOGO
-  value: '/brand-assets/logo.svg'
+# if you dont specify locked attribute, the default value will be true
+# which means the particular config will be locked
 - name: INSTALLATION_NAME
   value: 'Chatwoot'
+  locked: false
+- name: LOGO_THUMBNAIL
+  value: '/brand-assets/logo_thumbnail.svg'
+  locked: true
+- name: LOGO
+  value: '/brand-assets/logo.svg'
 - name: BRAND_URL
   value: 'https://www.chatwoot.com'
 - name: WIDGET_BRAND_URL
   value: 'https://www.chatwoot.com'
-- name: TERMS_URL
-  value: 'https://www.chatwoot.com/terms-of-service'
-- name: PRIVACY_URL
-  value: 'https://www.chatwoot.com/privacy-policy'
-- name: DISPLAY_MANIFEST
-  value: true
-- name: MAILER_INBOUND_EMAIL_DOMAIN
-  value:
-- name: MAILER_SUPPORT_EMAIL
-  value:
-- name: CREATE_NEW_ACCOUNT_FROM_DASHBOARD
-  value: false
 - name: BRAND_NAME
   value: 'Chatwoot'
+- name: TERMS_URL
+  value: 'https://www.chatwoot.com/terms-of-service'
+  locked: false
+- name: PRIVACY_URL
+  value: 'https://www.chatwoot.com/privacy-policy'
+  locked: false
+- name: DISPLAY_MANIFEST
+  value: true
+  locked: false
+- name: MAILER_INBOUND_EMAIL_DOMAIN
+  value:
+  locked: false
+- name: MAILER_SUPPORT_EMAIL
+  value:
+  locked: false
+- name: CREATE_NEW_ACCOUNT_FROM_DASHBOARD
+  value: false
+  locked: false
 - name: 'INSTALLATION_EVENTS_WEBHOOK_URL'
   value: 
+  locked: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,6 +219,7 @@ Rails.application.routes.draw do
       resources :users, only: [:index, :new, :create, :show, :edit, :update]
       resources :super_admins
       resources :access_tokens, only: [:index, :show]
+      resources :installation_configs, only: [:index, :new, :show, :edit, :update]
 
       # resources that doesn't appear in primary navigation in super admin
       resources :account_users, only: [:new, :create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,7 +219,7 @@ Rails.application.routes.draw do
       resources :users, only: [:index, :new, :create, :show, :edit, :update]
       resources :super_admins
       resources :access_tokens, only: [:index, :show]
-      resources :installation_configs, only: [:index, :new, :show, :edit, :update]
+      resources :installation_configs, only: [:index, :new, :create, :show, :edit, :update]
 
       # resources that doesn't appear in primary navigation in super admin
       resources :account_users, only: [:new, :create, :destroy]

--- a/db/migrate/20210113045116_add_locked_attribute_to_installation_config.rb
+++ b/db/migrate/20210113045116_add_locked_attribute_to_installation_config.rb
@@ -1,0 +1,26 @@
+class AddLockedAttributeToInstallationConfig < ActiveRecord::Migration[6.0]
+  def up
+    add_column :installation_configs, :locked, :boolean, default: true, null: false
+    purge_duplicates
+    add_index :installation_configs, :name, unique: true
+  end
+
+  def down
+    remove_column :installation_configs, :locked
+    remove_index :installation_configs, :name
+  end
+
+  def purge_duplicates
+    config_names = InstallationConfig.all.map(&:name).uniq
+
+    config_names.each do |name|
+      ids = InstallationConfig.where(name: name).pluck(&:id)
+      next if ids.size <= 1
+
+      # preserve the last config and destroy rest
+      ids.sort!
+      ids.pop
+      InstallationConfig.where(id: ids).destroy_all
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2021_01_09_211805) do
+ActiveRecord::Schema.define(version: 2021_01_13_045116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -293,7 +292,9 @@ ActiveRecord::Schema.define(version: 2021_01_09_211805) do
     t.jsonb "serialized_value", default: {}, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "locked", default: true, null: false
     t.index ["name", "created_at"], name: "index_installation_configs_on_name_and_created_at", unique: true
+    t.index ["name"], name: "index_installation_configs_on_name", unique: true
   end
 
   create_table "integrations_hooks", force: :cascade do |t|

--- a/spec/controllers/super_admin/installation_configs_controller_spec.rb
+++ b/spec/controllers/super_admin/installation_configs_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'Super Admin Installation Config API', type: :request do
+  let(:super_admin) { create(:super_admin) }
+
+  describe 'GET /super_admin/installation_configs/new' do
+    context 'when it is an unauthenticated super admin' do
+      it 'returns unauthorized' do
+        get '/super_admin/installation_configs/new'
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context 'when it is an authenticated super admin' do
+      let(:config) { create(:installation_config, { name: 'TESTCONFIG', value: 'TESTVALUE', locked: false }) }
+
+      before do
+        config
+      end
+
+      it 'shows the installation_configs create page' do
+        sign_in super_admin
+        get '/super_admin/installation_configs/new'
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'shows the installation_configs edit page' do
+        sign_in super_admin
+        editable_config = InstallationConfig.editable.first
+        get "/super_admin/installation_configs/#{editable_config.id}/edit"
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'shows the installation_configs list page' do
+        sign_in super_admin
+        get '/super_admin/installation_configs'
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(config.name)
+      end
+    end
+  end
+end

--- a/spec/factories/installation_config.rb
+++ b/spec/factories/installation_config.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :installation_config do
     name { 'xyc' }
     value { 1.5 }
+    locked { true }
   end
 end


### PR DESCRIPTION
## Description

* Added the ability for super admins to view, edit and update installation config values. Also, they can add new installation config values. The impact of editing and adding depends on which all installation config values are being used in the code.
* Known limitation now: Ability to edit hash values (for eg: feature flags) are disabled. This requires more work and will be taken up in a secondary set of changes.
* Minor UX improvement. Clicking on the Sidekiq option in the super admin sidebar will now open the Sidekiq dashboard in a new tab rather than in the same tab that you were using super admin.
* Added the scoping ability for installation configs to be selectively shown in the super admin console as some of them need not be exposed to the super admin and will be part of the Ops.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested in a local development environment.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
