### PR TITLE
chore: Add select field example to woot seeder

### DIFF
--- a/lib/woot_message_seeder.rb
+++ b/lib/woot_message_seeder.rb
@@ -77,8 +77,10 @@ module WootMessageSeeder
       content_attributes: {
         "items": [
           { "name": 'email', "placeholder": 'Please enter your email', "type": 'email', "label": 'Email' },
-          { "name": 'text_aread', "placeholder": 'Please enter text', "type": 'text_area', "label": 'Large Text' },
-          { "name": 'text', "placeholder": 'Please enter text', "type": 'text', "label": 'text', "default": 'defaut value' }
+          { "name": 'text_area', "placeholder": 'Please enter text', "type": 'text_area', "label": 'Large Text' },
+          { "name": 'text', "placeholder": 'Please enter text', "type": 'text', "label": 'text', "default": 'defaut value' },
+          {"name": 'select',"label": 'Select Option', "type": 'select', "options": [{ "label": '🌯 Burito', "value": 'Burito' },
+          { "label": '🍝 Pasta', "value": 'Pasta' }]  }
         ]
       }
     )

--- a/lib/woot_message_seeder.rb
+++ b/lib/woot_message_seeder.rb
@@ -79,8 +79,8 @@ module WootMessageSeeder
           { "name": 'email', "placeholder": 'Please enter your email', "type": 'email', "label": 'Email' },
           { "name": 'text_area', "placeholder": 'Please enter text', "type": 'text_area', "label": 'Large Text' },
           { "name": 'text', "placeholder": 'Please enter text', "type": 'text', "label": 'text', "default": 'defaut value' },
-          {"name": 'select',"label": 'Select Option', "type": 'select', "options": [{ "label": '🌯 Burito', "value": 'Burito' },
-          { "label": '🍝 Pasta', "value": 'Pasta' }]  }
+          { "name": 'select', "label": 'Select Option', "type": 'select', "options": [{ "label": '🌯 Burito', "value": 'Burito' },
+                                                                                      { "label": '🍝 Pasta', "value": 'Pasta' }] }
         ]
       }
     )


### PR DESCRIPTION
- add an example for select inputs in chat bot form message

fixes: #2076

