### PR TITLE
fix: DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated 

### DIFF
--- a/app/controllers/api/v1/accounts/csat_survey_responses_controller.rb
+++ b/app/controllers/api/v1/accounts/csat_survey_responses_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::Accounts::CsatSurveyResponsesController < Api::V1::Accounts::Base
   def download
     response.headers['Content-Type'] = 'text/csv'
     response.headers['Content-Disposition'] = 'attachment; filename=csat_report.csv'
-    render layout: false, template: 'api/v1/accounts/csat_survey_responses/download.csv.erb', format: 'csv'
+    render layout: false, template: 'api/v1/accounts/csat_survey_responses/download', formats: [:csv]
   end
 
   private

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::AccountsController < Api::BaseController
     ).perform
     if @user
       send_auth_headers(@user)
-      render 'api/v1/accounts/create.json', locals: { resource: @user }
+      render 'api/v1/accounts/create', format: :json, locals: { resource: @user }
     else
       render_error_response(CustomExceptions::Account::SignupFailed.new({}))
     end
@@ -32,7 +32,7 @@ class Api::V1::AccountsController < Api::BaseController
 
   def show
     @latest_chatwoot_version = ::Redis::Alfred.get(::Redis::Alfred::LATEST_CHATWOOT_VERSION)
-    render 'api/v1/accounts/show.json'
+    render 'api/v1/accounts/show', format: :json
   end
 
   def update

--- a/app/controllers/api/v2/accounts/reports_controller.rb
+++ b/app/controllers/api/v2/accounts/reports_controller.rb
@@ -14,22 +14,22 @@ class Api::V2::Accounts::ReportsController < Api::V1::Accounts::BaseController
 
   def agents
     @report_data = generate_agents_report
-    generate_csv('agents_report', 'api/v2/accounts/reports/agents.csv.erb')
+    generate_csv('agents_report', 'api/v2/accounts/reports/agents')
   end
 
   def inboxes
     @report_data = generate_inboxes_report
-    generate_csv('inboxes_report', 'api/v2/accounts/reports/inboxes.csv.erb')
+    generate_csv('inboxes_report', 'api/v2/accounts/reports/inboxes')
   end
 
   def labels
     @report_data = generate_labels_report
-    generate_csv('labels_report', 'api/v2/accounts/reports/labels.csv.erb')
+    generate_csv('labels_report', 'api/v2/accounts/reports/labels')
   end
 
   def teams
     @report_data = generate_teams_report
-    generate_csv('teams_report', 'api/v2/accounts/reports/teams.csv.erb')
+    generate_csv('teams_report', 'api/v2/accounts/reports/teams')
   end
 
   def conversations
@@ -43,7 +43,7 @@ class Api::V2::Accounts::ReportsController < Api::V1::Accounts::BaseController
   def generate_csv(filename, template)
     response.headers['Content-Type'] = 'text/csv'
     response.headers['Content-Disposition'] = "attachment; filename=#{filename}.csv"
-    render layout: false, template: template, format: 'csv'
+    render layout: false, template: template, formats: [:csv]
   end
 
   def check_authorization

--- a/app/controllers/devise_overrides/confirmations_controller.rb
+++ b/app/controllers/devise_overrides/confirmations_controller.rb
@@ -14,7 +14,7 @@ class DeviseOverrides::ConfirmationsController < Devise::ConfirmationsController
 
   def render_confirmation_success
     send_auth_headers(@confirmable)
-    render partial: 'devise/auth.json', locals: { resource: @confirmable }
+    render partial: 'devise/auth', formats: [:json], locals: { resource: @confirmable }
   end
 
   def render_confirmation_error

--- a/app/controllers/devise_overrides/sessions_controller.rb
+++ b/app/controllers/devise_overrides/sessions_controller.rb
@@ -16,7 +16,7 @@ class DeviseOverrides::SessionsController < ::DeviseTokenAuth::SessionsControlle
   end
 
   def render_create_success
-    render partial: 'devise/auth.json', locals: { resource: @resource }
+    render partial: 'devise', formats: [:json], locals: { resource: @resource }
   end
 
   private

--- a/app/controllers/devise_overrides/sessions_controller.rb
+++ b/app/controllers/devise_overrides/sessions_controller.rb
@@ -16,7 +16,7 @@ class DeviseOverrides::SessionsController < ::DeviseTokenAuth::SessionsControlle
   end
 
   def render_create_success
-    render partial: 'devise', formats: [:json], locals: { resource: @resource }
+    render partial: 'devise/auth', formats: [:json], locals: { resource: @resource }
   end
 
   private

--- a/app/controllers/devise_overrides/token_validations_controller.rb
+++ b/app/controllers/devise_overrides/token_validations_controller.rb
@@ -2,7 +2,7 @@ class DeviseOverrides::TokenValidationsController < ::DeviseTokenAuth::TokenVali
   def validate_token
     # @resource will have been set by set_user_by_token concern
     if @resource
-      render 'devise/token.json'
+      render 'devise/token', formats: [:json]
     else
       render_validate_token_error
     end

--- a/app/views/api/v1/accounts/agent_bots/create.json.jbuilder
+++ b/app/views/api/v1/accounts/agent_bots/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/agent_bot.json.jbuilder', resource: AgentBotPresenter.new(@agent_bot)
+json.partial! 'api/v1/models/agent_bot', formats: [:json], resource: AgentBotPresenter.new(@agent_bot)

--- a/app/views/api/v1/accounts/agent_bots/index.json.jbuilder
+++ b/app/views/api/v1/accounts/agent_bots/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @agent_bots do |agent_bot|
-  json.partial! 'api/v1/models/agent_bot.json.jbuilder', resource: AgentBotPresenter.new(agent_bot)
+  json.partial! 'api/v1/models/agent_bot', formats: [:json], resource: AgentBotPresenter.new(agent_bot)
 end

--- a/app/views/api/v1/accounts/agent_bots/show.json.jbuilder
+++ b/app/views/api/v1/accounts/agent_bots/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/agent_bot.json.jbuilder', resource: AgentBotPresenter.new(@agent_bot)
+json.partial! 'api/v1/models/agent_bot', formats: [:json], resource: AgentBotPresenter.new(@agent_bot)

