### PR TITLE
fix: Fixes flaky reporting_event_listener spec

### DIFF
--- a/spec/listeners/reporting_event_listener_spec.rb
+++ b/spec/listeners/reporting_event_listener_spec.rb
@@ -63,8 +63,9 @@ describe ReportingEventListener do
 
     # this ensures last_non_human_activity method accurately accounts for handoff events
     context 'when last handoff event exists' do
-      let(:conversation_updated_at) { 20.seconds.from_now }
-      let(:human_message_created_at) { 62.seconds.from_now }
+      let(:now) { Time.zone.now }
+      let(:conversation_updated_at) { now + 20.seconds }
+      let(:human_message_created_at) { now + 62.seconds }
       let(:new_conversation) { create(:conversation, account: account, inbox: inbox, assignee: user, updated_at: conversation_updated_at) }
       let(:new_message) do
         create(:message, message_type: 'outgoing', created_at: human_message_created_at, account: account, inbox: inbox,


### PR DESCRIPTION
## Description
The spec from time to time returns 43 seconds when `from_now` time is close to a second boundary. Making now time the same for both `conversation_updated_at` and `human_message_created_at` should make the spec more deterministic.

```
ReportingEventListener#first_reply_created when last handoff event exists creates first_response event with handoff value
     Failure/Error: expect(account.reporting_events.where(name: 'first_response')[0]['value']).to be 42.0

       expected #<Float:155374187144282114> => 42.0
            got #<Float:156500087051124738> => 43.0

       Compared using equal?, which compares object identity,
       but expected and actual are not the same object. Use
       `expect(actual).to eq(expected)` if you don't care about
       object identity in this example.
     # ./spec/listeners/reporting_event_listener_spec.rb:82:in `block (4 levels) in <top (required)>'
```

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The issue can be reproduced by running the spec.