### PR TITLE
bug: Fixes sidebar does not show an active page for settings page

### DIFF
--- a/app/javascript/dashboard/components/layout/sidebarComponents/SecondaryNavItem.vue
+++ b/app/javascript/dashboard/components/layout/sidebarComponents/SecondaryNavItem.vue
@@ -73,14 +73,48 @@ export default {
     hasSubMenu() {
       return !!this.menuItem.children;
     },
+    isInboxConversation() {
+      return (
+        this.$store.state.route.name === 'inbox_conversation' &&
+        this.menuItem.toStateName === 'home'
+      );
+    },
+    isTeamsSettings() {
+      return (
+        this.$store.state.route.name === 'settings_teams_edit' &&
+        this.menuItem.toStateName === 'settings_teams_list'
+      );
+    },
+    isInboxsSettings() {
+      return (
+        this.$store.state.route.name === 'settings_inbox_show' &&
+        this.menuItem.toStateName === 'settings_inbox_list'
+      );
+    },
+    isIntegrationsSettings() {
+      return (
+        this.$store.state.route.name === 'settings_integrations_webhook' &&
+        this.menuItem.toStateName === 'settings_integrations'
+      );
+    },
+    isApplicationsSettings() {
+      return (
+        this.$store.state.route.name === 'settings_applications_integration' &&
+        this.menuItem.toStateName === 'settings_applications'
+      );
+    },
+
     computedClass() {
       // If active Inbox is present
       // donot highlight conversations
       if (this.activeInbox) return ' ';
 
       if (
-        this.$store.state.route.name === 'inbox_conversation' &&
-        this.menuItem.toStateName === 'home'
+        this.isInboxConversation ||
+        this.isTeamsSettings ||
+        this.isInboxsSettings ||
+        this.isIntegrationsSettings ||
+        this.isApplicationsSettings
       ) {
         return 'is-active';
       }


### PR DESCRIPTION
# Pull Request Template

## Description

The secondary sidebar does not show an active page for the inbox, teams, integrations, applications settings page.

**Fixes** https://github.com/chatwoot/chatwoot/issues/3842

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Screen recording** 

https://user-images.githubusercontent.com/64252451/151338402-3775480b-760b-4061-a5de-8c1950727e4d.mov

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules