### PR TITLE
Eliminate deprecation warning in "app_config_controller_spec.rb"

### DIFF
--- a/spec/controllers/super_admin/app_config_controller_spec.rb
+++ b/spec/controllers/super_admin/app_config_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Super Admin Application Config API', type: :request do
         post '/super_admin/app_config', params: { app_config: { TESTKEY: 'TESTVALUE' } }
 
         expect(response.status).to eq(302)
-        expect(response).should redirect_to(super_admin_app_config_path)
+        expect(response).to redirect_to(super_admin_app_config_path)
 
         config = GlobalConfig.get('TESTKEY')
         expect(config['TESTKEY']).to eq('TESTVALUE')


### PR DESCRIPTION
This was generating a warning:

    Using `should` from rspec-expectations' old `:should` syntax without
    explicitly enabling the syntax is deprecated. Use the new `:expect` syntax
    or explicitly enable `:should` with `config.expect_with(:rspec) { |c|
    c.syntax = :should }` instead.
