### PR TITLE
fix: Update missing method onNewToastMessage

### DIFF
--- a/app/javascript/dashboard/components/SnackbarContainer.vue
+++ b/app/javascript/dashboard/components/SnackbarContainer.vue
@@ -34,11 +34,13 @@ export default {
   beforeDestroy() {
     bus.$off('newToastMessage', this.onNewToastMessage);
   },
-  onNewToastMessage(message) {
-    this.snackMessages.push({ key: new Date().getTime(), message });
-    window.setTimeout(() => {
-      this.snackMessages.splice(0, 1);
-    }, this.duration);
+  methods: {
+    onNewToastMessage(message) {
+      this.snackMessages.push({ key: new Date().getTime(), message });
+      window.setTimeout(() => {
+        this.snackMessages.splice(0, 1);
+      }, this.duration);
+    },
   },
 };
 </script>


### PR DESCRIPTION
A bug was introduced as a part of #3425, which blocked new alert messages.