### PR TITLE
Fix: Add missing referrer-link key for i18n

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/contactFilters.json
+++ b/app/javascript/dashboard/i18n/locale/en/contactFilters.json
@@ -38,7 +38,8 @@
             "CUSTOM_ATTRIBUTE_LINK": "Link",
             "CUSTOM_ATTRIBUTE_CHECKBOX": "Checkbox",
             "CREATED_AT": "Created At",
-            "LAST_ACTIVITY": "Last Activity"
+            "LAST_ACTIVITY": "Last Activity",
+            "REFERER_LINK": "Referrer link"
         },
         "GROUPS": {
             "STANDARD_FILTERS": "Standard Filters",


### PR DESCRIPTION
## Description
Adds missing i18n key for referrer link attribute in filters.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)