### PR TITLE
fix: Error when unsupported Whatsapp message status

### DIFF
--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -2,6 +2,8 @@
 # https://docs.360dialog.com/whatsapp-api/whatsapp-api/media
 # https://developers.facebook.com/docs/whatsapp/api/media/
 class Whatsapp::IncomingMessageBaseService
+  include ::Whatsapp::IncomingMessageServiceHelpers
+
   pattr_initialize [:inbox!, :params!]
 
   def perform
@@ -51,7 +53,7 @@ class Whatsapp::IncomingMessageBaseService
   end
 
   def create_messages
-    return if unprocessable_message_type?
+    return if unprocessable_message_type?(message_type)
 
     @message = @conversation.messages.build(
       content: message_content(@processed_params[:messages].first),
@@ -110,21 +112,8 @@ class Whatsapp::IncomingMessageBaseService
     @conversation = ::Conversation.create!(conversation_params)
   end
 
-  def file_content_type(file_type)
-    return :image if %w[image sticker].include?(file_type)
-    return :audio if %w[audio voice].include?(file_type)
-    return :video if ['video'].include?(file_type)
-    return :location if ['location'].include?(file_type)
-
-    :file
-  end
-
   def message_type
     @processed_params[:messages].first[:type]
-  end
-
-  def unprocessable_message_type?
-    %w[reaction contacts ephemeral unsupported].include?(message_type)
   end
 
   def attach_files

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -37,6 +37,8 @@ class Whatsapp::IncomingMessageBaseService
     return unless find_message_by_source_id(@processed_params[:statuses].first[:id])
 
     update_message_with_status(@message, @processed_params[:statuses].first)
+  rescue ArgumentError => e
+    Rails.logger.error "Error while processing whatsapp status update #{e.message}"
   end
 
   def update_message_with_status(message, status)

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -1,0 +1,14 @@
+module Whatsapp::IncomingMessageServiceHelpers
+  def file_content_type(file_type)
+    return :image if %w[image sticker].include?(file_type)
+    return :audio if %w[audio voice].include?(file_type)
+    return :video if ['video'].include?(file_type)
+    return :location if ['location'].include?(file_type)
+
+    :file
+  end
+
+  def unprocessable_message_type?(message_type)
+    %w[reaction contacts ephemeral unsupported].include?(message_type)
+  end
+end

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -113,6 +113,17 @@ describe Whatsapp::IncomingMessageService do
         expect(message.reload.status).to eq('failed')
         expect(message.external_error).to eq('123: abc')
       end
+
+      it 'will not throw error if unsupported status' do
+        status_params = {
+          'statuses' => [{ 'recipient_id' => from, 'id' => from, 'status' => 'deleted',
+                           'errors' => [{ 'code': 123, 'title': 'abc' }] }]
+        }.with_indifferent_access
+
+        message = Message.find_by!(source_id: from)
+        expect(message.status).to eq('sent')
+        expect { described_class.new(inbox: whatsapp_channel.inbox, params: status_params).perform }.not_to raise_error
+      end
     end
 
     context 'when valid interactive message params' do


### PR DESCRIPTION
Whatsapp now sends a `deleted` status message which throws an error in sidekiq. Temporarily handling that until we implement delete for the WhatsApp channel. 