### PR TITLE
fix: interactive messages - button should not respond to double click 

### DIFF
--- a/app/javascript/widget/store/modules/message.js
+++ b/app/javascript/widget/store/modules/message.js
@@ -12,9 +12,12 @@ export const getters = {
 
 export const actions = {
   update: async (
-    { commit, dispatch },
+    { commit, dispatch, getters: { getUIFlags: uiFlags } },
     { email, messageId, submittedValues }
   ) => {
+    if (uiFlags.isUpdating) {
+      return;
+    }
     commit('toggleUpdateStatus', true);
     try {
       await MessageAPI.update({

--- a/app/javascript/widget/store/modules/specs/message/actions.spec.js
+++ b/app/javascript/widget/store/modules/specs/message/actions.spec.js
@@ -17,7 +17,17 @@ describe('#actions', () => {
       API.patch.mockResolvedValue({
         data: { contact: { pubsub_token: '8npuMUfDgizrwVoqcK1t7FMY' } },
       });
-      await actions.update({ commit }, user);
+      await actions.update(
+        {
+          commit,
+          getters: {
+            getUIFlags: {
+              isUpdating: false,
+            },
+          },
+        },
+        user
+      );
       expect(commit.mock.calls).toEqual([
         ['toggleUpdateStatus', true],
         [
@@ -33,6 +43,22 @@ describe('#actions', () => {
         ],
         ['toggleUpdateStatus', false],
       ]);
+    });
+
+    it('blocks all new action calls when isUpdating', async () => {
+      await actions.update(
+        {
+          commit,
+          getters: {
+            getUIFlags: {
+              isUpdating: true,
+            },
+          },
+        },
+        {}
+      );
+
+      expect(commit.mock.calls).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
- Fixes https://github.com/chatwoot/chatwoot/issues/5957

## Description

This resolves an issue that occurs when a user double-clicks an interactive message resulting in a multi trigger of the handler function.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Created an interactive message using API
- Perform a double click on the `input-select`  options.
- The actions was being ran once, since other actions are bounced back if the message is already being updated

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


## Demo

### Before
https://user-images.githubusercontent.com/45232708/217775924-6b0b4f16-90a8-443e-bac3-e0c1562bff49.mov

### After

https://user-images.githubusercontent.com/45232708/217776437-206eafce-21cd-4ba4-88a4-0d68da44a18a.mov

