### PR TITLE
fix: Conversation filter on dates

### DIFF
--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -73,8 +73,6 @@ class FilterService
     "#{operator} '#{value}'::#{attribute_data_type}"
   end
 
-  def custom_compare_filter_values; end
-
   def days_before_filter_values(query_hash)
     date = Time.zone.today - query_hash['values'][0].to_i.days
     query_hash['values'] = [date.strftime]

--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -65,12 +65,15 @@ class FilterService
 
   def lt_gt_filter_values(query_hash)
     attribute_key = query_hash[:attribute_key]
-    attribute_type = custom_attribute(attribute_key, @account, query_hash['custom_attribute_type']).try(:attribute_display_type)
+    attribute_model = query_hash['custom_attribute_type'].presence || self.class::ATTRIBUTE_MODEL
+    attribute_type = custom_attribute(attribute_key, @account, attribute_model).try(:attribute_display_type)
     attribute_data_type = self.class::ATTRIBUTE_TYPES[attribute_type]
     value = query_hash['values'][0]
     operator = query_hash['filter_operator'] == 'is_less_than' ? '<' : '>'
     "#{operator} '#{value}'::#{attribute_data_type}"
   end
+
+  def custom_compare_filter_values; end
 
   def days_before_filter_values(query_hash)
     date = Time.zone.today - query_hash['values'][0].to_i.days
@@ -90,7 +93,7 @@ class FilterService
   def custom_attribute_query(query_hash, custom_attribute_type, current_index)
     attribute_key = query_hash[:attribute_key]
     query_operator = query_hash[:query_operator]
-    attribute_model = custom_attribute_type || self.class::ATTRIBUTE_MODEL
+    attribute_model = custom_attribute_type.presence || self.class::ATTRIBUTE_MODEL
 
     attribute_type = custom_attribute(attribute_key, @account, attribute_model).try(:attribute_display_type)
     filter_operator_value = filter_operation(query_hash, current_index)
@@ -107,7 +110,7 @@ class FilterService
 
   def custom_attribute(attribute_key, account, custom_attribute_type)
     current_account = account || Current.account
-    attribute_model = custom_attribute_type || self.class::ATTRIBUTE_MODEL
+    attribute_model = custom_attribute_type.presence || self.class::ATTRIBUTE_MODEL
     @custom_attribute = current_account.custom_attribute_definitions.where(
       attribute_model: attribute_model
     ).find_by(attribute_key: attribute_key)

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -163,8 +163,35 @@ describe ::Conversations::FilterService do
             attribute_key: 'labels',
             filter_operator: 'equal_to',
             values: ['support'],
-            query_operator: nil,
-            custom_attribute_type: ''
+            query_operator: nil
+          }.with_indifferent_access
+        ]
+        result = filter_service.new(params, user_1).perform
+        expect(result[:conversations].length).to be 1
+        expect(result[:conversations][0][:id]).to be user_2_assigned_conversation.id
+      end
+
+      it 'filter by custom_attributes and labels with custom_attribute_type nil' do
+        user_2_assigned_conversation.update_labels('support')
+        params[:payload] = [
+          {
+            attribute_key: 'conversation_type',
+            filter_operator: 'equal_to',
+            values: ['platinum'],
+            query_operator: 'AND'
+          }.with_indifferent_access,
+          {
+            attribute_key: 'conversation_created',
+            filter_operator: 'is_less_than',
+            values: ['2022-01-20'],
+            query_operator: 'OR',
+            custom_attribute_type: nil
+          }.with_indifferent_access,
+          {
+            attribute_key: 'labels',
+            filter_operator: 'equal_to',
+            values: ['support'],
+            query_operator: nil
           }.with_indifferent_access
         ]
         result = filter_service.new(params, user_1).perform
@@ -187,6 +214,27 @@ describe ::Conversations::FilterService do
             values: ['2022-01-20'],
             query_operator: nil,
             custom_attribute_type: ''
+          }.with_indifferent_access
+        ]
+        result = filter_service.new(params, user_1).perform
+        expect(result[:conversations].length).to be 1
+      end
+
+      it 'filter by custom_attributes with custom_attribute_type nil' do
+        params[:payload] = [
+          {
+            attribute_key: 'conversation_type',
+            filter_operator: 'equal_to',
+            values: ['platinum'],
+            query_operator: 'AND',
+            custom_attribute_type: nil
+          }.with_indifferent_access,
+          {
+            attribute_key: 'conversation_created',
+            filter_operator: 'is_less_than',
+            values: ['2022-01-20'],
+            query_operator: nil,
+            custom_attribute_type: nil
           }.with_indifferent_access
         ]
         result = filter_service.new(params, user_1).perform

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -58,13 +58,15 @@ describe ::Conversations::FilterService do
             attribute_key: 'browser_language',
             filter_operator: 'contains',
             values: 'en',
-            query_operator: 'AND'
+            query_operator: 'AND',
+            custom_attribute_type: ''
           }.with_indifferent_access,
           {
             attribute_key: 'status',
             filter_operator: 'not_equal_to',
             values: %w[resolved],
-            query_operator: nil
+            query_operator: nil,
+            custom_attribute_type: ''
           }.with_indifferent_access
         ]
       end
