### PR TITLE
fix: Render line-breaks properly in messages

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -137,7 +137,7 @@ export default {
           text_content: { full: fullTextContent, reply: replyTextContent } = {},
         } = {},
       } = this.contentAttributes;
-
+      const hasHTMLContent = replyHTMLContent || fullHTMLContent;
       let contentToBeParsed =
         replyHTMLContent ||
         replyTextContent ||
@@ -147,6 +147,12 @@ export default {
       if (contentToBeParsed && this.isIncoming) {
         const parsedContent = this.stripStyleCharacters(contentToBeParsed);
         if (parsedContent) {
+          if (!hasHTMLContent) {
+            return this.renderEmailMarkdownContent(parsedContent, {
+              gfm: true,
+              breaks: true,
+            });
+          }
           return parsedContent;
         }
       }

--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -144,7 +144,6 @@ export default {
           text_content: { full: fullTextContent, reply: replyTextContent } = {},
         } = {},
       } = this.contentAttributes;
-      const hasHTMLContent = replyHTMLContent || fullHTMLContent;
       let contentToBeParsed =
         replyHTMLContent ||
         replyTextContent ||
@@ -154,13 +153,7 @@ export default {
       if (contentToBeParsed && this.isIncoming) {
         const parsedContent = this.stripStyleCharacters(contentToBeParsed);
         if (parsedContent) {
-          if (!hasHTMLContent) {
-            return this.renderEmailMarkdownContent(parsedContent, {
-              gfm: true,
-              breaks: true,
-            });
-          }
-          return parsedContent;
+          return parsedContent.replace(/\n/g, '<br />');
         }
       }
       return (

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/MailHead.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/MailHead.vue
@@ -29,7 +29,7 @@
 export default {
   props: {
     emailAttributes: {
-      type: Array,
+      type: Object,
       default: () => ({}),
     },
     isIncoming: {

--- a/app/javascript/shared/helpers/MessageFormatter.js
+++ b/app/javascript/shared/helpers/MessageFormatter.js
@@ -47,7 +47,7 @@ class MessageFormatter {
       const markedDownOutput = marked(withHash);
       return markedDownOutput;
     }
-    return marked(this.message);
+    return marked(this.message, { breaks: true, gfm: true });
   }
 
   get formattedMessage() {

--- a/app/javascript/shared/mixins/messageFormatterMixin.js
+++ b/app/javascript/shared/mixins/messageFormatterMixin.js
@@ -1,6 +1,5 @@
 import MessageFormatter from '../helpers/MessageFormatter';
 import DOMPurify from 'dompurify';
-import marked from 'marked';
 
 export default {
   methods: {
@@ -11,9 +10,6 @@ export default {
     getPlainText(message, isATweet) {
       const messageFormatter = new MessageFormatter(message, isATweet);
       return messageFormatter.plainText;
-    },
-    renderEmailMarkdownContent(message = '') {
-      return marked(message, { gfm: true, breaks: true });
     },
     truncateMessage(description = '') {
       if (description.length < 100) {

--- a/app/javascript/shared/mixins/messageFormatterMixin.js
+++ b/app/javascript/shared/mixins/messageFormatterMixin.js
@@ -1,5 +1,6 @@
 import MessageFormatter from '../helpers/MessageFormatter';
 import DOMPurify from 'dompurify';
+import marked from 'marked';
 
 export default {
   methods: {
@@ -10,6 +11,9 @@ export default {
     getPlainText(message, isATweet) {
       const messageFormatter = new MessageFormatter(message, isATweet);
       return messageFormatter.plainText;
+    },
+    renderEmailMarkdownContent(message = '') {
+      return marked(message, { gfm: true, breaks: true });
     },
     truncateMessage(description = '') {
       if (description.length < 100) {

--- a/app/javascript/widget/components/UserMessage.vue
+++ b/app/javascript/widget/components/UserMessage.vue
@@ -126,5 +126,9 @@ export default {
       margin-top: $space-normal;
     }
   }
+
+  p:not(:last-child) {
+    margin-bottom: $space-normal;
+  }
 }
 </style>


### PR DESCRIPTION
- Use `gfm:true, breaks: true` for marked rendering
- Add margin-bottom for `<p>` in widget messages
- Render text-only messages on email channel with markdown

Fixes #1730 