### PR TITLE
chore: Improve memory usage in RemoveStaleNotificationsJob

### DIFF
--- a/app/jobs/migration/remove_stale_notifications_job.rb
+++ b/app/jobs/migration/remove_stale_notifications_job.rb
@@ -12,9 +12,8 @@ class Migration::RemoveStaleNotificationsJob < ApplicationJob
     deleted_ids = []
 
     Message.unscoped.distinct.pluck(:inbox_id).each_slice(1000) do |id_list|
-      deleted_ids << (id_list - Inbox.where(id: id_list).pluck(:id))
+      deleted_ids = (id_list - Inbox.where(id: id_list).pluck(:id))
+      Message.where(inbox_id: deleted_ids.flatten).destroy_all
     end
-
-    Message.where(inbox_id: deleted_ids.flatten).destroy_all
   end
 end


### PR DESCRIPTION
The job which we introduced recently for removing the stale migrations
would time out in instances with a large amount of deleted data.

So improving it for better memory utilization.

