### PR TITLE
chore: Use bang version of "find_or_create_by!" in Plaform UsersController

### DIFF
--- a/app/controllers/platform/api/v1/users_controller.rb
+++ b/app/controllers/platform/api/v1/users_controller.rb
@@ -9,7 +9,7 @@ class Platform::Api::V1::UsersController < PlatformController
     @resource = (User.find_by(email: user_params[:email]) || User.new(user_params))
     @resource.save!
     @resource.confirm
-    @platform_app.platform_app_permissibles.find_or_create_by(permissible: @resource)
+    @platform_app.platform_app_permissibles.find_or_create_by!(permissible: @resource)
   end
 
   def login


### PR DESCRIPTION
I just happened to notice this. Was it intentional that this could fail silently?  I don't think there's a probable scenario right now where it actually would fail, but seems like it might be good to use the bang version by default if we're not checking the return value?