### PR TITLE
Fix user email reconfirmation flow

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -177,4 +177,10 @@ class User < ApplicationRecord
       type: 'user'
     }
   end
+
+  # https://github.com/lynndylanhurley/devise_token_auth/blob/6d7780ee0b9750687e7e2871b9a1c6368f2085a9/app/models/devise_token_auth/concerns/user.rb#L45
+  # Since this method is overriden in devise_token_auth it breaks the email reconfirmation flow.
+  def will_save_change_to_email?
+    mutations_from_database.changed?('email')
+  end
 end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,13 +1,13 @@
 <p>Welcome, <%= @resource.name %>!</p>
 
 <% account_user = @resource&.account_users&.first %>
-<% if account_user&.inviter.present? %>
+<% if account_user&.inviter.present? && @resource.unconfirmed_email.blank? %>
   <p><%= account_user.inviter.name %>, with <%= account_user.account.name %>, has invited you to try out Chatwoot! </p>
 <% end %>
 
 <p>You can confirm your account email through the link below:</p>
 
-<% if account_user&.inviter.present? %>
+<% if account_user&.inviter.present? && @resource.unconfirmed_email.blank?  %>
 <p><%= link_to 'Confirm my account', frontend_url('auth/password/edit', reset_password_token: @resource.send(:set_reset_password_token)) %></p>
 <% else %>
 <p><%= link_to 'Confirm my account', frontend_url('auth/confirmation', confirmation_token: @token) %></p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -133,7 +133,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = false
+  config.reconfirmable = true
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]

--- a/spec/mailers/confirmation_instructions_spec.rb
+++ b/spec/mailers/confirmation_instructions_spec.rb
@@ -47,5 +47,19 @@ RSpec.describe 'Confirmation Instructions', type: :mailer do
         expect(mail.body).not_to include('app/auth/confirmation')
       end
     end
+
+    context 'when user updates the email' do
+      before do
+        confirmable_user.update!(email: 'user@example.com')
+      end
+
+      it 'sends a confirmation link' do
+        confirmation_mail = Devise::Mailer.confirmation_instructions(confirmable_user.reload, nil, {})
+
+        expect(confirmation_mail.body).to include('app/auth/confirmation?confirmation_token')
+        expect(confirmation_mail.body).not_to include('app/auth/password/edit')
+        expect(confirmable_user.unconfirmed_email.blank?).to be false
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -80,4 +80,11 @@ RSpec.describe User do
       expect(token_count).to eq(1)
     end
   end
+
+  context 'when user changes the email' do
+    it 'mutates the value' do
+      user.email = 'user@example.com'
+      expect(user.will_save_change_to_email?).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Description

Users can change their email from profile settings. They will be logged out immediately. Users can log in again with the updated email without verifying the same. This is a security problem.

So this change enforce the user to reconfirm the email after changing it. Users can log in with the updated email only after the confirmation.

Fixes: https://huntr.dev/bounties/7afd04b4-232e-4907-8a3c-acf8bd4b5b22/

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Go to user profile settings.
2. Update the email. 
  a. User should be logged out. 
  b. User should receive a confirmation link in the updated email.
3. Confirm the updated email.
4. Login with the updated email.
5. Go to user profile settings and verify the updated email.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
