### PR TITLE
chore: Reduce steps to spin up Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,8 @@
 # The below image is created out of the Dockerfile.base
 # It has the dependencies already installed so that codespace will boot up fast
-FROM ghcr.io/sojan-official/chatwoot_codespace:latest
+FROM ghcr.io/chatwoot/chatwoot_codespace:latest
 
 # Do the set up required for chatwoot app 
 WORKDIR /workspace
 COPY . /workspace
-RUN yarn
-
-COPY Gemfile Gemfile.lock ./
-RUN gem install bundler && bundle install
+RUN yarn && gem install bundler && bundle install 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 
   // Use 'postCreateCommand' to run commands after the container is created.
   // #TODO: can we move logic of copy env file into dockerfile ?
-  "postCreateCommand": "cp .env.example .env",
+  "postCreateCommand": ".devcontainer/scripts/setup.sh && bundle exec rake db:chatwoot_prepare",
   "portsAttributes": {
     "3000": {
       "label": "Rails Server"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 
   // Use 'postCreateCommand' to run commands after the container is created.
   // #TODO: can we move logic of copy env file into dockerfile ?
-  "postCreateCommand": ".devcontainer/scripts/setup.sh && bundle exec rake db:chatwoot_prepare",
+  "postCreateCommand": ".devcontainer/scripts/setup.sh && bundle exec rake db:chatwoot_prepare && yarn",
   "portsAttributes": {
     "3000": {
       "label": "Rails Server"

--- a/.devcontainer/scripts/setup.sh
+++ b/.devcontainer/scripts/setup.sh
@@ -1,0 +1,8 @@
+cp .env.example .env
+sed -i -e '/REDIS_URL/ s/=.*/=redis:\/\/localhost:6379/' .env
+sed -i -e '/POSTGRES_HOST/ s/=.*/=localhost/' .env
+sed -i -e '/SMTP_ADDRESS/ s/=.*/=localhost/' .env
+sed -i -e "/FRONTEND_URL/ s/=.*/=https:\/\/$CODESPACE_NAME-3000.githubpreview.dev/" .env
+
+
+

--- a/.devcontainer/scripts/setup.sh
+++ b/.devcontainer/scripts/setup.sh
@@ -3,6 +3,3 @@ sed -i -e '/REDIS_URL/ s/=.*/=redis:\/\/localhost:6379/' .env
 sed -i -e '/POSTGRES_HOST/ s/=.*/=localhost/' .env
 sed -i -e '/SMTP_ADDRESS/ s/=.*/=localhost/' .env
 sed -i -e "/FRONTEND_URL/ s/=.*/=https:\/\/$CODESPACE_NAME-3000.githubpreview.dev/" .env
-
-
-


### PR DESCRIPTION
Reduce the steps to spin up Codespaces

- use chatwoot base image
- script to set up the required .env file
- run `rake db:chatwoot_prepare` on init


updated instructions 
https://github.com/chatwoot/chatwoot/wiki/Using-chatwoot-codespace
