### PR TITLE
feat(perf): update contacts filter query

### DIFF
--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -119,11 +119,12 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def fetch_contacts_with_conversation_count(contacts)
-    contacts_with_conversation_count = filtrate(contacts).left_outer_joins(:conversations)
-                                                         .select('contacts.*, COUNT(conversations.id) as conversations_count')
-                                                         .group('contacts.id')
-                                                         .includes([{ avatar_attachment: [:blob] }])
-                                                         .page(@current_page).per(RESULTS_PER_PAGE)
+    conversation_count_sub_query = 'SELECT COUNT(*) FROM "conversations" WHERE "conversations"."contact_id" = "contacts"."id"'
+    contacts_with_conversation_count = filtrate(contacts)
+                                       .select("contacts.*, (#{conversation_count_sub_query}) as conversations_count")
+                                       .group('contacts.id')
+                                       .includes([{ avatar_attachment: [:blob] }])
+                                       .page(@current_page).per(RESULTS_PER_PAGE)
 
     return contacts_with_conversation_count.includes([{ contact_inboxes: [:inbox] }]) if @include_contact_inboxes
 


### PR DESCRIPTION
## Description

Update contacts API query to be faster

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Benchmarking

Here's a very naive benchmarking, done manually.  Used [this query](https://gist.github.com/scmmishra/8c3a10f58d23f49e9bc3cb798d5f3712) to find the accounts with these combinations. Ran the query with limit `2000` and offset `15` on a sizable test database

| Contacts Count | Conversations Count | New Query    | Old Query     | Notes                                 |
|----------------|---------------------|--------------|---------------|---------------------------------------|
| 51809          | 165927              | 92.051 ms    | 2485.252 ms   | Most active account                   |
| 13             | 126340              | 121.225 ms   | 876.705 ms    | Most conversations per contact        |
| 2980474        | 69 (nice)           | 12478.887 ms | 110929.665 ms | Least conversations per contacts      |
| 74155          | 315                 | 2881.742 ms  | 8991.240 ms   | A lot of contacts, but less chatter   |
| 618828         | 20195               | 3314.144 ms  | 11275.338 ms  | Highly active account                 |
| 3091           | 3328                | 163.074 ms   | 2151.075 ms   | Moderately active account             |
| 18672          | 9615                | 356.103 ms   | 1634.234 ms   | Moderately active account             |
| 85             | 315                 | 69.001 ms    | 1071.060 ms   | Mostly dormant account                |

## Query plans 

### Before

```sql
EXPLAIN (ANALYZE, COSTS, VERBOSE) SELECT 
  contacts.*, 
  COUNT(conversations.id) as conversations_count 
FROM 
  "contacts" 
  LEFT OUTER JOIN "conversations" ON "conversations"."contact_id" = "contacts"."id" 
WHERE 
  "contacts"."account_id" = 33521
  AND (
    COALESCE(
      NULLIF(contacts.email, ''), 
      NULLIF(contacts.phone_number, ''), 
      NULLIF(contacts.identifier, '')
    ) IS NOT NULL
  )
GROUP BY 
  "contacts"."id" 
LIMIT 
  20;
```

