### PR TITLE
feat: send instagram message after 24 hours

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -91,23 +91,19 @@ class Conversation < ApplicationRecord
   delegate :auto_resolve_duration, to: :account
 
   def can_reply?
-    return last_message_less_than_24_hrs? if additional_attributes['type'] == 'instagram_direct_message'
-
-    return true unless inbox&.channel&.has_24_hour_messaging_window?
-
     return false if last_incoming_message.nil?
 
-    last_message_less_than_24_hrs?
+    last_message_less_than_7_days?
   end
 
   def last_incoming_message
     messages&.incoming&.last
   end
 
-  def last_message_less_than_24_hrs?
+  def last_message_less_than_7_days?
     return false if last_incoming_message.nil?
 
-    Time.current < last_incoming_message.created_at + 24.hours
+    Time.current < last_incoming_message.created_at + 7.days
   end
 
   def update_assignee(agent = nil)

--- a/app/services/instagram/send_on_instagram_service.rb
+++ b/app/services/instagram/send_on_instagram_service.rb
@@ -27,7 +27,9 @@ class Instagram::SendOnInstagramService < Base::SendOnChannelService
       recipient: { id: contact.get_source_id(inbox.id) },
       message: {
         text: message.content
-      }
+      },
+      messaging_type: 'MESSAGE_TAG',
+      tag: 'HUMAN_AGENT'
     }
   end
 
@@ -42,7 +44,9 @@ class Instagram::SendOnInstagramService < Base::SendOnChannelService
             url: attachment.download_url
           }
         }
-      }
+      },
+      messaging_type: 'MESSAGE_TAG',
+      tag: 'HUMAN_AGENT'
     }
   end
 


### PR DESCRIPTION
# Pull Request Template

## Description

Added MESSAGE_TAG: HUMAN_AGENT for Instagram messages if the user wants to send it after the standard message window.

Fixes #4689 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Tested on staging

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
