### PR TITLE
fix: Not able to create a portal if the custom domain is empty

### DIFF
--- a/app/javascript/shared/helpers/Validators.js
+++ b/app/javascript/shared/helpers/Validators.js
@@ -18,6 +18,9 @@ export const isValidPassword = value => {
 };
 export const isNumber = value => /^\d+$/.test(value);
 export const isDomain = value => {
-  const domainRegex = /^([\p{L}0-9]+(-[\p{L}0-9]+)*\.)+[a-z]{2,}$/gmu;
-  return domainRegex.test(value);
+  if (value !== '') {
+    const domainRegex = /^([\p{L}0-9]+(-[\p{L}0-9]+)*\.)+[a-z]{2,}$/gmu;
+    return domainRegex.test(value);
+  }
+  return true;
 };


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will fix an issue which is occurred by domain validation PR, that we cannot create a portal if the custom domain field is empty.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
**Before**
<img width="742" alt="image" src="https://user-images.githubusercontent.com/64252451/211577313-56d24620-506e-4c5f-8ed1-dee92518df56.png">

**After**
https://www.loom.com/share/5a807911eda64337a3c5af39da1fe803


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
