### PR TITLE
bug: Fixes bot private message timestamp colour issue

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -423,6 +423,9 @@ export default {
       .message-text--metadata .time {
         color: var(--v-50);
       }
+      &.is-private .message-text--metadata .time {
+        color: var(--s-400);
+      }
     }
 
     &.is-failed {


### PR DESCRIPTION
Fixes #3623 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Screenshot**
 
<img width="284" alt="Screenshot 2022-01-13 at 4 12 26 PM" src="https://user-images.githubusercontent.com/64252451/149315313-9f6faf6e-78bf-4aca-87ee-496d43e66ec8.png">


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
