### PR TITLE
fix: Prevent overflowing content in articles in phones

### DIFF
--- a/app/views/public/api/v1/portals/articles/show.html.erb
+++ b/app/views/public/api/v1/portals/articles/show.html.erb
@@ -47,7 +47,7 @@
 </div>
 <div class="max-w-5xl flex-grow w-full px-6 py-8 mx-auto space-y-12">
   <article class="space-y-8 ">
-    <div class="text-slate-800 leading-8 text-lg subpixel-antialiased max-w-3xl prose">
+    <div class="text-slate-800 leading-8 text-lg subpixel-antialiased max-w-3xl prose break-words">
       <p><%= @parsed_content %></p>
     </div>
   </article>


### PR DESCRIPTION
## Description
Prevents this

https://user-images.githubusercontent.com/15716057/213369910-324484c9-a992-40a2-8467-bd20dd420c59.mp4


Adds bread-word class to article prose content
