### PR TITLE
Open "Switch Account" modal when clicking account name on dashboard

### DIFF
--- a/app/javascript/dashboard/components/layout/Sidebar.vue
+++ b/app/javascript/dashboard/components/layout/Sidebar.vue
@@ -19,6 +19,7 @@
       :menu-config="activeSecondaryMenu"
       :current-role="currentRole"
       @add-label="showAddLabelPopup"
+      @toggle-accounts="toggleAccountModal"
     />
   </aside>
 </template>

--- a/app/javascript/dashboard/components/layout/sidebarComponents/AccountContext.vue
+++ b/app/javascript/dashboard/components/layout/sidebarComponents/AccountContext.vue
@@ -1,16 +1,34 @@
 <template>
-  <div v-if="showShowCurrentAccountContext" class="account-context--group">
-    <a @click="$emit('toggle-accounts')">
-      {{ $t('SIDEBAR.CURRENTLY_VIEWING_ACCOUNT') }}
-      <p class="account-context--name text-ellipsis">
-        {{ account.name }}
-      </p>
-    </a>
+  <div
+    v-if="showShowCurrentAccountContext"
+    class="account-context--group"
+    @mouseover="setShowSwitch"
+    @mouseleave="resetShowSwitch"
+  >
+    {{ $t('SIDEBAR.CURRENTLY_VIEWING_ACCOUNT') }}
+    <p class="account-context--name text-ellipsis">
+      {{ account.name }}
+    </p>
+    <transition name="fade">
+      <div v-if="showSwitchButton" class="account-context--switch-group">
+        <woot-button
+          variant="clear"
+          icon="arrow-swap"
+          class="cursor-pointer"
+          @click="$emit('toggle-accounts')"
+        >
+          {{ $t('SIDEBAR.SWITCH') }}
+        </woot-button>
+      </div>
+    </transition>
   </div>
 </template>
 <script>
 import { mapGetters } from 'vuex';
 export default {
+  data() {
+    return { showSwitchButton: false };
+  },
   computed: {
     ...mapGetters({
       account: 'getCurrentAccount',
@@ -18,6 +36,14 @@ export default {
     }),
     showShowCurrentAccountContext() {
       return this.userAccounts.length > 1 && this.account.name;
+    },
+  },
+  methods: {
+    setShowSwitch() {
+      this.showSwitchButton = true;
+    },
+    resetShowSwitch() {
+      this.showSwitchButton = false;
     },
   },
 };
@@ -29,10 +55,43 @@ export default {
   font-size: var(--font-size-mini);
   padding: var(--space-small);
   margin-bottom: var(--space-small);
+  width: 100%;
+  position: relative;
+
+  &:hover {
+    background: var(--b-100);
+  }
 
   .account-context--name {
     font-weight: var(--font-weight-medium);
     margin-bottom: 0;
   }
+}
+
+.account-context--switch-group {
+  align-items: center;
+  background-image: var(--overlay-shadow--account-switcher);
+  border-top-left-radius: 0;
+  border-top-right-radius: var(--border-radius-normal);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: var(--border-radius-normal);
+  display: flex;
+  height: 100%;
+  justify-content: end;
+  opacity: 1;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 100%;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 300ms ease;
+}
+
+.fade-enter,
+.fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/app/javascript/dashboard/components/layout/sidebarComponents/AccountContext.vue
+++ b/app/javascript/dashboard/components/layout/sidebarComponents/AccountContext.vue
@@ -69,8 +69,14 @@ export default {
 }
 
 .account-context--switch-group {
+  --overlay-shadow: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 1) 50%
+  );
+
   align-items: center;
-  background-image: var(--overlay-shadow--account-switcher);
+  background-image: var(--overlay-shadow);
   border-top-left-radius: 0;
   border-top-right-radius: var(--border-radius-normal);
   border-bottom-left-radius: 0;

