### PR TITLE
fixed ConfigLoader process

### DIFF
--- a/db/migrate/20200510112339_create_installation_config.rb
+++ b/db/migrate/20200510112339_create_installation_config.rb
@@ -2,7 +2,8 @@ class CreateInstallationConfig < ActiveRecord::Migration[6.0]
   def change
     create_table :installation_configs do |t|
       t.string :name, null: false
-      t.jsonb :serialized_value, null: false, default: '{}'
+      t.jsonb :serialized_value, null: false, default: {}
+      t.boolean :locked, default: true, null: false
       t.timestamps
     end
 

--- a/db/migrate/20210113045116_add_locked_attribute_to_installation_config.rb
+++ b/db/migrate/20210113045116_add_locked_attribute_to_installation_config.rb
@@ -1,12 +1,12 @@
 class AddLockedAttributeToInstallationConfig < ActiveRecord::Migration[6.0]
   def up
-    add_column :installation_configs, :locked, :boolean, default: true, null: false
+    add_column :installation_configs, :locked, :boolean, default: true, null: false unless column_exists?(:installation_configs, :locked)
     purge_duplicates
     add_index :installation_configs, :name, unique: true
   end
 
   def down
-    remove_column :installation_configs, :locked
+    remove_column :installation_configs, :locked if column_exists?(:installation_configs, :locked)
     remove_index :installation_configs, :name
   end
 


### PR DESCRIPTION
# Fixed   ConfigLoader.new.process

## Description

When rails db migrate, current scheme version will raise error. Because `ConfigLoader.new.process` use the latest code.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

```ruby
rails db:drop
rails db:create
rails db:migrate

# will raise error
```

