### PR TITLE
fix: Remove overflow string in label delete confirm button

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/labels/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/labels/Index.vue
@@ -127,14 +127,10 @@ export default {
     }),
     // Delete Modal
     deleteConfirmText() {
-      return `${this.$t('LABEL_MGMT.DELETE.CONFIRM.YES')} ${
-        this.selectedResponse.title
-      }`;
+      return `${this.$t('LABEL_MGMT.DELETE.CONFIRM.YES')}`;
     },
     deleteRejectText() {
-      return `${this.$t('LABEL_MGMT.DELETE.CONFIRM.NO')} ${
-        this.selectedResponse.title
-      }`;
+      return `${this.$t('LABEL_MGMT.DELETE.CONFIRM.NO')}`;
     },
     deleteMessage() {
       return ` ${this.selectedResponse.title}?`;

--- a/app/javascript/dashboard/routes/dashboard/settings/labels/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/labels/Index.vue
@@ -127,10 +127,10 @@ export default {
     }),
     // Delete Modal
     deleteConfirmText() {
-      return `${this.$t('LABEL_MGMT.DELETE.CONFIRM.YES')}`;
+      return this.$t('LABEL_MGMT.DELETE.CONFIRM.YES');
     },
     deleteRejectText() {
-      return `${this.$t('LABEL_MGMT.DELETE.CONFIRM.NO')}`;
+      return this.$t('LABEL_MGMT.DELETE.CONFIRM.NO');
     },
     deleteMessage() {
       return ` ${this.selectedResponse.title}?`;


### PR DESCRIPTION
Fix [!7197](https://github.com/chatwoot/chatwoot/issues/7197) [CW-1900]

From
<img width="619" alt="image" src="https://github.com/chatwoot/chatwoot/assets/10057052/c9a57cad-bfca-47d5-b123-3a01fabf2190">
To
<img width="618" alt="image" src="https://github.com/chatwoot/chatwoot/assets/10057052/76bfa29c-1e5d-4f6e-b902-d70bc2469148">
