### PR TITLE
fix: Wrap references string into array

### DIFF
--- a/app/mailboxes/imap/imap_mailbox.rb
+++ b/app/mailboxes/imap/imap_mailbox.rb
@@ -54,7 +54,7 @@ class Imap::ImapMailbox
 
     return if @inbound_mail.references.blank?
 
-    references = @inbound_mail.references
+    references = Array.wrap(@inbound_mail.references)
 
     references.each do |message_id|
       message = @inbox.messages.find_by(source_id: message_id)

--- a/spec/mailboxes/imap/imap_mailbox_spec.rb
+++ b/spec/mailboxes/imap/imap_mailbox_spec.rb
@@ -111,6 +111,29 @@ RSpec.describe Imap::ImapMailbox do
         expect(conversation.messages.last.content).to eq('References Email')
         expect(references_email.mail.references).to include('test-reference-id')
       end
+
+      it 'append email to conversation with reference id string' do
+        inbox = Inbox.last
+        message = create(
+          :message,
+          content: 'Incoming Message',
+          message_type: 'incoming',
+          inbox: inbox,
+          source_id: 'test-reference-id-2',
+          account: account,
+          conversation: conversation
+        )
+        conversation = message.conversation
+
+        expect(conversation.messages.size).to eq(1)
+
+        references_email.mail.references = 'test-reference-id-2'
+        class_instance.process(references_email.mail, inbox.channel)
+
+        expect(conversation.messages.size).to eq(2)
+        expect(conversation.messages.last.content).to eq('References Email')
+        expect(references_email.mail.references).to include('test-reference-id-2')
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes: https://linear.app/chatwoot/issue/CW-1996/nomethoderror-undefined-method-each-for