### PR TITLE
fix: spacing for priority mark in inbox page

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue
@@ -443,11 +443,11 @@ export default {
   .conversation-metadata-attributes {
     display: flex;
     gap: var(--space-small);
+    margin-left: var(--space-small);
   }
 
   .assignee-label {
     display: inline-flex;
-    margin-left: var(--space-small);
     max-width: 50%;
   }
 }


### PR DESCRIPTION
<img width="401" alt="CleanShot 2023-04-26 at 14 42 27@2x" src="https://user-images.githubusercontent.com/18097732/234529208-7ecfd824-7684-4c3e-ba2f-7b0bece7c061.png">