### PR TITLE
fix: Upgrade chart.js to 2.9.4, fix grid-line option

### DIFF
--- a/app/javascript/dashboard/components/widgets/chart/BarChart.js
+++ b/app/javascript/dashboard/components/widgets/chart/BarChart.js
@@ -14,12 +14,12 @@ const chartOptions = {
   scales: {
     xAxes: [
       {
-        barPercentage: 1.26,
+        barPercentage: 1.1,
         ticks: {
           fontFamily,
         },
         gridLines: {
-          display: false,
+          drawOnChartArea: false,
         },
       },
     ],
@@ -30,7 +30,7 @@ const chartOptions = {
           beginAtZero: true,
         },
         gridLines: {
-          display: false,
+          drawOnChartArea: false,
         },
       },
     ],

--- a/app/javascript/dashboard/i18n/locale/en/report.json
+++ b/app/javascript/dashboard/i18n/locale/en/report.json
@@ -38,6 +38,18 @@
       {
         "id": 1,
         "name": "Last 30 days"
+      },
+      {
+        "id": 2,
+        "name": "Last 3 months"
+      },
+      {
+        "id": 3,
+        "name": "Last 6 months"
+      },
+      {
+        "id": 4,
+        "name": "Last year"
       }
     ]
   }

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/Index.vue
@@ -83,7 +83,14 @@ export default {
       return getUnixTime(startOfDay(new Date()));
     },
     from() {
-      const diff = this.currentDateRangeSelection.id ? 29 : 6;
+      const dateRange = {
+        0: 6,
+        1: 29,
+        2: 89,
+        3: 179,
+        4: 364,
+      };
+      const diff = dateRange[this.currentDateRangeSelection.id];
       const fromDate = subDays(new Date(), diff);
       return getUnixTime(startOfDay(fromDate));
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-vue-jsx": "^3.7.0",
     "bourbon": "^6.0.0",
-    "chart.js": "~2.5.0",
+    "chart.js": "~2.9.4",
     "copy-text-to-clipboard": "2.2.0",
     "core-js": "3.11.0",
     "country-code-emoji": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4372,13 +4372,13 @@ charenc@0.0.2:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
-chart.js@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.5.0.tgz#fe6e751a893769f56e72bee5ad91207e1c592957"
-  integrity sha1-/m51Gok3afVucr7lrZEgfhxZKVc=
+chart.js@~2.9.4:
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.9.4.tgz#0827f9563faffb2dc5c06562f8eb10337d5b9684"
+  integrity sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==
   dependencies:
-    chartjs-color "^2.0.0"
-    moment "^2.10.6"
+    chartjs-color "^2.1.0"
+    moment "^2.10.2"
 
 chartjs-color-string@^0.6.0:
   version "0.6.0"
@@ -4387,7 +4387,7 @@ chartjs-color-string@^0.6.0:
   dependencies:
     color-name "^1.0.0"
 
-chartjs-color@^2.0.0:
+chartjs-color@^2.1.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.4.1.tgz#6118bba202fe1ea79dd7f7c0f9da93467296c3b0"
   integrity sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==
@@ -10040,7 +10040,7 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.10.2, moment@^2.10.6, moment@^2.27.0:
+moment@^2.10.2, moment@^2.27.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
- Upgrade chart.js to 2.9.4 to fix CVE-2020-7746
- Add more options to the report selector
- Set drawOnChartArea to false, instead of display: false.