### PR TITLE
fix: Save content_type, multipart information to email message model

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -143,6 +143,9 @@ export default {
 
       const {
         email: {
+          // Assuming all previous emails to be multipart, otherwise
+          // previous message would render unnecessary line breaks.
+          multipart = true,
           html_content: { full: fullHTMLContent, reply: replyHTMLContent } = {},
           text_content: { full: fullTextContent, reply: replyTextContent } = {},
         } = {},
@@ -156,7 +159,9 @@ export default {
       if (contentToBeParsed && this.isIncoming) {
         const parsedContent = this.stripStyleCharacters(contentToBeParsed);
         if (parsedContent) {
-          return parsedContent.replace(/\n/g, '<br />');
+          return multipart
+            ? parsedContent
+            : parsedContent.replace(/\n/g, '<br />');
         }
       }
       return (

--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -143,9 +143,7 @@ export default {
 
       const {
         email: {
-          // Assuming all previous emails to be multipart, otherwise
-          // previous message would render unnecessary line breaks.
-          multipart = true,
+          content_type: contentType = '',
           html_content: { full: fullHTMLContent, reply: replyHTMLContent } = {},
           text_content: { full: fullTextContent, reply: replyTextContent } = {},
         } = {},
@@ -159,9 +157,12 @@ export default {
       if (contentToBeParsed && this.isIncoming) {
         const parsedContent = this.stripStyleCharacters(contentToBeParsed);
         if (parsedContent) {
-          return multipart
-            ? parsedContent
-            : parsedContent.replace(/\n/g, '<br />');
+          // This is a temporary fix for line-breaks in text/plain emails
+          // Now, It is not rendered properly in the email preview.
+          // FIXME: Remove this once we have a better solution for rendering text/plain emails
+          return contentType.includes('text/plain')
+            ? parsedContent.replace(/\n/g, '<br />')
+            : parsedContent;
         }
       }
       return (

--- a/app/mailboxes/mailbox_helper.rb
+++ b/app/mailboxes/mailbox_helper.rb
@@ -2,6 +2,7 @@ module MailboxHelper
   private
 
   def create_message
+    byebug
     @message = @conversation.messages.create(
       account_id: @conversation.account_id,
       sender: @conversation.contact,

--- a/app/mailboxes/mailbox_helper.rb
+++ b/app/mailboxes/mailbox_helper.rb
@@ -2,7 +2,6 @@ module MailboxHelper
   private
 
   def create_message
-    byebug
     @message = @conversation.messages.create(
       account_id: @conversation.account_id,
       sender: @conversation.contact,

--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -73,7 +73,7 @@ class MailPresenter < SimpleDelegator
       number_of_attachments: number_of_attachments,
       subject: subject,
       text_content: text_content,
-      to: to,
+      to: to
     }
   end
 

--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -61,18 +61,19 @@ class MailPresenter < SimpleDelegator
 
   def serialized_data
     {
-      text_content: text_content,
-      html_content: html_content,
-      number_of_attachments: number_of_attachments,
-      subject: subject,
-      date: date,
-      to: to,
-      from: from,
-      in_reply_to: in_reply_to,
-      cc: cc,
       bcc: bcc,
+      cc: cc,
+      content_type: content_type,
+      date: date,
+      from: from,
+      html_content: html_content,
+      in_reply_to: in_reply_to,
       message_id: message_id,
       multipart: multipart?,
+      number_of_attachments: number_of_attachments,
+      subject: subject,
+      text_content: text_content,
+      to: to,
     }
   end
 

--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -71,7 +71,8 @@ class MailPresenter < SimpleDelegator
       in_reply_to: in_reply_to,
       cc: cc,
       bcc: bcc,
-      message_id: message_id
+      message_id: message_id,
+      multipart: multipart?,
     }
   end
 

--- a/spec/mailboxes/reply_mailbox_spec.rb
+++ b/spec/mailboxes/reply_mailbox_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe ReplyMailbox, type: :mailbox do
     let(:reply_mail) { create_inbound_email_from_fixture('reply.eml') }
     let(:conversation) { create(:conversation, assignee: agent, inbox: create(:inbox, account: account, greeting_enabled: false), account: account) }
     let(:described_subject) { described_class.receive reply_mail }
-    let(:serialized_attributes) { %w[text_content html_content number_of_attachments subject date to from in_reply_to cc bcc message_id] }
+    let(:serialized_attributes) do
+      %w[bcc cc content_type date from html_content in_reply_to message_id multipart number_of_attachments subject text_content to]
+    end
 
     before do
       # this UUID is hardcoded in the reply.eml, that's why we are updating this

--- a/spec/mailboxes/support_mailbox_spec.rb
+++ b/spec/mailboxes/support_mailbox_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe SupportMailbox, type: :mailbox do
     let!(:channel_email) { create(:channel_email, account: account) }
     let(:support_mail) { create_inbound_email_from_fixture('support.eml') }
     let(:described_subject) { described_class.receive support_mail }
-    let(:serialized_attributes) { %w[text_content html_content number_of_attachments subject date to from in_reply_to cc bcc message_id] }
+    let(:serialized_attributes) do
+      %w[bcc cc content_type date from html_content in_reply_to message_id multipart number_of_attachments subject
+         text_content to]
+    end
     let(:conversation) { Conversation.where(inbox_id: channel_email.inbox).last }
 
     before do

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe MailPresenter do
                                 :number_of_attachments,
                                 :subject,
                                 :text_content,
-                                :to,
+                                :to
                               ])
-      expect(data[:content_type]).to include("multipart/alternative")
+      expect(data[:content_type]).to include('multipart/alternative')
       expect(data[:date].to_s).to eq('2020-04-20T04:20:20-04:00')
       expect(data[:message_id]).to eq(mail.message_id)
       expect(data[:multipart]).to eq(true)

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -32,13 +32,25 @@ RSpec.describe MailPresenter do
     it 'give the serialized data of the email to be stored in the message' do
       data = decorated_mail.serialized_data
       expect(data.keys).to eq([
-                                :text_content, :html_content, :number_of_attachments, :subject, :date, :to,
-                                :from, :in_reply_to, :cc, :bcc, :message_id, :multipart
+                                :bcc,
+                                :cc,
+                                :content_type,
+                                :date,
+                                :from,
+                                :html_content,
+                                :in_reply_to,
+                                :message_id,
+                                :multipart,
+                                :number_of_attachments,
+                                :subject,
+                                :text_content,
+                                :to,
                               ])
-      expect(data[:subject]).to eq(decorated_mail.subject)
+      expect(data[:content_type]).to include("multipart/alternative")
       expect(data[:date].to_s).to eq('2020-04-20T04:20:20-04:00')
       expect(data[:message_id]).to eq(mail.message_id)
       expect(data[:multipart]).to eq(true)
+      expect(data[:subject]).to eq(decorated_mail.subject)
     end
   end
 end

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -33,11 +33,12 @@ RSpec.describe MailPresenter do
       data = decorated_mail.serialized_data
       expect(data.keys).to eq([
                                 :text_content, :html_content, :number_of_attachments, :subject, :date, :to,
-                                :from, :in_reply_to, :cc, :bcc, :message_id
+                                :from, :in_reply_to, :cc, :bcc, :message_id, :multipart
                               ])
       expect(data[:subject]).to eq(decorated_mail.subject)
       expect(data[:date].to_s).to eq('2020-04-20T04:20:20-04:00')
       expect(data[:message_id]).to eq(mail.message_id)
+      expect(data[:multipart]).to eq(true)
     end
   end
 end


### PR DESCRIPTION
- Add a multipart flag to the email message model.
- Save content type to email message model
- Render line break if text/plain email.