### PR TITLE
feat: Send audio longer than 10 seconds

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/AudioRecorder.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/AudioRecorder.vue
@@ -10,11 +10,11 @@ import 'videojs-record/dist/css/videojs.record.css';
 
 import videojs from 'video.js';
 
-import inboxMixin from '../../../../shared/mixins/inboxMixin';
 import alertMixin from '../../../../shared/mixins/alertMixin';
 
 import Recorder from 'opus-recorder';
 import encoderWorker from 'opus-recorder/dist/encoderWorker.min';
+import waveWorker from 'opus-recorder/dist/waveWorker.min';
 
 import WaveSurfer from 'wavesurfer.js';
 import MicrophonePlugin from 'wavesurfer.js/dist/plugin/wavesurfer.microphone.js';
@@ -29,14 +29,19 @@ WaveSurfer.microphone = MicrophonePlugin;
 
 export default {
   name: 'WootAudioRecorder',
-  mixins: [inboxMixin, alertMixin],
+  mixins: [alertMixin],
+  props: {
+    audioRecordFormat: {
+      type: String,
+      default: AUDIO_FORMATS.WEBM,
+    },
+  },
   data() {
     return {
       player: false,
       recordingDateStarted: new Date(0),
       initialTimeDuration: '00:00',
       recorderOptions: {
-        debug: true,
         controls: true,
         bigPlayButton: false,
         fluid: false,
@@ -71,6 +76,9 @@ export default {
           record: {
             audio: true,
             video: false,
+            maxLength: 900,
+            timeSlice: 1000,
+            maxFileSize: 15 * 1024 * 1024,
             ...(this.audioRecordFormat === AUDIO_FORMATS.WEBM && {
               monitorGain: 0,
               recordingGain: 1,
@@ -80,11 +88,10 @@ export default {
               streamPages: true,
               maxFramesPerPage: 1,
               encoderFrameSize: 1,
-              encoderPath: 'opus-recorder/dist/waveWorker.min.js',
+              encoderPath: waveWorker,
             }),
             ...(this.audioRecordFormat === AUDIO_FORMATS.OGG && {
               displayMilliseconds: false,
-              maxLength: 300,
               audioEngine: 'opus-recorder',
               audioWorkerURL: encoderWorker,
               audioChannels: 1,
@@ -99,12 +106,6 @@ export default {
   computed: {
     isRecording() {
       return this.player && this.player.record().isRecording();
-    },
-    audioRecordFormat() {
-      if (this.isAWebWidgetInbox) {
-        return AUDIO_FORMATS.WEBM;
-      }
-      return AUDIO_FORMATS.OGG;
     },
   },
   mounted() {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -37,6 +37,7 @@
       <woot-audio-recorder
         v-if="showAudioRecorderEditor"
         ref="audioRecorderInput"
+        :audio-record-format="audioRecordFormat"
         @state-recorder-progress-changed="onStateProgressRecorderChanged"
         @state-recorder-changed="onStateRecorderChanged"
         @finish-record="onFinishRecorder"
@@ -147,6 +148,7 @@ import { checkFileSizeLimit } from 'shared/helpers/FileHelper';
 import {
   MAXIMUM_FILE_UPLOAD_SIZE,
   MAXIMUM_FILE_UPLOAD_SIZE_TWILIO_SMS_CHANNEL,
+  AUDIO_FORMATS,
 } from 'shared/constants/messages';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 
@@ -461,6 +463,12 @@ export default {
     },
     editorStateId() {
       return `draft-${this.conversationIdByRoute}-${this.replyType}`;
+    },
+    audioRecordFormat() {
+      if (this.isAWebWidgetInbox) {
+        return AUDIO_FORMATS.WEBM;
+      }
+      return AUDIO_FORMATS.OGG;
     },
   },
   watch: {

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -6,8 +6,16 @@ const vue = require('./loaders/vue');
 environment.plugins.prepend('VueLoaderPlugin', new VueLoaderPlugin());
 environment.loaders.prepend('vue', vue);
 
-environment.loaders.append('opus', {
+environment.loaders.append('opus-ogg', {
   test: /encoderWorker\.min\.js$/,
+  loader: 'file-loader',
+  options: {
+    name: '[name].[ext]',
+  },
+});
+
+environment.loaders.append('opus-wav', {
+  test: /waveWorker\.min\.js$/,
   loader: 'file-loader',
   options: {
     name: '[name].[ext]',


### PR DESCRIPTION
# Pull Request Template

## Description

The props were configured:
maxLength: Maximum length of the recorded clip. Default was 10s, set to 900 (15 minutes) 
timeSlice: Required parameter to use size (maxFileSize) management.
maxFileSize: Maximum file size of a recorded clip (in bytes). Recording will stop when the limit is reached. Can only be used when timeSlice option is also enabled.

Based on configured props videojs will cut the recording as soon as the first condition is met, size or time.

```
maxLength: 900,
timeSlice: 1000,
maxFileSize: 15 * 1024 * 1024,
```

I made an adjustment in passing the **audio-record-format** format.
When assembling the AudioRecorder component the inbox was undefined. I delegated to the parent component (RaplyBox) to send as a prop.

Fixes #6054 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Recorded audio.
Sent to Web Widget.
Sent to WhatsApp.
Sent to Telegram.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
