### PR TITLE
feat: Adds multiple path support for icons

### DIFF
--- a/app/javascript/shared/components/FluentIcon/DashboardIcon.vue
+++ b/app/javascript/shared/components/FluentIcon/DashboardIcon.vue
@@ -1,24 +1,15 @@
 <template>
-  <svg
-    :width="size"
-    :height="size"
-    fill="none"
-    viewBox="0 0 24 24"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      v-for="source in pathSource"
-      :key="source"
-      :d="source"
-      fill="currentColor"
-    />
-  </svg>
+  <base-icon :size="size" :icon="icon" :type="type" :icons="icons" />
 </template>
 <script>
+import BaseIcon from './Icon';
 import icons from './dashboard-icons.json';
 
 export default {
   name: 'FluentIcon',
+  components: {
+    BaseIcon,
+  },
   props: {
     icon: {
       type: String,
@@ -35,16 +26,6 @@ export default {
   },
   data() {
     return { icons };
-  },
-  computed: {
-    pathSource() {
-      // To support icons with multiple paths
-      const path = this.icons[`${this.icon}-${this.type}`];
-      if (path.constructor === Array) {
-        return path;
-      }
-      return [path];
-    },
   },
 };
 </script>

--- a/app/javascript/shared/components/FluentIcon/Icon.vue
+++ b/app/javascript/shared/components/FluentIcon/Icon.vue
@@ -15,13 +15,14 @@
   </svg>
 </template>
 <script>
-import icons from './dashboard-icons.json';
-
 export default {
-  name: 'FluentIcon',
   props: {
     icon: {
       type: String,
+      required: true,
+    },
+    icons: {
+      type: Object,
       required: true,
     },
     size: {
@@ -33,9 +34,7 @@ export default {
       default: 'outline',
     },
   },
-  data() {
-    return { icons };
-  },
+
   computed: {
     pathSource() {
       // To support icons with multiple paths

--- a/app/javascript/shared/components/FluentIcon/Index.vue
+++ b/app/javascript/shared/components/FluentIcon/Index.vue
@@ -1,27 +1,23 @@
 <template>
-  <svg
-    :width="size"
-    :height="size"
-    fill="none"
-    viewBox="0 0 24 24"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path :d="icons[`${icon}-${type}`]" fill="currentColor" />
-  </svg>
+  <base-icon :size="size" :icon="icon" :type="type" :icons="icons" />
 </template>
 <script>
+import BaseIcon from './Icon';
 import icons from './icons.json';
 
 export default {
   name: 'FluentIcon',
+  components: {
+    BaseIcon,
+  },
   props: {
     icon: {
       type: String,
       required: true,
     },
     size: {
-      type: String,
-      default: '20px',
+      type: [String, Number],
+      default: '20',
     },
     type: {
       type: String,


### PR DESCRIPTION
**Why**
Currently the component we use to render fluent icons does not support icon sources with multiple SVG paths.

