### PR TITLE
feat: Assign conversations to team

### DIFF
--- a/app/javascript/dashboard/api/inbox/conversation.js
+++ b/app/javascript/dashboard/api/inbox/conversation.js
@@ -31,11 +31,14 @@ class ConversationApi extends ApiClient {
     return axios.post(`${this.url}/${conversationId}/toggle_status`, {});
   }
 
-  assignAgent({ conversationId, agentId }) {
-    axios.post(
-      `${this.url}/${conversationId}/assignments?assignee_id=${agentId}`,
-      {}
-    );
+  setAssignee({ conversationId, agentId, teamId }) {
+    const params = {};
+    if (agentId) {
+      params.assignee_id = agentId;
+    } else if (teamId) {
+      params.team_id = teamId;
+    }
+    axios.post(`${this.url}/${conversationId}/assignments`, params);
   }
 
   markMessageRead({ id }) {

--- a/app/javascript/dashboard/api/specs/inbox/conversation.spec.js
+++ b/app/javascript/dashboard/api/specs/inbox/conversation.spec.js
@@ -10,7 +10,7 @@ describe('#ConversationAPI', () => {
     expect(conversationAPI).toHaveProperty('update');
     expect(conversationAPI).toHaveProperty('delete');
     expect(conversationAPI).toHaveProperty('toggleStatus');
-    expect(conversationAPI).toHaveProperty('assignAgent');
+    expect(conversationAPI).toHaveProperty('setAssignee');
     expect(conversationAPI).toHaveProperty('markMessageRead');
     expect(conversationAPI).toHaveProperty('toggleTyping');
     expect(conversationAPI).toHaveProperty('mute');

--- a/app/javascript/dashboard/components/layout/Sidebar.vue
+++ b/app/javascript/dashboard/components/layout/Sidebar.vue
@@ -179,6 +179,7 @@ export default {
     this.$store.dispatch('labels/get');
     this.$store.dispatch('inboxes/get');
     this.$store.dispatch('notifications/unReadCount');
+    this.$store.dispatch('teams/get');
     this.setChatwootUser();
   },
   methods: {

--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -103,11 +103,12 @@ const actions = {
     }
   },
 
-  assignAgent: async ({ commit }, { conversationId, agentId }) => {
+  setAssignee: async ({ commit }, { conversationId, agentId, teamId }) => {
     try {
-      const response = await ConversationApi.assignAgent({
+      const response = await ConversationApi.setAssignee({
         conversationId,
         agentId,
+        teamId,
       });
       commit(types.default.ASSIGN_AGENT, response.data);
     } catch (error) {


### PR DESCRIPTION
Fixes part of #866 

## Todo
- [ ] append assignee type on option value, since team and agent can have same id