### PR TITLE
fix: Unescape Slack incoming messages

### DIFF
--- a/lib/integrations/slack/incoming_message_builder.rb
+++ b/lib/integrations/slack/incoming_message_builder.rb
@@ -83,7 +83,7 @@ class Integrations::Slack::IncomingMessageBuilder
       message_type: :outgoing,
       account_id: conversation.account_id,
       inbox_id: conversation.inbox_id,
-      content: params[:event][:text],
+      content: Slack::Messages::Formatting.unescape(params[:event][:text] || ''),
       external_source_id_slack: params[:event][:ts],
       private: private_note?,
       sender: sender

--- a/spec/lib/integrations/slack/incoming_message_builder_spec.rb
+++ b/spec/lib/integrations/slack/incoming_message_builder_spec.rb
@@ -33,6 +33,7 @@ describe Integrations::Slack::IncomingMessageBuilder do
         allow(builder).to receive(:sender).and_return(nil)
         builder.perform
         expect(conversation.messages.count).to eql(messages_count + 1)
+        expect(conversation.messages.last.content).to eql('this is test https://chatwoot.com Hey @Sojan Test again')
       end
 
       it 'does not create message for invalid event type' do

--- a/spec/support/slack_stubs.rb
+++ b/spec/support/slack_stubs.rb
@@ -46,7 +46,7 @@ module SlackStubs
     {
       "client_msg_id": 'ffc6e64e-6f0c-4a3d-b594-faa6b44e48ab',
       "type": 'message',
-      "text": 'this is test',
+      "text": 'this is test <https://chatwoot.com> Hey <@U019KT237LP|Sojan> Test again',
       "user": 'ULYPAKE5S',
       "ts": '1588623033.006000',
       "team": 'TLST3048H',


### PR DESCRIPTION
Use unescape while saving the response on Chatwoot.

**Before**

<img width="382" alt="Screenshot 2021-07-09 at 2 39 16 PM" src="https://user-images.githubusercontent.com/2246121/125054849-432a7580-e0c4-11eb-8013-fbcf4d2161d2.png">

**After**

<img width="351" alt="Screenshot 2021-07-09 at 2 45 18 PM" src="https://user-images.githubusercontent.com/2246121/125054878-49b8ed00-e0c4-11eb-9e28-2d0b82b5d0df.png">

Fixes #2603 


Note: This PR is created and tested from Codespaces 👍 