### PR TITLE
fix: Clicking contact name in conversation should open contact details panel

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
@@ -10,7 +10,11 @@
           :status="currentContact.availability_status"
         />
         <div class="user--profile__meta">
-          <h3 class="user--name text-truncate">
+          <woot-button
+            variant="clear"
+            class="user--name text-truncate"
+            @click.prevent="$emit('contact-panel-toggle')"
+          >
             <span class="margin-right-smaller">{{ currentContact.name }}</span>
             <fluent-icon
               v-if="!isHMACVerified"
@@ -19,7 +23,7 @@
               class="hmac-warning__icon"
               icon="warning"
             />
-          </h3>
+          </woot-button>
           <div class="conversation--header--actions text-truncate">
             <inbox-name
               v-if="hasMultipleInboxes"
@@ -202,10 +206,12 @@ export default {
 .user--name {
   display: inline-block;
   font-size: var(--font-size-medium);
+  font-weight: var(--font-weight-medium);
   line-height: 1.3;
-  margin: 0;
   text-transform: capitalize;
-  width: 100%;
+  color: var(--color-heading) !important;
+  height: auto;
+  padding: 0;
 }
 
 .conversation--header--actions {

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
@@ -11,18 +11,23 @@
         />
         <div class="user--profile__meta">
           <woot-button
-            variant="clear"
-            class="user--name text-truncate"
+            variant="link"
+            color-scheme="secondary"
+            class="text-truncate"
             @click.prevent="$emit('contact-panel-toggle')"
           >
-            <span class="margin-right-smaller">{{ currentContact.name }}</span>
-            <fluent-icon
-              v-if="!isHMACVerified"
-              v-tooltip="$t('CONVERSATION.UNVERIFIED_SESSION')"
-              size="14"
-              class="hmac-warning__icon"
-              icon="warning"
-            />
+            <h3 class="sub-block-title user--name text-truncate">
+              <span class="margin-right-smaller">{{
+                currentContact.name
+              }}</span>
+              <fluent-icon
+                v-if="!isHMACVerified"
+                v-tooltip="$t('CONVERSATION.UNVERIFIED_SESSION')"
+                size="14"
+                class="hmac-warning__icon"
+                icon="warning"
+              />
+            </h3>
           </woot-button>
           <div class="conversation--header--actions text-truncate">
             <inbox-name
@@ -205,12 +210,9 @@ export default {
 
 .user--name {
   display: inline-block;
-  font-size: var(--font-size-medium);
-  font-weight: var(--font-weight-medium);
-  line-height: 1.3;
+  line-height: 1.2;
   text-transform: capitalize;
-  color: var(--color-heading) !important;
-  height: auto;
+  margin: 0;
   padding: 0;
 }
 


### PR DESCRIPTION
## Description

Clicking the contact name in conversation has no effect. This PR implements opening contact details panel when contact name in conversation is clicked

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Go to a conversation
- Click on contact name
- Contact details panel is opened

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Demo video
https://www.loom.com/share/729ad136af754685b46fd796408056a0