### PR TITLE
Support differnt input types in custom attributes

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ConversationAdvancedFilter.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationAdvancedFilter.vue
@@ -141,6 +141,12 @@ export default {
       switch (key) {
         case 'date':
           return 'date';
+        case 'text':
+          return 'plain_text';
+        case 'list':
+          return 'plain_text';
+        case 'checkbox':
+          return 'search_select';
         default:
           return 'plain_text';
       }
@@ -159,6 +165,30 @@ export default {
     },
     getDropdownValues(type) {
       const statusFilters = this.$t('CHAT_LIST.CHAT_STATUS_FILTER_ITEMS');
+      const allCustomAttributes = this.$store.getters[
+        'attributes/getAttributesByModel'
+      ](this.attributeModel);
+      const isCustomAttributeCheckbox = allCustomAttributes.find(attr => {
+        if (
+          attr.attribute_key === type &&
+          attr.attribute_display_type === 'checkbox'
+        ) {
+          return true;
+        }
+        return false;
+      });
+      if (isCustomAttributeCheckbox) {
+        return [
+          {
+            id: true,
+            name: this.$t('FILTER.ATTRIBUTE_LABELS.TRUE'),
+          },
+          {
+            id: false,
+            name: this.$t('FILTER.ATTRIBUTE_LABELS.FALSE'),
+          },
+        ];
+      }
       switch (type) {
         case 'status':
           return [

--- a/app/javascript/dashboard/i18n/locale/en/advancedFilters.json
+++ b/app/javascript/dashboard/i18n/locale/en/advancedFilters.json
@@ -23,6 +23,10 @@
       "is_greater_than": "Is greater than",
       "is_lesser_than": "Is lesser than"
     },
+    "ATTRIBUTE_LABELS": {
+      "TRUE": "True",
+      "FALSE": "False"
+    },
     "ATTRIBUTES": {
       "STATUS": "Status",
       "ASSIGNEE_NAME": "Assignee Name",

--- a/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsAdvancedFilters.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsAdvancedFilters.vue
@@ -147,6 +147,12 @@ export default {
       switch (key) {
         case 'date':
           return 'date';
+        case 'text':
+          return 'plain_text';
+        case 'list':
+          return 'plain_text';
+        case 'checkbox':
+          return 'search_select';
         default:
           return 'plain_text';
       }
@@ -164,6 +170,30 @@ export default {
       return type.filterOperators;
     },
     getDropdownValues(type) {
+      const allCustomAttributes = this.$store.getters[
+        'attributes/getAttributesByModel'
+      ](this.attributeModel);
+      const isCustomAttributeCheckbox = allCustomAttributes.find(attr => {
+        if (
+          attr.attribute_key === type &&
+          attr.attribute_display_type === 'checkbox'
+        ) {
+          return true;
+        }
+        return false;
+      });
+      if (isCustomAttributeCheckbox) {
+        return [
+          {
+            id: true,
+            name: this.$t('FILTER.ATTRIBUTE_LABELS.TRUE'),
+          },
+          {
+            id: false,
+            name: this.$t('FILTER.ATTRIBUTE_LABELS.FALSE'),
+          },
+        ];
+      }
       switch (type) {
         case 'country_code':
           return countries;


### PR DESCRIPTION
## Description

Adds support for different input types for custom attributes in contacts and conversations filters 

Fixes #3944 

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
