### PR TITLE
fix: assigned_conversation_new_message? NoMethod error

### DIFF
--- a/app/builders/notification_builder.rb
+++ b/app/builders/notification_builder.rb
@@ -15,7 +15,7 @@ class NotificationBuilder
 
   def user_subscribed_to_notification?
     notification_setting = user.notification_settings.find_by(account_id: account.id)
-    # added for the case where an assignee might be removed from the account but still remains in conversaton
+    # added for the case where an assignee might be removed from the account but remains in conversation
     return if notification_setting.blank?
 
     return true if notification_setting.public_send("email_#{notification_type}?")

--- a/app/builders/notification_builder.rb
+++ b/app/builders/notification_builder.rb
@@ -15,6 +15,9 @@ class NotificationBuilder
 
   def user_subscribed_to_notification?
     notification_setting = user.notification_settings.find_by(account_id: account.id)
+    # added for the case where an assignee might be removed from the account but still remains in conversaton
+    return if notification_setting.blank?
+
     return true if notification_setting.public_send("email_#{notification_type}?")
     return true if notification_setting.public_send("push_#{notification_type}?")
 

--- a/spec/builders/notification_builder_spec.rb
+++ b/spec/builders/notification_builder_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe ::NotificationBuilder do
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    let!(:account) { create(:account) }
+    let!(:user) { create(:user, account: account) }
+    let!(:primary_actor) { create(:conversation, account: account) }
+
+    before do
+      notification_setting = user.notification_settings.find_by(account_id: account.id)
+      notification_setting.selected_email_flags = [:email_conversation_creation]
+      notification_setting.save!
+    end
+
+    it 'creates a notification' do
+      expect do
+        described_class.new(
+          notification_type: 'conversation_creation',
+          user: user,
+          account: account,
+          primary_actor: primary_actor
+        ).perform
+      end.to change { user.notifications.count }.by(1)
+    end
+
+    it 'will not throw error if notification setting is not present' do
+      user.account_users.destroy_all
+      expect(
+        described_class.new(
+          notification_type: 'conversation_creation',
+          user: user,
+          account: account,
+          primary_actor: primary_actor
+        ).perform
+      ).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This issue occurs when the conversation assignee is removed from an account, but the assignment persists. This leads to an error when we try to fetch the user's notification settings associated with that account.

fixes: #5223

