### PR TITLE
fix: Add fixes for sentry errors

### DIFF
--- a/app/controllers/api/v1/widget/contacts_controller.rb
+++ b/app/controllers/api/v1/widget/contacts_controller.rb
@@ -21,14 +21,20 @@ class Api::V1::Widget::ContactsController < Api::V1::Widget::BaseController
   private
 
   def process_hmac
-    return if params[:identifier_hash].blank? && !@web_widget.hmac_mandatory
-
-    # Taking an extra caution that the hmac is triggered whenever identifier is present
-    return if params[:custom_attributes].present? && params[:identifier].blank?
+    return unless should_verify_hmac?
 
     render json: { error: 'HMAC failed: Invalid Identifier Hash Provided' }, status: :unauthorized unless valid_hmac?
 
     @contact_inbox.update(hmac_verified: true)
+  end
+
+  def should_verify_hmac?
+    return false if params[:identifier_hash].blank? && !@web_widget.hmac_mandatory
+
+    # Taking an extra caution that the hmac is triggered whenever identifier is present
+    return false if params[:custom_attributes].present? && params[:identifier].blank?
+
+    true
   end
 
   def valid_hmac?

--- a/app/controllers/api/v1/widget/contacts_controller.rb
+++ b/app/controllers/api/v1/widget/contacts_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::Widget::ContactsController < Api::V1::Widget::BaseController
-  before_action :process_hmac
+  before_action :process_hmac, only: [:update]
 
   def show; end
 
@@ -8,7 +8,7 @@ class Api::V1::Widget::ContactsController < Api::V1::Widget::BaseController
       contact: @contact,
       params: permitted_params.to_h.deep_symbolize_keys
     )
-    render json: contact_identify_action.perform
+    @contact = contact_identify_action.perform
   end
 
   # TODO : clean up this with proper routes delete contacts/custom_attributes
@@ -22,6 +22,9 @@ class Api::V1::Widget::ContactsController < Api::V1::Widget::BaseController
 
   def process_hmac
     return if params[:identifier_hash].blank? && !@web_widget.hmac_mandatory
+
+    # Taking an extra caution that the hmac is triggered whenever identifier is present
+    return if params[:custom_attributes].present? && params[:identifier].blank?
 
     render json: { error: 'HMAC failed: Invalid Identifier Hash Provided' }, status: :unauthorized unless valid_hmac?
 

--- a/app/drops/conversation_drop.rb
+++ b/app/drops/conversation_drop.rb
@@ -13,7 +13,7 @@ class ConversationDrop < BaseDrop
     @obj.try(:recent_messages).map do |message|
       {
         'sender' => message_sender_name(message.sender),
-        'content' => transform_user_mention_content(message.content),
+        'content' => render_message_content(transform_user_mention_content(message.content)),
         'attachments' => message.attachments.map(&:file_url)
       }
     end

--- a/app/drops/message_drop.rb
+++ b/app/drops/message_drop.rb
@@ -6,7 +6,7 @@ class MessageDrop < BaseDrop
   end
 
   def text_content
-    content = @obj.try(:content)
-    transform_user_mention_content content
+    content = @obj.try(:content) || ''
+    render_message_content(transform_user_mention_content(content))
   end
 end

--- a/app/helpers/message_format_helper.rb
+++ b/app/helpers/message_format_helper.rb
@@ -1,6 +1,13 @@
 module MessageFormatHelper
   include RegexHelper
+
   def transform_user_mention_content(message_content)
     message_content.gsub(MENTION_REGEX, '\1')
+  end
+
+  def render_message_content(message_content)
+    # rubocop:disable Rails/OutputSafety
+    CommonMarker.render_html(message_content).html_safe
+    # rubocop:enable Rails/OutputSafety
   end
 end

