### PR TITLE
fix: Icelandic locale shows only english

### DIFF
--- a/app/javascript/dashboard/i18n/index.js
+++ b/app/javascript/dashboard/i18n/index.js
@@ -33,6 +33,7 @@ import uk from './locale/uk';
 import vi from './locale/vi';
 import zh_CN from './locale/zh_CN';
 import zh_TW from './locale/zh_TW';
+import is from './locale/is';
 
 export default {
   ar,
@@ -70,4 +71,5 @@ export default {
   vi,
   zh_CN,
   zh_TW,
+  is,
 };

--- a/app/javascript/dashboard/i18n/locale/is/index.js
+++ b/app/javascript/dashboard/i18n/locale/is/index.js
@@ -1,0 +1,61 @@
+import advancedFilters from './advancedFilters.json';
+import agentBots from './agentBots.json';
+import agentMgmt from './agentMgmt.json';
+import attributesMgmt from './attributesMgmt.json';
+import automation from './automation.json';
+import bulkActions from './bulkActions.json';
+import campaign from './campaign.json';
+import cannedMgmt from './cannedMgmt.json';
+import chatlist from './chatlist.json';
+import contact from './contact.json';
+import contactFilters from './contactFilters.json';
+import conversation from './conversation.json';
+import csatMgmt from './csatMgmt.json';
+import emoji from './emoji.json';
+import generalSettings from './generalSettings.json';
+import helpCenter from './helpCenter.json';
+import inboxMgmt from './inboxMgmt.json';
+import integrationApps from './integrationApps.json';
+import integrations from './integrations.json';
+import labelsMgmt from './labelsMgmt.json';
+import login from './login.json';
+import macros from './macros.json';
+import report from './report.json';
+import resetPassword from './resetPassword.json';
+import setNewPassword from './setNewPassword.json';
+import settings from './settings.json';
+import signup from './signup.json';
+import teamsSettings from './teamsSettings.json';
+import whatsappTemplates from './whatsappTemplates.json';
+
+export default {
+  ...advancedFilters,
+  ...agentBots,
+  ...agentMgmt,
+  ...attributesMgmt,
+  ...automation,
+  ...bulkActions,
+  ...campaign,
+  ...cannedMgmt,
+  ...chatlist,
+  ...contact,
+  ...contactFilters,
+  ...conversation,
+  ...csatMgmt,
+  ...emoji,
+  ...generalSettings,
+  ...helpCenter,
+  ...inboxMgmt,
+  ...integrationApps,
+  ...integrations,
+  ...labelsMgmt,
+  ...login,
+  ...macros,
+  ...report,
+  ...resetPassword,
+  ...setNewPassword,
+  ...settings,
+  ...signup,
+  ...teamsSettings,
+  ...whatsappTemplates,
+};


### PR DESCRIPTION
Closes https://github.com/chatwoot/chatwoot/issues/6484

## Description

Fixes issue with displaying Icelandic language translations

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Go to 'settings'
2. Click on 'account settings'
3. Scroll down to 'site language'
4. change it to icelandic
5. click update settings button in top right corner
6. Verify that the language has been updated

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


https://user-images.githubusercontent.com/45232708/220324564-ff1c5205-86e8-4cbe-8b06-3129a6d483af.mov

