### PR TITLE
Show email signature with maximum height 8vh, fixes #4021

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -666,6 +666,8 @@ export default {
   justify-content: space-between;
   border: 1px dashed var(--s-100);
   border-radius: var(--border-radius-small);
+  max-height: 8vh;
+  overflow: auto;
 
   &:hover {
     background: var(--s-25);


### PR DESCRIPTION
Make email signature scrollable

## Description

If you have a slightly longer email signature, it takes up a lot of the space. This pull request ensures that the signature is not displayed too large depending on the display height.
Before:
![image](https://user-images.githubusercontent.com/64426524/154801388-4a4ece4a-7bc9-4247-aa01-d080fb2fe58b.png)
After:
![image](https://user-images.githubusercontent.com/64426524/155383239-5e637ac5-6cb7-4ee2-b068-7c9e640fb1a9.png)


Fixes #4021

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

It's only 2 lines of css, now that's not so difficult to test ;)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
