### PR TITLE
feat(perf): update query to reduce N+1 impact [CW-1926]

### DIFF
--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -155,9 +155,9 @@ class ConversationFinder
   end
 
   def conversations
-    @conversations = @conversations.includes(
-      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox
-    )
+    @conversations = @conversations.includes(:taggings, { inbox: [:channel] },
+                                             { assignee: [{ account_users: [:account] }, { avatar_attachment: [:blob] }] },
+                                             { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox, { messages: [:sender] })
     sort_by = SORT_OPTIONS[params[:sort_by]] || SORT_OPTIONS['latest']
     @conversations.send(sort_by).page(current_page)
   end

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -155,7 +155,7 @@ class ConversationFinder
   end
 
   def conversations
-    @conversations = @conversations.includes(:taggings, { inbox: [:channel] },
+    @conversations = @conversations.includes(:taggings, :inbox,
                                              { assignee: [{ account_users: [:account] }, { avatar_attachment: [:blob] }] },
                                              { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox, { messages: [:sender] })
     sort_by = SORT_OPTIONS[params[:sort_by]] || SORT_OPTIONS['latest']

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -157,7 +157,7 @@ class ConversationFinder
   def conversations
     @conversations = @conversations.includes(:taggings, :inbox,
                                              { assignee: [{ account_users: [:account] }, { avatar_attachment: [:blob] }] },
-                                             { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox, { messages: [:sender] })
+                                             { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox, :messages)
     sort_by = SORT_OPTIONS[params[:sort_by]] || SORT_OPTIONS['latest']
     @conversations.send(sort_by).page(current_page)
   end

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -22,7 +22,7 @@ if conversation.messages.first.blank?
 elsif conversation.unread_incoming_messages.count.zero?
   json.messages [conversation.messages.includes([{ attachments: [{ file_attachment: [:blob] }] }]).last.try(:push_event_data)]
 else
-  json.messages conversation.unread_messages.includes([:user, { attachments: [{ file_attachment: [:blob] }] }]).last(10).map(&:push_event_data)
+  json.messages conversation.unread_messages.includes([{ attachments: [{ file_attachment: [:blob] }] }]).last(10).map(&:push_event_data)
 end
 
 json.account_id conversation.account_id

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe 'Conversations API', type: :request do
             as: :json
 
         expect(response).to have_http_status(:success)
+
         response_data = JSON.parse(response.body, symbolize_names: true)
         expect(response_data[:meta][:all_count]).to eq(1)
         expect(response_data[:payload].first[:messages].first[:content]).to eq 'test1'

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -120,7 +120,6 @@ RSpec.describe 'Conversations API', type: :request do
             as: :json
 
         expect(response).to have_http_status(:success)
-
         response_data = JSON.parse(response.body, symbolize_names: true)
         expect(response_data[:meta][:all_count]).to eq(1)
         expect(response_data[:payload].first[:messages].first[:content]).to eq 'test1'


### PR DESCRIPTION
This PR reduces the impact on N+1 queries in the conversation list view. Reduces the number of queries while rendering the template by about 15%

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### After Fix

![CleanShot 2023-06-01 at 12 11 57@2x](https://github.com/chatwoot/chatwoot/assets/18097732/d525300b-590b-4a2d-ba2d-4827d335f408)

### Before Fix

![CleanShot 2023-05-31 at 17 56 34@2x](https://github.com/chatwoot/chatwoot/assets/18097732/35118e67-4114-4451-b062-19209750724b)

