### PR TITLE
feat: Add message content to mention email template

### DIFF
--- a/app/drops/message_drop.rb
+++ b/app/drops/message_drop.rb
@@ -1,12 +1,12 @@
 class MessageDrop < BaseDrop
+  include MessageFormatHelper
+
   def sender_display_name
     @obj.sender.try(:display_name)
   end
 
   def text_content
     content = @obj.try(:content)
-    # This will remove /[@user](mention://user/3/user)/ from the content
-    text = content.sub(%r{\[@.+\]\(mention://(user|team)/(\d+)/(.+)\) }, '') if content.present?
-    text
+    transform_user_mention_content content
   end
 end

--- a/app/drops/message_drop.rb
+++ b/app/drops/message_drop.rb
@@ -1,0 +1,12 @@
+class MessageDrop < BaseDrop
+  def sender_display_name
+    @obj.sender.try(:display_name)
+  end
+
+  def text_content
+    content = @obj.try(:content)
+    # This will remove /[@user](mention://user/3/user)/ from the content
+    text = content.sub(%r{\[@.+\]\(mention://(user|team)/(\d+)/(.+)\) }, '') if content.present?
+    text
+  end
+end

--- a/app/mailers/agent_notifications/conversation_notifications_mailer.rb
+++ b/app/mailers/agent_notifications/conversation_notifications_mailer.rb
@@ -24,6 +24,7 @@ class AgentNotifications::ConversationNotificationsMailer < ApplicationMailer
 
     @agent = agent
     @conversation = message.conversation
+    @message = message
     subject = "#{@agent.available_name}, You have been mentioned in conversation [ID - #{@conversation.display_id}]"
     @action_url = app_account_conversation_url(account_id: @conversation.account_id, id: @conversation.display_id)
     send_mail_with_liquid(to: @agent.email, subject: subject) and return
@@ -47,7 +48,8 @@ class AgentNotifications::ConversationNotificationsMailer < ApplicationMailer
     super.merge({
                   user: @agent,
                   conversation: @conversation,
-                  inbox: @conversation.inbox
+                  inbox: @conversation.inbox,
+                  message: @message
                 })
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,7 +3,7 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   # the models that exposed in email templates through liquid
-  DROPPABLES = %w[Account Channel Conversation Inbox User].freeze
+  DROPPABLES = %w[Account Channel Conversation Inbox User Message].freeze
 
   # ModelDrop class should exist in app/drops
   def to_drop

--- a/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
+++ b/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
@@ -1,18 +1,17 @@
-<head>
-  <style type="text/css">
-    .message_text_quote {
-      box-sizing:border-box;
-      padding:8px 16px;
-      margin:0 0 20px;
-      font-size:14px;
-      border-left:5px solid #eeeeee
-    }
-  </style>
-</head>
+<style type="text/css">
+  .quoted-text--content {
+    box-sizing:border-box;
+    padding:8px 16px;
+    margin:0 0 20px;
+    font-size:14px;
+    border-left:5px solid #eeeeee
+  }
+</style>
+
 <p>Hi {{user.available_name}}, </p>
 
 <p>You've been mentioned in a conversation. <b>{{message.sender_display_name}}</b> wrote:</p>
-<blockquote class='message_text_quote'>
+<blockquote class='quoted-text--content'>
   {{message.text_content}}
 </blockquote>
 

--- a/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
+++ b/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
@@ -1,8 +1,7 @@
-<p>Hi {{user.available_name}}</p>
+<p>Hi {{user.available_name}} </p>
 
+<p> {{message.sender_display_name}} mentioned you in a conversation.</p>
 
-<p>Time to save the world. You have been mentioned in a conversation</p>
+<p><a href="{{ action_url }}">View Message</a></p>
 
-<p>
-Click <a href="{{ action_url }}">here</a> to get cracking.
-</p>
+<p> {{message.text_content}} </p>

--- a/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
+++ b/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
@@ -1,7 +1,18 @@
+<head>
+  <style type="text/css">
+    .message_text_quote {
+      box-sizing:border-box;
+      padding:8px 16px;
+      margin:0 0 20px;
+      font-size:14px;
+      border-left:5px solid #eeeeee
+    }
+  </style>
+</head>
 <p>Hi {{user.available_name}}, </p>
 
 <p> You have been mentioned in a conversation. <b>{{message.sender_display_name}}</b> wrote:</p>
-<blockquote style="box-sizing:border-box;padding:8px 16px;margin:0 0 20px;font-size:14px;border-left:5px solid #eeeeee">
+<blockquote class='message_text_quote'>
   {{message.text_content}}
 </blockquote>
 

--- a/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
+++ b/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
@@ -11,7 +11,7 @@
 </head>
 <p>Hi {{user.available_name}}, </p>
 
-<p> You have been mentioned in a conversation. <b>{{message.sender_display_name}}</b> wrote:</p>
+<p>You've been mentioned in a conversation. <b>{{message.sender_display_name}}</b> wrote:</p>
 <blockquote class='message_text_quote'>
   {{message.text_content}}
 </blockquote>

--- a/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
+++ b/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
@@ -1,7 +1,8 @@
-<p>Hi {{user.available_name}} </p>
+<p>Hi {{user.available_name}}, </p>
 
-<p> {{message.sender_display_name}} mentioned you in a conversation.</p>
+<p> You have been mentioned in a conversation. <b>{{message.sender_display_name}}</b> wrote:</p>
+<blockquote style="box-sizing:border-box;padding:8px 16px;margin:0 0 20px;font-size:14px;border-left:5px solid #eeeeee">
+  {{message.text_content}}
+</blockquote>
 
 <p><a href="{{ action_url }}">View Message</a></p>
-
-<p> {{message.text_content}} </p>

--- a/spec/mailers/agent_notifications/conversation_notifications_mailer_spec.rb
+++ b/spec/mailers/agent_notifications/conversation_notifications_mailer_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe AgentNotifications::ConversationNotificationsMailer, type: :maile
     end
 
     it 'renders the senders name' do
-      expect(mail.body.encoded).to match("#{another_agent.display_name} mentioned you in a conversation.")
+      expect(mail.body.encoded).to match("You've been mentioned in a conversation. <b>#{another_agent.display_name}</b> wrote:")
     end
   end
 

--- a/spec/mailers/agent_notifications/conversation_notifications_mailer_spec.rb
+++ b/spec/mailers/agent_notifications/conversation_notifications_mailer_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe AgentNotifications::ConversationNotificationsMailer, type: :maile
   end
 
   describe 'conversation_mention' do
-    let(:message) { create(:message, conversation: conversation, account: account) }
+    let(:another_agent) { create(:user, email: 'agent2@example.com', account: account) }
+    let(:message) { create(:message, conversation: conversation, account: account, sender: another_agent) }
     let(:mail) { described_class.with(account: account).conversation_mention(message, agent).deliver_now }
 
     it 'renders the subject' do
@@ -48,6 +49,10 @@ RSpec.describe AgentNotifications::ConversationNotificationsMailer, type: :maile
 
     it 'renders the receiver email' do
       expect(mail.to).to eq([agent.email])
+    end
+
+    it 'renders the senders name' do
+      expect(mail.body.encoded).to match("#{another_agent.display_name} mentioned you in a conversation.")
     end
   end
 


### PR DESCRIPTION
## Description

Updated a template for the conversation_mention email. We have introduced in MessageDrop to get the message sender and message content in the template. This is not impacting other ConversationNotificationsMailer templates.

Fixes #2825 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. Mention agent in the conversation, checked updated mail body. 
2. Assign agent and checked the relevant template if it's not impacted.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
