### PR TITLE
Include website_token key in the inboxes response

### DIFF
--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -12,6 +12,7 @@ json.welcome_title resource.channel.try(:welcome_title)
 json.welcome_tagline resource.channel.try(:welcome_tagline)
 json.enable_auto_assignment resource.enable_auto_assignment
 json.web_widget_script resource.channel.try(:web_widget_script)
+json.website_token resource.channel.try(:website_token)
 json.forward_to_address resource.channel.try(:forward_to_address)
 json.phone_number resource.channel.try(:phone_number)
 json.selected_feature_flags resource.channel.try(:selected_feature_flags)


### PR DESCRIPTION
Many self-hosted instances require this key as a part of QA & maintenance. Since this key is not sensitive its better to send it as a part of the JSON response instead of having to use a regex to get it from the widget_script_tag

# Pull Request Template

## Description

Many self-hosted instances require this key as a part of QA & maintenance. Since this key is not sensitive its better to send it as a part of the JSON response instead of having to use a regex to get it from the widget_script_tag


Fixes #1764
https://github.com/chatwoot/chatwoot/issues/1764

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran the relevant tests.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
