### PR TITLE
feat(poc): Disable widget based on country

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -191,11 +191,7 @@ USE_INBOX_AVATAR_FOR_BOT=true
 ## https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#environment-variables
 # DD_TRACE_AGENT_URL=
 
-## IP look up configuration
-## ref https://github.com/alexreisner/geocoder/blob/master/README_API_GUIDE.md
-## works only on accounts with ip look up feature enabled
-# IP_LOOKUP_SERVICE=geoip2
-# maxmindb api key to use geoip2 service
+# MaxMindDB API key to download GeoLite2 City database
 # IP_LOOKUP_API_KEY=
 
 ## Rack Attack configuration

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: POSTGRES_STATEMENT_TIMEOUT=600s bundle exec rails db:chatwoot_prepare
-web: bin/rails server -p $PORT -e $RAILS_ENV
-worker: bundle exec sidekiq -C config/sidekiq.yml
+web: bundle exec rails ip_lookup:setup && bin/rails server -p $PORT -e $RAILS_ENV
+worker: bundle exec rails ip_lookup:setup && bundle exec sidekiq -C config/sidekiq.yml

--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -5,6 +5,7 @@ class WidgetsController < ActionController::Base
   before_action :set_global_config
   before_action :set_web_widget
   before_action :ensure_account_is_active
+  before_action :ensure_location_is_supported
   before_action :set_token
   before_action :set_contact
   before_action :build_contact
@@ -54,6 +55,8 @@ class WidgetsController < ActionController::Base
     render json: { error: 'Account is suspended' }, status: :unauthorized unless @web_widget.inbox.account.active?
   end
 
+  def ensure_location_is_supported; end
+
   def additional_attributes
     if @web_widget.inbox.account.feature_enabled?('ip_lookup')
       { created_at_ip: request.remote_ip }
@@ -70,3 +73,5 @@ class WidgetsController < ActionController::Base
     response.headers.delete('X-Frame-Options')
   end
 end
+
+WidgetsController.prepend_mod_with('WidgetsController')

--- a/app/jobs/contact_ip_lookup_job.rb
+++ b/app/jobs/contact_ip_lookup_job.rb
@@ -1,11 +1,7 @@
-require 'rubygems/package'
-
 class ContactIpLookupJob < ApplicationJob
   queue_as :default
 
   def perform(contact)
-    return unless ensure_look_up_service
-
     update_contact_location_from_ip(contact)
   rescue Errno::ETIMEDOUT => e
     Rails.logger.warn "Exception: ip resolution failed : #{e.message}"
@@ -13,18 +9,8 @@ class ContactIpLookupJob < ApplicationJob
 
   private
 
-  def ensure_look_up_service
-    return if ENV['IP_LOOKUP_SERVICE'].blank? || ENV['IP_LOOKUP_API_KEY'].blank?
-    return true if ENV['IP_LOOKUP_SERVICE'].to_sym != :geoip2
-
-    ensure_look_up_db
-  end
-
   def update_contact_location_from_ip(contact)
-    ip = get_contact_ip(contact)
-    return if ip.blank?
-
-    geocoder_result = Geocoder.search(ip).first
+    geocoder_result = IpLookupService.new(sync_lookup: false).perform(get_contact_ip(contact))
     return unless geocoder_result
 
     contact.additional_attributes ||= {}
@@ -36,29 +22,5 @@ class ContactIpLookupJob < ApplicationJob
 
   def get_contact_ip(contact)
     contact.additional_attributes&.dig('updated_at_ip') || contact.additional_attributes&.dig('created_at_ip')
-  end
-
-  def ensure_look_up_db
-    return true if File.exist?(GeocoderConfiguration::LOOK_UP_DB)
-
-    setup_vendor_db
-  end
-
-  def setup_vendor_db
-    base_url = 'https://download.maxmind.com/app/geoip_download'
-    source_file = Down.download(
-      "#{base_url}?edition_id=GeoLite2-City&suffix=tar.gz&license_key=#{ENV.fetch('IP_LOOKUP_API_KEY', nil)}"
-    )
-    tar_extract = Gem::Package::TarReader.new(Zlib::GzipReader.open(source_file))
-    tar_extract.rewind
-
-    tar_extract.each do |entry|
-      next unless entry.full_name.include?('GeoLite2-City.mmdb') && entry.file?
-
-      File.open GeocoderConfiguration::LOOK_UP_DB, 'wb' do |f|
-        f.print entry.read
-      end
-      return true
-    end
   end
 end

