### PR TITLE
chore: Remove unused _chatwoot_session

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_chatwoot_session', same_site: :lax
+Rails.application.config.session_store :disabled


### PR DESCRIPTION
- _chatwoot_session is not used by the backend, removing it for now.

Fixes #2683