### PR TITLE
feat: show external error in message

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -68,6 +68,7 @@
           :id="data.id"
           :sender="data.sender"
           :story-sender="storySender"
+          :external-error="externalError"
           :story-id="storyId"
           :is-a-tweet="isATweet"
           :is-a-whatsapp-channel="isAWhatsAppChannel"
@@ -261,6 +262,9 @@ export default {
     contentAttributes() {
       return this.data.content_attributes || {};
     },
+    externalError() {
+      return this.contentAttributes.external_error || null;
+    },
     sender() {
       return this.data.sender || {};
     },
@@ -351,7 +355,7 @@ export default {
         return false;
       }
       if (this.isFailed) {
-        return this.$t(`CONVERSATION.SEND_FAILED`);
+        return this.externalError ? '' : this.$t(`CONVERSATION.SEND_FAILED`);
       }
       return false;
     },

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -9,6 +9,14 @@
     >
       {{ readableTime }}
     </span>
+    <span v-if="externalError" class="read-indicator-wrap">
+      <fluent-icon
+        v-tooltip.top-start="externalError"
+        icon="error-circle"
+        class="action--icon"
+        size="14"
+      />
+    </span>
     <span v-if="showReadIndicator" class="read-indicator-wrap">
       <fluent-icon
         v-tooltip.top-start="$t('CHAT_LIST.MESSAGE_READ')"
@@ -95,6 +103,10 @@ export default {
       default: 0,
     },
     storySender: {
+      type: String,
+      default: '',
+    },
+    externalError: {
       type: String,
       default: '',
     },


### PR DESCRIPTION
# show external error in message

## Description

Show attribute external error when exist.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Simulate error message and print


<img width="467" alt="Captura de Tela 2023-03-18 às 23 54 37" src="https://user-images.githubusercontent.com/471685/226151120-add3500f-f5c7-40a5-8d55-1a864d83dda6.png">
