### PR TITLE
Remove unneeded `include EnsureCurrentAccountHelper`

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/base_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/base_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Accounts::Conversations::BaseController < Api::V1::Accounts::BaseController
-  include EnsureCurrentAccountHelper
   before_action :conversation
 
   private


### PR DESCRIPTION
This class inherits from `Api::V1::Accounts::BaseController`, which already includes `EnsureCurrentAccountHelper` and also sets up `before_action :current_account`.