```sql
"QUERY PLAN"
"Limit  (cost=0.87..9549.79 rows=15 width=148) (actual time=4890.414..5938.558 rows=15 loops=1)"
"  Output: contacts.id, contacts.name, contacts.email, contacts.phone_number, contacts.account_id, contacts.created_at, contacts.updated_at, contacts.additional_attributes, contacts.identifier, contacts.custom_attributes, contacts.last_activity_at, (count(conversations.id))"
"  ->  GroupAggregate  (cost=0.87..4227625.72 rows=6641 width=148) (actual time=4890.413..5938.552 rows=15 loops=1)"
"        Output: contacts.id, contacts.name, contacts.email, contacts.phone_number, contacts.account_id, contacts.created_at, contacts.updated_at, contacts.additional_attributes, contacts.identifier, contacts.custom_attributes, contacts.last_activity_at, count(conversations.id)"
"        Group Key: contacts.id"
"        ->  Nested Loop Left Join  (cost=0.87..4227526.10 rows=6641 width=144) (actual time=4889.814..5932.948 rows=51964 loops=1)"
"              Output: contacts.id, contacts.name, contacts.email, contacts.phone_number, contacts.account_id, contacts.created_at, contacts.updated_at, contacts.additional_attributes, contacts.identifier, contacts.custom_attributes, contacts.last_activity_at, conversations.id"
"              ->  Index Scan using contacts_pkey on public.contacts  (cost=0.44..3597909.55 rows=6641 width=140) (actual time=4888.448..4890.738 rows=16 loops=1)"
"                    Output: contacts.id, contacts.name, contacts.email, contacts.phone_number, contacts.account_id, contacts.created_at, contacts.updated_at, contacts.additional_attributes, contacts.identifier, contacts.custom_attributes, contacts.last_activity_at"
"                    Filter: ((contacts.account_id = 33521) AND (COALESCE(NULLIF((contacts.email)::text, ''::text), NULLIF((contacts.phone_number)::text, ''::text), NULLIF((contacts.identifier)::text, ''::text)) IS NOT NULL))"
"                    Rows Removed by Filter: 7702943"
"              ->  Index Scan using index_conversations_on_contact_id on public.conversations  (cost=0.43..94.42 rows=39 width=12) (actual time=0.183..64.607 rows=3248 loops=16)"
"                    Output: conversations.id, conversations.account_id, conversations.inbox_id, conversations.status, conversations.assignee_id, conversations.created_at, conversations.updated_at, conversations.contact_id, conversations.display_id, conversations.contact_last_seen_at, conversations.agent_last_seen_at, conversations.additional_attributes, conversations.contact_inbox_id, conversations.uuid, conversations.identifier, conversations.last_activity_at, conversations.team_id, conversations.campaign_id, conversations.snoozed_until, conversations.custom_attributes, conversations.assignee_last_seen_at, conversations.first_reply_created_at"
"                    Index Cond: (conversations.contact_id = contacts.id)"
"Planning Time: 1.350 ms"
"Execution Time: 5938.609 ms"
```

#### After

```sql
EXPLAIN (ANALYZE, COSTS, VERBOSE) SELECT 
  contacts.*, 
  (
    SELECT COUNT(*) 
    FROM "conversations" 
    WHERE "conversations"."contact_id" = "contacts"."id"
  ) as conversations_count 
FROM 
  "contacts" 
WHERE 
  "contacts"."account_id" = 33521
  AND (
    COALESCE(
      NULLIF(contacts.email, ''), 
      NULLIF(contacts.phone_number, ''), 
      NULLIF(contacts.identifier, '')
    ) IS NOT NULL
  )
LIMIT 
  20;
```

```sql
"QUERY PLAN"
"Limit  (cost=0.44..861.17 rows=15 width=148) (actual time=1.206..193.542 rows=13 loops=1)"
"  Output: contacts.id, contacts.name, contacts.email, contacts.phone_number, contacts.account_id, contacts.created_at, contacts.updated_at, contacts.additional_attributes, contacts.identifier, contacts.custom_attributes, contacts.last_activity_at, ((SubPlan 1))"
"  ->  Index Scan using index_contacts_on_account_id on public.contacts  (cost=0.44..381074.15 rows=6641 width=148) (actual time=1.205..193.538 rows=13 loops=1)"
"        Output: contacts.id, contacts.name, contacts.email, contacts.phone_number, contacts.account_id, contacts.created_at, contacts.updated_at, contacts.additional_attributes, contacts.identifier, contacts.custom_attributes, contacts.last_activity_at, (SubPlan 1)"
"        Index Cond: (contacts.account_id = 7641)"
"        Filter: (COALESCE(NULLIF((contacts.email)::text, ''::text), NULLIF((contacts.phone_number)::text, ''::text), NULLIF((contacts.identifier)::text, ''::text)) IS NOT NULL)"
"        SubPlan 1"
"          ->  Aggregate  (cost=54.80..54.81 rows=1 width=8) (actual time=14.704..14.704 rows=1 loops=13)"
"                Output: count(*)"
"                ->  Index Only Scan using index_conversations_on_contact_id on public.conversations  (cost=0.43..54.71 rows=39 width=0) (actual time=0.123..14.115 rows=9718 loops=13)"
"                      Output: conversations.contact_id"
"                      Index Cond: (conversations.contact_id = contacts.id)"
"                      Heap Fetches: 70762"
"Planning Time: 0.236 ms"
"Execution Time: 193.620 ms"
```
