### PR TITLE
fix: Quote database env variables

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -8,21 +8,21 @@ default: &default
   variables:
     # we are setting this value to be close to the racktimeout value. we will iterate and reduce this value going forward
     statement_timeout: <%= ENV["POSTGRES_STATEMENT_TIMEOUT"] || "14s" %>
-    
+
 development:
   <<: *default
-  database: <%= ENV.fetch('POSTGRES_DATABASE', 'chatwoot_dev') %>
-  username: <%= ENV.fetch('POSTGRES_USERNAME', 'postgres') %>
-  password: <%= ENV.fetch('POSTGRES_PASSWORD', '') %>
+  database: "<%= ENV.fetch('POSTGRES_DATABASE', 'chatwoot_dev') %>"
+  username: "<%= ENV.fetch('POSTGRES_USERNAME', 'postgres') %>"
+  password: "<%= ENV.fetch('POSTGRES_PASSWORD', '') %>"
 
 test:
   <<: *default
-  database: <%= ENV.fetch('POSTGRES_DATABASE', 'chatwoot_test') %>
-  username: <%= ENV.fetch('POSTGRES_USERNAME', 'postgres') %>
-  password: <%= ENV.fetch('POSTGRES_PASSWORD', '') %>
+  database: "<%= ENV.fetch('POSTGRES_DATABASE', 'chatwoot_test') %>"
+  username: "<%= ENV.fetch('POSTGRES_USERNAME', 'postgres') %>"
+  password: "<%= ENV.fetch('POSTGRES_PASSWORD', '') %>"
 
 production:
   <<: *default
-  database: <%= ENV.fetch('POSTGRES_DATABASE', 'chatwoot_production') %>
-  username: <%= ENV.fetch('POSTGRES_USERNAME', 'chatwoot_prod') %>
-  password: <%= ENV.fetch('POSTGRES_PASSWORD', 'chatwoot_prod') %>
+  database: "<%= ENV.fetch('POSTGRES_DATABASE', 'chatwoot_production') %>"
+  username: "<%= ENV.fetch('POSTGRES_USERNAME', 'chatwoot_prod') %>"
+  password: "<%= ENV.fetch('POSTGRES_PASSWORD', 'chatwoot_prod') %>"


### PR DESCRIPTION
## Description

Database credentials, passwords in particular, can easily contain characters that are reserved in YAML and must be quoted. In our case a password started with ']'.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The CI build on GitHub passes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
