### PR TITLE
chore: update newrelic gem to support log forwarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,11 +161,13 @@ USE_INBOX_AVATAR_FOR_BOT=true
 ## NewRelic
 # https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/
 # NEW_RELIC_LICENSE_KEY=
+# Set this to true to allow newrelic apm to send logs.
+# This is turned off by default.
+# NEW_RELIC_APPLICATION_LOGGING_ENABLED=
 
 ## Datadog
 ## https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#environment-variables
 # DD_TRACE_AGENT_URL=
-
 
 
 ## IP look up configuration

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,7 +376,7 @@ GEM
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     netrc (0.11.0)
-    newrelic_rpm (8.4.0)
+    newrelic_rpm (8.7.0)
     nio4r (2.5.8)
     nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -24,6 +24,24 @@ common: &default_settings
   # Logging level for log/newrelic_agent.log
   log_level: <%= ENV.fetch('NEW_RELIC_LOG_LEVEL', 'info')  %>
 
+  application_logging:
+    # If `true`, all logging-related features for the agent can be enabled or disabled
+    # independently. If `false`, all logging-related features are disabled.
+    enabled: <%= ENV.fetch('NEW_RELIC_APPLICATION_LOGGING_ENABLED', false) %>
+    forwarding:
+      # If `true`, the agent captures log records emitted by this application.
+      enabled: true
+      # Defines the maximum number of log records to buffer in memory at a time.
+      max_samples_stored: 30000
+    metrics:
+      # If `true`, the agent captures metrics related to logging for this application.
+      enabled: true
+    local_decorating:
+      # If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.
+      # This requires a log forwarder to send your log files to New Relic.
+      # This should not be used when forwarding is enabled.
+      enabled: false
+
 
 # Environment-specific settings are in this section.
 # RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.


### PR DESCRIPTION

# Pull Request Template

## Description

Newrelic gem 8.7 has application log forwarding support and
this is enabled by default. Update the gem to make use of this
feature. Chatwoot has turned this off by default though.

Set `NEW_RELIC_APPLICATION_LOGGING_ENABLED` to enable 
this feature. Make sure to disable any other log forwarding services
you have to prevent duplicated logs.

ref: https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-870

Fixes #4625 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Using this config in Chatwoot hub.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
