### PR TITLE
fix: Update user availability status in real-time when change from the mobile app 

### DIFF
--- a/app/javascript/dashboard/store/modules/auth.js
+++ b/app/javascript/dashboard/store/modules/auth.js
@@ -209,7 +209,16 @@ export const actions = {
 // mutations
 export const mutations = {
   [types.SET_CURRENT_USER_AVAILABILITY](_state, availability) {
-    Vue.set(_state.currentUser, 'availability', availability);
+    const accounts = _state.currentUser.accounts.map(account => {
+      if (account.id === _state.currentUser.account_id) {
+        return { ...account, availability, availability_status: availability };
+      }
+      return account;
+    });
+    Vue.set(_state, 'currentUser', {
+      ..._state.currentUser,
+      accounts,
+    });
   },
   [types.CLEAR_USER](_state) {
     _state.currentUser = initialState.currentUser;

--- a/app/javascript/dashboard/store/modules/specs/auth/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/auth/mutations.spec.js
@@ -42,4 +42,19 @@ describe('#mutations', () => {
       });
     });
   });
+  describe('#SET_CURRENT_USER_AVAILABILITY', () => {
+    const state = {
+      currentUser: {
+        id: 1,
+        accounts: [{ id: 1, availability_status: 'offline' }],
+        account_id: 1,
+      },
+    };
+    it('set availability status for current user', () => {
+      mutations[types.SET_CURRENT_USER_AVAILABILITY](state, 'online');
+      expect(state.currentUser.accounts[0].availability_status).toEqual(
+        'online'
+      );
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/chatwoot/chatwoot/issues/6374

**How to do QA?**

1. Login to the chatwoot app.
2. Login into the same account using the mobile app (or incognito window)
3. Change the availability status from the mobile app or incognito window.
4. Check user availability status updates in real time.