### PR TITLE
Added event for conversation opened

### DIFF
--- a/app/javascript/dashboard/helper/automationHelper.js
+++ b/app/javascript/dashboard/helper/automationHelper.js
@@ -165,6 +165,17 @@ export const getDefaultConditions = eventName => {
       },
     ];
   }
+  if (eventName === 'conversation_reopened') {
+    return [
+      {
+        attribute_key: 'browser_language',
+        filter_operator: 'equal_to',
+        values: '',
+        query_operator: 'and',
+        custom_attribute_type: '',
+      },
+    ];
+  }
   return [
     {
       attribute_key: 'status',

--- a/app/javascript/dashboard/helper/automationHelper.js
+++ b/app/javascript/dashboard/helper/automationHelper.js
@@ -165,7 +165,7 @@ export const getDefaultConditions = eventName => {
       },
     ];
   }
-  if (eventName === 'conversation_reopened') {
+  if (eventName === 'conversation_opened') {
     return [
       {
         attribute_key: 'browser_language',

--- a/app/javascript/dashboard/mixins/automations/methodsMixin.js
+++ b/app/javascript/dashboard/mixins/automations/methodsMixin.js
@@ -287,9 +287,6 @@ export default {
       this.automationTypes.conversation_opened.conditions.push(
         ...manifestedCustomAttributes
       );
-      this.automationTypes.conversation_reopened.conditions.push(
-        ...manifestedCustomAttributes
-      );
     },
   },
 };

--- a/app/javascript/dashboard/mixins/automations/methodsMixin.js
+++ b/app/javascript/dashboard/mixins/automations/methodsMixin.js
@@ -284,6 +284,12 @@ export default {
       this.automationTypes.conversation_updated.conditions.push(
         ...manifestedCustomAttributes
       );
+      this.automationTypes.conversation_opened.conditions.push(
+        ...manifestedCustomAttributes
+      );
+      this.automationTypes.conversation_reopened.conditions.push(
+        ...manifestedCustomAttributes
+      );
     },
   },
 };

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
@@ -420,6 +420,111 @@ export const AUTOMATIONS = {
       },
     ],
   },
+  conversation_reopened: {
+    conditions: [
+      {
+        key: 'browser_language',
+        name: 'Browser Language',
+        attributeI18nKey: 'BROWSER_LANGUAGE',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
+        key: 'mail_subject',
+        name: 'Email Subject',
+        attributeI18nKey: 'MAIL_SUBJECT',
+        inputType: 'plain_text',
+        filterOperators: OPERATOR_TYPES_2,
+      },
+      {
+        key: 'country_code',
+        name: 'Country',
+        attributeI18nKey: 'COUNTRY_NAME',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
+        key: 'referer',
+        name: 'Referrer Link',
+        attributeI18nKey: 'REFERER_LINK',
+        inputType: 'plain_text',
+        filterOperators: OPERATOR_TYPES_2,
+      },
+      {
+        key: 'assignee_id',
+        name: 'Assignee',
+        attributeI18nKey: 'ASSIGNEE_NAME',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_3,
+      },
+      {
+        key: 'team_id',
+        name: 'Team',
+        attributeI18nKey: 'TEAM_NAME',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_3,
+      },
+      {
+        key: 'inbox_id',
+        name: 'Inbox',
+        attributeI18nKey: 'INBOX',
+        inputType: 'multi_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+    ],
+    actions: [
+      {
+        key: 'assign_agent',
+        name: 'Assign to agent',
+        attributeI18nKey: 'ASSIGN_AGENT',
+      },
+      {
+        key: 'assign_team',
+        name: 'Assign a team',
+        attributeI18nKey: 'ASSIGN_TEAM',
+      },
+      {
+        key: 'assign_agent',
+        name: 'Assign an agent',
+        attributeI18nKey: 'ASSIGN_AGENT',
+      },
+      {
+        key: 'send_email_to_team',
+        name: 'Send an email to team',
+        attributeI18nKey: 'SEND_EMAIL_TO_TEAM',
+      },
+      {
+        key: 'send_message',
+        name: 'Send a message',
+        attributeI18nKey: 'SEND_MESSAGE',
+      },
+      {
+        key: 'send_email_transcript',
+        name: 'Send an email transcript',
+        attributeI18nKey: 'SEND_EMAIL_TRANSCRIPT',
+      },
+      {
+        key: 'mute_conversation',
+        name: 'Mute conversation',
+        attributeI18nKey: 'MUTE_CONVERSATION',
+      },
+      {
+        key: 'snooze_conversation',
+        name: 'Snooze conversation',
+        attributeI18nKey: 'MUTE_CONVERSATION',
+      },
+      {
+        key: 'send_webhook_event',
+        name: 'Send Webhook Event',
+        attributeI18nKey: 'SEND_WEBHOOK_EVENT',
+      },
+      {
+        key: 'send_attachment',
+        name: 'Send Attachment',
+        attributeI18nKey: 'SEND_ATTACHMENT',
+      },
+    ],
+  },
 };
 
 export const AUTOMATION_RULE_EVENTS = [
@@ -438,6 +543,10 @@ export const AUTOMATION_RULE_EVENTS = [
   {
     key: 'conversation_opened',
     value: 'Conversation Opened',
+  },
+  {
+    key: 'conversation_reopened',
+    value: 'Conversation Reopened',
   },
 ];
 

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
@@ -308,6 +308,118 @@ export const AUTOMATIONS = {
       },
     ],
   },
