### PR TITLE
fix: Reverts popover styling for search page

### DIFF
--- a/app/javascript/dashboard/modules/search/components/SearchHeader.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchHeader.vue
@@ -76,7 +76,8 @@ export default {
   display: flex;
   align-items: center;
   padding: var(--space-small) var(--space-normal);
-  border-bottom: 1px solid var(--s-100);
+  border: 1px solid var(--s-100);
+  border-radius: var(--border-radius-small);
   transition: border-bottom 0.2s ease-in-out;
 
   input[type='search'] {
@@ -86,7 +87,7 @@ export default {
   }
 
   &.is-focused {
-    border-bottom: 1px solid var(--w-100);
+    border-color: var(--w-100);
 
     .icon {
       color: var(--w-400);

--- a/app/javascript/dashboard/modules/search/components/SearchTabs.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchTabs.vue
@@ -35,6 +35,6 @@ export default {
 <style lang="scss" scoped>
 .tab-container {
   margin-top: var(--space-smaller);
-  border-bottom: 1px solid var(--s-50);
+  border-bottom: 1px solid var(--s-100);
 }
 </style>

--- a/app/javascript/dashboard/modules/search/components/SearchView.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchView.vue
@@ -47,7 +47,7 @@
             </p>
           </div>
           <div v-else class="empty text-center">
-            <p class="text-center">
+            <p class="text-center margin-bottom-0">
               <fluent-icon icon="search" size="24px" class="icon" />
             </p>
             <p class="empty-state__text">
@@ -202,23 +202,21 @@ export default {
 }
 .search-root {
   margin: 0 auto;
-  max-width: 64rem;
+  max-width: 72rem;
   min-height: 48rem;
   width: 100%;
   height: fit-content;
-  box-shadow: var(--shadow);
+  padding: var(--space-normal);
   display: flex;
   position: relative;
   flex-direction: column;
   background: white;
-  border-radius: var(--border-radius-large);
+  overflow-y: auto;
   margin-top: var(--space-large);
-  border-top: 1px solid var(--s-25);
+
   .search-results {
     flex-grow: 1;
     height: 100%;
-    max-height: 80vh;
-    overflow-y: auto;
     padding: 0 var(--space-small);
   }
 }
@@ -230,6 +228,7 @@ export default {
   justify-content: center;
   padding: var(--space-medium) var(--space-normal);
   border-radius: var(--border-radius-medium);
+  margin-top: var(--space-large);
   .icon {
     color: var(--s-500);
   }


### PR DESCRIPTION


## Description
![image](https://user-images.githubusercontent.com/1277421/225871391-6c57549f-530f-44f7-b4f5-3b7f93dffc92.png)


## Type of change
Reverts search page design to get rid of the popover feel.

Fixes: https://linear.app/chatwoot/issue/CW-5/followup-from-search-improvements
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
