### PR TITLE
Fix: Error with plurals in Invite members onboarding guide.

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -129,7 +129,7 @@
     },
     "TEAM_MEMBERS": {
       "TITLE": "Invite your team members",
-      "DESCRIPTION": "Since you are getting ready to talk to your customer, bring in your teammates to assist you. You can invite your teammates by adding their email address to the agent list.",
+      "DESCRIPTION": "Since you are getting ready to talk to your customer, bring in your teammates to assist you. You can invite your teammates by adding their email addresses to the agent list.",
       "NEW_LINK": "Click here to invite a team member"
     },
     "INBOXES": {


### PR DESCRIPTION
## Description
Updated "email address" to "email addresses" in the Invite your team members guide.


Fixes #3671 

## Type of change

Grammatical error

## How Has This Been Tested?
![image](https://user-images.githubusercontent.com/96977038/148687386-95ca36b8-5063-4cfe-b16b-fbcd32d09d20.png)


