### PR TITLE
chore: Minor Housekeeping tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ defaults: &defaults
   environment:
       - CC_TEST_REPORTER_ID: b1b5c4447bf93f6f0b06a64756e35afd0810ea83649f03971cbf303b4449456f
       - RAILS_LOG_TO_STDOUT: false
-      - ENABLE_RACK_ATTACK: false
 jobs:
   build:
     <<: *defaults

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -85,4 +85,4 @@ ActiveSupport::Notifications.subscribe('throttle.rack_attack') do |_name, _start
   Rails.logger.info "[Rack::Attack][Blocked] remote_ip: \"#{payload[:request].remote_ip}\", path: \"#{payload[:request].path}\""
 end
 
-Rack::Attack.enabled = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_RACK_ATTACK', true))
+Rack::Attack.enabled = Rails.env.production? ? ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_RACK_ATTACK', true)) : false

--- a/db/migrate/20210923190418_add_online_status_to_account_users.rb
+++ b/db/migrate/20210923190418_add_online_status_to_account_users.rb
@@ -4,12 +4,9 @@ class AddOnlineStatusToAccountUsers < ActiveRecord::Migration[6.1]
       t.integer :availability, default: 0, null: false
       t.boolean :auto_offline, default: true, null: false
     end
-
-    update_existing_user_availability
   end
 
-  private
-
+  # run as a seperate data migration if you want to migrate the user statuses
   def update_existing_user_availability
     User.find_in_batches do |user_batch|
       user_batch.each do |user|


### PR DESCRIPTION
- Enable rack attack only in production
- Make the long-running data migration optional