### PR TITLE
feat: Support sending and receiving attachments in Slack Integration

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -25,6 +25,7 @@ class Attachment < ApplicationRecord
   enum file_type: [:image, :audio, :video, :file, :location, :fallback]
 
   def push_event_data
+    return unless file_type
     return base_data.merge(location_metadata) if file_type.to_sym == :location
     return base_data.merge(fallback_data) if file_type.to_sym == :fallback
 

--- a/lib/integrations/slack/incoming_message_builder.rb
+++ b/lib/integrations/slack/incoming_message_builder.rb
@@ -88,8 +88,8 @@ class Integrations::Slack::IncomingMessageBuilder
       private: private_note?,
       sender: sender
     )
-    # check if it is inside the event and change the stub
-    process_attachments(params[:files]) if params[:files].present?
+
+    process_attachments(params[:event][:files]) if params[:event][:files].present?
 
     { status: 'success' }
   end
@@ -98,30 +98,27 @@ class Integrations::Slack::IncomingMessageBuilder
     @slack_client ||= Slack::Web::Client.new(token: @integration_hook.access_token)
   end
 
-  # ToDo: move process attachment for facebook instagram and slack in one place
+  # TODO: move process attachment for facebook instagram and slack in one place
+  # https://api.slack.com/messaging/files
   def process_attachments(attachments)
     attachments.each do |attachment|
+      tempfile = Down::NetHttp.download(attachment[:url_private], headers: { 'Authorization' => "Bearer #{integration_hook.access_token}" })
+
       attachment_params = {
         file_type: file_type(attachment),
         account_id: @message.account_id,
-        external_url: attachment[:permalink]
+        external_url: attachment[:url_private],
+        file: {
+          io: tempfile,
+          filename: tempfile.original_filename,
+          content_type: tempfile.content_type
+        }
       }
+
       attachment_obj = @message.attachments.new(attachment_params)
+      attachment_obj.file.content_type = attachment[:mimetype]
       attachment_obj.save!
-      attach_file(attachment_obj, attachment_params[:external_url]) if attachment_params[:external_url]
     end
-  end
-
-  def attach_file(attachment, file_url)
-    attachment_file = Down.download(
-      file_url
-    )
-
-    attachment.file.attach(
-      io: attachment_file,
-      filename: attachment_file.original_filename,
-      content_type: attachment_file.content_type
-    )
   end
 
   def file_type(attachment)

--- a/spec/lib/integrations/slack/incoming_message_builder_spec.rb
+++ b/spec/lib/integrations/slack/incoming_message_builder_spec.rb
@@ -61,7 +61,7 @@ describe Integrations::Slack::IncomingMessageBuilder do
         builder.perform
         expect(conversation.messages.count).to eql(messages_count + 1)
         expect(conversation.messages.last.content).to eql('this is test https://chatwoot.com Hey @Sojan Test again')
-        expect(conversation.messages.last.attachments.any?).to be_truthy
+        expect(conversation.messages.last.attachments).to be_any
       end
     end
   end

--- a/spec/lib/integrations/slack/incoming_message_builder_spec.rb
+++ b/spec/lib/integrations/slack/incoming_message_builder_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe Integrations::Slack::IncomingMessageBuilder do
   let(:account) { create(:account) }
   let(:message_params) { slack_message_stub }
+  let(:message_with_attachments) { slack_attachment_stub }
   let(:message_without_thread_ts) { slack_message_stub_without_thread_ts }
   let(:verification_params) { slack_url_verification_stub }
 
@@ -50,6 +51,17 @@ describe Integrations::Slack::IncomingMessageBuilder do
         builder = described_class.new(message_params)
         builder.perform
         expect(conversation.messages.count).to eql(messages_count)
+      end
+
+      it 'saves attachment if params files present' do
+        expect(hook).not_to eq nil
+        messages_count = conversation.messages.count
+        builder = described_class.new(message_with_attachments)
+        allow(builder).to receive(:sender).and_return(nil)
+        builder.perform
+        expect(conversation.messages.count).to eql(messages_count + 1)
+        expect(conversation.messages.last.content).to eql('this is test https://chatwoot.com Hey @Sojan Test again')
+        expect(conversation.messages.last.attachments.any?).to be_truthy
       end
     end
   end

--- a/spec/support/slack_stubs.rb
+++ b/spec/support/slack_stubs.rb
@@ -21,6 +21,21 @@ module SlackStubs
     }
   end
 
+  def slack_attachment_stub
+    {
+      token: '[FILTERED]',
+      team_id: 'TLST3048H',
+      api_app_id: 'A012S5UETV4',
+      event: message_event,
+      files: file_stub,
+      type: 'event_callback',
+      event_id: 'Ev013QUX3WV6',
+      event_time: 1_588_623_033,
+      authed_users: '[FILTERED]',
+      webhook: {}
+    }
+  end
+
   def slack_message_stub_without_thread_ts
     {
       token: '[FILTERED]',
@@ -57,6 +72,18 @@ module SlackStubs
       event_ts: '1588623033.006000',
       channel_type: 'group'
     }
+  end
+
+  def file_stub
+    [
+      {
+        mimetype: 'image/png',
+        permalink: 'https://via.placeholder.com/250x250.png',
+        name: 'name_of_the_file',
+        title: 'title_of_the_file',
+        filetype: 'png'
+      }
+    ]
   end
 
   def message_blocks

--- a/spec/support/slack_stubs.rb
+++ b/spec/support/slack_stubs.rb
@@ -27,7 +27,6 @@ module SlackStubs
       team_id: 'TLST3048H',
       api_app_id: 'A012S5UETV4',
       event: message_event,
-      files: file_stub,
       type: 'event_callback',
       event_id: 'Ev013QUX3WV6',
       event_time: 1_588_623_033,
@@ -67,6 +66,7 @@ module SlackStubs
       ts: '1588623033.006000',
       team: 'TLST3048H',
       blocks: message_blocks,
+      files: file_stub,
       thread_ts: '1588623023.005900',
       channel: 'G01354F6A6Q',
       event_ts: '1588623033.006000',
@@ -78,10 +78,11 @@ module SlackStubs
     [
       {
         mimetype: 'image/png',
-        permalink: 'https://via.placeholder.com/250x250.png',
+        url_private: 'https://via.placeholder.com/250x250.png',
         name: 'name_of_the_file',
         title: 'title_of_the_file',
-        filetype: 'png'
+        filetype: 'png',
+        url_private_download: 'https://via.placeholder.com/250x250.png'
       }
     ]
   end


### PR DESCRIPTION
# Pull Request Template

## Description

Slack was not able to process attachments, we chatwoot should be able to receive and send files.

Fixes https://github.com/chatwoot/product/issues/4

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Send an attachment through the slack channel check if we are able to see it in the chatwoot conversation
- Send an attachment to the slack channel check from chatwoot conversation.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
