### PR TITLE
fix: Stop processing broken liquid tags

### DIFF
--- a/app/models/concerns/liquidable.rb
+++ b/app/models/concerns/liquidable.rb
@@ -26,6 +26,8 @@ module Liquidable
 
     template = Liquid::Template.parse(modified_liquid_content)
     self.content = template.render(message_drops)
+  rescue Liquid::Error
+    # If there is an error in the liquid syntax, we don't want to process it
   end
 
   def modified_liquid_content

--- a/spec/models/concerns/liquidable_shared.rb
+++ b/spec/models/concerns/liquidable_shared.rb
@@ -36,6 +36,12 @@ shared_examples_for 'liqudable' do
         expect(message.content).to eq 'Can we send you an email at ?'
       end
 
+      it 'will skip processing broken liquid tags' do
+        message.content = 'Can we send you an email at {{contact.email}  {{hi}} ?'
+        message.save!
+        expect(message.content).to eq 'Can we send you an email at {{contact.email}  {{hi}} ?'
+      end
+
       it 'will not process liquid tags in multiple code blocks' do
         message.content = 'hey {{contact.name}} how are you? ```code: {{contact.name}}``` ``` code: {{contact.name}} ``` test `{{contact.name}}`'
         message.save!


### PR DESCRIPTION
It will not throw an error if messages have invalid liquid syntax.