### PR TITLE
feat: Support messages along with the actions in Dialogflow response

### DIFF
--- a/lib/integrations/dialogflow/processor_service.rb
+++ b/lib/integrations/dialogflow/processor_service.rb
@@ -39,14 +39,17 @@ class Integrations::Dialogflow::ProcessorService
   end
 
   def process_response(message, response)
-    text_response = response.query_result['fulfillment_text']
-
-    content_params = { content: text_response } if text_response.present?
-    content_params ||= response.query_result['fulfillment_messages'].first['payload'].to_h
-
-    process_action(message, content_params['action']) and return if content_params['action'].present?
-
-    create_conversation(message, content_params)
+    responses = response.query_result['fulfillment_messages']
+    responses.each do |response|
+      text_response = response['text'].to_h
+      content_params = { content: text_response[:text].first } if text_response[:text].present?
+      content_params ||= response['payload'].to_h
+      if content_params['action'].present?
+        process_action(message, content_params['action'])
+      else
+        create_conversation(message, content_params)
+      end
+    end
   end
 
   def create_conversation(message, content_params)

--- a/lib/integrations/dialogflow/processor_service.rb
+++ b/lib/integrations/dialogflow/processor_service.rb
@@ -39,11 +39,11 @@ class Integrations::Dialogflow::ProcessorService
   end
 
   def process_response(message, response)
-    responses = response.query_result['fulfillment_messages']
-    responses.each do |response|
-      text_response = response['text'].to_h
+    fulfillment_messages = response.query_result['fulfillment_messages']
+    fulfillment_messages.each do |fulfillment_message|
+      text_response = fulfillment_message['text'].to_h
       content_params = { content: text_response[:text].first } if text_response[:text].present?
-      content_params ||= response['payload'].to_h
+      content_params ||= fulfillment_message['payload'].to_h
       if content_params['action'].present?
         process_action(message, content_params['action'])
       else

--- a/lib/integrations/dialogflow/processor_service.rb
+++ b/lib/integrations/dialogflow/processor_service.rb
@@ -41,15 +41,20 @@ class Integrations::Dialogflow::ProcessorService
   def process_response(message, response)
     fulfillment_messages = response.query_result['fulfillment_messages']
     fulfillment_messages.each do |fulfillment_message|
-      text_response = fulfillment_message['text'].to_h
-      content_params = { content: text_response[:text].first } if text_response[:text].present?
-      content_params ||= fulfillment_message['payload'].to_h
+      content_params = generate_content_params(fulfillment_message)
       if content_params['action'].present?
         process_action(message, content_params['action'])
       else
         create_conversation(message, content_params)
       end
     end
+  end
+
+  def generate_content_params(fulfillment_message)
+    text_response = fulfillment_message['text'].to_h
+    content_params = { content: text_response[:text].first } if text_response[:text].present?
+    content_params ||= fulfillment_message['payload'].to_h
+    content_params
   end
 
   def create_conversation(message, content_params)


### PR DESCRIPTION
- Process every fulfilment message instead of the first one.
- Create multiple messages/actions based on the response

Fixes #2570 