### PR TITLE
chore: Add Telemetry

### DIFF
--- a/app/controllers/installation/onboarding_controller.rb
+++ b/app/controllers/installation/onboarding_controller.rb
@@ -27,7 +27,12 @@ class Installation::OnboardingController < ApplicationController
 
   def finish_onboarding
     ::Redis::Alfred.delete(::Redis::Alfred::CHATWOOT_INSTALLATION_ONBOARDING)
-    ChatwootHub.register_instance(onboarding_params) if onboarding_params[:subscribe_to_updates]
+    
+    ChatwootHub.register_instance(
+      onboarding_params.dig(:user, :company), 
+      onboarding_params.dig(:user, :name), 
+      onboarding_params.dig(:user, :email)
+    ) if onboarding_params.dig(:subscribe_to_updates).present?
   end
 
   def ensure_installation_onboarding

--- a/app/controllers/installation/onboarding_controller.rb
+++ b/app/controllers/installation/onboarding_controller.rb
@@ -27,12 +27,13 @@ class Installation::OnboardingController < ApplicationController
 
   def finish_onboarding
     ::Redis::Alfred.delete(::Redis::Alfred::CHATWOOT_INSTALLATION_ONBOARDING)
-    
+    return if onboarding_params[:subscribe_to_updates].blank?
+
     ChatwootHub.register_instance(
-      onboarding_params.dig(:user, :company), 
-      onboarding_params.dig(:user, :name), 
+      onboarding_params.dig(:user, :company),
+      onboarding_params.dig(:user, :name),
       onboarding_params.dig(:user, :email)
-    ) if onboarding_params.dig(:subscribe_to_updates).present?
+    )
   end
 
   def ensure_installation_onboarding

--- a/lib/chatwoot_hub.rb
+++ b/lib/chatwoot_hub.rb
@@ -13,7 +13,7 @@ class ChatwootHub
   def self.instance_config
     {
       installation_identifier: installation_identifier,
-      current_version: Chatwoot.config[:version],
+      installation_version: Chatwoot.config[:version],
       installation_host: URI.parse(ENV.fetch('FRONTEND_URL', '')).host
     }
   end

--- a/lib/chatwoot_hub.rb
+++ b/lib/chatwoot_hub.rb
@@ -1,16 +1,41 @@
 class ChatwootHub
-  BASE_URL = ENV['CHATWOOT_HUB_URL'] || 'https://hub.chatwoot.com'
+  BASE_URL = ENV['CHATWOOT_HUB_URL'] || 'https://hub.2.chatwoot.com'
+  PING_URL = "#{BASE_URL}/ping"
+  REGISTRATION_URL = "#{BASE_URL}/instances"
+  EVENTS_URL = "#{BASE_URL}/events"
+  
+
+  def self.installation_identifier
+    identifier = InstallationConfig.find_by(name: 'INSTALLATION_IDENTIFIER')&.value
+    identifier ||= InstallationConfig.create(name: 'INSTALLATION_IDENTIFIER', value: SecureRandom.uuid).value
+    identifier
+  end
 
   def self.instance_config
     {
-      installationVersion: Chatwoot.config[:version],
-      installationHost: URI.parse(ENV.fetch('FRONTEND_URL', '')).host
+      installation_identifier: installation_identifier,
+      current_version: Chatwoot.config[:version],
+      installation_host: URI.parse(ENV.fetch('FRONTEND_URL', '')).host
     }
+  end
+
+  def self.instance_metrics
+    { 
+      accounts_count: Account.count, 
+      users_count: User.count,
+      inboxes_count: Inbox.count,
+      conversations_count: Conversation.count,
+      incoming_messages_count: Message.incoming.count ,
+      outgoing_messages_count: Message.outgoing.count,
+      additional_information: {}
+    } 
   end
 
   def self.latest_version
     begin
-      response = RestClient.get(BASE_URL, { params: instance_config })
+      info = instance_config
+      info = info.merge(instance_metrics) unless ENV['DISABLE_TELEMETRY']
+      response = RestClient.post(PING_URL, info.to_json, { content_type: :json, accept: :json })
       version = JSON.parse(response)['version']
     rescue *ExceptionList::REST_CLIENT_EXCEPTIONS, *ExceptionList::URI_EXCEPTIONS => e
       Rails.logger.info "Exception: #{e.message}"
@@ -20,8 +45,19 @@ class ChatwootHub
     version
   end
 
