### PR TITLE
fix memory leek

### DIFF
--- a/app/javascript/dashboard/components/CustomAttribute.vue
+++ b/app/javascript/dashboard/components/CustomAttribute.vue
@@ -218,13 +218,17 @@ export default {
   },
   mounted() {
     this.editedValue = this.formattedValue;
-    bus.$on(BUS_EVENTS.FOCUS_CUSTOM_ATTRIBUTE, focusAttributeKey => {
+    bus.$on(BUS_EVENTS.FOCUS_CUSTOM_ATTRIBUTE, this.onFocusAttribute);
+  },
+  destroyed() {
+    bus.$off(BUS_EVENTS.FOCUS_CUSTOM_ATTRIBUTE, this.onFocusAttribute);
+  },
+  methods: {
+    onFocusAttribute(focusAttributeKey) {
       if (this.attributeKey === focusAttributeKey) {
         this.onEdit();
       }
-    });
-  },
-  methods: {
+    },
     focusInput() {
       if (this.$refs.inputfield) {
         this.$refs.inputfield.focus();


### PR DESCRIPTION

## Description

Hello, your CustomAttribute component is never cleared, which leads to memory leaks of several GB over time. All events must be turned off when the component destroyed.
