### PR TITLE
fix: Add a settings link for portals in sidebar

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -238,6 +238,7 @@
       "DRAFT": "Draft",
       "ARCHIVED": "Archived",
       "CATEGORY": "Category",
+      "SETTINGS": "Settings",
       "CATEGORY_EMPTY_MESSAGE": "No categories found"
     },
     "SET_AUTO_OFFLINE": {

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/HelpCenterLayout.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/HelpCenterLayout.vue
@@ -185,6 +185,15 @@ export default {
           toolTip: 'Archived',
           toStateName: 'list_archived_articles',
         },
+        {
+          icon: 'settings',
+          label: 'HELP_CENTER.SETTINGS',
+          key: 'edit_portal_information',
+          toState: frontendURL(
+            `accounts/${this.accountId}/portals/${this.selectedPortalSlug}/edit`
+          ),
+          toStateName: 'edit_portal_information',
+        },
       ];
     },
     additionalSecondaryMenuItems() {


### PR DESCRIPTION

## Description
The settings for a portal is very difficult to find. Adding this to the portal sidebar will improve the usability.
<img width="621" alt="image" src="https://user-images.githubusercontent.com/1277421/219557433-8825d95f-851d-4c60-b310-df597f6e4bcb.png">


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
