### PR TITLE
fix existent name override

### DIFF
--- a/app/controllers/api/v1/widget/messages_controller.rb
+++ b/app/controllers/api/v1/widget/messages_controller.rb
@@ -17,7 +17,8 @@ class Api::V1::Widget::MessagesController < Api::V1::Widget::BaseController
       @message.update!(submitted_email: contact_email)
       ContactIdentifyAction.new(
         contact: @contact,
-        params: { email: contact_email, name: contact_name }
+        params: { email: contact_email, name: contact_name },
+        retain_original_contact_name: true
       ).perform
     else
       @message.update!(message_update_params[:message])


### PR DESCRIPTION
# Pull Request Template

## Description

Currently if Enable email collect box is enable and the user starting the chat already has a account with the same email , it will override the current account with {name} from the email name@email.com , this fix it

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Scenario 1
New user starts a chat an enters an email that already matches a contact , the contact name will not be overriden
Scenario 2
New starts a chat an enters an email that doesn't match a contact , the contact name will become the first part of the email before @

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
