### PR TITLE
Escape search term before building regular expression

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/search/SearchMessageItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/search/SearchMessageItem.vue
@@ -64,10 +64,15 @@ export default {
   methods: {
     prepareContent(content = '') {
       const plainTextContent = this.getPlainText(content);
+      const escapedSearchTerm = this.escapeRegExp(this.searchTerm);
       return plainTextContent.replace(
-        new RegExp(`(${this.searchTerm})`, 'ig'),
+        new RegExp(`(${escapedSearchTerm})`, 'ig'),
         '<span class="searchkey--highlight">$1</span>'
       );
+    },
+    // from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+    escapeRegExp(string) {
+      return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     },
   },
 };


### PR DESCRIPTION
## Description

When doing a conversation search, if the search term includes any regular
expression characters and the search returns results, then this function would
interpret the regex characters and possibly throw an exception.

For example, if a conversation includes the text "+15555550111" and you search
for "+15555550111" then you get an exception like:

> Invalid regular expression: /(+15555550111)/: Nothing to repeat

Because the "+" is not escaped.

**NOTE:** I haven't added any tests b/c I'm not familiar w/ how to write tests for
frontend changes like this in chatwoot.

### Before the fix:

<img width="1783" alt="image" src="https://user-images.githubusercontent.com/23050/204814423-fe464c84-26fc-4b05-895f-2838efefafd3.png">

### After the fix:

<img width="1783" alt="image" src="https://user-images.githubusercontent.com/23050/204814499-c212a473-39ee-4b86-b6f7-897c9ba04746.png">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've only tested by running the code locally and testing in a browser.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
