### PR TITLE
bug: fixes typing indicator out of position in widget

### DIFF
--- a/app/javascript/widget/components/AgentTypingBubble.vue
+++ b/app/javascript/widget/components/AgentTypingBubble.vue
@@ -23,6 +23,10 @@ export default {
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style lang="scss" scoped>
 @import '~widget/assets/scss/variables.scss';
+.agent-message-wrap {
+  position: sticky;
+  bottom: $space-smaller;
+}
 
 .typing-bubble {
   max-width: $space-normal * 2.4;


### PR DESCRIPTION
Fixes #914 

**Preview**

https://user-images.githubusercontent.com/64252451/124226532-e6a8e280-db26-11eb-8f7b-c27ac0694b3c.mov

