### PR TITLE
chore: Add display id in conversation related push payload

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -66,7 +66,7 @@ class Notification < ApplicationRecord
       notification_type: notification_type,
       primary_actor_id: primary_actor_id,
       primary_actor_type: primary_actor_type,
-      primary_actor: primary_actor.push_event_data.slice(:conversation_id)
+      primary_actor: primary_actor.push_event_data.with_indifferent_access.slice('conversation_id', 'id')
     }
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -78,4 +78,23 @@ RSpec.describe Notification do
       expect(notification.push_message_title).to eq "[##{message.conversation.display_id}] Hey @John Peter please check this?"
     end
   end
+
+  context 'when fcm push data' do
+    it 'returns correct data for primary actor conversation' do
+      notification = create(:notification, notification_type: 'conversation_creation')
+      expect(notification.fcm_push_data[:primary_actor]).to eq({
+                                                                 'id' => notification.primary_actor.display_id
+                                                               })
+    end
+
+    it 'returns correct data for primary actor message' do
+      message = create(:message, sender: create(:user), content: Faker::Lorem.paragraphs(number: 2))
+      notification = create(:notification, notification_type: 'assigned_conversation_new_message', primary_actor: message)
+
+      expect(notification.fcm_push_data[:primary_actor]).to eq({
+                                                                 'id' => notification.primary_actor.id,
+                                                                 'conversation_id' => notification.primary_actor.conversation.display_id
+                                                               })
+    end
+  end
 end


### PR DESCRIPTION
- Added conversation display id in push payload for the notifications `conversation_creation` and `conversation_assignment`