### PR TITLE
feat: Display `sent` status of emails in email channel

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="message-text--metadata">
     <span class="time">{{ readableTime }}</span>
+    <span v-if="isOutgoing && sourceId && isAnEmailChannel" class="time">
+      <i
+        v-tooltip.top-start="$t('CHAT_LIST.SENT')"
+        class="icon ion-checkmark"
+      />
+    </span>
     <i
       v-if="isEmail"
       v-tooltip.top-start="$t('CHAT_LIST.RECEIVED_VIA_EMAIL')"
@@ -36,8 +42,10 @@
 <script>
 import { MESSAGE_TYPE } from 'shared/constants/messages';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
+import inboxMixin from 'shared/mixins/inboxMixin';
 
 export default {
+  mixins: [inboxMixin],
   props: {
     sender: {
       type: Object,
@@ -128,8 +136,7 @@ export default {
 }
 
 .right {
-  .ion-reply,
-  .ion-android-open {
+  .icon {
     color: var(--white);
   }
 }
@@ -200,5 +207,9 @@ export default {
       padding-left: var(--space-one);
     }
   }
+}
+
+.delivered-icon {
+  margin-left: -var(--space-normal);
 }
 </style>

--- a/app/javascript/dashboard/i18n/locale/en/chatlist.json
+++ b/app/javascript/dashboard/i18n/locale/en/chatlist.json
@@ -85,6 +85,7 @@
     "RECEIVED_VIA_EMAIL": "Received via email",
     "VIEW_TWEET_IN_TWITTER": "View tweet in Twitter",
     "REPLY_TO_TWEET": "Reply to this tweet",
+    "SENT": "Sent successfully",
     "NO_MESSAGES": "No Messages",
     "NO_CONTENT": "No content available",
     "HIDE_QUOTED_TEXT": "Hide Quoted Text",

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -49,14 +49,16 @@ class ConversationReplyMailer < ApplicationMailer
     init_conversation_attributes(message.conversation)
     @message = message
 
-    mail({
-           to: @contact&.email,
-           from: from_email_with_name,
-           reply_to: reply_email,
-           subject: mail_subject,
-           message_id: custom_message_id,
-           in_reply_to: in_reply_to_email
-         })
+    reply_mail_object = mail({
+      to: @contact&.email,
+      from: reply_email,
+      reply_to: reply_email,
+      subject: mail_subject,
+      message_id: custom_message_id,
+      in_reply_to: in_reply_to_email
+    })
+
+    message.update(source_id: reply_mail_object.message_id)
   end
 
   def conversation_transcript(conversation, to_email)
@@ -116,7 +118,7 @@ class ConversationReplyMailer < ApplicationMailer
 
   def reply_email
     if should_use_conversation_email_address?
-      "#{assignee_name} <reply+#{@conversation.uuid}@#{@account.inbound_email_domain}>"
+      "#{assignee_name} from #{@inbox.name} <reply+#{@conversation.uuid}@#{@account.inbound_email_domain}>"
     else
       @inbox.email_address || @agent&.email
     end

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -2,14 +2,14 @@ class ConversationReplyMailer < ApplicationMailer
   default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
   layout :choose_layout
 
-  def reply_with_summary(conversation, message_queued_time)
+  def reply_with_summary(conversation, last_queued_id)
     return unless smtp_config_set_or_development?
 
     init_conversation_attributes(conversation)
     return if conversation_already_viewed?
 
-    recap_messages = @conversation.messages.chat.where('created_at < ?', message_queued_time).last(10)
-    new_messages = @conversation.messages.chat.where('created_at >= ?', message_queued_time)
+    recap_messages = @conversation.messages.chat.where('id < ?', last_queued_id).last(10)
+    new_messages = @conversation.messages.chat.where('id >= ?', last_queued_id)
     @messages = recap_messages + new_messages
     @messages = @messages.select(&:email_reply_summarizable?)
 
@@ -23,15 +23,31 @@ class ConversationReplyMailer < ApplicationMailer
          })
   end
 
-  def reply_without_summary(conversation, message_queued_time)
+  def reply_without_summary(conversation, last_queued_id)
     return unless smtp_config_set_or_development?
 
     init_conversation_attributes(conversation)
     return if conversation_already_viewed?
 
