### PR TITLE
chore: ability to run Chatwoot as API only server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,6 +143,11 @@ USE_INBOX_AVATAR_FOR_BOT=true
 # maxmindb api key to use geoip2 service
 # IP_LOOKUP_API_KEY=
 
+
+## Running chatwoot as an API only server
+## setting this value to true will disable the frontend dashboard endpoints
+# CW_API_ONLY_SERVER=false
+
 ## Development Only Config
 # if you want to use letter_opener for local emails
 # LETTER_OPENER=true

--- a/Gemfile
+++ b/Gemfile
@@ -132,8 +132,6 @@ group :test do
 end
 
 group :development, :test do
-  # locking until https://github.com/codeclimate/test-reporter/issues/418 is resolved
-  gem 'action-cable-testing'
   gem 'bundle-audit', require: false
   gem 'byebug', platform: :mri
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,8 +16,6 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    action-cable-testing (0.6.1)
-      actioncable (>= 5.0)
     actioncable (6.0.3.7)
       actionpack (= 6.0.3.7)
       nio4r (~> 2.0)
@@ -613,7 +611,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  action-cable-testing
   activerecord-import
   acts-as-taggable-on
   administrate

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,4 +76,13 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.rails_logger = true
   end
+
+  # ref: https://github.com/cyu/rack-cors
+  config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins '*'
+      resource '/packs/*', headers: :any, methods: [:get, :options]
+      resource '*', headers: :any, methods: :any, expose: ['access-token', 'client', 'uid', 'expiry']
+    end
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -110,10 +110,14 @@ Rails.application.configure do
 
   # font cors issue with CDN
   # Ref: https://stackoverflow.com/questions/56960709/rails-font-cors-policy
+  # ref: https://github.com/cyu/rack-cors
   config.middleware.insert_before 0, Rack::Cors do
     allow do
       origins '*'
       resource '/packs/*', headers: :any, methods: [:get, :options]
+      if ActiveModel::Type::Boolean.new.cast(ENV.fetch('CW_API_ONLY_SERVER', false))
+        resource '*', headers: :any, methods: :any, expose: ['access-token', 'client', 'uid', 'expiry']
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,14 +8,19 @@ Rails.application.routes.draw do
     token_validations: 'devise_overrides/token_validations'
   }, via: [:get, :post]
 
-  root to: 'dashboard#index'
+  ## renders the frontend paths only if its not an api only server
+  if ActiveModel::Type::Boolean.new.cast(ENV.fetch('CW_API_ONLY_SERVER', false))
+    root to: 'api#index'
+  else
+    root to: 'dashboard#index'
 
-  get '/app', to: 'dashboard#index'
-  get '/app/*params', to: 'dashboard#index'
-  get '/app/accounts/:account_id/settings/inboxes/new/twitter', to: 'dashboard#index', as: 'app_new_twitter_inbox'
-  get '/app/accounts/:account_id/settings/inboxes/new/:inbox_id/agents', to: 'dashboard#index', as: 'app_twitter_inbox_agents'
+    get '/app', to: 'dashboard#index'
+    get '/app/*params', to: 'dashboard#index'
+    get '/app/accounts/:account_id/settings/inboxes/new/twitter', to: 'dashboard#index', as: 'app_new_twitter_inbox'
+    get '/app/accounts/:account_id/settings/inboxes/new/:inbox_id/agents', to: 'dashboard#index', as: 'app_twitter_inbox_agents'
 
-  resource :widget, only: [:show]
+    resource :widget, only: [:show]
+  end
 
   get '/api', to: 'api#index'
   namespace :api, defaults: { format: 'json' } do

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -17,4 +17,18 @@ describe '/app/login', type: :request do
       ENV['DEFAULT_LOCALE'] = 'en'
     end
   end
+
+  # Routes are loaded once on app start
+  # hence Rails.application.reload_routes! is used in this spec
+  # ref : https://stackoverflow.com/a/63584877/939299
+  context 'with CW_API_ONLY_SERVER true' do
+    it 'returns 404' do
+      ENV['CW_API_ONLY_SERVER'] = 'true'
+      Rails.application.reload_routes!
+      get '/app/login'
+      expect(response).to have_http_status(:not_found)
+      ENV['CW_API_ONLY_SERVER'] = nil
+      Rails.application.reload_routes!
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,6 +66,7 @@ RSpec.configure do |config|
   config.include SlackStubs
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include ActionCable::TestHelper
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
# Pull Request Template

## Description


- ability to run Chatwoot as an API only server
- removes action cable testing gem since it is merged to rails 6