### PR TITLE
fix: Slack integration redirect url missing client ID

### DIFF
--- a/app/views/api/v1/models/_app.json.jbuilder
+++ b/app/views/api/v1/models/_app.json.jbuilder
@@ -2,6 +2,7 @@ json.call(resource.params, *resource.params.keys)
 json.name resource.name
 json.description resource.description
 json.enabled resource.enabled?(@current_account)
+json.action resource.action
 json.button resource.action
 json.hooks do
   json.array! @current_account.hooks.where(app_id: resource.id) do |hook|

--- a/spec/controllers/api/v1/accounts/integrations/apps_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/apps_controller_spec.rb
@@ -25,6 +25,21 @@ RSpec.describe 'Integration Apps API', type: :request do
         expect(apps['id']).to eql(first_app.id)
         expect(apps['name']).to eql(first_app.name)
       end
+
+      it 'returns slack app with appropriate redirect url when configured' do 
+        ENV['SLACK_CLIENT_ID'] = 'client_id'
+        ENV['SLACK_CLIENT_SECRET'] = 'client_secret'
+        get api_v1_account_integrations_apps_url(account),
+            headers: agent.create_new_auth_token,
+            as: :json
+        
+        expect(response).to have_http_status(:success)
+        apps = JSON.parse(response.body)['payload']
+        slack_app = apps.find { |app| app["id"] == 'slack' }
+        expect(slack_app['action']).to include('client_id=client_id')
+        ENV['SLACK_CLIENT_ID'] = nil
+        ENV['SLACK_CLIENT_SECRET'] = nil
+      end
     end
   end
 

--- a/spec/controllers/api/v1/accounts/integrations/apps_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/apps_controller_spec.rb
@@ -26,16 +26,16 @@ RSpec.describe 'Integration Apps API', type: :request do
         expect(apps['name']).to eql(first_app.name)
       end
 
-      it 'returns slack app with appropriate redirect url when configured' do 
+      it 'returns slack app with appropriate redirect url when configured' do
         ENV['SLACK_CLIENT_ID'] = 'client_id'
         ENV['SLACK_CLIENT_SECRET'] = 'client_secret'
         get api_v1_account_integrations_apps_url(account),
             headers: agent.create_new_auth_token,
             as: :json
-        
+
         expect(response).to have_http_status(:success)
         apps = JSON.parse(response.body)['payload']
-        slack_app = apps.find { |app| app["id"] == 'slack' }
+        slack_app = apps.find { |app| app['id'] == 'slack' }
         expect(slack_app['action']).to include('client_id=client_id')
         ENV['SLACK_CLIENT_ID'] = nil
         ENV['SLACK_CLIENT_SECRET'] = nil


### PR DESCRIPTION
Fixes: #2304