### PR TITLE
feat(perf): improve performance of conversation filter API [CW-1605]

### DIFF
--- a/app/services/conversations/filter_service.rb
+++ b/app/services/conversations/filter_service.rb
@@ -58,7 +58,7 @@ class Conversations::FilterService < FilterService
 
   def conversations
     @conversations = @conversations.includes(
-      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :messages
+      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :messages, :contact_inbox
     )
 
     @conversations.latest.page(current_page)

--- a/app/services/conversations/filter_service.rb
+++ b/app/services/conversations/filter_service.rb
@@ -58,8 +58,9 @@ class Conversations::FilterService < FilterService
 
   def conversations
     @conversations = @conversations.includes(
-      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team
+      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :messages
     )
+
     @conversations.latest.page(current_page)
   end
 end

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -17,7 +17,7 @@ json.meta do
 end
 
 json.id conversation.display_id
-if conversation.messages.count.zero?
+if !conversation.messages.first.present?
   json.messages []
 elsif conversation.unread_incoming_messages.count.zero?
   json.messages [conversation.messages.includes([{ attachments: [{ file_attachment: [:blob] }] }]).last.try(:push_event_data)]

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -17,7 +17,7 @@ json.meta do
 end
 
 json.id conversation.display_id
-if !conversation.messages.first.present?
+if conversation.messages.first.blank?
   json.messages []
 elsif conversation.unread_incoming_messages.count.zero?
   json.messages [conversation.messages.includes([{ attachments: [{ file_attachment: [:blob] }] }]).last.try(:push_event_data)]


### PR DESCRIPTION
## Description

This PR fixes some N+1 queries for the conversation filter service. This caches the labels and precomputes the total message count. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Results

### Baseline

Total Queries: 251

![CleanShot 2023-05-18 at 18 07 44@2x](https://github.com/chatwoot/chatwoot/assets/18097732/2ceb28e7-0225-4b57-bf52-3f2b6a770782)


### Optimized

Total Queries: 213

![CleanShot 2023-05-18 at 18 08 15@2x](https://github.com/chatwoot/chatwoot/assets/18097732/75133651-baff-4bd6-8fbc-0236b22deba7)
