### PR TITLE
bug: Fixes width overflow issue with emoji selector in widget

### DIFF
--- a/app/javascript/widget/components/ChatInputWrap.vue
+++ b/app/javascript/widget/components/ChatInputWrap.vue
@@ -191,6 +191,7 @@ export default {
 .emoji-dialog {
   right: $space-smaller;
   top: -278px;
+  max-width: 100%;
 
   &::before {
     right: $space-one;


### PR DESCRIPTION


## Description
Fixes #5722 

**Before**
<img width="612" alt="image" src="https://user-images.githubusercontent.com/1277421/197651682-b7d6b2ca-d13f-4345-bfc4-658b6f65edea.png">


**After**
<img width="612" alt="image" src="https://user-images.githubusercontent.com/1277421/197651644-0f254f5c-38b7-4d63-894b-4265dac7fdb1.png">
