### PR TITLE
fix: incorrect label for team members

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportFilters.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportFilters.vue
@@ -90,7 +90,15 @@
     </div>
     <div v-else class="small-12 medium-3 pull-right">
       <p>
-        {{ $t('INBOX_REPORTS.FILTER_DROPDOWN_LABEL') }}
+        <template v-if="type === 'inbox'">
+          {{ $t('INBOX_REPORTS.FILTER_DROPDOWN_LABEL') }}
+        </template>
+        <template v-else-if="type === 'team'">
+          {{ $t('TEAM_REPORTS.FILTER_DROPDOWN_LABEL') }}
+        </template>
+        <template v-else>
+          {{ $t('FORMS.MULTISELECT.SELECT_ONE') }}
+        </template>
       </p>
       <multiselect
         v-model="currentSelectedFilter"

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportFilters.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportFilters.vue
@@ -96,6 +96,7 @@
         <template v-else-if="type === 'team'">
           {{ $t('TEAM_REPORTS.FILTER_DROPDOWN_LABEL') }}
         </template>
+        <!-- handle default condition because the prop is not limited to the given 4 values -->
         <template v-else>
           {{ $t('FORMS.MULTISELECT.SELECT_ONE') }}
         </template>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes incorrect form labels on the team reports page

<img width="811" alt="image" src="https://user-images.githubusercontent.com/18097732/210733620-7bfb8947-6452-4aa7-80af-76f58f63f798.png">


## Type of change

The fix is to handle the last `v-else` block to handle the `inbox` and `team` type separately, which earlier handled only the `inbox`.  Ideal solution to this would be to have a generic filter component that is used separately instead of handling multiple cases in the same component. But this fix should work for now

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Navigate to the `/app/accounts/<account_id>/reports/teams` page on any instance to find the incorrect label,
- The component is shared across other pages, navigating to other reports can verify that this fix does not break any of the existing pages

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ x I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
