### PR TITLE
refactor: use innerText instead of innerHTML

### DIFF
--- a/app/javascript/sdk/bubbleHelpers.js
+++ b/app/javascript/sdk/bubbleHelpers.js
@@ -46,7 +46,7 @@ export const createBubbleIcon = ({ className, path, target }) => {
   if (isExpandedView(window.$chatwoot.type)) {
     const textNode = document.createElement('div');
     textNode.id = 'woot-widget--expanded__text';
-    textNode.innerHTML = '';
+    textNode.innerText = '';
     target.appendChild(textNode);
     bubbleClassName += ' woot-widget--expanded';
   }

--- a/app/javascript/sdk/bubbleHelpers.js
+++ b/app/javascript/sdk/bubbleHelpers.js
@@ -16,7 +16,7 @@ export const notificationBubble = document.createElement('span');
 export const setBubbleText = bubbleText => {
   if (isExpandedView(window.$chatwoot.type)) {
     const textNode = document.getElementById('woot-widget--expanded__text');
-    textNode.innerHTML = bubbleText;
+    textNode.innerText = bubbleText;
   }
 };
 


### PR DESCRIPTION
## Description

This PR replaces use of `innerHTML` with `innerText`, using `innerHTML` is prone to security risks

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested locally

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
