### PR TITLE
fix: If desktop view is false then the view not getting updated

### DIFF
--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
@@ -81,8 +81,12 @@
   }
 
   .conversations-list {
-    @include scroll-on-hover;
+    overflow-y: auto;
     flex: 1 1;
+
+    @include breakpoint(large up) {
+      @include scroll-on-hover;
+    }
   }
 
   .chat-list__top {

--- a/app/javascript/dashboard/constants.js
+++ b/app/javascript/dashboard/constants.js
@@ -23,6 +23,6 @@ export default {
   },
   DOCS_URL: '//www.chatwoot.com/docs/product/',
   TESTIMONIAL_URL: 'https://testimonials.cdn.chatwoot.com/content.json',
-  SMALL_SCREEN_BREAKPOINT: 992,
+  SMALL_SCREEN_BREAKPOINT: 1024,
 };
 export const DEFAULT_REDIRECT_URL = '/app/';

--- a/app/javascript/dashboard/routes/dashboard/Dashboard.vue
+++ b/app/javascript/dashboard/routes/dashboard/Dashboard.vue
@@ -84,6 +84,12 @@ export default {
       } = this.uiSettings;
       return conversationDisplayType;
     },
+    previouslyUsedSidebarView() {
+      const {
+        previously_used_sidebar_view: showSecondarySidebar,
+      } = this.uiSettings;
+      return showSecondarySidebar;
+    },
   },
   watch: {
     displayLayoutType() {
@@ -93,6 +99,10 @@ export default {
           this.displayLayoutType === LAYOUT_TYPES.EXPANDED
             ? LAYOUT_TYPES.EXPANDED
             : this.previouslyUsedDisplayType,
+        show_secondary_sidebar:
+          this.displayLayoutType === LAYOUT_TYPES.EXPANDED
+            ? false
+            : this.previouslyUsedSidebarView,
       });
     },
   },
@@ -129,6 +139,7 @@ export default {
     toggleSidebar() {
       this.updateUISettings({
         show_secondary_sidebar: !this.isSidebarOpen,
+        previously_used_sidebar_view: !this.isSidebarOpen,
       });
     },
     openCreateAccountModal() {

--- a/app/javascript/dashboard/routes/dashboard/Dashboard.vue
+++ b/app/javascript/dashboard/routes/dashboard/Dashboard.vue
@@ -62,13 +62,12 @@ export default {
   mixins: [uiSettingsMixin],
   data() {
     return {
-      isOnDesktop: true,
       showAccountModal: false,
       showCreateAccountModal: false,
       showAddLabelModal: false,
       showShortcutModal: false,
       isNotificationPanel: false,
-      isDesktopView: false,
+      displayLayoutType: '',
     };
   },
   computed: {
@@ -87,12 +86,13 @@ export default {
     },
   },
   watch: {
-    isDesktopView() {
+    displayLayoutType() {
       const { LAYOUT_TYPES } = wootConstants;
       this.updateUISettings({
-        conversation_display_type: !this.isDesktopView
-          ? LAYOUT_TYPES.EXPANDED
-          : this.previouslyUsedDisplayType,
+        conversation_display_type:
+          this.displayLayoutType === LAYOUT_TYPES.EXPANDED
+            ? LAYOUT_TYPES.EXPANDED
+            : this.previouslyUsedDisplayType,
       });
     },
   },
@@ -108,7 +108,7 @@ export default {
 
   methods: {
     handleResize() {
-      const { SMALL_SCREEN_BREAKPOINT } = wootConstants;
+      const { SMALL_SCREEN_BREAKPOINT, LAYOUT_TYPES } = wootConstants;
       let throttled = false;
       const delay = 150;
 
@@ -120,9 +120,9 @@ export default {
       setTimeout(() => {
         throttled = false;
         if (window.innerWidth <= SMALL_SCREEN_BREAKPOINT) {
-          this.isDesktopView = false;
+          this.displayLayoutType = LAYOUT_TYPES.EXPANDED;
         } else {
-          this.isDesktopView = true;
+          this.displayLayoutType = LAYOUT_TYPES.CONDENSED;
         }
       }, delay);
     },


### PR DESCRIPTION
# Pull Request Template

## Description

1. This PR will fix the issue that if the desktop view is false, the conversation display layout is not updated on the first load. It is working fine when we resize the screen.
2. Handle the secondary sidebar on the small screen. If the inner width of the window is less than 1024, then the secondary sidebar will be closed else it will retain the previous state.
3. Fix the scrolling issue in the chat list for touchscreen devices.

Fixes https://github.com/chatwoot/product/issues/745

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Before**
https://www.loom.com/share/2278cfdcac1a4c93bc785e80fae460f9

**After**
https://www.loom.com/share/b7be2ac0e39544e294ff507acf04861d


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
