### PR TITLE
feat: make linux  installation non-interactive

### DIFF
--- a/deployment/setup_20.04.sh
+++ b/deployment/setup_20.04.sh
@@ -2,7 +2,7 @@
 
 # Description: Chatwoot installation script
 # OS: Ubuntu 20.04 LTS / Ubuntu 20.10
-# Script Version: 0.7
+# Script Version: 0.8
 # Run this script as root
 
 read -p 'Would you like to configure a domain and SSL for Chatwoot?(yes or no): ' configure_webserver
@@ -12,6 +12,7 @@ then
 read -p 'Enter your sub-domain to be used for Chatwoot (chatwoot.domain.com for example) : ' domain_name
 echo -e "\nThis script will try to generate SSL certificates via LetsEncrypt and serve chatwoot at
 "https://$domain_name". Proceed further once you have pointed your DNS to the IP of the instance.\n"
+read -p 'Enter the email LetsEncrypt can use to send reminders when your SSL certificate is up for renewal: ' le_email
 read -p 'Do you wish to proceed? (yes or no): ' exit_true
 if [ $exit_true == "no" ]
 then
@@ -138,7 +139,7 @@ else
 curl https://ssl-config.mozilla.org/ffdhe4096.txt >> /etc/ssl/dhparam
 wget https://raw.githubusercontent.com/chatwoot/chatwoot/develop/deployment/nginx_chatwoot.conf
 cp nginx_chatwoot.conf /etc/nginx/sites-available/nginx_chatwoot.conf
-certbot certonly --nginx -d $domain_name
+certbot certonly --non-interactive --agree-tos --nginx -m $le_email -d $domain_name
 sed -i "s/chatwoot.domain.com/$domain_name/g" /etc/nginx/sites-available/nginx_chatwoot.conf
 ln -s /etc/nginx/sites-available/nginx_chatwoot.conf /etc/nginx/sites-enabled/nginx_chatwoot.conf
 systemctl restart nginx


### PR DESCRIPTION
# Pull Request Template

## Description

- Modify Linux installation to be non-interactive (can be run unattended after initial selection)

This PR changes the LetsEncrypt behaviour to be non-interactive. Earlier, the installation flow was waiting for user input at the SSL cert generation stage. With this change, once the user confirms completes the initial selection, the installation can be completed unattended.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Tested on a fresh instance

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
