### PR TITLE
chore: Re-add "public" prefix to "public.gen_random_uuid()" in schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -438,7 +438,7 @@ ActiveRecord::Schema.define(version: 2023_03_15_105847) do
     t.datetime "agent_last_seen_at"
     t.jsonb "additional_attributes", default: {}
     t.bigint "contact_inbox_id"
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "uuid", default: -> { "public.gen_random_uuid()" }, null: false
     t.string "identifier"
     t.datetime "last_activity_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.bigint "team_id"


### PR DESCRIPTION
## Description

When I run `rails db:schema:dump` this is what is generated for me. It was previously in the chatwoot codebase _with_ the prefix, but was removed **[in this PR](https://github.com/chatwoot/chatwoot/pull/5338#discussion_r957645071)** without explanation as to why.

Should `public.` be in schema.rb or not? What was the reason for its removal? Do I have something unique about my setup that's causing it to be added?
