### PR TITLE
fixBug: email notification error, Attachment Message without content

### DIFF
--- a/app/helpers/message_format_helper.rb
+++ b/app/helpers/message_format_helper.rb
@@ -2,11 +2,8 @@ module MessageFormatHelper
   include RegexHelper
 
   def transform_user_mention_content(message_content)
-    if message_content
-      message_content.gsub(MENTION_REGEX, '\1')
-    else
-      ''
-    end
+    # attachment message without content, message_content is nil
+    message_content.presence ? message_content.gsub(MENTION_REGEX, '\1') : ''
   end
 
   def render_message_content(message_content)

--- a/app/helpers/message_format_helper.rb
+++ b/app/helpers/message_format_helper.rb
@@ -2,7 +2,11 @@ module MessageFormatHelper
   include RegexHelper
 
   def transform_user_mention_content(message_content)
-    message_content.gsub(MENTION_REGEX, '\1')
+    if message_content
+      message_content.gsub(MENTION_REGEX, '\1')
+    else
+      ''
+    end
   end
 
   def render_message_content(message_content)


### PR DESCRIPTION

## Description
1. Profile Settings -> open Email Notifications
2. send attachment message without content
3. trigger email notification
4. email can not show messages

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

1. Profile Settings -> open Email Notifications
2. send attachment message without content
3. trigger email notification
4. email content was correct

## error log
```ruby
ActionView::Template::Error: undefined method `gsub' for nil:NilClass
/app/app/helpers/message_format_helper.rb:5:in `transform_user_mention_content'
/app/app/drops/conversation_drop.rb:38:in `block in recent_messages'
/app/app/drops/conversation_drop.rb:35:in `map'
/app/app/drops/conversation_drop.rb:35:in `recent_messages'
/gems/ruby/3.0.0/gems/liquid-5.3.0/lib/liquid/drop.rb:37:in `invoke_drop'
```


