### PR TITLE
fix: Add link to conversation in slack message

### DIFF
--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -37,22 +37,24 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
     if conversation.identifier.present?
       "#{private_indicator}#{message_text}"
     else
-      "#{formatted_inbox_name}#{email_subject_line}\n#{message_text}"
+      "#{formatted_inbox_name}#{formatted_conversation_link}#{email_subject_line}\n#{message_text}"
     end
   end
 
   def message_text
     if message.content.present?
-      text = message.content.gsub(MENTION_REGEX, '\1')
-      text = "#{text}\n#{link_to_conversation}" if first_message?
+      message.content.gsub(MENTION_REGEX, '\1')
     else
-      text = message.content
+      message.content
     end
-    text
   end
 
   def formatted_inbox_name
     "\n*Inbox:* #{message.inbox.name} (#{message.inbox.inbox_type})\n"
+  end
+
+  def formatted_conversation_link
+    "*Conversation:* #{link_to_conversation}\n"
   end
 
   def email_subject_line
@@ -132,10 +134,6 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
 
   def slack_client
     @slack_client ||= Slack::Web::Client.new(token: hook.access_token)
-  end
-
-  def first_message?
-    conversation.messages.where(message_type: [:incoming, :outgoing]).count == 1
   end
 
   def link_to_conversation

--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -34,6 +34,8 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
 
   def message_content
     private_indicator = message.private? ? 'private: ' : ''
+    message_text = message.content.gsub(MENTION_REGEX, '\1')
+    message_text = "#{message_text}\\n#{link_to_conversation}" if first_message?
     if conversation.identifier.present?
       "#{private_indicator}#{message_text}"
     else
@@ -126,5 +128,13 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
 
   def slack_client
     @slack_client ||= Slack::Web::Client.new(token: hook.access_token)
+  end
+
+  def first_message?
+    conversation.messages.notifiable.count == 1
+  end
+
+  def link_to_conversation
+    "#{ENV.fetch('FRONTEND_URL', nil)}/app/accounts/#{Current.account.id}/conversations/#{conversation.display_id}"
   end
 end

