### PR TITLE
Add missing conversation id for first response event

### DIFF
--- a/app/listeners/event_listener.rb
+++ b/app/listeners/event_listener.rb
@@ -24,7 +24,8 @@ class EventListener < BaseListener
       value: first_response_time,
       account_id: conversation.account_id,
       inbox_id: conversation.inbox_id,
-      user_id: conversation.assignee_id
+      user_id: conversation.assignee_id,
+      conversation_id: conversation.id
     )
     event.save
   end

--- a/spec/builders/v2/report_builder_spec.rb
+++ b/spec/builders/v2/report_builder_spec.rb
@@ -215,7 +215,7 @@ describe ::V2::ReportBuilder do
       end
 
       it 'returns average first response time' do
-        FactoryBot.create(:event, conversation: label_2.conversations.last, account: account, name: 'first_response')
+        label_2.events.update(value: 1.5)
 
         params = {
           metric: 'avg_first_response_time',


### PR DESCRIPTION
# Pull Request Template

## Description

This change adds the missing conversation id for the first response event.

Fixes #2746

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Verified conversation id in the first response event record created in DB using rails console.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
