### PR TITLE
Adding .foreman file so the PORT can be specified there

### DIFF
--- a/.foreman
+++ b/.foreman
@@ -1,0 +1,2 @@
+procfile: Procfile.dev
+port: 3000

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-backend: bin/rails s -p 3000
+backend: bin/rails s
 frontend: bin/webpack-dev-server
 worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:watch": "jest -w 1 --watch --no-cache",
     "test:coverage": "jest -w 1 --no-cache --collectCoverage",
     "webpacker-start": "webpack-dev-server -d --config webpack.dev.config.js --content-base public/ --progress --colors",
-    "start:dev": "foreman start -f ./Procfile.dev"
+    "start:dev": "foreman start"
   },
   "dependencies": {
     "@chatwoot/prosemirror-schema": "https://github.com/chatwoot/prosemirror-schema.git#7e8acadd10d7b932c0dc0bd0a18f804434f83517",


### PR DESCRIPTION
# Pull Request Template

## Description

Instead of specifying PORT manually for rails backend in `Procfile.dev` we can specify it in the `.foreman` file. We also default procfile to use `Procfile.dev` when running `foreman start`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually run locally.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