@@ -94,13 +96,15 @@ describe ::Conversations::FilterService do
               user_1.id,
               user_2.id
             ],
-            query_operator: 'AND'
+            query_operator: 'AND',
+            custom_attribute_type: ''
           }.with_indifferent_access,
           {
             attribute_key: 'labels',
             filter_operator: 'equal_to',
             values: ['support'],
-            query_operator: nil
+            query_operator: nil,
+            custom_attribute_type: ''
           }.with_indifferent_access
         ]
         result = filter_service.new(params, user_1).perform
@@ -116,13 +120,15 @@ describe ::Conversations::FilterService do
               user_1.id,
               user_2.id
             ],
-            query_operator: 'AND'
+            query_operator: 'AND',
+            custom_attribute_type: ''
           }.with_indifferent_access,
           {
             attribute_key: 'campaign_id',
             filter_operator: 'is_present',
             values: [],
-            query_operator: nil
+            query_operator: nil,
+            custom_attribute_type: ''
           }.with_indifferent_access
         ]
         result = filter_service.new(params, user_1).perform
@@ -150,13 +156,15 @@ describe ::Conversations::FilterService do
             attribute_key: 'conversation_created',
             filter_operator: 'is_less_than',
             values: ['2022-01-20'],
-            query_operator: 'OR'
+            query_operator: 'OR',
+            custom_attribute_type: ''
           }.with_indifferent_access,
           {
             attribute_key: 'labels',
             filter_operator: 'equal_to',
             values: ['support'],
-            query_operator: nil
+            query_operator: nil,
+            custom_attribute_type: ''
           }.with_indifferent_access
         ]
         result = filter_service.new(params, user_1).perform
@@ -170,13 +178,15 @@ describe ::Conversations::FilterService do
             attribute_key: 'conversation_type',
             filter_operator: 'equal_to',
             values: ['platinum'],
-            query_operator: 'AND'
+            query_operator: 'AND',
+            custom_attribute_type: ''
           }.with_indifferent_access,
           {
             attribute_key: 'conversation_created',
             filter_operator: 'is_less_than',
             values: ['2022-01-20'],
-            query_operator: nil
+            query_operator: nil,
+            custom_attribute_type: ''
           }.with_indifferent_access
         ]
         result = filter_service.new(params, user_1).perform
@@ -189,13 +199,15 @@ describe ::Conversations::FilterService do
             attribute_key: 'conversation_type',
             filter_operator: 'equal_to',
             values: ['platinum'],
-            query_operator: 'AND'
+            query_operator: 'AND',
+            custom_attribute_type: ''
           }.with_indifferent_access,
           {
             attribute_key: 'browser_language',
             filter_operator: 'is_equal_to',
             values: 'en',
-            query_operator: nil
+            query_operator: nil,
+            custom_attribute_type: ''
           }.with_indifferent_access
         ]
         result = filter_service.new(params, user_1).perform
@@ -214,7 +226,8 @@ describe ::Conversations::FilterService do
             attribute_key: 'created_at',
             filter_operator: 'is_greater_than',
             values: ['2022-01-20'],
-            query_operator: nil
+            query_operator: nil,
+            custom_attribute_type: ''
           }.with_indifferent_access
         ]
         result = filter_service.new(params, user_1).perform
@@ -228,13 +241,15 @@ describe ::Conversations::FilterService do
             attribute_key: 'conversation_type',
             filter_operator: 'equal_to',
             values: ['platinum'],
-            query_operator: 'AND'
+            query_operator: 'AND',
+            custom_attribute_type: ''
           }.with_indifferent_access,
           {
             attribute_key: 'created_at',
             filter_operator: 'is_greater_than',
             values: ['2022-01-20'],
-            query_operator: nil
+            query_operator: nil,
+            custom_attribute_type: ''
           }.with_indifferent_access
         ]
         result = filter_service.new(params, user_1).perform
@@ -257,13 +272,15 @@ describe ::Conversations::FilterService do
               attribute_key: 'last_activity_at',
               filter_operator: 'days_before',
               values: [3],
-              query_operator: 'AND'
+              query_operator: 'AND',
+              custom_attribute_type: ''
             }.with_indifferent_access,
             {
               attribute_key: 'conversation_type',
               filter_operator: 'equal_to',
               values: ['platinum'],
-              query_operator: nil
+              query_operator: nil,
+              custom_attribute_type: ''
             }.with_indifferent_access
           ]
 
@@ -280,7 +297,8 @@ describe ::Conversations::FilterService do
               attribute_key: 'last_activity_at',
               filter_operator: 'days_before',
               values: [3],
-              query_operator: nil
+              query_operator: nil,
+              custom_attribute_type: ''
             }.with_indifferent_access
           ]
 


### PR DESCRIPTION

We are getting custom_attribute_type as an empty string so the filter was failing.
1. less_than and greater_than were not working because the OR operator wasn't working on an empty string
2. added presence check for custom_attribte_type

Fixes: 
https://sentry.io/organizations/chatwoot-p3/issues/3252991467/?project=6382945&query=StatementInvalid&statsPeriod=14d

https://sentry.io/organizations/chatwoot-p3/issues/3381238789/?project=6382945