### PR TITLE
fix: Identifier not persisted on customer created via Inbox API Channel

### DIFF
--- a/app/controllers/public/api/v1/inboxes/contacts_controller.rb
+++ b/app/controllers/public/api/v1/inboxes/contacts_controller.rb
@@ -7,7 +7,7 @@ class Public::Api::V1::Inboxes::ContactsController < Public::Api::V1::InboxesCon
     @contact_inbox = ::ContactInboxWithContactBuilder.new(
       source_id: source_id,
       inbox: @inbox_channel.inbox,
-      contact_attributes: permitted_params.except(:identifier, :identifier_hash)
+      contact_attributes: permitted_params.except(:identifier_hash)
     ).perform
   end
 

--- a/spec/controllers/public/api/v1/inbox/contacts_controller_spec.rb
+++ b/spec/controllers/public/api/v1/inbox/contacts_controller_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe 'Public Inbox Contacts API', type: :request do
       expect(data['source_id']).not_to be_nil
       expect(data['pubsub_token']).not_to be_nil
     end
+
+    it 'persists the identifier of the contact' do
+      identifier = 'contact-identifier'
+      post "/public/api/v1/inboxes/#{api_channel.identifier}/contacts", params: { identifier: identifier }
+
+      expect(response).to have_http_status(:success)
+      db_contact = api_channel.account.contacts.find_by(identifier: identifier)
+      expect(db_contact).not_to be_nil
+    end
   end
 
   describe 'GET /public/api/v1/inboxes/{identifier}/contact/{source_id}' do


### PR DESCRIPTION
# Pull Request Template

## Description

This seems to be a bigger issue than initially anticipated in the issue that this PR fixes. Because the identifier is never used to identify the contact, this results in having a new contact created every time if the email or phone is not supplied.
Fixes #5704 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Automated test has been added.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
