### PR TITLE
fix: Find email channel with bcc and x-original-to

### DIFF
--- a/app/finders/email_channel_finder.rb
+++ b/app/finders/email_channel_finder.rb
@@ -8,12 +8,17 @@ class EmailChannelFinder
   def perform
     channel = nil
 
-    recipient_mails = @email_object.to.to_a + @email_object.cc.to_a + @email_object.bcc.to_a + [@email_object['X-Original-To'].try(:value)]
     recipient_mails.each do |email|
       normalized_email = normalize_email_with_plus_addressing(email)
       channel = Channel::Email.find_by('lower(email) = ? OR lower(forward_to_email) = ?', normalized_email, normalized_email)
+
       break if channel.present?
     end
     channel
+  end
+
+  def recipient_mails
+    recipient_addresses = @email_object.to.to_a + @email_object.cc.to_a + @email_object.bcc.to_a + [@email_object['X-Original-To'].try(:value)]
+    recipient_addresses.flatten.compact
   end
 end

--- a/app/finders/email_channel_finder.rb
+++ b/app/finders/email_channel_finder.rb
@@ -7,7 +7,8 @@ class EmailChannelFinder
 
   def perform
     channel = nil
-    recipient_mails = @email_object.to.to_a + @email_object.cc.to_a
+
+    recipient_mails = @email_object.to.to_a + @email_object.cc.to_a + @email_object.bcc.to_a + [@email_object['X-Original-To'].try(:value)]
     recipient_mails.each do |email|
       normalized_email = normalize_email_with_plus_addressing(email)
       channel = Channel::Email.find_by('lower(email) = ? OR lower(forward_to_email) = ?', normalized_email, normalized_email)

--- a/spec/finders/email_channel_finder_spec.rb
+++ b/spec/finders/email_channel_finder_spec.rb
@@ -31,6 +31,30 @@ describe ::EmailChannelFinder do
         channel = described_class.new(reply_mail.mail).perform
         expect(channel).to eq(channel_email)
       end
+
+      it 'return channel with cc email' do
+        channel_email.update(email: 'test@example.com')
+        reply_mail.mail['to'] = nil
+        reply_mail.mail['cc'] = 'test@example.com'
+        channel = described_class.new(reply_mail.mail).perform
+        expect(channel).to eq(channel_email)
+      end
+
+      it 'return channel with bcc email' do
+        channel_email.update(email: 'test@example.com')
+        reply_mail.mail['to'] = nil
+        reply_mail.mail['bcc'] = 'test@example.com'
+        channel = described_class.new(reply_mail.mail).perform
+        expect(channel).to eq(channel_email)
+      end
+
+      it 'return channel with X-Original-To email' do
+        channel_email.update(email: 'test@example.com')
+        reply_mail.mail['to'] = nil
+        reply_mail.mail['X-Original-To'] = 'test@example.com'
+        channel = described_class.new(reply_mail.mail).perform
+        expect(channel).to eq(channel_email)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes: #6608  
ref: https://linear.app/chatwoot/issue/CW-30/emails-not-routed-based-on-x-original-to