### PR TITLE
fix: Handling facebook client error for deleted story

### DIFF
--- a/app/builders/messages/instagram/message_builder.rb
+++ b/app/builders/messages/instagram/message_builder.rb
@@ -18,15 +18,12 @@ class Messages::Instagram::MessageBuilder < Messages::Messenger::MessageBuilder
     return if @inbox.channel.reauthorization_required?
 
     ActiveRecord::Base.transaction do
-    binding.pry
-
       build_message
     end
   rescue Koala::Facebook::AuthenticationError
     @inbox.channel.authorization_error!
     raise
   rescue StandardError => e
-    binding.pry
     ChatwootExceptionTracker.new(e, account: @inbox.account).capture_exception
     true
   end

--- a/app/builders/messages/instagram/message_builder.rb
+++ b/app/builders/messages/instagram/message_builder.rb
@@ -18,12 +18,15 @@ class Messages::Instagram::MessageBuilder < Messages::Messenger::MessageBuilder
     return if @inbox.channel.reauthorization_required?
 
     ActiveRecord::Base.transaction do
+    binding.pry
+
       build_message
     end
   rescue Koala::Facebook::AuthenticationError
     @inbox.channel.authorization_error!
     raise
   rescue StandardError => e
+    binding.pry
     ChatwootExceptionTracker.new(e, account: @inbox.account).capture_exception
     true
   end

--- a/app/builders/messages/messenger/message_builder.rb
+++ b/app/builders/messages/messenger/message_builder.rb
@@ -71,6 +71,10 @@ class Messages::Messenger::MessageBuilder
   rescue Koala::Facebook::AuthenticationError
     @inbox.channel.authorization_error!
     raise
+  rescue Koala::Facebook::ClientError => e
+    # The exception occurs when we are trying fetch the deleted story or blocked story.
+    Rails.logger.error e
+    {}
   rescue StandardError => e
     ChatwootExceptionTracker.new(e, account: @inbox.account).capture_exception
     {}

--- a/app/builders/messages/messenger/message_builder.rb
+++ b/app/builders/messages/messenger/message_builder.rb
@@ -73,6 +73,7 @@ class Messages::Messenger::MessageBuilder
     raise
   rescue Koala::Facebook::ClientError => e
     # The exception occurs when we are trying fetch the deleted story or blocked story.
+    @message.update(content: I18n.t('conversations.messages.instagram_deleted_story_content'))
     Rails.logger.error e
     {}
   rescue StandardError => e

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,7 @@ en:
   conversations:
     messages:
       instagram_story_content: "%{story_sender} mentioned you in the story: "
+      instagram_deleted_story_content: This story is no longer available.
       deleted: This message was deleted
     activity:
       status:

--- a/spec/factories/instagram/instagram_message_create_event.rb
+++ b/spec/factories/instagram/instagram_message_create_event.rb
@@ -104,7 +104,7 @@ FactoryBot.define do
                   {
                     'type': 'share',
                     'payload': {
-                      'url': 'https://imagekit.io/blog/content/images/2020/05/media_library.jpeg'
+                      'url': 'https://www.example.com/test.jpeg'
                     }
                   }
                 ]
@@ -138,7 +138,7 @@ FactoryBot.define do
                   {
                     'type': 'story_mention',
                     'payload': {
-                      'url': 'https://imagekit.io/blog/content/images/2020/05/media_library.jpeg'
+                      'url': 'https://www.example.com/test.jpeg'
                     }
                   }
                 ]

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -6,7 +6,7 @@ describe Webhooks::InstagramEventsJob do
 
   before do
     stub_request(:post, /graph.facebook.com/)
-    stub_request(:get, 'https://imagekit.io/blog/content/images/2020/05/media_library.jpeg')
+    stub_request(:get, 'https://www.example.com/test.jpeg')
       .with(
         headers: {
           'Accept' => '*/*',
@@ -102,8 +102,7 @@ describe Webhooks::InstagramEventsJob do
           { story:
             {
               mention: {
-                link:
-                 'https://lookaside.fbsbx.com/ig_messaging_cdn/?asset_id=17920786367196703&signature=Aby8EXbvNu4on9efDQecXDasiJX2s0FgWhFGz3mNFB__CsHR22O_1bJiYHkbp3mC1NQeW4jHxls9WyqVgRPcyonUbSJmD44UwLfFhbCK2obesWnFi7VOnisqLu48Xd6KYuNex7uSCQKWM-nw55zQ23bBgfCYw6h5hiJjFHwJDZYm65zXpQ',
+                link: 'https://www.example.com/test.jpeg',
                 id: '17920786367196703'
               }
             },


### PR DESCRIPTION
Fixing: https://sentry.io/share/issue/930fed19b99d4f45a95c13c1f2e60652/

This known exception that Facebook throws when we are fetching the deleted story data. So instead of logging this to sentry, we are logging it to rails logger as we can not handle or resolve this issue from our end.

```
type: OAuthException, code: 9000001, message: (#9000001) This Message has been deleted by the user or the business., x-fb-trace-id: AH8KdfvtSee [HTTP 400]
```
