### PR TITLE
chore: run linting on staged files only

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 npx --no-install lint-staged
 git diff --name-only --cached | xargs ls -1 2>/dev/null | grep '\.rb$' | xargs bundle exec rubocop -a
+git add ./**/*.rb

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,11 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
+
+# lint js and vue files
 npx --no-install lint-staged
+
+# lint only staged ruby files
 git diff --name-only --cached | xargs ls -1 2>/dev/null | grep '\.rb$' | xargs bundle exec rubocop -a
-git add ./**/*.rb
+
+# stage rubocop changes to files
+git diff --name-only --cached | xargs git add

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 npx --no-install lint-staged
-git ls-files -m | xargs ls -1 2>/dev/null | grep '\.rb$' | xargs bundle exec rubocop -a
+git diff --name-only --cached | xargs ls -1 2>/dev/null | grep '\.rb$' | xargs bundle exec rubocop -a

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
-npm run eslint
-bundle exec rubocop -a
-git add
+npx --no-install lint-staged
+git ls-files -m | xargs ls -1 2>/dev/null | grep '\.rb$' | xargs bundle exec rubocop -a

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
       "pre-push": "sh bin/validate_push"
     }
   },
@@ -136,10 +135,6 @@
   "lint-staged": {
     "app/**/*.{js,vue}": [
       "eslint --fix",
-      "git add"
-    ],
-    "!(*schema).rb": [
-      "bundle exec rubocop -a",
       "git add"
     ],
     "*.scss": [


### PR DESCRIPTION
This PR speeds up the pre-commit hook to lint only the staged files, instead of running it across all files like it does right now.

## Type of change

This change affects developer workflow. **Note that it removes the `git add` at the end, not sure if that was intenional.** We can add that back and use `git ls-files -m` to show all modified files

## How Has This Been Tested?

Tested locally on my iTerm, with vanilla Git setup

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~New and existing unit tests pass locally with my changes~
- [ ] ~Any dependent changes have been merged and published in downstream modules~
