### PR TITLE
fix: Avoid audio URLs getting cached at the frontend

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -59,7 +59,7 @@
               controls
               class="skip-context-menu"
             >
-              <source :src="attachment.data_url" />
+              <source :src="`${attachment.data_url}?t=${Date.now()}`" />
             </audio>
             <bubble-video
               v-else-if="attachment.file_type === 'video'"


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-1728/wrong-cache-information-for-gcs-storage
Fixes https://github.com/chatwoot/chatwoot/issues/7000

- Force reload audio on each re-render.

@scmmishra Do you have any other ideas here? The issue here is that the redirect gets cached on the frontend, which eventually expires and the audio becomes in-accessible