### PR TITLE
fix: inconsistency in report and summary for metric counts

### DIFF
--- a/app/controllers/api/v2/accounts/reports_controller.rb
+++ b/app/controllers/api/v2/accounts/reports_controller.rb
@@ -67,14 +67,16 @@ class Api::V2::Accounts::ReportsController < Api::V1::Accounts::BaseController
   def current_summary_params
     common_params.merge({
                           since: range[:current][:since],
-                          until: range[:current][:until]
+                          until: range[:current][:until],
+                          timezone_offset: params[:timezone_offset]
                         })
   end
 
   def previous_summary_params
     common_params.merge({
                           since: range[:previous][:since],
-                          until: range[:previous][:until]
+                          until: range[:previous][:until],
+                          timezone_offset: params[:timezone_offset]
                         })
   end
 

--- a/app/helpers/date_range_helper.rb
+++ b/app/helpers/date_range_helper.rb
@@ -7,7 +7,7 @@ module DateRangeHelper
   def range
     return if params[:since].blank? || params[:until].blank?
 
-    parse_date_time(params[:since])..parse_date_time(params[:until])
+    parse_date_time(params[:since])...parse_date_time(params[:until])
   end
 
   def parse_date_time(datetime)

--- a/app/javascript/dashboard/api/reports.js
+++ b/app/javascript/dashboard/api/reports.js
@@ -40,6 +40,7 @@ class ReportsAPI extends ApiClient {
         id,
         group_by,
         business_hours,
+        timezone_offset: getTimeOffset(),
       },
     });
   }


### PR DESCRIPTION
## Description

The reports would generate inconsistent values, when the timezone of the request was farther away from UTC. The cause of this was a hidden "feature/bug" with the [groupdate gem](https://github.com/ankane/groupdate). 

The gem handled the timerange specifically if the `exclude_end` was included. If included an extra day was added, see [groupdate/series_builder.rb](https://github.com/ankane/groupdate/blob/57150dd7a91e4aa3e3f9c9f4acf5dfb701cc4085/lib/groupdate/series_builder.rb#L117-L124)

This cause the SQL query to yield data for an extra day. The frontend clamped the data between timestamps, however the summary which was calculated on the server side didn't have any check like this. The solution proposed is to exclude the end of the range. 

Have got to test this with more conditions, but prima facie, the solution seems to work.

**Note:** Made another critical change, making the summary timezone sensitive. I guess it makes sense that way. 

**This PR needs needs a thorough manual testing**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Before fix

<img width="700" alt="Screenshot 2023-04-03 at 4 03 02 PM" src="https://user-images.githubusercontent.com/18097732/229485504-729c0266-ae63-4cae-96c7-fa07ab56a74e.png">


### After fix

<img width="700" alt="Screenshot 2023-04-03 at 4 01 35 PM" src="https://user-images.githubusercontent.com/18097732/229485530-4cd59850-ec2c-411a-84d5-897309e6978d.png">


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
