### PR TITLE
fix: Reduce the height of the unread container while campaign is active

### DIFF
--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -29,7 +29,7 @@ export const SDK_CSS = `
 
 .woot-widget-holder.has-unread-view {
   border-radius: 0 !important;
-  min-height: 80px;
+  min-height: 80px !important;
   height: auto;
   bottom: 94px;
   box-shadow: none !important;


### PR DESCRIPTION
Reduce the campaign height in case of smaller text messages.