### PR TITLE
chore: Increase character limit for external url fields

### DIFF
--- a/app/models/agent_bot.rb
+++ b/app/models/agent_bot.rb
@@ -28,6 +28,7 @@ class AgentBot < ApplicationRecord
   enum bot_type: { webhook: 0, csml: 1 }
 
   validate :validate_agent_bot_config
+  validates :outgoing_url, length: { maximum: Limits::URL_LENGTH_LIMIT }
 
   def available_name
     name

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -37,7 +37,7 @@ class Attachment < ApplicationRecord
   belongs_to :message
   has_one_attached :file
   validate :acceptable_file
-  validates :external_url, length: { maximum: 1000 }
+  validates :external_url, length: { maximum: Limits::URL_LENGTH_LIMIT }
   enum file_type: [:image, :audio, :video, :file, :location, :fallback, :share, :story_mention, :contact]
 
   def push_event_data

--- a/app/models/channel/api.rb
+++ b/app/models/channel/api.rb
@@ -27,6 +27,7 @@ class Channel::Api < ApplicationRecord
   has_secure_token :identifier
   has_secure_token :hmac_token
   validate :ensure_valid_agent_reply_time_window
+  validates :webhook_url, length: { maximum: Limits::URL_LENGTH_LIMIT }
 
   def name
     'API'

--- a/lib/limits.rb
+++ b/lib/limits.rb
@@ -1,4 +1,5 @@
 module Limits
   BULK_ACTIONS_LIMIT = 100
   BULK_EXTERNAL_HTTP_CALLS_LIMIT = 25
+  URL_LENGTH_LIMIT = 2048 # https://stackoverflow.com/questions/417142
 end

--- a/spec/models/agent_bot_spec.rb
+++ b/spec/models/agent_bot_spec.rb
@@ -12,4 +12,19 @@ RSpec.describe AgentBot do
     it_behaves_like 'access_tokenable'
     it_behaves_like 'avatarable'
   end
+
+  context 'when it validates outgoing_url length' do
+    let(:agent_bot) { create(:agent_bot) }
+
+    it 'valid when within limit' do
+      agent_bot.outgoing_url = 'a' * Limits::URL_LENGTH_LIMIT
+      expect(agent_bot.valid?).to be true
+    end
+
+    it 'invalid when crossed the limit' do
+      agent_bot.outgoing_url = 'a' * (Limits::URL_LENGTH_LIMIT + 1)
+      agent_bot.valid?
+      expect(agent_bot.errors[:outgoing_url]).to include("is too long (maximum is #{Limits::URL_LENGTH_LIMIT} characters)")
+    end
+  end
 end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Attachment do
 
     context 'when it validates external url length' do
       it 'valid when within limit' do
-        attachment.external_url = 'a' * 1000
+        attachment.external_url = 'a' * Limits::URL_LENGTH_LIMIT
         expect(attachment.valid?).to be true
       end
 
       it 'invalid when crossed the limit' do
-        attachment.external_url = 'a' * 1500
+        attachment.external_url = 'a' * (Limits::URL_LENGTH_LIMIT + 5)
         attachment.valid?
-        expect(attachment.errors[:external_url]).to include('is too long (maximum is 1000 characters)')
+        expect(attachment.errors[:external_url]).to include("is too long (maximum is #{Limits::URL_LENGTH_LIMIT} characters)")
       end
     end
   end

--- a/spec/models/channel/api_spec.rb
+++ b/spec/models/channel/api_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Channel::Api do
+  # This validation happens in ApplicationRecord
+  describe 'length validations' do
+    let(:channel_api) { create(:channel_api) }
+
+    context 'when it validates webhook_url length' do
+      it 'valid when within limit' do
+        channel_api.webhook_url = 'a' * Limits::URL_LENGTH_LIMIT
+        expect(channel_api.valid?).to be true
+      end
+
+      it 'invalid when crossed the limit' do
+        channel_api.webhook_url = 'a' * (Limits::URL_LENGTH_LIMIT + 1)
+        channel_api.valid?
+        expect(channel_api.errors[:webhook_url]).to include("is too long (maximum is #{Limits::URL_LENGTH_LIMIT} characters)")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Increase the external URL field validation to 2048 characters

fixes: https://github.com/chatwoot/chatwoot/issues/7098

