### PR TITLE
fix: timing in the API

### DIFF
--- a/app/javascript/dashboard/api/reports.js
+++ b/app/javascript/dashboard/api/reports.js
@@ -10,8 +10,8 @@ class ReportsAPI extends ApiClient {
 
   getReports({
     metric,
-    since,
-    until,
+    from,
+    to,
     type = 'account',
     id,
     group_by,
@@ -20,8 +20,8 @@ class ReportsAPI extends ApiClient {
     return axios.get(`${this.url}`, {
       params: {
         metric,
-        since,
-        until,
+        since: from,
+        until: to,
         type,
         id,
         group_by,

--- a/app/javascript/dashboard/api/specs/reports.spec.js
+++ b/app/javascript/dashboard/api/specs/reports.spec.js
@@ -22,8 +22,8 @@ describe('#Reports API', () => {
     it('#getAccountReports', () => {
       reportsAPI.getReports({
         metric: 'conversations_count',
-        since: 1621103400,
-        until: 1621621800,
+        from: 1621103400,
+        to: 1621621800,
       });
       expect(context.axiosMock.get).toHaveBeenCalledWith('/api/v2/reports', {
         params: {


### PR DESCRIPTION
The reports timings we're not being passed correctly to the `ReportsAPI`, this PR fixes it