### PR TITLE
Fix: Errors in Heroku deployments

### DIFF
--- a/config/initializers/01_redis.rb
+++ b/config/initializers/01_redis.rb
@@ -1,16 +1,14 @@
-Rails.application.reloader.to_prepare do
-  # Alfred
-  # Add here as you use it for more features
-  # Used for Round Robin, Conversation Emails & Online Presence
-  $alfred = ConnectionPool.new(size: 5, timeout: 3) do
-    redis = Rails.env.test? ? MockRedis.new : Redis.new(Redis::Config.app)
-    Redis::Namespace.new('alfred', redis: redis, warning: true)
-  end
+# Alfred
+# Add here as you use it for more features
+# Used for Round Robin, Conversation Emails & Online Presence
+$alfred = ConnectionPool.new(size: 5, timeout: 3) do
+  redis = Rails.env.test? ? MockRedis.new : Redis.new(Redis::Config.app)
+  Redis::Namespace.new('alfred', redis: redis, warning: true)
+end
 
-  # Velma : Determined protector
-  # used in rack attack
-  $velma = ConnectionPool.new(size: 5, timeout: 3) do
-    config = Rails.env.test? ? MockRedis.new : Redis.new(Redis::Config.app)
-    Redis::Namespace.new('velma', redis: config, warning: true)
-  end
+# Velma : Determined protector
+# used in rack attack
+$velma = ConnectionPool.new(size: 5, timeout: 3) do
+  config = Rails.env.test? ? MockRedis.new : Redis.new(Redis::Config.app)
+  Redis::Namespace.new('velma', redis: config, warning: true)
 end


### PR DESCRIPTION
Due to https://github.com/chatwoot/chatwoot/commit/86ca7f4a8d5e2b7d45033e85d5e100870ed0bfa0 the Redis configuration in some Heroku deployments was breaking, temporarily reverting the part until we identify a fix.

fixes: #5938