--- a/app/views/api/v1/accounts/agent_bots/update.json.jbuilder
+++ b/app/views/api/v1/accounts/agent_bots/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/agent_bot.json.jbuilder', resource: AgentBotPresenter.new(@agent_bot)
+json.partial! 'api/v1/models/agent_bot', formats: [:json], resource: AgentBotPresenter.new(@agent_bot)

--- a/app/views/api/v1/accounts/agents/create.json.jbuilder
+++ b/app/views/api/v1/accounts/agents/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/agent.json.jbuilder', resource: @user
+json.partial! 'api/v1/models/agent', formats: [:json], resource: @user

--- a/app/views/api/v1/accounts/agents/index.json.jbuilder
+++ b/app/views/api/v1/accounts/agents/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @agents do |agent|
-  json.partial! 'api/v1/models/agent.json.jbuilder', resource: agent
+  json.partial! 'api/v1/models/agent', formats: [:json], resource: agent
 end

--- a/app/views/api/v1/accounts/agents/update.json.jbuilder
+++ b/app/views/api/v1/accounts/agents/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/agent.json.jbuilder', resource: @agent
+json.partial! 'api/v1/models/agent', formats: [:json], resource: @agent

--- a/app/views/api/v1/accounts/articles/_article.json.jbuilder
+++ b/app/views/api/v1/accounts/articles/_article.json.jbuilder
@@ -15,7 +15,7 @@ end
 
 if article.portal.present?
   json.portal do
-    json.partial! 'api/v1/accounts/portals/portal.json.jbuilder', portal: article.portal
+    json.partial! 'api/v1/accounts/portals/portal', formats: [:json], portal: article.portal
   end
 end
 
@@ -23,14 +23,14 @@ json.views article.views
 
 if article.author.present?
   json.author do
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: article.author
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: article.author
   end
 end
 
 json.associated_articles do
   if article.associated_articles.any?
     json.array! article.associated_articles.each do |associated_article|
-      json.partial! 'api/v1/accounts/articles/associated_article.json.jbuilder', article: associated_article
+      json.partial! 'api/v1/accounts/articles/associated_article', formats: [:json], article: associated_article
     end
   end
 end

--- a/app/views/api/v1/accounts/articles/_associated_article.json.jbuilder
+++ b/app/views/api/v1/accounts/articles/_associated_article.json.jbuilder
@@ -8,7 +8,7 @@ json.account_id article.account_id
 
 if article.portal.present?
   json.portal do
-    json.partial! 'api/v1/accounts/portals/portal.json.jbuilder', portal: article.portal
+    json.partial! 'api/v1/accounts/portals/portal', formats: [:json], portal: article.portal
   end
 end
 
@@ -16,6 +16,6 @@ json.views article.views
 
 if article.author.present?
   json.author do
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: article.author
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: article.author
   end
 end

--- a/app/views/api/v1/accounts/assignable_agents/index.json.jbuilder
+++ b/app/views/api/v1/accounts/assignable_agents/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.payload do
   json.array! @assignable_agents do |agent|
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: agent
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: agent
   end
 end

--- a/app/views/api/v1/accounts/automation_rules/clone.json.jbuilder
+++ b/app/views/api/v1/accounts/automation_rules/clone.json.jbuilder
@@ -1,3 +1,3 @@
 json.payload do
-  json.partial! 'api/v1/accounts/automation_rules/partials/automation_rule.json.jbuilder', automation_rule: @automation_rule
+  json.partial! 'api/v1/accounts/automation_rules/partials/automation_rule', formats: [:json], automation_rule: @automation_rule
 end

--- a/app/views/api/v1/accounts/automation_rules/create.json.jbuilder
+++ b/app/views/api/v1/accounts/automation_rules/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/accounts/automation_rules/partials/automation_rule.json.jbuilder', automation_rule: @automation_rule
+json.partial! 'api/v1/accounts/automation_rules/partials/automation_rule', formats: [:json], automation_rule: @automation_rule

--- a/app/views/api/v1/accounts/automation_rules/index.json.jbuilder
+++ b/app/views/api/v1/accounts/automation_rules/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.payload do
   json.array! @automation_rules do |automation_rule|
-    json.partial! 'api/v1/accounts/automation_rules/partials/automation_rule.json.jbuilder', automation_rule: automation_rule
+    json.partial! 'api/v1/accounts/automation_rules/partials/automation_rule', formats: [:json], automation_rule: automation_rule
   end
 end

--- a/app/views/api/v1/accounts/automation_rules/show.json.jbuilder
+++ b/app/views/api/v1/accounts/automation_rules/show.json.jbuilder
@@ -1,3 +1,3 @@
 json.payload do
-  json.partial! 'api/v1/accounts/automation_rules/partials/automation_rule.json.jbuilder', automation_rule: @automation_rule
+  json.partial! 'api/v1/accounts/automation_rules/partials/automation_rule', formats: [:json], automation_rule: @automation_rule
 end

--- a/app/views/api/v1/accounts/automation_rules/update.json.jbuilder
+++ b/app/views/api/v1/accounts/automation_rules/update.json.jbuilder
@@ -1,3 +1,3 @@
 json.payload do
-  json.partial! 'api/v1/accounts/automation_rules/partials/automation_rule.json.jbuilder', automation_rule: @automation_rule
+  json.partial! 'api/v1/accounts/automation_rules/partials/automation_rule', formats: [:json], automation_rule: @automation_rule
 end

--- a/app/views/api/v1/accounts/callbacks/reauthorize_page.json.jbuilder
+++ b/app/views/api/v1/accounts/callbacks/reauthorize_page.json.jbuilder
@@ -1,3 +1,3 @@
 json.data do
-  json.partial! 'api/v1/models/inbox.json.jbuilder', resource: @inbox
+  json.partial! 'api/v1/models/inbox', formats: [:json], resource: @inbox
 end

--- a/app/views/api/v1/accounts/campaigns/create.json.jbuilder
+++ b/app/views/api/v1/accounts/campaigns/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/campaign.json.jbuilder', resource: @campaign
+json.partial! 'api/v1/models/campaign', formats: [:json], resource: @campaign

--- a/app/views/api/v1/accounts/campaigns/index.json.jbuilder
+++ b/app/views/api/v1/accounts/campaigns/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @campaigns do |campaign|
-  json.partial! 'api/v1/models/campaign.json.jbuilder', resource: campaign
+  json.partial! 'api/v1/models/campaign', formats: [:json], resource: campaign
 end

