### PR TITLE
Use connection pooling for app redis

### DIFF
--- a/config/initializers/01_redis.rb
+++ b/config/initializers/01_redis.rb
@@ -3,8 +3,8 @@ redis = Rails.env.test? ? MockRedis.new : Redis.new(Redis::Config.app)
 # Alfred
 # Add here as you use it for more features
 # Used for Round Robin, Conversation Emails & Online Presence
-$alfred = Redis::Namespace.new('alfred', redis: redis, warning: true)
+$alfred = ConnectionPool::Wrapper.new(size: 5, timeout: 3) { Redis::Namespace.new('alfred', redis: redis, warning: true) }
 
 # Velma : Determined protector
 # used in rack attack
-$velma =  Redis::Namespace.new('velma', redis: redis, warning: true)
+$velma =  ConnectionPool::Wrapper.new(size: 5, timeout: 3) { Redis::Namespace.new('velma', redis: redis, warning: true) }


### PR DESCRIPTION
## Description

This change makes sure that the app redis uses connection pooling.

The problem with the current approach is that the redis connections are one global variable, so if there are multiple threads that needs connection to Redis, some threads have to wait on them until the other thread completes the operation.

With a connection pool, multiple threads can check out connections to Redis simultaneously (As the name suggests, it is a pool of connections), so there is no blocking involved. Once the operation is done, the connection is added back to the pool.

I have made the change to use `ConnectionPool::Wrapper` instead of the usual `ConnectionPool`, because the `Wrapper` class is the easiest way to make the most minimal change here.

However, it is not very performant because it uses `method_missing` under the hood to check out connections. But to get started on using connection pooling, this would be the most easiest solution.

Once you are confident with the working of connection pool, you can adopt the following way of coding Alfred everywhere, and then replace `ConnectionPool::Wrapper` with `ConnectionPool`.

```ruby
$alfred.with do |conn|
  conn.sadd('chatwoot', 0)
end
```

Next steps would be:

- replacing direct calls to redis from `$alfred` or `$velma` and start making the calls from within the `.with` block as described above.
- Add connection pooling for Sidekiq redis.
 
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality) - for performance
## How Has This Been Tested?

I am not in a position to test this change extensively. Maintainers - could you please test out the change for me? 🙂 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
