### PR TITLE
fix: Resolve conversation with id instead of current conversation

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -145,10 +145,10 @@ const actions = {
         status,
         snoozedUntil,
       });
-      commit(
-        types.default.RESOLVE_CONVERSATION,
-        response.data.payload.current_status
-      );
+      commit(types.default.RESOLVE_CONVERSATION, {
+        conversationId,
+        status: response.data.payload.current_status,
+      });
     } catch (error) {
       // Handle error
     }

--- a/app/javascript/dashboard/store/modules/conversations/getters.js
+++ b/app/javascript/dashboard/store/modules/conversations/getters.js
@@ -64,7 +64,9 @@ const getters = {
   getChatStatusFilter: ({ chatStatusFilter }) => chatStatusFilter,
   getSelectedInbox: ({ currentInbox }) => currentInbox,
   getConversationById: _state => conversationId => {
-    return _state.allConversations.find(value => value.id === conversationId);
+    return _state.allConversations.find(
+      value => value.id === Number(conversationId)
+    );
   },
 };
 

--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -69,9 +69,10 @@ export const mutations = {
     Vue.set(chat.meta, 'team', team);
   },
 
-  [types.default.RESOLVE_CONVERSATION](_state, status) {
-    const [chat] = getSelectedChatConversation(_state);
-    chat.status = status;
+  [types.default.RESOLVE_CONVERSATION](_state, { conversationId, status }) {
+    const conversation =
+      getters.getConversationById(_state)(conversationId) || {};
+    Vue.set(conversation, 'status', status);
   },
 
   [types.default.MUTE_CONVERSATION](_state) {

--- a/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
@@ -214,6 +214,22 @@ describe('#actions', () => {
     });
   });
 
+  describe('#toggleStatus', () => {
+    it('sends correct mutations if toggle status is successful', async () => {
+      axios.post.mockResolvedValue({
+        data: { payload: { conversation_id: 1, current_status: 'resolved' } },
+      });
+      await actions.toggleStatus(
+        { commit },
+        { conversationId: 1, status: 'resolved' }
+      );
+      expect(commit).toHaveBeenCalledTimes(1);
+      expect(commit.mock.calls).toEqual([
+        ['RESOLVE_CONVERSATION', { conversationId: 1, status: 'resolved' }],
+      ]);
+    });
+  });
+
   describe('#assignTeam', () => {
     it('sends correct mutations if assignment is successful', async () => {
       axios.post.mockResolvedValue({

--- a/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
@@ -160,4 +160,31 @@ describe('#mutations', () => {
       expect(global.bus.$emit).not.toHaveBeenCalled();
     });
   });
+
+  describe('#RESOLVE_CONVERSATION', () => {
+    it('updates the conversation status correctly', () => {
+      const state = {
+        allConversations: [
+          {
+            id: 1,
+            messages: [],
+            status: 'open',
+          },
+        ],
+      };
+
+      mutations[types.RESOLVE_CONVERSATION](state, {
+        conversationId: '1',
+        status: 'resolved',
+      });
+
+      expect(state.allConversations).toEqual([
+        {
+          id: 1,
+          messages: [],
+          status: 'resolved',
+        },
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
While reviewing #2672, resolve and move next shortcut had troubles because the action was resolving the current conversation.