### PR TITLE
fix: Disallow unread/campaign view if widget is active

### DIFF
--- a/app/javascript/widget/views/Router.vue
+++ b/app/javascript/widget/views/Router.vue
@@ -15,6 +15,7 @@
       :show-popout-button="showPopoutButton"
     />
     <unread
+      v-else
       :show-unread-view="showUnreadView"
       :has-fetched="hasFetched"
       :unread-message-count="unreadMessageCount"


### PR DESCRIPTION
Fixes #2430 
