### PR TITLE
fix: Disable import option in agent account

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/contacts/components/Header.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/components/Header.vue
@@ -70,6 +70,7 @@
         </woot-button>
 
         <woot-button
+          v-if="isAdmin"
           color-scheme="info"
           icon="upload"
           class="clear"
@@ -84,8 +85,10 @@
 
 <script>
 import { mapGetters } from 'vuex';
+import adminMixin from 'dashboard/mixins/isAdmin';
 
 export default {
+  mixins: [adminMixin],
   props: {
     headerTitle: {
       type: String,


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will enable the import option form the role admin accounts.

Fixes https://linear.app/chatwoot/issue/CW-1396/import-option-is-shown-to-agents

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
https://www.loom.com/share/32683696380041e4a2dafc18a911da0b


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
