### PR TITLE
chore: change the execution flow for deleting the invalid instagram story

### DIFF
--- a/app/models/channel/facebook_page.rb
+++ b/app/models/channel/facebook_page.rb
@@ -77,7 +77,7 @@ class Channel::FacebookPage < ApplicationRecord
   end
 
   def delete_instagram_story(message)
-    message.update(content: I18n.t('conversations.messages.instagram_deleted_story_content'), content_attributes: {})
     message.attachments.destroy_all
+    message.update(content: I18n.t('conversations.messages.instagram_deleted_story_content'), content_attributes: {})
   end
 end


### PR DESCRIPTION
To make sure, we delete the attachment before dispatching the message update event.