### PR TITLE
fix: Auto populate team after assigned via API

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -48,4 +48,11 @@ class Team < ApplicationRecord
   def reporting_events
     account.reporting_events.where(conversation_id: conversations.pluck(:id))
   end
+
+  def push_event_data
+    {
+      id: id,
+      name: name
+    }
+  end
 end

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -27,6 +27,7 @@ class Conversations::EventDataPresenter < SimpleDelegator
     {
       sender: contact.push_event_data,
       assignee: assignee&.push_event_data,
+      team: team&.push_event_data,
       hmac_verified: contact_inbox&.hmac_verified
     }
   end

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -428,6 +428,7 @@ RSpec.describe Conversation, type: :model do
         meta: {
           sender: conversation.contact.push_event_data,
           assignee: conversation.assignee,
+          team: conversation.team,
           hmac_verified: conversation.contact_inbox.hmac_verified
         },
         id: conversation.display_id,

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Conversations::EventDataPresenter do
         meta: {
           sender: conversation.contact.push_event_data,
           assignee: conversation.assignee,
+          team: conversation.team,
           hmac_verified: conversation.contact_inbox.hmac_verified
         },
         id: conversation.display_id,


### PR DESCRIPTION
# Pull Request Template

## Description

When we assign a team via API, it was not auto-populating on UI.
The issue was, that our broadcast push_event_data wasn't containing the team information.

Fixes https://github.com/chatwoot/satisfilabs/issues/29

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Tested on local and via test cases.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