--- a/app/javascript/dashboard/components/widgets/conversation/MoreActions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MoreActions.vue
@@ -85,7 +85,6 @@ export default {
     },
     toggleEmailActionsModal() {
       this.showEmailActionsModal = !this.showEmailActionsModal;
-      this.hideConversationActions();
     },
   },
 };

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -199,6 +199,10 @@ export const IFrameHelper = {
     },
 
     handleNotificationDot: event => {
+      if (window.$chatwoot.hideMessageBubble) {
+        return;
+      }
+
       const bubbleElement = document.querySelector('.woot-widget-bubble');
       if (
         event.unreadMessageCount > 0 &&

--- a/app/views/api/v1/widget/contacts/update.json.jbuilder
+++ b/app/views/api/v1/widget/contacts/update.json.jbuilder
@@ -1,0 +1,3 @@
+json.id @contact.id
+json.name @contact.name
+json.email @contact.email

--- a/app/views/layouts/mailer/base.liquid
+++ b/app/views/layouts/mailer/base.liquid
@@ -1,112 +1,94 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-
-<head>
+<html xmlns="http://www.w3.org/1999/xhtml" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+  <head>
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title></title>
-
     <style type="text/css">
-        img {
-            max-width: 100%;
-        }
+      img {
+        max-width: 100%;
+      }
 
+      body {
+        -webkit-font-smoothing: antialiased;
+        -webkit-text-size-adjust: none;
+        height: 100%;
+        line-height: 1.6em;
+        width: 100% !important;
+      }
+
+      body {
+        background-color: #F8FAFC;
+      }
+
+      @media only screen and (max-width: 640px) {
         body {
-            -webkit-font-smoothing: antialiased;
-            -webkit-text-size-adjust: none;
-            width: 100% !important;
-            height: 100%;
-            line-height: 1.6em;
+          padding: 0 !important;
         }
-
-        body {
-            background-color: #f6f6f6;
+        h1 {
+          font-size: 22px !important;
+          font-weight: 800 !important;
+          margin: 20px 0 5px !important;
         }
-
-        @media only screen and (max-width: 640px) {
-            body {
-                padding: 0 !important;
-            }
-            h1 {
-                font-weight: 800 !important;
-                margin: 20px 0 5px !important;
-            }
-            h2 {
-                font-weight: 800 !important;
-                margin: 20px 0 5px !important;
-            }
-            h3 {
-                font-weight: 800 !important;
-                margin: 20px 0 5px !important;
-            }
-            h4 {
-                font-weight: 800 !important;
-                margin: 20px 0 5px !important;
-            }
-            h1 {
-                font-size: 22px !important;
-            }
-            h2 {
-                font-size: 18px !important;
-            }
-            h3 {
-                font-size: 16px !important;
-            }
-            .container {
-                padding: 0 !important;
-                width: 100% !important;
-            }
-            .content {
-                padding: 0 !important;
-            }
-            .content-wrap {
-                padding: 10px !important;
-            }
-            .invoice {
-                width: 100% !important;
-            }
+        h2 {
+          font-size: 18px !important;
+          font-weight: 800 !important;
+          margin: 20px 0 5px !important;
         }
+        h3 {
+          font-size: 16px !important;
+          font-weight: 800 !important;
+          margin: 20px 0 5px !important;
+        }
+        h4 {
+          font-weight: 800 !important;
+          margin: 20px 0 5px !important;
+        }
+        .container {
+          padding: 0 !important;
+          width: 100% !important;
+        }
+        .content {
+          padding: 0 !important;
+        }
+        .content-wrap {
+          padding: 10px !important;
+        }
+      }
     </style>
-</head>
+  </head>
 
-<body itemscope itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
-
-    <table class="body-wrap" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
-        <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-            <td style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0;" valign="top"></td>
-            <td class="container" width="600" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; display: block !important; max-width: 600px !important; clear: both !important; margin: 0 auto;" valign="top">
-                <div class="content" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; max-width: 600px; display: block; margin: 0 auto; padding: 20px; text-align:center;">
-                    <table class="main" width="100%" cellpadding="0" cellspacing="0" itemprop="action" itemscope itemtype="http://schema.org/ConfirmAction" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; border-radius: 4px; background-color: #fff; text-align:left; margin: 0; border: 1px solid #e9e9e9; box-shadow:0 2px 11px 0 rgba(0,0,0,0.15)" bgcolor="#fff">
-                        <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-                            <td class="content-wrap" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 20px;" valign="top">
-                                <meta itemprop="name" content="Confirm Email" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
-                                <table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-                                    {{ content_for_layout }}
-                                </table>
-                            </td>
-                        </tr>
-                    </table>
-                    <div class="footer" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; clear: both; color: #999; margin: 0; padding: 20px;">
-                        <table width="100%" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-                            <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-                                {% if global_config['BRAND_NAME'] != '' %}
-                                    <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-                                        <td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-                                            Powered by
-                                            <a href="{{ global_config['BRAND_URL'] }}" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">
-                                                {{ global_config['BRAND_NAME'] }}
-                                            </a>
-                                        </td>
-                                    </tr>
-                                {% endif %}
-                            </tr>
-                        </table>
-                    </div>
-                </div>
-            </td>
-            <td style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0;" valign="top"></td>
-        </tr>
+  <body itemscope itemtype="http://schema.org/EmailMessage" style="font-size: 14px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #F8FAFC; margin: 0;" bgcolor="#F8FAFC">
+    <table class="body-wrap" style="width: 100%; background-color: #F8FAFC; margin: 0;" bgcolor="#F8FAFC">
+      <tr style="margin: 0;">
+        <td class="container" width="600" style="display: block !important; max-width: 600px !important; clear: both !important; margin: 0 auto;" valign="top">
+          <div class="content" style="display: block; margin: 0 auto; padding: 20px; text-align:center;">
+            <table class="main" width="100%" cellpadding="0" cellspacing="0" itemprop="action" itemscope itemtype="http://schema.org/ConfirmAction" style="border-radius: 6px;  background-color: #fff; text-align:left; margin: 0; border: 1px solid #e9e9e9; border-top:3px solid #0080f8;" bgcolor="#fff">
+              <tr style="margin: 0;">
+                <td class="content-wrap" style="vertical-align: top; margin: 0; padding: 20px;" valign="top">
+                  <table width="100%" cellpadding="0" cellspacing="0" style="margin: 0;">
+                    {{ content_for_layout }}
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div class="footer" style="color: #93AFC8; margin: 0; padding: 0 20px 40px; text-align: center">
+            <table width="100%" style="margin: 0;">
+              <tr style="margin: 0;">
+                {% if global_config['BRAND_NAME'] != '' %}
+                  <td class="content-block" style="vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    Powered by
+                    <a href="{{ global_config['BRAND_URL'] }}" style="vertical-align: top; color: #93AFC8; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">
+                      {{ global_config['BRAND_NAME'] }}
+                    </a>
+                  </td>
+                {% endif %}
+              </tr>
+            </table>
+          </div>
+        </td>
+      </tr>
     </table>
-</body>
-
+  </body>
 </html>

--- a/app/views/layouts/mailer/base.liquid
+++ b/app/views/layouts/mailer/base.liquid
@@ -65,7 +65,7 @@
           <div class="content" style="display: block; margin: 0 auto; padding: 20px; text-align:center;">
             <table class="main" width="100%" cellpadding="0" cellspacing="0" itemprop="action" itemscope itemtype="http://schema.org/ConfirmAction" style="border-radius: 6px;  background-color: #fff; text-align:left; margin: 0; border: 1px solid #e9e9e9; border-top:3px solid #0080f8;" bgcolor="#fff">
               <tr style="margin: 0;">
-                <td class="content-wrap" style="vertical-align: top; margin: 0; padding: 20px;" valign="top">
+                <td class="content-wrap" style="vertical-align: top; margin: 0; padding: 20px; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;" valign="top">
                   <table width="100%" cellpadding="0" cellspacing="0" style="margin: 0;">
                     {{ content_for_layout }}
                   </table>
@@ -77,7 +77,7 @@
             <table width="100%" style="margin: 0;">
               <tr style="margin: 0;">
                 {% if global_config['BRAND_NAME'] != '' %}
-                  <td class="content-block" style="vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                  <td class="content-block" style="font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
                     Powered by
                     <a href="{{ global_config['BRAND_URL'] }}" style="vertical-align: top; color: #93AFC8; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">
                       {{ global_config['BRAND_NAME'] }}

--- a/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
+++ b/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
@@ -5,6 +5,7 @@
   {{message.text_content}}
 </blockquote>
 
+<p><b>Previous messages:</b></p>
 {% for chat_message in conversation.recent_messages %}
   <div>
     {% if chat_message.sender == user.available_name %}
@@ -15,7 +16,6 @@
   </div>
 
   <div>
-    <p>Previous messages:</p>
     <p style="padding: 10px 20px; margin: 5px 0 20px 0; background: #F2F3F7; border-radius: 10px; display: inline-block; text-align: start; unicode-bidi: plaintext;">
       {% if chat_message.content %}
         {{chat_message.content}}

--- a/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
+++ b/app/views/mailers/agent_notifications/conversation_notifications_mailer/conversation_mention.liquid
@@ -15,7 +15,8 @@
   </div>
 
   <div>
-    <p style="padding: 10px 20px; margin: 5px 0 20px 0; background: #F2F3F7; border-radius: 10px; display: inline-block; font-family: "Helvetica Neue",Tahoma,Arial,sans-serif; text-align: start; unicode-bidi: plaintext;">
+    <p>Previous messages:</p>
+    <p style="padding: 10px 20px; margin: 5px 0 20px 0; background: #F2F3F7; border-radius: 10px; display: inline-block; text-align: start; unicode-bidi: plaintext;">
       {% if chat_message.content %}
         {{chat_message.content}}
       {% endif %}
@@ -28,5 +29,6 @@
     </p>
   </div>
 {% endfor %}
-
-<p><a href="{{ action_url }}">View Message</a></p>
+<p>
+  <a href="{{ action_url }}">View Message</a>
+</p>

--- a/spec/controllers/api/v1/widget/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/contacts_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
 
       before do
         allow(ContactIdentifyAction).to receive(:new).and_return(identify_action)
-        allow(identify_action).to receive(:perform)
+        allow(identify_action).to receive(:perform).and_return(contact)
       end
 
       it 'calls contact identify' do
@@ -47,7 +47,7 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
 
       before do
         allow(ContactIdentifyAction).to receive(:new).and_return(identify_action)
-        allow(identify_action).to receive(:perform)
+        allow(identify_action).to receive(:perform).and_return(contact)
       end
 
       it 'returns success when correct identifier hash is provided' do

--- a/spec/helpers/message_format_helper_spec.rb
+++ b/spec/helpers/message_format_helper_spec.rb
@@ -12,7 +12,7 @@ describe MessageFormatHelper, type: :helper do
   describe '#render_message_content' do
     context 'when render_message_content called' do
       it 'render text correctly' do
-        expect(helper.render_message_content('Hey there, how can I **help**?')).to eq '<p>Hey there, how can I <strong>help</strong>?</p>\n'
+        expect(helper.render_message_content('Hi *there*, I am mostly text!')).to eq "<p>Hi <em>there</em>, I am mostly text!</p>\n"
       end
     end
   end

--- a/spec/helpers/message_format_helper_spec.rb
+++ b/spec/helpers/message_format_helper_spec.rb
@@ -12,7 +12,7 @@ describe MessageFormatHelper, type: :helper do
   describe '#render_message_content' do
     context 'when render_message_content called' do
       it 'render text correctly' do
-        expect(helper.render_message_content('Hey there, how can I **help**?')).to eq '<p>Hey there, how can I <strong>help</strong>?</p>'
+        expect(helper.render_message_content('Hey there, how can I **help**?')).to eq '<p>Hey there, how can I <strong>help</strong>?</p>\n'
       end
     end
   end

--- a/spec/helpers/message_format_helper_spec.rb
+++ b/spec/helpers/message_format_helper_spec.rb
@@ -8,4 +8,12 @@ describe MessageFormatHelper, type: :helper do
       end
     end
   end
+
+  describe '#render_message_content' do
+    context 'when render_message_content called' do
+      it 'render text correctly' do
+        expect(helper.render_message_content('Hey there, how can I **help**?')).to eq '<p>Hey there, how can I <strong>help</strong>?</p>'
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Fix handleNotificationDot throwing error if hideMessageBubble is true.
- Fix missing hideConversationActions
- Process hmac only for update calls and ignore if custom_attributes are present
- Send only valid attributes in the update call instead of the whole contact object
- Update the email design to match the 2.0 designs
- Add a text "Previous messages"


### Updated design

<img width="692" alt="Screenshot 2021-12-07 at 7 14 19 PM" src="https://user-images.githubusercontent.com/2246121/145142457-3e069da2-5072-44cb-ae70-07f8f8bfdf0a.png">
