### PR TITLE
feat: Allow Twilio::REST::TwilioError errors to raise and prevent Inbox creation

### DIFF
--- a/app/services/twilio/webhook_setup_service.rb
+++ b/app/services/twilio/webhook_setup_service.rb
@@ -9,8 +9,6 @@ class Twilio::WebhookSetupService
     else
       update_phone_number
     end
-  rescue Twilio::REST::TwilioError => e
-    Rails.logger.error "TWILIO_FAILURE: #{e.message}"
   end
 
   private

--- a/spec/services/twilio/webhook_setup_service_spec.rb
+++ b/spec/services/twilio/webhook_setup_service_spec.rb
@@ -27,14 +27,6 @@ describe Twilio::WebhookSetupService do
 
         expect(services).to have_received(:update)
       end
-
-      it 'does not raise if TwilioError is thrown' do
-        expect(services).to receive(:update).and_raise(Twilio::REST::TwilioError)
-
-        expect do
-          described_class.new(inbox: channel_twilio_sms.inbox).perform
-        end.not_to raise_error
-      end
     end
 
     context 'with a phone number' do
@@ -67,15 +59,6 @@ describe Twilio::WebhookSetupService do
           sms_method: 'POST',
           sms_url: twilio_callback_index_url
         )
-      end
-
-      it 'does not call update if TwilioError is thrown' do
-        allow(twilio_client).to receive(:incoming_phone_numbers).and_return(phone_double)
-        allow(phone_double).to receive(:list).and_raise(Twilio::REST::TwilioError)
-
-        described_class.new(inbox: channel_twilio_sms.inbox).perform
-
-        expect(phone_double).not_to have_received(:update)
       end
     end
   end


### PR DESCRIPTION
This update will mean that errors will roll back the current transaction and the error will be sent back to the frontend and the user will know that the Inbox did not finish setting up successfully. We already do this if the credentials are invalid (when `authenticate_twilio` fails in `TwilioChannelsController`).

The current code seems a bit unexpected to me.  When `Twilio::WebhookSetupService.new(...).perform` fails it doesn't return or raise anything that indicates it failed, besides having sent a message to the logs.

Is there a common use case here where failure is expected?  Is there a way to tell when failure is expected and only squelch the error in that case?