### PR TITLE
fix: Labels cannot be added to conversations

### DIFF
--- a/app/controllers/api/v1/accounts/contacts/labels_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/labels_controller.rb
@@ -4,10 +4,10 @@ class Api::V1::Accounts::Contacts::LabelsController < Api::V1::Accounts::BaseCon
   private
 
   def model
-    @model ||= Current.account.contacts.find(params[:contact_id])
+    @model ||= Current.account.contacts.find(permitted_params[:contact_id])
   end
 
   def permitted_params
-    params.permit(:contact_id, :labels)
+    params.permit(:contact_id, labels: [])
   end
 end

--- a/app/controllers/api/v1/accounts/conversations/labels_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/labels_controller.rb
@@ -8,6 +8,6 @@ class Api::V1::Accounts::Conversations::LabelsController < Api::V1::Accounts::Co
   end
 
   def permitted_params
-    params.permit(:conversation_id, :labels)
+    params.permit(:conversation_id, labels: [])
   end
 end

--- a/spec/controllers/api/v1/accounts/contacts/labels_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/labels_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Contact Label API', type: :request do
     context 'when it is an unauthenticated user' do
       it 'returns unauthorized' do
         post api_v1_account_contact_labels_url(account_id: account.id, contact_id: contact.id),
-             params: { labels: 'label3,label4' },
+             params: { labels: %w[label3 label4] },
              as: :json
 
         expect(response).to have_http_status(:unauthorized)
@@ -54,7 +54,7 @@ RSpec.describe 'Contact Label API', type: :request do
 
       it 'creates labels for the contact' do
         post api_v1_account_contact_labels_url(account_id: account.id, contact_id: contact.id),
-             params: { labels: 'label3,label4' },
+             params: { labels: %w[label3 label4] },
              headers: agent.create_new_auth_token,
              as: :json
 

--- a/spec/controllers/api/v1/accounts/conversations/labels_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/labels_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Conversation Label API', type: :request do
     context 'when it is an unauthenticated user' do
       it 'returns unauthorized' do
         post api_v1_account_conversation_labels_url(account_id: account.id, conversation_id: conversation.display_id),
-             params: { labels: 'label3,label4' },
+             params: { labels: %w[label3 label4] },
              as: :json
 
         expect(response).to have_http_status(:unauthorized)
@@ -54,7 +54,7 @@ RSpec.describe 'Conversation Label API', type: :request do
 
       it 'creates labels for the conversation' do
         post api_v1_account_conversation_labels_url(account_id: account.id, conversation_id: conversation.display_id),
-             params: { labels: 'label3,label4' },
+             params: { labels: %w[label3 label4] },
              headers: agent.create_new_auth_token,
              as: :json
 


### PR DESCRIPTION
Labels were sent as an array rather than a string, so specs didn't cover this part. We were not able to add the labels to a conversation. 

This PR fixes the controller and the associated specs.