### PR TITLE
feat: Read/Delivery status for Whatsapp Cloud API

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -59,10 +59,12 @@
           :story-sender="storySender"
           :story-id="storyId"
           :is-a-tweet="isATweet"
+          :is-a-whatsapp-channel="isAWhatsAppChannel"
           :has-instagram-story="hasInstagramStory"
           :is-email="isEmailContentType"
           :is-private="data.private"
           :message-type="data.message_type"
+          :message-status="status"
           :readable-time="readableTime"
           :source-id="data.source_id"
           :inbox-id="data.inbox_id"
@@ -157,6 +159,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    isAWhatsAppChannel: {
+      type: Boolean,
+      default: false,
+    },
     hasInstagramStory: {
       type: Boolean,
       default: false,
@@ -230,6 +236,9 @@ export default {
     },
     sender() {
       return this.data.sender || {};
+    },
+    status() {
+      return this.data.status;
     },
     storySender() {
       return this.contentAttributes.story_sender || null;

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -38,6 +38,7 @@
         class="message--read ph-no-capture"
         :data="message"
         :is-a-tweet="isATweet"
+        :is-a-whatsapp-channel="isAWhatsAppChannel"
         :has-instagram-story="hasInstagramStory"
         :has-user-read-message="
           hasUserReadMessage(message.created_at, getLastSeenAt)
@@ -60,6 +61,7 @@
         class="message--unread ph-no-capture"
         :data="message"
         :is-a-tweet="isATweet"
+        :is-a-whatsapp-channel="isAWhatsAppChannel"
         :has-instagram-story="hasInstagramStory"
         :has-user-read-message="
           hasUserReadMessage(message.created_at, getLastSeenAt)

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -3,20 +3,30 @@
     <span class="time" :class="{ delivered: messageRead }">{{
       readableTime
     }}</span>
+    <span v-if="showReadIndicator" class="time">
+      <fluent-icon
+        v-tooltip.top-start="$t('CHAT_LIST.MESSAGE_READ')"
+        icon="checkmark-double"
+        class="action--icon read-tick read-indicator"
+        size="16"
+      />
+    </span>
+    <span v-if="showDeliveredIndicator" class="time">
+      <fluent-icon
+        v-tooltip.top-start="$t('CHAT_LIST.DELIVERED')"
+        icon="checkmark-double"
+        class="action--icon read-tick"
+        size="16"
+      />
+    </span>
     <span v-if="showSentIndicator" class="time">
       <fluent-icon
         v-tooltip.top-start="$t('CHAT_LIST.SENT')"
         icon="checkmark"
-        size="14"
+        class="action--icon read-tick"
+        size="16"
       />
     </span>
-    <fluent-icon
-      v-if="messageRead"
-      v-tooltip.top-start="$t('CHAT_LIST.MESSAGE_READ')"
-      icon="checkmark-double"
-      class="action--icon read-tick"
-      size="12"
-    />
     <fluent-icon
       v-if="isEmail"
       v-tooltip.top-start="$t('CHAT_LIST.RECEIVED_VIA_EMAIL')"
@@ -74,7 +84,7 @@
 </template>
 
 <script>
-import { MESSAGE_TYPE } from 'shared/constants/messages';
+import { MESSAGE_TYPE, MESSAGE_STATUS } from 'shared/constants/messages';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import inboxMixin from 'shared/mixins/inboxMixin';
 
@@ -117,6 +127,10 @@ export default {
       type: Number,
       default: 1,
     },
+    messageStatus: {
+      type: String,
+      default: '',
+    },
     sourceId: {
       type: String,
       default: '',
@@ -144,6 +158,15 @@ export default {
     isOutgoing() {
       return MESSAGE_TYPE.OUTGOING === this.messageType;
     },
+    isDelivered() {
+      return MESSAGE_STATUS.DELIVERED === this.messageStatus;
+    },
+    isRead() {
+      return MESSAGE_STATUS.READ === this.messageStatus;
+    },
+    isSent() {
+      return MESSAGE_STATUS.SENT === this.messageStatus;
+    },
     screenName() {
       const { additional_attributes: additionalAttributes = {} } =
         this.sender || {};
@@ -168,7 +191,23 @@ export default {
       return (
         this.isOutgoing &&
         this.sourceId &&
-        (this.isAnEmailChannel || this.isAWhatsAppChannel)
+        (this.isAnEmailChannel || (this.isAWhatsAppChannel && this.isSent))
+      );
+    },
+    showDeliveredIndicator() {
+      return (
+        this.isOutgoing &&
+        this.sourceId &&
+        this.isAWhatsAppChannel &&
+        this.isDelivered
+      );
+    },
+    showReadIndicator() {
+      return (
+        this.isOutgoing &&
+        this.sourceId &&
+        this.isAWhatsAppChannel &&
+        this.isRead
       );
     },
   },
@@ -182,6 +221,10 @@ export default {
 
 <style lang="scss" scoped>
 @import '~dashboard/assets/scss/woot';
+
+.read-indicator {
+  color: #44ce4b !important;
+}
 
 .right {
   .message-text--metadata {

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -3,28 +3,28 @@
     <span class="time" :class="{ delivered: messageRead }">{{
       readableTime
     }}</span>
-    <span v-if="showReadIndicator" class="time">
+    <span v-if="showReadIndicator" class="read-indicator-wrap">
       <fluent-icon
         v-tooltip.top-start="$t('CHAT_LIST.MESSAGE_READ')"
         icon="checkmark-double"
         class="action--icon read-tick read-indicator"
-        size="16"
+        size="14"
       />
     </span>
-    <span v-if="showDeliveredIndicator" class="time">
+    <span v-if="showDeliveredIndicator" class="read-indicator-wrap">
       <fluent-icon
         v-tooltip.top-start="$t('CHAT_LIST.DELIVERED')"
         icon="checkmark-double"
         class="action--icon read-tick"
-        size="16"
+        size="14"
       />
     </span>
-    <span v-if="showSentIndicator" class="time">
+    <span v-if="showSentIndicator" class="read-indicator-wrap">
       <fluent-icon
         v-tooltip.top-start="$t('CHAT_LIST.SENT')"
         icon="checkmark"
         class="action--icon read-tick"
-        size="16"
+        size="14"
       />
     </span>
     <fluent-icon
@@ -222,22 +222,22 @@ export default {
 <style lang="scss" scoped>
 @import '~dashboard/assets/scss/woot';
 
-.read-indicator {
-  color: #44ce4b !important;
-}
-
 .right {
   .message-text--metadata {
+    align-items: center;
     .time {
       color: var(--w-100);
     }
 
     .action--icon {
+      color: var(--white);
       &.read-tick {
         color: var(--v-100);
-        margin-top: calc(var(--space-micro) + var(--space-micro) / 2);
       }
-      color: var(--white);
+
+      &.read-indicator {
+        color: var(--g-300);
+      }
     }
 
     .lock--icon--private {
@@ -338,5 +338,11 @@ export default {
 
 .delivered-icon {
   margin-left: -var(--space-normal);
+}
+
+.read-indicator-wrap {
+  line-height: 1;
+  display: flex;
+  align-items: center;
 }
 </style>

--- a/app/javascript/dashboard/i18n/locale/en/chatlist.json
+++ b/app/javascript/dashboard/i18n/locale/en/chatlist.json
@@ -56,6 +56,8 @@
     "REPLY_TO_TWEET": "Reply to this tweet",
     "LINK_TO_STORY": "Go to instagram story",
     "SENT": "Sent successfully",
+    "READ": "Read successfully",
+    "DELIVERED": "Delivered successfully",
     "NO_MESSAGES": "No Messages",
     "NO_CONTENT": "No content available",
     "HIDE_QUOTED_TEXT": "Hide Quoted Text",

--- a/app/javascript/shared/constants/messages.js
+++ b/app/javascript/shared/constants/messages.js
@@ -1,6 +1,8 @@
 export const MESSAGE_STATUS = {
   FAILED: 'failed',
   SENT: 'sent',
+  DELIVERED: 'delivered',
+  READ: 'read',
   PROGRESS: 'progress',
 };
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -65,8 +65,9 @@ class Message < ApplicationRecord
   # [:in_reply_to] : Used to reply to a particular tweet in threads
   # [:deleted] : Used to denote whether the message was deleted by the agent
   # [:external_created_at] : Can specify if the message was created at a different timestamp externally
+  # [:external_error : Can specify if the message creation failed due to an error at external API
   store :content_attributes, accessors: [:submitted_email, :items, :submitted_values, :email, :in_reply_to, :deleted,
-                                         :external_created_at, :story_sender, :story_id], coder: JSON
+                                         :external_created_at, :story_sender, :story_id, :external_error], coder: JSON
 
   store :external_source_ids, accessors: [:slack], coder: JSON, prefix: :external_source_id
 

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -7,11 +7,45 @@ class Whatsapp::IncomingMessageBaseService
   def perform
     processed_params
 
+    perform_statuses
+
     set_contact
     return unless @contact
 
     set_conversation
 
+    perform_messages
+  end
+
+  private
+
+  def perform_statuses
+    return if @processed_params[:statuses].blank?
+
+    state = @processed_params[:statuses].first
+    @message = Message.find_by(source_id: state[:id])
+    return unless @message
+
+    ActiveRecord::Base.transaction do
+      create_message_for_failed_status(state)
+
+      @message.status = state[:status]
+      @message.save!
+    end
+  end
+
+  def create_message_for_failed_status(state)
+    return if state[:status] != 'failed' || state[:errors]&.empty?
+
+    error = state[:errors]&.first
+    Message.create!(
+      conversation_id: @message.conversation_id, content: "#{error[:code]}: #{error[:title]}",
+      account_id: @inbox.account_id, inbox_id: @inbox.id,
+      message_type: :activity, sender: @message.sender, source_id: @message.source_id
+    )
+  end
+
+  def perform_messages
     return if @processed_params[:messages].blank? || unprocessable_message_type?
 
     @message = @conversation.messages.build(
@@ -26,8 +60,6 @@ class Whatsapp::IncomingMessageBaseService
     attach_location
     @message.save!
   end
-
-  private
 
   def processed_params
     @processed_params ||= params

--- a/app/views/api/v1/models/_message.json.jbuilder
+++ b/app/views/api/v1/models/_message.json.jbuilder
@@ -5,6 +5,7 @@ json.echo_id message.echo_id if message.echo_id
 json.conversation_id message.conversation.display_id
 json.message_type message.message_type_before_type_cast
 json.content_type message.content_type
+json.status message.status
 json.content_attributes message.content_attributes
 json.created_at message.created_at.to_i
 json.private message.private

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -71,47 +71,42 @@ describe Whatsapp::IncomingMessageService do
     end
 
     context 'when valid status params' do
-      it 'update status message to read' do
-        source_id = 'SDFADSf23sfasdafasdfa'
-        from = '2423423243'
-        params = {
+      let(:from) { '2423423243' }
+      let(:contact_inbox) { create(:contact_inbox, inbox: whatsapp_channel.inbox, source_id: from) }
+      let(:params) do
+        {
           'contacts' => [{ 'profile' => { 'name' => 'Sojan Jose' }, 'wa_id' => from }],
-          'messages' => [{ 'from' => from, 'id' => source_id, 'text' => { 'body' => 'Test' },
+          'messages' => [{ 'from' => from, 'id' => from, 'text' => { 'body' => 'Test' },
                            'timestamp' => '1633034394', 'type' => 'text' }]
         }.with_indifferent_access
-        contact_inbox = create(:contact_inbox, inbox: whatsapp_channel.inbox, source_id: params[:messages].first[:from])
+      end
+
+      before do 
         create(:conversation, inbox: whatsapp_channel.inbox, contact_inbox: contact_inbox)
         described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+      end
 
+      it 'update status message to read' do
         status_params = {
-          'statuses' => [{ 'recipient_id' => from, 'id' => source_id, 'status' => 'read' }]
+          'statuses' => [{ 'recipient_id' => from, 'id' => from, 'status' => 'read' }]
         }.with_indifferent_access
-        expect(Message.find_by!(source_id: source_id).status).to eq('sent')
+        message = Message.find_by!(source_id: from)
+        expect(message.status).to eq('sent')
         described_class.new(inbox: whatsapp_channel.inbox, params: status_params).perform
-        expect(Message.find_by!(source_id: source_id).status).to eq('read')
+        expect(message.reload.status).to eq('read')
       end
 
       it 'update status message to failed' do
-        source_id = 'SDFADSf23sfasdafasdfa'
-        from = '2423423243'
-        params = {
-          'contacts' => [{ 'profile' => { 'name' => 'Sojan Jose' }, 'wa_id' => from }],
-          'messages' => [{ 'from' => from, 'id' => source_id, 'text' => { 'body' => 'Test' },
-                           'timestamp' => '1633034394', 'type' => 'text' }]
-        }.with_indifferent_access
-        contact_inbox = create(:contact_inbox, inbox: whatsapp_channel.inbox, source_id: params[:messages].first[:from])
-        last_conversation = create(:conversation, inbox: whatsapp_channel.inbox, contact_inbox: contact_inbox)
-        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
-
         status_params = {
-          'statuses' => [{ 'recipient_id' => from, 'id' => source_id, 'status' => 'failed',
+          'statuses' => [{ 'recipient_id' => from, 'id' => from, 'status' => 'failed',
                            'errors' => [{ 'code': 123, 'title': 'abc' }] }]
         }.with_indifferent_access
-        expect(Message.find_by!(source_id: source_id).status).to eq('sent')
-        expect(last_conversation.messages.count).to eq(1)
+        
+        message = Message.find_by!(source_id: from)
+        expect(message.status).to eq('sent')
         described_class.new(inbox: whatsapp_channel.inbox, params: status_params).perform
-        expect(last_conversation.messages.count).to eq(2)
-        expect(Message.find_by!(source_id: source_id).status).to eq('failed')
+        expect(message.reload.status).to eq('failed')
+        expect(message.external_error).to eq('123: abc')
       end
     end
 

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -70,6 +70,51 @@ describe Whatsapp::IncomingMessageService do
       end
     end
 
+    context 'when valid status params' do
+      it 'update status message to read' do
+        source_id = 'SDFADSf23sfasdafasdfa'
+        from = '2423423243'
+        params = {
+          'contacts' => [{ 'profile' => { 'name' => 'Sojan Jose' }, 'wa_id' => from }],
+          'messages' => [{ 'from' => from, 'id' => source_id, 'text' => { 'body' => 'Test' },
+                           'timestamp' => '1633034394', 'type' => 'text' }]
+        }.with_indifferent_access
+        contact_inbox = create(:contact_inbox, inbox: whatsapp_channel.inbox, source_id: params[:messages].first[:from])
+        create(:conversation, inbox: whatsapp_channel.inbox, contact_inbox: contact_inbox)
+        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+
+        status_params = {
+          'statuses' => [{ 'recipient_id' => from, 'id' => source_id, 'status' => 'read' }]
+        }.with_indifferent_access
+        expect(Message.find_by!(source_id: source_id).status).to eq('sent')
+        described_class.new(inbox: whatsapp_channel.inbox, params: status_params).perform
+        expect(Message.find_by!(source_id: source_id).status).to eq('read')
+      end
+
+      it 'update status message to failed' do
+        source_id = 'SDFADSf23sfasdafasdfa'
+        from = '2423423243'
+        params = {
+          'contacts' => [{ 'profile' => { 'name' => 'Sojan Jose' }, 'wa_id' => from }],
+          'messages' => [{ 'from' => from, 'id' => source_id, 'text' => { 'body' => 'Test' },
+                           'timestamp' => '1633034394', 'type' => 'text' }]
+        }.with_indifferent_access
+        contact_inbox = create(:contact_inbox, inbox: whatsapp_channel.inbox, source_id: params[:messages].first[:from])
+        last_conversation = create(:conversation, inbox: whatsapp_channel.inbox, contact_inbox: contact_inbox)
+        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+
+        status_params = {
+          'statuses' => [{ 'recipient_id' => from, 'id' => source_id, 'status' => 'failed',
+                           'errors' => [{ 'code': 123, 'title': 'abc' }] }]
+        }.with_indifferent_access
+        expect(Message.find_by!(source_id: source_id).status).to eq('sent')
+        expect(last_conversation.messages.count).to eq(1)
+        described_class.new(inbox: whatsapp_channel.inbox, params: status_params).perform
+        expect(last_conversation.messages.count).to eq(2)
+        expect(Message.find_by!(source_id: source_id).status).to eq('failed')
+      end
+    end
+
     context 'when valid interactive message params' do
       it 'creates appropriate conversations, message and contacts' do
         params = {

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -81,7 +81,7 @@ describe Whatsapp::IncomingMessageService do
         }.with_indifferent_access
       end
 
-      before do 
+      before do
         create(:conversation, inbox: whatsapp_channel.inbox, contact_inbox: contact_inbox)
         described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
       end
@@ -101,7 +101,7 @@ describe Whatsapp::IncomingMessageService do
           'statuses' => [{ 'recipient_id' => from, 'id' => from, 'status' => 'failed',
                            'errors' => [{ 'code': 123, 'title': 'abc' }] }]
         }.with_indifferent_access
-        
+
         message = Message.find_by!(source_id: from)
         expect(message.status).to eq('sent')
         described_class.new(inbox: whatsapp_channel.inbox, params: status_params).perform


### PR DESCRIPTION
ref: #1021

# Read/Delivery whatsapp cloud api status

## Description

Process field statuses receives in webhook whatsapp cloud api

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Creating a spec
