### PR TITLE
Fix - Truncates overflowing labels in bulk actions selector

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/conversationBulkActions/LabelActions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/conversationBulkActions/LabelActions.vue
@@ -249,6 +249,10 @@ ul {
 
     .label-title {
       flex-grow: 1;
+      width: 100%;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .label-pill {
@@ -256,6 +260,7 @@ ul {
       border-radius: var(--border-radius-medium);
       height: var(--space-slab);
       width: var(--space-slab);
+      flex-shrink: 0;
     }
   }
 }


### PR DESCRIPTION
## Description

| Before                                                                                                                                     | After                                                                                                                                      |
| ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
| ![Screenshot2022-06-20 at 21 08 06](https://user-images.githubusercontent.com/15716057/174637948-e9c60e20-b177-4d8f-9b84-62105ab3977b.png) | ![Screenshot2022-06-20 at 21 10 49](https://user-images.githubusercontent.com/15716057/174637973-7ee4d71f-7c6f-4ec7-949e-7bd85ec071be.png) |

After

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
