### PR TITLE
feat: Manage platform apps from Super Admin

### DIFF
--- a/app/controllers/super_admin/platform_apps_controller.rb
+++ b/app/controllers/super_admin/platform_apps_controller.rb
@@ -1,0 +1,44 @@
+class SuperAdmin::PlatformAppsController < SuperAdmin::ApplicationController
+  # Overwrite any of the RESTful controller actions to implement custom behavior
+  # For example, you may want to send an email after a foo is updated.
+  #
+  # def update
+  #   super
+  #   send_foo_updated_email(requested_resource)
+  # end
+
+  # Override this method to specify custom lookup behavior.
+  # This will be used to set the resource for the `show`, `edit`, and `update`
+  # actions.
+  #
+  # def find_resource(param)
+  #   Foo.find_by!(slug: param)
+  # end
+
+  # The result of this lookup will be available as `requested_resource`
+
+  # Override this if you have certain roles that require a subset
+  # this will be used to set the records shown on the `index` action.
+  #
+  # def scoped_resource
+  #   if current_user.super_admin?
+  #     resource_class
+  #   else
+  #     resource_class.with_less_stuff
+  #   end
+  # end
+
+  # Override `resource_params` if you want to transform the submitted
+  # data before it's persisted. For example, the following would turn all
+  # empty values into nil values. It uses other APIs such as `resource_class`
+  # and `dashboard`:
+  #
+  # def resource_params
+  #   params.require(resource_class.model_name.param_key).
+  #     permit(dashboard.permitted_attributes).
+  #     transform_values { |value| value == "" ? nil : value }
+  # end
+
+  # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+  # for more information
+end

--- a/app/dashboards/platform_app_dashboard.rb
+++ b/app/dashboards/platform_app_dashboard.rb
@@ -1,6 +1,6 @@
 require 'administrate/base_dashboard'
 
-class AccessTokenDashboard < Administrate::BaseDashboard
+class PlatformAppDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -8,9 +8,9 @@ class AccessTokenDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    owner: Field::Polymorphic,
+    access_token: Field::HasOne,
     id: Field::Number,
-    token: Field::String,
+    name: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -21,18 +21,15 @@ class AccessTokenDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-    owner
     id
-    token
-    created_at
+    name
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-    owner
     id
-    token
+    name
     created_at
     updated_at
   ].freeze
@@ -41,8 +38,7 @@ class AccessTokenDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    owner
-    token
+    name
   ].freeze
 
   # COLLECTION_FILTERS
@@ -55,16 +51,12 @@ class AccessTokenDashboard < Administrate::BaseDashboard
   #   COLLECTION_FILTERS = {
   #     open: ->(resources) { resources.where(open: true) }
   #   }.freeze
-  COLLECTION_FILTERS = {
-    user: ->(resources) { resources.where(owner_type: 'User') },
-    agent_bot: ->(resources) { resources.where(owner_type: 'AgentBot') },
-    platform_app: ->(resources) { resources.where(owner_type: 'PlatformApp') }
-  }.freeze
+  COLLECTION_FILTERS = {}.freeze
 
-  # Overwrite this method to customize how access tokens are displayed
+  # Overwrite this method to customize how platform apps are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(access_token)
-  #   "AccessToken ##{access_token.id}"
+  # def display_resource(platform_app)
+  #   "PlatformApp ##{platform_app.id}"
   # end
 end

--- a/app/views/super_admin/application/_navigation.html.erb
+++ b/app/views/super_admin/application/_navigation.html.erb
@@ -16,6 +16,7 @@ as defined by the routes in the `admin/` namespace
     users: 'ion ion-person-stalker',
     super_admins: 'ion ion-unlocked',
     access_tokens: 'ion-key',
+    platform_apps: 'ion ion-social-buffer',
     installation_configs: 'ion ion-settings'
   }
 %>
@@ -32,7 +33,7 @@ as defined by the routes in the `admin/` namespace
       <%= link_to "Dashboard", super_admin_root_url %>
     </li>
     <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
-      <% next if ["account_users", "agent_bots","dashboard", "devise/sessions"].include?  resource.resource %>
+      <% next if ["account_users", "agent_bots", "dashboard", "devise/sessions"].include?  resource.resource %>
       <li class="navigation__link navigation__link--<%= nav_link_state(resource) %>">
         <i class="<%= sidebar_icons[resource.resource.to_sym] %>"></i>
         <%= link_to(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -241,6 +241,7 @@ Rails.application.routes.draw do
       # resources that doesn't appear in primary navigation in super admin
       resources :account_users, only: [:new, :create, :destroy]
       resources :agent_bots, only: [:index, :new, :create, :show, :edit, :update]
+      resources :platform_apps, only: [:index, :new, :create, :show, :edit, :update]
     end
     authenticated :super_admin do
       mount Sidekiq::Web => '/monitoring/sidekiq'

--- a/spec/controllers/super_admin/platform_apps_controller_spec.rb
+++ b/spec/controllers/super_admin/platform_apps_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'Super Admin platform app API', type: :request do
+  let(:super_admin) { create(:super_admin) }
+
+  describe 'GET /super_admin/platform_apps' do
+    context 'when it is an unauthenticated super admin' do
+      it 'returns unauthorized' do
+        get '/super_admin/platform_apps'
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context 'when it is an authenticated super admin' do
+      let!(:platform_app) { create(:platform_app) }
+
+      it 'shows the list of users' do
+        sign_in super_admin
+        get '/super_admin/platform_apps'
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(platform_app.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION

# Pull Request Template

## Description

- ability to manage platform apps from super admin
- fixes #2021


## How to test? 

- create platform apps from the console, ref: https://github.com/chatwoot/chatwoot/wiki/Building-on-Top-of-Chatwoot:-Platform-APIs
- check and ensure access tokens URL in super admin is accessible
- try creating additional platform apps from super admin
