### PR TITLE
feat: Adds the ability to validate password at signup

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/signup.json
+++ b/app/javascript/dashboard/i18n/locale/en/signup.json
@@ -21,7 +21,8 @@
     "PASSWORD": {
       "LABEL": "Password",
       "PLACEHOLDER": "Password",
-      "ERROR": "Password is too short"
+      "ERROR": "Password is too short",
+      "IS_INVALID_PASSWORD": "Password should contain atleast 1 uppercase letter, 1 lowercase letter, 1 number and 1 special character"
     },
     "CONFIRM_PASSWORD": {
       "LABEL": "Confirm Password",

--- a/app/javascript/dashboard/routes/auth/Signup.vue
+++ b/app/javascript/dashboard/routes/auth/Signup.vue
@@ -54,14 +54,9 @@
             :class="{ error: $v.credentials.password.$error }"
             :label="$t('LOGIN.PASSWORD.LABEL')"
             :placeholder="$t('SET_NEW_PASSWORD.PASSWORD.PLACEHOLDER')"
-            :error="
-              $v.credentials.password.$error
-                ? $t('SET_NEW_PASSWORD.PASSWORD.ERROR')
-                : ''
-            "
+            :error="passwordErrorText"
             @blur="$v.credentials.password.$touch"
           />
-
           <woot-input
             v-model.trim="credentials.confirmPassword"
             type="password"
@@ -188,6 +183,19 @@ export default {
         return !!this.credentials.hCaptchaClientResponse;
       }
       return true;
+    },
+    passwordErrorText() {
+      const { password } = this.$v.credentials;
+      if (!password.$error) {
+        return '';
+      }
+      if (!password.minLength) {
+        return this.$t('REGISTER.PASSWORD.ERROR');
+      }
+      if (!password.isValidPassword) {
+        return this.$t('REGISTER.PASSWORD.IS_INVALID_PASSWORD');
+      }
+      return '';
     },
   },
   methods: {

--- a/app/javascript/dashboard/routes/auth/Signup.vue
+++ b/app/javascript/dashboard/routes/auth/Signup.vue
@@ -122,6 +122,7 @@ import globalConfigMixin from 'shared/mixins/globalConfigMixin';
 import alertMixin from 'shared/mixins/alertMixin';
 import { DEFAULT_REDIRECT_URL } from '../../constants';
 import VueHcaptcha from '@hcaptcha/vue-hcaptcha';
+import { isValidPassword } from 'shared/helpers/Validators';
 export default {
   components: {
     VueHcaptcha,
@@ -158,6 +159,7 @@ export default {
       },
       password: {
         required,
+        isValidPassword,
         minLength: minLength(6),
       },
       confirmPassword: {

--- a/app/javascript/shared/helpers/Validators.js
+++ b/app/javascript/shared/helpers/Validators.js
@@ -6,8 +6,8 @@ export const isValidPassword = value => {
   const containsUppercase = /[A-Z]/.test(value);
   const containsLowercase = /[a-z]/.test(value);
   const containsNumber = /[0-9]/.test(value);
-  const containsSpecial = /[%w!@#$%^&*()_+{}|'"^.,`<>:;?=~]/.test(value);
+  const containsSpecialCharacter = /[%w!@#$%^&*()_+{}|'"^.,`<>:;?=~]/.test(value);
   return (
-    containsUppercase && containsLowercase && containsNumber && containsSpecial
+    containsUppercase && containsLowercase && containsNumber && containsSpecialCharacter
   );
 };

--- a/app/javascript/shared/helpers/Validators.js
+++ b/app/javascript/shared/helpers/Validators.js
@@ -6,7 +6,7 @@ export const isValidPassword = value => {
   const containsUppercase = /[A-Z]/.test(value);
   const containsLowercase = /[a-z]/.test(value);
   const containsNumber = /[0-9]/.test(value);
-  const containsSpecialCharacter = /[%w!@#$%^&*()_+{}|'"^.,`<>:;?=~]/.test(
+  const containsSpecialCharacter = /[!@#$%^&*()_+\-=[\]{}|'"/\\.,`<>:;?~]/.test(
     value
   );
   return (

--- a/app/javascript/shared/helpers/Validators.js
+++ b/app/javascript/shared/helpers/Validators.js
@@ -2,3 +2,13 @@ export const isPhoneE164 = value => !!value.match(/^\+[1-9]\d{1,14}$/);
 export const isPhoneE164OrEmpty = value => isPhoneE164(value) || value === '';
 export const shouldBeUrl = (value = '') =>
   value ? value.startsWith('http') : true;
+
+export const isValidPassword = value => {
+  const containsUppercase = /[A-Z]/.test(value);
+  const containsLowercase = /[a-z]/.test(value);
+  const containsNumber = /[0-9]/.test(value);
+  const containsSpecial = /[%w!@#$%^&*()_+{}|'"^.,`<>:;?=~]/.test(value);
+  return (
+    containsUppercase && containsLowercase && containsNumber && containsSpecial
+  );
+};

--- a/app/javascript/shared/helpers/Validators.js
+++ b/app/javascript/shared/helpers/Validators.js
@@ -6,8 +6,13 @@ export const isValidPassword = value => {
   const containsUppercase = /[A-Z]/.test(value);
   const containsLowercase = /[a-z]/.test(value);
   const containsNumber = /[0-9]/.test(value);
-  const containsSpecialCharacter = /[%w!@#$%^&*()_+{}|'"^.,`<>:;?=~]/.test(value);
+  const containsSpecialCharacter = /[%w!@#$%^&*()_+{}|'"^.,`<>:;?=~]/.test(
+    value
+  );
   return (
-    containsUppercase && containsLowercase && containsNumber && containsSpecialCharacter
+    containsUppercase &&
+    containsLowercase &&
+    containsNumber &&
+    containsSpecialCharacter
   );
 };

--- a/app/javascript/shared/helpers/Validators.js
+++ b/app/javascript/shared/helpers/Validators.js
@@ -2,7 +2,6 @@ export const isPhoneE164 = value => !!value.match(/^\+[1-9]\d{1,14}$/);
 export const isPhoneE164OrEmpty = value => isPhoneE164(value) || value === '';
 export const shouldBeUrl = (value = '') =>
   value ? value.startsWith('http') : true;
-
 export const isValidPassword = value => {
   const containsUppercase = /[A-Z]/.test(value);
   const containsLowercase = /[a-z]/.test(value);

--- a/app/javascript/shared/helpers/specs/ValidatorsHelper.spec.js
+++ b/app/javascript/shared/helpers/specs/ValidatorsHelper.spec.js
@@ -10,9 +10,15 @@ describe('#shouldBeUrl', () => {
 describe('#isValidPassword', () => {
   it('should return correct password', () => {
     expect(isValidPassword('testPass4!')).toEqual(true);
+    expect(isValidPassword('testPass4-')).toEqual(true);
+    expect(isValidPassword('testPass4\\')).toEqual(true);
+    expect(isValidPassword("testPass4'")).toEqual(true);
   });
 
   it('should return wrong password', () => {
+    expect(isValidPassword('testpass4')).toEqual(false);
+    expect(isValidPassword('testPass4')).toEqual(false);
     expect(isValidPassword('testpass4!')).toEqual(false);
+    expect(isValidPassword('testPass!')).toEqual(false);
   });
 });

--- a/app/javascript/shared/helpers/specs/ValidatorsHelper.spec.js
+++ b/app/javascript/shared/helpers/specs/ValidatorsHelper.spec.js
@@ -11,4 +11,8 @@ describe('#isValidPassword', () => {
   it('should return correct password', () => {
     expect(isValidPassword('testPass4!')).toEqual(true);
   });
+
+  it('should return wrong password', () => {
+    expect(isValidPassword('testpass4!')).toEqual(false);
+  });
 });

--- a/app/javascript/shared/helpers/specs/ValidatorsHelper.spec.js
+++ b/app/javascript/shared/helpers/specs/ValidatorsHelper.spec.js
@@ -1,7 +1,14 @@
 import { shouldBeUrl } from '../Validators';
+import { isValidPassword } from '../Validators';
 
 describe('#shouldBeUrl', () => {
   it('should return correct url', () => {
     expect(shouldBeUrl('http')).toEqual(true);
+  });
+});
+
+describe('#isValidPassword', () => {
+  it('should return correct password', () => {
+    expect(isValidPassword('testPass4!')).toEqual(true);
   });
 });


### PR DESCRIPTION
# Pull Request Template

Fixes #4209 & https://github.com/chatwoot/product/issues/398

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**Validation**

`Before`

1. Minimum length for a password is 6.

`After`

1. Minimum length for a password is 6.
2. Must include one capital letter.
3. Must include one small letter.
4. Should include one numerical value between `0-9`.
5. Must include one special character like `[!@#$%^&*()_+\-=[\]{}|'"/\\.,``<>:;?~]`


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