--- a/app/views/api/v1/accounts/campaigns/show.json.jbuilder
+++ b/app/views/api/v1/accounts/campaigns/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/campaign.json.jbuilder', resource: @campaign
+json.partial! 'api/v1/models/campaign', formats: [:json], resource: @campaign

--- a/app/views/api/v1/accounts/campaigns/update.json.jbuilder
+++ b/app/views/api/v1/accounts/campaigns/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/campaign.json.jbuilder', resource: @campaign
+json.partial! 'api/v1/models/campaign', formats: [:json], resource: @campaign

--- a/app/views/api/v1/accounts/categories/_category.json.jbuilder
+++ b/app/views/api/v1/accounts/categories/_category.json.jbuilder
@@ -9,20 +9,20 @@ json.account_id category.account_id
 json.related_categories do
   if category.related_categories.any?
     json.array! category.related_categories.each do |related_category|
-      json.partial! 'api/v1/accounts/categories/associated_category.json.jbuilder', category: related_category
+      json.partial! 'api/v1/accounts/categories/associated_category', formats: [:json], category: related_category
     end
   end
 end
 
 if category.parent_category.present?
   json.parent_category do
-    json.partial! 'api/v1/accounts/categories/associated_category.json.jbuilder', category: category.parent_category
+    json.partial! 'api/v1/accounts/categories/associated_category', formats: [:json], category: category.parent_category
   end
 end
 
 if category.root_category.present?
   json.root_category do
-    json.partial! 'api/v1/accounts/categories/associated_category.json.jbuilder', category: category.root_category
+    json.partial! 'api/v1/accounts/categories/associated_category', formats: [:json], category: category.root_category
   end
 end
 

--- a/app/views/api/v1/accounts/channels/twilio_channels/create.json.jbuilder
+++ b/app/views/api/v1/accounts/channels/twilio_channels/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/inbox.json.jbuilder', resource: @inbox
+json.partial! 'api/v1/models/inbox', formats: [:json], resource: @inbox

--- a/app/views/api/v1/accounts/contacts/active.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/active.json.jbuilder
@@ -5,6 +5,6 @@ end
 
 json.payload do
   json.array! @contacts do |contact|
-    json.partial! 'api/v1/models/contact.json.jbuilder', resource: contact, with_contact_inboxes: true
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: contact, with_contact_inboxes: true
   end
 end

--- a/app/views/api/v1/accounts/contacts/avatar.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/avatar.json.jbuilder
@@ -1,3 +1,3 @@
 json.payload do
-  json.partial! 'api/v1/models/contact.json.jbuilder', resource: @contact, with_contact_inboxes: false
+  json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: false
 end

--- a/app/views/api/v1/accounts/contacts/contact_inboxes/create.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/contact_inboxes/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/contact_inbox.json.jbuilder', resource: @contact_inbox
+json.partial! 'api/v1/models/contact_inbox', formats: [:json], resource: @contact_inbox

--- a/app/views/api/v1/accounts/contacts/contactable_inboxes.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/contactable_inboxes.json.jbuilder
@@ -1,7 +1,7 @@
 json.payload do
   json.array! @contactable_inboxes do |contactable_inbox|
     json.inbox do
-      json.partial! 'api/v1/models/inbox.json.jbuilder', resource: contactable_inbox[:inbox]
+      json.partial! 'api/v1/models/inbox', formats: [:json], resource: contactable_inbox[:inbox]
     end
     json.source_id contactable_inbox[:source_id]
   end

--- a/app/views/api/v1/accounts/contacts/conversations/index.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/conversations/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.payload do
   json.array! @conversations do |conversation|
-    json.partial! 'api/v1/conversations/partials/conversation.json.jbuilder', conversation: conversation
+    json.partial! 'api/v1/conversations/partials/conversation', formats: [:json], conversation: conversation
   end
 end

--- a/app/views/api/v1/accounts/contacts/create.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/create.json.jbuilder
@@ -1,6 +1,6 @@
 json.payload do
   json.contact do
-    json.partial! 'api/v1/models/contact.json.jbuilder', resource: @contact, with_contact_inboxes: true
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: true
   end
   json.contact_inbox do
     json.inbox @contact_inbox&.inbox

--- a/app/views/api/v1/accounts/contacts/destroy_custom_attributes.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/destroy_custom_attributes.json.jbuilder
@@ -1,3 +1,3 @@
 json.payload do
-  json.partial! 'api/v1/models/contact.json.jbuilder', resource: @contact, with_contact_inboxes: true
+  json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: true
 end

--- a/app/views/api/v1/accounts/contacts/filter.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/filter.json.jbuilder
@@ -5,6 +5,6 @@ end
 
 json.payload do
   json.array! @contacts do |contact|
-    json.partial! 'api/v1/models/contact.json.jbuilder', resource: contact, with_contact_inboxes: @include_contact_inboxes
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: contact, with_contact_inboxes: @include_contact_inboxes
   end
 end

--- a/app/views/api/v1/accounts/contacts/index.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/index.json.jbuilder
@@ -5,6 +5,6 @@ end
 
 json.payload do
   json.array! @contacts do |contact|
-    json.partial! 'api/v1/models/contact.json.jbuilder', resource: contact, with_contact_inboxes: @include_contact_inboxes
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: contact, with_contact_inboxes: @include_contact_inboxes
   end
 end

--- a/app/views/api/v1/accounts/contacts/notes/create.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/notes/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/note.json.jbuilder', resource: @note
+json.partial! 'api/v1/models/note', formats: [:json], resource: @note

--- a/app/views/api/v1/accounts/contacts/notes/index.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/notes/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @notes do |note|
-  json.partial! 'api/v1/models/note.json.jbuilder', resource: note
+  json.partial! 'api/v1/models/note', formats: [:json], resource: note
 end

--- a/app/views/api/v1/accounts/contacts/notes/show.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/notes/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/note.json.jbuilder', resource: @note
+json.partial! 'api/v1/models/note', formats: [:json], resource: @note

--- a/app/views/api/v1/accounts/contacts/notes/update.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/notes/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/note.json.jbuilder', resource: @note
+json.partial! 'api/v1/models/note', formats: [:json], resource: @note

--- a/app/views/api/v1/accounts/contacts/search.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/search.json.jbuilder
@@ -5,6 +5,6 @@ end
 
 json.payload do
   json.array! @contacts do |contact|
-    json.partial! 'api/v1/models/contact.json.jbuilder', resource: contact, with_contact_inboxes: @include_contact_inboxes
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: contact, with_contact_inboxes: @include_contact_inboxes
   end
 end

