### PR TITLE
Add word-break to long content

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/canned/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/canned/Index.vue
@@ -46,7 +46,7 @@
                 {{ cannedItem.short_code }}
               </td>
               <!-- Content -->
-              <td>{{ cannedItem.content }}</td>
+              <td class="wrap-break-words">{{ cannedItem.content }}</td>
               <!-- Action Buttons -->
               <td class="button-wrapper">
                 <woot-button
@@ -208,5 +208,9 @@ export default {
 <style scoped>
 .short-code {
   width: 14rem;
+}
+.wrap-break-words {
+  word-break: break-all;
+  white-space: normal;
 }
 </style>


### PR DESCRIPTION
# Pull Request Template

## Description

Break words and wraps on longer content in canend responses table.

| Before                                                                                                                                                                                 | After                                                                                                                                                                                  |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1440" alt="Screenshot2022-11-22 at 14 54 26@2x" src="https://user-images.githubusercontent.com/15716057/203277130-1a3269b0-ef8a-4697-9e20-cbc2b6b86bc1.png"> | <img  width="1440"   alt="Screenshot2022-11-22 at 14 54 37@2x"   src="https://user-images.githubusercontent.com/15716057/203277153-b7739fd5-e3ba-4160-a020-908aed975c0b.png"> |

Fixes https://github.com/chatwoot/product/issues/660

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
