### PR TITLE
Possible change URL for WhatsApp Cloud API

### DIFF
--- a/app/javascript/dashboard/components/layout/specs/AvailabilityStatus.spec.js
+++ b/app/javascript/dashboard/components/layout/specs/AvailabilityStatus.spec.js
@@ -5,6 +5,7 @@ import VueI18n from 'vue-i18n';
 
 import WootButton from 'dashboard/components/ui/WootButton';
 import WootDropdownItem from 'shared/components/ui/dropdown/DropdownItem';
+import WootSwitch from 'dashboard/components/ui/Switch';
 import WootDropdownMenu from 'shared/components/ui/dropdown/DropdownMenu';
 import WootDropdownHeader from 'shared/components/ui/dropdown/DropdownHeader';
 import WootDropdownDivider from 'shared/components/ui/dropdown/DropdownDivider';
@@ -18,6 +19,7 @@ localVue.component('woot-dropdown-header', WootDropdownHeader);
 localVue.component('woot-dropdown-menu', WootDropdownMenu);
 localVue.component('woot-dropdown-divider', WootDropdownDivider);
 localVue.component('woot-dropdown-item', WootDropdownItem);
+localVue.component('woot-switch', WootSwitch);
 
 const i18nConfig = new VueI18n({
   locale: 'en',

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -211,6 +211,11 @@
           "PLACEHOLDER": "Please enter an inbox name",
           "ERROR": "This field is required"
         },
+        "URL": {
+          "LABEL": "Whatsapp Cloud API URL",
+          "PLACEHOLDER": "Please enter an Whatsapp Cloud API URL or use default https://graph.facebook.com",
+          "ERROR": "This field is required"
+        },
         "PHONE_NUMBER": {
           "LABEL": "Phone number",
           "PLACEHOLDER": "Please enter the phone number from which message will be sent.",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/CloudWhatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/CloudWhatsapp.vue
@@ -85,6 +85,26 @@
       </label>
     </div>
 
+    <div class="medium-8 columns">
+      <label :class="{ error: $v.url.$error }">
+        {{ $t('INBOX_MGMT.ADD.WHATSAPP.URL.LABEL') }}
+        <fieldset>
+          <legend>
+            <woot-switch v-model="advanced" size="small" :value="advanced" />
+          </legend>
+          <input
+            v-model.trim="url"
+            :disabled="!advanced"
+            type="text"
+            placeholder="$t('INBOX_MGMT.ADD.WHATSAPP.URL.PLACEHOLDER')"
+          />
+          <span v-if="$v.url.$error" class="message">
+            {{ $t('INBOX_MGMT.ADD.WHATSAPP.URL.ERROR') }}
+          </span>
+        </fieldset>
+      </label>
+    </div>
+
     <div class="medium-12 columns">
       <woot-submit-button
         :loading="uiFlags.isCreating"
@@ -99,7 +119,7 @@ import { mapGetters } from 'vuex';
 import alertMixin from 'shared/mixins/alertMixin';
 import { required } from 'vuelidate/lib/validators';
 import router from '../../../../index';
-import { isPhoneE164OrEmpty, isNumber } from 'shared/helpers/Validators';
+import { isPhoneE164OrEmpty } from 'shared/helpers/Validators';
 
 export default {
   mixins: [alertMixin],
@@ -108,8 +128,10 @@ export default {
       inboxName: '',
       phoneNumber: '',
       apiKey: '',
+      url: 'https://graph.facebook.com',
       phoneNumberId: '',
       businessAccountId: '',
+      advanced: false,
     };
   },
   computed: {
@@ -119,8 +141,9 @@ export default {
     inboxName: { required },
     phoneNumber: { required, isPhoneE164OrEmpty },
     apiKey: { required },
-    phoneNumberId: { required, isNumber },
-    businessAccountId: { required, isNumber },
+    phoneNumberId: { required },
+    businessAccountId: { required },
+    url: { required },
   },
   methods: {
     async createChannel() {
@@ -142,6 +165,7 @@ export default {
                 api_key: this.apiKey,
                 phone_number_id: this.phoneNumberId,
                 business_account_id: this.businessAccountId,
+                url: this.url,
               },
             },
           }

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -50,6 +50,7 @@ class Channel::Whatsapp < ApplicationRecord
     true
   end
 
+  delegate :whatsapp_cloud_api_unofficial?, to: :provider_service
   delegate :send_message, to: :provider_service
   delegate :send_template, to: :provider_service
   delegate :sync_templates, to: :provider_service

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -102,12 +102,13 @@ class Conversation < ApplicationRecord
   def can_reply?
     channel = inbox&.channel
 
+    return true if channel.try(:whatsapp_cloud_api_unofficial?)
+
     return can_reply_on_instagram? if additional_attributes['type'] == 'instagram_direct_message'
 
     return true unless channel&.messaging_window_enabled?
 
-    messaging_window = inbox.api? ? channel.additional_attributes['agent_reply_time_window'].to_i : 24
-    last_message_in_messaging_window?(messaging_window)
+    last_message_in_messaging_window?(inbox.messaging_window)
   end
 
   def last_incoming_message

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -142,6 +142,10 @@ class Inbox < ApplicationRecord
     members.ids
   end
 
+  def messaging_window
+    api? ? channel.additional_attributes['agent_reply_time_window'].to_i : 24
+  end
+
   private
 
   def ensure_valid_max_assignment_limit

--- a/app/services/whatsapp/providers/base_service.rb
+++ b/app/services/whatsapp/providers/base_service.rb
@@ -26,4 +26,8 @@ class Whatsapp::Providers::BaseService
   def validate_provider_config
     raise 'Overwrite this method in child class'
   end
+
+  def whatsapp_cloud_api_unofficial?
+    false
+  end
 end

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -37,18 +37,30 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   end
 
   def media_url(media_id)
-    "https://graph.facebook.com/v13.0/#{media_id}"
+    "#{api_base_path}/v13.0/#{media_id}"
+  end
+
+  def whatsapp_cloud_api_unofficial?
+    !api_base_path.start_with?(facebook_api_base_path)
   end
 
   private
 
+  def facebook_api_base_path
+    ENV.fetch('WHATSAPP_CLOUD_BASE_URL', 'https://graph.facebook.com')
+  end
+
+  def api_base_path
+    whatsapp_channel.provider_config['url'] || facebook_api_base_path
+  end
+
   # TODO: See if we can unify the API versions and for both paths and make it consistent with out facebook app API versions
   def phone_id_path
-    "https://graph.facebook.com/v13.0/#{whatsapp_channel.provider_config['phone_number_id']}"
+    "#{api_base_path}/v13.0/#{whatsapp_channel.provider_config['phone_number_id']}"
   end
 
   def business_account_path
-    "https://graph.facebook.com/v14.0/#{whatsapp_channel.provider_config['business_account_id']}"
+    "#{api_base_path}/v14.0/#{whatsapp_channel.provider_config['business_account_id']}"
   end
 
   def send_text_message(phone_number, message)

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -508,6 +508,23 @@ RSpec.describe Conversation, type: :model do
       end
     end
 
+    describe 'on channels is unnoficial whatsapp cloud api' do
+      let(:url) { 'https://some.whatsapp-api.com' }
+      let(:channel) do
+        create(
+          :channel_whatsapp,
+          { provider: 'whatsapp_cloud', provider_config: { 'url' => url }, validate_provider_config: false, sync_templates: false }
+        )
+      end
+      let(:inbox) { create(:inbox, channel: channel, account: channel.account) }
+      let(:conversation) { create(:conversation, inbox: inbox) }
+
+      it 'returns true' do
+        conversation.inbox.channel.provider_config['url'] = url
+        expect(conversation.can_reply?).to be true
+      end
+    end
+
     describe 'on channels with 24 hour restriction' do
       before do
         stub_request(:post, /graph.facebook.com/)

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -66,6 +66,15 @@ describe Whatsapp::Providers::WhatsappCloudService do
     end
   end
 
+  describe 'unnoficial whatsapp cloud api' do
+    let(:url) { 'https://some.whatsapp-api.com' }
+
+    it 'returns true' do
+      whatsapp_channel.provider_config['url'] = url
+      expect(whatsapp_channel.whatsapp_cloud_api_unofficial?).to be true
+    end
+  end
+
   describe '#send_template' do
     let(:template_info) do
       {


### PR DESCRIPTION
##  Whatsapp Cloud API unnoficial option

Add field in form Inbox type Whatsapp Cloud Api with default url to https://graph.facebook.com and a method whatsapp_cloud_api_unofficial? to compare this url to verify if message cloud be send


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This feature is possible use whatsapp with https://github.com/adiwajshing/Baileys ou any project implementing a whatsapp cloud api layer without error on Whatspp Cloud API Official
