### PR TITLE
feat(perf): contacts query performance

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -19,6 +19,7 @@
 #  index_contacts_on_account_id                          (account_id)
 #  index_contacts_on_lower_email_account_id              (lower((email)::text), account_id)
 #  index_contacts_on_name_email_phone_number_identifier  (name,email,phone_number,identifier) USING gin
+#  index_contacts_on_nonempty_fields                     (account_id,email,phone_number,identifier) WHERE (((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))
 #  index_contacts_on_phone_number_and_account_id         (phone_number,account_id)
 #  uniq_email_per_account_contact                        (email,account_id) UNIQUE
 #  uniq_identifier_per_account_contact                   (identifier,account_id) UNIQUE

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -19,7 +19,7 @@
 #  index_contacts_on_account_id                          (account_id)
 #  index_contacts_on_lower_email_account_id              (lower((email)::text), account_id)
 #  index_contacts_on_name_email_phone_number_identifier  (name,email,phone_number,identifier) USING gin
-#  index_contacts_on_nonempty_fields                     (account_id,email,phone_number,identifier) WHERE (((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))
+#  index_contacts_on_identifiable_fields                 (account_id,email,phone_number,identifier) WHERE (((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text)) # rubocop:disable Layout/LineLength
 #  index_contacts_on_phone_number_and_account_id         (phone_number,account_id)
 #  uniq_email_per_account_contact                        (email,account_id) UNIQUE
 #  uniq_identifier_per_account_contact                   (identifier,account_id) UNIQUE

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -136,7 +136,7 @@ class Contact < ApplicationRecord
   end
 
   def self.resolved_contacts
-    where("COALESCE(NULLIF(contacts.email,''),NULLIF(contacts.phone_number,''),NULLIF(contacts.identifier,'')) IS NOT NULL")
+    where("contacts.email <> '' OR contacts.phone_number <> '' OR contacts.identifier <> ''")
   end
 
   def discard_invalid_attrs

--- a/db/migrate/20230523104139_add_partial_index_for_resolved_contacts.rb
+++ b/db/migrate/20230523104139_add_partial_index_for_resolved_contacts.rb
@@ -1,0 +1,8 @@
+class AddPartialIndexForResolvedContacts < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :contacts, [:account_id, :email, :phone_number, :identifier], where: "(email <> '' OR phone_number <> '' OR identifier <> '')",
+                                                                            name: 'index_contacts_on_nonempty_fields', algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_15_051424) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_23_104139) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -405,6 +405,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_051424) do
     t.jsonb "custom_attributes", default: {}
     t.datetime "last_activity_at", precision: nil
     t.index "lower((email)::text), account_id", name: "index_contacts_on_lower_email_account_id"
+    t.index ["account_id", "email", "phone_number", "identifier"], name: "index_contacts_on_nonempty_fields", where: "(((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))"
     t.index ["account_id"], name: "index_contacts_on_account_id"
     t.index ["email", "account_id"], name: "uniq_email_per_account_contact", unique: true
     t.index ["identifier", "account_id"], name: "uniq_identifier_per_account_contact", unique: true


### PR DESCRIPTION
This PR adds a [partial index](https://www.postgresql.org/docs/current/indexes-partial.html) to the `contacts` table, based on conditions for `resolved_contacts`, i.e. It should have one value, either phone number, email or identifier.  The partial index shaves off about 90% of the execution time, this should speed up other queries as well

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This is tested on ChatwootQA instance, it has enough contacts that the count query hangs up the database. 

|               | Execution Time | Explain                                          | Notes                                                           |
|---------------|----------------|--------------------------------------------------|-----------------------------------------------------------------|
| Baseline      | 16.4s          | https://explain.dalibo.com/plan/6c3ce73g4c1e4b4b | base line with no extra indexes                                 |
| Regular Index | 6s             | https://explain.dalibo.com/plan/64274497gdc6ad79 | Regular index on account_id, email, phone number and identifier |
| Partial Index | 1.2s           | https://explain.dalibo.com/plan/66f5gfea8c4g5f9g | Partial index on non-empty fields                               |

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
