### PR TITLE
fix: Add missing timestamp in the real-time event

### DIFF
--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -38,7 +38,8 @@ class Conversations::EventDataPresenter < SimpleDelegator
     {
       agent_last_seen_at: agent_last_seen_at.to_i,
       contact_last_seen_at: contact_last_seen_at.to_i,
-      timestamp: last_activity_at.to_i
+      timestamp: last_activity_at.to_i,
+      created_at: created_at.to_i
     }
   end
 end

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -458,6 +458,7 @@ RSpec.describe Conversation, type: :model do
         first_reply_created_at: nil,
         contact_last_seen_at: conversation.contact_last_seen_at.to_i,
         agent_last_seen_at: conversation.agent_last_seen_at.to_i,
+        created_at: conversation.created_at.to_i,
         unread_count: 0
       }
     end

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Conversations::EventDataPresenter do
         first_reply_created_at: nil,
         contact_last_seen_at: conversation.contact_last_seen_at.to_i,
         agent_last_seen_at: conversation.agent_last_seen_at.to_i,
+        created_at: conversation.created_at.to_i,
         unread_count: 0
       }
     end


### PR DESCRIPTION
Fix the issue introduced in #6267