### PR TITLE
Fix: Fixes overflow issue for category name in article list

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleItem.vue
@@ -4,7 +4,7 @@
       <div class="article-content-wrap">
         <div class="article-block">
           <router-link :to="articleUrl(id)">
-            <h6 class="sub-block-title text-truncate">
+            <h6 :title="title" class="sub-block-title text-truncate">
               {{ title }}
             </h6>
           </router-link>
@@ -20,7 +20,9 @@
         class="fs-small button clear link secondary"
         :to="getCategoryRoute(category.slug)"
       >
-        {{ category.name }}
+        <span :title="category.name" class="category-link-button text-ellipsis">
+          {{ category.name }}
+        </span>
       </router-link>
     </td>
     <td>
@@ -154,5 +156,10 @@ td {
       font-size: var(--font-size-small);
     }
   }
+}
+
+.category-link-button {
+  max-width: 160px;
+  line-height: 1.5;
 }
 </style>

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleItem.vue
@@ -162,7 +162,7 @@ td {
 }
 
 .category-link-content {
-  max-width: 160px;
+  max-width: 16rem;
   line-height: 1.5;
 }
 </style>

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleItem.vue
@@ -20,7 +20,10 @@
         class="fs-small button clear link secondary"
         :to="getCategoryRoute(category.slug)"
       >
-        <span :title="category.name" class="category-link-button text-ellipsis">
+        <span
+          :title="category.name"
+          class="category-link-content text-ellipsis"
+        >
           {{ category.name }}
         </span>
       </router-link>
@@ -158,7 +161,7 @@ td {
   }
 }
 
-.category-link-button {
+.category-link-content {
   max-width: 160px;
   line-height: 1.5;
 }


### PR DESCRIPTION
**Why**
We recently made the category name in the article table clickable. This introduced an overflow issue for long category names.

