### PR TITLE
fix: Revert changes to fix name updation from pre-chat form

### DIFF
--- a/app/controllers/api/v1/widget/base_controller.rb
+++ b/app/controllers/api/v1/widget/base_controller.rb
@@ -54,7 +54,7 @@ class Api::V1::Widget::BaseController < ApplicationController
       ).perform
     else
       @contact.update!(email: email)
-      @contact.update!(name: contact_name) if contact_name.present?
+      update_contact_name
     end
   end
 
@@ -68,7 +68,12 @@ class Api::V1::Widget::BaseController < ApplicationController
       ).perform
     else
       @contact.update!(phone_number: phone_number)
+      update_contact_name
     end
+  end
+
+  def update_contact_name
+    @contact.update!(name: contact_name) if contact_name.present?
   end
 
   def contact_email

--- a/app/controllers/api/v1/widget/base_controller.rb
+++ b/app/controllers/api/v1/widget/base_controller.rb
@@ -54,6 +54,7 @@ class Api::V1::Widget::BaseController < ApplicationController
       ).perform
     else
       @contact.update!(email: email)
+      @contact.update!(name: contact_name) if contact_name.present?
     end
   end
 

--- a/app/controllers/api/v1/widget/conversations_controller.rb
+++ b/app/controllers/api/v1/widget/conversations_controller.rb
@@ -16,7 +16,6 @@ class Api::V1::Widget::ConversationsController < Api::V1::Widget::BaseController
   def process_update_contact
     update_contact(contact_email) if @contact.email.blank? && contact_email.present?
     update_contact_phone_number(contact_phone_number) if @contact.phone_number.blank? && contact_phone_number.present?
-    @contact.update!(name: contact_name) if contact_name.present?
   end
 
   def update_last_seen

--- a/spec/controllers/api/v1/widget/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/conversations_controller_spec.rb
@@ -69,6 +69,36 @@ RSpec.describe '/api/v1/widget/conversations/toggle_typing', type: :request do
       expect(json_response['id']).not_to eq nil
       expect(json_response['contact']['email']).to eq 'contact-email@chatwoot.com'
       expect(json_response['contact']['phone_number']).to eq '+919745313456'
+      expect(json_response['contact']['name']).to eq 'contact-name'
+      expect(json_response['custom_attributes']['order_id']).to eq '12345'
+      expect(json_response['messages'][0]['content']).to eq 'This is a test message'
+    end
+
+    it 'does not update the name if the contact already exist' do
+      existing_contact = create(:contact, account: account)
+
+      post '/api/v1/widget/conversations',
+           headers: { 'X-Auth-Token' => token },
+           params: {
+             website_token: web_widget.website_token,
+             contact: {
+               name: 'contact-name',
+               email: existing_contact.email,
+               phone_number: '+919745313456'
+             },
+             message: {
+               content: 'This is a test message'
+             },
+             custom_attributes: { order_id: '12345' }
+           },
+           as: :json
+
+      expect(response).to have_http_status(:success)
+      json_response = JSON.parse(response.body)
+      expect(json_response['id']).not_to eq nil
+      expect(json_response['contact']['email']).to eq existing_contact.email
+      expect(json_response['contact']['name']).not_to eq 'contact-name'
+      expect(json_response['contact']['phone_number']).to eq '+919745313456'
       expect(json_response['custom_attributes']['order_id']).to eq '12345'
       expect(json_response['messages'][0]['content']).to eq 'This is a test message'
     end


### PR DESCRIPTION
Fixes #4735 