### PR TITLE
fix: URL encode params on Platform API call

### DIFF
--- a/app/controllers/platform/api/v1/users_controller.rb
+++ b/app/controllers/platform/api/v1/users_controller.rb
@@ -13,7 +13,8 @@ class Platform::Api::V1::UsersController < PlatformController
   end
 
   def login
-    render json: { url: "#{ENV['FRONTEND_URL']}/app/login?email=#{@resource.email}&sso_auth_token=#{@resource.generate_sso_auth_token}" }
+    encoded_email = ERB::Util.url_encode(@resource.email)
+    render json: { url: "#{ENV['FRONTEND_URL']}/app/login?email=#{encoded_email}&sso_auth_token=#{@resource.generate_sso_auth_token}" }
   end
 
   def show; end

--- a/app/javascript/dashboard/routes/login/Login.vue
+++ b/app/javascript/dashboard/routes/login/Login.vue
@@ -133,7 +133,9 @@ export default {
     login() {
       this.loginApi.showLoading = true;
       const credentials = {
-        email: this.email ? this.email : this.credentials.email,
+        email: this.email
+          ? decodeURIComponent(this.email)
+          : this.credentials.email,
         password: this.credentials.password,
         sso_auth_token: this.ssoAuthToken,
       };

--- a/spec/controllers/platform/api/v1/users_controller_spec.rb
+++ b/spec/controllers/platform/api/v1/users_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Platform Users API', type: :request do
-  let!(:user) { create(:user, custom_attributes: { test: 'test' }) }
+  let!(:user) { create(:user, email: 'dev+testing@chatwoot.com', custom_attributes: { test: 'test' }) }
 
   describe 'GET /platform/api/v1/users/{user_id}' do
     context 'when it is an unauthenticated platform app' do
@@ -71,7 +71,7 @@ RSpec.describe 'Platform Users API', type: :request do
 
         expect(response).to have_http_status(:success)
         data = JSON.parse(response.body)
-        expect(data['url']).to include('sso_auth_token')
+        expect(data['url']).to include('email=dev%2Btesting%40chatwoot.com&sso_auth_token=')
       end
     end
   end


### PR DESCRIPTION
- Add URL encoding for the params in platform API calls.

Fixes [product#307](https://github.com/chatwoot/product/issues/307)
Fixes: #2186