### PR TITLE
fix: check content disposition, for inline messages in mail

### DIFF
--- a/app/mailboxes/mailbox_helper.rb
+++ b/app/mailboxes/mailbox_helper.rb
@@ -24,13 +24,45 @@ module MailboxHelper
     return if @message.blank?
 
     processed_mail.attachments.last(Message::NUMBER_OF_PERMITTED_ATTACHMENTS).each do |mail_attachment|
-      attachment = @message.attachments.new(
-        account_id: @conversation.account_id,
-        file_type: 'file'
-      )
-      attachment.file.attach(mail_attachment[:blob])
+      if inline_attachment?(mail_attachment) && @mail.html_part.present?
+        upload_inline_image(mail_attachment)
+      elsif inline_attachment?(mail_attachment) && @mail.text_part.present?
+        embed_plain_text_email_with_inline_image(mail_attachment)
+      else
+        attachment = @message.attachments.new(
+          account_id: @conversation.account_id,
+          file_type: 'file'
+        )
+        attachment.file.attach(mail_attachment[:blob])
+      end
     end
     @message.save!
+  end
+
+  def upload_inline_image(mail_attachment)
+    content_id = mail_attachment[:original].cid
+
+    @message.content_attributes[:email][:html_content][:full] = processed_mail.serialized_data[:html_content][:full].gsub(
+      "cid:#{content_id}", inline_image_url(mail_attachment[:blob]).to_s
+    )
+    @message.save!
+  end
+
+  def inline_attachment?(mail_attachment)
+    mail_attachment[:original].inline?
+  end
+
+  def embed_plain_text_email_with_inline_image(mail_attachment)
+    attachment_name = mail_attachment[:original].filename
+
+    @message.content_attributes[:email][:text_content][:full] = processed_mail.serialized_data[:text_content][:reply].gsub(
+      "[image: #{attachment_name}]", "<img src=\"#{inline_image_url(mail_attachment[:blob])}\" alt=\"#{attachment_name}>\""
+    )
+    @message.save!
+  end
+
+  def inline_image_url(blob)
+    Rails.application.routes.url_helpers.url_for(blob)
   end
 
   def create_contact

--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -70,6 +70,8 @@ class MailPresenter < SimpleDelegator
     }
   end
 
+  # check content disposition check
+  # if inline, upload to AWS and and take the URL
   def attachments
     # ref : https://github.com/gorails-screencasts/action-mailbox-action-text/blob/master/app/mailboxes/posts_mailbox.rb
     mail.attachments.map do |attachment|

--- a/spec/fixtures/files/forwarder_email.eml
+++ b/spec/fixtures/files/forwarder_email.eml
@@ -25,7 +25,7 @@ Content-Type: multipart/related;
 
 --Apple-Mail=_83444AF4-343C-4F75-AF8F-14E1E7434FC1
 Content-Transfer-Encoding: base64
-Content-Disposition: inline;
+Content-Disposition: attachment;
   filename=avatar1.jpeg
 Content-Type: image/jpg;
   name="avatar1.jpeg"
@@ -395,7 +395,7 @@ mk8VWW5WRGJGAOaAP//Z
 
 --Apple-Mail=_83444AF4-343C-4F75-AF8F-14E1E7434FC1
 Content-Transfer-Encoding: base64
-Content-Disposition: inline;
+Content-Disposition: attachment;
   filename=avatar2.jpg
 Content-Type: image/jpg;
   x-unix-mode=0700;

--- a/spec/fixtures/files/in_reply_to.eml
+++ b/spec/fixtures/files/in_reply_to.eml
@@ -24,7 +24,7 @@ Content-Type: multipart/related;
 
 --Apple-Mail=_83444AF4-343C-4F75-AF8F-14E1E7434FC1
 Content-Transfer-Encoding: base64
-Content-Disposition: inline;
+Content-Disposition: attachment;
   filename=avatar1.jpeg
 Content-Type: image/jpg;
   name="avatar1.jpeg"
@@ -394,7 +394,7 @@ mk8VWW5WRGJGAOaAP//Z
 
 --Apple-Mail=_83444AF4-343C-4F75-AF8F-14E1E7434FC1
 Content-Transfer-Encoding: base64
-Content-Disposition: inline;
+Content-Disposition: attachment;
   filename=avatar2.jpg
 Content-Type: image/jpg;
   x-unix-mode=0700;

