### PR TITLE
fix: empty account variable for custom_attrbute_definition running in background job

### DIFF
--- a/app/services/conversations/filter_service.rb
+++ b/app/services/conversations/filter_service.rb
@@ -2,7 +2,7 @@ class Conversations::FilterService < FilterService
   ATTRIBUTE_MODEL = 'conversation_attribute'.freeze
 
   def initialize(params, user, filter_account = nil)
-    @filter_account = filter_account
+    @account = filter_account || Current.account
     super(params, user)
   end
 
@@ -54,8 +54,7 @@ class Conversations::FilterService < FilterService
   end
 
   def base_relation
-    account = @filter_account || Current.account
-    account.conversations.left_outer_joins(:labels)
+    @account.conversations.left_outer_joins(:labels)
   end
 
   def current_page

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -370,4 +370,31 @@ describe Conversations::FilterService do
       end
     end
   end
+
+  describe '#perform on date filter with no current account' do
+    before do
+      Current.account = nil
+    end
+
+    context 'with query present' do
+      let!(:params) { { payload: [], page: 1 } }
+
+      it 'filter by created_at' do
+        params[:payload] = [
+          {
+            attribute_key: 'created_at',
+            filter_operator: 'is_greater_than',
+            values: ['2022-01-20'],
+            query_operator: nil,
+            custom_attribute_type: ''
+          }.with_indifferent_access
+        ]
+        result = filter_service.new(params, user_1, account).perform
+        expected_count = Conversation.where('created_at > ?', DateTime.parse('2022-01-20')).count
+
+        expect(Current.account).to be_nil
+        expect(result[:conversations].length).to be expected_count
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes: https://linear.app/chatwoot/issue/CW-2083/nomethoderror-undefined-method-custom-attribute-definitions-for