+  conversation_opened: {
+    conditions: [
+      {
+        key: 'status',
+        name: 'Status',
+        attributeI18nKey: 'STATUS',
+        inputType: 'multi_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
+        key: 'browser_language',
+        name: 'Browser Language',
+        attributeI18nKey: 'BROWSER_LANGUAGE',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
+        key: 'mail_subject',
+        name: 'Email Subject',
+        attributeI18nKey: 'MAIL_SUBJECT',
+        inputType: 'plain_text',
+        filterOperators: OPERATOR_TYPES_2,
+      },
+      {
+        key: 'country_code',
+        name: 'Country',
+        attributeI18nKey: 'COUNTRY_NAME',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
+        key: 'referer',
+        name: 'Referrer Link',
+        attributeI18nKey: 'REFERER_LINK',
+        inputType: 'plain_text',
+        filterOperators: OPERATOR_TYPES_2,
+      },
+      {
+        key: 'assignee_id',
+        name: 'Assignee',
+        attributeI18nKey: 'ASSIGNEE_NAME',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_3,
+      },
+      {
+        key: 'team_id',
+        name: 'Team',
+        attributeI18nKey: 'TEAM_NAME',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_3,
+      },
+      {
+        key: 'inbox_id',
+        name: 'Inbox',
+        attributeI18nKey: 'INBOX',
+        inputType: 'multi_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+    ],
+    actions: [
+      {
+        key: 'assign_agent',
+        name: 'Assign to agent',
+        attributeI18nKey: 'ASSIGN_AGENT',
+      },
+      {
+        key: 'assign_team',
+        name: 'Assign a team',
+        attributeI18nKey: 'ASSIGN_TEAM',
+      },
+      {
+        key: 'assign_agent',
+        name: 'Assign an agent',
+        attributeI18nKey: 'ASSIGN_AGENT',
+      },
+      {
+        key: 'send_email_to_team',
+        name: 'Send an email to team',
+        attributeI18nKey: 'SEND_EMAIL_TO_TEAM',
+      },
+      {
+        key: 'send_message',
+        name: 'Send a message',
+        attributeI18nKey: 'SEND_MESSAGE',
+      },
+      {
+        key: 'send_email_transcript',
+        name: 'Send an email transcript',
+        attributeI18nKey: 'SEND_EMAIL_TRANSCRIPT',
+      },
+      {
+        key: 'mute_conversation',
+        name: 'Mute conversation',
+        attributeI18nKey: 'MUTE_CONVERSATION',
+      },
+      {
+        key: 'snooze_conversation',
+        name: 'Snooze conversation',
+        attributeI18nKey: 'MUTE_CONVERSATION',
+      },
+      {
+        key: 'send_webhook_event',
+        name: 'Send Webhook Event',
+        attributeI18nKey: 'SEND_WEBHOOK_EVENT',
+      },
+      {
+        key: 'send_attachment',
+        name: 'Send Attachment',
+        attributeI18nKey: 'SEND_ATTACHMENT',
+      },
+    ],
+  },
 };
 
 export const AUTOMATION_RULE_EVENTS = [
@@ -322,6 +434,10 @@ export const AUTOMATION_RULE_EVENTS = [
   {
     key: 'message_created',
     value: 'Message Created',
+  },
+  {
+    key: 'conversation_opened',
+    value: 'Conversation Opened',
   },
 ];
 

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
@@ -311,118 +311,6 @@ export const AUTOMATIONS = {
   conversation_opened: {
     conditions: [
       {
-        key: 'status',
-        name: 'Status',
-        attributeI18nKey: 'STATUS',
-        inputType: 'multi_select',
-        filterOperators: OPERATOR_TYPES_1,
-      },
-      {
-        key: 'browser_language',
-        name: 'Browser Language',
-        attributeI18nKey: 'BROWSER_LANGUAGE',
-        inputType: 'search_select',
-        filterOperators: OPERATOR_TYPES_1,
-      },
-      {
-        key: 'mail_subject',
-        name: 'Email Subject',
-        attributeI18nKey: 'MAIL_SUBJECT',
-        inputType: 'plain_text',
-        filterOperators: OPERATOR_TYPES_2,
-      },
-      {
-        key: 'country_code',
-        name: 'Country',
-        attributeI18nKey: 'COUNTRY_NAME',
-        inputType: 'search_select',
-        filterOperators: OPERATOR_TYPES_1,
-      },
-      {
-        key: 'referer',
-        name: 'Referrer Link',
-        attributeI18nKey: 'REFERER_LINK',
-        inputType: 'plain_text',
-        filterOperators: OPERATOR_TYPES_2,
-      },
-      {
-        key: 'assignee_id',
-        name: 'Assignee',
-        attributeI18nKey: 'ASSIGNEE_NAME',
-        inputType: 'search_select',
-        filterOperators: OPERATOR_TYPES_3,
-      },
-      {
-        key: 'team_id',
-        name: 'Team',
-        attributeI18nKey: 'TEAM_NAME',
-        inputType: 'search_select',
-        filterOperators: OPERATOR_TYPES_3,
-      },
-      {
-        key: 'inbox_id',
-        name: 'Inbox',
-        attributeI18nKey: 'INBOX',
-        inputType: 'multi_select',
-        filterOperators: OPERATOR_TYPES_1,
-      },
-    ],
-    actions: [
-      {
-        key: 'assign_agent',
-        name: 'Assign to agent',
-        attributeI18nKey: 'ASSIGN_AGENT',
-      },
-      {
-        key: 'assign_team',
-        name: 'Assign a team',
-        attributeI18nKey: 'ASSIGN_TEAM',
-      },
-      {
-        key: 'assign_agent',
-        name: 'Assign an agent',
-        attributeI18nKey: 'ASSIGN_AGENT',
-      },
-      {
-        key: 'send_email_to_team',
-        name: 'Send an email to team',
-        attributeI18nKey: 'SEND_EMAIL_TO_TEAM',
-      },
-      {
-        key: 'send_message',
-        name: 'Send a message',
-        attributeI18nKey: 'SEND_MESSAGE',
-      },
-      {
-        key: 'send_email_transcript',
-        name: 'Send an email transcript',
-        attributeI18nKey: 'SEND_EMAIL_TRANSCRIPT',
-      },
-      {
-        key: 'mute_conversation',
-        name: 'Mute conversation',
-        attributeI18nKey: 'MUTE_CONVERSATION',
-      },
-      {
-        key: 'snooze_conversation',
-        name: 'Snooze conversation',
-        attributeI18nKey: 'MUTE_CONVERSATION',
-      },
-      {
-        key: 'send_webhook_event',
-        name: 'Send Webhook Event',
-        attributeI18nKey: 'SEND_WEBHOOK_EVENT',
-      },
-      {
-        key: 'send_attachment',
-        name: 'Send Attachment',
-        attributeI18nKey: 'SEND_ATTACHMENT',
-      },
-    ],
-  },
-  conversation_reopened: {
-    conditions: [
-      {
         key: 'browser_language',
         name: 'Browser Language',
         attributeI18nKey: 'BROWSER_LANGUAGE',
@@ -543,10 +431,6 @@ export const AUTOMATION_RULE_EVENTS = [
   {
     key: 'conversation_opened',
     value: 'Conversation Opened',
-  },
-  {
-    key: 'conversation_reopened',
-    value: 'Conversation Reopened',
   },
 ];
 


### PR DESCRIPTION
https://www.loom.com/share/46959eb3074549eb8694fc10daa42b47

@nithindavid Conversation opened working on this PR; please let me know your thoughts.

We used the conversation_opened event name instead of conversation_reopened because we use a similar event_name in agent_bot_listener to maintain consistency using the same event.  We can change the front_end display event though.