### PR TITLE
Add name error validation for account setting Profile name #1714

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/agents/AddAgent.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agents/AddAgent.vue
@@ -102,7 +102,7 @@ export default {
   validations: {
     agentName: {
       required,
-      minLength: minLength(4),
+      minLength: minLength(1),
     },
     agentEmail: {
       required,

--- a/app/javascript/dashboard/routes/dashboard/settings/agents/EditAgent.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agents/EditAgent.vue
@@ -112,7 +112,7 @@ export default {
   validations: {
     agentName: {
       required,
-      minLength: minLength(4),
+      minLength: minLength(1),
     },
     agentType: {
       required,

--- a/app/javascript/dashboard/routes/dashboard/settings/profile/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/profile/Index.vue
@@ -136,6 +136,7 @@ export default {
   validations: {
     name: {
       required,
+      minLength: minLength(1),
     },
     displayName: {},
     email: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,7 @@ class User < ApplicationRecord
   # validates_uniqueness_of :email, scope: :account_id
 
   validates :email, :name, presence: true
+  validates_length_of :name, minimum: 1
 
   has_many :account_users, dependent: :destroy
   has_many :accounts, through: :account_users

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe User do
   context 'validations' do
     it { is_expected.to validate_presence_of(:email) }
     it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_least(1) }
   end
 
   context 'associations' do


### PR DESCRIPTION
# Pull Request Template

## Description

Add name error validation for account settings Profile name. Have set minimum string length for the name as 4.
<img width="1788" alt="Screenshot 2021-02-01 at 11 24 55 PM" src="https://user-images.githubusercontent.com/6113982/106497943-b3651780-64e4-11eb-9555-a2ce5cd6ec85.png">


Fixes #1714

## Type of change

Bugfix (a non-breaking change that fixes an issue)

## How Has This Been Tested?

Setting the profile name in the account settings with a string value less than 4 throws an error as shown in the above image.

`bundle exec rspec spec/models/user_spec.rb`

