### PR TITLE
chore: Removes the multi-select dropdown from the conversation header

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ConversationBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationBox.vue
@@ -49,7 +49,7 @@ export default {
     },
     isContactPanelOpen: {
       type: Boolean,
-      default: false,
+      default: true,
     },
   },
   computed: {

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
@@ -32,33 +32,6 @@
       class="header-actions-wrap"
       :class="{ 'has-open-sidebar': isContactPanelOpen }"
     >
-      <div class="multiselect-box multiselect-wrap--small">
-        <i class="icon ion-headphone" />
-        <multiselect
-          v-model="currentChat.meta.assignee"
-          :loading="uiFlags.isFetching"
-          :allow-empty="true"
-          deselect-label=""
-          :options="agentsList"
-          :placeholder="$t('CONVERSATION.ASSIGNMENT.SELECT_AGENT')"
-          select-label=""
-          label="name"
-          selected-label
-          track-by="id"
-          @select="assignAgent"
-          @remove="removeAgent"
-        >
-          <template slot="option" slot-scope="props">
-            <div class="option__desc">
-              <availability-status-badge
-                :status="props.option.availability_status"
-              />
-              <span class="option__title">{{ props.option.name }}</span>
-            </div>
-          </template>
-          <span slot="noResult">{{ $t('AGENT_MGMT.SEARCH.NO_RESULTS') }}</span>
-        </multiselect>
-      </div>
       <more-actions :conversation-id="currentChat.id" />
     </div>
   </div>
@@ -69,14 +42,12 @@ import MoreActions from './MoreActions';
 import Thumbnail from '../Thumbnail';
 import agentMixin from '../../../mixins/agentMixin.js';
 import eventListenerMixins from 'shared/mixins/eventListenerMixins';
-import AvailabilityStatusBadge from '../conversation/AvailabilityStatusBadge';
 import { hasPressedAltAndOKey } from 'shared/helpers/KeyboardHelpers';
 
 export default {
   components: {
     MoreActions,
     Thumbnail,
-    AvailabilityStatusBadge,
   },
   mixins: [agentMixin, eventListenerMixins],
   props: {
@@ -124,17 +95,6 @@ export default {
         this.$emit('contact-panel-toggle');
       }
     },
-    assignAgent(agent) {
-      this.$store
-        .dispatch('assignAgent', {
-          conversationId: this.currentChat.id,
-          agentId: agent.id,
-        })
-        .then(() => {
-          bus.$emit('newToastMessage', this.$t('CONVERSATION.CHANGE_AGENT'));
-        });
-    },
-    removeAgent() {},
   },
 };
 </script>


### PR DESCRIPTION
## Describe the changes

-  Removes the multi-select agent dropdown from the conversation header.
-  By default changed the contact side panel from close to open.

 
## Screenshot
**Before**
<img width="583" alt="Screenshot 2021-08-10 at 2 02 23 PM" src="https://user-images.githubusercontent.com/64252451/128834898-0c63cc14-39f3-4a2f-bf5b-6b24eac5892f.png">


**After**
<img width="583" alt="Screenshot 2021-08-10 at 2 01 12 PM" src="https://user-images.githubusercontent.com/64252451/128834734-a782386f-e3ce-48f2-ac32-6f0bb33b5b59.png">
