### PR TITLE
hotfix: linux installation failure due to empty database name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ REDIS_SENTINEL_MASTER_NAME=
 # Postgres Database config variables
 # You can leave POSTGRES_DATABASE blank. The default name of 
 # the database in the production environment is chatwoot_production
-POSTGRES_DATABASE=
+# POSTGRES_DATABASE=
 POSTGRES_HOST=postgres
 POSTGRES_USERNAME=postgres
 POSTGRES_PASSWORD=


### PR DESCRIPTION
# Pull Request Template

## Description

The Linux installer is failing at the database migration stage for fresh `v2.8.0` installations. This is due to the empty `POSTGRES_DATABASE` variable from the `.env` file.

This does not affect docker and kubernetes installations.

Fixes #5281 
ref: https://github.com/chatwoot/chatwoot/runs/7869274506?check_suite_focus=true#step:6:31

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested on a fresh instance

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
