### PR TITLE
chore: Handle Sentry Errors

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -16,11 +16,18 @@ class ApplicationMailer < ActionMailer::Base
     end
   end
 
+  rescue_from(*ExceptionList::SMTP_EXCEPTIONS, with: :handle_smtp_exceptions)
+
   def smtp_config_set_or_development?
     ENV.fetch('SMTP_ADDRESS', nil).present? || Rails.env.development?
   end
 
   private
+
+  def handle_smtp_exceptions(message)
+    Rails.logger.info 'Failed to send Email'
+    Rails.logger.info "Exception: #{message}"
+  end
 
   def send_mail_with_liquid(*args)
     mail(*args) do |format|

--- a/lib/exception_list.rb
+++ b/lib/exception_list.rb
@@ -1,5 +1,8 @@
 module ExceptionList
-  URI_EXCEPTIONS = [Errno::ETIMEDOUT, Errno::ECONNREFUSED, URI::InvalidURIError, Net::OpenTimeout, SocketError].freeze
+  URI_EXCEPTIONS = [Errno::ETIMEDOUT, Errno::ECONNREFUSED, URI::InvalidURIError, Net::OpenTimeout, SocketError, OpenURI::HTTPError].freeze
   REST_CLIENT_EXCEPTIONS = [RestClient::NotFound, RestClient::GatewayTimeout, RestClient::BadRequest,
-                            RestClient::MethodNotAllowed, RestClient::Forbidden].freeze
+                            RestClient::MethodNotAllowed, RestClient::Forbidden, RestClient::InternalServerError, RestClient::PayloadTooLarge].freeze
+  SMTP_EXCEPTIONS = [
+    Net::SMTPSyntaxError
+  ].freeze
 end


### PR DESCRIPTION
- If a contact contains an invalid email address, the sidekiq jobs for conversation continuity would error out. handling this exception gracefully. 