### PR TITLE
fix: Confirmation mail template on email update

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -11,9 +11,11 @@
 <p>You can confirm your account email through the link below:</p>
 <% end %>
 
-<% if @resource.confirmed? %>
+<% if @resource.unconfirmed_email.present? %>
+<p><%= link_to 'Confirm my account', frontend_url('auth/confirmation', confirmation_token: @token) %></p>
+<% elsif @resource.confirmed? %>
 <p><%= link_to 'Login to my account', frontend_url('auth/sign_in') %></p>
-<% elsif account_user&.inviter.present? && @resource.unconfirmed_email.blank?  %>
+<% elsif account_user&.inviter.present? %>
 <p><%= link_to 'Confirm my account', frontend_url('auth/password/edit', reset_password_token: @resource.send(:set_reset_password_token)) %></p>
 <% else %>
 <p><%= link_to 'Confirm my account', frontend_url('auth/confirmation', confirmation_token: @token) %></p>

--- a/spec/mailers/confirmation_instructions_spec.rb
+++ b/spec/mailers/confirmation_instructions_spec.rb
@@ -63,6 +63,21 @@ RSpec.describe 'Confirmation Instructions', type: :mailer do
       end
     end
 
+    context 'when user is confirmed and updates the email' do
+      before do
+        confirmable_user.confirm
+        confirmable_user.update!(email: 'user@example.com')
+      end
+
+      it 'sends a confirmation link' do
+        confirmation_mail = Devise::Mailer.confirmation_instructions(confirmable_user.reload, nil, {})
+
+        expect(confirmation_mail.body).to include('app/auth/confirmation?confirmation_token')
+        expect(confirmation_mail.body).not_to include('app/auth/password/edit')
+        expect(confirmable_user.unconfirmed_email.blank?).to be false
+      end
+    end
+
     context 'when user already confirmed' do
       before do
         confirmable_user.confirm


### PR DESCRIPTION
# Pull Request Template

## Description

Fix the confirmation mail template when the user updates his email 
before this fix, if the user is confirmed and tries to update his email, he will receive an email with a login URL instead of a confirmation link for the new email.

![Screenshot 2022-11-24 at 14-12-55 MailHog](https://user-images.githubusercontent.com/58332033/203860779-426b8a92-3699-4276-b337-8389256e5281.png)

after this fix, if the user is confirmed and tries to update his email, he will receive an email with a confirmation link for the new email and will be able to update his email.

![Screenshot 2022-11-24 at 14-16-07 MailHog](https://user-images.githubusercontent.com/58332033/203860788-1671802a-b5f6-41fd-9b6a-7d67586652c5.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Try to log in with your confirmed email and update your email.
- Chatwoot will log you out and send you a confirmation email.
- The Confirmation email will contain a login link instead of a confirmation link.
- In this scenario, you will not be able to update your email.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
