### PR TITLE
chore: Fix Activerecord query cancelled when fetching email

### DIFF
--- a/app/jobs/inboxes/fetch_imap_emails_job.rb
+++ b/app/jobs/inboxes/fetch_imap_emails_job.rb
@@ -87,9 +87,11 @@ class Inboxes::FetchImapEmailsJob < ApplicationJob
   end
 
   def last_email_time(channel)
-    if channel.inbox.messages.any?
-      time = channel.inbox.messages.incoming.last.content_attributes['email']['date']
-      time ||= channel.inbox.messages.incoming.last.created_at.to_s
+    # we are only checking for emails in last 2 day
+    last_email_incoming_message = channel.inbox.messages.incoming.where('messages.created_at >= ?', 2.days.ago).last
+    if last_email_incoming_message.present?
+      time = last_email_incoming_message.content_attributes['email']['date']
+      time ||= last_email_incoming_message.created_at.to_s
     end
     time ||= 1.hour.ago.to_s
 


### PR DESCRIPTION
Limiting the query to 2 days to ensure that it runs timebound. 

fixes: https://linear.app/chatwoot/issue/CW-1747/activerecordquerycanceled-pgquerycanceled-error-canceling-statement

