### PR TITLE
fix: Resolve name only if assignee exists during unassignment

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -231,7 +231,7 @@ class Conversation < ApplicationRecord
   def create_assignee_change(user_name)
     return unless user_name
 
-    params = { assignee_name: assignee.name, user_name: user_name }.compact
+    params = { assignee_name: assignee&.name, user_name: user_name }.compact
     key = assignee_id ? 'assigned' : 'removed'
     key = 'self_assigned' if self_assign? assignee_id
     content = I18n.t("conversations.activity.assignee.#{key}", **params)

--- a/spec/controllers/api/v1/accounts/conversations/assignments_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/assignments_controller_spec.rb
@@ -29,5 +29,25 @@ RSpec.describe 'Conversation Assignment API', type: :request do
         expect(conversation.reload.assignee).to eq(agent)
       end
     end
+
+    context 'when conversation already has an assignee' do
+      let(:agent) { create(:user, account: account, role: :agent) }
+
+      before do
+        conversation.update!(assignee: agent)
+      end
+
+      it 'unassigns a user from the conversation' do
+        params = { assignee_id: 0 }
+        post api_v1_account_conversation_assignments_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: params,
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.assignee).to eq(nil)
+        expect(conversation.messages.last.content).to eq("Conversation unassigned by #{agent.name}")
+      end
+    end
   end
 end


### PR DESCRIPTION
- Un-assignment was broken because the assignee name was not resolved during the activity message creation. This PR fixes that issue.