### PR TITLE
chore: Use multiple connections in Redis connection pool

### DIFF
--- a/config/initializers/01_redis.rb
+++ b/config/initializers/01_redis.rb
@@ -1,10 +1,14 @@
-redis = Rails.env.test? ? MockRedis.new : Redis.new(Redis::Config.app)
-
 # Alfred
 # Add here as you use it for more features
 # Used for Round Robin, Conversation Emails & Online Presence
-$alfred = ConnectionPool::Wrapper.new(size: 5, timeout: 3) { Redis::Namespace.new('alfred', redis: redis, warning: true) }
+$alfred = ConnectionPool::Wrapper.new(size: 5, timeout: 3) do
+  redis = Rails.env.test? ? MockRedis.new : Redis.new(Redis::Config.app)
+  Redis::Namespace.new('alfred', redis: redis, warning: true)
+end
 
 # Velma : Determined protector
 # used in rack attack
-$velma =  ConnectionPool::Wrapper.new(size: 5, timeout: 3) { Redis::Namespace.new('velma', redis: redis, warning: true) }
+$velma = ConnectionPool::Wrapper.new(size: 5, timeout: 3) do
+  redis = Rails.env.test? ? MockRedis.new : Redis.new(Redis::Config.app)
+  Redis::Namespace.new('velma', redis: redis, warning: true)
+end


### PR DESCRIPTION
## Description

The initializer set up a connection pool, but both pools actually created namespace wrappers around a single global connection.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I am developing a feature where I tried using a blocking redis command.  Using this froze all of redis for the whole application since there was no connection pooling.  This change allowed me to continue.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
