### PR TITLE
fix: `NS_ERROR_STORAGE_BUSY` warnings in firefox

### DIFF
--- a/app/javascript/shared/helpers/localStorage.js
+++ b/app/javascript/shared/helpers/localStorage.js
@@ -4,11 +4,11 @@ export const LocalStorage = {
   },
 
   get(key) {
-    const value = window.localStorage.getItem(key);
     try {
+      const value = window.localStorage.getItem(key);
       return typeof value === 'string' ? JSON.parse(value) : value;
     } catch (error) {
-      return value;
+      return undefined;
     }
   },
   set(key, value) {

--- a/app/javascript/shared/helpers/localStorage.js
+++ b/app/javascript/shared/helpers/localStorage.js
@@ -4,11 +4,12 @@ export const LocalStorage = {
   },
 
   get(key) {
+    let value = null;
     try {
-      const value = window.localStorage.getItem(key);
+      value = window.localStorage.getItem(key);
       return typeof value === 'string' ? JSON.parse(value) : value;
     } catch (error) {
-      return undefined;
+      return value;
     }
   },
   set(key, value) {


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2075/ns-error-storage-busy-no-error-message