### PR TITLE
fix: Discard invalid contact attributes in widget conversation end point

### DIFF
--- a/app/controllers/api/v1/widget/conversations_controller.rb
+++ b/app/controllers/api/v1/widget/conversations_controller.rb
@@ -17,7 +17,8 @@ class Api::V1::Widget::ConversationsController < Api::V1::Widget::BaseController
     @contact = ContactIdentifyAction.new(
       contact: @contact,
       params: { email: contact_email, phone_number: contact_phone_number, name: contact_name },
-      retain_original_contact_name: true
+      retain_original_contact_name: true,
+      discard_invalid_attrs: true
     ).perform
   end
 

--- a/spec/controllers/api/v1/widget/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/conversations_controller_spec.rb
@@ -102,6 +102,29 @@ RSpec.describe '/api/v1/widget/conversations/toggle_typing', type: :request do
       expect(json_response['custom_attributes']['order_id']).to eq '12345'
       expect(json_response['messages'][0]['content']).to eq 'This is a test message'
     end
+
+    it 'doesnt not add phone number if the invalid phone number is provided' do
+      existing_contact = create(:contact, account: account)
+
+      post '/api/v1/widget/conversations',
+           headers: { 'X-Auth-Token' => token },
+           params: {
+             website_token: web_widget.website_token,
+             contact: {
+               name: 'contact-name-1',
+               email: existing_contact.email,
+               phone_number: '13456'
+             },
+             message: {
+               content: 'This is a test message'
+             },
+           },
+           as: :json
+
+      expect(response).to have_http_status(:success)
+      json_response = JSON.parse(response.body)
+      expect(json_response['contact']['phone_number']).to be_nil
+    end
   end
 
   describe 'POST /api/v1/widget/conversations/toggle_typing' do

--- a/spec/controllers/api/v1/widget/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/conversations_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe '/api/v1/widget/conversations/toggle_typing', type: :request do
              },
              message: {
                content: 'This is a test message'
-             },
+             }
            },
            as: :json
 


### PR DESCRIPTION
Fixes https://github.com/chatwoot/product/issues/601