### PR TITLE
feat: Add agent_reply_time_window in API channels

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
@@ -80,7 +80,7 @@
         @click="toggleMessageSignature"
       />
       <woot-button
-        v-if="showWhatsappTemplatesButton"
+        v-if="hasWhatsappTemplates"
         v-tooltip.top-end="'Whatsapp Templates'"
         icon="whatsapp"
         color-scheme="secondary"
@@ -274,9 +274,6 @@ export default {
     },
     showMessageSignatureButton() {
       return !this.isPrivate && this.isAnEmailChannel;
-    },
-    showWhatsappTemplatesButton() {
-      return !this.isOnPrivateNote && this.hasWhatsappTemplates;
     },
     sendWithSignature() {
       const { send_with_signature: isEnabled } = this.uiSettings;

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -1,19 +1,11 @@
 <template>
   <div class="view-box fill-height">
     <banner
-      v-if="!currentChat.can_reply && !isAWhatsappChannel"
+      v-if="!currentChat.can_reply"
       color-scheme="alert"
-      :banner-message="$t('CONVERSATION.CANNOT_REPLY')"
-      :href-link="facebookReplyPolicy"
-      :href-link-text="$t('CONVERSATION.24_HOURS_WINDOW')"
-    />
-
-    <banner
-      v-if="!currentChat.can_reply && isAWhatsappChannel"
-      color-scheme="alert"
-      :banner-message="$t('CONVERSATION.TWILIO_WHATSAPP_CAN_REPLY')"
-      :href-link="twilioWhatsAppReplyPolicy"
-      :href-link-text="$t('CONVERSATION.TWILIO_WHATSAPP_24_HOURS_WINDOW')"
+      :banner-message="replyWindowBannerMessage"
+      :href-link="replyWindowLink"
+      :href-link-text="replyWindowLinkText"
     />
 
     <banner
@@ -159,7 +151,6 @@ export default {
     hasSelectedTweetId() {
       return !!this.selectedTweetId;
     },
-
     tweetBannerText() {
       return !this.selectedTweetId
         ? this.$t('CONVERSATION.SELECT_A_TWEET_TO_REPLY')
@@ -237,12 +228,6 @@ export default {
       }
       return '';
     },
-    facebookReplyPolicy() {
-      return REPLY_POLICY.FACEBOOK;
-    },
-    twilioWhatsAppReplyPolicy() {
-      return REPLY_POLICY.TWILIO_WHATSAPP;
-    },
     isRightOrLeftIcon() {
       if (this.isContactPanelOpen) {
         return 'arrow-chevron-right';
@@ -253,6 +238,41 @@ export default {
       if (this.conversationLastSeen) return this.conversationLastSeen;
       const { contact_last_seen_at: contactLastSeenAt } = this.currentChat;
       return contactLastSeenAt;
+    },
+
+    replyWindowBannerMessage() {
+      if (this.isAWhatsappChannel) {
+        return this.$t('CONVERSATION.TWILIO_WHATSAPP_CAN_REPLY');
+      }
+      if (this.isAPIInbox) {
+        const { additional_attributes: additionalAttributes = {} } = this.inbox;
+        if (additionalAttributes) {
+          const {
+            agent_reply_time_window_message: agentReplyTimeWindowMessage,
+          } = additionalAttributes;
+          return agentReplyTimeWindowMessage;
+        }
+        return '';
+      }
+      return this.$t('CONVERSATION.CANNOT_REPLY');
+    },
+    replyWindowLink() {
+      if (this.isAWhatsappChannel) {
+        return REPLY_POLICY.FACEBOOK;
+      }
+      if (!this.isAPIInbox) {
+        return REPLY_POLICY.TWILIO_WHATSAPP;
+      }
+      return '';
+    },
+    replyWindowLinkText() {
+      if (this.isAWhatsappChannel) {
+        return this.$t('CONVERSATION.24_HOURS_WINDOW');
+      }
+      if (!this.isAPIInbox) {
+        return this.$t('CONVERSATION.TWILIO_WHATSAPP_24_HOURS_WINDOW');
+      }
+      return '';
     },
   },
 

--- a/app/models/channel/api.rb
+++ b/app/models/channel/api.rb
@@ -26,8 +26,22 @@ class Channel::Api < ApplicationRecord
 
   has_secure_token :identifier
   has_secure_token :hmac_token
+  validate :ensure_valid_agent_reply_time_window
 
   def name
     'API'
+  end
+
+  def message_window_enabled?
+    additional_attributes.present? && additional_attributes['agent_reply_time_window'].present?
+  end
+
+  private
+
+  def ensure_valid_agent_reply_time_window
+    return if additional_attributes['agent_reply_time_window'].blank?
+    return if additional_attributes['agent_reply_time_window'].to_i.positive?
+
+    errors.add(:agent_reply_time_window, 'agent_reply_time_window must be greater than 0')
   end
 end

--- a/app/models/channel/api.rb
+++ b/app/models/channel/api.rb
@@ -32,7 +32,7 @@ class Channel::Api < ApplicationRecord
     'API'
   end
 
-  def message_window_enabled?
+  def messaging_window_enabled?
     additional_attributes.present? && additional_attributes['agent_reply_time_window'].present?
   end
 

--- a/app/models/channel/facebook_page.rb
+++ b/app/models/channel/facebook_page.rb
@@ -32,7 +32,7 @@ class Channel::FacebookPage < ApplicationRecord
     'Facebook'
   end
 
-  def has_24_hour_messaging_window?
+  def messaging_window_enabled?
     false
   end
 

--- a/app/models/channel/twilio_sms.rb
+++ b/app/models/channel/twilio_sms.rb
@@ -34,7 +34,7 @@ class Channel::TwilioSms < ApplicationRecord
     medium == 'sms' ? 'Twilio SMS' : 'Whatsapp'
   end
 
-  def has_24_hour_messaging_window?
+  def messaging_window_enabled?
     medium == 'whatsapp'
   end
 end

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -57,7 +57,7 @@ class Channel::Whatsapp < ApplicationRecord
     { 'D360-API-KEY' => provider_config['api_key'], 'Content-Type' => 'application/json' }
   end
 
-  def has_24_hour_messaging_window?
+  def messaging_window_enabled?
     true
   end
 

--- a/app/models/concerns/channelable.rb
+++ b/app/models/concerns/channelable.rb
@@ -6,7 +6,7 @@ module Channelable
     has_one :inbox, as: :channel, dependent: :destroy_async
   end
 
-  def has_24_hour_messaging_window?
+  def messaging_window_enabled?
     false
   end
 end

--- a/spec/factories/channel/channel_api.rb
+++ b/spec/factories/channel/channel_api.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :channel_api, class: 'Channel::Api' do
     webhook_url { 'http://example.com' }
     account
+    additional_attributes { additional_attributes }
     after(:create) do |channel_api|
       create(:inbox, channel: channel_api, account: channel_api.account)
     end

--- a/spec/factories/channel/channel_api.rb
+++ b/spec/factories/channel/channel_api.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :channel_api, class: 'Channel::Api' do
     webhook_url { 'http://example.com' }
     account
-    additional_attributes { additional_attributes }
     after(:create) do |channel_api|
       create(:inbox, channel: channel_api, account: channel_api.account)
     end

--- a/spec/models/channel/twilio_sms_spec.rb
+++ b/spec/models/channel/twilio_sms_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Channel::TwilioSms do
     let!(:whatsapp_channel) { create(:channel_twilio_sms, medium: :whatsapp) }
 
     it 'returns true' do
-      expect(whatsapp_channel.has_24_hour_messaging_window?).to eq true
+      expect(whatsapp_channel.messaging_window_enabled?).to eq true
       expect(whatsapp_channel.name).to eq 'Whatsapp'
       expect(whatsapp_channel.medium).to eq 'whatsapp'
     end
@@ -17,7 +17,7 @@ RSpec.describe Channel::TwilioSms do
     let!(:sms_channel) { create(:channel_twilio_sms, medium: :sms) }
 
     it 'returns false' do
-      expect(sms_channel.has_24_hour_messaging_window?).to eq false
+      expect(sms_channel.messaging_window_enabled?).to eq false
       expect(sms_channel.name).to eq 'Twilio SMS'
       expect(sms_channel.medium).to eq 'sms'
     end


### PR DESCRIPTION
To use API channels to integrate with the third-party WhatsApp API provider this PR introduces 2 attributes `agent_reply_time_window` and `agent_reply_time_window_message`.

- Added agent_reply_time_window, agent_reply_time_window_message to additional_attributes
- Updated the method name from `has_24_hour_messaging_window?` to `messaging_window_enabled?`
- Update the `can_reply?` method to include `agent_reply_time_window`