### PR TITLE
fix: Fix and rename pg_database_url.sh helper script

### DIFF
--- a/docker/entrypoints/helpers/pg_database_url.rb
+++ b/docker/entrypoints/helpers/pg_database_url.rb
@@ -5,6 +5,6 @@ require 'uri'
 if !ENV['DATABASE_URL'].nil? && ENV['DATABASE_URL'] != ''
   uri = URI(ENV['DATABASE_URL'])
   puts "export POSTGRES_HOST=#{uri.host} POSTGRES_PORT=#{uri.port} POSTGRES_USERNAME=#{uri.user}"
-elif ENV['POSTGRES_PORT'].nil? || ENV['POSTGRES_PORT'] == ''
+elsif ENV['POSTGRES_PORT'].nil? || ENV['POSTGRES_PORT'] == ''
   puts "export POSTGRES_PORT=5432" 
 end

--- a/docker/entrypoints/helpers/pg_database_url.rb
+++ b/docker/entrypoints/helpers/pg_database_url.rb
@@ -6,5 +6,5 @@ if !ENV['DATABASE_URL'].nil? && ENV['DATABASE_URL'] != ''
   uri = URI(ENV['DATABASE_URL'])
   puts "export POSTGRES_HOST=#{uri.host} POSTGRES_PORT=#{uri.port} POSTGRES_USERNAME=#{uri.user}"
 elsif ENV['POSTGRES_PORT'].nil? || ENV['POSTGRES_PORT'] == ''
-  puts "export POSTGRES_PORT=5432" 
+  puts 'export POSTGRES_PORT=5432'
 end

--- a/docker/entrypoints/rails.sh
+++ b/docker/entrypoints/rails.sh
@@ -10,7 +10,7 @@ echo "Waiting for postgres to become ready...."
 
 # Let DATABASE_URL env take presedence over individual connection params.
 # This is done to avoid printing the DATABASE_URL in the logs
-$(docker/entrypoints/helpers/pg_database_url.sh)
+$(docker/entrypoints/helpers/pg_database_url.rb)
 PG_READY="pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USERNAME"
 
 until $PG_READY


### PR DESCRIPTION
# Pull Request Template

## Description

The `pg_database_url.sh` helper script (used in Docker entrypoint) wasn't working anymore because of a small syntax error.
This PR fixes this and also renames the file to have an appropiate extension (`.rb`).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested locally with own Docker image build.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
