### PR TITLE
fix: Upgrade browser gem to fix missing push config in Opera

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     bootsnap (1.4.8)
       msgpack (~> 1.0)
     brakeman (4.9.0)
-    browser (4.2.0)
+    browser (5.3.1)
     builder (3.2.4)
     bullet (6.1.0)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
Push settings were missing in Opera. `browser` gem wrongly identified Opera as safari. 

More context: https://github.com/fnando/browser/pull/483