### PR TITLE
chore: Fix puma http-parser error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,7 +396,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
-    puma (5.5.1)
+    puma (5.5.2)
       nio4r (~> 2.0)
     pundit (2.1.1)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
# Pull Request Template

## Description

This puma upgrade to `5.5.1` was causing the breakage as it dropped UTF-8 support in header values.  This PR upgrades puma to 5.5.2.

Ref: https://github.com/puma/puma/releases/tag/v5.5.2

- Fix puma http-parser error on upgrade to v1.21.0

Fixes #3228

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- tested on a  Linux instance 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

