### PR TITLE
fix: Avoid blob URLs getting cached

### DIFF
--- a/app/controllers/active_storage/blobs/redirect_controller.rb
+++ b/app/controllers/active_storage/blobs/redirect_controller.rb
@@ -1,0 +1,8 @@
+class ActiveStorage::Blobs::RedirectController < ActiveStorage::BaseController
+  include ActiveStorage::SetBlob
+
+  def show
+    response.set_header('Cache-Control', 'no-store')
+    redirect_to @blob.url(disposition: params[:disposition]), allow_other_host: true
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/chatwoot/chatwoot/issues/7000

related: https://github.com/chatwoot/chatwoot/pull/7062#issuecomment-1544601839

I fixed the issue by overriding the active storage blob redirect controller and removing the cache

Original rails 7 controller https://github.com/rails/rails/blob/7-0-stable/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb

@pranavrajs 