### PR TITLE
Fixes API call failing after opening the saved filter

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -368,7 +368,7 @@ export default {
       if (this.$route.name !== 'home') {
         this.$router.push({ name: 'home' });
       }
-      this.foldersQuery = { payload: payload };
+      this.foldersQuery = filterQueryGenerator(payload);
       this.$store.dispatch('conversationPage/reset');
       this.$store.dispatch('emptyAllConversations');
       this.fetchFilteredConversations(payload);

--- a/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsView.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsView.vue
@@ -340,7 +340,7 @@ export default {
     },
     onApplyFilter(payload) {
       this.closeContactInfoPanel();
-      this.segmentsQuery = { payload };
+      this.segmentsQuery = filterQueryGenerator(payload);
       this.$store.dispatch('contacts/filter', {
         queryPayload: filterQueryGenerator(payload),
       });


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes filter API calls failing issue after merging this PR https://github.com/chatwoot/chatwoot/pull/3926, when we open a newly saved folder. And will break the existing saved filter.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
