### PR TITLE
feat: API to list all attachments for a conversation

### DIFF
--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -22,6 +22,10 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
     @conversations_count = result[:count]
   end
 
+  def attachments
+    @attachments = @conversation.attachments
+  end
+
   def create
     ActiveRecord::Base.transaction do
       @conversation = ConversationBuilder.new(params: params, contact_inbox: @contact_inbox).perform

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -95,6 +95,7 @@ class Conversation < ApplicationRecord
   has_one :csat_survey_response, dependent: :destroy_async
   has_many :conversation_participants, dependent: :destroy_async
   has_many :notifications, as: :primary_actor, dependent: :destroy_async
+  has_many :attachments, through: :messages
 
   before_save :ensure_snooze_until_reset
   before_create :mark_conversation_pending_if_bot

--- a/app/views/api/v1/accounts/conversations/attachments.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/attachments.json.jbuilder
@@ -1,9 +1,1 @@
-json.array! @attachments do |attachment|
-  json.id attachment.id
-  json.message_id attachment.message_id
-  json.file_type attachment.file_type
-  json.external_url attachment.external_url
-  json.file url_for(attachment.file)
-  json.created_at attachment.created_at.to_i
-  json.updated_at attachment.updated_at.to_i
-end
+json.payload @attachments.map(&:push_event_data)

--- a/app/views/api/v1/accounts/conversations/attachments.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/attachments.json.jbuilder
@@ -1,0 +1,9 @@
+json.array! @attachments do |attachment|
+  json.id attachment.id
+  json.message_id attachment.message_id
+  json.file_type attachment.file_type
+  json.external_url attachment.external_url
+  json.file url_for(attachment.file)
+  json.created_at attachment.created_at.to_i
+  json.updated_at attachment.updated_at.to_i
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ Rails.application.routes.draw do
               post :update_last_seen
               post :unread
               post :custom_attributes
+              get :attachments
             end
           end
 

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -748,9 +748,7 @@ RSpec.describe 'Conversations API', type: :request do
       let(:administrator) { create(:user, account: account, role: :administrator) }
 
       before do
-        # file = fixture_file_upload(Rails.root.join('spec/assets/avatar.png'), 'image/png')
-        # create(:message, conversation: conversation, account: account, inbox: conversation.inbox, message_type: 'incoming', attachments: [file])
-        create(:message, conversation: conversation, account: account, inbox: conversation.inbox, content: 'Hello', message_type: 'incoming')
+        create(:message, :with_attachment, conversation: conversation, account: account, inbox: conversation.inbox, message_type: 'incoming')
       end
 
       it 'does not return the attachments if you do not have access to it' do
@@ -767,17 +765,18 @@ RSpec.describe 'Conversations API', type: :request do
             as: :json
 
         expect(response).to have_http_status(:success)
-        # expect(JSON.parse(response.body, symbolize_names: true)[:id]).to eq(conversation.display_id)
+        response_body = JSON.parse(response.body)
+        expect(response_body['payload'].first['file_type']).to eq('image')
       end
 
       it 'return the attachments if you are an agent with access to inbox' do
-        create(:inbox_member, user: agent, inbox: conversation.inbox)
         get "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/attachments",
-            headers: agent.create_new_auth_token,
+            headers: administrator.create_new_auth_token,
             as: :json
 
         expect(response).to have_http_status(:success)
-        # expect(JSON.parse(response.body, symbolize_names: true)[:id]).to eq(conversation.display_id)
+        response_body = JSON.parse(response.body)
+        expect(response_body['payload'].length).to eq(1)
       end
     end
   end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -20,6 +20,13 @@ FactoryBot.define do
       end
     end
 
+    trait :with_attachment do
+      after(:build) do |message|
+        attachment = message.attachments.new(account_id: message.account_id, file_type: :image)
+        attachment.file.attach(io: File.open(Rails.root.join('spec/assets/avatar.png')), filename: 'avatar.png', content_type: 'image/png')
+      end
+    end
+
     after(:build) do |message|
       message.sender ||= message.outgoing? ? create(:user, account: message.account) : create(:contact, account: message.account)
       message.inbox ||= message.conversation&.inbox || create(:inbox, account: message.account)


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-1678/api-to-list-all-attachments-for-a-conversation