### PR TITLE
Fix: apply alert conditions while document is hidden

### DIFF
--- a/app/javascript/shared/helpers/AudioNotificationHelper.js
+++ b/app/javascript/shared/helpers/AudioNotificationHelper.js
@@ -41,29 +41,26 @@ const shouldPlayAudio = data => {
     conversation_id: incomingConvId,
     sender_id: senderId,
     message_type: messageType,
+    private: isPrivate,
   } = data;
   const isFromCurrentUser = currentUserId === senderId;
 
   const playAudio =
-    currentConvId !== incomingConvId &&
-    !isFromCurrentUser &&
-    messageType === MESSAGE_TYPE.INCOMING;
-  return playAudio;
+    !isFromCurrentUser && (messageType === MESSAGE_TYPE.INCOMING || isPrivate);
+
+  if (document.hidden) return playAudio;
+  if (currentConvId !== incomingConvId) return playAudio;
+  return false;
 };
 
 export const newMessageNotification = data => {
   const {
     enable_audio_alerts: enableAudioAlerts = false,
   } = window.WOOT.$store.getters.getUISettings;
-  if (!enableAudioAlerts) return false;
 
-  if (document.hidden) {
+  const playAudio = shouldPlayAudio(data);
+
+  if (enableAudioAlerts && playAudio) {
     window.playAudioAlert();
-  } else {
-    const playAudio = shouldPlayAudio(data);
-    if (playAudio) {
-      window.playAudioAlert();
-    }
   }
-  return false;
 };

--- a/app/javascript/shared/helpers/AudioNotificationHelper.js
+++ b/app/javascript/shared/helpers/AudioNotificationHelper.js
@@ -34,31 +34,43 @@ export const getAlertAudio = async () => {
   }
 };
 
-const shouldPlayAudio = data => {
-  const { conversation_id: currentConvId } = window.WOOT.$route.params;
-  const currentUserId = window.WOOT.$store.getters.getCurrentUserID;
+export const shouldPlayAudio = (
+  message,
+  conversationId,
+  userId,
+  isDocHiddden
+) => {
   const {
     conversation_id: incomingConvId,
     sender_id: senderId,
     message_type: messageType,
     private: isPrivate,
-  } = data;
-  const isFromCurrentUser = currentUserId === senderId;
+  } = message;
+  const isFromCurrentUser = userId === senderId;
 
   const playAudio =
     !isFromCurrentUser && (messageType === MESSAGE_TYPE.INCOMING || isPrivate);
 
-  if (document.hidden) return playAudio;
-  if (currentConvId !== incomingConvId) return playAudio;
+  if (isDocHiddden) return playAudio;
+  if (conversationId !== incomingConvId) return playAudio;
   return false;
 };
 
 export const newMessageNotification = data => {
+  const { conversation_id: currentConvId } = window.WOOT.$route.params;
+  const currentUserId = window.WOOT.$store.getters.getCurrentUserID;
+  const isDocHiddden = document.hidden;
+
   const {
     enable_audio_alerts: enableAudioAlerts = false,
   } = window.WOOT.$store.getters.getUISettings;
 
-  const playAudio = shouldPlayAudio(data);
+  const playAudio = shouldPlayAudio(
+    data,
+    currentConvId,
+    currentUserId,
+    isDocHiddden
+  );
 
   if (enableAudioAlerts && playAudio) {
     window.playAudioAlert();

--- a/app/javascript/shared/helpers/specs/AudioNotificationHelper.spec.js
+++ b/app/javascript/shared/helpers/specs/AudioNotificationHelper.spec.js
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { shouldPlayAudio } from '../AudioNotificationHelper';
+
+describe('shouldPlayAudio', () => {
+  describe('Document active', () => {
+    it('Retuns true if incoming message', () => {
+      const message = {
+        conversation_id: 10,
+        sender_id: 5,
+        message_type: 0,
+        private: false,
+      };
+      const [conversationId, userId, isDocHiddden] = [1, 2, false];
+      const result = shouldPlayAudio(
+        message,
+        conversationId,
+        userId,
+        isDocHiddden
+      );
+      expect(result).toBe(true);
+    });
+    it('Retuns false if outgoing message', () => {
+      const message = {
+        conversation_id: 10,
+        sender_id: 5,
+        message_type: 1,
+        private: false,
+      };
+      const [conversationId, userId, isDocHiddden] = [1, 2, false];
+      const result = shouldPlayAudio(
+        message,
+        conversationId,
+        userId,
+        isDocHiddden
+      );
+      expect(result).toBe(false);
+    });
+
+    it('Retuns false if from Same sender', () => {
+      const message = {
+        conversation_id: 1,
+        sender_id: 2,
+        message_type: 0,
+        private: false,
+      };
+      const [conversationId, userId, isDocHiddden] = [1, 2, true];
+      const result = shouldPlayAudio(
+        message,
+        conversationId,
+        userId,
+        isDocHiddden
+      );
+      expect(result).toBe(false);
+    });
+    it('Retuns true if private message from another agent', () => {
+      const message = {
+        conversation_id: 1,
+        sender_id: 5,
+        message_type: 1,
+        private: true,
+      };
+      const [conversationId, userId, isDocHiddden] = [1, 2, true];
+      const result = shouldPlayAudio(
+        message,
+        conversationId,
+        userId,
+        isDocHiddden
+      );
+      expect(result).toBe(true);
+    });
+  });
+  describe('Document inactive', () => {
+    it('Retuns true if incoming message', () => {
+      const message = {
+        conversation_id: 1,
+        sender_id: 5,
+        message_type: 0,
+        private: false,
+      };
+      const [conversationId, userId, isDocHiddden] = [1, 2, true];
+      const result = shouldPlayAudio(
+        message,
+        conversationId,
+        userId,
+        isDocHiddden
+      );
+      expect(result).toBe(true);
+    });
+    it('Retuns false if outgoing message', () => {
+      const message = {
+        conversation_id: 1,
+        sender_id: 5,
+        message_type: 1,
+        private: false,
+      };
+      const [conversationId, userId, isDocHiddden] = [1, 2, true];
+      const result = shouldPlayAudio(
+        message,
+        conversationId,
+        userId,
+        isDocHiddden
+      );
+      expect(result).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
**Why**
- Notifications were playing while I was away from chatwoot tab, irrespective of the condition.
- Play for private notes from others 