### PR TITLE
fix: Setting a fallback name from the email address for MS email channel

### DIFF
--- a/app/controllers/microsoft/callbacks_controller.rb
+++ b/app/controllers/microsoft/callbacks_controller.rb
@@ -45,13 +45,20 @@ class Microsoft::CallbacksController < ApplicationController
     channel_email.inbox
   end
 
+  # Fallback name, for when name field is missing from users_data
+  def fallback_name
+    return 'New Inbox' if users_data['email'].blank?
+
+    users_data['email'].split('@').first.parameterize.titleize
+  end
+
   def create_microsoft_channel_with_inbox
     ActiveRecord::Base.transaction do
       channel_email = Channel::Email.create!(email: users_data['email'], account: account)
       account.inboxes.create!(
         account: account,
         channel: channel_email,
-        name: users_data['name'] || users_data['email'].split('@').first
+        name: users_data['name'] || fallback_name
       )
       channel_email
     end

--- a/app/controllers/microsoft/callbacks_controller.rb
+++ b/app/controllers/microsoft/callbacks_controller.rb
@@ -51,7 +51,7 @@ class Microsoft::CallbacksController < ApplicationController
       account.inboxes.create!(
         account: account,
         channel: channel_email,
-        name: users_data['name']
+        name: users_data['name'] || users_data['email'].split('@').first
       )
       channel_email
     end


### PR DESCRIPTION
## Description
Fixes #6353, by using the email address (part before the "@") as a fallback name.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I made this change, then managed to have the inbox successfully create in my own deploy.
As it is such a small change, no formal tests have been written.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
