### PR TITLE
fix: CSAT reports page failing to load

### DIFF
--- a/app/views/api/v1/models/_agent.json.jbuilder
+++ b/app/views/api/v1/models/_agent.json.jbuilder
@@ -1,4 +1,5 @@
-json.account_id resource.account.id
+# could be nil for a deleted agent hence the safe operator before account id
+json.account_id resource.account&.id
 json.availability_status resource.availability_status
 json.confirmed resource.confirmed?
 json.email resource.email

--- a/spec/controllers/api/v1/accounts/csat_survey_responses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/csat_survey_responses_controller_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe 'CSAT Survey Responses API', type: :request do
         expect(response_data.pluck('id')).to include(csat_3_days_ago.id)
         expect(response_data.pluck('id')).not_to include(csat_10_days_ago.id)
       end
+
+      it 'returns csat responses even if the agent is deleted from account' do
+        deleted_agent_csat = create(:csat_survey_response, account: account, assigned_agent: agent)
+        deleted_agent_csat.assigned_agent.account_users.destroy_all
+
+        get "/api/v1/accounts/#{account.id}/csat_survey_responses",
+            headers: administrator.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+      end
     end
   end
 


### PR DESCRIPTION
CSAT reports page was failing to load when there is an assigned agent who got deleted.

