### PR TITLE
fix: Handle dialogflow hook without setting and credentials

### DIFF
--- a/lib/integrations/dialogflow/processor_service.rb
+++ b/lib/integrations/dialogflow/processor_service.rb
@@ -13,6 +13,8 @@ class Integrations::Dialogflow::ProcessorService < Integrations::BotProcessorSer
   end
 
   def get_response(session_id, message)
+    Rails.logger.warn "Account: Hook: #{hook.id} credentials are not present." && return if hook.settings['credentials'].blank?
+
     Google::Cloud::Dialogflow.configure { |config| config.credentials = hook.settings['credentials'] }
     session_client = Google::Cloud::Dialogflow.sessions
     session = session_client.session_path project: hook.settings['project_id'], session: session_id


### PR DESCRIPTION
Fixes: https://github.com/chatwoot/product/issues/818

Sentry Issue: [CHATWOOT-3VH](https://chatwoot-p3.sentry.io/issues/3979086414/?referrer=github_integration)

