### PR TITLE
fix: Fetch categories by locale

### DIFF
--- a/app/controllers/public/api/v1/portals/articles_controller.rb
+++ b/app/controllers/public/api/v1/portals/articles_controller.rb
@@ -15,21 +15,30 @@ class Public::Api::V1::Portals::ArticlesController < PublicController
   private
 
   def set_article
-    @article = @category.articles.find(params[:id])
+    @article = @category.articles.find(permitted_params[:id])
     @article.increment_view_count
     @parsed_content = render_article_content(@article.content)
   end
 
   def set_category
-    @category = @portal.categories.find_by!(slug: params[:category_slug]) if params[:category_slug].present?
+    return if permitted_params[:category_slug].blank?
+
+    @category = @portal.categories.find_by!(
+      slug: permitted_params[:category_slug],
+      locale: permitted_params[:locale]
+    )
   end
 
   def portal
-    @portal ||= Portal.find_by!(slug: params[:slug], archived: false)
+    @portal ||= Portal.find_by!(slug: permitted_params[:slug], archived: false)
   end
 
   def list_params
     params.permit(:query)
+  end
+
+  def permitted_params
+    params.permit(:slug, :category_slug, :locale, :id)
   end
 
   def render_article_content(content)

--- a/spec/controllers/public/api/v1/portals/articles_controller_spec.rb
+++ b/spec/controllers/public/api/v1/portals/articles_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Public Articles API', type: :request do
   let(:agent) { create(:user, account: account, role: :agent) }
   let!(:portal) { create(:portal, slug: 'test-portal', config: { allowed_locales: %w[en es] }, custom_domain: 'www.example.com') }
   let!(:category) { create(:category, name: 'category', portal: portal, account_id: account.id, locale: 'en', slug: 'category_slug') }
-  let!(:category_2) { create(:category, name: 'category', portal: portal, account_id: account.id, locale: 'es', slug: 'category_2_slug') }
+  let!(:category_2) { create(:category, name: 'category', portal: portal, account_id: account.id, locale: 'es', slug: 'category_slug') }
   let!(:article) { create(:article, category: category, portal: portal, account_id: account.id, author_id: agent.id) }
 
   before do
@@ -43,6 +43,12 @@ RSpec.describe 'Public Articles API', type: :request do
       get "/hc/#{portal.slug}/#{category.locale}/#{category.slug}/#{article.id}"
       expect(response).to have_http_status(:success)
       expect(article.reload.views).to eq 1
+    end
+
+    it 'returns the article with the id with a different locale' do
+      article_in_locale = create(:article, category: category_2, portal: portal, account_id: account.id, author_id: agent.id)
+      get "/hc/#{portal.slug}/#{category_2.locale}/#{category_2.slug}/#{article_in_locale.id}"
+      expect(response).to have_http_status(:success)
     end
   end
 end


### PR DESCRIPTION
If there are categories with same slug in 2 different locales, then the API fails to find the article.