### PR TITLE
fix: Set cc, bcc default to empty string if unavailable

### DIFF
--- a/app/javascript/dashboard/api/inbox/message.js
+++ b/app/javascript/dashboard/api/inbox/message.js
@@ -8,8 +8,8 @@ export const buildCreatePayload = ({
   contentAttributes,
   echoId,
   file,
-  ccEmails,
-  bccEmails,
+  ccEmails = '',
+  bccEmails = '',
 }) => {
   let payload;
   if (file) {
@@ -47,8 +47,8 @@ class MessageApi extends ApiClient {
     contentAttributes,
     echo_id: echoId,
     file,
-    ccEmails,
-    bccEmails,
+    ccEmails = '',
+    bccEmails = '',
   }) {
     return axios({
       method: 'post',

--- a/app/javascript/dashboard/api/specs/inbox/message.spec.js
+++ b/app/javascript/dashboard/api/specs/inbox/message.spec.js
@@ -35,6 +35,7 @@ describe('#ConversationAPI', () => {
         message: 'test content',
         echoId: 12,
         isPrivate: true,
+
         file: new Blob(['test-content'], { type: 'application/pdf' }),
       });
       expect(formPayload).toBeInstanceOf(FormData);
@@ -57,6 +58,8 @@ describe('#ConversationAPI', () => {
         private: false,
         echo_id: 12,
         content_attributes: { in_reply_to: 12 },
+        bcc_emails: '',
+        cc_emails: '',
       });
     });
   });

--- a/app/javascript/dashboard/api/specs/inbox/message.spec.js
+++ b/app/javascript/dashboard/api/specs/inbox/message.spec.js
@@ -41,6 +41,7 @@ describe('#ConversationAPI', () => {
       expect(formPayload.get('content')).toEqual('test content');
       expect(formPayload.get('echo_id')).toEqual('12');
       expect(formPayload.get('private')).toEqual('true');
+      expect(formPayload.get('cc_emails')).toEqual('');
     });
 
     it('builds object payload if file is not available', () => {


### PR DESCRIPTION
The payload was generating 'undefined' value in cc/bcc emails. As it is a string backend was not able to recognize whether it was a wrong string or not. 

Followup actions: @tejaswinichile Please add email validation on cc_emails, bcc_emails on the backend. 