### PR TITLE
fix: Handle overflowing content in custom attrs table

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/attributes/CustomAttribute.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/attributes/CustomAttribute.vue
@@ -213,6 +213,7 @@ export default {
 .woot-table {
   width: 100%;
   margin-top: var(--space-small);
+  table-layout: fixed;
 }
 
 .no-items-error-message {


### PR DESCRIPTION
## Description
Truncates all table cells to a fixed width layout

Before
<img width="1440" alt="Screenshot2023-01-11 at 10 44 12@2x" src="https://user-images.githubusercontent.com/15716057/211723301-3cfd75b9-f9e6-45e8-8e46-624c3eff9d8e.png">

After
<img width="1440" alt="Screenshot2023-01-11 at 10 44 24@2x" src="https://user-images.githubusercontent.com/15716057/211723405-90afdbb7-3408-4d70-94ea-49d458bc28bc.png">

Fixes https://github.com/chatwoot/product/issues/747

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)