### PR TITLE
feat: add priority field to conversation

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -39,7 +39,9 @@
 #  index_conversations_on_id_and_account_id           (account_id,id)
 #  index_conversations_on_inbox_id                    (inbox_id)
 #  index_conversations_on_last_activity_at            (last_activity_at)
+#  index_conversations_on_priority                    (priority)
 #  index_conversations_on_status_and_account_id       (status,account_id)
+#  index_conversations_on_status_and_priority         (status,priority)
 #  index_conversations_on_team_id                     (team_id)
 #  index_conversations_on_uuid                        (uuid) UNIQUE
 #

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -11,6 +11,7 @@
 #  first_reply_created_at :datetime
 #  identifier             :string
 #  last_activity_at       :datetime         not null
+#  priority               :integer
 #  snoozed_until          :datetime
 #  status                 :integer          default("open"), not null
 #  uuid                   :uuid             not null
@@ -61,6 +62,7 @@ class Conversation < ApplicationRecord
   validate :validate_referer_url
 
   enum status: { open: 0, resolved: 1, pending: 2, snoozed: 3 }
+  enum priority: { low: 0, medium: 1, high: 2, urgent: 3 }
 
   scope :unassigned, -> { where(assignee_id: nil) }
   scope :assigned, -> { where.not(assignee_id: nil) }

--- a/db/migrate/20230418100944_add_priority_to_conversation.rb
+++ b/db/migrate/20230418100944_add_priority_to_conversation.rb
@@ -1,0 +1,5 @@
+class AddPriorityToConversation < ActiveRecord::Migration[6.1]
+  def change
+    add_column :conversations, :priority, :integer
+  end
+end

--- a/db/migrate/20230418100944_add_priority_to_conversation.rb
+++ b/db/migrate/20230418100944_add_priority_to_conversation.rb
@@ -1,5 +1,7 @@
 class AddPriorityToConversation < ActiveRecord::Migration[6.1]
   def change
     add_column :conversations, :priority, :integer
+    add_index :conversations, :priority
+    add_index :conversations, [:status, :priority]
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -458,7 +458,9 @@ ActiveRecord::Schema.define(version: 2023_04_18_100944) do
     t.index ["first_reply_created_at"], name: "index_conversations_on_first_reply_created_at"
     t.index ["inbox_id"], name: "index_conversations_on_inbox_id"
     t.index ["last_activity_at"], name: "index_conversations_on_last_activity_at"
+    t.index ["priority"], name: "index_conversations_on_priority"
     t.index ["status", "account_id"], name: "index_conversations_on_status_and_account_id"
+    t.index ["status", "priority"], name: "index_conversations_on_status_and_priority"
     t.index ["team_id"], name: "index_conversations_on_team_id"
     t.index ["uuid"], name: "index_conversations_on_uuid", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_07_191457) do
+ActiveRecord::Schema.define(version: 2023_04_18_100944) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -437,7 +437,7 @@ ActiveRecord::Schema.define(version: 2023_04_07_191457) do
     t.datetime "agent_last_seen_at"
     t.jsonb "additional_attributes", default: {}
     t.bigint "contact_inbox_id"
-    t.uuid "uuid", default: -> { "public.gen_random_uuid()" }, null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "identifier"
     t.datetime "last_activity_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.bigint "team_id"
@@ -446,6 +446,7 @@ ActiveRecord::Schema.define(version: 2023_04_07_191457) do
     t.jsonb "custom_attributes", default: {}
     t.datetime "assignee_last_seen_at"
     t.datetime "first_reply_created_at"
+    t.integer "priority"
     t.index ["account_id", "display_id"], name: "index_conversations_on_account_id_and_display_id", unique: true
     t.index ["account_id", "id"], name: "index_conversations_on_id_and_account_id"
     t.index ["account_id", "inbox_id", "status", "assignee_id"], name: "conv_acid_inbid_stat_asgnid_idx"


### PR DESCRIPTION
Seems like this can be done with minimal impact, tried it on staging instance with 2M rows, happened within 200ms

## References

- [StackOverflow](https://stackoverflow.com/a/19527223 )
- [PostgreSQL Docs](https://www.postgresql.org/docs/current/sql-altertable.html#:~:text=When%20a%20column,the%20table%20required.)

> When a column is added with ADD COLUMN and a non-volatile DEFAULT is specified, the default is evaluated at the time of the statement and the result stored in the table's metadata. That value will be used for the column for all existing rows. If no DEFAULT is specified, NULL is used. In neither case is a rewrite of the table required.


