### PR TITLE
fix: contact is not available for inaccessible sender

### DIFF
--- a/app/services/instagram/message_text.rb
+++ b/app/services/instagram/message_text.rb
@@ -42,7 +42,7 @@ class Instagram::MessageText < Instagram::WebhooksBaseService
       ChatwootExceptionTracker.new(e, account: @inbox.account).capture_exception
     end
 
-    find_or_create_contact(result)
+    find_or_create_contact(result) if result.present?
   end
 
   def agent_message_via_echo?
@@ -71,6 +71,8 @@ class Instagram::MessageText < Instagram::WebhooksBaseService
   end
 
   def create_message
+    return unless @contact_inbox
+
     Messages::Instagram::MessageBuilder.new(@messaging, @inbox, outgoing_echo: agent_message_via_echo?).perform
   end
 

--- a/spec/factories/instagram/instagram_message_create_event.rb
+++ b/spec/factories/instagram/instagram_message_create_event.rb
@@ -147,4 +147,39 @@ FactoryBot.define do
     end
     initialize_with { attributes }
   end
+
+  factory :instagram_story_mention_event_with_echo, class: Hash do
+    entry do
+      [
+        {
+          'id': 'instagram-message-id-1234',
+          'time': '2021-09-08T06:34:04+0000',
+          'messaging': [
+            {
+              'sender': {
+                'id': 'Sender-id-1'
+              },
+              'recipient': {
+                'id': 'chatwoot-app-user-id-1'
+              },
+              'timestamp': '2021-09-08T06:34:04+0000',
+              'message': {
+                'mid': 'message-id-1',
+                'attachments': [
+                  {
+                    'type': 'story_mention',
+                    'payload': {
+                      'url': 'https://www.example.com/test.jpeg'
+                    }
+                  }
+                ],
+                'is_echo': true
+              }
+            }
+          ]
+        }
+      ]
+    end
+    initialize_with { attributes }
+  end
 end


### PR DESCRIPTION
Fixes: #5508 

We can not read contact information, because of this error, as the messages are echo messages when the sender sends the message to contacts and we don't have the consent of the user until and unless they send messages to us.

So after this result to get information about the contact is empty and we are trying to create a contact inbox for the same and the error appears.


type: OAuthException, code: 230, message: (#230) User consent is required to access user profile, x-fb-trace-id: AaitxF/whwY [HTTP 403] (Koala::Facebook::ClientError)