### PR TITLE
refactor: remove redundant taggable declaration

### DIFF
--- a/app/models/concerns/liquidable.rb
+++ b/app/models/concerns/liquidable.rb
@@ -2,7 +2,6 @@ module Liquidable
   extend ActiveSupport::Concern
 
   included do
-    acts_as_taggable_on :labels
     before_create :process_liquid_in_content
   end
 


### PR DESCRIPTION
This PR removes the redundant Taggable declaration in `Liquidable.rb` concern

## Type of change

Possible breaking change

## How Has This Been Tested?

Long live CI

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
