### PR TITLE
fix: Use available_name instead of actual name in the sender name

### DIFF
--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -80,11 +80,11 @@ class ConversationReplyMailer < ApplicationMailer
   end
 
   def sender_name
-    @sender_name ||= current_message&.sender&.name || @agent&.available_name || 'Notifications'
+    @sender_name ||= current_message&.sender&.available_name || @agent&.available_name || 'Notifications'
   end
 
   def current_message
-    @message || @messages.last
+    @message || @conversation.messages.outgoing.last
   end
 
   def mail_subject

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -82,11 +82,11 @@ RSpec.describe ConversationReplyMailer do
 
     context 'without assignee' do
       let(:conversation) { create(:conversation, assignee: nil) }
-      let(:message) { create(:message, conversation: conversation) }
+      let(:message) { create(:message, message_type: :outgoing, conversation: conversation) }
       let(:mail) { described_class.reply_with_summary(message.conversation, message.id).deliver_now }
 
       it 'has correct name' do
-        expect(mail[:from].display_names).to eq(["#{message.sender.name} from Inbox"])
+        expect(mail[:from].display_names).to eq(["#{message.sender.available_name} from Inbox"])
       end
     end
 
@@ -171,13 +171,13 @@ RSpec.describe ConversationReplyMailer do
 
       it 'renders sender name in the from address' do
         mail = described_class.email_reply(message)
-        expect(mail['from'].value).to eq "#{message.sender.name} from #{smtp_email_channel.inbox.name} <#{smtp_email_channel.email}>"
+        expect(mail['from'].value).to eq "#{message.sender.available_name} from #{smtp_email_channel.inbox.name} <#{smtp_email_channel.email}>"
       end
 
       it 'renders sender name even when assignee is not present' do
         conversation.update(assignee_id: nil)
         mail = described_class.email_reply(message)
-        expect(mail['from'].value).to eq "#{message.sender.name} from #{smtp_email_channel.inbox.name} <#{smtp_email_channel.email}>"
+        expect(mail['from'].value).to eq "#{message.sender.available_name} from #{smtp_email_channel.inbox.name} <#{smtp_email_channel.email}>"
       end
 
       it 'renders assignee name in the from address when sender_name not available' do
@@ -261,7 +261,7 @@ RSpec.describe ConversationReplyMailer do
     context 'when the custom domain emails are enabled' do
       let(:account) { create(:account) }
       let(:conversation) { create(:conversation, assignee: agent, account: account).reload }
-      let(:message) { create(:message, conversation: conversation, account: account, inbox: conversation.inbox) }
+      let(:message) { create(:message, message_type: :outgoing, conversation: conversation, account: account, inbox: conversation.inbox) }
       let(:mail) { described_class.reply_with_summary(message.conversation, message.id).deliver_now }
 
       before do
@@ -274,13 +274,13 @@ RSpec.describe ConversationReplyMailer do
 
       it 'sets reply to email to be based on the domain' do
         reply_to_email = "reply+#{message.conversation.uuid}@#{conversation.account.domain}"
-        reply_to = "#{message.sender.name} from #{conversation.inbox.name} <#{reply_to_email}>"
+        reply_to = "#{message.sender.available_name} from #{conversation.inbox.name} <#{reply_to_email}>"
         expect(mail['REPLY-TO'].value).to eq(reply_to)
         expect(mail.reply_to).to eq([reply_to_email])
       end
 
       it 'sets the from email to be the support email' do
-        expect(mail['FROM'].value).to eq("#{conversation.messages.last.sender.name} from Inbox <#{conversation.account.support_email}>")
+        expect(mail['FROM'].value).to eq("#{conversation.messages.last.sender.available_name} from Inbox <#{conversation.account.support_email}>")
         expect(mail.from).to eq([conversation.account.support_email])
       end
 


### PR DESCRIPTION
We have display_name and the actual name for an agent. display_name is used in all public facing parts. The https://github.com/chatwoot/chatwoot/pull/7232/files PR missed this and used actual name instead.

This PR fixes it.