### PR TITLE
feat: Increase the width of the message bubble

### DIFF
--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
@@ -236,7 +236,7 @@
 
   .wrap {
     @include margin($zero $space-normal);
-    max-width: 69%;
+    max-width: 85%;
 
     .sender--name {
       font-size: $font-size-mini;


### PR DESCRIPTION
- Increase the width of the bubble to accommodate more content on smaller screens.

| Before | After |
| -- | -- |
| <img width="830" alt="Screenshot 2021-05-06 at 2 04 31 PM" src="https://user-images.githubusercontent.com/2246121/117267526-fd5af200-ae73-11eb-88d4-49556fd9e660.png"> | <img width="830" alt="Screenshot 2021-05-06 at 2 03 58 PM" src="https://user-images.githubusercontent.com/2246121/117267596-15327600-ae74-11eb-930e-f60a75f8a6bc.png"> | 

