### PR TITLE
feat: Show year in message timestamp if the message is not from the current year

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -175,7 +175,7 @@ export default {
       return MESSAGE_STATUS.SENT === this.messageStatus;
     },
     readableTime() {
-      return this.conversationMessageStamp(this.createdAt, 'LLL d, h:mm a');
+      return this.messageTimestamp(this.createdAt, 'LLL d, h:mm a');
     },
     screenName() {
       const { additional_attributes: additionalAttributes = {} } =

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -175,7 +175,7 @@ export default {
       return MESSAGE_STATUS.SENT === this.messageStatus;
     },
     readableTime() {
-      return this.messageStamp(this.createdAt, 'LLL d, h:mm a');
+      return this.conversationMessageStamp(this.createdAt, 'LLL d, h:mm a');
     },
     screenName() {
       const { additional_attributes: additionalAttributes = {} } =

--- a/app/javascript/dashboard/mixins/specs/time.spec.js
+++ b/app/javascript/dashboard/mixins/specs/time.spec.js
@@ -9,6 +9,20 @@ describe('#messageStamp', () => {
   });
 });
 
+describe('#conversationMessageStamp', () => {
+  it('should return the message date in the specified format if the message was sent in the current year', () => {
+    const now = new Date();
+    expect(
+      TimeMixin.methods.conversationMessageStamp(now.getTime() / 1000)
+    ).toEqual('Apr 5, 2023');
+  });
+  it('should return the message date and time in a different format if the message was sent in a different year', () => {
+    expect(TimeMixin.methods.conversationMessageStamp(1612971343)).toEqual(
+      'Feb 10 2021, 3:35 PM'
+    );
+  });
+});
+
 describe('#dynamicTime', () => {
   it('returns correct value', () => {
     expect(TimeMixin.methods.dynamicTime(1612971343)).toEqual(

--- a/app/javascript/dashboard/mixins/specs/time.spec.js
+++ b/app/javascript/dashboard/mixins/specs/time.spec.js
@@ -9,15 +9,15 @@ describe('#messageStamp', () => {
   });
 });
 
-describe('#conversationMessageStamp', () => {
+describe('#messageTimestamp', () => {
   it('should return the message date in the specified format if the message was sent in the current year', () => {
     const now = new Date();
-    expect(
-      TimeMixin.methods.conversationMessageStamp(now.getTime() / 1000)
-    ).toEqual('Apr 5, 2023');
+    expect(TimeMixin.methods.messageTimestamp(now.getTime() / 1000)).toEqual(
+      'Apr 5, 2023'
+    );
   });
   it('should return the message date and time in a different format if the message was sent in a different year', () => {
-    expect(TimeMixin.methods.conversationMessageStamp(1612971343)).toEqual(
+    expect(TimeMixin.methods.messageTimestamp(1612971343)).toEqual(
       'Feb 10 2021, 3:35 PM'
     );
   });

--- a/app/javascript/dashboard/mixins/time.js
+++ b/app/javascript/dashboard/mixins/time.js
@@ -11,7 +11,7 @@ export default {
       const unixTime = fromUnixTime(time);
       return format(unixTime, dateFormat);
     },
-    conversationMessageStamp(time, dateFormat = 'MMM d, yyyy') {
+    messageTimestamp(time, dateFormat = 'MMM d, yyyy') {
       const messageTime = fromUnixTime(time);
       const now = new Date();
       const messageDate = format(messageTime, dateFormat);

--- a/app/javascript/dashboard/mixins/time.js
+++ b/app/javascript/dashboard/mixins/time.js
@@ -1,12 +1,24 @@
-import fromUnixTime from 'date-fns/fromUnixTime';
-import format from 'date-fns/format';
-import formatDistanceToNow from 'date-fns/formatDistanceToNow';
+import {
+  format,
+  isSameYear,
+  fromUnixTime,
+  formatDistanceToNow,
+} from 'date-fns';
 
 export default {
   methods: {
     messageStamp(time, dateFormat = 'h:mm a') {
       const unixTime = fromUnixTime(time);
       return format(unixTime, dateFormat);
+    },
+    conversationMessageStamp(time, dateFormat = 'MMM d, yyyy') {
+      const messageTime = fromUnixTime(time);
+      const now = new Date();
+      const messageDate = format(messageTime, dateFormat);
+      if (!isSameYear(messageTime, now)) {
+        return format(messageTime, 'LLL d y, h:mm a');
+      }
+      return messageDate;
     },
     dynamicTime(time) {
       const unixTime = fromUnixTime(time);


### PR DESCRIPTION
# Pull Request Template

## Description

This PR allows one to see the year in the conversation message timestamp if the message is not from the current year.

Fixes https://linear.app/chatwoot/issue/CW-1423/show-year-if-the-date-is-not-from-the-current-year

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
https://www.loom.com/share/1aa01938420d4405b238df6b444fb04b


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
