### PR TITLE
fix: drop conv and campaign seq on account delete

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -79,6 +79,7 @@ class Account < ApplicationRecord
 
   before_validation :validate_limit_keys
   after_create_commit :notify_creation
+  after_destroy :remove_account_sequences
 
   def agents
     users.where(account_users: { role: :agent })
@@ -136,5 +137,10 @@ class Account < ApplicationRecord
 
   def validate_limit_keys
     # method overridden in enterprise module
+  end
+
+  def remove_account_sequences
+    ActiveRecord::Base.connection.exec_query("drop sequence IF EXISTS camp_dpid_seq_#{self.id}")
+    ActiveRecord::Base.connection.exec_query("drop sequence IF EXISTS conv_dpid_seq_#{self.id}")
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -140,7 +140,7 @@ class Account < ApplicationRecord
   end
 
   def remove_account_sequences
-    ActiveRecord::Base.connection.exec_query("drop sequence IF EXISTS camp_dpid_seq_#{self.id}")
-    ActiveRecord::Base.connection.exec_query("drop sequence IF EXISTS conv_dpid_seq_#{self.id}")
+    ActiveRecord::Base.connection.exec_query("drop sequence IF EXISTS camp_dpid_seq_#{id}")
+    ActiveRecord::Base.connection.exec_query("drop sequence IF EXISTS conv_dpid_seq_#{id}")
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -31,8 +31,7 @@ RSpec.describe Account do
     end
   end
 
-  context 'after destroy' do
-
+  context 'when after_destroy is called' do
     it 'conv_dpid_seq and camp_dpid_seq_ are deleted' do
       account = create(:account)
       query = "select * from information_schema.sequences where sequence_name in  ('camp_dpid_seq_#{account.id}', 'conv_dpid_seq_#{account.id}');"
@@ -41,5 +40,4 @@ RSpec.describe Account do
       expect(ActiveRecord::Base.connection.execute(query).count).to eq(0)
     end
   end
-
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -30,4 +30,16 @@ RSpec.describe Account do
       expect(account.usage_limits).to eq({ agents: ChatwootApp.max_limit, inboxes: ChatwootApp.max_limit })
     end
   end
+
+  context 'after destroy' do
+
+    it 'conv_dpid_seq and camp_dpid_seq_ are deleted' do
+      account = create(:account)
+      query = "select * from information_schema.sequences where sequence_name in  ('camp_dpid_seq_#{account.id}', 'conv_dpid_seq_#{account.id}');"
+      expect(ActiveRecord::Base.connection.execute(query).count).to eq(2)
+      account.destroy
+      expect(ActiveRecord::Base.connection.execute(query).count).to eq(0)
+    end
+  end
+
 end


### PR DESCRIPTION
# Pull Request Template

## Description

Conversation and campaign sequences persist in the database even after the related account is deleted. This PR adds an `after_desttory` callback on the account model that will delete the associated sequences.

Fixes #4252 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] added tests/spec

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
