### PR TITLE
fix: disable rack attack gem in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ defaults: &defaults
   environment:
       - CC_TEST_REPORTER_ID: b1b5c4447bf93f6f0b06a64756e35afd0810ea83649f03971cbf303b4449456f
       - RAILS_LOG_TO_STDOUT: false
+      - ENABLE_RACK_ATTACK: false
 jobs:
   build:
     <<: *defaults


### PR DESCRIPTION
# Pull Request Template

## Description

- Disable `rack-attack` gem on circle ci

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- circle ci tests are now passing


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

