### PR TITLE
fix: Single select for agents and teams in Macros actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ test/cypress/videos/*
 
 /config/master.key
 /config/*.enc
+
+.vscode/settings.json

--- a/app/javascript/dashboard/routes/dashboard/settings/macros/MacroEditor.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/macros/MacroEditor.vue
@@ -83,7 +83,7 @@ export default {
           const inputType = this.macroActionTypes.find(
             item => item.key === action.action_name
           ).inputType;
-          if (inputType === 'multi_select') {
+          if (inputType === 'multi_select' || inputType === 'search_select') {
             actionParams = [
               ...this.getDropdownValues(action.action_name, this.$store),
             ].filter(item => [...action.action_params].includes(item.id));

--- a/app/javascript/dashboard/routes/dashboard/settings/macros/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/macros/constants.js
@@ -2,12 +2,12 @@ export const MACRO_ACTION_TYPES = [
   {
     key: 'assign_team',
     label: 'Assign a team',
-    inputType: 'multi_select',
+    inputType: 'search_select',
   },
   {
     key: 'assign_best_agent',
     label: 'Assign an agent',
-    inputType: 'multi_select',
+    inputType: 'search_select',
   },
   {
     key: 'add_label',


### PR DESCRIPTION
## Description
Single select dropdown instead of multiple for Agents and teams in Macros dropdowns

https://user-images.githubusercontent.com/15716057/201093177-0bcb1987-ca9f-4153-bac9-21581bd70759.mp4

Fixes #5836 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
