### PR TITLE
fix: Delete content_attributes in message destroy API

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
 
   def destroy
     ActiveRecord::Base.transaction do
-      message.update!(content: I18n.t('conversations.messages.deleted'), deleted: true)
+      message.update!(content: I18n.t('conversations.messages.deleted'), content_attributes: { deleted: true })
       message.attachments.destroy_all
     end
   end

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe 'Conversation Messages API', type: :request do
   end
 
   describe 'DELETE /api/v1/accounts/{account.id}/conversations/:conversation_id/messages/:id' do
-    let(:message) { create(:message, account: account, content_attributes: { bcc_emails: ["hello@chatwoot.com"] }) }
+    let(:message) { create(:message, account: account, content_attributes: { bcc_emails: ['hello@chatwoot.com'] }) }
     let(:conversation) { message.conversation }
 
     context 'when it is an unauthenticated user' do
@@ -188,7 +188,7 @@ RSpec.describe 'Conversation Messages API', type: :request do
         expect(response).to have_http_status(:success)
         expect(message.reload.content).to eq 'This message was deleted'
         expect(message.reload.deleted).to eq true
-        expect(message.reload.content_attributes["bcc_emails"]).to eq nil
+        expect(message.reload.content_attributes['bcc_emails']).to eq nil
       end
     end
 

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe 'Conversation Messages API', type: :request do
   end
 
   describe 'DELETE /api/v1/accounts/{account.id}/conversations/:conversation_id/messages/:id' do
-    let(:message) { create(:message, account: account) }
+    let(:message) { create(:message, account: account, content_attributes: { bcc_emails: ["hello@chatwoot.com"] }) }
     let(:conversation) { message.conversation }
 
     context 'when it is an unauthenticated user' do
@@ -188,6 +188,7 @@ RSpec.describe 'Conversation Messages API', type: :request do
         expect(response).to have_http_status(:success)
         expect(message.reload.content).to eq 'This message was deleted'
         expect(message.reload.deleted).to eq true
+        expect(message.reload.content_attributes["bcc_emails"]).to eq nil
       end
     end
 


### PR DESCRIPTION
Delete the contents of content attributes while deleting a message.

 #4151