### PR TITLE
fix: nokogiri gem build failure in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,9 @@ COPY Gemfile Gemfile.lock ./
 
 # natively compile grpc and protobuf to support alpine musl (dialogflow-docker workflow)
 # https://github.com/googleapis/google-cloud-ruby/issues/13306
-RUN apk add --no-cache musl ruby-full ruby-dev gcc make musl-dev openssl openssl-dev g++ linux-headers
+# adding xz as nokogiri was failing to build libxml
+# https://github.com/chatwoot/chatwoot/issues/4045
+RUN apk add --no-cache musl ruby-full ruby-dev gcc make musl-dev openssl openssl-dev g++ linux-headers xz
 RUN bundle config set --local force_ruby_platform true
 
 # Do not install development or test gems in production


### PR DESCRIPTION
# Pull Request Template

## Description

Docker builds was failing as `nokogiri` gem failed to compile.

Nokogiri gem depends on `libxml2` and `libxslt` which is now compressed with `xz`. Previous releases of these libraries were gzipped. As we are compiling gems natively, `xz` needs to be installed.

Fixes #4045


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- 20.04 instance
- dockerhub CI


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
