### PR TITLE
feat: update cache headers for cache_keys

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def cache_keys
-    expires_in 10.seconds, public: false, stale_while_revalidate: 5.minutes
+    expires_in 10.seconds, public: false, stale_while_revalidate: 15.minutes
     render json: { cache_keys: get_cache_keys }, status: :ok
   end
 

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def cache_keys
-    expires_in 1.minute, public: false
+    expires_in 10.seconds, public: false, stale_while_revalidate: 5.minutes
     render json: { cache_keys: get_cache_keys }, status: :ok
   end
 

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -37,6 +37,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def cache_keys
+    expires_in 1.minute, public: false
     render json: { cache_keys: get_cache_keys }, status: :ok
   end
 

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def cache_keys
-    expires_in 10.seconds, public: false, stale_while_revalidate: 15.minutes
+    expires_in 10.seconds, public: false, stale_while_revalidate: 5.minutes
     render json: { cache_keys: get_cache_keys }, status: :ok
   end
 

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -151,6 +151,18 @@ RSpec.describe 'Accounts API', type: :request do
       expect(response).to have_http_status(:success)
       expect(response.parsed_body['cache_keys'].keys).to match_array(%w[label inbox team])
     end
+
+    it 'sets the appropriate cache headers' do
+      account.update(auto_resolve_duration: 30)
+
+      get "/api/v1/accounts/#{account.id}/cache_keys",
+          headers: admin.create_new_auth_token,
+          as: :json
+
+      expect(response.headers['Cache-Control']).to include('max-age=10')
+      expect(response.headers['Cache-Control']).to include('private')
+      expect(response.headers['Cache-Control']).to include('stale-while-revalidate=300')
+    end
   end
 
   describe 'PUT /api/v1/accounts/{account.id}' do

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -153,8 +153,6 @@ RSpec.describe 'Accounts API', type: :request do
     end
 
     it 'sets the appropriate cache headers' do
-      account.update(auto_resolve_duration: 30)
-
       get "/api/v1/accounts/#{account.id}/cache_keys",
           headers: admin.create_new_auth_token,
           as: :json


### PR DESCRIPTION
Update the cache headers for `cache_keys` to `max-age=10, private, stale-while-revalidate=300`

1. The cache will be fresh for 10 seconds (max-age=10). During this time, the browser will use the cached version without checking with the server.
1. After the initial 10 seconds, the browser can continue to serve the stale cache for up to 5 minutes (stale-while-revalidate=300). During this period, it will also try to revalidate and update the cache in the background.
1. After 310 seconds in total (10 seconds fresh, 300 seconds stale), if the browser has not been able to revalidate the cache, it will attempt to fetch the fresh resource directly from the server for subsequent requests, causing potential latency equivalent to a network request.

This means that the data will directly be revalidated only every 5 mins. Other times, it will stay fresh for 10 seconds and revalidate in the background. In most cases, we won't have to rely on cache validation check because there is a websocket event for revalidation, so we know if something changes. 

Right now the `stale-while-revalidate` is 5 minutes, we can then move it to 15 minutes.

> The `stale-while-revalidate` header is not supported in Safari, for Safari the cache keys will only stay in memory for 10 seconds before being marked stale

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested locally, the cache revalidation works perfectly fine

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
