### PR TITLE
chore: Notification subscription delete API

### DIFF
--- a/app/controllers/api/v1/notification_subscriptions_controller.rb
+++ b/app/controllers/api/v1/notification_subscriptions_controller.rb
@@ -7,6 +7,12 @@ class Api::V1::NotificationSubscriptionsController < Api::BaseController
     render json: notification_subscription
   end
 
+  def destroy
+    notification_subscription = NotificationSubscription.where(["subscription_attributes->>'push_token' = ?", params[:push_token]]).first
+    notification_subscription.destroy
+    head :ok
+  end
+
   private
 
   def set_user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -172,7 +172,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resource :notification_subscriptions, only: [:create]
+      resource :notification_subscriptions, only: [:create, :destroy]
 
       namespace :widget do
         resource :config, only: [:create]

--- a/spec/controllers/api/v1/notification_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/v1/notification_subscriptions_controller_spec.rb
@@ -80,4 +80,32 @@ RSpec.describe 'Notifications Subscriptions API', type: :request do
       end
     end
   end
+
+  describe 'DELETE /api/v1/notification_subscriptions' do
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized' do
+        delete '/api/v1/notification_subscriptions'
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an authenticated user' do
+      let(:agent) { create(:user, account: account, role: :agent) }
+
+      it 'delete existing notification subscription if subscription exists' do
+        subscription = create(:notification_subscription, subscription_type: 'fcm', subscription_attributes: { push_token: 'bUvZo8AYGGmCMr' },
+                                                          user: agent)
+        delete '/api/v1/notification_subscriptions',
+               params: {
+                 push_token: subscription.subscription_attributes['push_token']
+               },
+               headers: agent.create_new_auth_token,
+               as: :json
+
+        expect(response).to have_http_status(:success)
+        expect { subscription.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Added delete notification subscription API for clearing all the push tokens when logged out from the mobile app (https://github.com/chatwoot/chatwoot-mobile-app/issues/430)