### PR TITLE
fix: Canned Responses are not sent in the new message editor

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
@@ -260,9 +260,7 @@ export default {
       this.$emit('success');
     },
     replaceTextWithCannedResponse(message) {
-      setTimeout(() => {
-        this.message = message;
-      }, 50);
+      this.message = message;
     },
     toggleCannedMenu(value) {
       this.showCannedMenu = value;


### PR DESCRIPTION
# Pull Request Template

Fixes https://linear.app/chatwoot/issue/CW-1392/canned-responses-are-not-sent-in-the-new-message-editor

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
https://www.loom.com/share/fc179cc38be9420db2ce9425097d5bb7


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
