### PR TITLE
Bug: Instagram render template message twice

### DIFF
--- a/app/builders/messages/instagram/message_builder.rb
+++ b/app/builders/messages/instagram/message_builder.rb
@@ -38,6 +38,10 @@ class Messages::Instagram::MessageBuilder < Messages::Messenger::MessageBuilder
     @outgoing_echo ? :outgoing : :incoming
   end
 
+  def message_identifier
+    message[:mid]
+  end
+
   def message_source_id
     @outgoing_echo ? recipient_id : sender_id
   end
@@ -64,10 +68,6 @@ class Messages::Instagram::MessageBuilder < Messages::Messenger::MessageBuilder
 
   def message_content
     @messaging[:message][:text]
-  end
-
-  def content_attributes
-    { message_id: @messaging[:message][:mid] }
   end
 
   def build_message
@@ -103,22 +103,17 @@ class Messages::Instagram::MessageBuilder < Messages::Messenger::MessageBuilder
       account_id: conversation.account_id,
       inbox_id: conversation.inbox_id,
       message_type: message_type,
-      source_id: message_source_id,
+      source_id: message_identifier,
       content: message_content,
-      content_attributes: content_attributes,
       sender: @outgoing_echo ? nil : contact
     }
   end
 
   def already_sent_from_chatwoot?
     cw_message = conversation.messages.where(
-      source_id: nil,
-      message_type: %w[template outgoing],
-      content: message_content,
-      private: false,
-      status: :sent
+      source_id: @messaging[:message][:mid]
     ).first
-    cw_message.update(content_attributes: content_attributes) if cw_message.present?
+
     cw_message.present?
   end
 

--- a/app/builders/messages/instagram/message_builder.rb
+++ b/app/builders/messages/instagram/message_builder.rb
@@ -113,7 +113,7 @@ class Messages::Instagram::MessageBuilder < Messages::Messenger::MessageBuilder
   def already_sent_from_chatwoot?
     cw_message = conversation.messages.where(
       source_id: nil,
-      message_type: 'outgoing',
+      message_type: %w[template outgoing],
       content: message_content,
       private: false,
       status: :sent

--- a/app/services/instagram/send_on_instagram_service.rb
+++ b/app/services/instagram/send_on_instagram_service.rb
@@ -63,9 +63,10 @@ class Instagram::SendOnInstagramService < Base::SendOnChannelService
       query: query
     )
 
-    Rails.logger.info("Instagram response: #{response} : #{message_content}") if response[:body]
+    Rails.logger.info("Instagram response: #{response['error']} : #{message_content}") if response['error']
+    message.update!(source_id: response['message_id']) if response['message_id'].present?
 
-    response[:body]
+    response
   end
 
   def calculate_app_secret_proof(app_secret, access_token)

--- a/spec/services/instagram/send_on_instagram_service_spec.rb
+++ b/spec/services/instagram/send_on_instagram_service_spec.rb
@@ -21,7 +21,7 @@ describe Instagram::SendOnInstagramService do
         allow(Facebook::Messenger::Configuration::AppSecretProofCalculator).to receive(:call).and_return('app_secret_key', 'access_token')
         allow(HTTParty).to receive(:post).and_return(
           {
-            body: { recipient: { id: contact_inbox.source_id } }
+            'message_id': 'anyrandommessageid1234567890'
           }
         )
       end
@@ -29,7 +29,8 @@ describe Instagram::SendOnInstagramService do
       it 'if message is sent from chatwoot and is outgoing' do
         message = create(:message, message_type: 'outgoing', inbox: instagram_inbox, account: account, conversation: conversation)
         response = ::Instagram::SendOnInstagramService.new(message: message).perform
-        expect(response).to eq({ recipient: { id: contact_inbox.source_id } })
+
+        expect(response).to eq({  message_id: 'anyrandommessageid1234567890' })
       end
 
       it 'if message with attachment is sent from chatwoot and is outgoing' do
@@ -38,7 +39,8 @@ describe Instagram::SendOnInstagramService do
         attachment.file.attach(io: File.open(Rails.root.join('spec/assets/avatar.png')), filename: 'avatar.png', content_type: 'image/png')
         message.save!
         response = ::Instagram::SendOnInstagramService.new(message: message).perform
-        expect(response).to eq({ recipient: { id: contact_inbox.source_id } })
+
+        expect(response).to eq({ message_id: 'anyrandommessageid1234567890' })
       end
     end
   end


### PR DESCRIPTION
# Pull Request Template

## Description

When we send a welcome message to the Instagram user that message comes back again to save it in the Chatwoot inbox, we should consider a template message as a repeated message and neglect that.

Fixes #3196 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on staging

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
