### PR TITLE
feat: Frontend to customize the email sender name

### DIFF
--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -124,7 +124,7 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   def inbox_attributes
     [:name, :avatar, :greeting_enabled, :greeting_message, :enable_email_collect, :csat_survey_enabled,
      :enable_auto_assignment, :working_hours_enabled, :out_of_office_message, :timezone, :allow_messages_after_resolved,
-     :lock_to_single_conversation, :portal_id]
+     :lock_to_single_conversation, :portal_id, :custom_sender_name_enabled, :business_name]
   end
 
   def permitted_params(channel_attributes = [])

--- a/app/javascript/dashboard/components/SettingsSection.vue
+++ b/app/javascript/dashboard/components/SettingsSection.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="row settings--section">
+  <div class="row settings--section" :class="{ border: showBorder }">
     <div class="medium-4 small-12 title--section">
-      <p class="sub-block-title">
+      <p v-if="title" class="sub-block-title">
         {{ title }}
       </p>
       <p class="sub-head">
-        <slot name="subTitle">
+        <slot v-if="subTitle" name="subTitle">
           {{ subTitle }}
         </slot>
       </p>
@@ -25,11 +25,15 @@ export default {
   props: {
     title: {
       type: String,
-      required: true,
+      default: '',
     },
     subTitle: {
       type: String,
-      required: true,
+      default: '',
+    },
+    showBorder: {
+      type: Boolean,
+      default: true,
     },
     note: {
       type: String,
@@ -43,9 +47,13 @@ export default {
 @import '~dashboard/assets/scss/variables';
 
 .settings--section {
-  border-bottom: 1px solid $color-border;
   display: flex;
-  padding: $space-normal $space-normal $space-normal 0;
+  padding: 0 $space-normal $space-normal 0;
+
+  &.border {
+    padding-top: $space-normal;
+    border-bottom: 1px solid $color-border;
+  }
 
   .sub-block-title {
     color: $color-woot;

--- a/app/javascript/dashboard/components/ui/PreviewCard.vue
+++ b/app/javascript/dashboard/components/ui/PreviewCard.vue
@@ -13,9 +13,10 @@
     <div class="content-wrap">
       {{ content }}
     </div>
-    <div class="image-wrap">
+    <div v-if="src" class="image-wrap">
       <img :src="src" class="image" :class="{ activeimage: active }" />
     </div>
+    <slot v-else />
   </div>
 </template>
 

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -392,10 +392,17 @@
         "DISABLED": "Disabled"
       },
       "ENABLE_AGENT_NAME": {
-        "ENABLED": "Enabled",
-        "DISABLED": "Disabled",
-        "FRIENDLY": "Add the name of the agent who sent the reply in the sender name to make it friendly.",
-        "PROFESSIONAL": "Use only the configured business name as the sender name in the email header."
+        "TITLE": "Sender name",
+        "SUB_TEXT": "Select the name shown to the your customer when they receive emails from your agents.",
+        "FRIENDLY": {
+          "TITLE": "Friendly",
+          "FROM": "from",
+          "SUBTITLE": "Add the name of the agent who sent the reply in the sender name to make it friendly."
+        },
+        "PROFESSIONAL": {
+          "TITLE": "Professional",
+          "SUBTITLE": "Use only the configured business name as the sender name in the email header."
+        }
       },
       "ALLOW_MESSAGES_AFTER_RESOLVED": {
         "ENABLED": "Enabled",

--- a/app/javascript/dashboard/mixins/uiSettings.js
+++ b/app/javascript/dashboard/mixins/uiSettings.js
@@ -27,20 +27,6 @@ export const isEditorHotKeyEnabled = (uiSettings, key) => {
   return editorMessageKey === key;
 };
 
-export const friendlyNameEnabled = (uiSettings, key) => {
-  const {
-    editor_message_key: editorMessageKey,
-    enter_to_send_enabled: enterToSendEnabled,
-  } = uiSettings || {};
-  if (!editorMessageKey) {
-    if (enterToSendEnabled) {
-      return key === 'friendly';
-    }
-    return key === 'professional';
-  }
-  return editorMessageKey === key;
-};
-
 export default {
   computed: {
     ...mapGetters({ uiSettings: 'getUISettings' }),

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -23,6 +23,7 @@
       <settings-section
         :title="$t('INBOX_MGMT.SETTINGS_POPUP.INBOX_UPDATE_TITLE')"
         :sub-title="$t('INBOX_MGMT.SETTINGS_POPUP.INBOX_UPDATE_SUB_TEXT')"
+        :show-border="false"
       >
         <woot-avatar-uploader
           :label="$t('INBOX_MGMT.ADD.WEBSITE_CHANNEL.CHANNEL_AVATAR.LABEL')"
@@ -150,25 +151,6 @@
             }}
           </p>
         </label>
-
-        <div class="profile--settings--row row">
-          <div class="columns small-9 medium-5 card-preview">
-            <button
-              v-for="keyOption in keyOptions"
-              :key="keyOption.key"
-              class="preview-button"
-              @click="toggleEditorMessageKey(keyOption.key)"
-            >
-              <preview-card
-                :heading="keyOption.heading"
-                :content="keyOption.content"
-                :src="keyOption.src"
-                :active="friendlyNameEnabled(uiSettings, keyOption.key)"
-              />
-            </button>
-          </div>
-        </div>
-
         <div v-if="greetingEnabled" class="settings-item">
           <greetings-editor
             v-model.trim="greetingMessage"
@@ -365,7 +347,21 @@
             {{ $t('INBOX_MGMT.FEATURES.USE_INBOX_AVATAR_FOR_BOT') }}
           </label>
         </div>
-
+      </settings-section>
+      <settings-section
+        v-if="isAnEmailChannel"
+        :title="$t('INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.TITLE')"
+        :sub-title="$t('INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.SUB_TEXT')"
+        :show-border="false"
+      >
+        <div class="small-9 medium-5">
+          <sender-name-example-preview
+            :custom-sender-name-enabled="customSenderNameEnabled"
+            @update="toggleCustomSenderName"
+          />
+        </div>
+      </settings-section>
+      <settings-section :show-border="false">
         <woot-submit-button
           v-if="isAPIInbox"
           type="submit"
@@ -424,10 +420,7 @@ import CollaboratorsPage from './settingsPage/CollaboratorsPage';
 import WidgetBuilder from './WidgetBuilder';
 import BotConfiguration from './components/BotConfiguration';
 import { FEATURE_FLAGS } from '../../../../featureFlags';
-import PreviewCard from 'dashboard/components/ui/PreviewCard.vue';
-import uiSettingsMixin, {
-  friendlyNameEnabled,
-} from 'dashboard/mixins/uiSettings';
+import SenderNameExamplePreview from './components/SenderNameExamplePreview';
 
 export default {
   components: {
@@ -441,9 +434,9 @@ export default {
     SettingsSection,
     WeeklyAvailability,
     WidgetBuilder,
-    PreviewCard,
+    SenderNameExamplePreview,
   },
-  mixins: [alertMixin, configMixin, inboxMixin, uiSettingsMixin],
+  mixins: [alertMixin, configMixin, inboxMixin],
   data() {
     return {
       avatarFile: null,
@@ -466,20 +459,6 @@ export default {
       replyTime: '',
       selectedTabIndex: 0,
       selectedPortalSlug: '',
-      keyOptions: [
-        {
-          key: 'friendly',
-          src: '/assets/images/dashboard/editor/enter-editor.png',
-          heading: this.$t('INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.ENABLED'),
-          content: this.$t('INBOX_MGMT.SETTINGS_POPUP.ENABLE_AGENT_NAME_TEXT'),
-        },
-        {
-          key: 'professional',
-          src: '/assets/images/dashboard/editor/cmd-editor.png',
-          heading: this.$t('INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.DISABLED'),
-          content: this.$t('INBOX_MGMT.SETTINGS_POPUP.ENABLE_AGENT_NAME_TEXT'),
-        },
-      ],
     };
   },
   computed: {
@@ -629,7 +608,6 @@ export default {
     fetchPortals() {
       this.$store.dispatch('portals/index');
     },
-    friendlyNameEnabled,
     handleFeatureFlag(e) {
       this.selectedFeatureFlags = this.toggleInput(
         this.selectedFeatureFlags,
@@ -691,6 +669,7 @@ export default {
               ).id
             : null,
           lock_to_single_conversation: this.locktoSingleConversation,
+          custom_sender_name_enabled: this.customSenderNameEnabled,
           channel: {
             widget_color: this.inbox.widget_color,
             website_url: this.channelWebsiteUrl,
@@ -701,7 +680,6 @@ export default {
             reply_time: this.replyTime || 'in_a_few_minutes',
             tweets_enabled: this.tweetsEnabled,
             continuity_via_email: this.continuityViaEmail,
-            custom_sender_name_enabled: this.customSenderNameEnabled,
           },
         };
         if (this.avatarFile) {
@@ -736,8 +714,8 @@ export default {
         );
       }
     },
-    toggleEditorMessageKey(key) {
-      this.senderName = key;
+    toggleCustomSenderName(value) {
+      this.customSenderNameEnabled = value;
     },
   },
   validations: {
@@ -759,12 +737,6 @@ export default {
   .settings--tabs {
     ::v-deep .tabs {
       padding: 0;
-    }
-  }
-
-  .settings--content {
-    div:last-child {
-      border-bottom: 0;
     }
   }
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -259,7 +259,7 @@
             }}
           </p>
         </label>
-        <div class="medium-9 settings-item settings-item">
+        <div class="medium-9 settings-item">
           <label>
             {{ $t('INBOX_MGMT.HELP_CENTER.LABEL') }}
           </label>
@@ -314,7 +314,7 @@
             {{ $t('INBOX_MGMT.FEATURES.DISPLAY_FILE_PICKER') }}
           </label>
         </div>
-        <div v-if="isAWebWidgetInbox" class="settings-item settings-item">
+        <div v-if="isAWebWidgetInbox" class="settings-item">
           <input
             v-model="selectedFeatureFlags"
             type="checkbox"
@@ -325,7 +325,7 @@
             {{ $t('INBOX_MGMT.FEATURES.DISPLAY_EMOJI_PICKER') }}
           </label>
         </div>
-        <div v-if="isAWebWidgetInbox" class="settings-item settings-item">
+        <div v-if="isAWebWidgetInbox" class="settings-item">
           <input
             v-model="selectedFeatureFlags"
             type="checkbox"
@@ -336,7 +336,7 @@
             {{ $t('INBOX_MGMT.FEATURES.ALLOW_END_CONVERSATION') }}
           </label>
         </div>
-        <div v-if="isAWebWidgetInbox" class="settings-item settings-item">
+        <div v-if="isAWebWidgetInbox" class="settings-item">
           <input
             v-model="selectedFeatureFlags"
             type="checkbox"
@@ -354,7 +354,7 @@
         :sub-title="$t('INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.SUB_TEXT')"
         :show-border="false"
       >
-        <div class="small-9 medium-5">
+        <div class="medium-9 settings-item">
           <sender-name-example-preview
             :custom-sender-name-enabled="customSenderNameEnabled"
             @update="toggleCustomSenderName"

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -349,7 +349,6 @@
         </div>
       </settings-section>
       <settings-section
-        v-if="isAnEmailChannel"
         :title="$t('INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.TITLE')"
         :sub-title="$t('INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.SUB_TEXT')"
         :show-border="false"

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
@@ -14,7 +14,7 @@
         <div class="sender-name--preview-content">
           <span class="text">For eg:</span>
           <div class="sender-name--preview">
-            <thumbnail :username="userName(keyOption)" />
+            <thumbnail :username="userName(keyOption)" size="36px" />
             <div class="preview-card--content">
               <div>
                 <span v-if="isKeyOptionFriendly(keyOption.key)" class="name">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
@@ -14,7 +14,7 @@
         <div class="sender-name--preview-content">
           <span class="text">For eg:</span>
           <div class="sender-name--preview">
-            <thumbnail :username="userNames(keyOption)" />
+            <thumbnail :username="userName(keyOption)" />
             <div class="preview-card--content">
               <div>
                 <span v-if="isKeyOptionFriendly(keyOption.key)" class="name">
@@ -87,7 +87,7 @@ export default {
     isKeyOptionFriendly(key) {
       return key === 'friendly';
     },
-    userNames(keyOption) {
+    userName(keyOption) {
       return this.isKeyOptionFriendly(keyOption.key)
         ? keyOption.preview.senderName
         : keyOption.preview.businessName;

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
@@ -1,0 +1,146 @@
+<template>
+  <div class="sender-name--preview-container">
+    <button
+      v-for="keyOption in senderNameKeyOptions"
+      :key="keyOption.key"
+      class="preview-button"
+      @click="toggleCustomSenderName(keyOption.value)"
+    >
+      <preview-card
+        :heading="keyOption.heading"
+        :content="keyOption.content"
+        :active="keyOption.value === customSenderNameEnabled"
+      >
+        <div class="sender-name--preview-content">
+          <span class="text">For eg:</span>
+          <div class="sender-name--preview">
+            <thumbnail :username="userNames(keyOption)" />
+            <div class="preview-card--content">
+              <div>
+                <span v-if="isKeyOptionFriendly(keyOption.key)" class="name">
+                  {{ keyOption.preview.senderName }}
+                </span>
+                <span v-if="isKeyOptionFriendly(keyOption.key)" class="text">
+                  {{ $t('INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.FRIENDLY.FROM') }}
+                </span>
+                <span class="name">{{ keyOption.preview.businessName }}</span>
+              </div>
+              <span class="text">{{ keyOption.preview.email }}</span>
+            </div>
+          </div>
+        </div>
+      </preview-card>
+    </button>
+  </div>
+</template>
+
+<script>
+import PreviewCard from 'dashboard/components/ui/PreviewCard.vue';
+import Thumbnail from 'dashboard/components/widgets/Thumbnail';
+
+export default {
+  components: {
+    PreviewCard,
+    Thumbnail,
+  },
+  props: {
+    customSenderNameEnabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      senderNameKeyOptions: [
+        {
+          key: 'friendly',
+          value: false,
+          heading: this.$t('INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.FRIENDLY.TITLE'),
+          content: this.$t(
+            'INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.FRIENDLY.SUBTITLE'
+          ),
+          preview: {
+            senderName: 'Smith',
+            businessName: 'Chatwoot',
+            email: '<support@yourbusiness.com>',
+          },
+        },
+        {
+          key: 'professional',
+          value: true,
+          heading: this.$t(
+            'INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.PROFESSIONAL.TITLE'
+          ),
+          content: this.$t(
+            'INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.PROFESSIONAL.SUBTITLE'
+          ),
+          preview: {
+            senderName: '',
+            businessName: 'Chatwoot',
+            email: '<support@yourbusiness.com>',
+          },
+        },
+      ],
+    };
+  },
+  methods: {
+    isKeyOptionFriendly(key) {
+      return key === 'friendly';
+    },
+    userNames(keyOption) {
+      return this.isKeyOptionFriendly(keyOption.key)
+        ? keyOption.preview.senderName
+        : keyOption.preview.businessName;
+    },
+    toggleCustomSenderName(value) {
+      this.$emit('update', value);
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.sender-name--preview-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-normal);
+  margin-bottom: var(--space-normal);
+
+  .sender-name--preview-content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: var(--space-slab);
+    gap: var(--space-small);
+  }
+}
+
+.preview-button {
+  color: var(--s-700);
+  width: 25rem;
+
+  .text {
+    font-size: var(--font-size-mini);
+  }
+
+  .sender-name--preview {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-small);
+
+    .preview-card--content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--space-smaller);
+
+      .name {
+        font-size: var(--font-size-mini);
+        font-weight: var(--font-weight-bold);
+      }
+    }
+  }
+}
+</style>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
@@ -14,7 +14,7 @@
         <div class="sender-name--preview-content">
           <span class="text">For eg:</span>
           <div class="sender-name--preview">
-            <thumbnail :username="userName(keyOption)" size="36px" />
+            <thumbnail :username="userName(keyOption)" size="32px" />
             <div class="preview-card--content">
               <div>
                 <span v-if="isKeyOptionFriendly(keyOption.key)" class="name">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
@@ -54,7 +54,7 @@ export default {
       senderNameKeyOptions: [
         {
           key: 'friendly',
-          value: false,
+          value: true,
           heading: this.$t('INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.FRIENDLY.TITLE'),
           content: this.$t(
             'INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.FRIENDLY.SUBTITLE'
@@ -67,7 +67,7 @@ export default {
         },
         {
           key: 'professional',
-          value: true,
+          value: false,
           heading: this.$t(
             'INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.PROFESSIONAL.TITLE'
           ),

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
@@ -105,7 +105,6 @@ export default {
   flex-direction: row;
   align-items: center;
   gap: var(--space-normal);
-  margin-bottom: var(--space-normal);
 
   .sender-name--preview-content {
     display: flex;
@@ -118,7 +117,6 @@ export default {
 
 .preview-button {
   color: var(--s-700);
-  width: 25rem;
 
   .text {
     font-size: var(--font-size-mini);

--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -16,6 +16,8 @@ json.timezone resource.timezone
 json.callback_webhook_url resource.callback_webhook_url
 json.allow_messages_after_resolved resource.allow_messages_after_resolved
 json.lock_to_single_conversation resource.lock_to_single_conversation
+json.custom_sender_name_enabled resource.custom_sender_name_enabled
+json.business_name resource.business_name
 
 if resource.portal.present?
   json.help_center do
@@ -61,7 +63,6 @@ if resource.email?
   ## Email Channel Attributes
   json.forward_to_email resource.channel.try(:forward_to_email)
   json.email resource.channel.try(:email)
-  json.custom_sender_name_enabled resource.custom_sender_name_enabled
 
   ## IMAP
   if Current.account_user&.administrator?


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes https://linear.app/chatwoot/issue/CW-2098/frontend-getter-for-friendly-and-business-name

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**Screenshot**

<img width="1148" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/06eaf471-a3ec-4762-9c2e-b7c120675ca8">


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
