### PR TITLE
fix: Set account default language in account API

### DIFF
--- a/app/builders/account_builder.rb
+++ b/app/builders/account_builder.rb
@@ -2,7 +2,7 @@
 
 class AccountBuilder
   include CustomExceptions::Account
-  pattr_initialize [:account_name!, :email!, :confirmed, :user, :user_full_name, :user_password, :super_admin]
+  pattr_initialize [:account_name!, :email!, :confirmed, :user, :user_full_name, :user_password, :super_admin, :locale]
 
   def perform
     if @user.nil?

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -19,6 +19,7 @@ class Api::V1::AccountsController < Api::BaseController
       user_full_name: account_params[:user_full_name],
       email: account_params[:email],
       user_password: account_params[:password],
+      locale: account_params[:locale],
       user: current_user
     ).perform
     if @user

--- a/app/controllers/platform/api/v1/accounts_controller.rb
+++ b/app/controllers/platform/api/v1/accounts_controller.rb
@@ -27,6 +27,6 @@ class Platform::Api::V1::AccountsController < PlatformController
   end
 
   def account_params
-    params.permit(:name)
+    params.permit(:name, :locale)
   end
 end

--- a/app/views/api/v1/accounts/create.json.jbuilder
+++ b/app/views/api/v1/accounts/create.json.jbuilder
@@ -18,6 +18,7 @@ json.data do
       json.name account_user.account.name
       json.active_at account_user.active_at
       json.role account_user.role
+      json.locale account_user.account.locale
     end
   end
 end

--- a/db/migrate/20220720123615_set_default_locale_at_accounts.rb
+++ b/db/migrate/20220720123615_set_default_locale_at_accounts.rb
@@ -1,0 +1,5 @@
+class SetDefaultLocaleAtAccounts < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :accounts, :locale, from: nil, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_20_080126) do
+ActiveRecord::Schema.define(version: 2022_07_20_123615) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Accounts API', type: :request do
         with_modified_env ENABLE_ACCOUNT_SIGNUP: 'true' do
           allow(account_builder).to receive(:perform).and_return([user, account])
 
-          params = { account_name: 'test', email: email, user: nil, user_full_name: user_full_name, password: 'Password1!' }
+          params = { account_name: 'test', email: email, user: nil, locale: nil, user_full_name: user_full_name, password: 'Password1!' }
 
           post api_v1_accounts_url,
                params: params,
@@ -27,6 +27,7 @@ RSpec.describe 'Accounts API', type: :request do
           expect(AccountBuilder).to have_received(:new).with(params.except(:password).merge(user_password: params[:password]))
           expect(account_builder).to have_received(:perform)
           expect(response.headers.keys).to include('access-token', 'token-type', 'client', 'expiry', 'uid')
+          expect(response.body).to include('en')
         end
       end
 
@@ -37,7 +38,7 @@ RSpec.describe 'Accounts API', type: :request do
           allow(ChatwootCaptcha).to receive(:new).and_return(captcha)
           allow(captcha).to receive(:valid?).and_return(true)
 
-          params = { account_name: 'test', email: email, user: nil, user_full_name: user_full_name, password: 'Password1!',
+          params = { account_name: 'test', email: email, user: nil, locale: nil, user_full_name: user_full_name, password: 'Password1!',
                      h_captcha_client_response: '123' }
 
           post api_v1_accounts_url,
@@ -46,6 +47,7 @@ RSpec.describe 'Accounts API', type: :request do
 
           expect(ChatwootCaptcha).to have_received(:new).with('123')
           expect(response.headers.keys).to include('access-token', 'token-type', 'client', 'expiry', 'uid')
+          expect(response.body).to include('en')
         end
       end
 
@@ -53,7 +55,7 @@ RSpec.describe 'Accounts API', type: :request do
         with_modified_env ENABLE_ACCOUNT_SIGNUP: 'true' do
           allow(account_builder).to receive(:perform).and_return(nil)
 
-          params = { account_name: nil, email: nil, user: nil, user_full_name: nil }
+          params = { account_name: nil, email: nil, user: nil, locale: 'en', user_full_name: nil }
 
           post api_v1_accounts_url,
                params: params,
@@ -130,6 +132,7 @@ RSpec.describe 'Accounts API', type: :request do
         expect(response.body).to include(account.domain)
         expect(response.body).to include(account.support_email)
         expect(response.body).to include(account.auto_resolve_duration.to_s)
+        expect(response.body).to include(account.locale)
       end
     end
   end

--- a/spec/controllers/platform/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/platform/api/v1/accounts_controller_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe 'Platform Accounts API', type: :request do
         expect(response.body).to include('Test Account')
         expect(platform_app.platform_app_permissibles.first.permissible.name).to eq('Test Account')
       end
+
+      it 'creates an account with locale' do
+        post '/platform/api/v1/accounts', params: { name: 'Test Account', locale: 'es' },
+                                          headers: { api_access_token: platform_app.access_token.token }, as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include('Test Account')
+        expect(response.body).to include('es')
+      end
     end
   end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Account do
       account = create(:account)
       query = "select * from information_schema.sequences where sequence_name in  ('camp_dpid_seq_#{account.id}', 'conv_dpid_seq_#{account.id}');"
       expect(ActiveRecord::Base.connection.execute(query).count).to eq(2)
+      expect(account.locale).to eq('en')
       account.destroy
       expect(ActiveRecord::Base.connection.execute(query).count).to eq(0)
     end


### PR DESCRIPTION
# Pull Request Template

## Description

Setting Account default language in the account created via API.

Fixes #4855 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with the test cases

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
