### PR TITLE
Fix: handling UTF encoded mail

### DIFF
--- a/.github/workflows/run-foss-spec.yml
+++ b/.github/workflows/run-foss-spec.yml
@@ -1,0 +1,72 @@
+# #
+# # This action will strip the enterprise folder
+# # and run the spec.
+# # This is set to run against every PR.
+# #
+
+name: Run Chatwoot CE spec
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:10.8
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ""
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        # tmpfs makes DB faster by using RAM
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.head_ref }}
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.2 # Not needed with a .ruby-version file
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+    - name: yarn
+      run: yarn install
+
+    - name: Strip enterprise code
+      run: |
+        rm -rf enterprise
+        rm -rf spec/enterprise
+
+    - name: Create database
+      run: bundle exec rake db:create
+
+    - name: Seed database
+      run: bundle exec rake db:schema:load
+
+    - name: yarn check-files
+      run: yarn install --check-files
+
+    # Run rails tests
+    - name: Run backend tests
+      run: |
+        bundle exec rspec --profile=10 --format documentation

--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -33,7 +33,7 @@ class MailPresenter < SimpleDelegator
   # encodes mail raw body if mail.content_type is plain/text
   # encodes mail raw body if mail.content_type is html/text
   def text_html_mail(mail_part)
-    decoded = mail_part&.decoded || @mail.body&.decoded
+    decoded = mail_part&.decoded || @mail.decoded
     encoded = encode_to_unicode(decoded)
 
     encoded if html_mail_body? || text_mail_body?

--- a/spec/fixtures/files/non_utf_encoded_mail.eml
+++ b/spec/fixtures/files/non_utf_encoded_mail.eml
@@ -1,0 +1,15 @@
+In-Reply-To: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>, <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
+To: "Replies" <reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@example.com>
+From: "=?UTF-8?B?2YXYqtis2LEg2LPZiNmCINmG2Ko=?=" <example@gmail.com>
+Date: Sun, 3 Apr 2022 11:48:20 -0700
+Message-ID: <CAEjnyt3uiyywAF3SrJzEedMRV5H5XG4aYvFrGdFwxtuGoRCc0w@mail.gmail.com>
+Subject: =?UTF-8?Q?=D8=A3=D9=87=D9=84=D9=8A=D9=86_=D8=B9?= =?UTF-8?Q?=D9=85=D9=8A=D9=84=D9=86=D8=A7_=D8=A7=D9=84?= =?UTF-8?Q?=D9=83=D8=B1=D9=8A=D9=85_?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: base64
+Content-Disposition: inline
+Precedence: bulk
+X-Autoreply: yes
+Auto-Submitted: auto-replied
+
+2KPZhti42LHZiNin2Iwg2KPZhtinINij2K3Yqtin2KzZh9inINmB2YLYtyDZhNiq2YLZiNmFINio2KfZhNiq2K/ZgtmK2YIg2YHZiiDZhdmC2KfZhNiq2Yog2KfZhNi02K7YtdmK2KkK

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe MailPresenter do
   describe 'parsed mail decorator' do
     let(:mail) { create_inbound_email_from_fixture('welcome.eml').mail }
     let(:html_mail) { create_inbound_email_from_fixture('welcome_html.eml').mail }
+    let(:ascii_mail) { create_inbound_email_from_fixture('non_utf_encoded_mail.eml').mail }
     let(:decorated_mail) { described_class.new(mail) }
 
     let(:mail_with_no_subject) { create_inbound_email_from_fixture('mail_with_no_subject.eml').mail }
@@ -63,6 +64,14 @@ RSpec.describe MailPresenter do
       expect(decorated_html_mail.subject).to eq('Fwd: How good are you in English? How did you improve your English?')
       expect(decorated_html_mail.text_content[:reply][0..70]).to eq(
         "I'm learning English as a first language for the past 13 years, but to "
+      )
+    end
+
+    it 'encodes email to UTF-8' do
+      decorated_html_mail = described_class.new(ascii_mail)
+      expect(decorated_html_mail.subject).to eq('أهلين عميلنا الكريم ')
+      expect(decorated_html_mail.text_content[:reply][0..70]).to eq(
+        'أنظروا، أنا أحتاجها فقط لتقوم بالتدقيق في مقالتي الشخصية'
       )
     end
   end


### PR DESCRIPTION
# Pull Request Template

## Description

> The Action mailbox presenter was deciding mail.body without considering the mail content type.

> If mail encoding in base64 and non-UTF-8 charset, `mail.body.decoded` decodes the entire mail without knowing the mail body encoding type, and then when we encode it to UTF-8 it encodes it to invalid characters.

> mail.decoded actually works on mail decoding by checking the mail content type, so it decoded the mail body properly from the US-ASCII and then encode it to UTF-8

Fixes #4381 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Test Cases

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
