### PR TITLE
fix: send label list not object in event data presenter

### DIFF
--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -24,10 +24,6 @@ class Conversations::EventDataPresenter < SimpleDelegator
     [messages.chat.last&.push_event_data].compact
   end
 
-  def label_list
-    labels.pluck(:id, :name)
-  end
-
   def push_meta
     {
       sender: contact.push_event_data,

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -149,7 +149,7 @@ describe ActionCableListener do
     end
 
     it 'broadcast event with label data' do
-      expect(conversation.reload.push_event_data[:labels]).to eq(conversation.labels.pluck(:id, :name))
+      expect(conversation.reload.push_event_data[:labels]).to eq(conversation.labels.pluck(:name))
 
       expect(ActionCableBroadcastJob).to receive(:perform_later).with(
         [agent.pubsub_token, admin.pubsub_token, conversation.contact_inbox.pubsub_token],


### PR DESCRIPTION

Fixes https://github.com/chatwoot/product/issues/659

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


It was added for dispatching an event when the label is changing through macros or API.

- Test macros add_label for the impact.