### PR TITLE
Chore: Responsive fixes for common screen widths

### DIFF
--- a/app/javascript/dashboard/assets/scss/_foundation-settings.scss
+++ b/app/javascript/dashboard/assets/scss/_foundation-settings.scss
@@ -88,9 +88,9 @@ $print-transparent-backgrounds: true;
 $breakpoints: (small: 0,
   medium: 640px,
   large: 1024px,
-  xlarge: 1201px,
-  xxlarge: 1370px,
-  xxxlarge: 1536px,
+  xlarge: 1200px,
+  xxlarge: 1400px,
+  xxxlarge: 1600px,
 );
 $print-breakpoint: large;
 $breakpoint-classes: (small medium large);

--- a/app/javascript/dashboard/assets/scss/_foundation-settings.scss
+++ b/app/javascript/dashboard/assets/scss/_foundation-settings.scss
@@ -88,8 +88,10 @@ $print-transparent-backgrounds: true;
 $breakpoints: (small: 0,
   medium: 640px,
   large: 1024px,
-  xlarge: 1200px,
-  xxlarge: 1440px);
+  xlarge: 1201px,
+  xxlarge: 1370px,
+  xxxlarge: 1536px,
+);
 $print-breakpoint: large;
 $breakpoint-classes: (small medium large);
 

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -232,10 +232,13 @@ export default {
     width: 36rem;
   }
   @include breakpoint(xlarge up) {
-    width: 33rem;
+    width: 35rem;
   }
   @include breakpoint(xxlarge up) {
-    width: 42rem;
+    width: 38rem;
+  }
+  @include breakpoint(xxxlarge up) {
+    flex-basis: 46rem;
   }
 }
 </style>

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationBox.vue
@@ -87,23 +87,26 @@ export default {
 
 .conversation-sidebar-wrap {
   height: auto;
-  flex: 0 1;
+  flex: 0 0;
   overflow: hidden;
   overflow: auto;
   background: white;
-  flex-shrink: 0;
   flex-basis: 28rem;
 
   @include breakpoint(large up) {
-    flex-basis: 31em;
+    flex-basis: 30em;
   }
 
   @include breakpoint(xlarge up) {
-    flex-basis: 32em;
+    flex-basis: 31em;
   }
 
   @include breakpoint(xxlarge up) {
-    flex-basis: 36rem;
+    flex-basis: 33rem;
+  }
+
+  @include breakpoint(xxxlarge up) {
+    flex-basis: 40rem;
   }
 
   &::v-deep .contact--panel {


### PR DESCRIPTION
Fixes congestion because #1835 

Here's how it'll look on different screen sizes (title as pixels)
**1040**
![1040](https://user-images.githubusercontent.com/1277421/110077937-057fae00-7dad-11eb-9c24-960b85d7b581.png)

**1280**
![1280](https://user-images.githubusercontent.com/1277421/110077949-09abcb80-7dad-11eb-9e8d-3388b7786f67.png)

**1368**
![1368](https://user-images.githubusercontent.com/1277421/110077959-0adcf880-7dad-11eb-814d-98cf0eb3d69c.png)

**1440**
![1440](https://user-images.githubusercontent.com/1277421/110077962-0b758f00-7dad-11eb-847d-d54cf0095c4f.png)

**1740**
![1740](https://user-images.githubusercontent.com/1277421/110077965-0c0e2580-7dad-11eb-8438-12c95d108d49.png)
