### PR TITLE
chore: Remove extra audit column

### DIFF
--- a/db/migrate/20230202132107_install_audited.rb
+++ b/db/migrate/20230202132107_install_audited.rb
@@ -13,7 +13,7 @@ class InstallAudited < ActiveRecord::Migration[6.1]
       t.string :username
       t.string :action
       t.jsonb :audited_changes
-      t.integer :version, :integer, :default => 0
+      t.integer :version, :default => 0
       t.string :comment
       t.string :remote_address
       t.string :request_uuid

--- a/db/migrate/20230328131926_drop_extra_audit_integer_column.rb
+++ b/db/migrate/20230328131926_drop_extra_audit_integer_column.rb
@@ -1,0 +1,7 @@
+class DropExtraAuditIntegerColumn < ActiveRecord::Migration[6.1]
+  def change
+    # this column was added unintentionally for a time in a migration but not in schema.rb, so some
+    # installations will have it and some won't.
+    remove_column :audits, :integer, :integer, default: 0, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_15_105847) do
+ActiveRecord::Schema.define(version: 2023_03_28_131926) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"


### PR DESCRIPTION
# Pull Request Template

## Description

When I run the migration from **[this PR](https://github.com/chatwoot/chatwoot/pull/6434/files#diff-4e30cbc2669e4b0f6e1fc0526be0c6141082a5c1dc88aaddc8c0fbc1d742f0ddR16)**:
https://github.com/chatwoot/chatwoot/blob/3e6d23e0715a0a700404c02e5a7a32b4fa079187/db/migrate/20230202132107_install_audited.rb#L16
it adds an extra integer column named "integer" to my DB.

Diff in `db/schema.rb`:
```diff
   create_table "audits", force: :cascade do |t|
     t.bigint "auditable_id"
     t.string "auditable_type"
     t.bigint "associated_id"
     t.string "associated_type"
     t.bigint "user_id"
     t.string "user_type"
     t.string "username"
     t.string "action"
     t.jsonb "audited_changes"
     t.integer "version", default: 0
+    t.integer "integer", default: 0
     t.string "comment"
     t.string "remote_address"
     t.string "request_uuid"
     t.datetime "created_at"
     t.index ["associated_type", "associated_id"], name: "associated_index"
     t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
     t.index ["created_at"], name: "index_audits_on_created_at"
     t.index ["request_uuid"], name: "index_audits_on_request_uuid"
     t.index ["user_id", "user_type"], name: "user_index"
   end
```

Since this was added in the migration itself but wasn't committed to `schema.rb`, I think
we have to assume that some installations will have the extra column and some won't,
because newer installations will have bootstrapped from `schema.rb` and skipped the
migration while older installations will have run the migration. So I think the best option
is to fix the old migration and also run a new migration to drop the column conditionally.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
