### PR TITLE
Feat/5733 Add private note action in macros

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/Macros/MacroPreview.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/Macros/MacroPreview.vue
@@ -53,6 +53,7 @@ export default {
         send_webhook_event: params[0],
         send_message: params[0],
         send_email_transcript: params[0],
+        add_private_note: params[0],
       };
       return actionsMap[key] || '';
     },

--- a/app/javascript/dashboard/routes/dashboard/settings/macros/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/macros/constants.js
@@ -39,4 +39,9 @@ export const MACRO_ACTION_TYPES = [
     label: 'Send a message',
     inputType: 'textarea',
   },
+  {
+    key: 'add_private_note',
+    label: 'Add a private note',
+    inputType: 'textarea',
+  },
 ];

--- a/app/models/macro.rb
+++ b/app/models/macro.rb
@@ -33,7 +33,7 @@ class Macro < ApplicationRecord
   validate :json_actions_format
 
   ACTIONS_ATTRS = %w[send_message add_label assign_team assign_best_agent mute_conversation change_status
-                     resolve_conversation snooze_conversation send_email_transcript send_attachment].freeze
+                     resolve_conversation snooze_conversation send_email_transcript send_attachment add_private_note].freeze
 
   def set_visibility(user, params)
     self.visibility = params[:visibility]

--- a/app/services/macros/execution_service.rb
+++ b/app/services/macros/execution_service.rb
@@ -22,6 +22,16 @@ class Macros::ExecutionService < ActionService
 
   private
 
+  def add_private_note(message)
+    return if conversation_a_tweet?
+
+    params = { content: message[0], private: true }
+
+    # Added reload here to ensure conversation us persistent with the latest updates
+    mb = Messages::MessageBuilder.new(@user, @conversation.reload, params)
+    mb.perform
+  end
+
   def send_message(message)
     return if conversation_a_tweet?
 


### PR DESCRIPTION
Fixes #5733 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested on local, can save the macros with private note and when we execute the macros able to see private note in the conversation

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
