### PR TITLE
chore: Handle APM variables being empty

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,4 +1,4 @@
-if ENV['DD_TRACE_AGENT_URL']
+if ENV['DD_TRACE_AGENT_URL'].present?
   Datadog.configure do |c|
     # Instrumentation
     c.tracing.instrument :rails

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,4 @@
-if ENV['SENTRY_DSN']
+if ENV['SENTRY_DSN'].present?
   Sentry.init do |config|
     config.dsn = ENV['SENTRY_DSN']
     config.enabled_environments = %w[staging production]


### PR DESCRIPTION
- handle the case where the system fails to start when empty APM environment variables are present