### PR TITLE
chore: Add support for message_templates in API inbox

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -267,7 +267,7 @@ export default {
       return false;
     },
     hasWhatsappTemplates() {
-      return this.$store.getters['inboxes/getWhatsAppTemplates'](this.inboxId)
+      return !!this.$store.getters['inboxes/getWhatsAppTemplates'](this.inboxId)
         .length;
     },
     enterToSendEnabled() {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -267,7 +267,8 @@ export default {
       return false;
     },
     hasWhatsappTemplates() {
-      return !!this.inbox.message_templates;
+      return this.$store.getters['inboxes/getWhatsAppTemplates'](this.inboxId)
+        .length;
     },
     enterToSendEnabled() {
       return !!this.uiSettings.enter_to_send_enabled;

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -318,7 +318,6 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import { required } from 'vuelidate/lib/validators';
 import { shouldBeUrl } from 'shared/helpers/Validators';
 import configMixin from 'shared/mixins/configMixin';
 import alertMixin from 'shared/mixins/alertMixin';
@@ -562,7 +561,6 @@ export default {
   },
   validations: {
     webhookUrl: {
-      required,
       shouldBeUrl,
     },
   },

--- a/app/javascript/dashboard/store/modules/inboxes.js
+++ b/app/javascript/dashboard/store/modules/inboxes.js
@@ -51,9 +51,20 @@ export const getters = {
     const [inbox] = $state.records.filter(
       record => record.id === Number(inboxId)
     );
+
+    const {
+      message_templates: whatsAppMessageTemplates,
+      additional_attributes: additionalAttributes,
+    } = inbox;
+
+    const { message_templates: apiInboxMessageTemplates } =
+      additionalAttributes || {};
+    const messagesTemplates =
+      whatsAppMessageTemplates || apiInboxMessageTemplates;
+
     // filtering out the whatsapp templates with media
-    if (inbox.message_templates) {
-      return inbox.message_templates.filter(template => {
+    if (messagesTemplates) {
+      return messagesTemplates.filter(template => {
         return !template.components.some(
           i => i.format === 'IMAGE' || i.format === 'VIDEO'
         );

--- a/app/models/channel/api.rb
+++ b/app/models/channel/api.rb
@@ -2,14 +2,15 @@
 #
 # Table name: channel_api
 #
-#  id             :bigint           not null, primary key
-#  hmac_mandatory :boolean          default(FALSE)
-#  hmac_token     :string
-#  identifier     :string
-#  webhook_url    :string
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  account_id     :integer          not null
+#  id                    :bigint           not null, primary key
+#  additional_attributes :jsonb
+#  hmac_mandatory        :boolean          default(FALSE)
+#  hmac_token            :string
+#  identifier            :string
+#  webhook_url           :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  account_id            :integer          not null
 #
 # Indexes
 #
@@ -21,7 +22,7 @@ class Channel::Api < ApplicationRecord
   include Channelable
 
   self.table_name = 'channel_api'
-  EDITABLE_ATTRS = [:webhook_url].freeze
+  EDITABLE_ATTRS = [:webhook_url, { additional_attributes: {} }].freeze
 
   has_secure_token :identifier
   has_secure_token :hmac_token

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -116,18 +116,19 @@ class Message < ApplicationRecord
 
   def webhook_data
     {
-      id: id,
-      content: content,
-      created_at: created_at,
-      message_type: message_type,
-      content_type: content_type,
-      private: private,
+      account: account.webhook_data,
+      additional_attributes: additional_attributes,
       content_attributes: content_attributes,
-      source_id: source_id,
-      sender: sender.try(:webhook_data),
-      inbox: inbox.webhook_data,
+      content_type: content_type,
+      content: content,
       conversation: conversation.webhook_data,
-      account: account.webhook_data
+      created_at: created_at,
+      id: id,
+      inbox: inbox.webhook_data,
+      message_type: message_type,
+      private: private,
+      sender: sender.try(:webhook_data),
+      source_id: source_id
     }
   end
 

--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -77,6 +77,7 @@ end
 if resource.api?
   json.webhook_url resource.channel.try(:webhook_url)
   json.inbox_identifier resource.channel.try(:identifier)
+  json.additional_attributes resource.channel.try(:additional_attributes)
 end
 
 ### WhatsApp Channel

--- a/db/migrate/20220610091206_add_additional_attributes_to_api_channel.rb
+++ b/db/migrate/20220610091206_add_additional_attributes_to_api_channel.rb
@@ -1,0 +1,5 @@
+class AddAdditionalAttributesToApiChannel < ActiveRecord::Migration[6.1]
+  def change
+    add_column :channel_api, :additional_attributes, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_25_141844) do
+ActiveRecord::Schema.define(version: 2022_06_10_091206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -205,6 +205,7 @@ ActiveRecord::Schema.define(version: 2022_05_25_141844) do
     t.string "identifier"
     t.string "hmac_token"
     t.boolean "hmac_mandatory", default: false
+    t.jsonb "additional_attributes", default: {}
     t.index ["hmac_token"], name: "index_channel_api_on_hmac_token", unique: true
     t.index ["identifier"], name: "index_channel_api_on_identifier", unique: true
   end


### PR DESCRIPTION
- Save message templates in the additional attributes in the API inbox
- Render template selector if message templates are present