### PR TITLE
fix: use response.status instead of success

### DIFF
--- a/app/controllers/twitter/callbacks_controller.rb
+++ b/app/controllers/twitter/callbacks_controller.rb
@@ -14,7 +14,7 @@ class Twitter::CallbacksController < Twitter::BaseController
       redirect_to app_twitter_inbox_agents_url(account_id: account.id, inbox_id: inbox.id)
     end
   rescue StandardError => e
-    Rails.logger.error e
+    ChatwootExceptionTracker.new(e).capture_exception
     redirect_to twitter_app_redirect_url
   end
 

--- a/app/controllers/twitter/callbacks_controller.rb
+++ b/app/controllers/twitter/callbacks_controller.rb
@@ -60,7 +60,7 @@ class Twitter::CallbacksController < Twitter::BaseController
   def save_profile_image(inbox)
     response = twitter_client.user_show(screen_name: inbox.name)
 
-    return unless response.success?
+    return unless response.status == '200'
 
     parsed_user_profile = JSON.parse(response.read_body)
 

--- a/app/controllers/twitter/callbacks_controller.rb
+++ b/app/controllers/twitter/callbacks_controller.rb
@@ -60,7 +60,7 @@ class Twitter::CallbacksController < Twitter::BaseController
   def save_profile_image(inbox)
     response = twitter_client.user_show(screen_name: inbox.name)
 
-    return unless response.status == '200'
+    return unless response.status.to_i == 200
 
     parsed_user_profile = JSON.parse(response.read_body)
 


### PR DESCRIPTION
The `twitter_client.user_show(screen_name: inbox.name)` returns a 403 from Twitter API with the following error

```json
{
  "errors": [
    {
      "message": "You currently have Essential access which includes access to Twitter API v2 endpoints only. If you need access to this endpoint, you’ll need to apply for Elevated access via the Developer Portal. You can learn more here: https://developer.twitter.com/en/docs/twitter-api/getting-started/about-twitter-api#v2-access-leve",
      "code": 453
    }
  ]
}
```


The next statement was `return unless response.success?` but the `success` property does not exist on the Twitty Response class, so it breaks the creation of twitter inbox. This PR fixes that

