### PR TITLE
fix: Invalidate cache if any of the related objects change

### DIFF
--- a/app/models/concerns/account_cache_revalidator.rb
+++ b/app/models/concerns/account_cache_revalidator.rb
@@ -2,9 +2,7 @@ module AccountCacheRevalidator
   extend ActiveSupport::Concern
 
   included do
-    after_save :update_account_cache
-    after_destroy :update_account_cache
-    after_create :update_account_cache
+    after_commit :update_account_cache
   end
 
   def update_account_cache

--- a/app/models/concerns/channelable.rb
+++ b/app/models/concerns/channelable.rb
@@ -3,7 +3,7 @@ module Channelable
   included do
     validates :account_id, presence: true
     belongs_to :account
-    has_one :inbox, as: :channel, dependent: :destroy_async
+    has_one :inbox, as: :channel, dependent: :destroy_async, touch: true
   end
 
   def messaging_window_enabled?

--- a/spec/models/inbox_spec.rb
+++ b/spec/models/inbox_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Inbox do
       allow(Rails.configuration.dispatcher).to receive(:dispatch)
     end
 
-    it 'resets cache key if there is an update' do
+    it 'resets cache key if there is an update in the channel' do
       channel = inbox.channel
       channel.update(widget_color: '#fff')
 

--- a/spec/models/inbox_spec.rb
+++ b/spec/models/inbox_spec.rb
@@ -194,4 +194,25 @@ RSpec.describe Inbox do
       end
     end
   end
+
+  describe '#update' do
+    let!(:inbox) { FactoryBot.create(:inbox) }
+
+    before do
+      allow(Rails.configuration.dispatcher).to receive(:dispatch)
+    end
+
+    it 'resets cache key if there is an update' do
+      channel = inbox.channel
+      channel.update(widget_color: '#fff')
+
+      expect(Rails.configuration.dispatcher).to have_received(:dispatch)
+        .with(
+          'account.cache_invalidated',
+          kind_of(Time),
+          account: inbox.account,
+          cache_keys: inbox.account.cache_keys
+        )
+    end
+  end
 end


### PR DESCRIPTION
The changes in channel object (for eg: whatsapp templates or config in the website live chat) doesn't trigger an cache invalidation right now. The user has to logout and log back in to get the changes. 

To avoid this, we have to invalidate the inbox cache if there is any change in the associated channel object.

To reproduce the issue. 
Open rails console, get the first web widget and update any attribute in the channel object. Check if the inbox cache invalidation event is triggered.