--- a/spec/lib/integrations/slack/send_on_slack_service_spec.rb
+++ b/spec/lib/integrations/slack/send_on_slack_service_spec.rb
@@ -78,7 +78,7 @@ describe Integrations::Slack::SendOnSlackService do
       it 'sent message to slack' do
         expect(slack_client).to receive(:chat_postMessage).with(
           channel: hook.reference_id,
-          text: message.content.to_s,
+          text: message.content,
           username: "#{message.sender.name} (Contact)",
           thread_ts: conversation.identifier,
           icon_url: anything
@@ -92,7 +92,7 @@ describe Integrations::Slack::SendOnSlackService do
       it 'sent attachment on slack' do
         expect(slack_client).to receive(:chat_postMessage).with(
           channel: hook.reference_id,
-          text: message.content.to_s,
+          text: message.content,
           username: "#{message.sender.name} (Contact)",
           thread_ts: conversation.identifier,
           icon_url: anything
@@ -122,7 +122,7 @@ describe Integrations::Slack::SendOnSlackService do
       it 'disables hook on Slack AccountInactive error' do
         expect(slack_client).to receive(:chat_postMessage).with(
           channel: hook.reference_id,
-          text: message.content.to_s,
+          text: message.content,
           username: "#{message.sender.name} (Contact)",
           thread_ts: conversation.identifier,
           icon_url: anything
@@ -179,7 +179,7 @@ describe Integrations::Slack::SendOnSlackService do
 
         expect(slack_client).to receive(:chat_postMessage).with(
           channel: hook.reference_id,
-          text: formatted_message_text.to_s,
+          text: formatted_message_text,
           username: "#{message.sender.name} (Contact)",
           thread_ts: 'random_slack_thread_ts',
           icon_url: anything

--- a/spec/lib/integrations/slack/send_on_slack_service_spec.rb
+++ b/spec/lib/integrations/slack/send_on_slack_service_spec.rb
@@ -9,17 +9,20 @@ describe Integrations::Slack::SendOnSlackService do
   let!(:message) do
     create(:message, account: conversation.account, inbox: conversation.inbox, conversation: conversation)
   end
+
   let(:slack_message) { double }
   let(:file_attachment) { double }
   let(:slack_message_content) { double }
   let(:slack_client) { double }
   let(:builder) { described_class.new(message: message, hook: hook) }
+  let(:conversation_link) { "#{ENV.fetch('FRONTEND_URL', nil)}/app/accounts/#{account.id}/conversations/#{conversation.display_id}" }
 
   before do
     allow(builder).to receive(:slack_client).and_return(slack_client)
     allow(slack_message).to receive(:[]).with('ts').and_return('12345.6789')
     allow(slack_message).to receive(:[]).with('message').and_return(slack_message_content)
     allow(slack_message_content).to receive(:[]).with('ts').and_return('6789.12345')
+    create(:message, account: conversation.account, inbox: conversation.inbox, conversation: conversation)
   end
 
   describe '#perform' do
@@ -75,7 +78,7 @@ describe Integrations::Slack::SendOnSlackService do
       it 'sent message to slack' do
         expect(slack_client).to receive(:chat_postMessage).with(
           channel: hook.reference_id,
-          text: message.content,
+          text: message.content.to_s,
           username: "#{message.sender.name} (Contact)",
           thread_ts: conversation.identifier,
           icon_url: anything
@@ -89,7 +92,7 @@ describe Integrations::Slack::SendOnSlackService do
       it 'sent attachment on slack' do
         expect(slack_client).to receive(:chat_postMessage).with(
           channel: hook.reference_id,
-          text: message.content,
+          text: message.content.to_s,
           username: "#{message.sender.name} (Contact)",
           thread_ts: conversation.identifier,
           icon_url: anything
@@ -119,7 +122,7 @@ describe Integrations::Slack::SendOnSlackService do
       it 'disables hook on Slack AccountInactive error' do
         expect(slack_client).to receive(:chat_postMessage).with(
           channel: hook.reference_id,
-          text: message.content,
+          text: message.content.to_s,
           username: "#{message.sender.name} (Contact)",
           thread_ts: conversation.identifier,
           icon_url: anything
@@ -130,6 +133,25 @@ describe Integrations::Slack::SendOnSlackService do
         builder.perform
         expect(hook).to be_disabled
         expect(hook).to have_received(:authorization_error!)
+      end
+    end
+
+    context 'with first message' do
+      it 'send conversation_link' do
+        Message.last.destroy!
+        inbox = conversation.inbox
+        message.update!(content: "Hi [@#{contact.name}](mention://user/#{contact.id}/#{contact.name}), welcome to Chatwoot!")
+        formatted_message_text = message.content.gsub(RegexHelper::MENTION_REGEX, '\1')
+
+        expect(slack_client).to receive(:chat_postMessage).with(
+          channel: hook.reference_id,
+          text: "\n*Inbox:* #{inbox.name} (#{inbox.inbox_type})\n\n#{formatted_message_text}\n#{conversation_link}",
+          username: "#{message.sender.name} (Contact)",
+          thread_ts: nil,
+          icon_url: anything
+        ).and_return(slack_message)
+
+        builder.perform
       end
     end
 
@@ -157,7 +179,7 @@ describe Integrations::Slack::SendOnSlackService do
 
         expect(slack_client).to receive(:chat_postMessage).with(
           channel: hook.reference_id,
-          text: formatted_message_text,
+          text: formatted_message_text.to_s,
           username: "#{message.sender.name} (Contact)",
           thread_ts: 'random_slack_thread_ts',
           icon_url: anything


### PR DESCRIPTION
Fixes: https://linear.app/chatwoot/issue/CW-1336/add-conversation-link-at-the-start-of-the-thread-in-slack

https://www.loom.com/share/8f21c9e97e804613a15833587dc3c86a