### PR TITLE
fix: Invalidate session if user cookie is absent

### DIFF
--- a/app/javascript/dashboard/api/auth.js
+++ b/app/javascript/dashboard/api/auth.js
@@ -61,7 +61,9 @@ export default {
   },
 
   isLoggedIn() {
-    return !!Cookies.getJSON('auth_data');
+    const hasAuthCookie = !!Cookies.getJSON('auth_data');
+    const hasUserCookie = !!Cookies.getJSON('user');
+    return hasAuthCookie && hasUserCookie;
   },
 
   isAdmin() {
@@ -79,7 +81,9 @@ export default {
   },
   getPubSubToken() {
     if (this.isLoggedIn()) {
-      return Cookies.getJSON('user').pubsub_token;
+      const user = Cookies.getJSON('user') || {};
+      const { pubsub_token: pubsubToken } = user;
+      return pubsubToken;
     }
     return null;
   },


### PR DESCRIPTION
**Why?**
Fixes the page freeze issue #2042

**What went wrong?**
The user cookie might get invalidated before auth cookie. But we are determining whether a user session only based on validity of auth cookie.

**Fix**
Added check for user cookie on login check