### PR TITLE
fix: Add `/api/v1` to the team_members API documentation

### DIFF
--- a/swagger/paths/index.yml
+++ b/swagger/paths/index.yml
@@ -382,7 +382,7 @@
     $ref: ./application/teams/update.yml
   delete:
     $ref: ./application/teams/delete.yml
-/accounts/{account_id}/teams/{team_id}/team_members:
+/api/v1/accounts/{account_id}/teams/{team_id}/team_members:
   parameters:
     - $ref: '#/parameters/account_id'
     - $ref: '#/parameters/team_id'

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -3980,7 +3980,7 @@
         }
       }
     },
-    "/accounts/{account_id}/teams/{team_id}/team_members": {
+    "/api/v1/accounts/{account_id}/teams/{team_id}/team_members": {
       "parameters": [
         {
           "$ref": "#/parameters/account_id"


### PR DESCRIPTION
Fixes a mistake in the URL for team_members.