### PR TITLE
chore: mitigate CVE-2021-41098

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,3 @@
+---
+ignore:
+  - CVE-2021-41098 # https://github.com/chatwoot/chatwoot/issues/3097 (update once azure blob storage is updated)


### PR DESCRIPTION
ignoring CVE-2021-41098 as Chatwoot doesn't support JRuby at the moment

fixes: #3097

