### PR TITLE
chore: Remove `mobile-v2` from feature flags

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -37,8 +37,6 @@
   enabled: true
 - name: voice_recorder
   enabled: true
-- name: mobile_v2
-  enabled: false
 - name: channel_website
   enabled: true
 - name: campaigns


### PR DESCRIPTION
This PR removes the feature `mobile-v2` since the updated mobile app is already released to all the users.