### PR TITLE
fix: sentry CHATWOOT-37A ActiveRecord::RecordNotUnique

### DIFF
--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -142,6 +142,8 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
     # and deprecate the support of passing only source_id as the param
     @contact_inbox ||= ::ContactInbox.find_by!(source_id: params[:source_id])
     authorize @contact_inbox.inbox, :show?
+  rescue ActiveRecord::RecordNotUnique
+    render json: { error: 'source_id should be unique' }, status: :unprocessable_entity
   end
 
   def build_contact_inbox
@@ -152,8 +154,6 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
       inbox: @inbox,
       source_id: params[:source_id]
     ).perform
-  rescue ActiveRecord::RecordNotUnique
-    render json: { error: 'source_id should be unique' }, status: :unprocessable_entity
   end
 
   def conversation_finder

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -152,6 +152,8 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
       inbox: @inbox,
       source_id: params[:source_id]
     ).perform
+  rescue ActiveRecord::RecordNotUnique
+    redirect_to :action => 'unprocessable_entity', :status => :unprocessable_entity
   end
 
   def conversation_finder

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -153,7 +153,7 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
       source_id: params[:source_id]
     ).perform
   rescue ActiveRecord::RecordNotUnique
-    redirect_to :action => 'unprocessable_entity', :status => :unprocessable_entity
+    render json: { error: 'source_id should be unique' }, status: :unprocessable_entity
   end
 
   def conversation_finder

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe 'Conversations API', type: :request do
   describe 'POST /api/v1/accounts/{account.id}/conversations' do
     let(:contact) { create(:contact, account: account) }
     let(:inbox) { create(:inbox, account: account) }
-    let(:contact_inbox) { create(:contact_inbox, contact: contact, inbox: inbox) }
+    let!(:contact_inbox) { create(:contact_inbox, contact: contact, inbox: inbox) }
 
     context 'when it is an unauthenticated user' do
       it 'returns unauthorized' do
@@ -249,6 +249,16 @@ RSpec.describe 'Conversations API', type: :request do
           expect(response).to have_http_status(:success)
           response_data = JSON.parse(response.body, symbolize_names: true)
           expect(response_data[:additional_attributes]).to eq(additional_attributes)
+        end
+
+        it 'does not create a new conversation if source_id is not unique' do
+          create(:contact_inbox, contact: contact, inbox: inbox, source_id: 'test')
+
+          post "/api/v1/accounts/#{account.id}/conversations",
+               headers: agent.create_new_auth_token,
+               params: { source_id: 'test', inbox_id: inbox.id },
+               as: :json
+          expect(response).to have_http_status(:unprocessable_entity)
         end
 
         it 'creates a conversation in specificed status' do

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -252,11 +252,11 @@ RSpec.describe 'Conversations API', type: :request do
         end
 
         it 'does not create a new conversation if source_id is not unique' do
-          create(:contact_inbox, contact: contact, inbox: inbox, source_id: 'test')
+          new_contact = create(:contact, account: account)
 
           post "/api/v1/accounts/#{account.id}/conversations",
                headers: agent.create_new_auth_token,
-               params: { source_id: 'test', inbox_id: inbox.id },
+               params: { source_id: contact_inbox.source_id, inbox_id: inbox.id, contact_id: new_contact.id },
                as: :json
           expect(response).to have_http_status(:unprocessable_entity)
         end


### PR DESCRIPTION
# Pull Request Template

## Description

- Capture `ActiveRecord::RecordNotUnique` and return 422

Fixes #6457 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added spec

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
