### PR TITLE
Fix 'imap_enabled' and 'smtp_enabled' condition in inbox config page

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
@@ -88,8 +88,8 @@
         <woot-code :script="inbox.forward_to_email" />
       </settings-section>
     </div>
-    <imap-settings :inbox="inbox" />
-    <smtp-settings v-if="inbox.imap_enabled" :inbox="inbox" />
+    <imap-settings v-if="inbox.imap_enabled" :inbox="inbox" />
+    <smtp-settings v-if="inbox.smtp_enabled" :inbox="inbox" />
   </div>
   <div v-else-if="isAWhatsappChannel && !isATwilioChannel">
     <div v-if="inbox.provider_config" class="settings--content">


### PR DESCRIPTION
## Description

Hi, I'm currently getting to know your awesome project. I have found a missing and a wrong condition in a settings page and I thought this could by my first contribution to this project.

Fixes # (issue)
* Missing condition for IMAP settings (`imap_enabled`).
* Wrong condition for SMTP settings component. `smtp_enabled` instead of `imap_enabled`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Test suite is fine.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
