### PR TITLE
Add user login api docs addition

### DIFF
--- a/swagger/paths/platform/users/login.yml
+++ b/swagger/paths/platform/users/login.yml
@@ -2,7 +2,7 @@ tags:
   - Users
 operationId: get-sso-url-of-a-user
 summary: Get User SSO Link
-description: Get the sso link of a user
+description: Get the sso link of a user. The sso link can only be obtained for users created inside Chatwoot's admin interface.
 security:
   - platformAppApiKey: []
 responses:


### PR DESCRIPTION
## Description

The user login API method works only for users created in Chatwoot's admin panel and does not work for users created via platform API (as described in https://github.com/chatwoot/chatwoot/discussions/4499#discussioncomment-2617376). Information about that was added to API docs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Open swagger docs and check the addition in `GET /platform/api/v1/users/{id}/login` method's documentation.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
