### PR TITLE
fix: flaky test whatsapp_cloud_service_spec.rb:17

### DIFF
--- a/lib/regex_helper.rb
+++ b/lib/regex_helper.rb
@@ -9,5 +9,5 @@ module RegexHelper
 
   TWILIO_CHANNEL_SMS_REGEX = Regexp.new('^\+\d{1,15}\z')
   TWILIO_CHANNEL_WHATSAPP_REGEX = Regexp.new('^whatsapp:\+\d{1,15}\z')
-  WHATSAPP_CHANNEL_REGEX = Regexp.new('^\d{1,14}\z')
+  WHATSAPP_CHANNEL_REGEX = Regexp.new('^\d{1,15}\z')
 end

--- a/spec/models/contact_inbox_spec.rb
+++ b/spec/models/contact_inbox_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe ContactInbox do
         expect(valid_source_id.valid?).to be(true)
         expect(ci_character_in_source_id.valid?).to be(false)
         expect(ci_character_in_source_id.errors.full_messages).to eq(
-          ['Source invalid source id for whatsapp inbox. valid Regex (?-mix:^\\d{1,14}\\z)']
+          ['Source invalid source id for whatsapp inbox. valid Regex (?-mix:^\\d{1,15}\\z)']
         )
         expect(ci_plus_in_source_id.valid?).to be(false)
         expect(ci_plus_in_source_id.errors.full_messages).to eq(
-          ['Source invalid source id for whatsapp inbox. valid Regex (?-mix:^\\d{1,14}\\z)']
+          ['Source invalid source id for whatsapp inbox. valid Regex (?-mix:^\\d{1,15}\\z)']
         )
       end
 


### PR DESCRIPTION
Fix flaky test : flaky /spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb:17

example build : https://app.circleci.com/pipelines/github/chatwoot/chatwoot/48955/workflows/a2959d25-19ea-4812-ba15-5aac69c43265/jobs/49523

cause : factory bot can create phone numbers of length 15 digits,  which is valid e164, while our regex only handled uptill 14 digits