### PR TITLE
fix: Update the profile API URL in the documentation

### DIFF
--- a/swagger/paths/index.yml
+++ b/swagger/paths/index.yml
@@ -360,7 +360,7 @@
 
 
 # Profile
-/profile:
+/api/v1/profile:
   $ref: ./profile/index.yml
 
 

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -3817,7 +3817,7 @@
         }
       }
     },
-    "/profile": {
+    "/api/v1/profile": {
       "get": {
         "tags": [
           "Profile"


### PR DESCRIPTION
Change /profile to /api/v1/profile

Reported by: [#22988](https://app.chatwoot.com/app/accounts/1/conversations/22988)