### PR TITLE
fix: around_action not yielding if params are absent

### DIFF
--- a/app/controllers/public/api/v1/portals/base_controller.rb
+++ b/app/controllers/public/api/v1/portals/base_controller.rb
@@ -6,6 +6,8 @@ class Public::Api::V1::Portals::BaseController < PublicController
   def set_locale(&)
     switch_locale_with_portal(&) if params[:locale].present?
     switch_locale_with_article(&) if params[:article_slug].present?
+
+    yield
   end
 
   def switch_locale_with_portal(&)


### PR DESCRIPTION
Fix missing yield. The redirect to the default locale page was not working.