### PR TITLE
chore: Add readonly attribute to woot-input component

### DIFF
--- a/app/javascript/dashboard/components/widgets/forms/Input.vue
+++ b/app/javascript/dashboard/components/widgets/forms/Input.vue
@@ -5,6 +5,7 @@
       :value="value"
       :type="type"
       :placeholder="placeholder"
+      :readonly="readonly"
       @input="onChange"
       @blur="onBlur"
     />
@@ -41,6 +42,10 @@ export default {
     error: {
       type: String,
       default: '',
+    },
+    readonly: {
+      type: String,
+      deafaut: '',
     },
   },
   methods: {

--- a/app/javascript/dashboard/components/widgets/forms/Input.vue
+++ b/app/javascript/dashboard/components/widgets/forms/Input.vue
@@ -44,8 +44,8 @@ export default {
       default: '',
     },
     readonly: {
-      type: String,
-      deafaut: '',
+      type: Boolean,
+      deafaut: false,
     },
   },
   methods: {


### PR DESCRIPTION
# Pull Request Template

## Description

Add a read-only attribute to woot-input component.

Fixes https://github.com/chatwoot/chatwoot/issues/3120

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

UI 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
