### PR TITLE
feat: Add an option to use darkMode only in the widget

### DIFF
--- a/app/javascript/sdk/constants.js
+++ b/app/javascript/sdk/constants.js
@@ -1,3 +1,3 @@
 export const BUBBLE_DESIGN = ['standard', 'expanded_bubble'];
 export const WIDGET_DESIGN = ['standard', 'flat'];
-export const DARK_MODE = ['light', 'auto'];
+export const DARK_MODE = ['light', 'auto', 'dark'];

--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -2,6 +2,7 @@
   <div
     v-if="!conversationSize && isFetchingList"
     class="flex flex-1 items-center h-full bg-black-25 justify-center"
+    :class="{ dark: prefersDarkMode }"
   >
     <spinner size="" />
   </div>
@@ -13,6 +14,7 @@
       'is-widget-right': isRightAligned,
       'is-bubble-hidden': hideMessageBubble,
       'is-flat-design': isWidgetStyleFlat,
+      dark: prefersDarkMode,
     }"
   >
     <router-view />
@@ -65,6 +67,7 @@ export default {
       isFetchingList: 'conversation/getIsFetchingList',
       isRightAligned: 'appConfig/isRightAligned',
       isWidgetOpen: 'appConfig/getIsWidgetOpen',
+      darkMode: 'appConfig/darkMode',
       messageCount: 'conversation/getMessageCount',
       unreadMessageCount: 'conversation/getUnreadMessageCount',
       isWidgetStyleFlat: 'appConfig/isWidgetStyleFlat',
@@ -74,6 +77,12 @@ export default {
     },
     isRNWebView() {
       return RNHelper.isRNWebView();
+    },
+    prefersDarkMode() {
+      const isOSOnDarkMode =
+        this.darkMode === 'auto' &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches;
+      return isOSOnDarkMode || this.darkMode === 'dark';
     },
   },
   watch: {

--- a/app/javascript/widget/components/ConversationWrap.vue
+++ b/app/javascript/widget/components/ConversationWrap.vue
@@ -60,7 +60,7 @@ export default {
       isAgentTyping: 'conversation/getIsAgentTyping',
     }),
     colorSchemeClass() {
-      return `${this.darkMode === 'light' ? 'light' : 'dark'}`;
+      return `${this.darkMode === 'dark' ? 'dark-scheme' : 'light-scheme'}`;
     },
   },
   watch: {
@@ -117,10 +117,10 @@ export default {
   overflow-y: auto;
   color-scheme: light dark;
 
-  &.light {
+  &.light-scheme {
     color-scheme: light;
   }
-  &.dark {
+  &.dark-scheme {
     color-scheme: dark;
   }
 }

--- a/app/javascript/widget/mixins/darkModeMixin.js
+++ b/app/javascript/widget/mixins/darkModeMixin.js
@@ -9,6 +9,9 @@ export default {
       if (this.darkMode === 'light') {
         return light;
       }
+      if (this.darkMode === 'dark') {
+        return dark;
+      }
       return light + ' ' + dark;
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 const { colors } = require('tailwindcss/defaultTheme');
 
 module.exports = {
+  dark: 'class',
   purge: [
     './app/javascript/widget/**/*.vue',
     './app/javascript/portal/**/*.vue',
@@ -10,6 +11,9 @@ module.exports = {
   ],
   future: {
     removeDeprecatedGapUtilities: true,
+  },
+  experimental: {
+    darkModeVariant: true,
   },
   theme: {
     colors: {


### PR DESCRIPTION
- Added an option to use dark Mode only in the widget. 
- Accept `dark` in the sdk options.
- Change the Tailwind Dark Mode style strategy to `class` to override color changes based on the OS preference.

https://www.loom.com/share/dc16ac938c6f454e882e32b2c07b30f1