### PR TITLE
[2887] Display available name in email

### DIFF
--- a/app/drops/message_drop.rb
+++ b/app/drops/message_drop.rb
@@ -2,7 +2,7 @@ class MessageDrop < BaseDrop
   include MessageFormatHelper
 
   def sender_display_name
-    @obj.sender.try(:display_name)
+    @obj.sender.try(:available_name)
   end
 
   def text_content


### PR DESCRIPTION
## Description

When the user mentions the agent in conversation it sends one email mention_conversation_email where we use display_name of a sender. If display_name is not present for the sender then the email template should display the sender name in the email.


Fixes #2887 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on local with letter opener.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
