### PR TITLE
Don't send confirmation email when creating User via platform api

### DIFF
--- a/app/controllers/platform/api/v1/users_controller.rb
+++ b/app/controllers/platform/api/v1/users_controller.rb
@@ -7,8 +7,8 @@ class Platform::Api::V1::UsersController < PlatformController
 
   def create
     @resource = (User.find_by(email: user_params[:email]) || User.new(user_params))
+    @resource.skip_confirmation!
     @resource.save!
-    @resource.confirm
     @platform_app.platform_app_permissibles.find_or_create_by!(permissible: @resource)
   end
 

--- a/spec/controllers/platform/api/v1/users_controller_spec.rb
+++ b/spec/controllers/platform/api/v1/users_controller_spec.rb
@@ -95,9 +95,11 @@ RSpec.describe 'Platform Users API', type: :request do
       let(:platform_app) { create(:platform_app) }
 
       it 'creates a new user and permissible for the user' do
-        post '/platform/api/v1/users/', params: { name: 'test', email: 'test@test.com', password: 'Password1!',
-                                                  custom_attributes: { test: 'test_create' } },
-                                        headers: { api_access_token: platform_app.access_token.token }, as: :json
+        expect do
+          post '/platform/api/v1/users/', params: { name: 'test', email: 'test@test.com', password: 'Password1!',
+                                                    custom_attributes: { test: 'test_create' } },
+                                          headers: { api_access_token: platform_app.access_token.token }, as: :json
+        end.not_to enqueue_mail
 
         expect(response).to have_http_status(:success)
         data = JSON.parse(response.body)


### PR DESCRIPTION
Call `skip_confirmation!` before saving the user (instead of `confirm` after
saving the user) so that the user is marked as confirmed already and the
confirmation email isn't sent.

The platform api automatically confirms users so we don't need to send this
email.