### PR TITLE
Fix: Links inside private note is not visible

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -208,6 +208,9 @@ export default {
       max-width: 32rem;
       padding: var(--space-small) var(--space-normal);
     }
+    &.is-private.is-text > .message-text__wrap .link {
+      color: var(--w-700);
+    }
   }
 
   &.is-pending {


### PR DESCRIPTION
Fixes #1770 

**Fix**
Added CSS to Message.vue to fix the color issue. Changed to blue.


<img width="372" alt="Screenshot 2021-02-15 at 4 29 44 PM" src="https://user-images.githubusercontent.com/64252451/107938212-06da6980-6fab-11eb-8e36-4f8ccfae336f.png">
