### PR TITLE
feat: Support `after` param in messages end point

### DIFF
--- a/app/finders/message_finder.rb
+++ b/app/finders/message_finder.rb
@@ -22,11 +22,29 @@ class MessageFinder
 
   def current_messages
     if @params[:after].present? && @params[:before].present?
-      messages.reorder('created_at asc').where('id >= ? AND id < ?', @params[:after].to_i, @params[:before].to_i).limit(1000)
+      messages_between(@params[:after].to_i, @params[:before].to_i)
     elsif @params[:before].present?
-      messages.reorder('created_at desc').where('id < ?', @params[:before].to_i).limit(20).reverse
+      messages_before(@params[:before].to_i)
+    elsif @params[:after].present?
+      messages_after(@params[:after].to_i)
     else
       messages.reorder('created_at desc').limit(20).reverse
     end
+  end
+
+  def messages_after
+    messages.reorder('created_at asc').where('id > ?', @params[:after].to_i).limit(100)
+  end
+
+  def messages_before
+    messages.reorder('created_at desc').where('id < ?', @params[:before].to_i).limit(20).reverse
+  end
+
+  def messages_between
+    messages.reorder('created_at asc').where('id >= ? AND id < ?', @params[:after].to_i, @params[:before].to_i).limit(1000)
+  end
+
+  def messages_latest
+    messages.reorder('created_at desc').limit(20).reverse
   end
 end

--- a/app/finders/message_finder.rb
+++ b/app/finders/message_finder.rb
@@ -28,20 +28,20 @@ class MessageFinder
     elsif @params[:after].present?
       messages_after(@params[:after].to_i)
     else
-      messages.reorder('created_at desc').limit(20).reverse
+      messages_latest
     end
   end
 
-  def messages_after
-    messages.reorder('created_at asc').where('id > ?', @params[:after].to_i).limit(100)
+  def messages_after(after_id)
+    messages.reorder('created_at asc').where('id > ?', after_id).limit(100)
   end
 
-  def messages_before
-    messages.reorder('created_at desc').where('id < ?', @params[:before].to_i).limit(20).reverse
+  def messages_before(before_id)
+    messages.reorder('created_at desc').where('id < ?', before_id).limit(20).reverse
   end
 
-  def messages_between
-    messages.reorder('created_at asc').where('id >= ? AND id < ?', @params[:after].to_i, @params[:before].to_i).limit(1000)
+  def messages_between(after_id, before_id)
+    messages.reorder('created_at asc').where('id >= ? AND id < ?', after_id, before_id).limit(1000)
   end
 
   def messages_latest

--- a/spec/finders/message_finder_spec.rb
+++ b/spec/finders/message_finder_spec.rb
@@ -64,7 +64,7 @@ describe ::MessageFinder do
 
       it 'filter conversations by status' do
         result = message_finder.perform
-        expect(result.count).to be 5
+        expect(result.count).to be 6
         expect(result.first.id).to be conversation.messages.first.id
         expect(result.last.message_type).to eq 'activity'
       end

--- a/spec/finders/message_finder_spec.rb
+++ b/spec/finders/message_finder_spec.rb
@@ -53,20 +53,24 @@ describe ::MessageFinder do
 
       it 'filter conversations by status' do
         result = message_finder.perform
-        expect(result.count).to be 6
-        expect(result.first.id).to be conversation.messages.first.id
+        expect(result.count).to be 5
+        expect(result.first.id).to be conversation.messages.second.id
         expect(result.last.message_type).to eq 'outgoing'
       end
     end
 
     context 'with after and before attribute' do
-      let(:params) { { after: conversation.messages.first.id, before: conversation.messages.last.id } }
+      let(:params) do
+        {
+          after: conversation.messages.first.id,
+          before: conversation.messages.last.id
+        }
+      end
 
       it 'filter conversations by status' do
         result = message_finder.perform
-        expect(result.count).to be 6
-        expect(result.first.id).to be conversation.messages.first.id
-        expect(result.last.message_type).to eq 'activity'
+        expect(result.count).to be 5
+        expect(result.last.id).to be conversation.messages[-2].id
       end
     end
   end

--- a/spec/finders/message_finder_spec.rb
+++ b/spec/finders/message_finder_spec.rb
@@ -58,5 +58,16 @@ describe ::MessageFinder do
         expect(result.last.message_type).to eq 'outgoing'
       end
     end
+
+    context 'with after and before attribute' do
+      let(:params) { { after: conversation.messages.first.id, before: conversation.messages.last.id } }
+
+      it 'filter conversations by status' do
+        result = message_finder.perform
+        expect(result.count).to be 5
+        expect(result.first.id).to be conversation.messages.first.id
+        expect(result.last.message_type).to eq 'activity'
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-1475/support-after-param-in-messages-end-point