### PR TITLE
chore: Disable invalid contact resolved activity messages

### DIFF
--- a/app/models/concerns/activity_message_handler.rb
+++ b/app/models/concerns/activity_message_handler.rb
@@ -20,7 +20,7 @@ module ActivityMessageHandler
   def create_status_change_message(user_name)
     content = if user_name
                 I18n.t("conversations.activity.status.#{status}", user_name: user_name)
-              elsif Current.contact.present?
+              elsif Current.contact.present? && resolved?
                 I18n.t('conversations.activity.status.contact_resolved', contact_name: Current.contact.name.capitalize)
               elsif resolved?
                 I18n.t('conversations.activity.status.auto_resolved', duration: auto_resolve_duration)

--- a/spec/controllers/api/v1/widget/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/messages_controller_spec.rb
@@ -87,6 +87,28 @@ RSpec.describe '/api/v1/widget/messages', type: :request do
         expect(response).to have_http_status(:success)
         expect(conversation.reload.resolved?).to eq(true)
       end
+
+      it 'does not create resolved activity messages when snoozed conversation is opened' do
+        conversation.snoozed!
+
+        message_params = { content: 'hello world', timestamp: Time.current }
+        post api_v1_widget_messages_url,
+             params: { website_token: web_widget.website_token, message: message_params },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(Conversations::ActivityMessageJob).not_to have_been_enqueued.at_least(:once).with(
+          conversation,
+          {
+            account_id: conversation.account_id,
+            inbox_id: conversation.inbox_id,
+            message_type: :activity,
+            content: "Conversation was resolved by #{contact.name}"
+          }
+        )
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.open?).to eq(true)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes the bug which triggered "Contact resolved conversation" activity messages when snoozed conversations were reopened

