### PR TITLE
fix: Allow integration apps to be listed by an agent

### DIFF
--- a/app/controllers/api/v1/accounts/integrations/apps_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/apps_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::Accounts::Integrations::AppsController < Api::V1::Accounts::BaseController
-  before_action :check_admin_authorization?
+  before_action :check_admin_authorization?, except: [:index, :show]
   before_action :fetch_apps, only: [:index]
   before_action :fetch_app, only: [:show]
 

--- a/app/views/api/v1/models/_app.json.jbuilder
+++ b/app/views/api/v1/models/_app.json.jbuilder
@@ -1,9 +1,14 @@
-json.call(resource.params, *resource.params.keys)
+json.id resource.id
 json.name resource.name
 json.description resource.description
 json.enabled resource.enabled?(@current_account)
-json.action resource.action
-json.button resource.action
+
+if Current.account_user&.administrator?
+  json.call(resource.params, *resource.params.keys)
+  json.action resource.action
+  json.button resource.action
+end
+
 json.hooks do
   json.array! @current_account.hooks.where(app_id: resource.id) do |hook|
     json.partial! 'api/v1/models/hook', formats: [:json], resource: hook

--- a/app/views/api/v1/models/_hook.json.jbuilder
+++ b/app/views/api/v1/models/_hook.json.jbuilder
@@ -5,6 +5,4 @@ json.inbox resource.inbox&.slice(:id, :name)
 json.account_id resource.account_id
 json.hook_type resource.hook_type
 
-if Current.account_user&.administrator?
-  json.settings resource.settings
-end
+json.settings resource.settings if Current.account_user&.administrator?

--- a/app/views/api/v1/models/_hook.json.jbuilder
+++ b/app/views/api/v1/models/_hook.json.jbuilder
@@ -4,4 +4,7 @@ json.status resource.enabled?
 json.inbox resource.inbox&.slice(:id, :name)
 json.account_id resource.account_id
 json.hook_type resource.hook_type
-json.settings resource.settings
+
+if Current.account_user&.administrator?
+  json.settings resource.settings
+end

--- a/spec/controllers/api/v1/accounts/integrations/apps_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/apps_controller_spec.rb
@@ -12,9 +12,10 @@ RSpec.describe 'Integration Apps API', type: :request do
     end
 
     context 'when it is an authenticated user' do
-      let(:agent) { create(:user, account: account, role: :administrator) }
+      let(:agent) { create(:user, account: account, role: :agent) }
+      let(:admin) { create(:user, account: account, role: :administrator) }
 
-      it 'returns all active apps' do
+      it 'returns all active apps without sensitive information if the user is an agent' do
         first_app = Integrations::App.all.find(&:active?)
         get api_v1_account_integrations_apps_url(account),
             headers: agent.create_new_auth_token,
@@ -24,12 +25,26 @@ RSpec.describe 'Integration Apps API', type: :request do
         apps = JSON.parse(response.body)['payload'].first
         expect(apps['id']).to eql(first_app.id)
         expect(apps['name']).to eql(first_app.name)
+        expect(apps['action']).to be_nil
+      end
+
+      it 'returns all active apps with sensitive information if user is an admin' do
+        first_app = Integrations::App.all.find(&:active?)
+        get api_v1_account_integrations_apps_url(account),
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        apps = JSON.parse(response.body)['payload'].first
+        expect(apps['id']).to eql(first_app.id)
+        expect(apps['name']).to eql(first_app.name)
+        expect(apps['action']).to eql(first_app.action)
       end
 
       it 'returns slack app with appropriate redirect url when configured' do
         with_modified_env SLACK_CLIENT_ID: 'client_id', SLACK_CLIENT_SECRET: 'client_secret' do
           get api_v1_account_integrations_apps_url(account),
-              headers: agent.create_new_auth_token,
+              headers: admin.create_new_auth_token,
               as: :json
 
           expect(response).to have_http_status(:success)


### PR DESCRIPTION
Fixes https://github.com/chatwoot/chatwoot/issues/6570

- Allow listing the connected apps without exposing credentials