### PR TITLE
chore: Contact builder should Identify contacts based on phone number

### DIFF
--- a/app/builders/contact_builder.rb
+++ b/app/builders/contact_builder.rb
@@ -43,6 +43,8 @@ class ContactBuilder
 
     contact ||= account.contacts.find_by(email: contact_attributes[:email]) if contact_attributes[:email].present?
 
+    contact ||= account.contacts.find_by(phone_number: contact_attributes[:phone_number]) if contact_attributes[:phone_number].present?
+
     contact
   end
 

--- a/spec/builders/contact_builder_spec.rb
+++ b/spec/builders/contact_builder_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 describe ::ContactBuilder do
   let(:account) { create(:account) }
   let(:inbox) { create(:inbox, account: account) }
-  let(:contact) { create(:contact, account: account) }
+  let(:contact) { create(:contact, account: account, identifier: '123') }
   let(:existing_contact_inbox) { create(:contact_inbox, contact: contact, inbox: inbox) }
 
   describe '#perform' do
-    it 'doesnot create contact if it already exist' do
+    it 'doesnot create contact if it already exist with source id' do
       contact_inbox = described_class.new(
         source_id: existing_contact_inbox.source_id,
         inbox: inbox,
@@ -21,7 +21,7 @@ describe ::ContactBuilder do
       expect(contact_inbox.contact.id).to be(contact.id)
     end
 
-    it 'creates contact if contact doesnot exist' do
+    it 'creates contact if contact doesnot exist with source id' do
       contact_inbox = described_class.new(
         source_id: '123456',
         inbox: inbox,
@@ -35,6 +35,49 @@ describe ::ContactBuilder do
       expect(contact_inbox.contact.id).not_to eq(contact.id)
       expect(contact_inbox.contact.name).to eq('Contact')
       expect(contact_inbox.inbox_id).to eq(inbox.id)
+    end
+
+    it 'doesnot create contact if it already exist with identifier' do
+      contact_inbox = described_class.new(
+        source_id: '123456',
+        inbox: inbox,
+        contact_attributes: {
+          name: 'Contact',
+          identifier: contact.identifier,
+          phone_number: contact.phone_number,
+          email: 'testemail@example.com'
+        }
+      ).perform
+
+      expect(contact_inbox.contact.id).to be(contact.id)
+    end
+
+    it 'doesnot create contact if it already exist with email' do
+      contact_inbox = described_class.new(
+        source_id: '123456',
+        inbox: inbox,
+        contact_attributes: {
+          name: 'Contact',
+          phone_number: '+1234567890',
+          email: contact.email
+        }
+      ).perform
+
+      expect(contact_inbox.contact.id).to be(contact.id)
+    end
+
+    it 'doesnot create contact if it already exist with phone number' do
+      contact_inbox = described_class.new(
+        source_id: '123456',
+        inbox: inbox,
+        contact_attributes: {
+          name: 'Contact',
+          phone_number: contact.phone_number,
+          email: 'testemail@example.com'
+        }
+      ).perform
+
+      expect(contact_inbox.contact.id).to be(contact.id)
     end
   end
 end


### PR DESCRIPTION
- Contact builder should identify existing contacts based on phone number


QA
---

1) Create Twilio Inbox A in chatwoot and create a conversation through SMS/Whatsapp
2) Create Twilio account B in the same account and create a conversation with the same phone numbers
3) Conversations should be successfully created and grouped under same contact