### PR TITLE
fixes: Editor adding slash char while creating block quotes [cw-1505]

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@braid/vue-formulate": "^2.5.2",
-    "@chatwoot/prosemirror-schema": "https://github.com/chatwoot/prosemirror-schema.git#d0b25001f37b4997c0e4f96861fef97d145d0414",
+    "@chatwoot/prosemirror-schema": "https://github.com/chatwoot/prosemirror-schema.git",
     "@chatwoot/utils": "^0.0.16",
     "@hcaptcha/vue-hcaptcha": "^0.3.2",
     "@june-so/analytics-next": "^1.36.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@braid/vue-formulate": "^2.5.2",
-    "@chatwoot/prosemirror-schema": "https://github.com/chatwoot/prosemirror-schema.git",
+    "@chatwoot/prosemirror-schema": "https://github.com/chatwoot/prosemirror-schema.git#d0b25001f37b4997c0e4f96861fef97d145d0414",
     "@chatwoot/utils": "^0.0.16",
     "@hcaptcha/vue-hcaptcha": "^0.3.2",
     "@june-so/analytics-next": "^1.36.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,9 +2178,9 @@
     is-url "^1.2.4"
     nanoid "^2.1.11"
 
-"@chatwoot/prosemirror-schema@https://github.com/chatwoot/prosemirror-schema.git":
+"@chatwoot/prosemirror-schema@https://github.com/chatwoot/prosemirror-schema.git#d0b25001f37b4997c0e4f96861fef97d145d0414":
   version "1.0.0"
-  resolved "https://github.com/chatwoot/prosemirror-schema.git#3306cdb220797090ce41ea607174e940330177e1"
+  resolved "https://github.com/chatwoot/prosemirror-schema.git#d0b25001f37b4997c0e4f96861fef97d145d0414"
   dependencies:
     prosemirror-commands "^1.1.4"
     prosemirror-dropcursor "^1.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,9 +2178,9 @@
     is-url "^1.2.4"
     nanoid "^2.1.11"
 
-"@chatwoot/prosemirror-schema@https://github.com/chatwoot/prosemirror-schema.git#d0b25001f37b4997c0e4f96861fef97d145d0414":
+"@chatwoot/prosemirror-schema@https://github.com/chatwoot/prosemirror-schema.git":
   version "1.0.0"
-  resolved "https://github.com/chatwoot/prosemirror-schema.git#d0b25001f37b4997c0e4f96861fef97d145d0414"
+  resolved "https://github.com/chatwoot/prosemirror-schema.git#b937c3cb44210b7d251daf766988758975befec7"
   dependencies:
     prosemirror-commands "^1.1.4"
     prosemirror-dropcursor "^1.3.2"


### PR DESCRIPTION
**Description**
This was because of an error in the code. the nodes object was coming with different keys.

**Loom**
https://www.loom.com/share/82d8beba08de49f5b2405783ce2d3d0b

**Pr on schema side** 
https://github.com/chatwoot/prosemirror-schema/pull/11

Fixes # (issue)
https://linear.app/chatwoot/issue/CW-1505/editor-adds-a-stray-/-in-a-conversation

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
