### PR TITLE
fix: Show only approved whatsapp templates

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplatesPicker.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplatesPicker.vue
@@ -67,7 +67,9 @@ export default {
   },
   computed: {
     whatsAppTemplateMessages() {
-      return this.$store.getters['inboxes/getWhatsAppTemplates'](this.inboxId);
+      return this.$store.getters['inboxes/getWhatsAppTemplates'](
+        this.inboxId
+      ).filter(template => template.status === 'approved');
     },
     filteredTemplateMessages() {
       return this.whatsAppTemplateMessages.filter(template =>


### PR DESCRIPTION
## Description

Filters and removes all templates from whatsapp template picker, where the status is not equal to `approved`

Fixes [# (issue)](https://github.com/chatwoot/product/issues/779)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested locally 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
