### PR TITLE
fix: Save hostname for the custom domain in the portal

### DIFF
--- a/app/controllers/api/v1/accounts/portals_controller.rb
+++ b/app/controllers/api/v1/accounts/portals_controller.rb
@@ -21,6 +21,7 @@ class Api::V1::Accounts::PortalsController < Api::V1::Accounts::BaseController
 
   def create
     @portal = Current.account.portals.build(portal_params)
+    @portal.custom_domain = parsed_custom_domain
     @portal.save!
     process_attached_logo
   end
@@ -28,6 +29,7 @@ class Api::V1::Accounts::PortalsController < Api::V1::Accounts::BaseController
   def update
     ActiveRecord::Base.transaction do
       @portal.update!(portal_params) if params[:portal].present?
+      # @portal.custom_domain = parsed_custom_domain
       process_attached_logo
     rescue StandardError => e
       Rails.logger.error e
@@ -72,5 +74,10 @@ class Api::V1::Accounts::PortalsController < Api::V1::Accounts::BaseController
 
   def set_current_page
     @current_page = params[:page] || 1
+  end
+
+  def parsed_custom_domain
+    domain = URI.parse(@portal.custom_domain)
+    domain.is_a?(URI::HTTP) ? domain.host : @portal.custom_domain
   end
 end

--- a/spec/controllers/api/v1/accounts/portals_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/portals_controller_spec.rb
@@ -91,7 +91,8 @@ RSpec.describe 'Api::V1::Accounts::Portals', type: :request do
         portal_params = {
           portal: {
             name: 'test_portal',
-            slug: 'test_kbase'
+            slug: 'test_kbase',
+            custom_domain: 'https://support.chatwoot.dev'
           },
           logo: file
         }
@@ -103,6 +104,7 @@ RSpec.describe 'Api::V1::Accounts::Portals', type: :request do
         json_response = JSON.parse(response.body)
         expect(json_response['name']).to eql('test_portal')
         expect(json_response['logo']['filename']).to eql('avatar.png')
+        expect(json_response['custom_domain']).to eql('support.chatwoot.dev')
       end
     end
   end


### PR DESCRIPTION
Saving the custom-domain with validation of URL, impacting the backend functionality to check the custom-domain against portal records.

So while saving the records we are only saving the hostname not the whole URL in the backend.

Fixes #5983 


- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?



