### PR TITLE
feat: Use rich text editor for automation and macros message action

### DIFF
--- a/app/javascript/dashboard/components/widgets/AutomationActionInput.vue
+++ b/app/javascript/dashboard/components/widgets/AutomationActionInput.vue
@@ -88,9 +88,9 @@
       v-model="action_params"
       :teams="dropdownValues"
     />
-    <textarea
+    <woot-message-editor
       v-if="inputType === 'textarea'"
-      v-model="action_params"
+      v-model="castMessageVmodel"
       rows="4"
       :placeholder="$t('AUTOMATION.ACTION.TEAM_MESSAGE_INPUT_PLACEHOLDER')"
       class="action-message"
@@ -107,10 +107,12 @@
 <script>
 import AutomationActionTeamMessageInput from './AutomationActionTeamMessageInput.vue';
 import AutomationActionFileInput from './AutomationFileInput.vue';
+import WootMessageEditor from 'dashboard/components/widgets/WootWriter/Editor';
 export default {
   components: {
     AutomationActionTeamMessageInput,
     AutomationActionFileInput,
+    WootMessageEditor,
   },
   props: {
     value: {
@@ -172,6 +174,17 @@ export default {
         'has-error': this.v.action_params.$dirty && this.v.action_params.$error,
         'is-a-macro': this.isMacro,
       };
+    },
+    castMessageVmodel: {
+      get() {
+        if (Array.isArray(this.action_params)) {
+          return this.action_params[0];
+        }
+        return this.action_params;
+      },
+      set(value) {
+        this.action_params = value;
+      },
     },
   },
   methods: {
@@ -280,5 +293,9 @@ export default {
 }
 .action-message {
   margin: var(--space-small) var(--space-zero) var(--space-zero);
+}
+// Prosemirror does not have a native way of hiding the menu bar, hence
+::v-deep .ProseMirror-menubar {
+  display: none;
 }
 </style>


### PR DESCRIPTION
Uses rich message editor instead of native textarea for message actions in automations and macros editors
<img width="1440" alt="Screenshot2023-01-10 at 14 14 41@2x" src="https://user-images.githubusercontent.com/15716057/211503752-0ecd8e53-5ce9-4ed0-9cd0-2288ef28a39e.png">
<img width="1440" alt="Screenshot2023-01-10 at 14 14 19@2x" src="https://user-images.githubusercontent.com/15716057/211503782-e70d42a5-824f-4cb8-8dab-1289005d125b.png">
