### PR TITLE
fix: Add correct thread message_id to the email message

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,8 @@ Metrics/ClassLength:
   Max: 125
   Exclude:
     - 'app/models/conversation.rb'
+    - 'app/mailers/conversation_reply_mailer.rb'
+    - 'app/models/message.rb'
 RSpec/ExampleLength:
   Max: 25
 Style/Documentation:

--- a/app/mailboxes/support_mailbox.rb
+++ b/app/mailboxes/support_mailbox.rb
@@ -47,6 +47,7 @@ class SupportMailbox < ApplicationMailbox
                                              contact_inbox_id: @contact_inbox.id,
                                              additional_attributes: {
                                                source: 'email',
+                                               mail_subject: @processed_mail.subject,
                                                initiated_at: {
                                                  timestamp: Time.now.utc
                                                }

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -66,12 +66,8 @@ class ConversationReplyMailer < ApplicationMailer
     @inbox = @conversation.inbox
   end
 
-  def email_inbox?
-    @inbox.inbox_type == 'Email'
-  end
-
   def should_use_conversation_email_address?
-    email_inbox? || inbound_email_enabled?
+    @inbox.inbox_type == 'Email' || inbound_email_enabled?
   end
 
   def conversation_already_viewed?

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -66,6 +66,14 @@ class ConversationReplyMailer < ApplicationMailer
     @inbox = @conversation.inbox
   end
 
+  def email_inbox?
+    @inbox.inbox_type == 'Email'
+  end
+
+  def should_use_conversation_email_address?
+    email_inbox? || inbound_email_enabled?
+  end
+
   def conversation_already_viewed?
     # whether contact already saw the message on widget
     return unless @conversation.contact_last_seen_at
@@ -83,12 +91,18 @@ class ConversationReplyMailer < ApplicationMailer
   end
 
   def mail_subject
+    return "Re: #{incoming_mail_subject}" if incoming_mail_subject
+
     subject_line = I18n.t('conversations.reply.email_subject')
     "[##{@conversation.display_id}] #{subject_line}"
   end
 
+  def incoming_mail_subject
+    @incoming_mail_subject ||= @conversation.additional_attributes['mail_subject']
+  end
+
   def reply_email
-    if inbound_email_enabled?
+    if should_use_conversation_email_address?
       "#{assignee_name} <reply+#{@conversation.uuid}@#{current_domain}>"
     else
       @inbox.email_address || @agent&.email
@@ -96,7 +110,7 @@ class ConversationReplyMailer < ApplicationMailer
   end
 
   def from_email_with_name
-    if inbound_email_enabled?
+    if should_use_conversation_email_address?
       "#{assignee_name} <#{account_support_email}>"
     else
       "#{assignee_name} <#{from_email_address}>"
@@ -114,7 +128,11 @@ class ConversationReplyMailer < ApplicationMailer
   end
 
   def in_reply_to_email
-    "<account/#{@account.id}/conversation/#{@conversation.uuid}@#{current_domain}>"
+    conversation_reply_email_id || "<account/#{@account.id}/conversation/#{@conversation.uuid}@#{current_domain}>"
+  end
+
+  def conversation_reply_email_id
+    "<#{@conversation.messages.incoming.last.content_attributes['email']['message_id']}>"
   end
 
   def inbound_email_enabled?

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -132,7 +132,13 @@ class ConversationReplyMailer < ApplicationMailer
   end
 
   def conversation_reply_email_id
-    "<#{@conversation.messages.incoming.last.content_attributes['email']['message_id']}>"
+    content_attributes = @conversation.messages.incoming.last&.content_attributes
+
+    if content_attributes && content_attributes['email'] && content_attributes['message_id']
+      "<#{@conversation.messages.incoming.last.content_attributes['email']['message_id']}>"
+    end
+
+    nil
   end
 
   def inbound_email_enabled?

--- a/app/models/channel/email.rb
+++ b/app/models/channel/email.rb
@@ -37,7 +37,7 @@ class Channel::Email < ApplicationRecord
   private
 
   def ensure_forward_to_address
-    # TODO : implement better logic here
-    self.forward_to_address ||= "#{SecureRandom.hex}@xyc.com"
+    email_domain = InstallationConfig.find_by(name: 'MAILER_INBOUND_EMAIL_DOMAIN')&.value
+    self.forward_to_address ||= "#{SecureRandom.hex}@#{email_domain}"
   end
 end

--- a/app/workers/conversation_reply_email_worker.rb
+++ b/app/workers/conversation_reply_email_worker.rb
@@ -7,7 +7,7 @@ class ConversationReplyEmailWorker
     @conversation = Conversation.find(conversation_id)
 
     # send the email
-    if @conversation.messages.incoming&.last&.content_type == 'incoming_email'
+    if @conversation.messages.incoming&.last&.content_type == 'incoming_email' || email_inbox?
       ConversationReplyMailer.reply_without_summary(@conversation, queued_time).deliver_later
     else
       ConversationReplyMailer.reply_with_summary(@conversation, queued_time).deliver_later
@@ -18,6 +18,10 @@ class ConversationReplyEmailWorker
   end
 
   private
+
+  def email_inbox?
+    @conversation.inbox&.inbox_type == 'Email'
+  end
 
   def conversation_mail_key
     format(::Redis::Alfred::CONVERSATION_MAILER_KEY, conversation_id: @conversation.id)


### PR DESCRIPTION
The intention is to allow public to beta test email channel
- Fixed thread issues with outgoing email, now it would select the last incoming email message_id
- Fixed outgoing message subject name, set it to `re: original message name`
- Send email in email channel without 2 minute delay
- Display generated email address in the UI