### PR TITLE
chore: Add notification ID to tag to make it unique

### DIFF
--- a/app/services/notification/push_notification_service.rb
+++ b/app/services/notification/push_notification_service.rb
@@ -33,7 +33,7 @@ class Notification::PushNotificationService
   def push_message
     {
       title: notification.push_message_title,
-      tag: "#{notification.notification_type}_#{conversation.display_id}",
+      tag: "#{notification.notification_type}_#{conversation.display_id}_#{notification.id}",
       url: push_url
     }
   end


### PR DESCRIPTION
Right now, if 2 messages are sent in an assigned conversation, we will only see one browser push notification. This is happening because the tag generated is not unique and is the same for both notifications. `new_message_{conversation_id}`

This PR updates the logic to generate a unique tag.

Fixes https://github.com/chatwoot/satisfilabs/issues/19