### PR TITLE
chore: Show chatwoot_edition in Instance details

### DIFF
--- a/app/controllers/super_admin/instance_statuses_controller.rb
+++ b/app/controllers/super_admin/instance_statuses_controller.rb
@@ -5,6 +5,17 @@ class SuperAdmin::InstanceStatusesController < SuperAdmin::ApplicationController
     sha
     postgres_status
     redis_metrics
+    chatwoot_edition
+  end
+
+  def chatwoot_edition
+    @metrics['Chatwoot edition'] = if ChatwootApp.enterprise?
+                                     'Enterprise'
+                                   elsif ChatwootApp.custom?
+                                     'Custom'
+                                   else
+                                     'Community'
+                                   end
   end
 
   def chatwoot_version


### PR DESCRIPTION
To check the edition anytime in admin dashboard, Showing as below:

<img width="1175" alt="image" src="https://github.com/chatwoot/chatwoot/assets/10057052/a9a5fc67-24b0-423c-b4c6-2ba0d30967d0">
