### PR TITLE
Fix: prevent IMAPBadResponse exception from sending the authorization mail

### DIFF
--- a/app/jobs/inboxes/fetch_imap_emails_job.rb
+++ b/app/jobs/inboxes/fetch_imap_emails_job.rb
@@ -7,9 +7,10 @@ class Inboxes::FetchImapEmailsJob < ApplicationJob
     return unless should_fetch_email?(channel)
 
     process_email_for_channel(channel)
-  rescue *ExceptionList::IMAP_EXCEPTIONS
+  rescue *ExceptionList::IMAP_EXCEPTIONS => e
+    ChatwootExceptionTracker.new(e, account: channel.account).capture_exception
     channel.authorization_error!
-  rescue EOFError, OpenSSL::SSL::SSLError => e
+  rescue EOFError, OpenSSL::SSL::SSLError, Net::IMAP::NoResponseError => e
     Rails.logger.error e
   rescue StandardError => e
     ChatwootExceptionTracker.new(e, account: channel.account).capture_exception

--- a/app/jobs/inboxes/fetch_imap_emails_job.rb
+++ b/app/jobs/inboxes/fetch_imap_emails_job.rb
@@ -8,7 +8,7 @@ class Inboxes::FetchImapEmailsJob < ApplicationJob
 
     process_email_for_channel(channel)
   rescue *ExceptionList::IMAP_EXCEPTIONS => e
-    ChatwootExceptionTracker.new(e, account: channel.account).capture_exception
+    Rails.logger.error e
     channel.authorization_error!
   rescue EOFError, OpenSSL::SSL::SSLError, Net::IMAP::NoResponseError => e
     Rails.logger.error e

--- a/lib/exception_list.rb
+++ b/lib/exception_list.rb
@@ -12,7 +12,7 @@ module ExceptionList
   ].freeze
 
   IMAP_EXCEPTIONS = [
-    Errno::ECONNREFUSED, Net::OpenTimeout, Net::IMAP::NoResponseError,
+    Errno::ECONNREFUSED, Net::OpenTimeout,
     Errno::ECONNRESET, Errno::ENETUNREACH, Net::IMAP::ByeResponseError,
     SocketError
   ].freeze


### PR DESCRIPTION
Reference: https://app.chatwoot.com/app/accounts/1/conversations/23909

We discovered that Google throws this error while fetching the email as a warning that you are giving access to the app[chatwoot], which does not implement the 2-factor authentication.

This seems to be issue with Gmail server: [https://answers.microsoft.com/en-us/outlook_com/forum/all/imap-too-many-simultaneous-connections/9e0c2393-d7a8-4433-adb2-4a72ff80ed66\](https://answers.microsoft.com/en-us/outlook_com/forum/all/imap-too-many-simultaneous-connections/9e0c2393-d7a8-4433-adb2-4a72ff80ed66%5C)

We will be removing this warning from our side, for now.