### PR TITLE
chore: Fix puma configuration

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,7 +25,7 @@ pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch('WEB_CONCURRENCY', 1)
+workers ENV.fetch('WEB_CONCURRENCY', 0)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
fixes the console warning 
```
backend  | [29359] ! WARNING: Detected running cluster mode with 1 worker.
backend  | [29359] ! Running Puma in cluster mode with a single worker is often a misconfiguration.
backend  | [29359] ! Consider running Puma in single-mode (workers = 0) in order to reduce memory overhead.
backend  | [29359] ! Set the `silence_single_worker_warning` option to silence this warning message.
backend  | [29359] - Worker 0 (PID: 29412) booted in 0.04s, phase: 0
```