### PR TITLE
chore: Support Email should give priority to environment variable

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -111,7 +111,7 @@ class Account < ApplicationRecord
   end
 
   def support_email
-    super || ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>') || GlobalConfig.get('MAILER_SUPPORT_EMAIL')['MAILER_SUPPORT_EMAIL'] 
+    super || ENV['MAILER_SENDER_EMAIL'] || GlobalConfig.get('MAILER_SUPPORT_EMAIL')['MAILER_SUPPORT_EMAIL']
   end
 
   def usage_limits

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -111,7 +111,7 @@ class Account < ApplicationRecord
   end
 
   def support_email
-    super || GlobalConfig.get('MAILER_SUPPORT_EMAIL')['MAILER_SUPPORT_EMAIL'] || ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
+    super || ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>') || GlobalConfig.get('MAILER_SUPPORT_EMAIL')['MAILER_SUPPORT_EMAIL'] 
   end
 
   def usage_limits


### PR DESCRIPTION
Account support_email should give priority to environment variables over installation config

Fixes: #3304

