### PR TITLE
fix: Dig params in widget contact end point

### DIFF
--- a/app/controllers/api/v1/widget/base_controller.rb
+++ b/app/controllers/api/v1/widget/base_controller.rb
@@ -71,7 +71,7 @@ class Api::V1::Widget::BaseController < ApplicationController
   end
 
   def contact_email
-    permitted_params[:contact][:email].downcase if permitted_params[:contact].present?
+    permitted_params[:contact][:email].downcase if permitted_params.dig(:contact, :email).present?
   end
 
   def contact_name
@@ -79,7 +79,7 @@ class Api::V1::Widget::BaseController < ApplicationController
   end
 
   def contact_phone_number
-    params[:contact][:phone_number]
+    params[:contact][:phone_number] if permitted_params.dig(:contact, :phone_number).present?
   end
 
   def browser_params


### PR DESCRIPTION
- Fixed contact update API failure if we don't pass email and phone number 