### PR TITLE
fix: Text color bug on attachment bubble

### DIFF
--- a/app/javascript/widget/components/AgentMessage.vue
+++ b/app/javascript/widget/components/AgentMessage.vue
@@ -24,7 +24,7 @@
         <div
           v-if="hasAttachments"
           class="chat-bubble has-attachment agent"
-          :class="(wrapClass, $dm('bg-white', 'dark:bg-slate-50'))"
+          :class="(wrapClass, $dm('bg-white', 'dark:bg-slate-700'))"
         >
           <div v-for="attachment in message.attachments" :key="attachment.id">
             <image-bubble

--- a/app/javascript/widget/components/FileBubble.vue
+++ b/app/javascript/widget/components/FileBubble.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="file flex flex-row items-center p-3 cursor-pointer">
-    <div class="icon-wrap" :style="{ color: textColor }">
+    <div class="icon-wrap">
       <fluent-icon icon="document" size="28" />
     </div>
     <div class="meta">
-      <div class="title" :style="{ color: textColor }">
+      <div class="title dark:text-slate-50">
         {{ title }}
       </div>
       <div class="link-wrap mb-1">
@@ -12,7 +12,6 @@
           class="download"
           rel="noreferrer noopener nofollow"
           target="_blank"
-          :style="{ color: textColor }"
           :href="url"
         >
           {{ $t('COMPONENTS.FILE_BUBBLE.DOWNLOAD') }}
@@ -24,12 +23,13 @@
 
 <script>
 import FluentIcon from 'shared/components/FluentIcon/Index.vue';
-import { getContrastingTextColor } from '@chatwoot/utils';
+import darkModeMixin from 'widget/mixins/darkModeMixin.js';
 
 export default {
   components: {
     FluentIcon,
   },
+  mixins: [darkModeMixin],
   props: {
     url: {
       type: String,
@@ -52,9 +52,6 @@ export default {
     },
     fileName() {
       return this.url.substring(this.url.lastIndexOf('/') + 1);
-    },
-    textColor() {
-      return getContrastingTextColor(this.widgetColor);
     },
   },
   methods: {

--- a/app/javascript/widget/components/FileBubble.vue
+++ b/app/javascript/widget/components/FileBubble.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="file flex flex-row items-center p-3 cursor-pointer">
-    <div class="icon-wrap">
+    <div class="icon-wrap" :style="{ color: textColor }">
       <fluent-icon icon="document" size="28" />
     </div>
     <div class="meta">
-      <div class="title dark:text-slate-50">
+      <div class="title" :class="titleColor" :style="{ color: textColor }">
         {{ title }}
       </div>
       <div class="link-wrap mb-1">
@@ -12,6 +12,7 @@
           class="download"
           rel="noreferrer noopener nofollow"
           target="_blank"
+          :style="{ color: textColor }"
           :href="url"
         >
           {{ $t('COMPONENTS.FILE_BUBBLE.DOWNLOAD') }}
@@ -24,6 +25,7 @@
 <script>
 import FluentIcon from 'shared/components/FluentIcon/Index.vue';
 import darkModeMixin from 'widget/mixins/darkModeMixin.js';
+import { getContrastingTextColor } from '@chatwoot/utils';
 
 export default {
   components: {
@@ -43,6 +45,10 @@ export default {
       type: String,
       default: '',
     },
+    isUserBubble: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     title() {
@@ -52,6 +58,19 @@ export default {
     },
     fileName() {
       return this.url.substring(this.url.lastIndexOf('/') + 1);
+    },
+    contrastingTextColor() {
+      return getContrastingTextColor(this.widgetColor);
+    },
+    textColor() {
+      return this.isUserBubble && this.widgetColor
+        ? this.contrastingTextColor
+        : '';
+    },
+    titleColor() {
+      return !this.isUserBubble
+        ? this.$dm('text-black-900', 'dark:text-slate-50')
+        : '';
     },
   },
   methods: {

--- a/app/javascript/widget/components/UserMessage.vue
+++ b/app/javascript/widget/components/UserMessage.vue
@@ -29,6 +29,7 @@
               :url="attachment.data_url"
               :is-in-progress="isInProgress"
               :widget-color="widgetColor"
+              is-user-bubble
             />
           </div>
         </div>


### PR DESCRIPTION
## Description
The text color in the widget was using a contrast helper on the bubbles for messages coming from agent to the user, where the bubbles are always white color, so inverting the color did not make sense, I have removed these styles from the bubble. 

Now it will use the default colors and fixed the same for dark mode.
Before 
![image](https://user-images.githubusercontent.com/15716057/216915047-f37a5801-9dfa-40d7-911d-5ff5f412c3c8.png)

Now
![Screenshot2023-02-06 at 13 17 13](https://user-images.githubusercontent.com/15716057/216914661-dd13f354-4430-42af-b90c-0762a92ea280.png)


Fixes #6352 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
