### PR TITLE
Feat/conversation filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,3 @@ Thanks goes to all these [wonderful people](https://www.chatwoot.com/docs/contri
 
 
 *Chatwoot* &copy; 2017-2021, Chatwoot Inc - Released under the MIT License.
-
-CWFORK TEST

--- a/README.md
+++ b/README.md
@@ -100,3 +100,5 @@ Thanks goes to all these [wonderful people](https://www.chatwoot.com/docs/contri
 
 
 *Chatwoot* &copy; 2017-2021, Chatwoot Inc - Released under the MIT License.
+
+CWFORK TEST

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -99,7 +99,7 @@ class ConversationFinder
   end
 
   def filter_by_custom_attributes 
-    @conversations = conversations.joins(:contact).where("custom_attributes->>'recordingSessionUUID' :sessionUUID", sessionUUID: params[:sessionUUID])
+    @conversations = conversations.joins(:contact).where("custom_attributes->>'recordingSessionUUID' = :sessionUUID", sessionUUID: params[:sessionUUID])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -99,7 +99,7 @@ class ConversationFinder
   end
 
   def filter_by_additional_attributes
-    @conversations = @conversations.where(additional_attributes.sessionUUID: params[:sessionUUID])
+    @conversations = @conversations.where(additional_attributes: params[:sessionUUID])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -30,7 +30,7 @@ class ConversationFinder
     filter_by_team if @team
     filter_by_labels if params[:labels]
     filter_by_query if params[:q]
-    filter_by_additional_attributes if params[:additional_attributes]
+    filter_by_additional_attributes if params[:sessionUUID]
 
     mine_count, unassigned_count, all_count = set_count_for_all_conversations
 
@@ -99,7 +99,7 @@ class ConversationFinder
   end
 
   def filter_by_additional_attributes
-    @conversations = @conversations.where(additional_attributes: params[:additional_attributes])
+    @conversations = @conversations.where(additional_attributes.sessionUUID: params[:sessionUUID])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -98,7 +98,7 @@ class ConversationFinder
     @conversations = @conversations.tagged_with(params[:labels], any: true)
   end
 
-  def filter_by_custom_attributes
+  def filter_by_custom_attributes 
     @conversations = @conversations.where(meta.sender.custom_attributes.sessionUUID: params[:sessionUUID])
   end
 

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -99,7 +99,7 @@ class ConversationFinder
   end
 
   def filter_by_custom_attributes 
-    @conversations = @conversations.where(meta.sender.custom_attributes.sessionUUID: params[:sessionUUID])
+    @conversations = @conversations.where('meta.sender.custom_attributes ILIKE :sessionUUID', sessionUUID: params[:sessionUUID])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -91,7 +91,7 @@ class ConversationFinder
   end
 
   def filter_by_team
-    @conversations = @conversations.where(team: @team)
+    @conversations = @conversations.where(team: @team) 
   end
 
   def filter_by_labels

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -99,7 +99,7 @@ class ConversationFinder
   end
 
   def filter_by_custom_attributes 
-    @conversations = @conversations.where('meta.sender.custom_attributes ILIKE :sessionUUID', sessionUUID: params[:sessionUUID])
+    @conversations = current_account.conversations.where('meta.sender.custom_attributes ILIKE :sessionUUID', sessionUUID: params[:sessionUUID])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -99,7 +99,7 @@ class ConversationFinder
   end
 
   def filter_by_custom_attributes 
-    @conversations = conversations.joins(:meta).joins(:sender).where('meta.sender ILIKE :sessionUUID', sessionUUID: params[:sessionUUID])
+    @conversations = conversations.joins(:meta).where('meta.sender ILIKE :sessionUUID', sessionUUID: params[:sessionUUID])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -99,7 +99,7 @@ class ConversationFinder
   end
 
   def filter_by_custom_attributes 
-    @conversations = current_account.conversations.where('messages.content ILIKE :sessionUUID', sessionUUID: params[:sessionUUID])
+    @conversations = conversations.joins(:meta).joins(:sender).where('meta.sender ILIKE :sessionUUID', sessionUUID: params[:sessionUUID])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -30,7 +30,7 @@ class ConversationFinder
     filter_by_team if @team
     filter_by_labels if params[:labels]
     filter_by_query if params[:q]
-    filter_by_additional_attributes if params[:sessionUUID]
+    filter_by_custom_attributes if params[:sessionUUID]
 
     mine_count, unassigned_count, all_count = set_count_for_all_conversations
 
@@ -98,8 +98,8 @@ class ConversationFinder
     @conversations = @conversations.tagged_with(params[:labels], any: true)
   end
 
-  def filter_by_additional_attributes
-    @conversations = @conversations.where(additional_attributes: params[:sessionUUID])
+  def filter_by_custom_attributes
+    @conversations = @conversations.where(custom_attributes: params[:sessionUUID])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -99,7 +99,7 @@ class ConversationFinder
   end
 
   def filter_by_custom_attributes 
-    @conversations = conversations.joins(:contact).where("custom_attributes->>'recordingSessionUUID' = :sessionUUID", sessionUUID: params[:sessionUUID])
+    @conversations = conversations.joins(:contact).where("custom_attributes->>'recordingSessionUUID' = ?", params[:sessionUUID])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -30,7 +30,7 @@ class ConversationFinder
     filter_by_team if @team
     filter_by_labels if params[:labels]
     filter_by_query if params[:q]
-    filter_by_custom_attributes if params[:sessionUUID]
+    filter_by_custom_attributes if params[:customKey] && params[:customValue]
 
     mine_count, unassigned_count, all_count = set_count_for_all_conversations
 
@@ -99,7 +99,7 @@ class ConversationFinder
   end
 
   def filter_by_custom_attributes 
-    @conversations = conversations.joins(:contact).where("custom_attributes->>'recordingSessionUUID' = ?", params[:sessionUUID])
+    @conversations = conversations.joins(:contact).where("custom_attributes->>'#{params[:customKey]}' = ?", params[:customValue])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -30,6 +30,7 @@ class ConversationFinder
     filter_by_team if @team
     filter_by_labels if params[:labels]
     filter_by_query if params[:q]
+    filter_by_additional_attributes if params[:additional_attributes]
 
     mine_count, unassigned_count, all_count = set_count_for_all_conversations
 
@@ -95,6 +96,10 @@ class ConversationFinder
 
   def filter_by_labels
     @conversations = @conversations.tagged_with(params[:labels], any: true)
+  end
+
+  def filter_by_additional_attributes
+    @conversations = @conversations.where(additional_attributes: params[:additional_attributes])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -99,7 +99,7 @@ class ConversationFinder
   end
 
   def filter_by_custom_attributes
-    @conversations = @conversations.where(custom_attributes: params[:sessionUUID])
+    @conversations = @conversations.where(meta.sender.custom_attributes.sessionUUID: params[:sessionUUID])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -99,7 +99,7 @@ class ConversationFinder
   end
 
   def filter_by_custom_attributes 
-    @conversations = conversations.joins(:meta).where('meta.sender ILIKE :sessionUUID', sessionUUID: params[:sessionUUID])
+    @conversations = conversations.joins(:contact).where("custom_attributes->>'recordingSessionUUID' :sessionUUID", sessionUUID: params[:sessionUUID])
   end
 
   def set_count_for_all_conversations

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -99,7 +99,7 @@ class ConversationFinder
   end
 
   def filter_by_custom_attributes 
-    @conversations = current_account.conversations.where('meta.sender.custom_attributes ILIKE :sessionUUID', sessionUUID: params[:sessionUUID])
+    @conversations = current_account.conversations.where('messages.content ILIKE :sessionUUID', sessionUUID: params[:sessionUUID])
   end
 
   def set_count_for_all_conversations

--- a/app/views/layouts/vueapp.html.erb
+++ b/app/views/layouts/vueapp.html.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>
-      <%= @global_config['INSTALLATION_NAME'] %> (test)
+      <%= @global_config['INSTALLATION_NAME'] %>
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
     <% if @global_config['DISPLAY_MANIFEST'] %>

--- a/app/views/layouts/vueapp.html.erb
+++ b/app/views/layouts/vueapp.html.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>
-      <%= @global_config['INSTALLATION_NAME'] %>
+      <%= @global_config['INSTALLATION_NAME'] %> (test)
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
     <% if @global_config['DISPLAY_MANIFEST'] %>


### PR DESCRIPTION
Add filtering for custom_attributes in conversation finder

This adds the ability to search for matches in custom_attributes in order to find matching conversation(s) for processing.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

This was tested via Postman to produce filtered results by custom attributes.
In order to use this feature, you have to add customKey and customValue to your GET for conversations:

/api/v1/accounts/1/conversations?customKey=<yourCustomAttributeKey>&customValue=<yourCustomAttributeValue>

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
