### PR TITLE
fix: Return if window.$chatwoot is already defined

### DIFF
--- a/app/javascript/packs/sdk.js
+++ b/app/javascript/packs/sdk.js
@@ -27,6 +27,10 @@ export const hasUserKeys = user =>
   REQUIRED_USER_KEYS.reduce((acc, key) => acc || !!user[key], false);
 
 const runSDK = ({ baseUrl, websiteToken }) => {
+  if (window.$chatwoot) {
+    return;
+  }
+
   const chatwootSettings = window.chatwootSettings || {};
   window.$chatwoot = {
     baseUrl,


### PR DESCRIPTION
- [ ] Disable running the SDK methods if window.$chatwoot is already defined

Fixes #3848 