### PR TITLE
chore: Support telegram `edited_message` events

### DIFF
--- a/app/jobs/webhooks/telegram_events_job.rb
+++ b/app/jobs/webhooks/telegram_events_job.rb
@@ -3,7 +3,6 @@ class Webhooks::TelegramEventsJob < ApplicationJob
 
   def perform(params = {})
     return unless params[:bot_token]
-    return unless params[:telegram]
 
     channel = Channel::Telegram.find_by(bot_token: params[:bot_token])
     return unless channel
@@ -14,6 +13,8 @@ class Webhooks::TelegramEventsJob < ApplicationJob
   private
 
   def process_event_params(channel, params)
+    return unless params[:telegram]
+
     if params.dig(:telegram, :edited_message).present?
       Telegram::UpdateMessageService.new(inbox: channel.inbox, params: params['telegram'].with_indifferent_access).perform
     else

--- a/app/jobs/webhooks/telegram_events_job.rb
+++ b/app/jobs/webhooks/telegram_events_job.rb
@@ -8,6 +8,12 @@ class Webhooks::TelegramEventsJob < ApplicationJob
     channel = Channel::Telegram.find_by(bot_token: params[:bot_token])
     return unless channel
 
+    process_event_params(channel, params)
+  end
+
+  private
+
+  def process_event_params(channel, params)
     if params.dig(:telegram, :edited_message).present?
       Telegram::UpdateMessageService.new(inbox: channel.inbox, params: params['telegram'].with_indifferent_access).perform
     else

--- a/app/jobs/webhooks/telegram_events_job.rb
+++ b/app/jobs/webhooks/telegram_events_job.rb
@@ -3,10 +3,15 @@ class Webhooks::TelegramEventsJob < ApplicationJob
 
   def perform(params = {})
     return unless params[:bot_token]
+    return unless params[:telegram]
 
     channel = Channel::Telegram.find_by(bot_token: params[:bot_token])
     return unless channel
 
-    Telegram::IncomingMessageService.new(inbox: channel.inbox, params: params['telegram'].with_indifferent_access).perform
+    if params.dig(:telegram, :edited_message).present?
+      Telegram::UpdateMessageService.new(inbox: channel.inbox, params: params['telegram'].with_indifferent_access).perform
+    else
+      Telegram::IncomingMessageService.new(inbox: channel.inbox, params: params['telegram'].with_indifferent_access).perform
+    end
   end
 end

--- a/app/services/telegram/update_message_service.rb
+++ b/app/services/telegram/update_message_service.rb
@@ -1,0 +1,33 @@
+# Find the various telegram payload samples here: https://core.telegram.org/bots/webhooks#testing-your-bot-with-updates
+# https://core.telegram.org/bots/api#available-types
+
+class Telegram::UpdateMessageService
+  pattr_initialize [:inbox!, :params!]
+
+  def perform
+    find_contact_inbox
+    find_conversation
+    find_message
+    update_message
+  rescue StandardError => e
+    Rails.logger.error "Error while processing telegram message update #{e.message}"
+  end
+
+  private
+
+  def find_contact_inbox
+    @contact_inbox = inbox.contact_inboxes.find_by!(source_id: params[:edited_message][:chat][:id])
+  end
+
+  def find_conversation
+    @conversation = @contact_inbox.conversations.last
+  end
+
+  def find_message
+    @message = @conversation.messages.find_by(source_id: params[:edited_message][:message_id])
+  end
+
+  def update_message
+    @message.update!(content: params[:edited_message][:text])
+  end
+end

--- a/spec/jobs/webhooks/telegram_events_job_spec.rb
+++ b/spec/jobs/webhooks/telegram_events_job_spec.rb
@@ -30,7 +30,21 @@ RSpec.describe Webhooks::TelegramEventsJob, type: :job do
       expect(Telegram::IncomingMessageService).to receive(:new).with(inbox: telegram_channel.inbox,
                                                                      params: params['telegram'].with_indifferent_access)
       expect(process_service).to receive(:perform)
-      described_class.perform_now(params)
+      described_class.perform_now(params.with_indifferent_access)
+    end
+  end
+
+  context 'when update message params' do
+    let!(:params) { { :bot_token => telegram_channel.bot_token, 'telegram' => { edited_message: 'test' } } }
+
+    it 'calls Telegram::UpdateMessageService' do
+      process_service = double
+      allow(Telegram::UpdateMessageService).to receive(:new).and_return(process_service)
+      allow(process_service).to receive(:perform)
+      expect(Telegram::UpdateMessageService).to receive(:new).with(inbox: telegram_channel.inbox,
+                                                                   params: params['telegram'].with_indifferent_access)
+      expect(process_service).to receive(:perform)
+      described_class.perform_now(params.with_indifferent_access)
     end
   end
 end

--- a/spec/services/telegram/incoming_message_service_spec.rb
+++ b/spec/services/telegram/incoming_message_service_spec.rb
@@ -233,7 +233,7 @@ describe Telegram::IncomingMessageService do
       end
     end
 
-    context 'when valid callbac_query params' do
+    context 'when valid callback_query params' do
       it 'creates appropriate conversations, message and contacts' do
         params = {
           'update_id' => 2_342_342_343_242,

--- a/spec/services/telegram/update_message_service_spec.rb
+++ b/spec/services/telegram/update_message_service_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe Telegram::UpdateMessageService do
+  let!(:telegram_channel) { create(:channel_telegram) }
+  let!(:update_params) do
+    {
+      'update_id': 2_323_484,
+      'edited_message': {
+        'message_id': 48,
+        'from': {
+          'id': 512_313_123_171_248,
+          'is_bot': false,
+          'first_name': 'Sojan',
+          'last_name': 'Jose',
+          'username': 'sojan'
+        },
+        'chat': {
+          'id': 517_123_213_211_248,
+          'first_name': 'Sojan',
+          'last_name': 'Jose',
+          'username': 'sojan',
+          'type': 'private'
+        },
+        'date': 1_680_088_034,
+        'edit_date': 1_680_088_056,
+        'text': 'updated message'
+      }
+    }
+  end
+
+  describe '#perform' do
+    context 'when valid update message params' do
+      it 'updates the appropriate message' do
+        contact_inbox = create(:contact_inbox, inbox: telegram_channel.inbox, source_id: update_params[:edited_message][:chat][:id])
+        conversation = create(:conversation, contact_inbox: contact_inbox)
+        message = create(:message, conversation: conversation, source_id: update_params[:edited_message][:message_id])
+        described_class.new(inbox: telegram_channel.inbox, params: update_params.with_indifferent_access).perform
+        expect(message.reload.content).to eq('updated message')
+      end
+    end
+
+    context 'when invalid update message params' do
+      it 'will not raise errors' do
+        expect do
+          described_class.new(inbox: telegram_channel.inbox, params: {}).perform
+        end.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add support for telegram `edited_message` events : Update the user message back in Chatwoot dashboard when updated by the contact

## QA 

https://user-images.githubusercontent.com/73185/228543477-f976ae75-27c9-4044-a3db-bcc38f4019cf.mov



