### PR TITLE
fix: un-assign agent from conversation after removal

### DIFF
--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -33,7 +33,7 @@ class AccountUser < ApplicationRecord
   accepts_nested_attributes_for :account
 
   after_create_commit :notify_creation, :create_notification_setting
-  after_destroy :notify_deletion, :remove_user_from_account, :unassign_conversations
+  after_destroy :notify_deletion, :remove_user_from_account
   after_save :update_presence_in_redis, if: :saved_change_to_availability?
 
   validates :user_id, uniqueness: { scope: :account_id }
@@ -61,9 +61,5 @@ class AccountUser < ApplicationRecord
 
   def update_presence_in_redis
     OnlineStatusTracker.set_status(account.id, user.id, availability)
-  end
-
-  def unassign_conversations
-    user.assigned_conversations.where(account: account).find_each(&:update_assignee)
   end
 end

--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -33,7 +33,7 @@ class AccountUser < ApplicationRecord
   accepts_nested_attributes_for :account
 
   after_create_commit :notify_creation, :create_notification_setting
-  after_destroy :notify_deletion, :remove_user_from_account
+  after_destroy :notify_deletion, :remove_user_from_account, :unassign_conversations
   after_save :update_presence_in_redis, if: :saved_change_to_availability?
 
   validates :user_id, uniqueness: { scope: :account_id }
@@ -61,5 +61,9 @@ class AccountUser < ApplicationRecord
 
   def update_presence_in_redis
     OnlineStatusTracker.set_status(account.id, user.id, availability)
+  end
+
+  def unassign_conversations
+    user.assigned_conversations.where(account: account).find_each(&:update_assignee)
   end
 end

--- a/app/services/agents/destroy_service.rb
+++ b/app/services/agents/destroy_service.rb
@@ -6,6 +6,7 @@ class Agents::DestroyService
       destroy_notification_setting
       remove_user_from_teams
       remove_user_from_inboxes
+      unassign_conversations
     end
   end
 
@@ -26,5 +27,9 @@ class Agents::DestroyService
   def destroy_notification_setting
     setting = user.notification_settings.find_by(account_id: account.id)
     setting&.destroy!
+  end
+
+  def unassign_conversations
+    user.assigned_conversations.where(account: account).find_each(&:update_assignee)
   end
 end

--- a/spec/services/agents/destroy_service_spec.rb
+++ b/spec/services/agents/destroy_service_spec.rb
@@ -9,6 +9,7 @@ describe Agents::DestroyService do
   before do
     create(:team_member, team: team1, user: user)
     create(:inbox_member, inbox: inbox, user: user)
+    create(:conversation, account: account, assignee: user, inbox: inbox)
   end
 
   describe '#perform' do
@@ -18,6 +19,7 @@ describe Agents::DestroyService do
       expect(user.teams.length).to eq 0
       expect(user.inboxes.length).to eq 0
       expect(user.notification_settings.length).to eq 0
+      expect(user.assigned_conversations.where(account: account).length).to eq 0
     end
   end
 end

--- a/spec/services/agents/destroy_service_spec.rb
+++ b/spec/services/agents/destroy_service_spec.rb
@@ -13,7 +13,7 @@ describe Agents::DestroyService do
   end
 
   describe '#perform' do
-    it 'remove inboxes and teams when removed from account' do
+    it 'remove inboxes, teams, and conversations when removed from account' do
       described_class.new(account: account, user: user).perform
       user.reload
       expect(user.teams.length).to eq 0


### PR DESCRIPTION
# Pull Request Template

## Description

Unassign agents from the conversation when they are removed from the account.

Fixes #4555

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested manually


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