--- a/app/views/api/v1/accounts/contacts/show.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/show.json.jbuilder
@@ -1,3 +1,3 @@
 json.payload do
-  json.partial! 'api/v1/models/contact.json.jbuilder', resource: @contact, with_contact_inboxes: true
+  json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: true
 end

--- a/app/views/api/v1/accounts/contacts/update.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/update.json.jbuilder
@@ -1,3 +1,3 @@
 json.payload do
-  json.partial! 'api/v1/models/contact.json.jbuilder', resource: @contact, with_contact_inboxes: true
+  json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: true
 end

--- a/app/views/api/v1/accounts/conversations/create.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/conversations/partials/conversation.json.jbuilder', conversation: @conversation
+json.partial! 'api/v1/conversations/partials/conversation', formats: [:json], conversation: @conversation

--- a/app/views/api/v1/accounts/conversations/filter.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/filter.json.jbuilder
@@ -5,6 +5,6 @@ json.meta do
 end
 json.payload do
   json.array! @conversations do |conversation|
-    json.partial! 'api/v1/conversations/partials/conversation.json.jbuilder', conversation: conversation
+    json.partial! 'api/v1/conversations/partials/conversation', formats: [:json], conversation: conversation
   end
 end

--- a/app/views/api/v1/accounts/conversations/index.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/index.json.jbuilder
@@ -7,7 +7,7 @@ json.data do
   end
   json.payload do
     json.array! @conversations do |conversation|
-      json.partial! 'api/v1/conversations/partials/conversation.json.jbuilder', conversation: conversation
+      json.partial! 'api/v1/conversations/partials/conversation', formats: [:json], conversation: conversation
     end
   end
 end

--- a/app/views/api/v1/accounts/conversations/search.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/search.json.jbuilder
@@ -5,6 +5,6 @@ json.meta do
 end
 json.payload do
   json.array! @conversations do |conversation|
-    json.partial! 'api/v1/models/conversation.json.jbuilder', conversation: conversation
+    json.partial! 'api/v1/models/conversation', formats: [:json], conversation: conversation
   end
 end

--- a/app/views/api/v1/accounts/conversations/show.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/conversations/partials/conversation.json.jbuilder', conversation: @conversation
+json.partial! 'api/v1/conversations/partials/conversation', formats: [:json], conversation: @conversation

--- a/app/views/api/v1/accounts/conversations/update_last_seen.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/update_last_seen.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/conversations/partials/conversation.json.jbuilder', conversation: @conversation
+json.partial! 'api/v1/conversations/partials/conversation', formats: [:json], conversation: @conversation

--- a/app/views/api/v1/accounts/csat_survey_responses/index.json.jbuilder
+++ b/app/views/api/v1/accounts/csat_survey_responses/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @csat_survey_responses do |csat_survey_response|
-  json.partial! 'api/v1/models/csat_survey_response.json.jbuilder', resource: csat_survey_response
+  json.partial! 'api/v1/models/csat_survey_response', formats: [:json], resource: csat_survey_response
 end

--- a/app/views/api/v1/accounts/custom_attribute_definitions/create.json.jbuilder
+++ b/app/views/api/v1/accounts/custom_attribute_definitions/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/custom_attribute_definition.json.jbuilder', resource: @custom_attribute_definition
+json.partial! 'api/v1/models/custom_attribute_definition', formats: [:json], resource: @custom_attribute_definition

--- a/app/views/api/v1/accounts/custom_attribute_definitions/index.json.jbuilder
+++ b/app/views/api/v1/accounts/custom_attribute_definitions/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @custom_attribute_definitions do |custom_attribute_definition|
-  json.partial! 'api/v1/models/custom_attribute_definition.json.jbuilder', resource: custom_attribute_definition
+  json.partial! 'api/v1/models/custom_attribute_definition', formats: [:json], resource: custom_attribute_definition
 end

--- a/app/views/api/v1/accounts/custom_attribute_definitions/show.json.jbuilder
+++ b/app/views/api/v1/accounts/custom_attribute_definitions/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/custom_attribute_definition.json.jbuilder', resource: @custom_attribute_definition
+json.partial! 'api/v1/models/custom_attribute_definition', formats: [:json], resource: @custom_attribute_definition

--- a/app/views/api/v1/accounts/custom_attribute_definitions/update.json.jbuilder
+++ b/app/views/api/v1/accounts/custom_attribute_definitions/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/custom_attribute_definition.json.jbuilder', resource: @custom_attribute_definition
+json.partial! 'api/v1/models/custom_attribute_definition', formats: [:json], resource: @custom_attribute_definition

--- a/app/views/api/v1/accounts/custom_filters/create.json.jbuilder
+++ b/app/views/api/v1/accounts/custom_filters/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/custom_filter.json.jbuilder', resource: @custom_filter
+json.partial! 'api/v1/models/custom_filter', formats: [:json], resource: @custom_filter

--- a/app/views/api/v1/accounts/custom_filters/index.json.jbuilder
+++ b/app/views/api/v1/accounts/custom_filters/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @custom_filters do |custom_filter|
-  json.partial! 'api/v1/models/custom_filter.json.jbuilder', resource: custom_filter
+  json.partial! 'api/v1/models/custom_filter', formats: [:json], resource: custom_filter
 end

--- a/app/views/api/v1/accounts/custom_filters/show.json.jbuilder
+++ b/app/views/api/v1/accounts/custom_filters/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/custom_filter.json.jbuilder', resource: @custom_filter
+json.partial! 'api/v1/models/custom_filter', formats: [:json], resource: @custom_filter

--- a/app/views/api/v1/accounts/custom_filters/update.json.jbuilder
+++ b/app/views/api/v1/accounts/custom_filters/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/custom_filter.json.jbuilder', resource: @custom_filter
+json.partial! 'api/v1/models/custom_filter', formats: [:json], resource: @custom_filter

--- a/app/views/api/v1/accounts/dashboard_apps/create.json.jbuilder
+++ b/app/views/api/v1/accounts/dashboard_apps/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/dashboard_app.json.jbuilder', resource: @dashboard_app
+json.partial! 'api/v1/models/dashboard_app', formats: [:json], resource: @dashboard_app