-  def self.register_instance(info)
-    RestClient.post("#{BASE_URL}/register_instance", info.merge(instance_config).to_json, { content_type: :json, accept: :json })
+  def self.register_instance(company_name, owner_name, owner_email)
+    info = { company_name: company_name, owner_name: owner_name, owner_email: owner_email, subscribed_to_mailers: true }
+    RestClient.post(REGISTRATION_URL, info.merge(instance_config).to_json, { content_type: :json, accept: :json })
+  rescue *ExceptionList::REST_CLIENT_EXCEPTIONS, *ExceptionList::URI_EXCEPTIONS => e
+    Rails.logger.info "Exception: #{e.message}"
+  rescue StandardError => e
+    Raven.capture_exception(e)
+  end
+
+  def self.emit_event(event_name, event_data)
+    return if ENV['DISABLE_TELEMETRY']
+    info =  { event_name: event_name, event_data: event_data }
+    RestClient.post(EVENTS_URL, info.merge(instance_config).to_json, { content_type: :json, accept: :json })
   rescue *ExceptionList::REST_CLIENT_EXCEPTIONS, *ExceptionList::URI_EXCEPTIONS => e
     Rails.logger.info "Exception: #{e.message}"
   rescue StandardError => e

--- a/lib/chatwoot_hub.rb
+++ b/lib/chatwoot_hub.rb
@@ -1,9 +1,8 @@
 class ChatwootHub
   BASE_URL = ENV['CHATWOOT_HUB_URL'] || 'https://hub.2.chatwoot.com'
-  PING_URL = "#{BASE_URL}/ping"
-  REGISTRATION_URL = "#{BASE_URL}/instances"
-  EVENTS_URL = "#{BASE_URL}/events"
-  
+  PING_URL = "#{BASE_URL}/ping".freeze
+  REGISTRATION_URL = "#{BASE_URL}/instances".freeze
+  EVENTS_URL = "#{BASE_URL}/events".freeze
 
   def self.installation_identifier
     identifier = InstallationConfig.find_by(name: 'INSTALLATION_IDENTIFIER')&.value
@@ -20,15 +19,15 @@ class ChatwootHub
   end
 
   def self.instance_metrics
-    { 
-      accounts_count: Account.count, 
+    {
+      accounts_count: Account.count,
       users_count: User.count,
       inboxes_count: Inbox.count,
       conversations_count: Conversation.count,
-      incoming_messages_count: Message.incoming.count ,
+      incoming_messages_count: Message.incoming.count,
       outgoing_messages_count: Message.outgoing.count,
       additional_information: {}
-    } 
+    }
   end
 
   def self.latest_version
@@ -56,7 +55,8 @@ class ChatwootHub
 
   def self.emit_event(event_name, event_data)
     return if ENV['DISABLE_TELEMETRY']
-    info =  { event_name: event_name, event_data: event_data }
+
+    info = { event_name: event_name, event_data: event_data }
     RestClient.post(EVENTS_URL, info.merge(instance_config).to_json, { content_type: :json, accept: :json })
   rescue *ExceptionList::REST_CLIENT_EXCEPTIONS, *ExceptionList::URI_EXCEPTIONS => e
     Rails.logger.info "Exception: #{e.message}"

--- a/spec/lib/chatwoot_hub_spec.rb
+++ b/spec/lib/chatwoot_hub_spec.rb
@@ -1,15 +1,66 @@
 require 'rails_helper'
 
 describe ChatwootHub do
-  it 'get latest version from chatwoot hub' do
-    version = '1.1.1'
-    allow(RestClient).to receive(:get).and_return({ version: version }.to_json)
-    expect(described_class.latest_version).to eq version
-    expect(RestClient).to have_received(:get).with(described_class::BASE_URL, { params: described_class.instance_config })
+  it 'generates installation identifier' do
+    installation_identifier = described_class.installation_identifier
+    expect(installation_identifier).not_to eq nil
+    expect(described_class.installation_identifier).to eq installation_identifier
   end
 
