### PR TITLE
Timezone fixes for ReportBuilder and for ReportController spec

### DIFF
--- a/app/builders/v2/report_builder.rb
+++ b/app/builders/v2/report_builder.rb
@@ -19,7 +19,7 @@ class V2::ReportBuilder
   # For backward compatible with old report
   def build
     timeseries.each_with_object([]) do |p, arr|
-      arr << { value: p[1], timestamp: p[0].to_time.to_i }
+      arr << { value: p[1], timestamp: p[0].in_time_zone(@timezone).to_i }
     end
   end
 

--- a/spec/controllers/api/v2/accounts/report_controller_spec.rb
+++ b/spec/controllers/api/v2/accounts/report_controller_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe 'Reports API', type: :request do
   let!(:user) { create(:user, account: account) }
   let!(:inbox) { create(:inbox, account: account) }
   let(:inbox_member) { create(:inbox_member, user: user, inbox: inbox) }
+  let(:date_timestamp) { Time.current.beginning_of_day.to_i }
+  let(:params) { { timezone_offset: Time.zone.utc_offset } }
 
   before do
     create_list(:conversation, 10, account: account, inbox: inbox,
@@ -23,12 +25,14 @@ RSpec.describe 'Reports API', type: :request do
     end
 
     context 'when it is an authenticated user' do
-      params = {
-        metric: 'conversations_count',
-        type: :account,
-        since: Time.zone.today.to_time.to_i.to_s,
-        until: Time.zone.today.to_time.to_i.to_s
-      }
+      let(:params) do
+        super().merge(
+          metric: 'conversations_count',
+          type: :account,
+          since: date_timestamp.to_s,
+          until: date_timestamp.to_s
+        )
+      end
 
       it 'returns unauthorized for agents' do
         get "/api/v2/accounts/#{account.id}/reports",
@@ -48,7 +52,7 @@ RSpec.describe 'Reports API', type: :request do
         expect(response).to have_http_status(:success)
         json_response = JSON.parse(response.body)
 
-        current_day_metric = json_response.select { |x| x['timestamp'] == Time.zone.today.to_time.to_i }
+        current_day_metric = json_response.select { |x| x['timestamp'] == date_timestamp }
         expect(current_day_metric.length).to eq(1)
         expect(current_day_metric[0]['value']).to eq(10)
       end
@@ -65,11 +69,13 @@ RSpec.describe 'Reports API', type: :request do
     end
 
     context 'when it is an authenticated user' do
-      params = {
-        type: :account,
-        since: Time.zone.today.to_time.to_i.to_s,
-        until: Time.zone.today.to_time.to_i.to_s
-      }
+      let(:params) do
+        super().merge(
+          type: :account,
+          since: date_timestamp.to_s,
+          until: date_timestamp.to_s
+        )
+      end
 
       it 'returns unauthorized for agents' do
         get "/api/v2/accounts/#{account.id}/reports/summary",
@@ -104,10 +110,12 @@ RSpec.describe 'Reports API', type: :request do
     end
 
     context 'when it is an authenticated user' do
-      params = {
-        since: 30.days.ago.to_i.to_s,
-        until: Time.zone.today.to_time.to_i.to_s
-      }
+      let(:params) do
+        super().merge(
+          since: 30.days.ago.to_i.to_s,
+          until: date_timestamp.to_s
+        )
+      end
 
       it 'returns unauthorized for agents' do
         get "/api/v2/accounts/#{account.id}/reports/agents.csv",
@@ -137,10 +145,12 @@ RSpec.describe 'Reports API', type: :request do
     end
 
     context 'when it is an authenticated user' do
-      params = {
-        since: 30.days.ago.to_i.to_s,
-        until: Time.zone.today.to_time.to_i.to_s
-      }
+      let(:params) do
+        super().merge(
+          since: 30.days.ago.to_i.to_s,
+          until: date_timestamp.to_s
+        )
+      end
 
       it 'returns unauthorized for inboxes' do
         get "/api/v2/accounts/#{account.id}/reports/inboxes",
@@ -170,10 +180,12 @@ RSpec.describe 'Reports API', type: :request do
     end
 
     context 'when it is an authenticated user' do
-      params = {
-        since: 30.days.ago.to_i.to_s,
-        until: Time.zone.today.to_time.to_i.to_s
-      }
+      let(:params) do
+        super().merge(
+          since: 30.days.ago.to_i.to_s,
+          until: date_timestamp.to_s
+        )
+      end
 
       it 'returns unauthorized for labels' do
         get "/api/v2/accounts/#{account.id}/reports/labels.csv",
@@ -203,10 +215,12 @@ RSpec.describe 'Reports API', type: :request do
     end
 
     context 'when it is an authenticated user' do
-      params = {
-        since: 30.days.ago.to_i.to_s,
-        until: Time.zone.today.to_time.to_i.to_s
-      }
+      let(:params) do
+        super().merge(
+          since: 30.days.ago.to_i.to_s,
+          until: date_timestamp.to_s
+        )
+      end
 
       it 'returns unauthorized for teams' do
         get "/api/v2/accounts/#{account.id}/reports/teams.csv",


### PR DESCRIPTION
I noticed this because I was getting test failures in `spec/controllers/api/v2/accounts/report_controller_spec.rb` running the tests locally on my laptop.

- ReportBuilder wasn't using the specified time zone for the timestamp in the
"build" method
- The ReportController spec was calling `Time.zone.today.to_time`, but
that sequence loses time zone information because `today` is a Date and
Dates don't have time zones in Ruby, so the time ended up in the system
time start-of-date instead of the `Time.zone` start-of-date.
