### PR TITLE
Run chatwoot prepare and migrate as a part of docker image deploying …

### DIFF
--- a/docker/dockerfiles/web.Dockerfile
+++ b/docker/dockerfiles/web.Dockerfile
@@ -1,0 +1,5 @@
+FROM chatwoot/chatwoot:latest
+COPY docker/entrypoints/rails.sh docker/entrypoints/rails.sh
+RUN chmod +x docker/entrypoints/rails.sh
+ENTRYPOINT ["docker/entrypoints/rails.sh"]
+CMD bundle exec rails db:chatwoot_prepare ; bundle exec rails db:migrate ; bundle exec rails s -b 0.0.0.0 -p 3000

--- a/docker/dockerfiles/worker.Dockerfile
+++ b/docker/dockerfiles/worker.Dockerfile
@@ -1,0 +1,5 @@
+FROM chatwoot/chatwoot:latest
+COPY docker/entrypoints/rails.sh docker/entrypoints/rails.sh
+RUN chmod +x docker/entrypoints/rails.sh
+ENTRYPOINT ["docker/entrypoints/rails.sh"]
+CMD bundle exec rails db:chatwoot_prepare ; bundle exec rails db:migrate ; bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
# Pull Request Template

## Description

The Dockerfiles and especially the rails command to run the migration for a new and upgraded instance is not part of the official docker web or worker image file and this commit adds the file as well as the command to run that so docker deployment is simpler.

Fixes # (issue)
https://github.com/chatwoot/chatwoot/issues/1882

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
