### PR TITLE
fix: Fixes external css interference for widget bubble

### DIFF
--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -73,6 +73,7 @@ export const SDK_CSS = `.woot-widget-holder {
 }
 
 .woot-widget-bubble img {
+  all: revert;
   height: 24px;
   margin: 20px;
   width: 24px;


### PR DESCRIPTION
**Before**
![image](https://user-images.githubusercontent.com/1277421/129362551-de08ebfc-81f0-4eb0-80e0-3f93fd0c1ce3.png)

**After**
![image](https://user-images.githubusercontent.com/1277421/129362589-fedb89f1-3814-4ac6-980f-b0a7d3a23c32.png)
