### PR TITLE
feat: Use audio tag instead of download file button

### DIFF
--- a/app/helpers/file_type_helper.rb
+++ b/app/helpers/file_type_helper.rb
@@ -9,6 +9,8 @@ module FileTypeHelper
       'image/bmp'
     ].include?(content_type)
 
+    return :audio if content_type.include?('audio/')
+
     :file
   end
 end

--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -21,8 +21,11 @@
               :url="attachment.data_url"
               :readable-time="readableTime"
             />
+            <audio v-else-if="attachment.file_type === 'audio'" controls>
+              <source :src="attachment.data_url" />
+            </audio>
             <bubble-file
-              v-if="attachment.file_type !== 'image'"
+              v-else
               :url="attachment.data_url"
               :readable-time="readableTime"
             />


### PR DESCRIPTION
![Screenshot_2021-02-11 Chatwoot(1)](https://user-images.githubusercontent.com/2246121/107568149-9c24d900-6c0c-11eb-934e-e186b8d5407c.png)


Looks a little bit ugly. Since this would get the product to be useful, I'm inclined to this approach.

@sojan-official @nithindavid Any thoughts?

Fixes #1458 