--- a/app/jobs/contact_ip_lookup_job.rb
+++ b/app/jobs/contact_ip_lookup_job.rb
@@ -10,7 +10,7 @@ class ContactIpLookupJob < ApplicationJob
   private
 
   def update_contact_location_from_ip(contact)
-    geocoder_result = IpLookupService.new(sync_lookup: false).perform(get_contact_ip(contact))
+    geocoder_result = IpLookupService.new.perform(get_contact_ip(contact))
     return unless geocoder_result
 
     contact.additional_attributes ||= {}

--- a/app/services/ip_lookup_service.rb
+++ b/app/services/ip_lookup_service.rb
@@ -24,12 +24,10 @@ class IpLookupService
   def ensure_look_up_db
     return true if File.exist?(GeocoderConfiguration::LOOK_UP_DB)
 
-    setup_vendor_db
+    setup_vendor_db if sync_lookup == true
   end
 
   def setup_vendor_db
-    return if sync_lookup == true
-
     base_url = 'https://download.maxmind.com/app/geoip_download'
     source_file = Down.download(
       "#{base_url}?edition_id=GeoLite2-City&suffix=tar.gz&license_key=#{ENV.fetch('IP_LOOKUP_API_KEY', nil)}"

--- a/app/services/ip_lookup_service.rb
+++ b/app/services/ip_lookup_service.rb
@@ -1,0 +1,49 @@
+require 'rubygems/package'
+
+class IpLookupService
+  pattr_initialize [sync_lookup: true]
+
+  def perform(ip_address)
+    return if ip_address.blank?
+    return unless ensure_look_up_service
+
+    Geocoder.search(ip_address).first
+  rescue Errno::ETIMEDOUT => e
+    Rails.logger.warn "Exception: ip resolution failed : #{e.message}"
+  end
+
+  private
+
+  def ensure_look_up_service
+    return if ENV['IP_LOOKUP_SERVICE'].blank? || ENV['IP_LOOKUP_API_KEY'].blank?
+    return true if ENV['IP_LOOKUP_SERVICE'].to_sym != :geoip2
+
+    ensure_look_up_db
+  end
+
+  def ensure_look_up_db
+    return true if File.exist?(GeocoderConfiguration::LOOK_UP_DB)
+
+    setup_vendor_db
+  end
+
+  def setup_vendor_db
+    return if sync_lookup == true
+
+    base_url = 'https://download.maxmind.com/app/geoip_download'
+    source_file = Down.download(
+      "#{base_url}?edition_id=GeoLite2-City&suffix=tar.gz&license_key=#{ENV.fetch('IP_LOOKUP_API_KEY', nil)}"
+    )
+    tar_extract = Gem::Package::TarReader.new(Zlib::GzipReader.open(source_file))
+    tar_extract.rewind
+
+    tar_extract.each do |entry|
+      next unless entry.full_name.include?('GeoLite2-City.mmdb') && entry.file?
+
+      File.open GeocoderConfiguration::LOOK_UP_DB, 'wb' do |f|
+        f.print entry.read
+      end
+      return true
+    end
+  end
+end

--- a/app/services/ip_lookup_service.rb
+++ b/app/services/ip_lookup_service.rb
@@ -1,47 +1,15 @@
-require 'rubygems/package'
-
 class IpLookupService
-  pattr_initialize [sync_lookup: true]
-
   def perform(ip_address)
-    return if ip_address.blank?
-    return unless ensure_look_up_service
+    return if ip_address.blank? || !ip_database_available?
 
     Geocoder.search(ip_address).first
   rescue Errno::ETIMEDOUT => e
-    Rails.logger.warn "Exception: ip resolution failed : #{e.message}"
+    Rails.logger.warn "Exception: IP resolution failed :#{e.message}"
   end
 
   private
 
-  def ensure_look_up_service
-    return if ENV['IP_LOOKUP_SERVICE'].blank? || ENV['IP_LOOKUP_API_KEY'].blank?
-    return true if ENV['IP_LOOKUP_SERVICE'].to_sym != :geoip2
-
-    ensure_look_up_db
-  end
-
-  def ensure_look_up_db
-    return true if File.exist?(GeocoderConfiguration::LOOK_UP_DB)
-
-    setup_vendor_db if sync_lookup == true
-  end
-
-  def setup_vendor_db
-    base_url = 'https://download.maxmind.com/app/geoip_download'
-    source_file = Down.download(
-      "#{base_url}?edition_id=GeoLite2-City&suffix=tar.gz&license_key=#{ENV.fetch('IP_LOOKUP_API_KEY', nil)}"
-    )
-    tar_extract = Gem::Package::TarReader.new(Zlib::GzipReader.open(source_file))
-    tar_extract.rewind
-
-    tar_extract.each do |entry|
-      next unless entry.full_name.include?('GeoLite2-City.mmdb') && entry.file?
-
-      File.open GeocoderConfiguration::LOOK_UP_DB, 'wb' do |f|
-        f.print entry.read
-      end
-      return true
-    end
+  def ip_database_available?
+    File.exist?(GeocoderConfiguration::LOOK_UP_DB)
   end
 end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -23,10 +23,4 @@ module GeocoderConfiguration
   LOOK_UP_DB = Rails.root.join('vendor/db/GeoLiteCity.mmdb')
 end
 
-if ENV['IP_LOOKUP_SERVICE'].present?
-  if ENV['IP_LOOKUP_SERVICE'] == 'geoip2'
-    Geocoder.configure(ip_lookup: :geoip2, geoip2: { file: GeocoderConfiguration::LOOK_UP_DB })
-  else
-    Geocoder.configure(ip_lookup: ENV['IP_LOOKUP_SERVICE'].to_sym, api_key: ENV.fetch('IP_LOOKUP_API_KEY', nil))
-  end
-end
+Geocoder.configure(ip_lookup: :geoip2, geoip2: { file: GeocoderConfiguration::LOOK_UP_DB }) if ENV['IP_LOOKUP_API_KEY'].present?

--- a/enterprise/app/controllers/enterprise/widgets_controller.rb
+++ b/enterprise/app/controllers/enterprise/widgets_controller.rb
@@ -1,0 +1,14 @@
+module Enterprise::WidgetsController
+  private
+
+  def ensure_location_is_supported
+    countries = @web_widget.inbox.account.custom_attributes['allowed_countries']
+    return if countries.blank?
+
+    geocoder_result = IpLookupService.new(sync_lookup: false).perform(request.remote_ip)
+    return unless geocoder_result
+
+    country_enabled = countries.include?(geocoder_result.country_code)
+    render json: { error: 'Location is not supported' }, status: :unauthorized unless country_enabled
+  end
+end

--- a/enterprise/app/controllers/enterprise/widgets_controller.rb
+++ b/enterprise/app/controllers/enterprise/widgets_controller.rb
@@ -5,7 +5,7 @@ module Enterprise::WidgetsController
     countries = @web_widget.inbox.account.custom_attributes['allowed_countries']
     return if countries.blank?
 
-    geocoder_result = IpLookupService.new(sync_lookup: false).perform(request.remote_ip)
+    geocoder_result = IpLookupService.new.perform(request.remote_ip)
     return unless geocoder_result
 
     country_enabled = countries.include?(geocoder_result.country_code)

--- a/lib/tasks/ip_lookup.rake
+++ b/lib/tasks/ip_lookup.rake
@@ -1,0 +1,33 @@
+require 'rubygems/package'
+
+namespace :ip_lookup do
+  task setup: :environment do
+    next if File.exist?(GeocoderConfiguration::LOOK_UP_DB)
+
+    ip_lookup_api_key = ENV.fetch('IP_LOOKUP_API_KEY')
+    next if ip_lookup_api_key.blank?
+
+    puts '[rake ip_lookup:setup] Fetch GeoLite2-City database'
+
+    begin
+      base_url = 'https://download.maxmind.com/app/geoip_download'
+      source_file = Down.download(
+        "#{base_url}?edition_id=GeoLite2-City&suffix=tar.gz&license_key=#{ip_lookup_api_key}"
+      )
+
+      tar_extract = Gem::Package::TarReader.new(Zlib::GzipReader.open(source_file))
+      tar_extract.rewind
+
+      tar_extract.each do |entry|
+        next unless entry.full_name.include?('GeoLite2-City.mmdb') && entry.file?
+
+        File.open GeocoderConfiguration::LOOK_UP_DB, 'wb' do |f|
+          f.print entry.read
+        end
+      end
+      puts '[rake ip_lookup:setup] Fetch complete'
+    rescue StandardError => e
+      puts "[rake ip_lookup:setup] #{e.message}"
+    end
+  end
+end


### PR DESCRIPTION
- Disable widget based on country code from IP address

https://www.loom.com/share/f2363462485b4aa8a6826f77a8964bf7


### Changes:

The database download has been moved to a rake task and will be downloaded during boot up. Dynamically fetching (async fetches via Sidekiq) the database does not work well with synchronous calls since each server requires a copy of the file.

I updated the Procfile to download the DB initially and then run the service afterwards. This change may increase the bootup time by 3-4 seconds, depending on network latency.

I removed the IP_LOOKUP_SERVICE variable because none of the other services will work without the lookup parameter. Therefore, managing this variable is pointless.