### PR TITLE
Add option button CSS rules

### DIFF
--- a/app/javascript/shared/components/ChatOption.vue
+++ b/app/javascript/shared/components/ChatOption.vue
@@ -41,8 +41,8 @@ export default {
 @import '~widget/assets/scss/variables.scss';
 
 .option {
-  border: 1px solid $color-woot;
   border-radius: $space-jumbo;
+  border: 1px solid $color-woot;
   float: left;
   margin: $space-smaller;
   max-width: 100%;
@@ -53,6 +53,9 @@ export default {
     border: 0;
     color: $color-woot;
     cursor: pointer;
+    height: auto;
+    line-height: 1.5;
+    min-height: $space-two * 2;
     text-align: left;
     white-space: normal;
 

--- a/app/javascript/shared/components/ChatOption.vue
+++ b/app/javascript/shared/components/ChatOption.vue
@@ -45,6 +45,7 @@ export default {
   border-radius: $space-jumbo;
   float: left;
   margin: $space-smaller;
+  max-width: 100%;
 
   .option-button {
     background: transparent;
@@ -53,6 +54,7 @@ export default {
     color: $color-woot;
     cursor: pointer;
     text-align: left;
+    white-space: normal;
 
     span {
       display: inline-block;


### PR DESCRIPTION
Add CSS rules to ChatOption to make long options wrap instead of going outside of the chat bubble.

# Pull Request Template

## Description

As requested by @pranavrajs I have raised a pull request regarding the option buttons in the chat widget going out of the chat bubble when they are long:

Old version:
![old version](https://cdn.discordapp.com/attachments/647729576427913228/888054843665694771/unknown.png)

New version:
![new version](https://cdn.discordapp.com/attachments/647729576427913228/888057030374461490/unknown.png)

**! As I don't know the code base very well, please verify if I didn't break something somewhere else !**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have only tested this by editing the HTML source of my chat widget in the browser (via dev tools). **No rebuild of the source has been performed.**

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
