### PR TITLE
chore: Ability to update user email via Platform APIs

### DIFF
--- a/app/controllers/platform/api/v1/users_controller.rb
+++ b/app/controllers/platform/api/v1/users_controller.rb
@@ -21,6 +21,10 @@ class Platform::Api::V1::UsersController < PlatformController
 
   def update
     @resource.assign_attributes(user_update_params)
+
+    # We are using devise's reconfirmable flow for changing emails
+    # But in case of platform APIs we don't want user to go through this extra step
+    @resource.skip_reconfirmation! if user_update_params[:email].present?
     @resource.save!
   end
 

--- a/spec/controllers/platform/api/v1/users_controller_spec.rb
+++ b/spec/controllers/platform/api/v1/users_controller_spec.rb
@@ -145,14 +145,17 @@ RSpec.describe 'Platform Users API', type: :request do
         expect(response).to have_http_status(:unauthorized)
       end
 
-      it 'updates the user' do
+      it 'updates the user attributes' do
         create(:platform_app_permissible, platform_app: platform_app, permissible: user)
-        patch "/platform/api/v1/users/#{user.id}", params: { name: 'test123', custom_attributes: { test: 'test_update' } },
+        patch "/platform/api/v1/users/#{user.id}", params: {
+          name: 'test123', email: 'newtestemail@test.com', custom_attributes: { test: 'test_update' }
+        },
                                                    headers: { api_access_token: platform_app.access_token.token }, as: :json
 
         expect(response).to have_http_status(:success)
         data = JSON.parse(response.body)
         expect(data['name']).to eq('test123')
+        expect(data['email']).to eq('newtestemail@test.com')
         expect(data['custom_attributes']['test']).to eq('test_update')
       end
     end


### PR DESCRIPTION
When the platform update API is called with a new user email, Chatwoot will still follow the same behaviour as in the dashboard where the user will have to confirm the new email activation link until the email gets updated on the user record.

In the case of platform APIs, this might not be the ideal behaviour since the original app will already have a flow to update the user emails. Hence we need to confirm the emails without the extra step in this case

fixes: #4510 