### PR TITLE
fix: Avoid styles getting purged on prod build

### DIFF
--- a/app/javascript/portal/application.scss
+++ b/app/javascript/portal/application.scss
@@ -28,8 +28,12 @@ body {
 }
 
 .heading {
+  .permalink {
+    visibility: hidden;
+  }
+
   &:hover {
-    a {
+    .permalink {
       visibility: visible;
     }
   }

--- a/app/javascript/portal/portalHelpers.js
+++ b/app/javascript/portal/portalHelpers.js
@@ -11,7 +11,7 @@ export const getHeadingsfromTheArticle = () => {
     const slug = slugifyWithCounter(element.innerText);
     element.id = slug;
     element.className = 'scroll-mt-24 heading';
-    element.innerHTML += `<a class="invisible text-slate-600 ml-3" href="#${slug}" title="${element.innerText}" data-turbolinks="false">#</a>`;
+    element.innerHTML += `<a class="permalink text-slate-600 ml-3" href="#${slug}" title="${element.innerText}" data-turbolinks="false">#</a>`;
     rows.push({
       slug,
       title: element.innerText,


### PR DESCRIPTION
Our tailwind configuration purges the styles that don't appear in a Vue file. Fixes the invisible styles getting removed as it is generated using javascript.

I will find a proper fix for this later.