### PR TITLE
fix: chatwoot_webpack failure due to missing git

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,6 +80,7 @@ RUN apk add --update --no-cache \
     tzdata \
     postgresql-client \
     imagemagick \
+    git \
   && gem install bundler
 
 RUN if [ "$RAILS_ENV" != "production" ]; then \


### PR DESCRIPTION
# Pull Request Template

## Description

Chatwoot `webpack` docker for local setup was failing due to missing git binary.

- add git binary in chatwoot base image

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested on 20.04 Ubuntu instance

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
