### PR TITLE
fix: build_id in heroku installations

### DIFF
--- a/config/initializers/git_sha.rb
+++ b/config/initializers/git_sha.rb
@@ -5,6 +5,9 @@ def fetch_git_sha
     sha.strip
   elsif File.exist?('.git_sha')
     File.read('.git_sha').strip
+  # This is for Heroku. Ensure heroku labs:enable runtime-dyno-metadata is turned on.
+  elsif ENV.fetch('HEROKU_SLUG_COMMIT', nil).present?
+    ENV.fetch('HEROKU_SLUG_COMMIT', nil)
   else
     'unknown'
   end


### PR DESCRIPTION
# Pull Request Template

## Description

- Read commit hash using HEROKU_SLUG_COMMIT env var for Heroku installations.
- The requires that Heroku labs feature dyno-metadata is turned on for the application.
- 

Fixes #6931 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
