### PR TITLE
feat: Add a confirmation note before deleting a note about a contact

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -72,7 +72,10 @@
   },
   "DELETE_NOTE": {
     "CONFIRM":{
-      "MESSAGE": "Are you want sure to delete this note?"
+      "TITLE": "Confirm Deletion",
+      "MESSAGE": "Are you want sure to delete this note?",
+      "YES": "Yes, Delete it",
+      "NO": "No, Keep it"
     }
   },
   "DELETE_CONTACT": {

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -70,6 +70,11 @@
     "SUCCESS_MESSAGE": "Contacts saved successfully",
     "ERROR_MESSAGE": "There was an error, please try again"
   },
+  "DELETE_NOTE": {
+    "CONFIRM":{
+      "MESSAGE": "Are you want sure to delete this note?"
+    }
+  },
   "DELETE_CONTACT": {
     "BUTTON_LABEL": "Delete Contact",
     "TITLE": "Delete contact",

--- a/app/javascript/dashboard/modules/notes/components/ContactNote.vue
+++ b/app/javascript/dashboard/modules/notes/components/ContactNote.vue
@@ -16,16 +16,26 @@
       </div>
       <div class="actions">
         <woot-button
-          v-tooltip="$t('NOTES.CONTENT_HEADER.DELETE')"
-          variant="smooth"
-          size="tiny"
-          icon="delete"
-          color-scheme="secondary"
-          @click="onDelete"
+            v-tooltip="$t('NOTES.CONTENT_HEADER.DELETE')"
+            variant="smooth"
+            size="tiny"
+            icon="delete"
+            color-scheme="secondary"
+            @click="toggleDeleteModal"
+        />
+        <woot-delete-modal
+            v-if="showDeleteModal"
+            :show.sync="showDeleteModal"
+            :on-close="closeDelete"
+            :on-confirm="confirmDeletion"
+            :title="$t('DELETE_CONTACT.CONFIRM.TITLE')"
+            :message="$t('DELETE_NOTE.CONFIRM.MESSAGE')"
+            :confirm-text="$t('DELETE_CONTACT.CONFIRM.YES')"
+            :reject-text="$t('DELETE_CONTACT.CONFIRM.NO')"
         />
       </div>
     </div>
-    <p class="note__content" v-html="formatMessage(note || '')" />
+    <p class="note__content" v-html="formatMessage(note || '')"/>
   </div>
 </template>
 
@@ -52,14 +62,19 @@ export default {
     },
     user: {
       type: Object,
-      default: () => {},
+      default: () => {
+      },
     },
     createdAt: {
       type: Number,
       default: 0,
     },
   },
-
+  data() {
+    return {
+      showDeleteModal: false,
+    };
+  },
   computed: {
     readableTime() {
       return this.dynamicTime(this.createdAt);
@@ -73,9 +88,19 @@ export default {
   },
 
   methods: {
+    toggleDeleteModal() {
+      this.showDeleteModal = !this.showDeleteModal;
+    },
     onDelete() {
       this.$emit('delete', this.id);
     },
+    confirmDeletion() {
+      this.onDelete();
+      this.closeDelete();
+    },
+    closeDelete() {
+      this.showDeleteModal = false;
+    }
   },
 };
 </script>

--- a/app/javascript/dashboard/modules/notes/components/ContactNote.vue
+++ b/app/javascript/dashboard/modules/notes/components/ContactNote.vue
@@ -16,26 +16,26 @@
       </div>
       <div class="actions">
         <woot-button
-            v-tooltip="$t('NOTES.CONTENT_HEADER.DELETE')"
-            variant="smooth"
-            size="tiny"
-            icon="delete"
-            color-scheme="secondary"
-            @click="toggleDeleteModal"
-        />
-        <woot-delete-modal
-            v-if="showDeleteModal"
-            :show.sync="showDeleteModal"
-            :on-close="closeDelete"
-            :on-confirm="confirmDeletion"
-            :title="$t('DELETE_CONTACT.CONFIRM.TITLE')"
-            :message="$t('DELETE_NOTE.CONFIRM.MESSAGE')"
-            :confirm-text="$t('DELETE_CONTACT.CONFIRM.YES')"
-            :reject-text="$t('DELETE_CONTACT.CONFIRM.NO')"
+          v-tooltip="$t('NOTES.CONTENT_HEADER.DELETE')"
+          variant="smooth"
+          size="tiny"
+          icon="delete"
+          color-scheme="secondary"
+          @click="toggleDeleteModal"
         />
       </div>
+      <woot-delete-modal
+        v-if="showDeleteModal"
+        :show.sync="showDeleteModal"
+        :on-close="closeDelete"
+        :on-confirm="confirmDeletion"
+        :title="$t('DELETE_NOTE.CONFIRM.TITLE')"
+        :message="$t('DELETE_NOTE.CONFIRM.MESSAGE')"
+        :confirm-text="$t('DELETE_NOTE.CONFIRM.YES')"
+        :reject-text="$t('DELETE_NOTE.CONFIRM.NO')"
+      />
     </div>
-    <p class="note__content" v-html="formatMessage(note || '')"/>
+    <p class="note__content" v-html="formatMessage(note || '')" />
   </div>
 </template>
 
@@ -62,8 +62,7 @@ export default {
     },
     user: {
       type: Object,
-      default: () => {
-      },
+      default: () => {},
     },
     createdAt: {
       type: Number,
@@ -100,7 +99,7 @@ export default {
     },
     closeDelete() {
       this.showDeleteModal = false;
-    }
+    },
   },
 };
 </script>


### PR DESCRIPTION
# Pull Request Template

## Description

Add a confirmation note before deleting a note about a contact #4124

## Type of change
 - [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Login to to any user (e.g john@acme.inc)
- Go to contact menu, then choose on of the contact to see contact detail panel
- Add notes to the contact
- Click trash button on the right top corner of the note, the pop up confirmation should appear
- Click button with label "Yes, Delete", the note must be deleted
- Click button with label "No, keep:, the note must be keep

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
