### PR TITLE
fix: Cannot read properties of undefined (reading 'some')

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -58,11 +58,10 @@ export const mutations = {
     }
   },
   [types.SET_ALL_ATTACHMENTS](_state, { id, data }) {
-    if (data.length) {
-      const [chat] = _state.allConversations.filter(c => c.id === id);
-      Vue.set(chat, 'attachments', []);
-      chat.attachments.push(...data);
-    }
+    const [chat] = _state.allConversations.filter(c => c.id === id);
+    if (!chat) return;
+    Vue.set(chat, 'attachments', []);
+    chat.attachments.push(...data);
   },
   [types.SET_MISSING_MESSAGES](_state, { id, data }) {
     const [chat] = _state.allConversations.filter(c => c.id === id);
@@ -134,11 +133,10 @@ export const mutations = {
 
     const isMessageSent =
       message.status === MESSAGE_STATUS.SENT && message.attachments;
-    const { attachments: chatAttachments = [] } = chat;
     if (isMessageSent) {
       message.attachments.forEach(attachment => {
-        if (!chatAttachments.some(a => a.id === attachment.id)) {
-          chatAttachments.push(attachment);
+        if (!chat.attachments.some(a => a.id === attachment.id)) {
+          chat.attachments.push(attachment);
         }
       });
     }

--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -134,10 +134,11 @@ export const mutations = {
 
     const isMessageSent =
       message.status === MESSAGE_STATUS.SENT && message.attachments;
+    const { attachments: chatAttachments = [] } = chat;
     if (isMessageSent) {
       message.attachments.forEach(attachment => {
-        if (!chat.attachments.some(a => a.id === attachment.id)) {
-          chat.attachments.push(attachment);
+        if (!chatAttachments.some(a => a.id === attachment.id)) {
+          chatAttachments.push(attachment);
         }
       });
     }

--- a/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
@@ -288,6 +288,14 @@ describe('#mutations', () => {
       mutations[types.SET_ALL_ATTACHMENTS](state, { id: 1, data });
       expect(state.allConversations[0].attachments).toEqual(data);
     });
+    it('set attachments key even if the attachments are empty', () => {
+      const state = {
+        allConversations: [{ id: 1 }],
+      };
+      const data = [];
+      mutations[types.SET_ALL_ATTACHMENTS](state, { id: 1, data });
+      expect(state.allConversations[0].attachments).toEqual([]);
+    });
   });
 
   describe('#ADD_CONVERSATION_ATTACHMENTS', () => {


### PR DESCRIPTION
Fix retry messages popping if there were no attachments previously.

<img width="420" alt="Screenshot 2023-06-08 at 7 50 26 PM" src="https://github.com/chatwoot/chatwoot/assets/2246121/f2ddf31e-130d-4a4b-9f66-8c34cd93a2b6">

Fixes https://linear.app/chatwoot/issue/CW-2041/typeerror-cannot-read-properties-of-undefined-reading-some
Fixes https://linear.app/chatwoot/issue/CW-2042/typeerror-cannot-read-properties-of-undefined-reading-filter
