### PR TITLE
Fix: Files in Whatsapp arrives with a different Name

### DIFF
--- a/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
@@ -69,17 +69,18 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
   def send_attachment_message(phone_number, message)
     attachment = message.attachments.first
     type = %w[image audio video].include?(attachment.file_type) ? attachment.file_type : 'document'
-    attachment_url = attachment.download_url
+    type_content = {
+      'link': attachment.download_url
+    }
+    type_content['caption'] = message.content unless %w[audio sticker].include?(type)
+    type_content['filename'] = attachment.file.filename if type == 'document'
     response = HTTParty.post(
       "#{api_base_path}/messages",
       headers: api_headers,
       body: {
         'to' => phone_number,
         'type' => type,
-        type.to_s => {
-          'link': attachment_url,
-          'caption': message.content
-        }
+        type.to_s => type_content
       }.to_json
     )
 

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -69,11 +69,11 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   def send_attachment_message(phone_number, message)
     attachment = message.attachments.first
     type = %w[image audio video].include?(attachment.file_type) ? attachment.file_type : 'document'
-    attachment_url = attachment.download_url
     type_content = {
-      'link': attachment_url
+      'link': attachment.download_url
     }
-    type_content['caption'] = message.content if type != 'audio'
+    type_content['caption'] = message.content unless %w[audio sticker].include?(type)
+    type_content['filename'] = attachment.file.filename if type == 'document'
     response = HTTParty.post(
       "#{phone_id_path}/messages",
       headers: api_headers,


### PR DESCRIPTION
# Pull Request Template

## Description

Adjusted the way the Cloud service and Dialog360 send the attachment name.
According to documentation:
![image](https://user-images.githubusercontent.com/9892674/202971253-ad1de7de-28cc-4ee3-ac16-fa265a9f8cab.png)

- [X]  Replace caption with filename when attachment type is document
- [X] Implement the same for whatsapp cloud
- [X] Verify behaviour of audio messages for 360dialog when caption is present: ref: (https://github.com/chatwoot/chatwoot/issues/5078)

About this:
- Send message content as a separate message before the attachment ( since whatsapp doesn't support message and attachments attached together )

Only audio/sticker type attachments do not allow text.

The other models allow text along with the attachment (caption), but when there is content (text) and it is not audio/sticker, the text will be sent as a caption.

Fixes # (issue)
#4481 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Attached image with and without content in message.
Attached PDF with and without content in the message.
Recorded Audio (Recorded audio does not allow message text).

In both cases the messages were received on WhatsApp.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
