### PR TITLE
fix: Enable `ogg` audio format for API channel

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -501,7 +501,7 @@ export default {
       return `draft-${this.conversationIdByRoute}-${this.replyType}`;
     },
     audioRecordFormat() {
-      if (this.isAWhatsAppChannel) {
+      if (this.isAWhatsAppChannel || this.isAPIInbox) {
         return AUDIO_FORMATS.OGG;
       }
       return AUDIO_FORMATS.WAV;


### PR DESCRIPTION
Fixes https://github.com/chatwoot/chatwoot/issues/7048 and https://linear.app/chatwoot/issue/CW-1837/problems-sending-audios-by-whatsapp