### PR TITLE
Fix colors for attachments in private note

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -208,6 +208,17 @@ export default {
       max-width: 32rem;
       padding: var(--space-small) var(--space-normal);
     }
+    &.is-private .file.message-text__wrap {
+      .ion-document-text {
+        color: var(--w-400);
+      }
+      .text-block-title {
+        color: #3c4858;
+      }
+      .download.button {
+        color: var(--w-400);
+      }
+    }
   }
 
   &.is-pending {


### PR DESCRIPTION

Fixes #1567 

**Describe the FIx**

Fixes color for file name, file icon for attachments in private note.

<img width="372" alt="Screenshot 2021-02-15 at 5 02 08 PM" src="https://user-images.githubusercontent.com/64252451/107941803-46f01b00-6fb0-11eb-9fcd-f74653ba1eca.png">