--- a/app/javascript/dashboard/components/layout/sidebarComponents/AccountContext.vue
+++ b/app/javascript/dashboard/components/layout/sidebarComponents/AccountContext.vue
@@ -1,9 +1,11 @@
 <template>
   <div v-if="showShowCurrentAccountContext" class="account-context--group">
-    {{ $t('SIDEBAR.CURRENTLY_VIEWING_ACCOUNT') }}
-    <p class="account-context--name text-ellipsis">
-      {{ account.name }}
-    </p>
+    <a @click="$emit('toggle-accounts')">
+      {{ $t('SIDEBAR.CURRENTLY_VIEWING_ACCOUNT') }}
+      <p class="account-context--name text-ellipsis">
+        {{ account.name }}
+      </p>
+    </a>
   </div>
 </template>
 <script>

--- a/app/javascript/dashboard/components/layout/sidebarComponents/Secondary.vue
+++ b/app/javascript/dashboard/components/layout/sidebarComponents/Secondary.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="hasSecondaryMenu" class="main-nav secondary-menu">
-    <account-context />
+    <account-context @toggle-accounts="toggleAccountModal" />
     <transition-group name="menu-list" tag="ul" class="menu vertical">
       <secondary-nav-item
         v-for="menuItem in accessibleMenuItems"
@@ -223,6 +223,9 @@ export default {
   methods: {
     showAddLabelPopup() {
       this.$emit('add-label');
+    },
+    toggleAccountModal() {
+      this.$emit('toggle-accounts');
     },
   },
 };

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -147,6 +147,7 @@
   },
   "SIDEBAR": {
     "CURRENTLY_VIEWING_ACCOUNT": "Currently viewing:",
+    "SWITCH": "Switch",
     "CONVERSATIONS": "Conversations",
     "ALL_CONVERSATIONS": "All Conversations",
     "MENTIONED_CONVERSATIONS": "Mentions",

--- a/app/javascript/shared/assets/stylesheets/shadows.scss
+++ b/app/javascript/shared/assets/stylesheets/shadows.scss
@@ -8,4 +8,11 @@
         0 4px 6px -2px rgba(0, 0, 0, 0.05);
     --shadow-larger: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
         0 10px 10px -5px rgba(0, 0, 0, 0.04);
+
+    /* Custom Colors */
+    --overlay-shadow--account-switcher: linear-gradient(
+        to right,
+        rgba(255, 255, 255, 0) 0%,
+        rgba(255, 255, 255, 1) 50%
+      );
 }

--- a/app/javascript/shared/assets/stylesheets/shadows.scss
+++ b/app/javascript/shared/assets/stylesheets/shadows.scss
@@ -8,11 +8,4 @@
         0 4px 6px -2px rgba(0, 0, 0, 0.05);
     --shadow-larger: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
         0 10px 10px -5px rgba(0, 0, 0, 0.04);
-
-    /* Custom Colors */
-    --overlay-shadow--account-switcher: linear-gradient(
-        to right,
-        rgba(255, 255, 255, 0) 0%,
-        rgba(255, 255, 255, 1) 50%
-      );
 }


### PR DESCRIPTION
## Description

When multiple accounts are present and the "Currently viewing" div is viewable, my assumption was that I could click on that div to change which account I was viewing. Instead I found that the account switcher was somewhat hidden under the "Profile Settings" menu.

This PR makes the "Currently viewing" div also clickable for switching accounts

**Note:**

- I'm a complete newbie to Vue and I focus more on backend code in general. I may be doing things incorrectly.
- I don't know if making the whole thing a blue link is the ideal styling we'd want?

I'm happy to make changes if this looks OK in general, just lmk (or feel free to just add changes).

![2022-05-03 13 19 04](https://user-images.githubusercontent.com/23050/166550954-834155ba-0f87-42fc-a29a-0024065db1b4.gif)

Fixes #4632

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I tried it out locally.
