### PR TITLE
fix: calculation for resolution count

### DIFF
--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -29,7 +29,8 @@ module ReportHelper
   end
 
   def resolutions_count
-    (get_grouped_values scope.conversations.where(account_id: account.id).resolved).count
+    object_scope = scope.reporting_events.select(:conversation_id).where(account_id: account.id, name: :conversation_resolved).distinct
+    (get_grouped_values object_scope).count
   end
 
   def avg_first_response_time

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -29,7 +29,8 @@ module ReportHelper
   end
 
   def resolutions_count
-    object_scope = scope.reporting_events.select(:conversation_id).where(account_id: account.id, name: :conversation_resolved).distinct
+    object_scope = scope.reporting_events.joins(:conversation).select(:conversation_id).where(account_id: account.id, name: :conversation_resolved,
+                                                                                              conversations: { status: :resolved }).distinct
     (get_grouped_values object_scope).count
   end
 

--- a/spec/builders/v2/report_builder_spec.rb
+++ b/spec/builders/v2/report_builder_spec.rb
@@ -111,7 +111,7 @@ describe V2::ReportBuilder do
           conversations.each(&:resolved!)
 
           # Reopen 1 conversation
-          conversation.first.open!
+          conversations.first.open!
         end
 
         builder = described_class.new(account, params)

--- a/spec/builders/v2/report_builder_spec.rb
+++ b/spec/builders/v2/report_builder_spec.rb
@@ -106,12 +106,15 @@ describe V2::ReportBuilder do
         }
 
         conversations = account.conversations.where('created_at < ?', 1.day.ago)
-        conversations.each(&:resolved!)
+        perform_enqueued_jobs do
+          conversations.each(&:resolved!)
+        end
+
         builder = described_class.new(account, params)
         metrics = builder.timeseries
 
-        expect(metrics[Time.zone.today]).to be 0
-        expect(metrics[Time.zone.today - 2.days]).to be 5
+        expect(metrics[Time.zone.today]).to be 5
+        expect(metrics[Time.zone.today - 2.days]).to be 0
       end
 
       it 'returns average first response time' do
@@ -216,11 +219,16 @@ describe V2::ReportBuilder do
         }
 
         conversations = account.conversations.where('created_at < ?', 1.day.ago)
-        conversations.each(&:resolved!)
+
+        perform_enqueued_jobs do
+          conversations.each(&:resolved!)
+        end
+
         builder = described_class.new(account, params)
         metrics = builder.timeseries
 
-        expect(metrics[Time.zone.today - 2.days]).to be 5
+        expect(metrics[Time.zone.today]).to be 5
+        expect(metrics[Time.zone.today - 2.days]).to be 0
       end
 
       it 'returns average first response time' do


### PR DESCRIPTION
The current method that gets the resolved conversation count is the following, along with it's SQL query

```rb
def resolutions_count
  (get_grouped_values scope.conversations.where(account_id: account.id).resolved).count
end
```

<details>
<summary>Resultant Query</summary>

```sql
SELECT 
  COUNT(*) AS "count_all", 
  DATE_TRUNC(
    'day', "conversations"."created_at" :: timestamptz AT TIME ZONE 'Asia/Kolkata'
  ):: date AS "date_trunc_day_conversations_created_at_timestamptz_at_time_zon" 
FROM 
  "conversations" 
WHERE 
  "conversations"."account_id" = $1 
  AND "conversations"."account_id" = $2 
  AND "conversations"."status" = $3 
  AND (
    "conversations"."created_at" >= '2023-06-05 18:30:00' 
    AND "conversations"."created_at" < '2023-06-12 18:29:59'
  ) 
GROUP BY 
  DATE_TRUNC(
    'day', "conversations"."created_at" :: timestamptz AT TIME ZONE 'Asia/Kolkata'
  ):: date;
```

</details>

The problem is that it ranges with conversation created, so only the conversation created during that time period and resolved in that time period will show up

The solution in this PR is to rely on reporting events. We get a list of **distinct** `conversation_id` for all events named `conversation_resolved` (from the `reporting_events` table), scoped by current account and filtered to ensure that the conversation is currently actually resolved: 

```rb
def resolutions_count
  object_scope = scope.reporting_events
                      .joins(:conversation).select(:conversation_id)
                      .where(account_id: account.id, name: :conversation_resolved, conversations: { status: :resolved })
                      .distinct
  (get_grouped_values object_scope).count
end
```

<details>
<summary>Resultant Query</summary>

```sql
SELECT
  COUNT(DISTINCT "reporting_events"."conversation_id") AS "count_conversation_id",
  DATE_TRUNC(
    'day',
    "reporting_events"."created_at" :: timestamptz AT TIME ZONE 'Asia/Kolkata'
  ) :: date AS "date_trunc_day_reporting_events_created_at_timestamptz_at_time_"
FROM
  "reporting_events"
  INNER JOIN "conversations" ON "conversations"."id" = "reporting_events"."conversation_id"
WHERE
  "reporting_events"."account_id" = $ 1
  AND "reporting_events"."account_id" = $ 2
  AND "reporting_events"."name" = $ 3
  AND "conversations"."status" = $ 4
  AND (
    "reporting_events"."created_at" >= '2023-06-05 18:30:00'
    AND "reporting_events"."created_at" < '2023-06-12 18:29:59'
  )
GROUP BY
  DATE_TRUNC(
    'day',
    "reporting_events"."created_at" :: timestamptz AT TIME ZONE 'Asia/Kolkata'
  ) :: date;
```

</details>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
