### PR TITLE
fix: order for canned response

### DIFF
--- a/app/controllers/api/v1/accounts/canned_responses_controller.rb
+++ b/app/controllers/api/v1/accounts/canned_responses_controller.rb
@@ -33,7 +33,10 @@ class Api::V1::Accounts::CannedResponsesController < Api::V1::Accounts::BaseCont
 
   def canned_responses
     if params[:search]
-      Current.account.canned_responses.where('short_code ILIKE :search OR content ILIKE :search', search: "%#{params[:search]}%")
+      Current.account.canned_responses
+             .where('short_code ILIKE :search OR content ILIKE :search', search: "%#{params[:search]}%")
+             .order_by_search(params[:search])
+
     else
       Current.account.canned_responses
     end

--- a/app/models/canned_response.rb
+++ b/app/models/canned_response.rb
@@ -17,4 +17,14 @@ class CannedResponse < ApplicationRecord
   validates_uniqueness_of :short_code, scope: :account_id
 
   belongs_to :account
+
+  scope :order_by_search, lambda { |search|
+    short_code_starts_with = sanitize_sql_array(['WHEN short_code ILIKE ? THEN 1', "#{search}%"])
+    short_code_like = sanitize_sql_array(['WHEN short_code ILIKE ? THEN 0.5', "%#{search}%"])
+    content_like = sanitize_sql_array(['WHEN content ILIKE ? THEN 0.2', "%#{search}%"])
+
+    order_clause = "CASE #{short_code_starts_with} #{short_code_like} #{content_like} ELSE 0 END"
+
+    order(Arel.sql(order_clause) => :desc)
+  }
 end

--- a/spec/controllers/api/v1/accounts/canned_responses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/canned_responses_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Canned Responses API', type: :request do
   let(:account) { create(:account) }
 
   before do
-    create(:canned_response, account: account)
+    create(:canned_response, account: account, content: 'Hey {{ contact.name }}, Thanks for reaching out', short_code: 'name-short-code')
   end
 
   describe 'GET /api/v1/accounts/{account.id}/canned_responses' do
@@ -29,9 +29,12 @@ RSpec.describe 'Canned Responses API', type: :request do
       end
 
       it 'returns all the canned responses the user searched for' do
-        create(:canned_response, account: account)
+        cr1 = account.canned_responses.first
+        create(:canned_response, account: account, content: 'Great! Looking forward', short_code: 'short-code')
+        cr2 = create(:canned_response, account: account, content: 'Thanks for reaching out', short_code: 'content-with-thanks')
+        cr3 = create(:canned_response, account: account, content: 'Thanks for reaching out', short_code: 'Thanks')
 
-        params = { search: CannedResponse.last.short_code }
+        params = { search: 'thanks' }
 
         get "/api/v1/accounts/#{account.id}/canned_responses",
             params: params,
@@ -39,7 +42,9 @@ RSpec.describe 'Canned Responses API', type: :request do
             as: :json
 
         expect(response).to have_http_status(:success)
-        expect(JSON.parse(response.body)).to eq([CannedResponse.last].as_json)
+        expect(JSON.parse(response.body)).to eq(
+          [cr3, cr2, cr1].as_json
+        )
       end
     end
   end
@@ -65,7 +70,7 @@ RSpec.describe 'Canned Responses API', type: :request do
              as: :json
 
         expect(response).to have_http_status(:success)
-        expect(CannedResponse.count).to eq(2)
+        expect(account.canned_responses.count).to eq(2)
       end
     end
   end


### PR DESCRIPTION
## Description

This PR updates the canned response search query to order by short_code matches first

Fixes: https://github.com/chatwoot/product/issues/788

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested locally

https://www.loom.com/share/7d5df79f7f8646a7bb0c8a6fa236f84b

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