--- a/spec/fixtures/files/mail_with_inline_images.eml
+++ b/spec/fixtures/files/mail_with_inline_images.eml
@@ -1,0 +1,47 @@
+MIME-Version: 1.0
+Date: Wed, 31 May 2023 15:27:36 +0530
+Message-ID: <CAFkiBVzURp=z2g5nAevAtdQvFfxkLrpvTeDFcwFaGQhdo_-Mkg@mail.gmail.com>
+Subject: New inline image test email conversation
+From: Sony Mathew <sony@chatwoot.com>
+To: "Replies" <reply+6bdc3f4d-0bed-4515-a284-5d916fdde489@example.com>
+Content-Type: multipart/related; boundary="0000000000007a538405fcfa5967"
+
+--0000000000007a538405fcfa5967
+Content-Type: multipart/alternative; boundary="0000000000007a538205fcfa5966"
+
+--0000000000007a538205fcfa5966
+Content-Type: text/plain; charset="UTF-8"
+
+[image: ptrol.jpeg]
+
+HTML content and inline images
+
+--
+*Tejaswini Chile.*
+Software developer
+*Mob:8485827731 | *@tejaswini_chile <https://twitter.com/tejaswini_chile>
+
+--0000000000007a538205fcfa5966
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+<div dir=3D"ltr"><img src=3D"cid:ii_libj9tsr0" alt=3D"ptrol.jpeg" width=3D"=
+286" height=3D"508"><div><br></div><div>Let&#39;s add no HTML content here,=
+ just plain text and images<br><div><br></div><span class=3D"gmail_signatur=
+e_prefix">-- </span><br><div dir=3D"ltr" class=3D"gmail_signature" data-sma=
+rtmail=3D"gmail_signature"><div dir=3D"ltr"><div><div dir=3D"ltr"><div><div=
+><b>Tejaswini Chile.</b><br></div><span style=3D"font-family:times new roma=
+n,serif"><span></span><span></span>Software developer</span><br></div><b>Mo=
+b:8485827731 |=C2=A0</b><a href=3D"https://twitter.com/tejaswini_chile" tar=
+get=3D"_blank">@tejaswini_chile</a></div></div></div></div></div></div>
+
+--0000000000007a538205fcfa5966--
+--0000000000007a538405fcfa5967
+Content-Type: image/jpeg; name="ptrol.jpeg"
+Content-Disposition: inline; filename="ptrol.jpeg"
+Content-Transfer-Encoding: base64
+X-Attachment-Id: ii_libj9tsr0
+Content-ID: <ii_libj9tsr0>
+
+
+--0000000000007a538405fcfa5967--

--- a/spec/fixtures/files/mail_with_plain_text_and_inline_image.eml
+++ b/spec/fixtures/files/mail_with_plain_text_and_inline_image.eml
@@ -1,0 +1,33 @@
+MIME-Version: 1.0
+Date: Wed, 31 May 2023 15:27:36 +0530
+Message-ID: <CAFkiBVzURp=z2g5nAevAtdQvFfxkLrpvTeDFcwFaGQhdo_-Mkg@mail.gmail.com>
+Subject: New inline image test email conversation
+From: Sony Mathew <sony@chatwoot.com>
+To: "Replies" <reply+6bdc3f4d-0bed-4515-a284-5d916fdde489@example.com>
+Content-Type: multipart/related; boundary="0000000000007a538405fcfa5967"
+
+--0000000000007a538405fcfa5967
+Content-Type: multipart/alternative; boundary="0000000000007a538205fcfa5966"
+
+--0000000000007a538205fcfa5966
+Content-Type: text/plain; charset="UTF-8"
+
+[image: ptrol.jpeg]
+
+Let's add no HTML content here, just plain text and images
+
+--
+*Tejaswini Chile.*
+Software developer
+*Mob:8485827731 | *@tejaswini_chile <https://twitter.com/tejaswini_chile>
+
+
+--0000000000007a538405fcfa5967
+Content-Type: image/jpeg; name="ptrol.jpeg"
+Content-Disposition: inline; filename="ptrol.jpeg"
+Content-Transfer-Encoding: base64
+X-Attachment-Id: ii_libj9tsr0
+Content-ID: <ii_libj9tsr0>
+
+
+--0000000000007a538405fcfa5967--

--- a/spec/fixtures/files/reply.eml
+++ b/spec/fixtures/files/reply.eml
@@ -25,7 +25,7 @@ Content-Type: multipart/related;
 
 --Apple-Mail=_83444AF4-343C-4F75-AF8F-14E1E7434FC1
 Content-Transfer-Encoding: base64
-Content-Disposition: inline;
+Content-Disposition: attachment;
   filename=avatar1.jpeg
 Content-Type: image/jpg;
   name="avatar1.jpeg"
