### PR TITLE
Fixed spacing issue as per - Issue 3669

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/cannedMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/cannedMgmt.json
@@ -4,7 +4,7 @@
     "HEADER_BTN_TXT": "Add Canned Response",
     "LOADING": "Fetching Canned Responses",
     "SEARCH_404": "There are no items matching this query",
-    "SIDEBAR_TXT": "<p><b>Canned Responses</b> </p><p> Canned Responses are saved reply templates which can be used to quickly send out a reply to a conversation . </p><p> For creating a Canned Response, just click on the <b>Add Canned Response</b>. You can also edit or delete an existing Canned Response by clicking on the Edit or Delete button </p><p> Canned responses are used with the help of <b>Short Codes</b>. Agents can access canned responses while on a chat by typing <b>'/'</b> followed by the short code. </p>",
+    "SIDEBAR_TXT": "<p><b>Canned Responses</b> </p><p> Canned Responses are saved reply templates which can be used to quickly send out a reply to a conversation. </p><p> For creating a Canned Response, just click on the <b>Add Canned Response</b>. You can also edit or delete an existing Canned Response by clicking on the Edit or Delete button </p><p> Canned responses are used with the help of <b>Short Codes</b>. Agents can access canned responses while on a chat by typing <b>'/'</b> followed by the short code. </p>",
     "LIST": {
       "404": "There are no canned responses available in this account.",
       "TITLE": "Manage canned responses",
@@ -17,7 +17,7 @@
     },
     "ADD": {
       "TITLE": "Add Canned Response",
-      "DESC": "Canned Responses are saved reply templates which can be used to quickly send out reply to conversation .",
+      "DESC": "Canned Responses are saved reply templates which can be used to quickly send out reply to conversation.",
       "CANCEL_BUTTON_TEXT": "Cancel",
       "FORM": {
         "SHORT_CODE": {


### PR DESCRIPTION


## Description
Removed extra space before "." as mentioned in the issue: https://github.com/chatwoot/chatwoot/issues/3669

Fixes # (3669)

## Type of change
Fixed a typo

## How Has This Been Tested?
Replication steps:
1. Open "Add Canned Responses" modal.
2. Refer to the description of modal under the title.
3. There is an extra space before "." in the description.
![image](https://user-images.githubusercontent.com/96977038/148686425-6b8af331-1c35-4116-aab3-935e67a0e5d2.png)



