### PR TITLE
feat(perf): add index to messages created at

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -27,6 +27,7 @@
 #  index_messages_on_additional_attributes_campaign_id  (((additional_attributes -> 'campaign_id'::text))) USING gin
 #  index_messages_on_content                            (content) USING gin
 #  index_messages_on_conversation_id                    (conversation_id)
+#  index_messages_on_created_at                         (created_at)
 #  index_messages_on_inbox_id                           (inbox_id)
 #  index_messages_on_sender_type_and_sender_id          (sender_type,sender_id)
 #  index_messages_on_source_id                          (source_id)

--- a/db/migrate/20230509101256_add_index_to_messages_created_at.rb
+++ b/db/migrate/20230509101256_add_index_to_messages_created_at.rb
@@ -1,0 +1,6 @@
+class AddIndexToMessagesCreatedAt < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def change
+    add_index :messages, [:created_at], name: 'index_messages_on_created_at', algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_26_130150) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_09_101256) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -667,6 +667,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_26_130150) do
     t.index ["account_id"], name: "index_messages_on_account_id"
     t.index ["content"], name: "index_messages_on_content", opclass: :gin_trgm_ops, using: :gin
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
+    t.index ["created_at"], name: "index_messages_on_created_at"
     t.index ["inbox_id"], name: "index_messages_on_inbox_id"
     t.index ["sender_type", "sender_id"], name: "index_messages_on_sender_type_and_sender_id"
     t.index ["source_id"], name: "index_messages_on_source_id"


### PR DESCRIPTION
This PR adds index on message `created_at` field, this PR speeds up the labels reports that counts messages.

Before: https://explain.dalibo.com/plan/33521ebf4f883cd6
After: https://explain.dalibo.com/plan/33521ebf4f883cd6

The improvements are marginal for most use-cases but for larger tables this should speed things up significantly

## Testing

Here's a query you can try to test

```sql
EXPLAIN (ANALYZE, COSTS, VERBOSE, BUFFERS, FORMAT JSON) SELECT 
  COUNT(*) AS count_all, 
  DATE_TRUNC('day', "messages"."created_at" :: timestamptz AT TIME ZONE 'Asia/Kolkata'):: date AS date_trunc_day_messages_created_at_timestamptz_at_time_zone_eur 
FROM 
  messages 
WHERE 
  messages.account_id = 1 
  AND messages.conversation_id IN (
    9856, 9857, 9858, 9859, 9860, 9861, 9862, 
    9863, 9864, 9865, 9866, 9867, 9868, 
    9869, 9870, 9871, 9872, 9873, 9874, 
    9875, 9896, 9897, 9898, 9899, 9900, 
    9901, 9902, 9903, 9904, 9905, 9906, 
    9907, 9908, 9909, 9910, 9911, 9912, 
    9913, 9914, 9915, 9916, 9917, 9918, 
    9919, 9920, 9921, 9922, 9923, 9924, 
    9925, 9926, 9927, 9928, 9929, 9930, 
    9931, 9932, 9933, 9934, 9935, 9562
  ) 
  AND messages.account_id = 1 
  AND messages.message_type = 0 
  AND (
    messages.created_at >= '2023-04-25 18:30:01' 
    AND messages.created_at < '2023-05-02 18:30:00'
  ) 
GROUP BY 
  DATE_TRUNC(
    'day', messages.created_at :: timestamptz AT TIME ZONE 'Asia/Kolkata'
  ):: date;
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] ~I have commented on my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
