### PR TITLE
fix: Case insensitive email match

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,6 +106,10 @@ class User < ApplicationRecord
 
   scope :order_by_full_name, -> { order('lower(name) ASC') }
 
+  before_validation do
+    self.email = email.try(:downcase)
+  end
+
   def send_devise_notification(notification, *args)
     devise_mailer.with(account: Current.account).send(notification, self, *args).deliver_later
   end

--- a/spec/controllers/platform/api/v1/users_controller_spec.rb
+++ b/spec/controllers/platform/api/v1/users_controller_spec.rb
@@ -115,6 +115,11 @@ RSpec.describe 'Platform Users API', type: :request do
           )
         )
         expect(platform_app.platform_app_permissibles.first.permissible_id).to eq data['id']
+
+        post '/platform/api/v1/users/', params: { name: 'test', email: 'TesT@test.com', password: 'Password1!' },
+                                        headers: { api_access_token: platform_app.access_token.token }, as: :json
+        data = JSON.parse(response.body)
+        expect(data['message']).to eq('Email has already been taken')
       end
 
       it 'fetch existing user and creates permissible for the user' do


### PR DESCRIPTION

Fixes: https://linear.app/chatwoot/issue/CW-1354/email-id-case-sensitive
