### PR TITLE
chore: Use feature_flags attribute instead of settings_flags

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -39,12 +39,12 @@
           <label v-if="featureInboundEmailEnabled">
             {{ $t('GENERAL_SETTINGS.FORM.FEATURES.INBOUND_EMAIL_ENABLED') }}
           </label>
-          <label v-if="featureCustomDomainEmailEnabled">
+          <label v-if="featureCustomReplyDomainEnabled">
             {{
               $t('GENERAL_SETTINGS.FORM.FEATURES.CUSTOM_EMAIL_DOMAIN_ENABLED')
             }}
           </label>
-          <label v-if="featureCustomDomainEmailEnabled">
+          <label v-if="featureCustomReplyDomainEnabled">
             {{ $t('GENERAL_SETTINGS.FORM.DOMAIN.LABEL') }}
             <input
               v-model="domain"
@@ -52,7 +52,7 @@
               :placeholder="$t('GENERAL_SETTINGS.FORM.DOMAIN.PLACEHOLDER')"
             />
           </label>
-          <label v-if="featureCustomDomainEmailEnabled">
+          <label v-if="featureCustomReplyEmailEnabled">
             {{ $t('GENERAL_SETTINGS.FORM.SUPPORT_EMAIL.LABEL') }}
             <input
               v-model="supportEmail"
@@ -192,8 +192,16 @@ export default {
       return !!this.features.inbound_emails;
     },
 
