### PR TITLE
Feat/telegram incoming location message

### DIFF
--- a/app/services/telegram/incoming_message_service.rb
+++ b/app/services/telegram/incoming_message_service.rb
@@ -20,6 +20,7 @@ class Telegram::IncomingMessageService
       sender: @contact,
       source_id: (params[:message][:message_id]).to_s
     )
+    attach_location
     attach_files
     @message.save!
   end
@@ -111,8 +112,23 @@ class Telegram::IncomingMessageService
     )
   end
 
+  def attach_location
+    return unless location
+
+    @message.attachments.new(
+      account_id: @message.account_id,
+      file_type: :location,
+      coordinates_lat: location['latitude'],
+      coordinates_long: location['longitude']
+    )
+  end
+
   def file
     @file ||= visual_media_params || params[:message][:voice].presence || params[:message][:audio].presence || params[:message][:document].presence
+  end
+
+  def location
+    @location ||= params[:message][:location].presence
   end
 
   def visual_media_params

--- a/spec/services/telegram/incoming_message_service_spec.rb
+++ b/spec/services/telegram/incoming_message_service_spec.rb
@@ -214,5 +214,23 @@ describe Telegram::IncomingMessageService do
         expect(telegram_channel.inbox.messages.first.attachments.first.file_type).to eq('file')
       end
     end
+
+    context 'when valid location message params' do
+      it 'creates appropriate conversations, message and contacts' do
+        params = {
+          'update_id' => 2_342_342_343_242,
+          'message' => {
+            'location': {
+              'latitude': 37.7893768,
+              'longitude': -122.3895553
+            }
+          }.merge(message_params)
+        }.with_indifferent_access
+        described_class.new(inbox: telegram_channel.inbox, params: params).perform
+        expect(telegram_channel.inbox.conversations.count).not_to eq(0)
+        expect(Contact.all.first.name).to eq('Sojan Jose')
+        expect(telegram_channel.inbox.messages.first.attachments.first.file_type).to eq('location')
+      end
+    end
   end
 end


### PR DESCRIPTION


## Description

Added telegram incoming location message attachment similar to what was done for Whatsapp in #5742 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

**First**, this is what the telegram payload looks like.

```json
{
  "update_id": 283113056,
  "message": {
    "from": {
      "id": 1111111,
      "is_bot": false,
      "first_name": "Test",
      "last_name": "Test",
      "username": "Test",
      "language_code": "en"
    },
    "message_id": 1365,
    "chat": {
      "id": 1111111,
      "first_name": "Test",
      "last_name": "Test",
      "username": "Test",
      "type": "private"
    },
    "date": 1672532395,
    "location": {
      "latitude": 37.7893768,
      "longitude": -122.3895553
    }
  }
}
```

**Locally**, I have tested this with postman and made a request to telegram webhook with the above payload 
and this is the result

![Screenshot_20230101_112152](https://user-images.githubusercontent.com/58332033/210166437-31e8607d-bb59-4cea-a3b5-4c5e324fdff2.png)


**Live**, I have tested this with a real telegram channel and account and worked with the same result


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
