### PR TITLE
fix: Name missing when email is collected via email hook

### DIFF
--- a/app/controllers/api/v1/widget/messages_controller.rb
+++ b/app/controllers/api/v1/widget/messages_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::Widget::MessagesController < Api::V1::Widget::BaseController
       @message.update!(submitted_email: contact_email)
       ContactIdentifyAction.new(
         contact: @contact,
-        params: { email: contact_email }
+        params: { email: contact_email, name: contact_name }
       ).perform
     else
       @message.update!(message_update_params[:message])

--- a/spec/controllers/api/v1/widget/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/messages_controller_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe '/api/v1/widget/messages', type: :request do
         message.reload
         expect(message.submitted_email).to eq(email)
         expect(message.conversation.contact.email).to eq(email)
+        expect(message.conversation.contact.name).to eq(email.split('@')[0])
       end
     end
 


### PR DESCRIPTION
The name is not updated when the email is updated via the email collect message. This PR fixes that.