-  it 'returns nil when chatwoot hub is down' do
-    allow(RestClient).to receive(:get).and_raise(ExceptionList::REST_CLIENT_EXCEPTIONS.sample)
-    expect(described_class.latest_version).to eq nil
+  context 'when fetching latest_version' do
+    it 'get latest version from chatwoot hub' do
+      version = '1.1.1'
+      allow(RestClient).to receive(:post).and_return({ version: version }.to_json)
+      expect(described_class.latest_version).to eq version
+      expect(RestClient).to have_received(:post).with(described_class::PING_URL, described_class.instance_config.merge(described_class.instance_metrics).to_json, { content_type: :json, accept: :json })
+    end
+
+    it 'will not send instance metrics when telemetry is disabled' do
+      version = '1.1.1'
+      ENV['DISABLE_TELEMETRY'] = 'true'
+      allow(RestClient).to receive(:post).and_return({ version: version }.to_json)
+      expect(described_class.latest_version).to eq version
+      expect(RestClient).to have_received(:post).with(described_class::PING_URL, described_class.instance_config.to_json, { content_type: :json, accept: :json })
+      ENV['DISABLE_TELEMETRY'] = nil
+    end
+
+    it 'returns nil when chatwoot hub is down' do
+      allow(RestClient).to receive(:post).and_raise(ExceptionList::REST_CLIENT_EXCEPTIONS.sample)
+      expect(described_class.latest_version).to eq nil
+    end
+  end
+
+  context 'when register instance' do
+    let(:company_name) { 'test'}
+    let(:owner_name) { 'test' }
+    let(:owner_email) { 'test@test.com'}
+
+    it 'sends info of registration' do
+      info = { company_name: company_name, owner_name: owner_name, owner_email: owner_email, subscribed_to_mailers: true }
+            allow(RestClient).to receive(:post)
+      described_class.register_instance(company_name, owner_name, owner_email)
+      expect(RestClient).to have_received(:post).with(described_class::REGISTRATION_URL, info.merge(described_class.instance_config).to_json, { content_type: :json, accept: :json })
+    end
+  end
+
+  context 'when sending events' do 
+    let(:event_name) { 'sample_event'}
+    let(:event_data) { { 'sample_data' => 'sample_data' } }
+   
+    it 'will send instance events' do
+      info = {event_name: event_name, event_data: event_data }
+      allow(RestClient).to receive(:post)
+      described_class.emit_event(event_name, event_data)
+      expect(RestClient).to have_received(:post).with(described_class::EVENTS_URL, info.merge(described_class.instance_config).to_json, { content_type: :json, accept: :json })
+    end
+ 
+   it 'will not send instance events when telemetry is disabled' do
+      ENV['DISABLE_TELEMETRY'] = 'true'
+      info = {event_name: event_name, event_data: event_data }
+      allow(RestClient).to receive(:post)
+      described_class.emit_event(event_name, event_data)
+      expect(RestClient).not_to have_received(:post).with(described_class::EVENTS_URL, info.merge(described_class.instance_config).to_json, { content_type: :json, accept: :json })
+      ENV['DISABLE_TELEMETRY'] = nil
+    end
   end
 end

--- a/spec/lib/chatwoot_hub_spec.rb
+++ b/spec/lib/chatwoot_hub_spec.rb
@@ -12,7 +12,8 @@ describe ChatwootHub do
       version = '1.1.1'
       allow(RestClient).to receive(:post).and_return({ version: version }.to_json)
       expect(described_class.latest_version).to eq version
-      expect(RestClient).to have_received(:post).with(described_class::PING_URL, described_class.instance_config.merge(described_class.instance_metrics).to_json, { content_type: :json, accept: :json })
+      expect(RestClient).to have_received(:post).with(described_class::PING_URL, described_class.instance_config
+        .merge(described_class.instance_metrics).to_json, { content_type: :json, accept: :json })
     end
 
     it 'will not send instance metrics when telemetry is disabled' do
@@ -20,7 +21,8 @@ describe ChatwootHub do
       ENV['DISABLE_TELEMETRY'] = 'true'
       allow(RestClient).to receive(:post).and_return({ version: version }.to_json)
       expect(described_class.latest_version).to eq version
-      expect(RestClient).to have_received(:post).with(described_class::PING_URL, described_class.instance_config.to_json, { content_type: :json, accept: :json })
+      expect(RestClient).to have_received(:post).with(described_class::PING_URL,
+                                                      described_class.instance_config.to_json, { content_type: :json, accept: :json })
       ENV['DISABLE_TELEMETRY'] = nil
     end
 
@@ -31,35 +33,38 @@ describe ChatwootHub do
   end
 
   context 'when register instance' do
-    let(:company_name) { 'test'}
+    let(:company_name) { 'test' }
     let(:owner_name) { 'test' }
