### PR TITLE
fix: Agent typing indicator for website widget

### DIFF
--- a/app/jobs/data_import_job.rb
+++ b/app/jobs/data_import_job.rb
@@ -21,9 +21,6 @@ class DataImportJob < ApplicationJob
 
     contact.name = params[:name] if params[:name].present?
     contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name)))
-
-    # since callbacks aren't triggered lets ensure a pubsub token
-    contact.pubsub_token ||= SecureRandom.base58(24)
     contact
   end
 

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -135,7 +135,8 @@ class ActionCableListener < BaseListener
   private
 
   def typing_event_listener_tokens(account, conversation, user)
-    (user_tokens(account, conversation.inbox.members) + [conversation.contact.pubsub_token]) - [user&.pubsub_token]
+    current_user_token = user.is_a?(Contact) ? conversation.contact_inbox.pubsub_token : user.pubsub_token
+    (user_tokens(account, conversation.inbox.members) + [conversation.contact_inbox.pubsub_token]) - [current_user_token]
   end
 
   def user_tokens(account, agents)

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -10,7 +10,6 @@
 #  last_activity_at      :datetime
 #  name                  :string
 #  phone_number          :string
-#  pubsub_token          :string
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  account_id            :integer          not null
@@ -19,13 +18,11 @@
 #
 #  index_contacts_on_account_id                   (account_id)
 #  index_contacts_on_phone_number_and_account_id  (phone_number,account_id)
-#  index_contacts_on_pubsub_token                 (pubsub_token) UNIQUE
 #  uniq_email_per_account_contact                 (email,account_id) UNIQUE
 #  uniq_identifier_per_account_contact            (identifier,account_id) UNIQUE
 #
 
 class Contact < ApplicationRecord
-  # TODO: remove the pubsub_token attribute from this model in future.
   include Avatarable
   include AvailabilityStatusable
   include Labelable
@@ -117,7 +114,6 @@ class Contact < ApplicationRecord
       identifier: identifier,
       name: name,
       phone_number: phone_number,
-      pubsub_token: pubsub_token,
       thumbnail: avatar_url,
       type: 'contact'
     }

--- a/db/migrate/20220418094715_remove_contact_pubsub_token.rb
+++ b/db/migrate/20220418094715_remove_contact_pubsub_token.rb
@@ -1,0 +1,5 @@
+class RemoveContactPubsubToken < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :contacts, :pubsub_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_09_044943) do
+ActiveRecord::Schema.define(version: 2022_04_18_094715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -325,7 +325,6 @@ ActiveRecord::Schema.define(version: 2022_04_09_044943) do
     t.integer "account_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "pubsub_token"
     t.jsonb "additional_attributes", default: {}
     t.string "identifier"
     t.jsonb "custom_attributes", default: {}
@@ -334,7 +333,6 @@ ActiveRecord::Schema.define(version: 2022_04_09_044943) do
     t.index ["email", "account_id"], name: "uniq_email_per_account_contact", unique: true
     t.index ["identifier", "account_id"], name: "uniq_identifier_per_account_contact", unique: true
     t.index ["phone_number", "account_id"], name: "index_contacts_on_phone_number_and_account_id"
-    t.index ["pubsub_token"], name: "index_contacts_on_pubsub_token", unique: true
   end
 
   create_table "conversations", id: :serial, force: :cascade do |t|

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -17,8 +17,5 @@ RSpec.describe DataImportJob, type: :job do
     expect(data_import.account.contacts.count).to eq(csv_length)
     expect(data_import.reload.total_records).to eq(csv_length)
     expect(data_import.reload.processed_records).to eq(csv_length)
-
-    # should generate pubsub tokens for contacts
-    expect(data_import.account.contacts.last.pubsub_token).present?
   end
 end


### PR DESCRIPTION
When we migrated the pubsub tokens from contact to contact inboxes, we missed out on doing this update for the typing indicator events. Hence the agent typing events weren't visible on the widget side. This change fixes that as well as removes the necessary column contact pubsub token from the model.


fixes: #4476
