### PR TITLE
fix: redis health status in superadmin panel

### DIFF
--- a/app/controllers/super_admin/instance_statuses_controller.rb
+++ b/app/controllers/super_admin/instance_statuses_controller.rb
@@ -28,7 +28,7 @@ class SuperAdmin::InstanceStatusesController < SuperAdmin::ApplicationController
     r = Redis.new(Redis::Config.app)
     if r.ping == 'PONG'
       redis_server = r.info
-      @metrics['Redis alive'] = 'false'
+      @metrics['Redis alive'] = 'true'
       @metrics['Redis version'] = redis_server['redis_version']
       @metrics['Redis number of connected clients'] = redis_server['connected_clients']
       @metrics["Redis 'maxclients' setting"] = redis_server['maxclients']


### PR DESCRIPTION
# Pull Request Template

## Description

- Fix Redis status when Redis is online in the super-admin Instance health page

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
