### PR TITLE
chore: Upgrade to next gen docker convenience image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ defaults: &defaults
     # Specify service dependencies here if necessary
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: cimg/postgres:alpine
-    - image: cimg/redis:alpine
+    - image: cimg/postgres:14.1
+    - image: cimg/redis:6.2.6
   environment:
       - CC_TEST_REPORTER_ID: b1b5c4447bf93f6f0b06a64756e35afd0810ea83649f03971cbf303b4449456f
       - RAILS_LOG_TO_STDOUT: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ defaults: &defaults
     # Specify service dependencies here if necessary
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: circleci/postgres:alpine
-    - image: circleci/redis:alpine
+    - image: cimg/postgres:alpine
+    - image: cimg/redis:alpine
   environment:
       - CC_TEST_REPORTER_ID: b1b5c4447bf93f6f0b06a64756e35afd0810ea83649f03971cbf303b4449456f
       - RAILS_LOG_TO_STDOUT: false


### PR DESCRIPTION
# Pull Request Template

## Description

CircleCI has deprecated old docker images in favour of their next-gen images published under a new registry. This PR switches the docker images used by Chatwoot to next-gen images from CircleCI.

ref: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

Fixes https://github.com/chatwoot/product/issues/353 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] CircleCI tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
