### PR TITLE
Chore: Change to hight priority push notifications

### DIFF
--- a/app/services/notification/push_notification_service.rb
+++ b/app/services/notification/push_notification_service.rb
@@ -97,6 +97,14 @@ class Notification::PushNotificationService
         body: notification.push_message_title,
         sound: 'default'
       },
+      android:{
+        priority:"high"
+      },
+      apns:{
+        headers:{
+          apns-priority:"10"
+        }
+      },
       data: { notification: notification.fcm_push_data.to_json },
       collapse_key: "chatwoot_#{notification.primary_actor_type.downcase}_#{notification.primary_actor_id}"
     }


### PR DESCRIPTION
# Chore: Change to hight priority push notifications

## Description

By this time, push notifications won't awake the device if it is in sleeping mode. So if a customer sends a message and the agent's device is sleeping, no notificatión was show until device awakes.

In order to get a fast notification when a new conversation/message was created even if the device is sleeping, priority must be set as high. This behaviour will perform a better service as agent can get fastly notificated about new messages and conversations.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
