### PR TITLE
chore: Disable throwing Webhook exceptions to Sentry

### DIFF
--- a/lib/webhooks/trigger.rb
+++ b/lib/webhooks/trigger.rb
@@ -8,6 +8,6 @@ class Webhooks::Trigger
     )
     Rails.logger.info "Performed Request:  Code - #{response.code}"
   rescue StandardError => e
-    Rails.logger.error "Exception: invalid webhook url #{url} : #{e.message}"
+    Rails.logger.warn "Exception: invalid webhook url #{url} : #{e.message}"
   end
 end

--- a/lib/webhooks/trigger.rb
+++ b/lib/webhooks/trigger.rb
@@ -7,10 +7,7 @@ class Webhooks::Trigger
       timeout: 5
     )
     Rails.logger.info "Performed Request:  Code - #{response.code}"
-  rescue *ExceptionList::REST_CLIENT_EXCEPTIONS, URI::InvalidURIError => e
-    Rails.logger.error "Exception: invalid webhook url #{url} : #{e.message}"
   rescue StandardError => e
     Rails.logger.error "Exception: invalid webhook url #{url} : #{e.message}"
-    ChatwootExceptionTracker.new(e).capture_exception
   end
 end


### PR DESCRIPTION
- There is little value in throwing the third-party webhook-related exceptions to sentry. Let's rather write it to logs instead.