### PR TITLE
Avoid crashing when `AudioContext` is not available.

### DIFF
--- a/app/javascript/shared/helpers/AudioNotificationHelper.js
+++ b/app/javascript/shared/helpers/AudioNotificationHelper.js
@@ -5,29 +5,40 @@ import { showBadgeOnFavicon } from './faviconHelper';
 
 export const initOnEvents = ['click', 'touchstart', 'keypress', 'keydown'];
 export const getAlertAudio = async (baseUrl = '', type = 'dashboard') => {
-  const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  let audioCtx;
+
+  try {
+    audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  } catch {
+    // AudioContext is not available.
+  }
+
   const playsound = audioBuffer => {
     window.playAudioAlert = () => {
-      const source = audioCtx.createBufferSource();
-      source.buffer = audioBuffer;
-      source.connect(audioCtx.destination);
-      source.loop = false;
-      source.start();
+      if (audioCtx) {
+        const source = audioCtx.createBufferSource();
+        source.buffer = audioBuffer;
+        source.connect(audioCtx.destination);
+        source.loop = false;
+        source.start();
+      }
     };
   };
 
-  const resourceUrl = `${baseUrl}/audio/${type}/ding.mp3`;
-  const audioRequest = new Request(resourceUrl);
+  if (audioCtx) {
+    const resourceUrl = `${baseUrl}/audio/${type}/ding.mp3`;
+    const audioRequest = new Request(resourceUrl);
 
-  fetch(audioRequest)
-    .then(response => response.arrayBuffer())
-    .then(buffer => {
-      audioCtx.decodeAudioData(buffer).then(playsound);
-      return new Promise(res => res());
-    })
-    .catch(() => {
-      // error
-    });
+    fetch(audioRequest)
+      .then(response => response.arrayBuffer())
+      .then(buffer => {
+        audioCtx.decodeAudioData(buffer).then(playsound);
+        return new Promise(res => res());
+      })
+      .catch(() => {
+        // error
+      });
+  }
 };
 
 export const notificationEnabled = (enableAudioAlerts, id, userId) => {

--- a/app/javascript/shared/helpers/AudioNotificationHelper.js
+++ b/app/javascript/shared/helpers/AudioNotificationHelper.js
@@ -5,13 +5,7 @@ import { showBadgeOnFavicon } from './faviconHelper';
 
 export const initOnEvents = ['click', 'touchstart', 'keypress', 'keydown'];
 export const getAlertAudio = async (baseUrl = '', type = 'dashboard') => {
-  let audioCtx;
-
-  try {
-    audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-  } catch {
-    // AudioContext is not available.
-  }
+  const audioCtx = getAudioContext();
 
   const playsound = audioBuffer => {
     window.playAudioAlert = () => {
@@ -39,6 +33,18 @@ export const getAlertAudio = async (baseUrl = '', type = 'dashboard') => {
         // error
       });
   }
+};
+
+export const getAudioContext = () => {
+  let audioCtx;
+
+  try {
+    audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  } catch {
+    // AudioContext is not available.
+  }
+
+  return audioCtx;
 };
 
 export const notificationEnabled = (enableAudioAlerts, id, userId) => {


### PR DESCRIPTION
## Description

See #4942. We've also had a number of crash reports show up in our logs related to this. Typically we see "undefined is not a constrcutor" because `window.AudioContext || window.webkitAudioContext` returns `undefined`.

Fixes #4942.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
