### PR TITLE
fix: Add resetTriggered flag to fix reset loop

### DIFF
--- a/app/javascript/packs/sdk.js
+++ b/app/javascript/packs/sdk.js
@@ -25,6 +25,7 @@ const runSDK = ({ baseUrl, websiteToken }) => {
     launcherTitle: chatwootSettings.launcherTitle || '',
     showPopoutButton: chatwootSettings.showPopoutButton || false,
     widgetStyle: chatwootSettings.widgetStyle || 'standard',
+    resetTriggered: false,
 
     toggle(state) {
       IFrameHelper.events.toggleBubble(state);
@@ -100,6 +101,8 @@ const runSDK = ({ baseUrl, websiteToken }) => {
         baseUrl: window.$chatwoot.baseUrl,
         websiteToken: window.$chatwoot.websiteToken,
       });
+
+      window.$chatwoot.resetTriggered = true;
     },
   };
 

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -136,7 +136,9 @@ export const IFrameHelper = {
       if (window.$chatwoot.user) {
         IFrameHelper.sendMessage('set-user', window.$chatwoot.user);
       }
-      dispatchWindowEvent({ eventName: CHATWOOT_READY });
+      if (!window.$chatwoot.resetTriggered) {
+        dispatchWindowEvent({ eventName: CHATWOOT_READY });
+      }
     },
     error: ({ errorType, data }) => {
       dispatchWindowEvent({ eventName: CHATWOOT_ERROR, data: data });


### PR DESCRIPTION
- Added a resetTriggered flag to check if the loaded event was triggered by a reset method. 
- If resetTriggered, the ready event will not be fired again.

Fixes #3963, #3918