### PR TITLE
fix: Increase the max concurrent number of devices 

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -15,7 +15,7 @@ DeviseTokenAuth.setup do |config|
 
   # Sets the max number of concurrent devices per user, which is 10 by default.
   # After this limit is reached, the oldest tokens will be removed.
-  # config.max_number_of_devices = 10
+  config.max_number_of_devices = 25
 
   # Sometimes it's necessary to make several requests to the API at the same
   # time. In this case, each request in the batch will need to share the same


### PR DESCRIPTION
Fixes https://github.com/chatwoot/chatwoot-mobile-app/issues/532

It is just a temporary workaround to fix the auto-logout issue for accounts used by multiple people/devices. 