### PR TITLE
chore: Hide inbox name only has one inbox

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
@@ -21,7 +21,11 @@
           />
         </h3>
         <div class="conversation--header--actions">
-          <inbox-name :inbox="inbox" class="margin-right-small" />
+          <inbox-name
+            v-if="hasMultipleInboxes"
+            :inbox="inbox"
+            class="margin-right-small"
+          />
           <span
             v-if="isSnoozed"
             class="snoozed--display-text margin-right-small"
@@ -144,6 +148,9 @@ export default {
     inbox() {
       const { inbox_id: inboxId } = this.chat;
       return this.$store.getters['inboxes/getInbox'](inboxId);
+    },
+    hasMultipleInboxes() {
+      return this.$store.getters['inboxes/getInboxes'].length > 1;
     },
   },
 


### PR DESCRIPTION
# Pull Request Template

## Description

If you only have one inbox, the inbox name in the chat header will be hidden.

Fixes https://github.com/chatwoot/chatwoot/issues/5843

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
