### PR TITLE
fix: external db with non-standard port

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -21,7 +21,8 @@ class Account < ApplicationRecord
   include Featurable
 
   DEFAULT_QUERY_SETTING = {
-    flag_query_mode: :bit_operator
+    flag_query_mode: :bit_operator,
+    check_for_column: false
   }.freeze
 
   ACCOUNT_SETTINGS_FLAGS = {

--- a/app/models/channel/web_widget.rb
+++ b/app/models/channel/web_widget.rb
@@ -39,7 +39,9 @@ class Channel::WebWidget < ApplicationRecord
 
   has_flags 1 => :attachments,
             2 => :emoji_picker,
-            :column => 'feature_flags'
+            :column => 'feature_flags',
+            :check_for_column => false
+
   enum reply_time: { in_a_few_minutes: 0, in_a_few_hours: 1, in_a_day: 2 }
 
   def name

--- a/app/models/concerns/featurable.rb
+++ b/app/models/concerns/featurable.rb
@@ -2,7 +2,8 @@ module Featurable
   extend ActiveSupport::Concern
 
   QUERY_MODE = {
-    flag_query_mode: :bit_operator
+    flag_query_mode: :bit_operator,
+    check_for_column: false
   }.freeze
 
   FEATURE_LIST = YAML.safe_load(File.read(Rails.root.join('config/features.yml'))).freeze

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -23,7 +23,8 @@ class NotificationSetting < ApplicationRecord
   belongs_to :user
 
   DEFAULT_QUERY_SETTING = {
-    flag_query_mode: :bit_operator
+    flag_query_mode: :bit_operator,
+    check_for_column: false
   }.freeze
 
   EMAIL_NOTIFICATION_FLAGS = ::Notification::NOTIFICATION_TYPES.transform_keys { |key| "email_#{key}".to_sym }.invert.freeze

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,7 @@ default: &default
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: <%= ENV.fetch('POSTGRES_HOST', 'localhost') %>
+  port: <%= ENV.fetch('POSTGRES_PORT', '5432') %>
 
 development:
   <<: *default

--- a/docker/entrypoints/helpers/pg_database_url.sh
+++ b/docker/entrypoints/helpers/pg_database_url.sh
@@ -5,6 +5,6 @@ require 'uri'
 if !ENV['DATABASE_URL'].nil? && ENV['DATABASE_URL'] != ''
   uri = URI(ENV['DATABASE_URL'])
   puts "export POSTGRES_HOST=#{uri.host} POSTGRES_PORT=#{uri.port} POSTGRES_USERNAME=#{uri.user}"
-else
-  puts "export POSTGRES_PORT=5432"
+elif ENV['POSTGRES_PORT'].nil? || ENV['POSTGRES_PORT'] == ''
+  puts "export POSTGRES_PORT=5432" 
 end


### PR DESCRIPTION
# Pull Request Template

## Description

POSTGRES_PORT was not taking effect if provided separately
instead of using DATABASE_URL. This adds support for using
databases running on non-standard ports.

- Fix docker entry point for rails to respect `POSTGRES_PORT` setting
- Fix database.yml to respect `POSTGRES_PORT` setting
- Toggle flag_shitzu gem `check_for_column` to false

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Tested across a new Chatwoot Kubernetes deployment using Chatwoot helm package

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