-    let(:owner_email) { 'test@test.com'}
+    let(:owner_email) { 'test@test.com' }
 
     it 'sends info of registration' do
       info = { company_name: company_name, owner_name: owner_name, owner_email: owner_email, subscribed_to_mailers: true }
-            allow(RestClient).to receive(:post)
+      allow(RestClient).to receive(:post)
       described_class.register_instance(company_name, owner_name, owner_email)
-      expect(RestClient).to have_received(:post).with(described_class::REGISTRATION_URL, info.merge(described_class.instance_config).to_json, { content_type: :json, accept: :json })
+      expect(RestClient).to have_received(:post).with(described_class::REGISTRATION_URL,
+                                                      info.merge(described_class.instance_config).to_json, { content_type: :json, accept: :json })
     end
   end
 
-  context 'when sending events' do 
-    let(:event_name) { 'sample_event'}
+  context 'when sending events' do
+    let(:event_name) { 'sample_event' }
     let(:event_data) { { 'sample_data' => 'sample_data' } }
-   
+
     it 'will send instance events' do
-      info = {event_name: event_name, event_data: event_data }
+      info = { event_name: event_name, event_data: event_data }
       allow(RestClient).to receive(:post)
       described_class.emit_event(event_name, event_data)
-      expect(RestClient).to have_received(:post).with(described_class::EVENTS_URL, info.merge(described_class.instance_config).to_json, { content_type: :json, accept: :json })
+      expect(RestClient).to have_received(:post).with(described_class::EVENTS_URL,
+                                                      info.merge(described_class.instance_config).to_json, { content_type: :json, accept: :json })
     end
- 
-   it 'will not send instance events when telemetry is disabled' do
+
+    it 'will not send instance events when telemetry is disabled' do
       ENV['DISABLE_TELEMETRY'] = 'true'
-      info = {event_name: event_name, event_data: event_data }
+      info = { event_name: event_name, event_data: event_data }
       allow(RestClient).to receive(:post)
       described_class.emit_event(event_name, event_data)
-      expect(RestClient).not_to have_received(:post).with(described_class::EVENTS_URL, info.merge(described_class.instance_config).to_json, { content_type: :json, accept: :json })
+      expect(RestClient).not_to have_received(:post).with(described_class::EVENTS_URL,
+                                                          info.merge(described_class.instance_config).to_json, { content_type: :json, accept: :json })
       ENV['DISABLE_TELEMETRY'] = nil
     end
   end


### PR DESCRIPTION

Chatwoot tracks usage of its products which helps the team to improve and deliver better software. You can opt-out of this telemetry at any time.

## **What data is collected**

None of your customer data is ever transmitted by Chatwoot installation. The telemetry data collected by our products are purely usage statics of various software features. 

### On-boarding

Our software onboarding screens may contain optional forms to subscribe to our product newsletters or a callback request. These inputs are completely optional and the user preferences updated in these onboarding steps are completely adhered to.

### Self-hosted installations

Chatwoot sends anonymised metadata to our telemetry instance at a defined interval. The following list contains the various attributes in this metadata. 

- Aggregated number various data models like users, accounts, labels, canned responses etc.
- Distribution of inboxes by type.
- Distribution of conversations by inbox type.
- The list of enabled integrations

### Mobile Apps

- Usage events on various feature interactions.

## **How is the data used**

This data will only be used by Chatwoot team for:

- Directly improving the product and identifying the parts of the product which are popular.
- Identifying areas with limited usage or where our users get stuck.
- Prioritizing the next set of features to be developed.

## **How is the data collected and who has access**

The telemetry data is stored securely on Chatwoot systems, with appropriate encryptions and access controls in place.

The self-hosted installation interacts with the URLs (hub.chatwoot.com, hub.2.chatwoot.com) every day. Both the URLs are hosted and owned by Chatwoot.

The data can only be accessed by Chatwoot employees who have the appropriate training and access permissions. The data is not shared with any 3rd parties.

## How to opt-out of data collection

If you want to disable telemetry you can do the following.

- **Disable data collection:** Use the environment variable 'DISABLE_TELEMETRY' in the installation. Set it to true to disable the data collection.
- **Disable update email subscription:** While you signup, you have to option to disable the subscription to update emails. If the option is disabled, Chatwoot won't collect the emails.





ref: https://github.com/chatwoot/docs/pull/63