### PR TITLE
Fix: Twilio whatsapp attachment messages not working

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -148,7 +148,9 @@ class Message < ApplicationRecord
   end
 
   def send_reply
-    ::SendReplyJob.perform_later(id)
+    # FIXME: Giving it few seconds for the attachment to be uploaded to the service
+    # active storage attaches the file only after commit
+    attachments.blank? ? ::SendReplyJob.perform_later(id) : ::SendReplyJob.set(wait: 2.seconds).perform_later(id)
   end
 
   def reopen_conversation


### PR DESCRIPTION
We have issues reported on installations where attachment messages for WhatsApp weren't working at times. So here is a fix for the same.

## How to Test

1) Create a Twilio Inbox
2) Ensure attachments can be sent
