### PR TITLE
fix : Help Center article view count

### DIFF
--- a/app/controllers/api/v1/accounts/articles_controller.rb
+++ b/app/controllers/api/v1/accounts/articles_controller.rb
@@ -55,14 +55,14 @@ class Api::V1::Accounts::ArticlesController < Api::V1::Accounts::BaseController
 
   def article_params
     params.require(:article).permit(
-      :title, :slug, :content, :description, :position, :category_id, :author_id, :associated_article_id, :status, :views, meta: [:title,
-                                                                                                                                  :description,
-                                                                                                                                  { tags: [] }]
+      :title, :slug, :content, :description, :position, :category_id, :author_id, :associated_article_id, :status, meta: [:title,
+                                                                                                                          :description,
+                                                                                                                          { tags: [] }]
     )
   end
 
   def list_params
-    params.permit(:locale, :query, :page, :category_slug, :status, :author_id, :views)
+    params.permit(:locale, :query, :page, :category_slug, :status, :author_id)
   end
 
   def set_current_page

--- a/app/controllers/api/v1/accounts/articles_controller.rb
+++ b/app/controllers/api/v1/accounts/articles_controller.rb
@@ -55,13 +55,14 @@ class Api::V1::Accounts::ArticlesController < Api::V1::Accounts::BaseController
 
   def article_params
     params.require(:article).permit(
-      :title, :slug, :content, :description, :position, :category_id, :author_id, :associated_article_id, :status, meta: [:title, :description,
-                                                                                                                          { tags: [] }]
+      :title, :slug, :content, :description, :position, :category_id, :author_id, :associated_article_id, :status, :views, meta: [:title,
+                                                                                                                                  :description,
+                                                                                                                                  { tags: [] }]
     )
   end
 
   def list_params
-    params.permit(:locale, :query, :page, :category_slug, :status, :author_id)
+    params.permit(:locale, :query, :page, :category_slug, :status, :author_id, :views)
   end
 
   def set_current_page

--- a/app/controllers/public/api/v1/portals/articles_controller.rb
+++ b/app/controllers/public/api/v1/portals/articles_controller.rb
@@ -16,6 +16,8 @@ class Public::Api::V1::Portals::ArticlesController < PublicController
 
   def set_article
     @article = @category.articles.find(params[:id])
+    @article.views = @article.views ? @article.views + 1 : 1
+    @article.save
     @parsed_content = render_article_content(@article.content)
   end
 

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleItem.vue
@@ -30,7 +30,7 @@
     </td>
     <td>
       <span class="fs-small">
-        {{ readCount }}
+        {{ views || 0 }}
       </span>
     </td>
     <td>
@@ -76,7 +76,7 @@ export default {
       type: Object,
       default: () => {},
     },
-    readCount: {
+    views: {
       type: Number,
       default: 0,
     },

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleTable.vue
@@ -21,7 +21,7 @@
           :title="article.title"
           :author="article.author"
           :category="article.category"
-          :read-count="article.readCount"
+          :views="article.views"
           :status="article.status"
           :updated-at="article.updated_at"
         />

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/stories/ArticleItem.stories.js
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/stories/ArticleItem.stories.js
@@ -15,7 +15,7 @@ export default {
         type: 'text',
       },
     },
-    readCount: {
+    views: {
       defaultValue: 13,
       control: {
         type: 'number',
@@ -57,7 +57,7 @@ ArticleItem.args = {
     name: 'John Doe',
   },
   category: 'Getting started',
-  readCount: 12,
+  views: 12,
   status: 'published',
   updatedAt: 1657255863,
 };


### PR DESCRIPTION
Fixes https://github.com/chatwoot/chatwoot/issues/5756

## Description

Article views is not incremented when the article is access in portal. This PR implements the increasing the views count when article is access in portal

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Create an article in help center
- Initially the views count is 0
- When that article is access on portal, the views count increases

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Demo video
https://www.loom.com/share/938f88e5d349455481168072c87f29ac