### PR TITLE
feature: Extend the message limit for the Facebook Channels

### DIFF
--- a/app/javascript/shared/helpers/MessageTypeHelper.js
+++ b/app/javascript/shared/helpers/MessageTypeHelper.js
@@ -4,7 +4,7 @@ export const isASubmittedFormMessage = (message = {}) =>
 
 export const MESSAGE_MAX_LENGTH = {
   GENERAL: 10000,
-  FACEBOOK: 640,
+  FACEBOOK: 1000,
   TWILIO_SMS: 320,
   TWILIO_WHATSAPP: 1600,
   TWEET: 280,


### PR DESCRIPTION
# Pull Request Template

## Description

Message length on Facebook and Instagram are currently limited to 640 characters but

the Facebook doc says the limit 2000 characters.
reference -> https://developers.facebook.com/docs/messenger-platform/reference/send-api#request

the Instagram doc says the limit is 1000 characters

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change
This pull request extend the message length to 1000 characters to meet the facebook and instagram limit.

- [ ] Bug fix (non-breaking change which fixes an issue)
-  [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
