### PR TITLE
fix: Fixes offset issue for Business hours on timezones with DST

### DIFF
--- a/app/views/api/v1/widget/configs/create.json.jbuilder
+++ b/app/views/api/v1/widget/configs/create.json.jbuilder
@@ -16,7 +16,7 @@ json.chatwoot_website_channel do
   json.csat_survey_enabled @web_widget.inbox.csat_survey_enabled
   json.working_hours @web_widget.inbox.working_hours
   json.out_of_office_message @web_widget.inbox.out_of_office_message
-  json.utc_off_set ActiveSupport::TimeZone[@web_widget.inbox.timezone].formatted_offset
+  json.utc_off_set ActiveSupport::TimeZone[@web_widget.inbox.timezone].now.formatted_offset
 end
 json.chatwoot_widget_defaults do
   json.use_inbox_avatar_for_bot ActiveModel::Type::Boolean.new.cast(ENV.fetch('USE_INBOX_AVATAR_FOR_BOT', false))

--- a/app/views/widgets/show.html.erb
+++ b/app/views/widgets/show.html.erb
@@ -23,7 +23,7 @@
         csatSurveyEnabled: <%= @web_widget.inbox.csat_survey_enabled %>,
         workingHours: <%= @web_widget.inbox.working_hours.to_json.html_safe %>,
         outOfOfficeMessage: <%= @web_widget.inbox.out_of_office_message.to_json.html_safe %>,
-        utcOffset: '<%= ActiveSupport::TimeZone[@web_widget.inbox.timezone].formatted_offset %>'
+        utcOffset: '<%= ActiveSupport::TimeZone[@web_widget.inbox.timezone].now.formatted_offset %>'
       }
       window.chatwootWidgetDefaults = {
         useInboxAvatarForBot: <%= ActiveModel::Type::Boolean.new.cast(ENV.fetch('USE_INBOX_AVATAR_FOR_BOT', false)) %>,


### PR DESCRIPTION
# Pull Request Template

## Description

At widget the timezone offset is sent but it doesn't take dst in mind. The problem is that at widget settings the offset is taken from the timezone itself and it has no context of the current date. Solution is to get the offset from a current date instance.

Fixes #2882

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
