### PR TITLE
fix: Disable attribute item from settings menu

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/settings.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/settings.routes.js
@@ -10,7 +10,6 @@ import profile from './profile/profile.routes';
 import reports from './reports/reports.routes';
 import campaigns from './campaigns/campaigns.routes';
 import teams from './teams/teams.routes';
-import attributes from './attributes/attributes.routes';
 import store from '../../../store';
 
 export default {
@@ -36,7 +35,6 @@ export default {
     ...reports.routes,
     ...teams.routes,
     ...campaigns.routes,
-    ...attributes.routes,
     ...integrationapps.routes,
   ],
 };


### PR DESCRIPTION
The `Attributes` item is disabled from the settings menu. We will enable it only after all the items in https://github.com/chatwoot/chatwoot/issues/2863 are complete.