### PR TITLE
feat: Add support for `after` param in messages API

### DIFF
--- a/app/finders/message_finder.rb
+++ b/app/finders/message_finder.rb
@@ -21,7 +21,9 @@ class MessageFinder
   end
 
   def current_messages
-    if @params[:before].present?
+    if @params[:after].present?
+      messages.reorder('created_at asc').where('id >= ?', @params[:before].to_i).limit(20)
+    elsif @params[:before].present?
       messages.reorder('created_at desc').where('id < ?', @params[:before].to_i).limit(20).reverse
     else
       messages.reorder('created_at desc').limit(20).reverse

--- a/spec/finders/message_finder_spec.rb
+++ b/spec/finders/message_finder_spec.rb
@@ -47,5 +47,16 @@ describe ::MessageFinder do
         expect(result.count).to be 6
       end
     end
+
+    context 'with after attribute' do
+      let(:params) { { after: conversation.messages.first.id } }
+
+      it 'filter conversations by status' do
+        result = message_finder.perform
+        expect(result.count).to be 6
+        expect(result.first.id).to be conversation.messages.first.id
+        expect(result.last.message_type).to eq 'outgoing'
+      end
+    end
   end
 end


### PR DESCRIPTION
To support https://github.com/chatwoot/chatwoot/issues/3320