### PR TITLE
fix: Use canned response menu from the editor in contact messages

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
@@ -61,7 +61,7 @@
         <div class="columns">
           <div class="canned-response">
             <canned-response
-              v-if="showMentions && hasSlashCommand"
+              v-if="showCannedResponseMenu && hasSlashCommand"
               :search-key="cannedResponseSearchKey"
               @click="replaceTextWithCannedResponse"
             />
@@ -158,7 +158,7 @@ export default {
       name: '',
       subject: '',
       message: '',
-      showMentions: false,
+      showCannedResponseMenu: false,
       cannedResponseSearchKey: '',
       selectedInbox: '',
       bccEmails: '',
@@ -244,10 +244,10 @@ export default {
       const isShortCodeActive = this.hasSlashCommand && !hasNextWord;
       if (isShortCodeActive) {
         this.cannedResponseSearchKey = value.substring(1);
-        this.showMentions = true;
+        this.showCannedResponseMenu = true;
       } else {
         this.cannedResponseSearchKey = '';
-        this.showMentions = false;
+        this.showCannedResponseMenu = false;
       }
     },
   },

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
@@ -61,7 +61,7 @@
         <div class="columns">
           <div class="canned-response">
             <canned-response
-              v-if="showCannedMenu && hasSlashCommand"
+              v-if="showMentions && hasSlashCommand"
               :search-key="cannedResponseSearchKey"
               @click="replaceTextWithCannedResponse"
             />
@@ -158,6 +158,7 @@ export default {
       name: '',
       subject: '',
       message: '',
+      showMentions: false,
       cannedResponseSearchKey: '',
       selectedInbox: '',
       bccEmails: '',
@@ -243,10 +244,10 @@ export default {
       const isShortCodeActive = this.hasSlashCommand && !hasNextWord;
       if (isShortCodeActive) {
         this.cannedResponseSearchKey = value.substring(1);
-        this.showCannedMenu = true;
+        this.showMentions = true;
       } else {
         this.cannedResponseSearchKey = '';
-        this.showCannedMenu = false;
+        this.showMentions = false;
       }
     },
   },

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
@@ -61,12 +61,12 @@
         <div class="columns">
           <div class="canned-response">
             <canned-response
-              v-if="showCannedResponseMenu && hasSlashCommand"
+              v-if="showCannedMenu && hasSlashCommand"
               :search-key="cannedResponseSearchKey"
               @click="replaceTextWithCannedResponse"
             />
           </div>
-          <div v-if="isAnEmailInbox || isAnWebWidgetInbox">
+          <div v-if="isEmailOrWebWidgetInbox">
             <label>
               {{ $t('NEW_CONVERSATION.FORM.MESSAGE.LABEL') }}
               <reply-email-head
@@ -80,6 +80,7 @@
                   class="message-editor"
                   :class="{ editor_warning: $v.message.$error }"
                   :placeholder="$t('NEW_CONVERSATION.FORM.MESSAGE.PLACEHOLDER')"
+                  @toggle-canned-menu="toggleCannedMenu"
                   @blur="$v.message.$touch"
                 />
                 <span v-if="$v.message.$error" class="editor-warning__message">
@@ -157,7 +158,6 @@ export default {
       name: '',
       subject: '',
       message: '',
-      showCannedResponseMenu: false,
       cannedResponseSearchKey: '',
       selectedInbox: '',
       bccEmails: '',
@@ -229,21 +229,24 @@ export default {
         this.selectedInbox.inbox.channel_type === INBOX_TYPES.WEB
       );
     },
+    isEmailOrWebWidgetInbox() {
+      return this.isAnEmailInbox || this.isAnWebWidgetInbox;
+    },
     hasWhatsappTemplates() {
       return !!this.selectedInbox.inbox?.message_templates;
     },
   },
   watch: {
     message(value) {
-      this.hasSlashCommand = value[0] === '/';
+      this.hasSlashCommand = value[0] === '/' && !this.isEmailOrWebWidgetInbox;
       const hasNextWord = value.includes(' ');
       const isShortCodeActive = this.hasSlashCommand && !hasNextWord;
       if (isShortCodeActive) {
         this.cannedResponseSearchKey = value.substring(1);
-        this.showCannedResponseMenu = true;
+        this.showCannedMenu = true;
       } else {
         this.cannedResponseSearchKey = '';
-        this.showCannedResponseMenu = false;
+        this.showCannedMenu = false;
       }
     },
   },
@@ -258,6 +261,9 @@ export default {
       setTimeout(() => {
         this.message = message;
       }, 50);
+    },
+    toggleCannedMenu(value) {
+      this.showCannedMenu = value;
     },
     prepareWhatsAppMessagePayload({ message: content, templateParams }) {
       const payload = {
@@ -315,12 +321,10 @@ export default {
 }
 
 .canned-response {
-  position: relative;
-  top: var(--space-medium);
-
   ::v-deep .mention--box {
     border-left: 1px solid var(--color-border);
     border-right: 1px solid var(--color-border);
+    top: var(--space-jumbo) !important;
   }
 }
 
@@ -354,5 +358,15 @@ export default {
 }
 .row.gutter-small {
   gap: var(--space-small);
+}
+
+::v-deep .mention--box {
+  border-left: 1px solid var(--color-border);
+  border-right: 1px solid var(--color-border);
+  left: 0;
+  margin: auto;
+  right: 0;
+  top: 18rem !important;
+  width: 90%;
 }
 </style>


### PR DESCRIPTION
# Pull Request Template

## Description

By this PR the canned response menu in the rich editor is showing from the editor component before its showing from the imported component.


Fixes https://github.com/chatwoot/product/issues/724

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
https://www.loom.com/share/2c937f19af7c42b7b10f12fa733bbc54


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
