### PR TITLE
fix: last incoming message sort

### DIFF
--- a/app/models/concerns/sort_handler.rb
+++ b/app/models/concerns/sort_handler.rb
@@ -11,14 +11,14 @@ module SortHandler
     end
 
     def self.last_messaged_conversations
-      Message.except(:order).select('DISTINCT ON (conversation_id) *').order('conversation_id, created_at DESC')
+      Message.except(:order).select(
+        'DISTINCT ON (conversation_id) conversation_id, id, created_at, message_type'
+      ).order('conversation_id, created_at DESC')
     end
 
     def self.sort_on_last_user_message_at
-      where(
-        'grouped_conversations.message_type = 0'
-      ).order(
-        'grouped_conversations.created_at ASC'
+      order(
+        'grouped_conversations.message_type', 'grouped_conversations.created_at ASC'
       )
     end
   end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -72,7 +72,7 @@ class Conversation < ApplicationRecord
 
   scope :last_user_message_at, lambda {
     joins(
-      "INNER JOIN (#{last_messaged_conversations.to_sql}) grouped_conversations
+      "INNER JOIN (#{last_messaged_conversations.to_sql}) AS grouped_conversations
       ON grouped_conversations.conversation_id = conversations.id"
     ).sort_on_last_user_message_at
   }

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -46,7 +46,7 @@ class Mention < ApplicationRecord
     # Then select only latest incoming message from the conversations which doesn't have last message as outgoing
     # Order by message created_at
     Mention.joins(
-      "INNER JOIN (#{last_messaged_conversations.to_sql}) grouped_conversations
+      "INNER JOIN (#{last_messaged_conversations.to_sql}) AS grouped_conversations
       ON grouped_conversations.conversation_id = mentions.conversation_id"
     ).sort_on_last_user_message_at
   end

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -480,7 +480,6 @@ RSpec.describe Conversation, type: :model do
 
       it 'return true for facebook channels' do
         stub_request(:post, /graph.facebook.com/)
-        
         facebook_channel = create(:channel_facebook_page)
         facebook_inbox = create(:inbox, channel: facebook_channel, account: facebook_channel.account)
         fb_conversation = create(:conversation, inbox: facebook_inbox, account: facebook_channel.account)

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -637,22 +637,45 @@ RSpec.describe Conversation, type: :model do
       expect(records.last.id).to eq(conversation_2.id)
     end
 
-    it 'Sort conversations based on last_user_message_at' do
-      create(:message, conversation_id: conversation_3.id, message_type: :outgoing, created_at: DateTime.now - 9.days)
-      create(:message, conversation_id: conversation_1.id, message_type: :incoming, created_at: DateTime.now - 8.days)
-      create(:message, conversation_id: conversation_1.id, message_type: :incoming, created_at: DateTime.now - 8.days)
-      create(:message, conversation_id: conversation_1.id, message_type: :outgoing, created_at: DateTime.now - 7.days)
-      create(:message, conversation_id: conversation_2.id, message_type: :incoming, created_at: DateTime.now - 6.days)
-      create(:message, conversation_id: conversation_2.id, message_type: :incoming, created_at: DateTime.now - 6.days)
-      create(:message, conversation_id: conversation_3.id, message_type: :incoming, created_at: DateTime.now - 6.days)
-      create(:message, conversation_id: conversation_3.id, message_type: :incoming, created_at: DateTime.now - 6.days)
-      create(:message, conversation_id: conversation_3.id, message_type: :incoming, created_at: DateTime.now - 2.days)
+    context 'when sort on last_user_message_at' do
+      before do
+        create(:message, conversation_id: conversation_3.id, message_type: :outgoing, created_at: DateTime.now - 9.days)
+        create(:message, conversation_id: conversation_1.id, message_type: :incoming, created_at: DateTime.now - 8.days)
+        create(:message, conversation_id: conversation_1.id, message_type: :incoming, created_at: DateTime.now - 8.days)
+        create(:message, conversation_id: conversation_1.id, message_type: :outgoing, created_at: DateTime.now - 7.days)
+        create(:message, conversation_id: conversation_2.id, message_type: :incoming, created_at: DateTime.now - 6.days)
+        create(:message, conversation_id: conversation_2.id, message_type: :incoming, created_at: DateTime.now - 6.days)
+        create(:message, conversation_id: conversation_3.id, message_type: :incoming, created_at: DateTime.now - 6.days)
+        create(:message, conversation_id: conversation_3.id, message_type: :incoming, created_at: DateTime.now - 6.days)
+        create(:message, conversation_id: conversation_3.id, message_type: :incoming, created_at: DateTime.now - 2.days)
+      end
 
-      records = described_class.last_user_message_at
+      # conversation_2 has last unanswered incoming message 6 days ago
+      # conversation_3 has last unanswered incoming message 2 days ago
+      # conversation_1 has incoming message 8 days ago but outgoing message on 7 days ago
+      # so we won't consider it to show it on top of the sort as it is answered/replied conversation
+      it 'Sort conversations with oldest unanswered incoming message first' do
+        conversation_with_message_count = described_class.joins(:messages).uniq.count
+        records = described_class.last_user_message_at
 
-      expect(records[0]['id']).to eq(conversation_2.id)
-      expect(records[1]['id']).to eq(conversation_3.id)
-      expect(records.pluck(:id)).not_to include(conversation_4.id)
+        expect(records.length).to eq(conversation_with_message_count)
+        expect(records[0]['id']).to eq(conversation_2.id)
+        expect(records[1]['id']).to eq(conversation_3.id)
+        expect(records[2]['id']).to eq(conversation_1.id)
+        expect(records.pluck(:id)).not_to include(conversation_4.id)
+      end
+
+      # Now we have no incoming message the sprt will happen on the created at
+      it 'Sort based on oldest message first when there are no incoming message' do
+        Message.where(message_type: :incoming).update(message_type: :template)
+        conversation_with_message_count = described_class.joins(:messages).uniq.count
+        records = described_class.last_user_message_at
+
+        expect(records.length).to eq(conversation_with_message_count)
+        expect(records[0]['id']).to eq(conversation_1.id)
+        expect(records[1]['id']).to eq(conversation_2.id)
+        expect(records[2]['id']).to eq(conversation_3.id)
+      end
     end
 
     context 'when last_activity_at updated by some actions' do
@@ -674,7 +697,7 @@ RSpec.describe Conversation, type: :model do
             account_id: conversation_1.account_id,
             inbox_id: conversation_1.inbox_id,
             message_type: :activity,
-            content: 'Conversation was marked resolved by system due to  days of inactivity'
+            content: 'Conversation was marked resolved by system due to days of inactivity'
           )
         end
         records = described_class.latest

--- a/spec/models/mention_spec.rb
+++ b/spec/models/mention_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Mention, type: :model do
 
       expect(records.first.id).to eq(mention_2.id)
       expect(records.first.conversation_id).to eq(conversation_2.id)
-      expect(records.last.conversation_id).to eq(conversation_3.id)
+      expect(records.last.conversation_id).to eq(conversation_1.id)
       expect(records.pluck(:id)).not_to include(conversation_4.id)
     end
 


### PR DESCRIPTION
# Pull Request Template

## Description

I have faced the issue where I have no conversations with the last message as an incoming message, all were either activity messages or template messages, because of the previous change it sent an empty conversation list which is the wrong result. So to fix this

1.  I have removed the filer i.e `where clause` from the sort query.
2. Added sort based on message_type and message created_at on the conversation table. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
