### PR TITLE
chore: Remove flay, rspec from development/test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -156,11 +156,6 @@ group :test do
 end
 
 group :development, :test do
-  # TODO: is this needed ?
-  # errors thrown by devise password gem
-  gem 'flay'
-  gem 'rspec'
-  # for error thrown by devise password gem
   gem 'active_record_query_trace'
   gem 'bundle-audit', require: false
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chatwoot/devise-secure_password
-  revision: de11e8765654b8242d42101ee9c8ffc8126f7975
+  revision: d777b04f12652d576b1272b8f39857e3e0b3fc26
   specs:
     devise-secure_password (2.0.1)
       devise (>= 4.0.0, < 5.0.0)
@@ -182,7 +182,6 @@ GEM
       regexp_parser (~> 2.2)
     email_reply_trimmer (0.1.13)
     erubi (1.10.0)
-    erubis (2.7.0)
     et-orbi (1.2.7)
       tzinfo
     execjs (2.8.1)
@@ -204,11 +203,6 @@ GEM
       faraday (~> 1)
     ffi (1.15.5)
     flag_shih_tzu (0.3.23)
-    flay (2.12.1)
-      erubis (~> 2.7.0)
-      path_expander (~> 1.0)
-      ruby_parser (~> 3.0)
-      sexp_processor (~> 4.0)
     foreman (0.87.2)
     fugit (1.5.3)
       et-orbi (~> 1, >= 1.2.7)
@@ -393,7 +387,6 @@ GEM
     parallel (1.21.0)
     parser (3.1.1.0)
       ast (~> 2.4.1)
-    path_expander (1.1.0)
     pg (1.3.2)
     procore-sift (0.16.0)
       rails (> 4.2.0)
@@ -468,10 +461,6 @@ GEM
       netrc (~> 0.8)
     retriable (3.1.2)
     rexml (3.2.5)
-    rspec (3.11.0)
-      rspec-core (~> 3.11.0)
-      rspec-expectations (~> 3.11.0)
-      rspec-mocks (~> 3.11.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
     rspec-expectations (3.11.0)
@@ -681,7 +670,6 @@ DEPENDENCIES
   faker
   fcm
   flag_shih_tzu
-  flay
   foreman
   geocoder
   google-cloud-dialogflow
@@ -718,7 +706,6 @@ DEPENDENCIES
   redis-namespace
   responders
   rest-client
-  rspec
   rspec-rails (~> 5.0.0)
   rubocop
   rubocop-performance
@@ -755,4 +742,4 @@ RUBY VERSION
    ruby 3.0.4p208
 
 BUNDLED WITH
-   2.3.10
+   2.3.14


### PR DESCRIPTION
`flay` and `rspec` are development dependencies of the `devise-secure_password` gem. It shouldn't generate an error message ideally if we have not installed it. So, I made a change [here](https://github.com/chatwoot/devise-secure_password/commit/d777b04f12652d576b1272b8f39857e3e0b3fc26) to avoid that. 

These 2 gems create a lot of warnings on the M1 mac. This PR removes these gems.