### PR TITLE
fix: rvm gpg key issue

### DIFF
--- a/deployment/setup_18.04.sh
+++ b/deployment/setup_18.04.sh
@@ -22,7 +22,7 @@ apt install -y \
 adduser --disabled-login --gecos "" chatwoot
 
 sudo -i -u chatwoot bash << EOF
-gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+gpg --keyserver hkp://keyserver.ubuntu.com  --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 curl -sSL https://get.rvm.io | bash -s stable
 EOF
 

--- a/deployment/setup_20.04.sh
+++ b/deployment/setup_20.04.sh
@@ -22,8 +22,8 @@ apt install -y \
 
 adduser --disabled-login --gecos "" chatwoot
 
-gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 curl -sSL https://get.rvm.io | bash -s stable
 addgroup chatwoot rvm
 


### PR DESCRIPTION
# Pull Request Template

## Description

Context:
`sks-keyserver.net` `gpg` pool is now deprecated due to GDPR issues and is no longer reliable. Switching to use ubuntu keyserver for the time being as this is the only server returning `rvm` maintainers `gpg` keys at the moment.

Quoting [sks-keyserver.net](https://sks-keyservers.net/status/) domain,
```
This service is deprecated. This means it is no longer maintained, and
new HKPS certificates will not be issued. Service reliability should not
be expected.

Update 2021-06-21: Due to even more GDPR takedown requests, the DNS
records for the pool will no longer be provided at all.

```

Change(s)
- Switch gpg keyserver being used to fetch rvm keys

Fixes #2508 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested on a fresh Ubuntu 20.04 instance. The script completes fully and Chatwoot is available at the domain. 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
