### PR TITLE
chore: Revert the migration for inbox name changes

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -326,7 +326,7 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import { shouldBeUrl, isValidName } from 'shared/helpers/Validators';
+import { shouldBeUrl } from 'shared/helpers/Validators';
 import configMixin from 'shared/mixins/configMixin';
 import alertMixin from 'shared/mixins/alertMixin';
 import SettingIntroBanner from 'dashboard/components/widgets/SettingIntroBanner';
@@ -571,7 +571,7 @@ export default {
     webhookUrl: {
       shouldBeUrl,
     },
-    selectedInboxName: { isValidName },
+    selectedInboxName: {},
   },
 };
 </script>

--- a/app/javascript/shared/helpers/Validators.js
+++ b/app/javascript/shared/helpers/Validators.js
@@ -16,4 +16,3 @@ export const isValidPassword = value => {
     containsSpecialCharacter
   );
 };
-export const isValidName = value => /^\b[\w\s]*\b$/.test(value);

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -33,7 +33,7 @@ class Inbox < ApplicationRecord
   include Avatarable
   include OutOfOffisable
 
-  validates :name, presence: true, format: { with: /^\b[\w\s]*\b$/, multiline: true }
+  validates :name, presence: true
   validates :account_id, presence: true
   validates :timezone, inclusion: { in: TZInfo::Timezone.all_identifiers }
   validate :ensure_valid_max_assignment_limit

--- a/db/migrate/20220616154502_remove_special_characters_from_inbox_name.rb
+++ b/db/migrate/20220616154502_remove_special_characters_from_inbox_name.rb
@@ -6,12 +6,10 @@ class RemoveSpecialCharactersFromInboxName < ActiveRecord::Migration[6.1]
   private
 
   def remove_special_characters_from_inbox_name
-    ::Inbox.find_in_batches do |inbox_batch|
-      Rails.logger.info "Migrated till #{inbox_batch.first.id}\n"
-      inbox_batch.each do |inbox|
-        inbox.name = inbox.name.gsub(/[^\w\s_]/, '')
-        inbox.save!
-      end
-    end
+    # ::Inbox.find_in_batches do |inbox_batch|
+    #   inbox_batch.map do |inbox|
+    #     inbox.name.gsub(/[^\w\s_]/, '')
+    #   end
+    # end
   end
 end

--- a/db/migrate/20220616154502_remove_special_characters_from_inbox_name.rb
+++ b/db/migrate/20220616154502_remove_special_characters_from_inbox_name.rb
@@ -1,15 +1,8 @@
 class RemoveSpecialCharactersFromInboxName < ActiveRecord::Migration[6.1]
-  def change
-    remove_special_characters_from_inbox_name
-  end
+  # This PR tried to remove special characters from the inbox name
+  # It broke in the Chatwoot Cloud as there were inboxes with valid special characters
+  # We had to push a temporary fix to continue the deployment by removing the logic
+  # from this migration. Keeping this migration here to remove inconsistency.
 
-  private
-
-  def remove_special_characters_from_inbox_name
-    # ::Inbox.find_in_batches do |inbox_batch|
-    #   inbox_batch.map do |inbox|
-    #     inbox.name.gsub(/[^\w\s_]/, '')
-    #   end
-    # end
-  end
+  def change; end
 end


### PR DESCRIPTION
Revert #4883

PR #4883 tried to remove special characters from the inbox name. It broke in the Chatwoot Cloud as there were inboxes with valid special characters. We had to push a temporary fix to continue the deployment by removing the logic from the migration. This PR reverts the changes done in #4883