-    @messages = @conversation.messages.chat.where(message_type: [:outgoing, :template]).where('created_at >= ?', message_queued_time)
+    @messages = @conversation.messages.chat.where(message_type: [:outgoing, :template]).where('id >= ?', last_queued_id)
     @messages = @messages.reject { |m| m.template? && !m.input_csat? }
     return false if @messages.count.zero?
+
+    mail({
+           to: @contact&.email,
+           from: from_email_with_name,
+           reply_to: reply_email,
+           subject: mail_subject,
+           message_id: custom_message_id,
+           in_reply_to: in_reply_to_email
+         })
+  end
+
+  def email_reply(message)
+    return unless smtp_config_set_or_development?
+
+    init_conversation_attributes(message.conversation)
+    @message = message
 
     mail({
            to: @contact&.email,
@@ -148,7 +164,7 @@ class ConversationReplyMailer < ApplicationMailer
   end
 
   def choose_layout
-    return false if action_name == 'reply_without_summary'
+    return false if action_name == 'reply_without_summary' || action_name == 'email_reply'
 
     'mailer/base'
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -198,17 +198,15 @@ class Message < ApplicationRecord
   end
 
   def trigger_notify_via_mail
+    return EmailReplyWorker.perform_in(1.second, id) if inbox.inbox_type == 'Email'
+
     # will set a redis key for the conversation so that we don't need to send email for every new message
     # last few messages coupled together is sent every 2 minutes rather than one email for each message
     # if redis key exists there is an unprocessed job that will take care of delivering the email
     return if Redis::Alfred.get(conversation_mail_key).present?
 
-    Redis::Alfred.setex(conversation_mail_key, Time.zone.now)
-    if inbox.inbox_type == 'Email'
-      ConversationReplyEmailWorker.perform_in(2.seconds, conversation.id, Time.zone.now)
-    else
-      ConversationReplyEmailWorker.perform_in(2.minutes, conversation.id, Time.zone.now)
-    end
+    Redis::Alfred.setex(conversation_mail_key, id)
+    ConversationReplyEmailWorker.perform_in(2.minutes, conversation.id, Time.zone.now)
   end
 
   def conversation_mail_key

--- a/app/views/mailers/conversation_reply_mailer/email_reply.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/email_reply.html.erb
@@ -1,0 +1,8 @@
+<% if @message.content %>
+  <%= CommonMarker.render_html(@message.content).html_safe %>
+<% end %>
+<% if @message.attachments %>
+  <% @message.attachments.each do |attachment| %>
+    attachment [<a href="<%= attachment.file_url %>" _target="blank">click here to view</a>]
+  <% end %>
+<% end %>

--- a/app/workers/conversation_reply_email_worker.rb
+++ b/app/workers/conversation_reply_email_worker.rb
@@ -3,14 +3,14 @@ class ConversationReplyEmailWorker
   include Sidekiq::Worker
   sidekiq_options queue: :mailers
 
-  def perform(conversation_id, queued_time)
+  def perform(conversation_id, last_queued_id)
     @conversation = Conversation.find(conversation_id)
 
     # send the email
-    if @conversation.messages.incoming&.last&.content_type == 'incoming_email' || email_inbox?
-      ConversationReplyMailer.with(account: @conversation.account).reply_without_summary(@conversation, queued_time).deliver_later
+    if @conversation.messages.incoming&.last&.content_type == 'incoming_email'
+      ConversationReplyMailer.with(account: @conversation.account).reply_without_summary(@conversation, last_queued_id).deliver_later
     else
-      ConversationReplyMailer.with(account: @conversation.account).reply_with_summary(@conversation, queued_time).deliver_later
+      ConversationReplyMailer.with(account: @conversation.account).reply_with_summary(@conversation, last_queued_id).deliver_later
     end
 
     # delete the redis set from the first new message on the conversation

--- a/app/workers/email_reply_worker.rb
+++ b/app/workers/email_reply_worker.rb
@@ -1,0 +1,11 @@
+class EmailReplyWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :mailers
+
+  def perform(message_id)
+    message = Message.find(message_id)
+
+    # send the email
+    ConversationReplyMailer.with(account: message.account).email_reply(message).deliver_later
+  end
+end

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
       let(:conversation) { create(:conversation, account: account, assignee: agent) }
       let(:message) { create(:message, account: account, conversation: conversation) }
       let(:private_message) { create(:message, account: account, content: 'This is a private message', conversation: conversation) }
-      let(:mail) { described_class.reply_with_summary(message.conversation, Time.zone.now).deliver_now }
+      let(:mail) { described_class.reply_with_summary(message.conversation, message.id).deliver_now }
 
       it 'renders the subject' do
         expect(mail.subject).to eq("[##{message.conversation.display_id}] New messages on this conversation")
@@ -42,7 +42,7 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
     context 'without assignee' do
       let(:conversation) { create(:conversation, assignee: nil) }
       let(:message) { create(:message, conversation: conversation) }
-      let(:mail) { described_class.reply_with_summary(message.conversation, Time.zone.now).deliver_now }
+      let(:mail) { described_class.reply_with_summary(message.conversation, message.id).deliver_now }
 
       it 'has correct name' do
         expect(mail[:from].display_names).to eq(['Notifications from Inbox'])
@@ -60,7 +60,7 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
                account: account,
                message_type: 'outgoing').reload
       end
-      let(:mail) { described_class.reply_without_summary(message_1.conversation, Time.zone.now - 1.minute).deliver_now }
+      let(:mail) { described_class.reply_without_summary(message_2.conversation, message_2.id).deliver_now }
 
       before do
         message_2.save
@@ -94,7 +94,7 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
       let(:inbox_member) { create(:inbox_member, user: agent, inbox: inbox) }
       let(:conversation) { create(:conversation, assignee: agent, inbox: inbox_member.inbox, account: account) }
       let!(:message) { create(:message, conversation: conversation, account: account) }
-      let(:mail) { described_class.reply_with_summary(message.conversation, Time.zone.now).deliver_now }
+      let(:mail) { described_class.reply_with_summary(message.conversation, message.id).deliver_now }
       let(:domain) { account.inbound_email_domain }
 
       it 'renders the receiver email' do
@@ -118,7 +118,7 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
       let(:inbox) { create(:inbox, account: account, email_address: 'noreply@chatwoot.com') }
       let(:conversation) { create(:conversation, assignee: agent, inbox: inbox, account: account) }
       let!(:message) { create(:message, conversation: conversation, account: account) }
-      let(:mail) { described_class.reply_with_summary(message.conversation, Time.zone.now).deliver_now }
+      let(:mail) { described_class.reply_with_summary(message.conversation, message.id).deliver_now }
 
       it 'set reply to email address as inbox email address' do
         expect(mail.from).to eq([inbox.email_address])
@@ -130,7 +130,7 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
       let(:account) { create(:account) }
       let(:conversation) { create(:conversation, assignee: agent, account: account).reload }
       let(:message) { create(:message, conversation: conversation, account: account, inbox: conversation.inbox) }
-      let(:mail) { described_class.reply_with_summary(message.conversation, Time.zone.now).deliver_now }
+      let(:mail) { described_class.reply_with_summary(message.conversation, message.id).deliver_now }
 
       before do
         account = conversation.account
@@ -142,7 +142,7 @@ RSpec.describe ConversationReplyMailer, type: :mailer do
 
       it 'sets reply to email to be based on the domain' do
         reply_to_email = "reply+#{message.conversation.uuid}@#{conversation.account.domain}"
-        reply_to = "#{agent.available_name} <#{reply_to_email}>"
+        reply_to = "#{agent.available_name} from #{conversation.inbox.name} <#{reply_to_email}>"
         expect(mail['REPLY-TO'].value).to eq(reply_to)
         expect(mail.reply_to).to eq([reply_to_email])
       end


### PR DESCRIPTION
- [ ] Display a `sent` indicator that shows that the email has been sent from Chatwoot.
- [ ] Remove message being grouped in the email channel, each message in the conversation will have a corresponding email message
- [ ] Use message.id instead of queued time to group messages in a conversation sent from website channel