### PR TITLE
Fix warning on new inbox page

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/ChannelList.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/ChannelList.vue
@@ -7,7 +7,7 @@
     <div class="row channels">
       <channel-item
         v-for="channel in channelList"
-        :key="channel"
+        :key="channel.key"
         :channel="channel"
         :enabled-features="enabledFeatures"
         @channel-item-click="initChannelAuth"


### PR DESCRIPTION
- The key in `v-for` expects a string but mistakenly we are using an object there