### PR TITLE
fix: Refresh user teams after creating a new team

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/teams/Create/AddAgents.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/teams/Create/AddAgents.vue
@@ -107,6 +107,7 @@ export default {
             teamId,
           },
         });
+        this.$store.dispatch('teams/get');
       } catch (error) {
         this.showAlert(error.message);
       }

--- a/app/javascript/dashboard/routes/dashboard/settings/teams/Edit/EditAgents.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/teams/Edit/EditAgents.vue
@@ -129,6 +129,7 @@ export default {
             teamId,
           },
         });
+        this.$store.dispatch('teams/get');
       } catch (error) {
         this.showAlert(error.message);
       }


### PR DESCRIPTION
Fixes #2068 