--- a/app/views/api/v1/accounts/dashboard_apps/index.json.jbuilder
+++ b/app/views/api/v1/accounts/dashboard_apps/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @dashboard_apps do |dashboard_app|
-  json.partial! 'api/v1/models/dashboard_app.json.jbuilder', resource: dashboard_app
+  json.partial! 'api/v1/models/dashboard_app', formats: [:json], resource: dashboard_app
 end

--- a/app/views/api/v1/accounts/dashboard_apps/show.json.jbuilder
+++ b/app/views/api/v1/accounts/dashboard_apps/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/dashboard_app.json.jbuilder', resource: @dashboard_app
+json.partial! 'api/v1/models/dashboard_app', formats: [:json], resource: @dashboard_app

--- a/app/views/api/v1/accounts/dashboard_apps/update.json.jbuilder
+++ b/app/views/api/v1/accounts/dashboard_apps/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/dashboard_app.json.jbuilder', resource: @dashboard_app
+json.partial! 'api/v1/models/dashboard_app', formats: [:json], resource: @dashboard_app

--- a/app/views/api/v1/accounts/inbox_members/create.json.jbuilder
+++ b/app/views/api/v1/accounts/inbox_members/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.payload do
   json.array! @agents do |agent|
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: agent
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: agent
   end
 end

--- a/app/views/api/v1/accounts/inbox_members/show.json.jbuilder
+++ b/app/views/api/v1/accounts/inbox_members/show.json.jbuilder
@@ -1,5 +1,5 @@
 json.payload do
   json.array! @agents do |agent|
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: agent
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: agent
   end
 end

--- a/app/views/api/v1/accounts/inbox_members/update.json.jbuilder
+++ b/app/views/api/v1/accounts/inbox_members/update.json.jbuilder
@@ -1,5 +1,5 @@
 json.payload do
   json.array! @agents do |agent|
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: agent
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: agent
   end
 end

--- a/app/views/api/v1/accounts/inboxes/agent_bot.json.jbuilder
+++ b/app/views/api/v1/accounts/inboxes/agent_bot.json.jbuilder
@@ -1,3 +1,3 @@
 json.agent_bot do
-  json.partial! 'api/v1/models/agent_bot.json.jbuilder', resource: @agent_bot if @agent_bot.present?
+  json.partial! 'api/v1/models/agent_bot', formats: [:json], resource: @agent_bot if @agent_bot.present?
 end

--- a/app/views/api/v1/accounts/inboxes/assignable_agents.json.jbuilder
+++ b/app/views/api/v1/accounts/inboxes/assignable_agents.json.jbuilder
@@ -1,5 +1,5 @@
 json.payload do
   json.array! @assignable_agents do |agent|
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: agent
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: agent
   end
 end

--- a/app/views/api/v1/accounts/inboxes/campaigns.json.jbuilder
+++ b/app/views/api/v1/accounts/inboxes/campaigns.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @campaigns do |campaign|
-  json.partial! 'api/v1/models/campaign.json.jbuilder', resource: campaign
+  json.partial! 'api/v1/models/campaign', formats: [:json], resource: campaign
 end

--- a/app/views/api/v1/accounts/inboxes/create.json.jbuilder
+++ b/app/views/api/v1/accounts/inboxes/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/inbox.json.jbuilder', resource: @inbox
+json.partial! 'api/v1/models/inbox', formats: [:json], resource: @inbox

--- a/app/views/api/v1/accounts/inboxes/index.json.jbuilder
+++ b/app/views/api/v1/accounts/inboxes/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.payload do
   json.array! @inboxes do |inbox|
-    json.partial! 'api/v1/models/inbox.json.jbuilder', resource: inbox
+    json.partial! 'api/v1/models/inbox', formats: [:json], resource: inbox
   end
 end

--- a/app/views/api/v1/accounts/inboxes/show.json.jbuilder
+++ b/app/views/api/v1/accounts/inboxes/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/inbox.json.jbuilder', resource: @inbox
+json.partial! 'api/v1/models/inbox', formats: [:json], resource: @inbox

--- a/app/views/api/v1/accounts/inboxes/update.json.jbuilder
+++ b/app/views/api/v1/accounts/inboxes/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/inbox.json.jbuilder', resource: @inbox
+json.partial! 'api/v1/models/inbox', formats: [:json], resource: @inbox

--- a/app/views/api/v1/accounts/integrations/apps/index.json.jbuilder
+++ b/app/views/api/v1/accounts/integrations/apps/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.payload do
   json.array! @apps do |app|
-    json.partial! 'api/v1/models/app.json.jbuilder', resource: app
+    json.partial! 'api/v1/models/app', formats: [:json], resource: app
   end
 end

--- a/app/views/api/v1/accounts/integrations/apps/show.json.jbuilder
+++ b/app/views/api/v1/accounts/integrations/apps/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/app.json.jbuilder', resource: @app
+json.partial! 'api/v1/models/app', formats: [:json], resource: @app

--- a/app/views/api/v1/accounts/integrations/hooks/create.json.jbuilder
+++ b/app/views/api/v1/accounts/integrations/hooks/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/hook.json.jbuilder', resource: @hook
+json.partial! 'api/v1/models/hook', formats: [:json], resource: @hook

--- a/app/views/api/v1/accounts/integrations/hooks/update.json.jbuilder
+++ b/app/views/api/v1/accounts/integrations/hooks/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/hook.json.jbuilder', resource: @hook
+json.partial! 'api/v1/models/hook', formats: [:json], resource: @hook

--- a/app/views/api/v1/accounts/macros/create.json.jbuilder
+++ b/app/views/api/v1/accounts/macros/create.json.jbuilder
@@ -1,3 +1,3 @@
 json.payload do
-  json.partial! 'api/v1/models/macro.json.jbuilder', macro: @macro
+  json.partial! 'api/v1/models/macro', formats: [:json], macro: @macro
 end

--- a/app/views/api/v1/accounts/macros/index.json.jbuilder
+++ b/app/views/api/v1/accounts/macros/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.payload do
   json.array! @macros do |macro|
-    json.partial! 'api/v1/models/macro.json.jbuilder', macro: macro
+    json.partial! 'api/v1/models/macro', formats: [:json], macro: macro
   end
 end

--- a/app/views/api/v1/accounts/macros/show.json.jbuilder
+++ b/app/views/api/v1/accounts/macros/show.json.jbuilder
@@ -1,3 +1,3 @@
 json.payload do
