### PR TITLE
feat:  audit trail for team events

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/auditLogs.json
+++ b/app/javascript/dashboard/i18n/locale/en/auditLogs.json
@@ -38,6 +38,11 @@
     "USER_ACTION": {
       "SIGN_IN": "%{agentName} signed in",
       "SIGN_OUT": "%{agentName} signed out"
+    },
+    "TEAM": {
+      "ADD": "%{agentName} created a new team (#%{id})",
+      "EDIT": "%{agentName} updated a team (#%{id})",
+      "DELETE": "%{agentName} deleted a team (#%{id})"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale/en/auditLogs.json
+++ b/app/javascript/dashboard/i18n/locale/en/auditLogs.json
@@ -43,6 +43,6 @@
       "ADD": "%{agentName} created a new team (#%{id})",
       "EDIT": "%{agentName} updated a team (#%{id})",
       "DELETE": "%{agentName} deleted a team (#%{id})"
-    }
+  }
   }
 }

--- a/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
@@ -127,6 +127,9 @@ export default {
         'inbox:destroy': `AUDIT_LOGS.INBOX.DELETE`,
         'user:sign_in': `AUDIT_LOGS.USER_ACTION.SIGN_IN`,
         'user:sign_out': `AUDIT_LOGS.USER_ACTION.SIGN_OUT`,
+        'team:create': `AUDIT_LOGS.TEAM.ADD`,
+        'team:update': `AUDIT_LOGS.TEAM.EDIT`,
+        'team:destroy': `AUDIT_LOGS.TEAM.DELETE`,
       };
 
       return this.$t(translationKeys[logActionKey] || '', translationPayload);

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -54,3 +54,5 @@ class Team < ApplicationRecord
     }
   end
 end
+
+Team.include_mod_with('Audit::Team')

--- a/enterprise/app/models/enterprise/audit/team.rb
+++ b/enterprise/app/models/enterprise/audit/team.rb
@@ -1,0 +1,7 @@
+module Enterprise::Audit::Team
+  extend ActiveSupport::Concern
+
+  included do
+    audited associated_with: :account
+  end
+end

--- a/spec/enterprise/models/team_spec.rb
+++ b/spec/enterprise/models/team_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Team do
 
     context 'when team is updated' do
       it 'has associated audit log created' do
-        team.update(url: 'https://example.com')
+        team.update(description: 'awesome team')
         expect(Audited::Audit.where(auditable_type: 'Team', action: 'update').count).to eq 1
       end
     end

--- a/spec/enterprise/models/team_spec.rb
+++ b/spec/enterprise/models/team_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Team do
+  let(:account) { create(:account) }
+  let!(:team) { create(:team, account: account) }
+
+  describe 'audit log' do
+    context 'when team is created' do
+      it 'has associated audit log created' do
+        expect(Audited::Audit.where(auditable_type: 'Team', action: 'create').count).to eq 1
+      end
+    end
+
+    context 'when team is updated' do
+      it 'has associated audit log created' do
+        team.update(url: 'https://example.com')
+        expect(Audited::Audit.where(auditable_type: 'Team', action: 'update').count).to eq 1
+      end
+    end
+
+    context 'when team is deleted' do
+      it 'has associated audit log created' do
+        team.destroy!
+        expect(Audited::Audit.where(auditable_type: 'Team', action: 'destroy').count).to eq 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Template

## Description

- Adds audit trail for team events 

Fixes https://linear.app/chatwoot/issue/CW-1771/team-changes-as-events-for-audit-logs

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Tested locally.
- Added specs


![image](https://github.com/chatwoot/chatwoot/assets/3526167/d64a7f77-f7eb-404a-8b1a-4e08bf323541)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
