### PR TITLE
Fix: Fetch contactable inboxes on new conversion 

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/NewConversation.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/NewConversation.vue
@@ -32,6 +32,11 @@ export default {
       default: () => ({}),
     },
   },
+  watch: {
+    'contact.id'(id) {
+      this.$store.dispatch('contacts/fetchContactableInbox', id);
+    },
+  },
   mounted() {
     const { id } = this.contact;
     this.$store.dispatch('contacts/fetchContactableInbox', id);


### PR DESCRIPTION
**Why**
New conversation inboxes are not fetched for contacts.

