### PR TITLE
chore: validation spec for schedules

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,5 +1,6 @@
 # https://github.com/ondrejbartas/sidekiq-cron
 # use https://crontab.guru/ to validate
+# validations for this file exist in /spec/configs/schedule_spec.rb
 
 # executed At 12:00 on every day-of-month.
 internal_check_new_versions_job:

--- a/spec/configs/schedule_spec.rb
+++ b/spec/configs/schedule_spec.rb
@@ -1,0 +1,24 @@
+## we had instances where after copy pasting the schedule block,
+## the dev forgets to changes the schedule key,
+## this would break some of the scheduled jobs with out explicit errors
+require 'rails_helper'
+
+RSpec.context 'with valid schedule.yml' do
+  it 'does not have duplicates' do
+    file = Rails.root.join('config/schedule.yml')
+    schedule_keys = []
+    invalid_line_starts = [' ', '#', "\n"]
+    # couldn't figure out a proper solution with yaml.parse
+    # so the rudementary solution is to read the file and parse it
+    # check for duplicates in the array
+    File.open(file).each do |f|
+      f.each_line do |line|
+        next if invalid_line_starts.include?(line[0])
+
+        schedule_keys << line.split(':')[0]
+      end
+    end
+    # ensure that no duplicates exist
+    assert_equal schedule_keys.uniq.count, schedule_keys.count
+  end
+end


### PR DESCRIPTION
we had instances where after copy-pasting the schedule block, the dev forgets to change the schedule key,
This would break some of the scheduled jobs without explicit errors

this PR add a spec that will prevent 