### PR TITLE
Update Twilio SMS MSG Limit to 320 characters

### DIFF
--- a/app/javascript/shared/helpers/MessageTypeHelper.js
+++ b/app/javascript/shared/helpers/MessageTypeHelper.js
@@ -5,7 +5,7 @@ export const isASubmittedFormMessage = (message = {}) =>
 export const MESSAGE_MAX_LENGTH = {
   GENERAL: 10000,
   FACEBOOK: 640,
-  TWILIO_SMS: 160,
+  TWILIO_SMS: 320,
   TWILIO_WHATSAPP: 1600,
   TWEET: 280,
 };


### PR DESCRIPTION
Twilio recommends 320 characters as an upper limit for SMS to ensure delivery. 

This changes the hardcoded message length limit for Twilio SMS messages from 160 to 320 in Chatwoot UI. 320 was chosen since it's the upper limit for SMS suggested by Twilio to ensure the best deliverability and user experience.
[Maximum Message Length with Twilio Programmable Messaging](https://support.twilio.com/hc/en-us/articles/360033806753-Maximum-Message-Length-with-Twilio-Programmable-Messaging)

The only downside is when messages are greater than 160 characters, concatenation  which is handled by Twilio automatic is necessary. This takes up 7 characters per segment  so only a  maximum of 153 characters using GSM encoding can be contained in each segment. This means a message of 320 characters with GSM encoding would get billed as 3 messages.

[https://support.twilio.com/hc/en-us/articles/223133407-How-much-does-it-cost-to-send-a-message-with-more-than-160-characters-](https://support.twilio.com/hc/en-us/articles/223133407-How-much-does-it-cost-to-send-a-message-with-more-than-160-characters-)
Fixes #2333 (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Opened new conversation in a dev instance of Chatwoot, replied to conversation with a reply over 160 characters. Twilio shows message sent as 2 segments and arrived correctly on user's handset as well.

I'm not sure if 320 is the best value  for the character limit since it would result in messages taking 3 segments with concatenation padding.  306 characters would be the limit using GSM encoding to have a max of 2 segments. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
