### PR TITLE
System default monospace fonts for code elem

### DIFF
--- a/app/javascript/dashboard/assets/scss/_foundation-custom.scss
+++ b/app/javascript/dashboard/assets/scss/_foundation-custom.scss
@@ -26,7 +26,8 @@
 
 code {
   border: 0;
-  font-family: 'Monaco', Verdana;
+  font-family: 'ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas',
+    '"Liberation Mono"', '"Courier New"', 'monospace';
   font-size: $font-size-mini;
 
   &.hljs {
@@ -54,7 +55,6 @@ code {
 .columns.with-right-space {
   padding-right: var(--space-normal);
 }
-
 
 .badge {
   border-radius: var(--border-radius-normal);


### PR DESCRIPTION
## Description
Adds monospace fonts for Linux systems.
![before](https://user-images.githubusercontent.com/15716057/159113526-2f7e2198-a863-4cdd-85d4-39ebd66ea774.png)

![after](https://user-images.githubusercontent.com/15716057/159113531-c6fe08bd-9e6d-49d3-ac9a-226fa8004475.png)

