### PR TITLE
Enhancement: Open web widget when clicking on any un-read message

### DIFF
--- a/app/javascript/widget/components/UnreadMessage.vue
+++ b/app/javascript/widget/components/UnreadMessage.vue
@@ -83,8 +83,9 @@ export default {
     onClickMessage() {
       if (this.campaignId) {
         bus.$emit('on-campaign-view-clicked', this.campaignId);
+      } else {
+        bus.$emit('on-unread-view-clicked');
       }
-      bus.$emit('on-unread-view-clicked');
     },
   },
 };


### PR DESCRIPTION
## Description

Open web widget when clicking on any un-read message

#3105 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Close the chat widget on the client-side and send some messages as an agent, the unread messages will be displayed on top of the chat widget as cards. On clicking any of the card items, the entire chatbox will be opening.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
