### PR TITLE
fix: Adds condition to handle base and mergee contact being same

### DIFF
--- a/app/actions/contact_merge_action.rb
+++ b/app/actions/contact_merge_action.rb
@@ -2,6 +2,10 @@ class ContactMergeAction
   pattr_initialize [:account!, :base_contact!, :mergee_contact!]
 
   def perform
+    # This case happens when an agent updates a contact email in dashboard,
+    # while the contact also update his email via email collect box
+    return if base_contact.id == mergee_contact.id
+
     ActiveRecord::Base.transaction do
       validate_contacts
       merge_conversations

--- a/app/actions/contact_merge_action.rb
+++ b/app/actions/contact_merge_action.rb
@@ -4,7 +4,7 @@ class ContactMergeAction
   def perform
     # This case happens when an agent updates a contact email in dashboard,
     # while the contact also update his email via email collect box
-    return if base_contact.id == mergee_contact.id
+    return @base_contact if base_contact.id == mergee_contact.id
 
     ActiveRecord::Base.transaction do
       validate_contacts

--- a/spec/actions/contact_merge_action_spec.rb
+++ b/spec/actions/contact_merge_action_spec.rb
@@ -19,6 +19,14 @@ describe ::ContactMergeAction do
       expect { mergee_contact.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
+    context 'when base contact and merge contact are same' do
+      it 'does not delete contact' do
+        mergee_contact = base_contact
+        contact_merge
+        expect { mergee_contact.reload }.not_to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
     context 'when mergee contact has conversations' do
       it 'moves the conversations to base contact' do
         contact_merge


### PR DESCRIPTION
When an agent updates a contact email in the dashboard, while the contact also update his email via the email collect box,
Merge action receives the same base and mergee contacts which could cause data corruption.

