### PR TITLE
Fix: Add check for id on update conversation

### DIFF
--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -48,7 +48,10 @@ class ActionCableConnector extends BaseActionCableConnector {
   };
 
   onAssigneeChanged = payload => {
-    this.app.$store.dispatch('updateConversation', payload);
+    const { id } = payload;
+    if (id) {
+      this.app.$store.dispatch('updateConversation', payload);
+    }
     this.fetchConversationStats();
   };
 


### PR DESCRIPTION
**Why**
When a new conversation is created, sometimes action cable event for `conversation.update` arrives before `created`. In this case the data in updated might be missing `id` attribute.