### PR TITLE
chore: add `--force-exclusion` option to rubocop pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,7 +5,7 @@
 npx --no-install lint-staged
 
 # lint only staged ruby files
-git diff --name-only --cached | xargs ls -1 2>/dev/null | grep '\.rb$' | xargs bundle exec rubocop -a
+git diff --name-only --cached | xargs ls -1 2>/dev/null | grep '\.rb$' | xargs bundle exec rubocop --force-exclusion -a
 
 # stage rubocop changes to files
 git diff --name-only --cached | xargs git add


### PR DESCRIPTION
## Description

The pre-commit hook would format event those files excluded in the config. This is because the files were passed as args instead of the linter running on the entire project. When this happens, the exclude is not respect. 

The `--force-exclusion` flag instructs our machine overlords to force exlucde files specified in the configuration `Exclude` even if they are explicitly passed as arguments.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Tested 

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/18097732/221168943-8315b995-81d4-4b86-a91c-5b8548b7c587.png">

