### PR TITLE
fix: Fixes email overflow issue in conversation.

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -339,5 +339,6 @@ export default {
 .view-box.fill-height {
   height: auto;
   flex-grow: 1;
+  min-width: 0;
 }
 </style>


### PR DESCRIPTION
**Why**
Conversations with emails would push the right sidebar. Thereby cutting a part of the info on the sidebar.


<img width="719" alt="Screenshot 2021-05-25 at 12 33 48 PM" src="https://user-images.githubusercontent.com/1277421/119453831-7784e500-bd55-11eb-82f0-3aa8c43a3822.png">
