### PR TITLE
fix: Fixes inconsistent spacing in message bubble

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -280,7 +280,6 @@ export default {
 .message-text--metadata {
   align-items: flex-start;
   display: flex;
-  margin-left: var(--space-small);
 
   .time {
     margin-right: var(--space-small);


### PR DESCRIPTION

## Description
This PR will fix the space issue with the timestamp in every bubble. It's showing an extra margin, which looks inconsistent.

**Before**
![image](https://user-images.githubusercontent.com/1277421/211552337-0cf43c4c-dd12-481a-ad74-64b4134801c8.png)

**After**
![image](https://user-images.githubusercontent.com/1277421/211552253-4b1a1762-be99-4b7c-8373-7fb6af9f8f30.png)


