### PR TITLE
Chore: Make prechat message minimum length to 1

### DIFF
--- a/app/javascript/widget/components/PreChat/Form.vue
+++ b/app/javascript/widget/components/PreChat/Form.vue
@@ -85,7 +85,7 @@ export default {
     const messageValidation = {
       message: {
         required,
-        minLength: minLength(10),
+        minLength: minLength(1),
       },
     };
     if (this.options.requireEmail) {


### PR DESCRIPTION
**Why**
Having the prechat form with minimum length set to 10 makes it difficult to start conversations for users.