### PR TITLE
fix: Update agent metrics query to show data from current account

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/report.json
+++ b/app/javascript/dashboard/i18n/locale/en/report.json
@@ -387,18 +387,18 @@
     "LIVE": "Live",
     "ACCOUNT_CONVERSATIONS": {
       "HEADER": "Open Conversations",
-      "LOADING_MESSAGE": "Conversations Loading...",
-      "TOTAL" : "Total",
+      "LOADING_MESSAGE": "Loading conversation metrics...",
+      "OPEN" : "Open",
       "UNATTENDED": "Unattended",
       "UNASSIGNED": "Unassigned"
     },
     "AGENT_CONVERSATIONS": {
       "HEADER": "Conversations by agents",
-      "LOADING_MESSAGE": "Agents Loading...",
+      "LOADING_MESSAGE": "Loading agent metrics...",
       "NO_AGENTS": "There are no conversations by agents",
       "TABLE_HEADER": {
         "AGENT": "Agent",
-        "TOTAL": "Total",
+        "OPEN": "OPEN",
         "UNATTENDED": "Unattended",
         "STATUS": "Status"
       }

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
@@ -59,6 +59,13 @@
       </div>
       <div class="row">
         <div class="columns">
+          <div class="canned-response">
+            <canned-response
+              v-if="showCannedResponseMenu && hasSlashCommand"
+              :search-key="cannedResponseSearchKey"
+              @click="replaceTextWithCannedResponse"
+            />
+          </div>
           <div v-if="isAnEmailInbox || isAnWebWidgetInbox">
             <label>
               {{ $t('NEW_CONVERSATION.FORM.MESSAGE.LABEL') }}
@@ -113,6 +120,7 @@ import { mapGetters } from 'vuex';
 import Thumbnail from 'dashboard/components/widgets/Thumbnail';
 import WootMessageEditor from 'dashboard/components/widgets/WootWriter/Editor';
 import ReplyEmailHead from 'dashboard/components/widgets/conversation/ReplyEmailHead';
+import CannedResponse from 'dashboard/components/widgets/conversation/CannedResponse.vue';
 
 import alertMixin from 'shared/mixins/alertMixin';
 import { INBOX_TYPES } from 'shared/mixins/inboxMixin';
@@ -124,6 +132,7 @@ export default {
     Thumbnail,
     WootMessageEditor,
     ReplyEmailHead,
+    CannedResponse,
   },
   mixins: [alertMixin],
   props: {
@@ -141,6 +150,8 @@ export default {
       name: '',
       subject: '',
       message: '',
+      showCannedResponseMenu: false,
+      cannedResponseSearchKey: '',
       selectedInbox: '',
       bccEmails: '',
       ccEmails: '',
@@ -211,6 +222,20 @@ export default {
       );
     },
   },
+  watch: {
+    message(value) {
+      this.hasSlashCommand = value[0] === '/';
+      const hasNextWord = value.includes(' ');
+      const isShortCodeActive = this.hasSlashCommand && !hasNextWord;
+      if (isShortCodeActive) {
+        this.cannedResponseSearchKey = value.substr(1, value.length);
+        this.showCannedResponseMenu = true;
+      } else {
+        this.cannedResponseSearchKey = '';
+        this.showCannedResponseMenu = false;
+      }
+    },
+  },
   methods: {
     onCancel() {
       this.$emit('cancel');
@@ -244,6 +269,11 @@ export default {
         }
       }
     },
+    replaceTextWithCannedResponse(message) {
+      setTimeout(() => {
+        this.message = message;
+      }, 50);
+    },
   },
 };
 </script>
