### PR TITLE
fix: Disable "none" option from agent dropdown If agent is not selected

### DIFF
--- a/app/javascript/dashboard/mixins/agentMixin.js
+++ b/app/javascript/dashboard/mixins/agentMixin.js
@@ -10,17 +10,24 @@ export default {
     ...mapGetters({
       currentUser: 'getCurrentUser',
     }),
+    isAgentSelected() {
+      return this.currentChat?.meta?.assignee;
+    },
     agentsList() {
       const agents = this.assignableAgents || [];
       return [
-        {
-          confirmed: true,
-          name: 'None',
-          id: 0,
-          role: 'agent',
-          account_id: 0,
-          email: 'None',
-        },
+        ...(this.isAgentSelected
+          ? [
+              {
+                confirmed: true,
+                name: 'None',
+                id: 0,
+                role: 'agent',
+                account_id: 0,
+                email: 'None',
+              },
+            ]
+          : []),
         ...agents,
       ].map(item =>
         item.id === this.currentUser.id

--- a/app/javascript/dashboard/mixins/specs/agentMixin.spec.js
+++ b/app/javascript/dashboard/mixins/specs/agentMixin.spec.js
@@ -24,7 +24,10 @@ describe('agentMixin', () => {
       title: 'TestComponent',
       mixins: [agentMixin],
       data() {
-        return { inboxId: 1 };
+        return {
+          inboxId: 1,
+          currentChat: { meta: { assignee: { name: 'John' } } },
+        };
       },
       computed: {
         assignableAgents() {


### PR DESCRIPTION
Fixes #2686 