### PR TITLE
fix:  Appending markdown as HTML into editor

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -139,8 +139,17 @@ export default {
     value(newValue = '') {
       if (newValue !== this.lastValue) {
         const { tr } = this.state;
-        tr.insertText(newValue, 0, tr.doc.content.size);
-        this.state = this.view.state.apply(tr);
+        if (this.isFormatMode) {
+          this.state = createState(
+            newValue,
+            this.placeholder,
+            this.plugins,
+            this.isFormatMode
+          );
+        } else {
+          tr.insertText(newValue, 0, tr.doc.content.size);
+          this.state = this.view.state.apply(tr);
+        }
         this.view.updateState(this.state);
       }
     },


### PR DESCRIPTION
**Why**
- This pr will stop escaping markdown when passed down as props into editor component.
- Will fix issue blocked in #2577