### PR TITLE
fix: Emails not delivered when case does not match

### DIFF
--- a/app/mailboxes/application_mailbox.rb
+++ b/app/mailboxes/application_mailbox.rb
@@ -22,7 +22,7 @@ class ApplicationMailbox < ActionMailbox::Base
     proc do |inbound_mail_obj|
       is_a_support_email = false
       inbound_mail_obj.mail.to&.each do |email|
-        channel = Channel::Email.find_by('email = ? OR forward_to_email = ?', email, email)
+        channel = Channel::Email.find_by('lower(email) = ? OR lower(forward_to_email) = ?', email.downcase, email.downcase)
         if channel.present?
           is_a_support_email = true
           break

--- a/app/mailboxes/support_mailbox.rb
+++ b/app/mailboxes/support_mailbox.rb
@@ -21,7 +21,7 @@ class SupportMailbox < ApplicationMailbox
 
   def find_channel
     mail.to.each do |email|
-      @channel = Channel::Email.find_by('email = ? OR forward_to_email = ?', email, email)
+      @channel = Channel::Email.find_by('lower(email) = ? OR lower(forward_to_email) = ?', email.downcase, email.downcase)
       break if @channel.present?
     end
     raise 'Email channel/inbox not found' if @channel.nil?

--- a/spec/fixtures/files/support_without_sender_name.eml
+++ b/spec/fixtures/files/support_without_sender_name.eml
@@ -4,7 +4,7 @@ Content-Type: multipart/alternative; boundary="Apple-Mail=_33A037C7-4BB3-4772-AE
 Subject: Discussion: Let's debate these attachments
 Date: Tue, 20 Apr 2020 04:20:20 -0400
 In-Reply-To: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
-To: "Replies" <care@example.com>
+To: "Replies" <Care@example.com>
 References: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
 Message-Id: <0CB459E0-0336-41DA-BC88-E6E28C697DDB@chatwoot.com>
 X-Mailer: Apple Mail (2.1244.3)

--- a/spec/mailboxes/support_mailbox_spec.rb
+++ b/spec/mailboxes/support_mailbox_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe SupportMailbox, type: :mailbox do
       end
     end
 
+    describe 'Sender with upcase mail address' do
+      let(:support_mail_without_sender_name) { create_inbound_email_from_fixture('support_without_sender_name.eml') }
+      let(:described_subject) { described_class.receive support_mail_without_sender_name }
+
+      it 'create a new inbox with the email case insensitive' do
+        described_subject
+        expect(conversation.inbox.id).to eq(channel_email.inbox.id)
+      end
+    end
+
     describe 'handle inbox contacts' do
       let(:contact) { create(:contact, account: account, email: support_mail.mail.from.first) }
       let(:contact_inbox) { create(:contact_inbox, inbox: channel_email.inbox, contact: contact) }


### PR DESCRIPTION
# Pull Request Template

## Description

Check the email channel case insensitive.

Fixes #2504 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Send an email to email channel and receive the message in email channel inbox

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
