### PR TITLE
fix: exclude private and activity messages from public API

### DIFF
--- a/app/views/public/api/v1/models/_conversation.json.jbuilder
+++ b/app/views/public/api/v1/models/_conversation.json.jbuilder
@@ -4,7 +4,7 @@ json.contact_last_seen_at resource.contact_last_seen_at.to_i
 json.status resource.status
 json.agent_last_seen_at resource.agent_last_seen_at.to_i
 json.messages do
-  json.array! resource.messages do |message|
+  json.array! resource.messages.where(private: false) do |message|
     json.partial! 'public/api/v1/models/message', formats: [:json], resource: message
   end
 end

--- a/app/views/public/api/v1/models/_conversation.json.jbuilder
+++ b/app/views/public/api/v1/models/_conversation.json.jbuilder
@@ -4,7 +4,7 @@ json.contact_last_seen_at resource.contact_last_seen_at.to_i
 json.status resource.status
 json.agent_last_seen_at resource.agent_last_seen_at.to_i
 json.messages do
-  json.array! resource.messages.where(private: false) do |message|
+  json.array! resource.messages.chat do |message|
     json.partial! 'public/api/v1/models/message', formats: [:json], resource: message
   end
 end

--- a/spec/controllers/public/api/v1/inbox/conversations_controller_spec.rb
+++ b/spec/controllers/public/api/v1/inbox/conversations_controller_spec.rb
@@ -14,6 +14,22 @@ RSpec.describe 'Public Inbox Contact Conversations API', type: :request do
       data = JSON.parse(response.body)
       expect(data.length).to eq 1
     end
+
+    it 'does not return any private messages' do
+      conversation = create(:conversation, contact_inbox: contact_inbox)
+      create(:message, account: conversation.account, inbox: conversation.inbox, conversation: conversation, content: 'message-1')
+      create(:message, account: conversation.account, inbox: conversation.inbox, conversation: conversation, content: 'message-2')
+      create(:message, account: conversation.account, inbox: conversation.inbox, conversation: conversation, content: 'private-message-1',
+                       private: true)
+
+      get "/public/api/v1/inboxes/#{api_channel.identifier}/contacts/#{contact_inbox.source_id}/conversations"
+
+      expect(response).to have_http_status(:success)
+      data = JSON.parse(response.body)
+      expect(data.length).to eq 1
+      expect(data.first['messages'].length).to eq 2
+      expect(data.first['messages'].map { |m| m['content'] }).not_to include('private-message-1')
+    end
   end
 
   describe 'POST /public/api/v1/inboxes/{identifier}/contact/{source_id}/conversations' do

--- a/spec/controllers/public/api/v1/inbox/conversations_controller_spec.rb
+++ b/spec/controllers/public/api/v1/inbox/conversations_controller_spec.rb
@@ -15,12 +15,14 @@ RSpec.describe 'Public Inbox Contact Conversations API', type: :request do
       expect(data.length).to eq 1
     end
 
-    it 'does not return any private messages' do
+    it 'does not return any private or activity message' do
       conversation = create(:conversation, contact_inbox: contact_inbox)
       create(:message, account: conversation.account, inbox: conversation.inbox, conversation: conversation, content: 'message-1')
       create(:message, account: conversation.account, inbox: conversation.inbox, conversation: conversation, content: 'message-2')
       create(:message, account: conversation.account, inbox: conversation.inbox, conversation: conversation, content: 'private-message-1',
                        private: true)
+      create(:message, account: conversation.account, inbox: conversation.inbox, conversation: conversation, content: 'activity-message-1',
+                       message_type: :activity)
 
       get "/public/api/v1/inboxes/#{api_channel.identifier}/contacts/#{contact_inbox.source_id}/conversations"
 
@@ -29,6 +31,7 @@ RSpec.describe 'Public Inbox Contact Conversations API', type: :request do
       expect(data.length).to eq 1
       expect(data.first['messages'].length).to eq 2
       expect(data.first['messages'].map { |m| m['content'] }).not_to include('private-message-1')
+      expect(data.first['messages'].map { |m| m['message_type'] }).not_to include('activity')
     end
   end
 


### PR DESCRIPTION
Remove private notes from conversation list public API

Fixes: https://github.com/chatwoot/chatwoot/issues/7075

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested locally and added relevant unit tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
