### PR TITLE
feat: Add "Enter to send" option on format mode

### DIFF
--- a/app/javascript/dashboard/assets/scss/widgets/_reply-box.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_reply-box.scss
@@ -18,7 +18,7 @@
       max-height: 14rem;
       overflow: auto;
       position: absolute;
-      width: 24rem;
+      width: 100%;
       z-index: 100;
 
       .active a {

--- a/app/javascript/dashboard/assets/scss/widgets/_reply-box.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_reply-box.scss
@@ -9,14 +9,13 @@
 
   .reply-box__top {
     .canned {
-      @include elegant-card;
-      background: $color-white;
-      border-bottom: $space-small solid $color-white;
-      border-top: $space-small solid $color-white;
+      background: var(--white);
+      border-bottom: var(--space-small) solid var(--white);
+      border-top: 1px solid var(--color-border);
       left: 0;
-
       max-height: 14rem;
       overflow: auto;
+      padding-top: var(--space-small);
       position: absolute;
       width: 100%;
       z-index: 100;

--- a/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
@@ -31,6 +31,17 @@
       </button>
     </div>
     <div class="right-wrap">
+      <div v-if="isFormatMode" class="enter-to-send--checkbox">
+        <input
+          :checked="enterToSendEnabled"
+          type="checkbox"
+          value="enterToSend"
+          @input="toggleEnterToSend"
+        />
+        <label for="enterToSend">
+          {{ $t('CONVERSATION.REPLYBOX.ENTER_TO_SEND') }}
+        </label>
+      </div>
       <button
         class="button nice primary button--send"
         :class="buttonClass"
@@ -95,6 +106,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    enterToSendEnabled: {
+      type: Boolean,
+      default: true,
+    },
   },
   computed: {
     isNote() {
@@ -118,6 +133,9 @@ export default {
   methods: {
     toggleFormatMode() {
       this.setFormatMode(!this.isFormatMode);
+    },
+    toggleEnterToSend() {
+      this.$emit('toggleEnterToSend', !this.enterToSendEnabled);
     },
   },
 };
@@ -173,8 +191,8 @@ export default {
 }
 
 .left-wrap {
-  display: flex;
   align-items: center;
+  display: flex;
 }
 
 .button--reply {
@@ -184,5 +202,22 @@ export default {
 .icon--font {
   color: var(--s-600);
   font-size: var(--font-size-default);
+}
+
+.right-wrap {
+  display: flex;
+
+  .enter-to-send--checkbox {
+    align-items: center;
+    display: flex;
+
+    input {
+      margin: 0;
+    }
+
+    label {
+      color: var(--s-500);
+    }
+  }
 }
 </style>

--- a/app/javascript/dashboard/components/widgets/conversation/CannedResponse.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/CannedResponse.vue
@@ -35,6 +35,13 @@ export default {
       cannedMessages: 'getCannedResponses',
     }),
   },
+  watch: {
+    cannedMessages(newCannedMessages) {
+      if (newCannedMessages.length < this.selectedIndex + 1) {
+        this.selectedIndex = 0;
+      }
+    },
+  },
   mounted() {
     document.addEventListener('keydown', this.keyListener);
   },

--- a/app/javascript/dashboard/components/widgets/conversation/CannedResponse.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/CannedResponse.vue
@@ -51,7 +51,7 @@ export default {
   methods: {
     getTopPadding() {
       if (this.cannedMessages.length <= 4) {
-        return -this.cannedMessages.length * 3.5;
+        return -(this.cannedMessages.length * 2.8 + 1.7);
       }
       return -14;
     },

--- a/app/javascript/dashboard/components/widgets/conversation/CannedResponse.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/CannedResponse.vue
@@ -75,7 +75,7 @@ export default {
       if (this.isEnter(e)) {
         this.onKeyenter(this.cannedMessages[this.selectedIndex].content);
       }
-      this.$el.scrollTop = 34 * this.selectedIndex;
+      this.$el.scrollTop = 28 * this.selectedIndex;
     },
     onHover(index) {
       this.selectedIndex = index;

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -44,7 +44,8 @@
       "TWEET": "Tweet",
       "TIP_FORMAT_ICON": "Show rich text editor",
       "TIP_EMOJI_ICON": "Show emoji selector",
-      "TIP_ATTACH_ICON": "Attach files"
+      "TIP_ATTACH_ICON": "Attach files",
+      "ENTER_TO_SEND": "Enter to send"
     },
     "VISIBLE_TO_AGENTS": "Private Note: Only visible to you and your team",
     "CHANGE_STATUS": "Conversation status changed",


### PR DESCRIPTION
- Add an option to toggle enter to send 
- Save enter to send in uiSettings
- Fix key down scroll height in canned responses.
- Allow canned responses on private notes.

<img width="522" alt="Screenshot 2021-01-19 at 2 40 04 PM" src="https://user-images.githubusercontent.com/2246121/105012534-41142200-5a64-11eb-8b49-296bc4a81820.png">

<img width="514" alt="Screenshot 2021-01-19 at 2 56 23 PM" src="https://user-images.githubusercontent.com/2246121/105014532-905b5200-5a66-11eb-90a2-a3c727f923a5.png">

