### PR TITLE
bug: NoMethodError: undefined method `match' for in_reply_to 

### DIFF
--- a/app/mailboxes/reply_mailbox.rb
+++ b/app/mailboxes/reply_mailbox.rb
@@ -63,14 +63,15 @@ class ReplyMailbox < ApplicationMailbox
   # find conversation uuid from below pattern
   # <conversation/#{@conversation.uuid}/messages/#{@messages&.last&.id}@#{@account.inbound_email_domain}>
   def find_conversation_with_in_reply_to
-    in_reply_to = mail.in_reply_to
-    match_result = in_reply_to.match(ApplicationMailbox::CONVERSATION_MESSAGE_ID_PATTERN) if in_reply_to.present?
+    in_reply_to_addresses = mail.in_reply_to
+    in_reply_to_addresses = [in_reply_to_addresses] unless in_reply_to_addresses.is_a?(Array)
 
-    if match_result
-      find_conversation_by_uuid(match_result)
-    else
-      find_conversation_by_message_id(in_reply_to)
+    in_reply_to_addresses.each do |in_reply_to|
+      match_result = in_reply_to.match(::ApplicationMailbox::CONVERSATION_MESSAGE_ID_PATTERN) if in_reply_to.present?
+      find_conversation_by_uuid(match_result) if match_result
     end
+
+    find_conversation_by_message_id(in_reply_to) unless @conversation.present?
   end
 
   def verify_decoded_params

--- a/app/mailboxes/reply_mailbox.rb
+++ b/app/mailboxes/reply_mailbox.rb
@@ -63,15 +63,19 @@ class ReplyMailbox < ApplicationMailbox
   # find conversation uuid from below pattern
   # <conversation/#{@conversation.uuid}/messages/#{@messages&.last&.id}@#{@account.inbound_email_domain}>
   def find_conversation_with_in_reply_to
+    match_result = nil
     in_reply_to_addresses = mail.in_reply_to
-    in_reply_to_addresses = [in_reply_to_addresses] unless in_reply_to_addresses.is_a?(Array)
-
+    in_reply_to_addresses = [in_reply_to_addresses] if in_reply_to_addresses.is_a?(String)
     in_reply_to_addresses.each do |in_reply_to|
-      match_result = in_reply_to.match(::ApplicationMailbox::CONVERSATION_MESSAGE_ID_PATTERN) if in_reply_to.present?
-      find_conversation_by_uuid(match_result) if match_result
+      match_result = in_reply_to.match(::ApplicationMailbox::CONVERSATION_MESSAGE_ID_PATTERN)
+      break if match_result
     end
+    find_by_in_reply_to_addresses(match_result, in_reply_to_addresses)
+  end
 
-    find_conversation_by_message_id(in_reply_to) unless @conversation.present?
+  def find_by_in_reply_to_addresses(match_result, in_reply_to_addresses)
+    find_conversation_by_uuid(match_result) if match_result
+    find_conversation_by_message_id(in_reply_to_addresses) if @conversation.blank?
   end
 
   def verify_decoded_params

--- a/spec/fixtures/files/forwarder_email.eml
+++ b/spec/fixtures/files/forwarder_email.eml
@@ -4,7 +4,7 @@ Content-Type: multipart/alternative; boundary="Apple-Mail=_33A037C7-4BB3-4772-AE
 Subject: Discussion: Let's debate these attachments
 Date: Tue, 20 Apr 2020 04:20:20 -0400
 X-Forwarded-For: reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@example.com
-In-Reply-To: <reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@test.com>
+In-Reply-To: reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@test.com
 References: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
 Message-Id: <0CB459E0-0336-41DA-BC88-E6E28C697DDB@chatwoot.com>
 X-Mailer: Apple Mail (2.1244.3)

--- a/spec/fixtures/files/forwarder_email.eml
+++ b/spec/fixtures/files/forwarder_email.eml
@@ -4,7 +4,7 @@ Content-Type: multipart/alternative; boundary="Apple-Mail=_33A037C7-4BB3-4772-AE
 Subject: Discussion: Let's debate these attachments
 Date: Tue, 20 Apr 2020 04:20:20 -0400
 X-Forwarded-For: reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@example.com
-In-Reply-To: reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@test.com
+In-Reply-To: <reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@test.com> <reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@test.com>
 References: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
 Message-Id: <0CB459E0-0336-41DA-BC88-E6E28C697DDB@chatwoot.com>
 X-Mailer: Apple Mail (2.1244.3)

--- a/spec/fixtures/files/reply.eml
+++ b/spec/fixtures/files/reply.eml
@@ -3,7 +3,7 @@ Mime-Version: 1.0 (Apple Message framework v1244.3)
 Content-Type: multipart/alternative; boundary="Apple-Mail=_33A037C7-4BB3-4772-AE52-FCF2D7535F74"
 Subject: Discussion: Let's debate these attachments
 Date: Tue, 20 Apr 2020 04:20:20 -0400
-In-Reply-To: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
+In-Reply-To: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>, <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
 To: "Replies" <reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@example.com>
 References: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
 Message-Id: <0CB459E0-0336-41DA-BC88-E6E28C697DDB@chatwoot.com>

--- a/spec/fixtures/files/reply_mail_without_uuid.eml
+++ b/spec/fixtures/files/reply_mail_without_uuid.eml
@@ -3,7 +3,7 @@ Mime-Version: 1.0 (Apple Message framework v1244.3)
 Content-Type: multipart/alternative; boundary="Apple-Mail=_33A037C7-4BB3-4772-AE52-FCF2D7535F74"
 Subject: Discussion: Let's debate these attachments
 Date: Tue, 20 Apr 2020 04:20:20 -0400
-In-Reply-To: <account/1/conversation/6bdc3f4d-0bec-4515-a284-5d916fdde489@test.com>
+In-Reply-To: <account/1/conversation/6bdc3f4d-0bec-4515-a284-5d916fdde489@test.com> <conversation/6bdc3f4d-0bec-4515-a284-5d916fdde489/messages/123@test.com>
 To: "Replies" <test@example.com>
 References: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
 Message-Id: <0CB459E0-0336-41DA-BC88-E6E28C697DDB@chatwoot.com>

--- a/spec/mailboxes/reply_mailbox_spec.rb
+++ b/spec/mailboxes/reply_mailbox_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ReplyMailbox, type: :mailbox do
 
       before do
         conversation_1.update!(uuid: '6bdc3f4d-0bec-4515-a284-5d916fdde489')
-        reply_mail_without_uuid.mail['In-Reply-To'] = '<conversation/6bdc3f4d-0bec-4515-a284-5d916fdde489/messages/123@test.com>'
+        # reply_mail_without_uuid.mail['In-Reply-To'] = ''
       end
 
       it 'find channel with reply to mail' do

--- a/spec/mailboxes/reply_mailbox_spec.rb
+++ b/spec/mailboxes/reply_mailbox_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ReplyMailbox, type: :mailbox do
 
       before do
         conversation_1.update!(uuid: '6bdc3f4d-0bec-4515-a284-5d916fdde489')
-        # reply_mail_without_uuid.mail['In-Reply-To'] = ''
+        reply_mail_without_uuid.mail['In-Reply-To'] = '<conversation/6bdc3f4d-0bec-4515-a284-5d916fdde489/messages/123@test.com>'
       end
 
       it 'find channel with reply to mail' do


### PR DESCRIPTION
# Pull Request Template

## Description

Instead of string, we consider array for in_reply_to mail header.

Fixes #3615

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Change the string type to array for in reply to.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
