### PR TITLE
fix: Rename migration for Campaigns

### DIFF
--- a/db/migrate/20210428135041_add_campaigns.rb
+++ b/db/migrate/20210428135041_add_campaigns.rb
@@ -1,4 +1,4 @@
-class Campaigns < ActiveRecord::Migration[6.0]
+class AddCampaigns < ActiveRecord::Migration[6.0]
   def change
     create_table :campaigns do |t|
       t.integer :display_id, null: false


### PR DESCRIPTION
Rename the migration to fix `previous definition of Campaigns was here` 