### PR TITLE
fix: Fixing message create issue for deleted instagram story

### DIFF
--- a/app/builders/messages/messenger/message_builder.rb
+++ b/app/builders/messages/messenger/message_builder.rb
@@ -54,6 +54,9 @@ class Messages::Messenger::MessageBuilder
   def fetch_story_link(attachment)
     message = attachment.message
     result = get_story_object_from_source_id(message.source_id)
+
+    return if result.blank?
+
     story_id = result['story']['mention']['id']
     story_sender = result['from']['username']
     message.content_attributes[:story_sender] = story_sender


### PR DESCRIPTION
1. when Instagram story is deleted
2. We try to fetch the attachment and story link for the same from the background job
3. FB raises the `Koala::Facebook::ClientError` error and then the story mention_id is empty.

Which causes https://sentry.io/organizations/chatwoot-p3/issues/3253162714/?project=6382945&query=is%3Aunresolved#context-sidekiq