### PR TITLE
feat: Enable features on successful subscription

### DIFF
--- a/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
@@ -48,6 +48,20 @@ describe Enterprise::Billing::HandleStripeEventService do
                                                      })
     end
 
+    it 'update features on customer.subscription.updated' do
+      allow(event).to receive(:type).and_return('customer.subscription.updated')
+      allow(subscription).to receive(:customer).and_return('cus_123')
+      stripe_event_service.new.perform(event: event)
+      expect(account.reload.custom_attributes).to eq({
+                                                       'stripe_customer_id' => 'cus_123',
+                                                       'stripe_price_id' => 'test',
+                                                       'stripe_product_id' => 'plan_id',
+                                                       'plan_name' => 'Hacker',
+                                                       'subscribed_quantity' => '10'
+                                                     })
+      expect(account).to be_feature_enabled('channel_email')
+    end
+
     it 'handles customer.subscription.deleted' do
       stripe_customer_service = double
       allow(event).to receive(:type).and_return('customer.subscription.deleted')


### PR DESCRIPTION
Fixes: https://linear.app/chatwoot/issue/CW-1369/update-custom-attribute-and-feature-flags-when-subscription-is-created