### PR TITLE
chore: Ensure updating message_templates_last_updated column

### DIFF
--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -50,6 +50,12 @@ class Channel::Whatsapp < ApplicationRecord
     true
   end
 
+  def mark_message_templates_updated
+    # rubocop:disable Rails/SkipsModelValidations
+    update_column(:message_templates_last_updated, Time.zone.now)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
   delegate :send_message, to: :provider_service
   delegate :send_template, to: :provider_service
   delegate :sync_templates, to: :provider_service

--- a/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
@@ -22,9 +22,10 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
   end
 
   def sync_templates
+    # ensuring that channels with wrong provider config wouldn't keep trying to sync templates
+    whatsapp_channel.mark_message_templates_updated
     response = HTTParty.get("#{api_base_path}/configs/templates", headers: api_headers)
-    whatsapp_channel[:message_templates] = response['waba_templates'] if response.success?
-    whatsapp_channel.update(message_templates_last_updated: Time.now.utc)
+    whatsapp_channel.update(message_templates: response['waba_templates'], message_templates_last_updated: Time.now.utc) if response.success?
   end
 
   def validate_provider_config?

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -23,9 +23,10 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   end
 
   def sync_templates
+    # ensuring that channels with wrong provider config wouldn't keep trying to sync templates
+    whatsapp_channel.mark_message_templates_updated
     templates = fetch_whatsapp_templates("#{business_account_path}/message_templates?access_token=#{whatsapp_channel.provider_config['api_key']}")
-    whatsapp_channel[:message_templates] = templates if templates.present?
-    whatsapp_channel.update(message_templates_last_updated: Time.now.utc)
+    whatsapp_channel.update(message_templates: templates, message_templates_last_updated: Time.now.utc) if templates.present?
   end
 
   def fetch_whatsapp_templates(url)


### PR DESCRIPTION
Fix for the cases where there are multiple channels with invalid provider config, which results in templates sync scheduler failing to schedule jobs for valid channels.

fixes: https://linear.app/chatwoot/issue/CW-2032/bug-whatsapp-template-sync-failing-in-cloud