### PR TITLE
chore: Add specs for stripe Webhooks endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,10 +234,10 @@ Rails.application.routes.draw do
               post :subscription
             end
           end
-
-          post 'webhooks/stripe', to: 'webhooks/stripe#process_payload'
         end
       end
+
+      post 'webhooks/stripe', to: 'webhooks/stripe#process_payload'
     end
   end
 

--- a/enterprise/app/controllers/enterprise/webhooks/stripe_controller.rb
+++ b/enterprise/app/controllers/enterprise/webhooks/stripe_controller.rb
@@ -1,4 +1,4 @@
-class Enterprise::Api::V1::Webhooks::StripeController < ActionController::API
+class Enterprise::Webhooks::StripeController < ActionController::API
   def process_payload
     # Get the event payload and signature
     payload = request.body.read

--- a/spec/enterprise/controllers/enterprise/webooks/stripe_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/webooks/stripe_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'Enterprise::Webhooks::StripeController', type: :request do
+  describe 'POST /enterprise/webhooks/stripe' do
+    let(:params) { { content: 'hello' } }
+
+    it 'call the Enterprise::Billing::HandleStripeEventService with the params' do
+      handle_stripe = double
+      allow(Stripe::Webhook).to receive(:construct_event).and_return(params)
+      allow(Enterprise::Billing::HandleStripeEventService).to receive(:new).and_return(handle_stripe)
+      allow(handle_stripe).to receive(:perform)
+      post '/enterprise/webhooks/stripe', headers: { 'Stripe-Signature': 'test' }, params: params
+      expect(handle_stripe).to have_received(:perform).with(event: params)
+    end
+
+    it 'returns a bad request if the headers are missing' do
+      post '/enterprise/webhooks/stripe', params: params
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'returns a bad request if the headers are invalid' do
+      post '/enterprise/webhooks/stripe', headers: { 'Stripe-Signature': 'test' }, params: params
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end

--- a/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe Enterprise::Billing::HandleStripeEventService do
+  subject(:stripe_event_service) { described_class }
+  let(:event) { double }
+  let(:data) { double }
+  let(:subscription) { double }
+  let!(:account) { create(:account, custom_attributes: { stripe_customer_id: 'cus_123' }) }
+  
+  before do
+    allow(event).to receive(:data).and_return(data)
+    allow(data).to receive(:object).and_return(subscription)
+    allow(subscription).to receive(:[]).with('plan').
+      and_return({
+        'id' => 'test', 'product' => 'plan_id', 'name' => 'plan_name'
+      })
+    allow(subscription).to receive(:[]).with('quantity').and_return('10')
+    allow(subscription).to receive(:customer).and_return('cus_123')
+    create(:installation_config, { 
+      name: 'CHATWOOT_CLOUD_PLANS', 
+      value: [
+        {
+          "name"=>"Hacker",
+          "product_id"=>["plan_id"],
+          "price_ids"=>["price_1"]
+        },
+        {
+          "name"=>"Startups",
+          "product_id"=>["plan_id_2"],
+          "price_ids"=>["price_2"]
+        }
+      ] 
+    }) 
+  end
+
+  describe '#perform' do
+    it 'handle customer.subscription.updated' do
+      allow(event).to receive(:type).and_return('customer.subscription.updated')
+      allow(subscription).to receive(:customer).and_return('cus_123')
+      stripe_event_service.new.perform(event: event)
+      expect(account.reload.custom_attributes).to eq({
+        'stripe_customer_id' => 'cus_123',
+        'stripe_price_id' => 'test',
+        'stripe_product_id' => 'plan_id',
+        'plan_name' => 'Hacker',
+        'subscribed_quantity' => '10'
+      })
+    end
+
+    it 'handles customer.subscription.deleted' do
+      stripe_customer_service = double
+      allow(event).to receive(:type).and_return('customer.subscription.deleted')
+      allow(Enterprise::Billing::CreateStripeCustomerService).to receive(:new).and_return(stripe_customer_service)
+      allow(stripe_customer_service).to receive(:perform)
+      stripe_event_service.new.perform(event: event)
+      expect(Enterprise::Billing::CreateStripeCustomerService).to have_received(:new).with(account: account)
+    end
+  end
+end

--- a/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
@@ -2,35 +2,36 @@ require 'rails_helper'
 
 describe Enterprise::Billing::HandleStripeEventService do
   subject(:stripe_event_service) { described_class }
+
   let(:event) { double }
   let(:data) { double }
   let(:subscription) { double }
   let!(:account) { create(:account, custom_attributes: { stripe_customer_id: 'cus_123' }) }
-  
+
   before do
     allow(event).to receive(:data).and_return(data)
     allow(data).to receive(:object).and_return(subscription)
-    allow(subscription).to receive(:[]).with('plan').
-      and_return({
-        'id' => 'test', 'product' => 'plan_id', 'name' => 'plan_name'
-      })
+    allow(subscription).to receive(:[]).with('plan')
+                                       .and_return({
+                                                     'id' => 'test', 'product' => 'plan_id', 'name' => 'plan_name'
+                                                   })
     allow(subscription).to receive(:[]).with('quantity').and_return('10')
     allow(subscription).to receive(:customer).and_return('cus_123')
-    create(:installation_config, { 
-      name: 'CHATWOOT_CLOUD_PLANS', 
-      value: [
-        {
-          "name"=>"Hacker",
-          "product_id"=>["plan_id"],
-          "price_ids"=>["price_1"]
-        },
-        {
-          "name"=>"Startups",
-          "product_id"=>["plan_id_2"],
-          "price_ids"=>["price_2"]
-        }
-      ] 
-    }) 
+    create(:installation_config, {
+             name: 'CHATWOOT_CLOUD_PLANS',
+             value: [
+               {
+                 'name' => 'Hacker',
+                 'product_id' => ['plan_id'],
+                 'price_ids' => ['price_1']
+               },
+               {
+                 'name' => 'Startups',
+                 'product_id' => ['plan_id_2'],
+                 'price_ids' => ['price_2']
+               }
+             ]
+           })
   end
 
   describe '#perform' do
@@ -39,12 +40,12 @@ describe Enterprise::Billing::HandleStripeEventService do
       allow(subscription).to receive(:customer).and_return('cus_123')
       stripe_event_service.new.perform(event: event)
       expect(account.reload.custom_attributes).to eq({
-        'stripe_customer_id' => 'cus_123',
-        'stripe_price_id' => 'test',
-        'stripe_product_id' => 'plan_id',
-        'plan_name' => 'Hacker',
-        'subscribed_quantity' => '10'
-      })
+                                                       'stripe_customer_id' => 'cus_123',
+                                                       'stripe_price_id' => 'test',
+                                                       'stripe_product_id' => 'plan_id',
+                                                       'plan_name' => 'Hacker',
+                                                       'subscribed_quantity' => '10'
+                                                     })
     end
 
     it 'handles customer.subscription.deleted' do


### PR DESCRIPTION
note: 
This will require a slight change in the webhook URL of stripe right after deploy
( to confirm with the URL schema of other webhooks which we use )
