### PR TITLE
chore: support for APMs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,8 +85,6 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=
 
-# Sentry
-SENTRY_DSN=
 
 # Log settings
 # Disable if you want to write logs to a file
@@ -137,6 +135,25 @@ ANDROID_SHA256_CERT_FINGERPRINT=AC:73:8E:DE:EB:56:EA:CC:10:87:02:A7:65:37:7B:38:
 
 ## Bot Customizations
 USE_INBOX_AVATAR_FOR_BOT=true
+
+
+### APM and Error Monitoring configurations
+## Sentry
+# SENTRY_DSN=
+
+## Scout
+## https://scoutapm.com/docs/ruby/configuration
+# SCOUT_KEY=YOURKEY
+# SCOUT_NAME=YOURAPPNAME (Production)
+# SCOUT_MONITOR=true
+
+## NewRelic
+# https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/
+# NEW_RELIC_LICENSE_KEY=
+
+## Datadog
+## https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#environment-variables
+# DD_TRACE_AGENT_URL=
 
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -96,11 +96,11 @@ gem 'brakeman'
 
 ##-- apm and error monitoring ---#
 gem 'ddtrace'
+gem 'newrelic_rpm'
 gem 'scout_apm'
 gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'sentry-sidekiq'
-gem 'newrelic_rpm'
 
 ##-- background job processing --##
 gem 'sidekiq'

--- a/Gemfile
+++ b/Gemfile
@@ -93,11 +93,14 @@ gem 'google-cloud-dialogflow'
 ##--- gems for debugging and error reporting ---##
 # static analysis
 gem 'brakeman'
+
+##-- apm and error monitoring ---#
 gem 'ddtrace'
 gem 'scout_apm'
 gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'sentry-sidekiq'
+gem 'newrelic_rpm'
 
 ##-- background job processing --##
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,6 +362,7 @@ GEM
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     netrc (0.11.0)
+    newrelic_rpm (7.2.0)
     nio4r (2.5.8)
     nokogiri (1.11.7-arm64-darwin)
       racc (~> 1.4)
@@ -682,6 +683,7 @@ DEPENDENCIES
   listen
   maxminddb
   mock_redis
+  newrelic_rpm
   pg
   procore-sift
   pry-rails

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,0 +1,6 @@
+if ENV['DD_TRACE_AGENT_URL']
+  Datadog.configure do |c|
+    # This will activate auto-instrumentation for Rails
+    c.use :rails
+  end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,6 @@
-Sentry.init do |config|
-  config.dsn = ENV['SENTRY_DSN']
-  config.enabled_environments = %w[staging production]
+if ENV['SENTRY_DSN']
+  Sentry.init do |config|
+    config.dsn = ENV['SENTRY_DSN']
+    config.enabled_environments = %w[staging production]
+  end
 end

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,45 @@
+#
+# This file configures the New Relic Agent.  New Relic monitors Ruby, Java,
+# .NET, PHP, Python, Node, and Go applications with deep visibility and low
+# overhead.  For more information, visit www.newrelic.com.
+#
+#
+# For full documentation of agent configuration options, please refer to
+# https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
+
+common: &default_settings
+  # Required license key associated with your New Relic account.
+  license_key: <%= ENV['NEW_RELIC_LICENSE_KEY'] %>
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  app_name:  <%= ENV.fetch('NEW_RELIC_APP_NAME', 'Chatwoot')  %>
+
+  distributed_tracing:
+    enabled: true
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  agent_enabled: <%= ENV['NEW_RELIC_LICENSE_KEY'].present? && ENV.fetch('NEW_RELIC_AGENT_ENABLED', true)  %>
+
+  # Logging level for log/newrelic_agent.log
+  log_level: <%= ENV.fetch('NEW_RELIC_LOG_LEVEL', 'info')  %>
+
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+  app_name: <%= ENV.fetch('NEW_RELIC_APP_NAME', 'Chatwoot')  %> (Development)
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+staging:
+  <<: *default_settings
+  app_name: <%= ENV.fetch('NEW_RELIC_APP_NAME', 'Chatwoot')  %> (Staging)
+
+production:
+  <<: *default_settings


### PR DESCRIPTION
Add the support for Newrelic and Datadog.
ref: https://www.chatwoot.com/docs/self-hosted/monitoring/apm-and-error-monitoring

fixes: #2861