### PR TITLE
feat: support audio player on widget

### DIFF
--- a/app/javascript/widget/assets/scss/views/_conversation.scss
+++ b/app/javascript/widget/assets/scss/views/_conversation.scss
@@ -51,7 +51,7 @@
 
   .has-attachment {
     overflow: hidden;
-    
+
     :not([audio]) {
       padding: 0;
     }
@@ -222,7 +222,7 @@
 
   :not([audio]) {
     max-width: 100%;
-  }  
+  }
 
   >a {
     color: $color-primary;

--- a/app/javascript/widget/assets/scss/views/_conversation.scss
+++ b/app/javascript/widget/assets/scss/views/_conversation.scss
@@ -51,7 +51,10 @@
 
   .has-attachment {
     overflow: hidden;
-    padding: 0;
+    
+    :not([audio]) {
+      padding: 0;
+    }
 
     &.has-text {
       margin-top: $space-smaller;
@@ -213,10 +216,13 @@
   display: inline-block;
   font-size: $font-size-default;
   line-height: 1.5;
-  max-width: 100%;
   padding: $space-slab $space-normal;
   text-align: left;
   word-break: break-word;
+
+  :not([audio]) {
+    max-width: 100%;
+  }  
 
   >a {
     color: $color-primary;

--- a/app/javascript/widget/components/AgentMessage.vue
+++ b/app/javascript/widget/components/AgentMessage.vue
@@ -34,6 +34,9 @@
               :readable-time="readableTime"
               @error="onImageLoadError"
             />
+            <audio v-else-if="attachment.file_type === 'audio'" controls style="padding: 0px">
+              <source :src="attachment.data_url" />
+            </audio>            
             <file-bubble v-else :url="attachment.data_url" />
           </div>
         </div>

--- a/app/javascript/widget/components/AgentMessage.vue
+++ b/app/javascript/widget/components/AgentMessage.vue
@@ -34,9 +34,9 @@
               :readable-time="readableTime"
               @error="onImageLoadError"
             />
-            <audio v-else-if="attachment.file_type === 'audio'" controls style="padding: 0px">
+            <audio v-else-if="attachment.file_type === 'audio'" controls>
               <source :src="attachment.data_url" />
-            </audio>            
+            </audio>
             <file-bubble v-else :url="attachment.data_url" />
           </div>
         </div>


### PR DESCRIPTION
# Pull Request Template

## Description

Adds visualization in the form of an audio player inside the Widget.

Fixes #3603
https://github.com/chatwoot/chatwoot/issues/3603

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Sent an audio type attachment.
Audio recorded.
Attached photo type.
Sent PDF attachment

<img width="548" alt="image" src="https://user-images.githubusercontent.com/9892674/159620216-00fcfcf7-9b48-4505-9011-0cc156bab8b6.png">

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My changes generate no new warnings