@@ -395,7 +395,7 @@ mk8VWW5WRGJGAOaAP//Z
 
 --Apple-Mail=_83444AF4-343C-4F75-AF8F-14E1E7434FC1
 Content-Transfer-Encoding: base64
-Content-Disposition: inline;
+Content-Disposition: attachment;
   filename=avatar2.jpg
 Content-Type: image/jpg;
   x-unix-mode=0700;

--- a/spec/fixtures/files/reply_mail_without_uuid.eml
+++ b/spec/fixtures/files/reply_mail_without_uuid.eml
@@ -25,7 +25,7 @@ Content-Type: multipart/related;
 
 --Apple-Mail=_83444AF4-343C-4F75-AF8F-14E1E7434FC1
 Content-Transfer-Encoding: base64
-Content-Disposition: inline;
+Content-Disposition: attachment;
   filename=avatar1.jpeg
 Content-Type: image/jpg;
   name="avatar1.jpeg"
@@ -395,7 +395,7 @@ mk8VWW5WRGJGAOaAP//Z
 
 --Apple-Mail=_83444AF4-343C-4F75-AF8F-14E1E7434FC1
 Content-Transfer-Encoding: base64
-Content-Disposition: inline;
+Content-Disposition: attachment;
   filename=avatar2.jpg
 Content-Type: image/jpg;
   x-unix-mode=0700;

--- a/spec/fixtures/files/reply_to.eml
+++ b/spec/fixtures/files/reply_to.eml
@@ -26,7 +26,7 @@ Content-Type: multipart/related;
 
 --Apple-Mail=_83444AF4-343C-4F75-AF8F-14E1E7434FC1
 Content-Transfer-Encoding: base64
-Content-Disposition: inline;
+Content-Disposition: attachment;
   filename=avatar1.jpeg
 Content-Type: image/jpg;
   name="avatar1.jpeg"
@@ -396,7 +396,7 @@ mk8VWW5WRGJGAOaAP//Z
 
 --Apple-Mail=_83444AF4-343C-4F75-AF8F-14E1E7434FC1
 Content-Transfer-Encoding: base64
-Content-Disposition: inline;
+Content-Disposition: attachment;
   filename=avatar2.jpg
 Content-Type: image/jpg;
   x-unix-mode=0700;

--- a/spec/mailboxes/reply_mailbox_spec.rb
+++ b/spec/mailboxes/reply_mailbox_spec.rb
@@ -62,7 +62,51 @@ RSpec.describe ReplyMailbox do
 
       it 'find channel with in-reply-to mail' do
         described_subject
-        expect(conversation_1.messages.last.content).to eq("Let's talk about these images:")
+        expect(conversation_1.messages.last.content).to include("Let's talk about these images:")
+      end
+    end
+
+    context 'with inline attachments' do
+      let(:mail_with_inline_images) { create_inbound_email_from_fixture('mail_with_inline_images.eml') }
+      let(:described_subject) { described_class.receive mail_with_inline_images }
+
+      before do
+        conversation.uuid = '6bdc3f4d-0bed-4515-a284-5d916fdde489'
+        conversation.save!
+
+        described_subject
+      end
+
+      it 'mail content contains img source' do
+        expect(conversation.messages.last.content).to include('HTML content and inline images')
+      end
+
+      it 'will not add the attachments' do
+        expect(conversation.messages.last.attachments.count).to eq(0)
+
+        html_full_content = conversation.messages.last.content_attributes[:email][:html_content][:full]
+        expect(html_full_content).to include('img')
+      end
+    end
+
+    context 'with inline attachments and plain text' do
+      let(:mail_with_plain_text_and_inline_image) { create_inbound_email_from_fixture('mail_with_plain_text_and_inline_image.eml') }
+      let(:described_subject) { described_class.receive mail_with_plain_text_and_inline_image }
+
+      before do
+        conversation.uuid = '6bdc3f4d-0bed-4515-a284-5d916fdde489'
+        conversation.save!
+
+        described_subject
+      end
+
+      it 'will not add the attachments' do
+        described_class.receive mail_with_plain_text_and_inline_image
+        text_full_content = conversation.messages.last.content_attributes[:email][:text_content][:full]
+
+        expect(text_full_content).to include('img')
+        expect(conversation.messages.last.content).to include("Let's add no HTML content here, just plain text and images")
+        expect(conversation.messages.last.attachments.count).to eq(0)
       end
     end
 


### PR DESCRIPTION
Fixes: https://linear.app/chatwoot/issue/CW-1718/chore-inline-images-are-shown-as-attachments-in-email-channel