### PR TITLE
refactor: make category non-mandatory

### DIFF
--- a/app/views/api/v1/accounts/articles/_article.json.jbuilder
+++ b/app/views/api/v1/accounts/articles/_article.json.jbuilder
@@ -8,11 +8,14 @@ json.position article.position
 json.account_id article.account_id
 json.updated_at article.updated_at.to_i
 json.meta article.meta
-json.category do
-  json.id article.category_id
-  json.name article.category.name
-  json.slug article.category.slug
-  json.locale article.category.locale
+
+if article.category.present?
+  json.category do
+    json.id article.category_id
+    json.name article.category.name
+    json.slug article.category.slug
+    json.locale article.category.locale
+  end
 end
 
 json.views article.views

--- a/app/views/api/v1/accounts/articles/_article.json.jbuilder
+++ b/app/views/api/v1/accounts/articles/_article.json.jbuilder
@@ -9,13 +9,11 @@ json.account_id article.account_id
 json.updated_at article.updated_at.to_i
 json.meta article.meta
 
-if article.category.present?
-  json.category do
-    json.id article.category_id
-    json.name article.category.name
-    json.slug article.category.slug
-    json.locale article.category.locale
-  end
+json.category do
+  json.id article.category_id
+  json.name article.category&.name
+  json.slug article.category&.slug
+  json.locale article.category&.locale
 end
 
 json.views article.views

--- a/spec/controllers/api/v1/accounts/articles_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/articles_controller_spec.rb
@@ -41,6 +41,29 @@ RSpec.describe 'Api::V1::Accounts::Articles', type: :request do
         expect(json_response['payload']['position']).to be(3)
       end
 
+      it 'creates article even if category is not provided' do
+        article_params = {
+          article: {
+            category_id: nil,
+            description: 'test description',
+            title: 'MyTitle',
+            slug: 'my-title',
+            content: 'This is my content.',
+            status: :published,
+            author_id: agent.id,
+            position: 3
+          }
+        }
+        post "/api/v1/accounts/#{account.id}/portals/#{portal.slug}/articles",
+             params: article_params,
+             headers: agent.create_new_auth_token
+        expect(response).to have_http_status(:success)
+        json_response = JSON.parse(response.body)
+        expect(json_response['payload']['title']).to eql('MyTitle')
+        expect(json_response['payload']['status']).to eql('draft')
+        expect(json_response['payload']['position']).to be(3)
+      end
+
       it 'associate to the root article' do
         root_article = create(:article, category: category, slug: 'root-article', portal: portal, account_id: account.id, author_id: agent.id,
                                         associated_article_id: nil)


### PR DESCRIPTION
## Description

When on a new help-center, I tried to create an article, but the action would fail with an internal server error, see screenshot below

<img width="500" alt="CleanShot 2023-05-18 at 12 11 59@2x" src="https://github.com/chatwoot/chatwoot/assets/18097732/389786ea-af64-46bc-aaab-8c64062c914b">

This is the error on [sentry](https://chatwoot-p3.sentry.io/share/issue/d5abdec089304223830fee829c6eb705/). This is happening becuase the **help center does not have any existing categories.**  This PR is a temporary fix for this issue, ideally we should have better onboarding and ask users to create a few categories first.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested locally, updated unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