-  json.partial! 'api/v1/models/macro.json.jbuilder', macro: @macro
+  json.partial! 'api/v1/models/macro', formats: [:json], macro: @macro
 end

--- a/app/views/api/v1/accounts/macros/update.json.jbuilder
+++ b/app/views/api/v1/accounts/macros/update.json.jbuilder
@@ -1,3 +1,3 @@
 json.payload do
-  json.partial! 'api/v1/models/macro.json.jbuilder', macro: @macro
+  json.partial! 'api/v1/models/macro', formats: [:json], macro: @macro
 end

--- a/app/views/api/v1/accounts/portals/_portal.json.jbuilder
+++ b/app/views/api/v1/accounts/portals/_portal.json.jbuilder
@@ -11,7 +11,7 @@ json.archived portal.archived
 json.config do
   json.allowed_locales do
     json.array! portal.config['allowed_locales'].each do |locale|
-      json.partial! 'api/v1/models/portal_config.json.jbuilder', locale: locale, portal: portal
+      json.partial! 'api/v1/models/portal_config', formats: [:json], locale: locale, portal: portal
     end
   end
 end
@@ -21,7 +21,7 @@ json.logo portal.file_base_data if portal.logo.present?
 json.portal_members do
   if portal.members.any?
     json.array! portal.members.each do |member|
-      json.partial! 'api/v1/models/agent.json.jbuilder', resource: member
+      json.partial! 'api/v1/models/agent', formats: [:json], resource: member
     end
   end
 end

--- a/app/views/api/v1/accounts/show.json.jbuilder
+++ b/app/views/api/v1/accounts/show.json.jbuilder
@@ -1,2 +1,2 @@
-json.partial! 'api/v1/models/account.json.jbuilder', resource: @account
+json.partial! 'api/v1/models/account', formats: [:json], resource: @account
 json.latest_chatwoot_version @latest_chatwoot_version

--- a/app/views/api/v1/accounts/team_members/create.json.jbuilder
+++ b/app/views/api/v1/accounts/team_members/create.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @team_members do |team_member|
-  json.partial! 'api/v1/models/agent.json.jbuilder', resource: team_member
+  json.partial! 'api/v1/models/agent', formats: [:json], resource: team_member
 end

--- a/app/views/api/v1/accounts/team_members/index.json.jbuilder
+++ b/app/views/api/v1/accounts/team_members/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @team_members do |team_member|
-  json.partial! 'api/v1/models/agent.json.jbuilder', resource: team_member
+  json.partial! 'api/v1/models/agent', formats: [:json], resource: team_member
 end

--- a/app/views/api/v1/accounts/teams/create.json.jbuilder
+++ b/app/views/api/v1/accounts/teams/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/team.json.jbuilder', resource: @team
+json.partial! 'api/v1/models/team', formats: [:json], resource: @team

--- a/app/views/api/v1/accounts/teams/index.json.jbuilder
+++ b/app/views/api/v1/accounts/teams/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @teams do |team|
-  json.partial! 'api/v1/models/team.json.jbuilder', resource: team
+  json.partial! 'api/v1/models/team', formats: [:json], resource: team
 end

--- a/app/views/api/v1/accounts/teams/show.json.jbuilder
+++ b/app/views/api/v1/accounts/teams/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/team.json.jbuilder', resource: @team
+json.partial! 'api/v1/models/team', formats: [:json], resource: @team

--- a/app/views/api/v1/accounts/teams/update.json.jbuilder
+++ b/app/views/api/v1/accounts/teams/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/team.json.jbuilder', resource: @team
+json.partial! 'api/v1/models/team', formats: [:json], resource: @team

--- a/app/views/api/v1/accounts/update.json.jbuilder
+++ b/app/views/api/v1/accounts/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/account.json.jbuilder', resource: @account
+json.partial! 'api/v1/models/account', formats: [:json], resource: @account

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -1,16 +1,16 @@
 json.meta do
   json.sender do
-    json.partial! 'api/v1/models/contact.json.jbuilder', resource: conversation.contact
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: conversation.contact
   end
   json.channel conversation.inbox.try(:channel_type)
   if conversation.assignee&.account
     json.assignee do
-      json.partial! 'api/v1/models/agent.json.jbuilder', resource: conversation.assignee
+      json.partial! 'api/v1/models/agent', formats: [:json], resource: conversation.assignee
     end
   end
   if conversation.team.present?
     json.team do
-      json.partial! 'api/v1/models/team.json.jbuilder', resource: conversation.team
+      json.partial! 'api/v1/models/team', formats: [:json], resource: conversation.team
     end
   end
   json.hmac_verified conversation.contact_inbox&.hmac_verified

--- a/app/views/api/v1/models/_app.json.jbuilder
+++ b/app/views/api/v1/models/_app.json.jbuilder
@@ -6,6 +6,6 @@ json.action resource.action
 json.button resource.action
 json.hooks do
   json.array! @current_account.hooks.where(app_id: resource.id) do |hook|
-    json.partial! 'api/v1/models/hook.json.jbuilder', resource: hook
+    json.partial! 'api/v1/models/hook', formats: [:json], resource: hook
   end
 end

--- a/app/views/api/v1/models/_campaign.json.jbuilder
+++ b/app/views/api/v1/models/_campaign.json.jbuilder
@@ -3,10 +3,10 @@ json.title resource.title
 json.description resource.description
 json.account_id resource.account_id
 json.inbox do
-  json.partial! 'api/v1/models/inbox.json.jbuilder', resource: resource.inbox
+  json.partial! 'api/v1/models/inbox', formats: [:json], resource: resource.inbox
 end
 json.sender do
-  json.partial! 'api/v1/models/agent.json.jbuilder', resource: resource.sender if resource.sender.present?
+  json.partial! 'api/v1/models/agent', formats: [:json], resource: resource.sender if resource.sender.present?
 end
 json.message resource.message
 json.campaign_status resource.campaign_status

