### PR TITLE
fix: Add a check for automation_created message in FIRST_REPLY_CREATED

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -196,9 +196,13 @@ class Message < ApplicationRecord
                 .where("(additional_attributes->'campaign_id') is null").count == 1
   end
 
+  def not_created_by_automation?
+    content_attributes['automation_rule_id'].blank?
+  end
+
   def dispatch_create_events
     Rails.configuration.dispatcher.dispatch(MESSAGE_CREATED, Time.zone.now, message: self, performed_by: Current.executed_by)
-    if outgoing? && first_human_response?
+    if outgoing? && first_human_response? && not_created_by_automation?
       Rails.configuration.dispatcher.dispatch(FIRST_REPLY_CREATED, Time.zone.now, message: self, performed_by: Current.executed_by)
     end
   end


### PR DESCRIPTION
Document: 

For conversations: 4029, 4041, and 4038:

`dispatch_create_events[message_created]: first_human_response? && outgoing?` was always true in the `model/message.rb`

It needs one more check; if the message is not being sent by 'Automation'.
When we trigger FIRST_REPLY_CREATED, we have one more action to update the conversation with `message.created_at.`

And that was again triggering:-

`conversation_updated` -> which has `send_message` automation which will again trigger `message_created` -> `FIRST_REPLY_CREATED`

And this was going in a loop.

So this condition is valid for all the affected messages: 

```
----------
For Account 58:  
conversations: 1483, 1482
automation: 521
 ---- - ----
- ----- ----
For Account 61: 
conversations: 4041, 4038, 4029
automation: 476
------------
```

