### PR TITLE
chore: Limit conversation resolution Job

### DIFF
--- a/app/jobs/conversations/resolution_job.rb
+++ b/app/jobs/conversations/resolution_job.rb
@@ -1,8 +1,9 @@
 class Conversations::ResolutionJob < ApplicationJob
-  queue_as :medium
+  queue_as :low
 
   def perform(account:)
-    resolvable_conversations = account.conversations.resolvable(account.auto_resolve_duration)
+    # limiting the number of conversations to be resolved to avoid any performance issues
+    resolvable_conversations = account.conversations.resolvable(account.auto_resolve_duration).limit(Limits::BULK_ACTIONS_LIMIT)
     resolvable_conversations.each(&:toggle_status)
   end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -63,7 +63,7 @@ class Conversation < ApplicationRecord
   scope :assigned, -> { where.not(assignee_id: nil) }
   scope :assigned_to, ->(agent) { where(assignee_id: agent.id) }
   scope :resolvable, lambda { |auto_resolve_duration|
-    return [] if auto_resolve_duration.to_i.zero?
+    return none if auto_resolve_duration.to_i.zero?
 
     open.where('last_activity_at < ? ', Time.now.utc - auto_resolve_duration.days)
   }

--- a/lib/limits.rb
+++ b/lib/limits.rb
@@ -1,0 +1,3 @@
+module Limits
+  BULK_ACTIONS_LIMIT = 100
+end

--- a/spec/jobs/conversations/resolution_job_spec.rb
+++ b/spec/jobs/conversations/resolution_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Conversations::ResolutionJob, type: :job do
   it 'enqueues the job' do
     expect { job }.to have_enqueued_job(described_class)
       .with(account)
-      .on_queue('medium')
+      .on_queue('low')
   end
 
   it 'does nothing when there is no auto resolve duration' do
@@ -22,5 +22,13 @@ RSpec.describe Conversations::ResolutionJob, type: :job do
     conversation.update(last_activity_at: 13.days.ago)
     described_class.perform_now(account: account)
     expect(conversation.reload.status).to eq('resolved')
+  end
+
+  it 'resolved only a limited number of conversations in a single execution' do
+    stub_const('Limits::BULK_ACTIONS_LIMIT', 2)
+    account.update(auto_resolve_duration: 10)
+    create_list(:conversation, 3, account: account, last_activity_at: 13.days.ago)
+    described_class.perform_now(account: account)
+    expect(account.conversations.resolved.count).to eq(Limits::BULK_ACTIONS_LIMIT)
   end
 end


### PR DESCRIPTION
We will be adding a limit to the resolution job so that it is performed at a spaced interval. This will ensure there won't be a sudden spike in resource usage

fixes: https://github.com/chatwoot/product/issues/707

ref customer report 

> An account had -20k unresolved conversations. Those conversations got resolved at once due to inactivity. This event triggered around 400k jobs in Sidekiq, eventually leading to increased memory and CPU usage. The number of jobs is common (not unusual), considering each resolution event can lead to 8-20 smaller jobs performing several activities like webhook notifications, email alerts, or realtime messages to agents.