--- a/app/views/api/v1/models/_contact.json.jbuilder
+++ b/app/views/api/v1/models/_contact.json.jbuilder
@@ -14,7 +14,7 @@ json.last_activity_at resource.last_activity_at.to_i if resource[:last_activity_
 if defined?(with_contact_inboxes) && with_contact_inboxes.present?
   json.contact_inboxes do
     json.array! resource.contact_inboxes do |contact_inbox|
-      json.partial! 'api/v1/models/contact_inbox.json.jbuilder', resource: contact_inbox
+      json.partial! 'api/v1/models/contact_inbox', formats: [:json], resource: contact_inbox
     end
   end
 end

--- a/app/views/api/v1/models/_contact_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_contact_inbox.json.jbuilder
@@ -1,4 +1,4 @@
 json.source_id resource.source_id
 json.inbox do
-  json.partial! 'api/v1/models/inbox.json.jbuilder', resource: resource.inbox
+  json.partial! 'api/v1/models/inbox', formats: [:json], resource: resource.inbox
 end

--- a/app/views/api/v1/models/_csat_survey_response.json.jbuilder
+++ b/app/views/api/v1/models/_csat_survey_response.json.jbuilder
@@ -5,13 +5,13 @@ json.account_id resource.account_id
 json.message_id resource.message_id
 if resource.contact
   json.contact do
-    json.partial! 'api/v1/models/contact.json.jbuilder', resource: resource.contact
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: resource.contact
   end
 end
 json.conversation_id resource.conversation.display_id
 if resource.assigned_agent
   json.assigned_agent do
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: resource.assigned_agent
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: resource.assigned_agent
   end
 end
 json.created_at resource.created_at.to_i

--- a/app/views/api/v1/models/_macro.json.jbuilder
+++ b/app/views/api/v1/models/_macro.json.jbuilder
@@ -4,13 +4,13 @@ json.visibility macro.visibility
 
 if macro.created_by.present?
   json.created_by do
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: macro.created_by
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: macro.created_by
   end
 end
 
 if macro.updated_by.present?
   json.updated_by do
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: macro.updated_by
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: macro.updated_by
   end
 end
 

--- a/app/views/api/v1/models/_note.json.jbuilder
+++ b/app/views/api/v1/models/_note.json.jbuilder
@@ -4,7 +4,7 @@ json.account_id json.account_id
 json.contact_id json.contact_id
 if resource.user.present?
   json.user do
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: resource.user
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: resource.user
   end
 end
 json.created_at resource.created_at.to_i

--- a/app/views/api/v1/profiles/availability.jbuilder
+++ b/app/views/api/v1/profiles/availability.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/user.json.jbuilder', resource: @user
+json.partial! 'api/v1/models/user', formats: [:json], resource: @user

--- a/app/views/api/v1/profiles/show.json.jbuilder
+++ b/app/views/api/v1/profiles/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/user.json.jbuilder', resource: @user
+json.partial! 'api/v1/models/user', formats: [:json], resource: @user

--- a/app/views/api/v1/profiles/update.json.jbuilder
+++ b/app/views/api/v1/profiles/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/user.json.jbuilder', resource: @user
+json.partial! 'api/v1/models/user', formats: [:json], resource: @user

--- a/app/views/devise/_auth.json.jbuilder
+++ b/app/views/devise/_auth.json.jbuilder
@@ -1,3 +1,3 @@
 json.data do
-  json.partial! 'api/v1/models/user.json.jbuilder', resource: resource
+  json.partial! 'api/v1/models/user', formats: [:json], resource: resource
 end

--- a/app/views/devise/token.json.jbuilder
+++ b/app/views/devise/token.json.jbuilder
@@ -1,6 +1,6 @@
 json.payload do
   json.success true
-  json.partial! 'auth.json.jbuilder', resource: @resource
+  json.partial! 'auth', formats: [:json], resource: @resource
   json.data do
     json.created_at @resource.created_at
   end

--- a/app/views/platform/api/v1/agent_bots/create.json.jbuilder
+++ b/app/views/platform/api/v1/agent_bots/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'platform/api/v1/models/agent_bot.json.jbuilder', resource: @resource
+json.partial! 'platform/api/v1/models/agent_bot', formats: [:json], resource: @resource

--- a/app/views/platform/api/v1/agent_bots/index.json.jbuilder
+++ b/app/views/platform/api/v1/agent_bots/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @resources do |resource|
-  json.partial! 'platform/api/v1/models/agent_bot.json.jbuilder', resource: resource.permissible
+  json.partial! 'platform/api/v1/models/agent_bot', formats: [:json], resource: resource.permissible
 end

--- a/app/views/platform/api/v1/agent_bots/show.json.jbuilder
+++ b/app/views/platform/api/v1/agent_bots/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'platform/api/v1/models/agent_bot.json.jbuilder', resource: @resource
+json.partial! 'platform/api/v1/models/agent_bot', formats: [:json], resource: @resource

--- a/app/views/platform/api/v1/agent_bots/update.json.jbuilder
+++ b/app/views/platform/api/v1/agent_bots/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'platform/api/v1/models/agent_bot.json.jbuilder', resource: @resource
+json.partial! 'platform/api/v1/models/agent_bot', formats: [:json], resource: @resource

--- a/app/views/platform/api/v1/users/create.json.jbuilder
+++ b/app/views/platform/api/v1/users/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'platform/api/v1/models/user.json.jbuilder', resource: @resource
+json.partial! 'platform/api/v1/models/user', formats: [:json], resource: @resource

--- a/app/views/platform/api/v1/users/show.json.jbuilder
+++ b/app/views/platform/api/v1/users/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'platform/api/v1/models/user.json.jbuilder', resource: @resource
+json.partial! 'platform/api/v1/models/user', formats: [:json], resource: @resource

--- a/app/views/platform/api/v1/users/update.json.jbuilder
+++ b/app/views/platform/api/v1/users/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'platform/api/v1/models/user.json.jbuilder', resource: @resource
+json.partial! 'platform/api/v1/models/user', formats: [:json], resource: @resource

--- a/app/views/public/api/v1/csat_survey/show.json.jbuilder
+++ b/app/views/public/api/v1/csat_survey/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'public/api/v1/models/csat_survey.json.jbuilder', resource: @message
+json.partial! 'public/api/v1/models/csat_survey', formats: [:json], resource: @message

--- a/app/views/public/api/v1/csat_survey/update.json.jbuilder
+++ b/app/views/public/api/v1/csat_survey/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'public/api/v1/models/csat_survey.json.jbuilder', resource: @message
+json.partial! 'public/api/v1/models/csat_survey', formats: [:json], resource: @message

--- a/app/views/public/api/v1/inboxes/contacts/create.json.jbuilder
+++ b/app/views/public/api/v1/inboxes/contacts/create.json.jbuilder
@@ -1,3 +1,3 @@
 json.source_id @contact_inbox.source_id
 json.pubsub_token @contact_inbox.pubsub_token
-json.partial! 'public/api/v1/models/contact.json.jbuilder', resource: @contact_inbox.contact
+json.partial! 'public/api/v1/models/contact', resource: @contact_inbox.contact, formats: [:json]

--- a/app/views/public/api/v1/inboxes/contacts/show.json.jbuilder
+++ b/app/views/public/api/v1/inboxes/contacts/show.json.jbuilder
@@ -1,3 +1,3 @@
 json.source_id @contact_inbox.source_id
 json.pubsub_token @contact_inbox.pubsub_token
-json.partial! 'public/api/v1/models/contact.json.jbuilder', resource: @contact_inbox.contact
+json.partial! 'public/api/v1/models/contact', formats: [:json], resource: @contact_inbox.contact

--- a/app/views/public/api/v1/inboxes/contacts/update.json.jbuilder
+++ b/app/views/public/api/v1/inboxes/contacts/update.json.jbuilder
@@ -1,3 +1,3 @@
 json.source_id @contact_inbox.source_id
 json.pubsub_token @contact_inbox.pubsub_token
-json.partial! 'public/api/v1/models/contact.json.jbuilder', resource: @contact_inbox.contact
+json.partial! 'public/api/v1/models/contact', formats: [:json], resource: @contact_inbox.contact

--- a/app/views/public/api/v1/inboxes/conversations/create.json.jbuilder
+++ b/app/views/public/api/v1/inboxes/conversations/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'public/api/v1/models/conversation.json.jbuilder', resource: @conversation
+json.partial! 'public/api/v1/models/conversation', formats: [:json], resource: @conversation

--- a/app/views/public/api/v1/inboxes/conversations/index.json.jbuilder
+++ b/app/views/public/api/v1/inboxes/conversations/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @conversations do |conversation|
-  json.partial! 'public/api/v1/models/conversation.json.jbuilder', resource: conversation
+  json.partial! 'public/api/v1/models/conversation', formats: [:json], resource: conversation
 end

--- a/app/views/public/api/v1/inboxes/messages/create.json.jbuilder
+++ b/app/views/public/api/v1/inboxes/messages/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'public/api/v1/models/message.json.jbuilder', resource: @message
+json.partial! 'public/api/v1/models/message', formats: [:json], resource: @message

--- a/app/views/public/api/v1/inboxes/messages/index.json.jbuilder
+++ b/app/views/public/api/v1/inboxes/messages/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @messages do |message|
-  json.partial! 'public/api/v1/models/message.json.jbuilder', resource: message
+  json.partial! 'public/api/v1/models/message', formats: [:json], resource: message
 end

--- a/app/views/public/api/v1/inboxes/messages/update.json.jbuilder
+++ b/app/views/public/api/v1/inboxes/messages/update.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'public/api/v1/models/message.json.jbuilder', resource: @message
+json.partial! 'public/api/v1/models/message', formats: [:json], resource: @message

--- a/app/views/public/api/v1/models/_article.json.jbuilder
+++ b/app/views/public/api/v1/models/_article.json.jbuilder
@@ -9,7 +9,7 @@ json.last_updated_at article.updated_at
 
 if article.portal.present?
   json.portal do
-    json.partial! 'api/v1/accounts/portals/portal.json.jbuilder', portal: article.portal
+    json.partial! 'api/v1/accounts/portals/portal', formats: [:json], portal: article.portal
   end
 end
 
@@ -17,14 +17,14 @@ json.views article.views
 
 if article.author.present?
   json.author do
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: article.author
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: article.author
   end
 end
 
 json.associated_articles do
   if article.associated_articles.any?
     json.array! article.associated_articles.each do |associated_article|
-      json.partial! 'api/v1/accounts/articles/associated_article.json.jbuilder', article: associated_article
+      json.partial! 'api/v1/accounts/articles/associated_article', formats: [:json], article: associated_article
     end
   end
 end

--- a/app/views/public/api/v1/models/_associated_article.json.jbuilder
+++ b/app/views/public/api/v1/models/_associated_article.json.jbuilder
@@ -10,6 +10,6 @@ json.views article.views
 
 if article.author.present?
   json.author do
-    json.partial! 'api/v1/models/agent.json.jbuilder', resource: article.author
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: article.author
   end
 end

--- a/app/views/public/api/v1/models/_conversation.json.jbuilder
+++ b/app/views/public/api/v1/models/_conversation.json.jbuilder
@@ -5,7 +5,7 @@ json.status resource.status
 json.agent_last_seen_at resource.agent_last_seen_at.to_i
 json.messages do
   json.array! resource.messages do |message|
-    json.partial! 'public/api/v1/models/message.json.jbuilder', resource: message
+    json.partial! 'public/api/v1/models/message', formats: [:json], resource: message
   end
 end
 json.contact resource.contact

--- a/app/views/public/api/v1/models/_portal.json.jbuilder
+++ b/app/views/public/api/v1/models/_portal.json.jbuilder
@@ -8,7 +8,7 @@ json.slug portal.slug
 json.categories do
   if portal.categories.any?
     json.array! portal.categories.each do |category|
-      json.partial! 'public/api/v1/models/category.json.jbuilder', category: category
+      json.partial! 'public/api/v1/models/category', formats: [:json], category: category
     end
   end
 end

--- a/app/views/public/api/v1/portals/articles/show.json.jbuilder
+++ b/app/views/public/api/v1/portals/articles/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'public/api/v1/models/article.json.jbuilder', article: @article
+json.partial! 'public/api/v1/models/article', formats: [:json], article: @article

--- a/app/views/public/api/v1/portals/categories/show.json.jbuilder
+++ b/app/views/public/api/v1/portals/categories/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'public/api/v1/models/category.json.jbuilder', category: @category
+json.partial! 'public/api/v1/models/category', formats: [:json], category: @category

--- a/app/views/public/api/v1/portals/show.json.jbuilder
+++ b/app/views/public/api/v1/portals/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'public/api/v1/models/portal.json.jbuilder', portal: @portal
+json.partial! 'public/api/v1/models/portal', formats: [:json], portal: @portal


### PR DESCRIPTION
## Description

Modified calling render partial with '.json.jbuilder' to formats: [:json]

Fixes #2819 

## Type of change

Please delete options that are not relevant.

- [x] Fixed deprecation warnings

## How Has This Been Tested?

Ran rspec in local

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
