### PR TITLE
fix: Add blank check for file param in Import API

### DIFF
--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -30,10 +30,13 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def import
+    render json: { error: 'File is blank' }, status: :unprocessable_entity and return if params[:import_file].blank?
+
     ActiveRecord::Base.transaction do
       import = Current.account.data_imports.create!(data_type: 'contacts')
       import.import_file.attach(params[:import_file])
     end
+
     head :ok
   end
 

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -30,7 +30,7 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def import
-    render json: { error: 'File is blank' }, status: :unprocessable_entity and return if params[:import_file].blank?
+    render json: { error: I18n.t('errors.contacts.import.failed') }, status: :unprocessable_entity and return if params[:import_file].blank?
 
     ActiveRecord::Base.transaction do
       import = Current.account.data_imports.create!(data_type: 'contacts')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,9 @@ en:
       invalid_email: You have entered an invalid email
       email_already_exists: "You have already signed up for an account with %{email}"
       failed: Signup failed
+    contacts:
+      import:
+        failed: File is blank  
 
   reports:
     period: Reporting period %{since} to %{until}

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -110,11 +110,11 @@ RSpec.describe 'Contacts API', type: :request do
       let(:admin) { create(:user, account: account, role: :administrator) }
 
       it 'returns Unprocessable Entity' do
-       post "/api/v1/accounts/#{account.id}/contacts/import",
+        post "/api/v1/accounts/#{account.id}/contacts/import",
              headers: admin.create_new_auth_token
 
         json_response = JSON.parse(response.body)
-        
+
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_response['error']).to eq('File is blank')
       end

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -105,6 +105,20 @@ RSpec.describe 'Contacts API', type: :request do
         expect(account.data_imports.first.import_file.attached?).to eq(true)
       end
     end
+
+    context 'when file is empty' do
+      let(:admin) { create(:user, account: account, role: :administrator) }
+
+      it 'returns Unprocessable Entity' do
+       post "/api/v1/accounts/#{account.id}/contacts/import",
+             headers: admin.create_new_auth_token
+
+        json_response = JSON.parse(response.body)
+        
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['error']).to eq('File is blank')
+      end
+    end
   end
 
   describe 'GET /api/v1/accounts/{account.id}/contacts/active' do


### PR DESCRIPTION

## Description

Fix for Contact Imports API, it returns 200 success even if there is no file attached in the request

Fixes #3031 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Tried passing `import_file` param as `nil` in request payload and verified it.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes
