### PR TITLE
fix: Render checkbox if string value passed 

### DIFF
--- a/app/javascript/dashboard/components/CustomAttribute.vue
+++ b/app/javascript/dashboard/components/CustomAttribute.vue
@@ -154,10 +154,10 @@ export default {
 
   computed: {
     formattedValue() {
-      if (this.attributeType === 'date') {
+      if (this.isAttributeTypeDate) {
         return format(new Date(this.value || new Date()), DATE_FORMAT);
       }
-      if (this.attributeType === 'checkbox') {
+      if (this.isAttributeTypeCheckbox) {
         return this.value === 'false' ? false : this.value;
       }
       return this.value;
@@ -180,6 +180,9 @@ export default {
     },
     isAttributeTypeLink() {
       return this.attributeType === 'link';
+    },
+    isAttributeTypeDate() {
+      return this.attributeType === 'date';
     },
     notAttributeTypeCheckboxAndList() {
       return !this.isAttributeTypeCheckbox && !this.isAttributeTypeList;

--- a/app/javascript/dashboard/components/CustomAttribute.vue
+++ b/app/javascript/dashboard/components/CustomAttribute.vue
@@ -158,13 +158,7 @@ export default {
         return format(new Date(this.value || new Date()), DATE_FORMAT);
       }
       if (this.attributeType === 'checkbox') {
-        if (this.value === 'true') {
-          return true;
-        }
-        if (this.value === 'false') {
-          return false;
-        }
-        return this.value;
+        return this.value === 'false' ? false : this.value;
       }
       return this.value;
     },

--- a/app/javascript/dashboard/components/CustomAttribute.vue
+++ b/app/javascript/dashboard/components/CustomAttribute.vue
@@ -66,7 +66,7 @@
           {{ value || '---' }}
         </a>
         <p v-else class="value">
-          {{ formattedValue || '---' }}
+          {{ displayValue || '---' }}
         </p>
         <div class="action-buttons__wrap">
           <woot-button
@@ -138,10 +138,7 @@ export default {
   data() {
     return {
       isEditing: false,
-      editedValue:
-        this.attributeType === 'date'
-          ? format(new Date(this.value || new Date()), DATE_FORMAT)
-          : this.value,
+      editedValue: null,
     };
   },
   validations() {
@@ -156,6 +153,21 @@ export default {
   },
 
   computed: {
+    formattedValue() {
+      if (this.attributeType === 'date') {
+        return format(new Date(this.value || new Date()), DATE_FORMAT);
+      }
+      if (this.attributeType === 'checkbox') {
+        if (this.value === 'true') {
+          return true;
+        }
+        if (this.value === 'false') {
+          return false;
+        }
+        return this.value;
+      }
+      return this.value;
+    },
     listOptions() {
       return this.values.map((value, index) => ({
         id: index + 1,
@@ -190,7 +202,7 @@ export default {
       }
       return this.$t('CUSTOM_ATTRIBUTES.VALIDATIONS.REQUIRED');
     },
-    formattedValue() {
+    displayValue() {
       if (this.attributeType === 'date') {
         return format(new Date(this.editedValue), 'dd-MM-yyyy');
       }
@@ -198,6 +210,7 @@ export default {
     },
   },
   mounted() {
+    this.editedValue = this.formattedValue;
     bus.$on(BUS_EVENTS.FOCUS_CUSTOM_ATTRIBUTE, focusAttributeKey => {
       if (this.attributeKey === focusAttributeKey) {
         this.onEdit();


### PR DESCRIPTION
Before adding rich types in custom attributes, all the boolean values are stored in string format ("true"/"false"). This fix will render all these values in boolean format.

### How Has This Been Tested?

1. Create a new contact attribute with type **checkbox**
2. Set attribute via SDK method

Ex: 

```
 window.$chatwoot.setCustomAttributes({
  cloudCustomer: "false" // "true"
});
```
3. Check this attribute is rendering properly in the contact sidebar