@@ -251,9 +281,15 @@ export default {
 <style scoped lang="scss">
 .conversation--form {
   padding: var(--space-normal) var(--space-large) var(--space-large);
+}
 
-  .columns {
-    padding: 0 var(--space-smaller);
+.canned-response {
+  position: relative;
+  top: var(--space-medium);
+
+  ::v-deep .mention--box {
+    border-left: 1px solid var(--color-border);
+    border-right: 1px solid var(--color-border);
   }
 }
 

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/overview/AgentTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/overview/AgentTable.vue
@@ -20,8 +20,8 @@
       <ve-pagination
         :total="totalAgents"
         :page-index="pageIndex"
-        :page-size="10"
-        :page-size-option="[10]"
+        :page-size="25"
+        :page-size-option="[25]"
         @on-page-number-change="onPageNumberChange"
       />
     </div>
@@ -70,7 +70,7 @@ export default {
           agent: agent.name,
           email: agent.email,
           thumbnail: agent.thumbnail,
-          total: agent.metric.total || 0,
+          open: agent.metric.open || 0,
           unattended: agent.metric.unattended || 0,
           status: agent.availability,
         };
@@ -103,10 +103,10 @@ export default {
           ),
         },
         {
-          field: 'total',
-          key: 'total',
+          field: 'open',
+          key: 'open',
           title: this.$t(
-            'OVERVIEW_REPORTS.AGENT_CONVERSATIONS.TABLE_HEADER.TOTAL'
+            'OVERVIEW_REPORTS.AGENT_CONVERSATIONS.TABLE_HEADER.OPEN'
           ),
           align: 'left',
           width: 10,

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/constants.js
@@ -123,7 +123,7 @@ export const METRIC_CHART = {
 };
 
 export const OVERVIEW_METRICS = {
-  total: 'TOTAL',
+  open: 'OPEN',
   unattended: 'UNATTENDED',
   unassigned: 'UNASSIGNED',
   online: 'ONLINE',

--- a/spec/controllers/api/v2/accounts/report_controller_spec.rb
+++ b/spec/controllers/api/v2/accounts/report_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Reports API', type: :request do
         expect(response).to have_http_status(:success)
         json_response = JSON.parse(response.body)
 
-        expect(json_response['total']).to eq(11)
+        expect(json_response['open']).to eq(11)
         expect(json_response['unattended']).to eq(11)
         expect(json_response['unassigned']).to eq(1)
       end
@@ -96,7 +96,7 @@ RSpec.describe 'Reports API', type: :request do
         user_metrics = json_response.find { |item| item['name'] == admin[:name] }
         expect(user_metrics.present?).to be true
 
-        expect(user_metrics['metric']['total']).to eq(2)
+        expect(user_metrics['metric']['open']).to eq(2)
         expect(user_metrics['metric']['unattended']).to eq(2)
       end
 
@@ -116,7 +116,7 @@ RSpec.describe 'Reports API', type: :request do
 
         json_response = JSON.parse(response.body)
         expect(json_response.blank?).to be false
-        expect(json_response[0]['metric']['total']).to eq(10)
+        expect(json_response[0]['metric']['open']).to eq(10)
         expect(json_response[0]['metric']['unattended']).to eq(10)
       end
     end

--- a/spec/controllers/api/v2/accounts/report_controller_spec.rb
+++ b/spec/controllers/api/v2/accounts/report_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Reports API', type: :request do
   let(:default_timezone) { ActiveSupport::TimeZone[0]&.name }
   let(:date_timestamp) { Time.current.in_time_zone(default_timezone).beginning_of_day.to_i }
   let(:params) { { timezone_offset: Time.zone.utc_offset } }
+  let(:new_account) { create(:account) }
 
   before do
     create_list(:conversation, 10, account: account, inbox: inbox,
@@ -80,6 +81,8 @@ RSpec.describe 'Reports API', type: :request do
 
       it 'return conversation metrics for user in account level' do
         create_list(:conversation, 2, account: account, inbox: inbox,
+                                      assignee: admin, created_at: Time.zone.today)
+        create_list(:conversation, 2, account: new_account, inbox: inbox,
                                       assignee: admin, created_at: Time.zone.today)
 
         get "/api/v2/accounts/#{account.id}/reports/conversations",


### PR DESCRIPTION
## Description

This change restricts the agent conversations metrics query to show data from the current account.

Fixes #4556

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

https://user-images.githubusercontent.com/5848740/165285615-0c419e44-9279-4b0e-b9bb-80da8522cad4.mp4

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
