### PR TITLE
Use "destroy!" instead of "destroy" when not checking the return value

### DIFF
--- a/app/controllers/api/v1/accounts/agent_bots_controller.rb
+++ b/app/controllers/api/v1/accounts/agent_bots_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::Accounts::AgentBotsController < Api::V1::Accounts::BaseController
   end
 
   def destroy
-    @agent_bot.destroy
+    @agent_bot.destroy!
     head :ok
   end
 

--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
   end
 
   def destroy
-    @agent.current_account_user.destroy
+    @agent.current_account_user.destroy!
     head :ok
   end
 

--- a/app/controllers/api/v1/accounts/campaigns_controller.rb
+++ b/app/controllers/api/v1/accounts/campaigns_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::Accounts::CampaignsController < Api::V1::Accounts::BaseController
   end
 
   def destroy
-    @campaign.destroy
+    @campaign.destroy!
     head :ok
   end
 

--- a/app/controllers/api/v1/accounts/canned_responses_controller.rb
+++ b/app/controllers/api/v1/accounts/canned_responses_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::Accounts::CannedResponsesController < Api::V1::Accounts::BaseCont
   end
 
   def destroy
-    @canned_response.destroy
+    @canned_response.destroy!
     head :ok
   end
 

--- a/app/controllers/api/v1/accounts/contacts/notes_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/notes_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::Accounts::Contacts::NotesController < Api::V1::Accounts::Contacts
   end
 
   def destroy
-    @note.destroy
+    @note.destroy!
     head :ok
   end
 

--- a/app/controllers/api/v1/accounts/custom_attribute_definitions_controller.rb
+++ b/app/controllers/api/v1/accounts/custom_attribute_definitions_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::Accounts::CustomAttributeDefinitionsController < Api::V1::Account
   end
 
   def destroy
-    @custom_attribute_definition.destroy
+    @custom_attribute_definition.destroy!
     head :no_content
   end
 

--- a/app/controllers/api/v1/accounts/custom_filters_controller.rb
+++ b/app/controllers/api/v1/accounts/custom_filters_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::Accounts::CustomFiltersController < Api::V1::Accounts::BaseContro
   end
 
   def destroy
-    @custom_filter.destroy
+    @custom_filter.destroy!
     head :no_content
   end
 

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -73,7 +73,7 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   end
 
   def destroy
-    @inbox.destroy
+    @inbox.destroy!
     head :ok
   end
 

--- a/app/controllers/api/v1/accounts/integrations/hooks_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/hooks_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::Accounts::Integrations::HooksController < Api::V1::Accounts::Base
   end
 
   def destroy
-    @hook.destroy
+    @hook.destroy!
     head :ok
   end
 

--- a/app/controllers/api/v1/accounts/integrations/slack_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/slack_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::Accounts::Integrations::SlackController < Api::V1::Accounts::Base
   end
 
   def destroy
-    @hook.destroy
+    @hook.destroy!
 
     head :ok
   end

--- a/app/controllers/api/v1/accounts/kbase/categories_controller.rb
+++ b/app/controllers/api/v1/accounts/kbase/categories_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::Accounts::Kbase::CategoriesController < Api::V1::Accounts::Kbase:
   end
 
   def destroy
-    @category.destroy
+    @category.destroy!
     head :ok
   end
 

--- a/app/controllers/api/v1/accounts/kbase/portals_controller.rb
+++ b/app/controllers/api/v1/accounts/kbase/portals_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::Accounts::Kbase::PortalsController < Api::V1::Accounts::Kbase::Ba
   end
 
   def destroy
-    @portal.destroy
+    @portal.destroy!
     head :ok
   end
 

--- a/app/controllers/api/v1/accounts/labels_controller.rb
+++ b/app/controllers/api/v1/accounts/labels_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::Accounts::LabelsController < Api::V1::Accounts::BaseController
   end
 
   def destroy
-    @label.destroy
+    @label.destroy!
     head :ok
   end
 

--- a/app/controllers/api/v1/accounts/teams_controller.rb
+++ b/app/controllers/api/v1/accounts/teams_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::Accounts::TeamsController < Api::V1::Accounts::BaseController
   end
 
   def destroy
-    @team.destroy
+    @team.destroy!
     head :ok
   end
 

--- a/app/controllers/api/v1/accounts/webhooks_controller.rb
+++ b/app/controllers/api/v1/accounts/webhooks_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::Accounts::WebhooksController < Api::V1::Accounts::BaseController
   end
 
   def destroy
-    @webhook.destroy
+    @webhook.destroy!
     head :ok
   end
 

--- a/app/controllers/api/v1/notification_subscriptions_controller.rb
+++ b/app/controllers/api/v1/notification_subscriptions_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::NotificationSubscriptionsController < Api::BaseController
 
   def destroy
     notification_subscription = NotificationSubscription.where(["subscription_attributes->>'push_token' = ?", params[:push_token]]).first
-    notification_subscription.destroy
+    notification_subscription.destroy!
     head :ok
   end
 

--- a/app/controllers/platform/api/v1/account_users_controller.rb
+++ b/app/controllers/platform/api/v1/account_users_controller.rb
@@ -13,7 +13,7 @@ class Platform::Api::V1::AccountUsersController < PlatformController
   end
 
   def destroy
-    @resource.account_users.find_by(user_id: account_user_params[:user_id])&.destroy
+    @resource.account_users.find_by(user_id: account_user_params[:user_id])&.destroy!
     head :ok
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -38,7 +38,7 @@ class Team < ApplicationRecord
   end
 
   def remove_member(user_id)
-    team_members.find_by(user_id: user_id)&.destroy
+    team_members.find_by(user_id: user_id)&.destroy!
   end
 
   def messages

--- a/spec/controllers/api/v1/widget/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/messages_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe '/api/v1/widget/messages', type: :request do
   describe 'POST /api/v1/widget/messages' do
     context 'when post request is made' do
       it 'creates message in conversation' do
-        conversation.destroy # Test all params
+        conversation.destroy! # Test all params
         message_params = { content: 'hello world', timestamp: Time.current }
         post api_v1_widget_messages_url,
              params: { website_token: web_widget.website_token, message: message_params },
@@ -46,7 +46,7 @@ RSpec.describe '/api/v1/widget/messages', type: :request do
       end
 
       it 'does not create the message' do
-        conversation.destroy # Test all params
+        conversation.destroy! # Test all params
         message_params = { content: "#{'h' * 150 * 1000}a", timestamp: Time.current }
         post api_v1_widget_messages_url,
              params: { website_token: web_widget.website_token, message: message_params },

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -482,7 +482,7 @@ RSpec.describe Conversation, type: :model do
     let!(:notification) { create(:notification, notification_type: 'conversation_creation', primary_actor: conversation) }
 
     it 'delete associated notifications if conversation is deleted' do
-      conversation.destroy
+      conversation.destroy!
       expect { notification.reload }.to raise_error ActiveRecord::RecordNotFound
     end
   end


### PR DESCRIPTION
There are not many ways for `destroy` to fail, but it seems best to use the bang version by default when not checking the return value.