### PR TITLE
fix: Set message sender to macros excution

### DIFF
--- a/app/services/macros/execution_service.rb
+++ b/app/services/macros/execution_service.rb
@@ -3,6 +3,7 @@ class Macros::ExecutionService < ActionService
     super(conversation)
     @macro = macro
     @account = macro.account
+    @user = user
     Current.user = user
   end
 
@@ -27,7 +28,7 @@ class Macros::ExecutionService < ActionService
     params = { content: message[0], private: false }
 
     # Added reload here to ensure conversation us persistent with the latest updates
-    mb = Messages::MessageBuilder.new(nil, @conversation.reload, params)
+    mb = Messages::MessageBuilder.new(@user, @conversation.reload, params)
     mb.perform
   end
 
@@ -43,7 +44,7 @@ class Macros::ExecutionService < ActionService
     params = { content: nil, private: false, attachments: blobs }
 
     # Added reload here to ensure conversation us persistent with the latest updates
-    mb = Messages::MessageBuilder.new(nil, @conversation.reload, params)
+    mb = Messages::MessageBuilder.new(@user, @conversation.reload, params)
     mb.perform
   end
 end

--- a/spec/controllers/api/v1/accounts/macros_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/macros_controller_spec.rb
@@ -247,21 +247,55 @@ RSpec.describe 'Api::V1::Accounts::MacrosController', type: :request do
     end
 
     context 'when it is an authenticated user' do
-      it 'execute the macro' do
-        expect(conversation.messages).to be_empty
-        expect(conversation.labels).to be_empty
+      context 'when execute the macro' do
+        it 'send the message with sender' do
+          expect(conversation.messages).to be_empty
 
-        perform_enqueued_jobs do
-          post "/api/v1/accounts/#{account.id}/macros/#{macro.id}/execute",
-               params: { conversation_ids: [conversation.display_id] },
-               headers: administrator.create_new_auth_token
+          perform_enqueued_jobs do
+            post "/api/v1/accounts/#{account.id}/macros/#{macro.id}/execute",
+                 params: { conversation_ids: [conversation.display_id] },
+                 headers: administrator.create_new_auth_token
+          end
+
+          expect(conversation.messages.chat.last.content).to eq('Send this message.')
+          expect(conversation.messages.chat.last.sender).to eq(administrator)
         end
 
-        expect(conversation.reload.status).to eql('snoozed')
-        expect(conversation.messages.chat.last.content).to eq('Send this message.')
-        expect(conversation.messages.chat.last.sender).to eq(administrator)
-        expect(conversation.label_list).to match_array(%w[support priority_customer])
-        expect(conversation.messages.activity.last.content).to eq("Assigned to #{user_1.name} by #{administrator.name}")
+        it 'Assign the agent' do
+          expect(conversation.assignee).to be_nil
+
+          perform_enqueued_jobs do
+            post "/api/v1/accounts/#{account.id}/macros/#{macro.id}/execute",
+                 params: { conversation_ids: [conversation.display_id] },
+                 headers: administrator.create_new_auth_token
+          end
+
+          expect(conversation.messages.activity.last.content).to eq("Assigned to #{user_1.name} by #{administrator.name}")
+        end
+
+        it 'Assign the labels' do
+          expect(conversation.labels).to be_empty
+
+          perform_enqueued_jobs do
+            post "/api/v1/accounts/#{account.id}/macros/#{macro.id}/execute",
+                 params: { conversation_ids: [conversation.display_id] },
+                 headers: administrator.create_new_auth_token
+          end
+
+          expect(conversation.reload.label_list).to match_array(%w[support priority_customer])
+        end
+
+        it 'Update the status' do
+          expect(conversation.reload.status).to eql('open')
+
+          perform_enqueued_jobs do
+            post "/api/v1/accounts/#{account.id}/macros/#{macro.id}/execute",
+                 params: { conversation_ids: [conversation.display_id] },
+                 headers: administrator.create_new_auth_token
+          end
+
+          expect(conversation.reload.status).to eql('snoozed')
+        end
       end
     end
   end

--- a/spec/controllers/api/v1/accounts/macros_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/macros_controller_spec.rb
@@ -249,7 +249,6 @@ RSpec.describe 'Api::V1::Accounts::MacrosController', type: :request do
     context 'when it is an authenticated user' do
       it 'execute the macro' do
         expect(conversation.messages).to be_empty
-        expect(conversation.assignee).to be_nil
         expect(conversation.labels).to be_empty
 
         perform_enqueued_jobs do
@@ -260,6 +259,7 @@ RSpec.describe 'Api::V1::Accounts::MacrosController', type: :request do
 
         expect(conversation.reload.status).to eql('snoozed')
         expect(conversation.messages.chat.last.content).to eq('Send this message.')
+        expect(conversation.messages.chat.last.sender).to eq(administrator)
         expect(conversation.label_list).to match_array(%w[support priority_customer])
         expect(conversation.messages.activity.last.content).to eq("Assigned to #{user_1.name} by #{administrator.name}")
       end


### PR DESCRIPTION
## Description

- For event send_message and send_attachment set message sender to the macro executer

Fixes #5731 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added test cases for the same

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
