### PR TITLE
fix: Condition based backend validation

### DIFF
--- a/app/models/automation_rule.rb
+++ b/app/models/automation_rule.rb
@@ -25,6 +25,7 @@ class AutomationRule < ApplicationRecord
 
   validate :json_conditions_format
   validate :json_actions_format
+  validate :query_operator_presence
   validates :account_id, presence: true
 
   scope :active, -> { where(active: true) }
@@ -66,5 +67,12 @@ class AutomationRule < ApplicationRecord
     actions = attributes - ACTIONS_ATTRS
 
     errors.add(:actions, "Automation actions #{actions.join(',')} not supported.") if actions.any?
+  end
+
+  def query_operator_presence
+    return if conditions.blank?
+
+    operators = conditions.select { |obj, _| obj['query_operator'].nil? }
+    errors.add(:conditions, 'Automation conditions should have query operator.') if operators.length > 1
   end
 end

--- a/spec/models/automation_rule_spec.rb
+++ b/spec/models/automation_rule_spec.rb
@@ -48,5 +48,12 @@ RSpec.describe AutomationRule, type: :model do
       rule = FactoryBot.build(:automation_rule, params)
       expect(rule.valid?).to be true
     end
+
+    it 'returns invalid record' do
+      params[:conditions][0].delete('query_operator')
+      rule = FactoryBot.build(:automation_rule, params)
+      expect(rule.valid?).to be false
+      expect(rule.errors.messages[:conditions]).to eq(['Automation conditions should have query operator.'])
+    end
   end
 end


### PR DESCRIPTION
Fix: https://github.com/chatwoot/product/issues/809

Adding condition-based validation for automation rule to prevent it from creating invalid records such as with no `query_operator`