### PR TITLE
feat: Allow Dashboard App Frames to query the information 

### DIFF
--- a/app/javascript/dashboard/components/widgets/DashboardApp/Frame.vue
+++ b/app/javascript/dashboard/components/widgets/DashboardApp/Frame.vue
@@ -38,6 +38,18 @@ export default {
       return this.currentChat?.meta?.sender?.id;
     },
   },
+
+  mounted() {
+    window.onmessage = e => {
+      if (
+        typeof e.data !== 'string' ||
+        e.data === 'chatwoot-dashboard-app:fetch-info'
+      ) {
+        return;
+      }
+      this.onIframeLoad(0);
+    };
+  },
   methods: {
     onIframeLoad(index) {
       const frameElement = document.getElementById(

--- a/app/javascript/dashboard/components/widgets/DashboardApp/Frame.vue
+++ b/app/javascript/dashboard/components/widgets/DashboardApp/Frame.vue
@@ -43,7 +43,7 @@ export default {
     window.onmessage = e => {
       if (
         typeof e.data !== 'string' ||
-        e.data === 'chatwoot-dashboard-app:fetch-info'
+        e.data !== 'chatwoot-dashboard-app:fetch-info'
       ) {
         return;
       }


### PR DESCRIPTION
Allow dashboard app frames to query information after the load event. Following [this tweet](https://twitter.com/ericmigi/status/1560321001405050880), the Tooljet team and I did a sync-up to figure out why the events are not working.

- Dashboard Apps expected the message event to be registered on the load event.
- The Tooljet Apps had delayed loading. Their main page would fire the load event even before the event listeners were registered.
- There needed a way to query the information after the page was loaded.

With this change, the child iframe pages can send an event `chatwoot-dashboard-app:fetch-info` using postMessage. Then Chatwoot would respond with the appContext payload.