### PR TITLE
fix: db/seeds.rb field contact_inbox is undefined

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,19 +46,19 @@ unless Rails.env.production?
   inbox = Inbox.create!(channel: web_widget, account: account, name: 'Acme Support')
   InboxMember.create!(user: user, inbox: inbox)
 
-  contact = ::ContactInboxWithContactBuilder.new(
+  contact_inbox = ::ContactInboxWithContactBuilder.new(
     source_id: user.id,
     inbox: inbox,
     hmac_verified: true,
     contact_attributes: { name: 'jane', email: 'jane@example.com', phone_number: '+2320000' }
-  ).perform&.contact
+  ).perform
 
   conversation = Conversation.create!(
     account: account,
     inbox: inbox,
     status: :open,
     assignee: user,
-    contact: contact,
+    contact: contact_inbox.contact,
     contact_inbox: contact_inbox,
     additional_attributes: {}
   )


### PR DESCRIPTION
# Pull Request Template

## Description

run: `docker-compose run --rm rails bundle exec rails db:chatwoot_prepare` error: field contact_inbox is undefine


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
