### PR TITLE
chore: The label creation UI input is transform to lowercase

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/labels/AddLabel.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/labels/AddLabel.vue
@@ -8,7 +8,7 @@
       <woot-input
         v-model.trim="title"
         :class="{ error: $v.title.$error }"
-        class="medium-12 columns"
+        class="medium-12 columns label-name--input"
         :label="$t('LABEL_MGMT.FORM.NAME.LABEL')"
         :placeholder="$t('LABEL_MGMT.FORM.NAME.PLACEHOLDER')"
         :error="getLabelTitleErrorMessage"
@@ -91,7 +91,7 @@ export default {
         await this.$store.dispatch('labels/create', {
           color: this.color,
           description: this.description,
-          title: this.title,
+          title: this.title.toLowerCase(),
           show_on_sidebar: this.showOnSidebar,
         });
         this.showAlert(this.$t('LABEL_MGMT.ADD.API.SUCCESS_MESSAGE'));
@@ -105,3 +105,13 @@ export default {
   },
 };
 </script>
+<style lang="scss" scoped>
+// Label API supports only lowercase letters
+.label-name--input {
+  ::v-deep {
+    input {
+      text-transform: lowercase;
+    }
+  }
+}
+</style>

--- a/app/javascript/dashboard/routes/dashboard/settings/labels/EditLabel.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/labels/EditLabel.vue
@@ -5,7 +5,7 @@
       <woot-input
         v-model.trim="title"
         :class="{ error: $v.title.$error }"
-        class="medium-12 columns"
+        class="medium-12 columns label-name--input"
         :label="$t('LABEL_MGMT.FORM.NAME.LABEL')"
         :placeholder="$t('LABEL_MGMT.FORM.NAME.PLACEHOLDER')"
         :error="getLabelTitleErrorMessage"
@@ -101,7 +101,7 @@ export default {
           id: this.selectedResponse.id,
           color: this.color,
           description: this.description,
-          title: this.title,
+          title: this.title.toLowerCase(),
           show_on_sidebar: this.showOnSidebar,
         })
         .then(() => {
@@ -115,3 +115,13 @@ export default {
   },
 };
 </script>
+<style lang="scss" scoped>
+// Label API supports only lowercase letters
+.label-name--input {
+  ::v-deep {
+    input {
+      text-transform: lowercase;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will transform the label name input to lowercase for add and edit label modal.

Fixes https://linear.app/chatwoot/issue/CW-375/the-label-creation-ui-input-should-transform-to-lowercase

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
https://www.loom.com/share/a4bd824255ca473fad033c45e20b0b12

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
