### PR TITLE
chore: Expose contact custom attributes in events

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -55,6 +55,7 @@ class Contact < ApplicationRecord
   def push_event_data
     {
       additional_attributes: additional_attributes,
+      custom_attributes: custom_attributes,
       email: email,
       id: id,
       identifier: identifier,


### PR DESCRIPTION
Expose contact custom attributes in events so the external system can behave accordingly without triggering an  additional API call

