### PR TITLE
feat: add index to reporting events [CW-1960]

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -19,7 +19,7 @@
 #  index_contacts_on_account_id                          (account_id)
 #  index_contacts_on_lower_email_account_id              (lower((email)::text), account_id)
 #  index_contacts_on_name_email_phone_number_identifier  (name,email,phone_number,identifier) USING gin
-#  index_contacts_on_identifiable_fields                 (account_id,email,phone_number,identifier) WHERE (((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text)) # rubocop:disable Layout/LineLength
+#  index_contacts_on_nonempty_fields                     (account_id,email,phone_number,identifier) WHERE (((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))  # rubocop:disable Layout/LineLength
 #  index_contacts_on_phone_number_and_account_id         (phone_number,account_id)
 #  uniq_email_per_account_contact                        (email,account_id) UNIQUE
 #  uniq_identifier_per_account_contact                   (identifier,account_id) UNIQUE

--- a/app/models/reporting_event.rb
+++ b/app/models/reporting_event.rb
@@ -17,12 +17,13 @@
 #
 # Indexes
 #
-#  index_reporting_events_on_account_id       (account_id)
-#  index_reporting_events_on_conversation_id  (conversation_id)
-#  index_reporting_events_on_created_at       (created_at)
-#  index_reporting_events_on_inbox_id         (inbox_id)
-#  index_reporting_events_on_name             (name)
-#  index_reporting_events_on_user_id          (user_id)
+#  index_reporting_events_on_account_id            (account_id)
+#  index_reporting_events_on_conversation_id       (conversation_id)
+#  index_reporting_events_on_created_at            (created_at)
+#  index_reporting_events_on_inbox_id              (inbox_id)
+#  index_reporting_events_on_name                  (name)
+#  index_reporting_events_on_user_id               (user_id)
+#  reporting_events__account_id__name__created_at  (account_id,name,created_at)
 #
 
 class ReportingEvent < ApplicationRecord

--- a/db/migrate/20230612103936_add_index_to_reporting_events.rb
+++ b/db/migrate/20230612103936_add_index_to_reporting_events.rb
@@ -1,0 +1,7 @@
+class AddIndexToReportingEvents < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :reporting_events, [:account_id, :name, :created_at], name: 'reporting_events__account_id__name__created_at', algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_08_040738) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_12_103936) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -798,6 +798,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_08_040738) do
     t.float "value_in_business_hours"
     t.datetime "event_start_time", precision: nil
     t.datetime "event_end_time", precision: nil
+    t.index ["account_id", "name", "created_at"], name: "reporting_events__account_id__name__created_at"
     t.index ["account_id"], name: "index_reporting_events_on_account_id"
     t.index ["conversation_id"], name: "index_reporting_events_on_conversation_id"
     t.index ["created_at"], name: "index_reporting_events_on_created_at"


### PR DESCRIPTION
This PR adds better indexes `reporting_events (account_id, name, created_at)`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Before fix: https://explain.dalibo.com/plan/3437h21f244defae
After-fix: https://explain.dalibo.com/plan/427cdd84gdc86g7d

Notice that the number of rows planned in the `Bitmap index scan` block is around 7K, which reduced from 26K, drastically reducing the cost of the subsequent heap scan. The query time reduced to 8ms from 34ms.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
