### PR TITLE
fix: Instagram events job NoMethodError: undefined method  for nil:Ni…

### DIFF
--- a/app/jobs/webhooks/instagram_events_job.rb
+++ b/app/jobs/webhooks/instagram_events_job.rb
@@ -31,6 +31,6 @@ class Webhooks::InstagramEventsJob < ApplicationJob
   end
 
   def messages(entry)
-    (entry[:messaging].presence || entry[:standby])
+    (entry[:messaging].presence || entry[:standby] || [])
   end
 end


### PR DESCRIPTION
…lClass entry[:messaging].each do |messaging|

## Description

Sometimes tag entry does not have messaging or standby and cause a error

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
