### PR TITLE
Fix 5085: Delete all outgoing message related to deleted contact

### DIFF
--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -90,7 +90,10 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
       return render_error({ message: I18n.t('contacts.online.delete', contact_name: @contact.name.capitalize) },
                           :unprocessable_entity)
     end
-
+    conversation = Conversation.where(contact_id: @contact.id).first!
+    if conversation
+    	Message.where(conversation_id: conversation.id).destroy_all
+    end
     @contact.destroy!
     head :ok
   end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will update some logic on destroy method under contacts controller. The added code aim to remove all outgoing messages that related to contact that will be deleted

Fixes #5085

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Already tested on my local. Here is the step
- Sending message and fill email on widget, this will created new contact and message will coming on portal
- Send message to the just added contact
- Go to Reports page, check that Outgoing Message count more than 0
- Delete the just added contact
- Go to Reports page, check that Outgoing Message back to 0


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings