### PR TITLE
fix: Update Re-rendering behaviour for lists in conversation view

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/Dashboard.vue
+++ b/app/javascript/dashboard/routes/dashboard/Dashboard.vue
@@ -2,7 +2,7 @@
   <div class="row app-wrapper">
     <sidebar :route="currentRoute" :class="sidebarClassName"></sidebar>
     <section class="app-content columns" :class="contentClassName">
-      <router-view :key="$route.path"></router-view>
+      <router-view></router-view>
     </section>
   </div>
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/Wrapper.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/Wrapper.vue
@@ -9,9 +9,10 @@
       :back-url="backUrl"
       :show-new-button="showNewButton"
     />
-    <keep-alive>
+    <keep-alive v-if="keepAlive">
       <router-view></router-view>
     </keep-alive>
+    <router-view v-else></router-view>
   </div>
 </template>
 
@@ -27,6 +28,10 @@ export default {
     headerTitle: String,
     headerButtonText: String,
     icon: String,
+    keepAlive: {
+      type: Boolean,
+      default: true,
+    },
     newButtonRoutes: {
       type: Array,
       default: () => [],

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/WootReports.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/WootReports.vue
@@ -134,7 +134,6 @@ export default {
     },
   },
   mounted() {
-    console.log('hi');
     this.$store.dispatch(this.actionKey);
   },
   methods: {

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/WootReports.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/WootReports.vue
@@ -134,6 +134,7 @@ export default {
     },
   },
   mounted() {
+    console.log('hi');
     this.$store.dispatch(this.actionKey);
   },
   methods: {

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/reports.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/reports.routes.js
@@ -14,6 +14,7 @@ export default {
       props: {
         headerTitle: 'REPORT.HEADER',
         icon: 'ion-arrow-graph-up-right',
+        keepAlive: false,
       },
       children: [
         {
@@ -34,6 +35,7 @@ export default {
       props: {
         headerTitle: 'CSAT_REPORTS.HEADER',
         icon: 'ion-happy-outline',
+        keepAlive: false,
       },
       children: [
         {
@@ -49,7 +51,8 @@ export default {
       component: SettingsContent,
       props: {
         headerTitle: 'AGENT_REPORTS.HEADER',
-        icon: 'ion-people',
+        icon: 'ion-ios-people',
+        keepAlive: false,
       },
       children: [
         {
@@ -66,6 +69,7 @@ export default {
       props: {
         headerTitle: 'LABEL_REPORTS.HEADER',
         icon: 'ion-pricetags',
+        keepAlive: false,
       },
       children: [
         {
@@ -82,6 +86,7 @@ export default {
       props: {
         headerTitle: 'INBOX_REPORTS.HEADER',
         icon: 'ion-archive',
+        keepAlive: false,
       },
       children: [
         {


### PR DESCRIPTION
As part of #3084, a key was added to router-view which forced re-render every time a URL is changed. This was done to force re-render report views.

To fix that: 

- [x] I removed the key from router-view so that views won't re-rendering every time the URL is changed.
- [x] To force re-render the views for reports, I added a `keepAlive` key and set it to false, so that the view won't be cached.