### PR TITLE
fix: Cannot delete message with attachments without content

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -105,7 +105,8 @@
         v-if="isBubble && !isMessageDeleted"
         :is-open="showContextMenu"
         :show-copy="hasText"
-        :show-canned-response-option="isOutgoing"
+        :show-delete="hasTextOrAttachment"
+        :show-canned-response-option="isOutgoing && hasText"
         :menu-position="contextMenuPosition"
         :message-content="data.content"
         @toggle="handleContextMenuClick"
@@ -307,6 +308,9 @@ export default {
     },
     hasText() {
       return !!this.data.content;
+    },
+    hasTextOrAttachment() {
+      return this.hasText || this.data.attachments.length > 0;
     },
     tooltipForSender() {
       const name = this.senderNameForAvatar;

--- a/app/javascript/dashboard/modules/conversations/components/MessageContextMenu.vue
+++ b/app/javascript/dashboard/modules/conversations/components/MessageContextMenu.vue
@@ -24,18 +24,18 @@
       :class="`dropdown-pane--${menuPosition}`"
     >
       <woot-dropdown-menu>
+        <woot-dropdown-item v-if="showDelete">
+          <woot-button
+            variant="clear"
+            color-scheme="alert"
+            size="small"
+            icon="delete"
+            @click="handleDelete"
+          >
+            {{ $t('CONVERSATION.CONTEXT_MENU.DELETE') }}
+          </woot-button>
+        </woot-dropdown-item>
         <woot-dropdown-item v-if="showCopy">
-          <woot-dropdown-item>
-            <woot-button
-              variant="clear"
-              color-scheme="alert"
-              size="small"
-              icon="delete"
-              @click="handleDelete"
-            >
-              {{ $t('CONVERSATION.CONTEXT_MENU.DELETE') }}
-            </woot-button>
-          </woot-dropdown-item>
           <woot-button
             variant="clear"
             size="small"
@@ -46,10 +46,8 @@
             {{ $t('CONVERSATION.CONTEXT_MENU.COPY') }}
           </woot-button>
         </woot-dropdown-item>
-
-        <woot-dropdown-item>
+        <woot-dropdown-item v-if="showCannedResponseOption">
           <woot-button
-            v-if="showCannedResponseOption"
             variant="clear"
             size="small"
             icon="comment-add"
@@ -91,6 +89,10 @@ export default {
       default: false,
     },
     showCopy: {
+      type: Boolean,
+      default: false,
+    },
+    showDelete: {
       type: Boolean,
       default: false,
     },


### PR DESCRIPTION
# Pull Request Template

## Description
1. Show the delete button in the context menu for messages and attachments.
2. Removed add canned response button in the context menu for attachments.

Fixes https://github.com/chatwoot/product/issues/789

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
https://www.loom.com/share/f3ed0ede5c8e46058fa3f8ccc992a189


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
