### PR TITLE
Add status reopen activity message for api channel

### DIFF
--- a/app/models/concerns/activity_message_handler.rb
+++ b/app/models/concerns/activity_message_handler.rb
@@ -21,7 +21,7 @@ module ActivityMessageHandler
 
   def create_status_change_message(user_name)
     content = if user_name
-                I18n.t("conversations.activity.status.#{status}", user_name: user_name)
+                activity_message_based_on_type(user_name)
               elsif Current.contact.present? && resolved?
                 I18n.t('conversations.activity.status.contact_resolved', contact_name: Current.contact.name.capitalize)
               elsif resolved?
@@ -31,6 +31,14 @@ module ActivityMessageHandler
               end
 
     ::Conversations::ActivityMessageJob.perform_later(self, activity_message_params(content)) if content
+  end
+
+  def activity_message_based_on_type(user_name)
+    if incoming? && !private? && open?
+      I18n.t('conversations.activity.status.system_auto_open')
+    else
+      I18n.t("conversations.activity.status.#{status}", user_name: user_name)
+    end
   end
 
   def send_automation_activity

--- a/app/models/concerns/activity_message_handler.rb
+++ b/app/models/concerns/activity_message_handler.rb
@@ -26,6 +26,8 @@ module ActivityMessageHandler
                 I18n.t('conversations.activity.status.contact_resolved', contact_name: Current.contact.name.capitalize)
               elsif resolved?
                 I18n.t('conversations.activity.status.auto_resolved', duration: auto_resolve_duration)
+              elsif open?
+                I18n.t('conversations.activity.status.system_auto_open')
               end
 
     ::Conversations::ActivityMessageJob.perform_later(self, activity_message_params(content)) if content

--- a/app/models/concerns/activity_message_handler.rb
+++ b/app/models/concerns/activity_message_handler.rb
@@ -26,8 +26,6 @@ module ActivityMessageHandler
                 I18n.t('conversations.activity.status.contact_resolved', contact_name: Current.contact.name.capitalize)
               elsif resolved?
                 I18n.t('conversations.activity.status.auto_resolved', duration: auto_resolve_duration)
-              elsif open?
-                I18n.t('conversations.activity.status.system_auto_open')
               end
 
     ::Conversations::ActivityMessageJob.perform_later(self, activity_message_params(content)) if content

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -257,7 +257,7 @@ class Message < ApplicationRecord
     # mark resolved bot conversation as pending to be reopened by bot processor service
     if conversation.inbox.active_bot?
       conversation.pending!
-    else
+    elsif conversation.inbox.api?
       Current.executed_by = sender if reopened_by_contact?
       conversation.open!
     end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -258,8 +258,13 @@ class Message < ApplicationRecord
     if conversation.inbox.active_bot?
       conversation.pending!
     else
+      Current.executed_by = sender if reopened_by_contact?
       conversation.open!
     end
+  end
+
+  def reopened_by_contact?
+    incoming? && !private? && Current.user.class != sender.class && sender.instance_of?(Contact)
   end
 
   def execute_message_template_hooks

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -260,6 +260,8 @@ class Message < ApplicationRecord
     elsif conversation.inbox.api?
       Current.executed_by = sender if reopened_by_contact?
       conversation.open!
+    else
+      conversation.open!
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,6 +129,7 @@ en:
         pending: "Conversation was marked as pending by %{user_name}"
         snoozed: "Conversation was snoozed by %{user_name}"
         auto_resolved: "Conversation was marked resolved by system due to %{duration} days of inactivity"
+        system_auto_open: System reopened the conversation due to a new incoming message.
       assignee:
         self_assigned: "%{user_name} self-assigned this conversation"
         assigned: "Assigned to %{assignee_name} by %{user_name}"

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -80,6 +80,30 @@ RSpec.describe 'Conversation Messages API', type: :request do
         expect(conversation.messages.last.attachments.first.file.present?).to be(true)
         expect(conversation.messages.last.attachments.first.file_type).to eq('image')
       end
+
+      it 'reopens the conversation with new incoming message' do
+        api_channel = create(:channel_api, account: account)
+        api_inbox = create(:inbox, channel: api_channel, account: account)
+        create(:inbox_member, user: agent, inbox: api_inbox)
+        conversation = create(:conversation, inbox: api_inbox, account: account)
+
+        create(:message, conversation: conversation, account: account)
+        conversation.resolved!
+
+        params = { content: 'test-message', private: false, message_type: 'incoming' }
+
+        post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: params,
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.status).to eq('open')
+        expect(Conversations::ActivityMessageJob)
+          .to(have_been_enqueued.at_least(:once)
+            .with(conversation, { account_id: conversation.account_id, inbox_id: conversation.inbox_id, message_type: :activity,
+                                  content: 'System reopened the conversation due to a new incoming message.' }))
+      end
     end
 
     context 'when it is an authenticated agent bot' do

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -81,28 +81,30 @@ RSpec.describe 'Conversation Messages API', type: :request do
         expect(conversation.messages.last.attachments.first.file_type).to eq('image')
       end
 
-      it 'reopens the conversation with new incoming message' do
-        api_channel = create(:channel_api, account: account)
-        api_inbox = create(:inbox, channel: api_channel, account: account)
-        create(:inbox_member, user: agent, inbox: api_inbox)
-        conversation = create(:conversation, inbox: api_inbox, account: account)
+      context 'when api inbox' do
+        let(:api_channel) { create(:channel_api, account: account) }
+        let(:api_inbox) { create(:inbox, channel: api_channel, account: account) }
+        let(:inbox_member) { create(:inbox_member, user: agent, inbox: api_inbox) }
+        let(:conversation) { create(:conversation, inbox: api_inbox, account: account) }
 
-        create(:message, conversation: conversation, account: account)
-        conversation.resolved!
+        it 'reopens the conversation with new incoming message' do
+          create(:message, conversation: conversation, account: account)
+          conversation.resolved!
 
-        params = { content: 'test-message', private: false, message_type: 'incoming' }
+          params = { content: 'test-message', private: false, message_type: 'incoming' }
 
-        post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
-             params: params,
-             headers: agent.create_new_auth_token,
-             as: :json
+          post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+               params: params,
+               headers: agent.create_new_auth_token,
+               as: :json
 
-        expect(response).to have_http_status(:success)
-        expect(conversation.reload.status).to eq('open')
-        expect(Conversations::ActivityMessageJob)
-          .to(have_been_enqueued.at_least(:once)
-            .with(conversation, { account_id: conversation.account_id, inbox_id: conversation.inbox_id, message_type: :activity,
-                                  content: 'System reopened the conversation due to a new incoming message.' }))
+          expect(response).to have_http_status(:success)
+          expect(conversation.reload.status).to eq('open')
+          expect(Conversations::ActivityMessageJob)
+            .to(have_been_enqueued.at_least(:once)
+              .with(conversation, { account_id: conversation.account_id, inbox_id: conversation.inbox_id, message_type: :activity,
+                                    content: 'System reopened the conversation due to a new incoming message.' }))
+        end
       end
     end
 


### PR DESCRIPTION
Fixes: https://linear.app/chatwoot/issue/CW-1359/activity-message-generation-error-using-an-api

1. Create Conversation In any way
2. Resolve the conversation
3. Send Message via API with the api_access_token: See the activity message
4. Again, resolve the conversation
5. Send a message using a public API endpoint: See the activity message

https://www.loom.com/share/aaccdb8bb31146d88637feffba147ca9