### PR TITLE
fix: Show inbox name only if more > 1 inbox present

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue
@@ -18,7 +18,7 @@
       size="40px"
     />
     <div class="conversation--details columns">
-      <span v-if="showInboxName" v-tooltip.bottom="inboxName" class="label">
+      <span v-if="showInboxName" class="label">
         <i :class="computedInboxClass" />
         {{ inboxName }}
       </span>
@@ -161,7 +161,11 @@ export default {
     },
 
     showInboxName() {
-      return !this.hideInboxName && this.isInboxNameVisible;
+      return (
+        !this.hideInboxName &&
+        this.isInboxNameVisible &&
+        this.inboxesList.length > 1
+      );
     },
     inboxName() {
       const stateInbox = this.chatInbox;


### PR DESCRIPTION
The name of the inbox needs to be shown in the conversation list only if there are more than 1 inbox present otherwise it is unnecessary repetition.

