### PR TITLE
feat: Ability to close and reopen the chat window via SDK

### DIFF
--- a/app/javascript/packs/sdk.js
+++ b/app/javascript/packs/sdk.js
@@ -40,8 +40,8 @@ const runSDK = ({ baseUrl, websiteToken }) => {
     launcherTitle: chatwootSettings.launcherTitle || '',
     showPopoutButton: chatwootSettings.showPopoutButton || false,
 
-    toggle() {
-      IFrameHelper.events.toggleBubble();
+    toggle(state) {
+      IFrameHelper.events.toggleBubble(state);
     },
 
     setUser(identifier, user) {

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -137,7 +137,7 @@ export const IFrameHelper = {
       setBubbleText(window.$chatwoot.launcherTitle || message.label);
     },
 
-    toggleBubble: (state) => {
+    toggleBubble: state => {
       if (state === 'open') {
         onBubbleClick({ toggleValue: true });
       } else if (state === 'close') {

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -137,8 +137,14 @@ export const IFrameHelper = {
       setBubbleText(window.$chatwoot.launcherTitle || message.label);
     },
 
-    toggleBubble: () => {
-      onBubbleClick();
+    toggleBubble: (state) => {
+      if (state === 'open') {
+        onBubbleClick({ toggleValue: true });
+      } else if (state === 'close') {
+        onBubbleClick({ toggleValue: false });
+      } else {
+        onBubbleClick();
+      }
     },
 
     onBubbleToggle: isOpen => {

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -138,13 +138,14 @@ export const IFrameHelper = {
     },
 
     toggleBubble: state => {
+      let bubbleState = {};
       if (state === 'open') {
-        onBubbleClick({ toggleValue: true });
+        bubbleState.toggleValue = true;
       } else if (state === 'close') {
-        onBubbleClick({ toggleValue: false });
-      } else {
-        onBubbleClick();
+        bubbleState.toggleValue = false;
       }
+
+      onBubbleClick(bubbleState);
     },
 
     onBubbleToggle: isOpen => {


### PR DESCRIPTION
## Description

The `window.$chatwoot.toggle();` provided in the SDK can be inadequate in some cases because there is no way to know the current status of the chatWindow whether it toggled close or open. 

So this change allows the user to explicitly pass the state to `window.$chatwoot.toggle();` function. which helps to open or close the chat window.

Fixes #3040

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

1. Create a new chat window using inbox Messenger Script.
2. window.$chatwoot.toggle(); should retains current behaviour
3. window.$chatwoot.toggle('close'); should close the window if open
4. window.$chatwoot.toggle('open;); should open window if closed


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (https://github.com/chatwoot/docs/pull/101)
- [x] My changes generate no new warnings
