### PR TITLE
Fix 3396: Mention the env variables SMTP_TLS and SMTP_SSL in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,8 +58,8 @@ SMTP_ENABLE_STARTTLS_AUTO=true
 # Can be: 'none', 'peer', 'client_once', 'fail_if_no_peer_cert', see http://api.rubyonrails.org/classes/ActionMailer/Base.html
 SMTP_OPENSSL_VERIFY_MODE=peer
 # Comment out the following environment variables if required by your SMTP server
-#SMTP_TLS=
-#SMTP_SSL=
+# SMTP_TLS=
+# SMTP_SSL=
 
 # Mail Incoming
 # This is the domain set for the reply emails when conversation continuity is enabled

--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,8 @@ SMTP_AUTHENTICATION=
 SMTP_ENABLE_STARTTLS_AUTO=true
 # Can be: 'none', 'peer', 'client_once', 'fail_if_no_peer_cert', see http://api.rubyonrails.org/classes/ActionMailer/Base.html
 SMTP_OPENSSL_VERIFY_MODE=peer
+SMTP_TLS=
+SMTP_SSL=
 
 # Mail Incoming
 # This is the domain set for the reply emails when conversation continuity is enabled

--- a/.env.example
+++ b/.env.example
@@ -57,8 +57,9 @@ SMTP_AUTHENTICATION=
 SMTP_ENABLE_STARTTLS_AUTO=true
 # Can be: 'none', 'peer', 'client_once', 'fail_if_no_peer_cert', see http://api.rubyonrails.org/classes/ActionMailer/Base.html
 SMTP_OPENSSL_VERIFY_MODE=peer
-SMTP_TLS=
-SMTP_SSL=
+# Comment out the following environment variables if required by your SMTP server
+#SMTP_TLS=
+#SMTP_SSL=
 
 # Mail Incoming
 # This is the domain set for the reply emails when conversation continuity is enabled


### PR DESCRIPTION
## Description

Added `SMTP_TLS` and `SMTP_SSL` in .env.example

Fixes #3396

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update
- [x] Mention the environment variables SMTP_TLS and SMTP_SSL in .env.example

## Checklist:

- [x] I have made corresponding changes to the documentation
