### PR TITLE
fix: Redis 6 on Heroku breaks ActionCable config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ REDIS_SENTINELS=
 # You can find list of master using "SENTINEL masters" command
 REDIS_SENTINEL_MASTER_NAME=
 
+# Redis premium breakage in heroku fix
+# enable the following configuration
+# ref: https://github.com/chatwoot/chatwoot/issues/2420
+# REDIS_OPENSSL_VERIFY_MODE=none
+
 # Postgres Database config variables
 POSTGRES_HOST=postgres
 POSTGRES_USERNAME=postgres

--- a/app.json
+++ b/app.json
@@ -32,6 +32,10 @@
     "INSTALLATION_ENV": {
       "description": "Installation method used for Chatwoot.",
       "value": "heroku"
+    },
+    "REDIS_OPENSSL_VERIFY_MODE":{
+      "description": "OpenSSL verification mode for Redis connections. ref https://help.heroku.com/HC0F8CUS/redis-connection-issues",
+      "value": "none"
     }
   },
   "formation": {

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,4 +33,13 @@ module Chatwoot
   def self.config
     @config ||= Rails.configuration.x
   end
+
+  def self.redis_ssl_verify_mode
+    # Introduced this method to fix the issue in heroku where redis connections fail for redis 6
+    # ref: https://github.com/chatwoot/chatwoot/issues/2420
+    #
+    # unless the redis verify mode is explicitly specified as none, we will fall back to the default 'verify peer'
+    # ref: https://www.rubydoc.info/stdlib/openssl/OpenSSL/SSL/SSLContext#DEFAULT_PARAMS-constant
+    ENV['REDIS_OPENSSL_VERIFY_MODE'] == 'none' ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+  end
 end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -2,6 +2,8 @@ default: &default
   adapter: redis
   url: <%= ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379') %>
   password: <%= ENV.fetch('REDIS_PASSWORD', nil).presence %>
+  ssl_params: 
+    verify_mode: <%= Chatwoot.redis_ssl_verify_mode %>
   channel_prefix: <%= "chatwoot_#{Rails.env}_action_cable"  %>
 
 development:

--- a/lib/redis/config.rb
+++ b/lib/redis/config.rb
@@ -13,6 +13,7 @@ module Redis::Config
       {
         url: ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379'),
         password: ENV.fetch('REDIS_PASSWORD', nil).presence,
+        ssl_params: { verify_mode: Chatwoot.redis_ssl_verify_mode },
         reconnect_attempts: 2,
         network_timeout: 5
       }


### PR DESCRIPTION
Heroku made some SSL/TLS changes with Redis 6, which is breaking the ActionCable configuration.
Hence providing an environment variable configuration `REDIS_OPENSSL_VERIFY_MODE` to fix that.

fixeS: #2420 