### PR TITLE
feat(perf): add additional indexes for messages

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -26,6 +26,7 @@
 #  index_messages_on_account_id_and_inbox_id            (account_id,inbox_id)
 #  index_messages_on_additional_attributes_campaign_id  (((additional_attributes -> 'campaign_id'::text))) USING gin
 #  index_messages_on_content                            (content) USING gin
+#  index_messages_on_conversation_account_type_created  (conversation_id,account_id,message_type,created_at)
 #  index_messages_on_conversation_id                    (conversation_id)
 #  index_messages_on_created_at                         (created_at)
 #  index_messages_on_inbox_id                           (inbox_id)

--- a/db/migrate/20230510060828_add_index_to_messages_for_reportings.rb
+++ b/db/migrate/20230510060828_add_index_to_messages_for_reportings.rb
@@ -1,0 +1,7 @@
+class AddIndexToMessagesForReportings < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def change
+    add_index :messages, [:conversation_id, :account_id, :message_type, :created_at], name: 'index_messages_on_conversation_account_type_created',
+                                                                                      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_09_101256) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_10_060828) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -666,6 +666,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_09_101256) do
     t.index ["account_id", "inbox_id"], name: "index_messages_on_account_id_and_inbox_id"
     t.index ["account_id"], name: "index_messages_on_account_id"
     t.index ["content"], name: "index_messages_on_content", opclass: :gin_trgm_ops, using: :gin
+    t.index ["conversation_id", "account_id", "message_type", "created_at"], name: "index_messages_on_conversation_account_type_created"
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["created_at"], name: "index_messages_on_created_at"
     t.index ["inbox_id"], name: "index_messages_on_inbox_id"


### PR DESCRIPTION
Extension to the following PR: https://github.com/chatwoot/chatwoot/pull/7044

---

An index on `conversation_id`, `account_id`, `message_type` and `created_at` does speed things up for the query

## results
Before: https://explain.dalibo.com/plan/da7c4h9e9161ba64
After: https://explain.dalibo.com/plan/b2c9ece7247120c8
