### PR TITLE
fix: Border color for CSAT component in widget

### DIFF
--- a/app/javascript/shared/components/CustomerSatisfaction.vue
+++ b/app/javascript/shared/components/CustomerSatisfaction.vue
@@ -233,4 +233,10 @@ export default {
     }
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  .customer-satisfaction .feedback-form input {
+    border-top: 1px solid var(--b-500);
+  }
+}
 </style>

--- a/app/javascript/widget/components/template/EmailInput.vue
+++ b/app/javascript/widget/components/template/EmailInput.vue
@@ -75,7 +75,8 @@ export default {
     },
     inputColor() {
       return `${this.$dm('bg-white', 'dark:bg-slate-600')}
-        ${this.$dm('text-black-900', 'dark:text-slate-50')}`;
+        ${this.$dm('text-black-900', 'dark:text-slate-50')}
+        ${this.$dm('border-black-200', 'dark:border-black-500')}`;
     },
     inputHasError() {
       return this.$v.email.$error


### PR DESCRIPTION
# Pull Request Template

## Description

1. FIx border color for CSAT
2. Fix the border color in the email input

Fixes https://linear.app/chatwoot/issue/CW-38/bug-fix-border-color-for-csat-component-in-widget

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Screenshot**
<img width="433" alt="Screenshot 2023-04-17 at 3 07 51 PM" src="https://user-images.githubusercontent.com/64252451/232447104-d5308144-c510-46a0-ba8d-b9bc761dd7e1.png">



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
