### PR TITLE
feat: Read/Delivery status Whatsapp (#1021)

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -53,10 +53,12 @@
           :story-sender="storySender"
           :story-id="storyId"
           :is-a-tweet="isATweet"
+          :is-a-whatsapp-channel="isAWhatsappChannel"
           :has-instagram-story="hasInstagramStory"
           :is-email="isEmailContentType"
           :is-private="data.private"
           :message-type="data.message_type"
+          :message-status="status"
           :readable-time="readableTime"
           :source-id="data.source_id"
           :inbox-id="data.inbox_id"
@@ -150,6 +152,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    isAWhatsappChannel: {
+      type: Boolean,
+      default: false,
+    },
     hasInstagramStory: {
       type: Boolean,
       default: false,
@@ -219,6 +225,9 @@ export default {
     },
     sender() {
       return this.data.sender || {};
+    },
+    status() {
+      return this.data.status;
     },
     storySender() {
       return this.contentAttributes.story_sender || null;

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -38,6 +38,7 @@
         class="message--read"
         :data="message"
         :is-a-tweet="isATweet"
+        :is-a-whatsapp-channel="isAWhatsappChannel"
         :has-instagram-story="hasInstagramStory"
         :has-user-read-message="
           hasUserReadMessage(message.created_at, getLastSeenAt)
@@ -60,6 +61,7 @@
         class="message--unread"
         :data="message"
         :is-a-tweet="isATweet"
+        :is-a-whatsapp-channel="isAWhatsappChannel"
         :has-instagram-story="hasInstagramStory"
         :has-user-read-message="
           hasUserReadMessage(message.created_at, getLastSeenAt)

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -3,20 +3,30 @@
     <span class="time" :class="{ delivered: messageRead }">{{
       readableTime
     }}</span>
+    <span v-if="showReadIndicator" class="time">
+      <fluent-icon
+        v-tooltip.top-start="$t('CHAT_LIST.MESSAGE_READ')"
+        icon="checkmark-double"
+        class="action--icon read-tick read-indicator"
+        size="16"
+      />
+    </span>
+    <span v-if="showDeliveredIndicator" class="time">
+      <fluent-icon
+        v-tooltip.top-start="$t('CHAT_LIST.DELIVERED')"
+        icon="checkmark-double"
+        class="action--icon read-tick"
+        size="16"
+      />
+    </span>
     <span v-if="showSentIndicator" class="time">
       <fluent-icon
         v-tooltip.top-start="$t('CHAT_LIST.SENT')"
         icon="checkmark"
-        size="14"
+        class="action--icon read-tick"
+        size="16"
       />
     </span>
-    <fluent-icon
-      v-if="messageRead"
-      v-tooltip.top-start="$t('CHAT_LIST.MESSAGE_READ')"
-      icon="checkmark-double"
-      class="action--icon read-tick"
-      size="12"
-    />
     <fluent-icon
       v-if="isEmail"
       v-tooltip.top-start="$t('CHAT_LIST.RECEIVED_VIA_EMAIL')"
@@ -74,7 +84,7 @@
 </template>
 
 <script>
-import { MESSAGE_TYPE } from 'shared/constants/messages';
+import { MESSAGE_TYPE, MESSAGE_STATUS } from 'shared/constants/messages';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import inboxMixin from 'shared/mixins/inboxMixin';
 
@@ -117,6 +127,10 @@ export default {
       type: Number,
       default: 1,
     },
+    messageStatus: {
+      type: String,
+      default: '',
+    },
     sourceId: {
       type: String,
       default: '',
@@ -144,6 +158,15 @@ export default {
     isOutgoing() {
       return MESSAGE_TYPE.OUTGOING === this.messageType;
     },
+    isDelivered() {
+      return MESSAGE_STATUS.DELIVERED === this.messageStatus;
+    },
+    isRead() {
+      return MESSAGE_STATUS.READ === this.messageStatus;
+    },
+    isSent() {
+      return MESSAGE_STATUS.SENT === this.messageStatus;
+    },
     screenName() {
       const { additional_attributes: additionalAttributes = {} } =
         this.sender || {};
@@ -168,8 +191,14 @@ export default {
       return (
         this.isOutgoing &&
         this.sourceId &&
-        (this.isAnEmailChannel || this.isAWhatsappChannel)
+        (this.isAnEmailChannel || (this.isAWhatsappChannel && this.isSent))
       );
+    },
+    showDeliveredIndicator() {
+      return this.isAWhatsappChannel && this.isDelivered;
+    },
+    showReadIndicator() {
+      return this.isAWhatsappChannel && this.isRead;
     },
   },
   methods: {
@@ -182,6 +211,10 @@ export default {
 
 <style lang="scss" scoped>
 @import '~dashboard/assets/scss/woot';
+
+.read-indicator {
+  color: #44ce4b !important;
+}
 
 .right {
   .message-text--metadata {

--- a/app/javascript/dashboard/i18n/locale/en/chatlist.json
+++ b/app/javascript/dashboard/i18n/locale/en/chatlist.json
@@ -56,6 +56,8 @@
     "REPLY_TO_TWEET": "Reply to this tweet",
     "LINK_TO_STORY": "Go to instagram story",
     "SENT": "Sent successfully",
+    "READ": "Read successfully",
+    "DELIVERED": "Delivered successfully",
     "NO_MESSAGES": "No Messages",
     "NO_CONTENT": "No content available",
     "HIDE_QUOTED_TEXT": "Hide Quoted Text",

--- a/app/javascript/shared/constants/messages.js
+++ b/app/javascript/shared/constants/messages.js
@@ -1,6 +1,8 @@
 export const MESSAGE_STATUS = {
   FAILED: 'failed',
   SENT: 'sent',
+  DELIVERED: 'delivered',
+  READ: 'read',
   PROGRESS: 'progress',
 };
 

--- a/app/views/api/v1/models/_message.json.jbuilder
+++ b/app/views/api/v1/models/_message.json.jbuilder
@@ -5,6 +5,7 @@ json.echo_id message.echo_id if message.echo_id
 json.conversation_id message.conversation.display_id
 json.message_type message.message_type_before_type_cast
 json.content_type message.content_type
+json.status message.status
 json.content_attributes message.content_attributes
 json.created_at message.created_at.to_i
 json.private message.private


### PR DESCRIPTION
## Read/Delivery whatsapp cloud api status

Process field `statuses` receives in webhook whatsapp cloud api


## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Create a spec
