### PR TITLE
fix: Disable processing events if account is suspended

### DIFF
--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -3,9 +3,7 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
 
   def perform(params = {})
     channel = find_channel_from_whatsapp_business_payload(params) || find_channel(params)
-    return if channel.blank?
-    return if channel.reauthorization_required?
-    return unless channel.account.active?
+    return if channel_is_inactive?(channel)
 
     case channel.provider
     when 'whatsapp_cloud'
@@ -16,6 +14,14 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
   end
 
   private
+
+  def channel_is_inactive?(channel)
+    return true if channel.blank?
+    return true if channel.reauthorization_required?
+    return true unless channel.account.active?
+
+    false
+  end
 
   def find_channel(params)
     return unless params[:phone_number]

--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -1,10 +1,11 @@
 class Webhooks::WhatsappEventsJob < ApplicationJob
-  queue_as :default
+  queue_as :low
 
   def perform(params = {})
     channel = find_channel_from_whatsapp_business_payload(params) || find_channel(params)
     return if channel.blank?
     return if channel.reauthorization_required?
+    return unless channel.account.active?
 
     case channel.provider
     when 'whatsapp_cloud'

--- a/spec/jobs/webhooks/whatsapp_events_job_spec.rb
+++ b/spec/jobs/webhooks/whatsapp_events_job_spec.rb
@@ -14,26 +14,46 @@ RSpec.describe Webhooks::WhatsappEventsJob, type: :job do
   it 'enqueues the job' do
     expect { job.perform_later(params) }.to have_enqueued_job(described_class)
       .with(params)
-      .on_queue('default')
+      .on_queue('low')
   end
 
   context 'when whatsapp_cloud provider' do
-    it 'enques Whatsapp::IncomingMessageWhatsappCloudService' do
+    it 'enqueue Whatsapp::IncomingMessageWhatsappCloudService' do
       allow(Whatsapp::IncomingMessageWhatsappCloudService).to receive(:new).and_return(process_service)
       expect(Whatsapp::IncomingMessageWhatsappCloudService).to receive(:new)
       job.perform_now(params)
     end
 
-    it 'will not enques Whatsapp::IncomingMessageWhatsappCloudService if channel reauthorization required' do
+    it 'will not enqueue Whatsapp::IncomingMessageWhatsappCloudService if channel reauthorization required' do
       channel.prompt_reauthorization!
       allow(Whatsapp::IncomingMessageWhatsappCloudService).to receive(:new).and_return(process_service)
       expect(Whatsapp::IncomingMessageWhatsappCloudService).not_to receive(:new)
       job.perform_now(params)
     end
+
+    it 'will not enqueue if channel is not present' do
+      allow(Whatsapp::IncomingMessageWhatsappCloudService).to receive(:new).and_return(process_service)
+      allow(Whatsapp::IncomingMessageService).to receive(:new).and_return(process_service)
+
+      expect(Whatsapp::IncomingMessageWhatsappCloudService).not_to receive(:new)
+      expect(Whatsapp::IncomingMessageService).not_to receive(:new)
+      job.perform_now(phone_number: 'random_phone_number')
+    end
+
+    it 'will not enqueue Whatsapp::IncomingMessageWhatsappCloudService if account is suspended' do
+      account = channel.account
+      account.update!(status: :suspended)
+      allow(Whatsapp::IncomingMessageWhatsappCloudService).to receive(:new).and_return(process_service)
+      allow(Whatsapp::IncomingMessageService).to receive(:new).and_return(process_service)
+
+      expect(Whatsapp::IncomingMessageWhatsappCloudService).not_to receive(:new)
+      expect(Whatsapp::IncomingMessageService).not_to receive(:new)
+      job.perform_now(params)
+    end
   end
 
   context 'when default provider' do
-    it 'enques Whatsapp::IncomingMessageService' do
+    it 'enqueue Whatsapp::IncomingMessageService' do
       stub_request(:post, 'https://waba.360dialog.io/v1/configs/webhook')
       channel.update(provider: 'default')
       allow(Whatsapp::IncomingMessageService).to receive(:new).and_return(process_service)
@@ -43,7 +63,7 @@ RSpec.describe Webhooks::WhatsappEventsJob, type: :job do
   end
 
   context 'when whatsapp business params' do
-    it 'enques Whatsapp::IncomingMessageWhatsappCloudService based on the number in payload' do
+    it 'enqueue Whatsapp::IncomingMessageWhatsappCloudService based on the number in payload' do
       other_channel = create(:channel_whatsapp, phone_number: '+1987654', provider: 'whatsapp_cloud', sync_templates: false,
                                                 validate_provider_config: false)
       wb_params = {


### PR DESCRIPTION
- Disable processing events if an account is suspended.
- Move the processing to low, as this job affects all other real-time actions.