### PR TITLE
chore: Remove context menu on links

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -444,9 +444,9 @@ export default {
       this.hasImageError = true;
     },
     openContextMenu(e) {
-      const shouldSkipContextMenu = e.target?.classList.contains(
-        'skip-context-menu'
-      );
+      const shouldSkipContextMenu =
+        e.target?.classList.contains('skip-context-menu') ||
+        e.target.tagName.toLowerCase() === 'a';
       if (shouldSkipContextMenu || getSelection().toString()) {
         return;
       }


### PR DESCRIPTION
If hovering a link, the default context menu would be shown. 

> There is a right click menu in Chatwoot now on messages. If there is an URL in a message, I can’t right click it anymore to copy the link. That is something I do a lot and it is annoying that Chatwoot now prevents me from doing that.
> Discord also has a right click menu but they did add the “copy link” option to resolve that problem. Maybe something for Chatwoot too.
> I actually thought “Copy” would do that when right clicking a link but it seems to copy the entire message.
> I would change “Copy” to “Copy message” and if a link was right click, change it to “Copy link”



<img width="438" alt="Screenshot 2023-04-10 at 1 50 51 PM" src="https://user-images.githubusercontent.com/2246121/230996266-19d45bec-43d3-41fa-90ac-7f5685bd10ae.png">