-    featureCustomDomainEmailEnabled() {
-      return this.featureInboundEmailEnabled && !!this.customEmailDomainEnabled;
+    featureCustomReplyDomainEnabled() {
+      return (
+        this.featureInboundEmailEnabled && !!this.features.custom_reply_domain
+      );
+    },
+
+    featureCustomReplyEmailEnabled() {
+      return (
+        this.featureInboundEmailEnabled && !!this.features.custom_reply_email
+      );
     },
 
     getAccountId() {
@@ -215,7 +223,6 @@ export default {
           id,
           domain,
           support_email,
-          custom_email_domain_enabled,
           features,
           auto_resolve_duration,
           latest_chatwoot_version: latestChatwootVersion,
@@ -227,7 +234,6 @@ export default {
         this.id = id;
         this.domain = domain;
         this.supportEmail = support_email;
-        this.customEmailDomainEnabled = custom_email_domain_enabled;
         this.features = features;
         this.autoResolveDuration = auto_resolve_duration;
         this.latestChatwootVersion = latestChatwootVersion;

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -10,7 +10,6 @@
 #  limits                :jsonb
 #  locale                :integer          default("en")
 #  name                  :string           not null
-#  settings_flags        :integer          default(0), not null
 #  status                :integer          default("active")
 #  support_email         :string(100)
 #  created_at            :datetime         not null
@@ -31,10 +30,6 @@ class Account < ApplicationRecord
   DEFAULT_QUERY_SETTING = {
     flag_query_mode: :bit_operator,
     check_for_column: false
-  }.freeze
-
-  ACCOUNT_SETTINGS_FLAGS = {
-    1 => :custom_email_domain_enabled
   }.freeze
 
   validates :name, presence: true
@@ -81,8 +76,6 @@ class Account < ApplicationRecord
   has_many :webhooks, dependent: :destroy_async
   has_many :whatsapp_channels, dependent: :destroy_async, class_name: '::Channel::Whatsapp'
   has_many :working_hours, dependent: :destroy_async
-
-  has_flags ACCOUNT_SETTINGS_FLAGS.merge(column: 'settings_flags').merge(DEFAULT_QUERY_SETTING)
 
   enum locale: LANGUAGES_CONFIG.map { |key, val| [val[:iso_639_1_code], key] }.to_h
   enum status: { active: 0, suspended: 1 }

--- a/app/views/api/v1/models/_account.json.jbuilder
+++ b/app/views/api/v1/models/_account.json.jbuilder
@@ -6,7 +6,6 @@ if resource.custom_attributes.present?
     json.subscribed_quantity resource.custom_attributes['subscribed_quantity']
   end
 end
-json.custom_email_domain_enabled @account.custom_email_domain_enabled
 json.domain @account.domain
 json.features @account.enabled_features
 json.id @account.id

--- a/config/features.yml
+++ b/config/features.yml
@@ -49,3 +49,7 @@
   enabled: true
 - name: auto_resolve_conversations
   enabled: true
+- name: custom_reply_email
+  enabled: false
+- name: custom_reply_domain
+  enabled: false

--- a/db/migrate/20230404030719_remove_settings_flags_from_account.rb
+++ b/db/migrate/20230404030719_remove_settings_flags_from_account.rb
@@ -1,0 +1,13 @@
+class RemoveSettingsFlagsFromAccount < ActiveRecord::Migration[6.1]
+  def up
+    change_table :accounts do |t|
+      t.remove :settings_flags
+    end
+  end
+
+  def down
+    change_table :accounts do |t|
+      t.integer :settings_flags, default: 0, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -621,7 +621,7 @@ ActiveRecord::Schema.define(version: 2023_04_04_030719) do
     t.integer "visibility", default: 0
     t.bigint "created_by_id"
     t.bigint "updated_by_id"
-    t.jsonb "actions", default: "{}", null: false
+    t.jsonb "actions", default: {}, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["account_id"], name: "index_macros_on_account_id"
@@ -715,19 +715,6 @@ ActiveRecord::Schema.define(version: 2023_04_04_030719) do
     t.index ["primary_actor_type", "primary_actor_id"], name: "uniq_primary_actor_per_account_notifications"
     t.index ["secondary_actor_type", "secondary_actor_id"], name: "uniq_secondary_actor_per_account_notifications"
     t.index ["user_id"], name: "index_notifications_on_user_id"
-  end
-
-  create_table "pg_search_documents", force: :cascade do |t|
-    t.text "content"
-    t.bigint "conversation_id"
-    t.bigint "account_id"
-    t.string "searchable_type"
-    t.bigint "searchable_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["account_id"], name: "index_pg_search_documents_on_account_id"
-    t.index ["conversation_id"], name: "index_pg_search_documents_on_conversation_id"
-    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable"
   end
 
   create_table "platform_app_permissibles", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_28_131926) do
+ActiveRecord::Schema.define(version: 2023_04_04_030719) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -50,7 +50,6 @@ ActiveRecord::Schema.define(version: 2023_03_28_131926) do
     t.integer "locale", default: 0
     t.string "domain", limit: 100
     t.string "support_email", limit: 100
-    t.integer "settings_flags", default: 0, null: false
     t.integer "feature_flags", default: 0, null: false
     t.integer "auto_resolve_duration"
     t.jsonb "limits", default: {}
@@ -622,7 +621,7 @@ ActiveRecord::Schema.define(version: 2023_03_28_131926) do
     t.integer "visibility", default: 0
     t.bigint "created_by_id"
     t.bigint "updated_by_id"
-    t.jsonb "actions", default: {}, null: false
+    t.jsonb "actions", default: "{}", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["account_id"], name: "index_macros_on_account_id"
@@ -716,6 +715,19 @@ ActiveRecord::Schema.define(version: 2023_03_28_131926) do
     t.index ["primary_actor_type", "primary_actor_id"], name: "uniq_primary_actor_per_account_notifications"
     t.index ["secondary_actor_type", "secondary_actor_id"], name: "uniq_secondary_actor_per_account_notifications"
     t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
+  create_table "pg_search_documents", force: :cascade do |t|
+    t.text "content"
+    t.bigint "conversation_id"
+    t.bigint "account_id"
+    t.string "searchable_type"
+    t.bigint "searchable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["account_id"], name: "index_pg_search_documents_on_account_id"
+    t.index ["conversation_id"], name: "index_pg_search_documents_on_conversation_id"
+    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable"
   end
 
   create_table "platform_app_permissibles", force: :cascade do |t|

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
   factory :account do
     sequence(:name) { |n| "Account #{n}" }
     status { 'active' }
-    custom_email_domain_enabled { false }
     domain { 'test.com' }
     support_email { 'support@test.com' }
   end


### PR DESCRIPTION
The custom domain feature uses the settings_flag attribute (an old implementation), which was not used anywhere else. I have migrated the flag to the feature_flags attribute so that it can be updated via the UI.


This PR:
- Migrates custom_reply_domain and custom_reply_email to feature_flags.
- Remove the settings_flags attribute from the account model.