### PR TITLE
fix: hook exception for empty hook

### DIFF
--- a/lib/integrations/bot_processor_service.rb
+++ b/lib/integrations/bot_processor_service.rb
@@ -1,4 +1,5 @@
 class Integrations::BotProcessorService
+  # TODO: In CSML processor service, the argument is agent bot, update initializers accordingly.
   pattr_initialize [:event_name!, :hook!, :event_data!]
 
   def perform
@@ -7,7 +8,7 @@ class Integrations::BotProcessorService
 
     process_content(message)
   rescue StandardError => e
-    ChatwootExceptionTracker.new(e, account: hook.account).capture_exception
+    ChatwootExceptionTracker.new(e, account: (hook&.account || agent_bot&.account)).capture_exception
   end
 
   private


### PR DESCRIPTION
Sentry Issue: [EXTERNAL-SOCIALBOT-5R](https://chatwoot-p3.sentry.io/issues/3990919574/?referrer=github_integration)