### PR TITLE
fix: Issue with i18n in update banner

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -3,6 +3,7 @@
     "TITLE": "Account settings",
     "SUBMIT": "Update settings",
     "BACK": "Back",
+    "DISMISS": "Dismiss",
     "UPDATE": {
       "ERROR": "Could not update settings, try again!",
       "SUCCESS": "Successfully updated account settings"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR included a fix for dismiss button text missing in the i18n file for the update banner. Issue occurred from this [PR](https://github.com/chatwoot/chatwoot/pull/7296/files#diff-1b188675b65350cc8e8e40c86be834a1471d3d8ad6dcaf800eafe51c117de215R34) 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Before**
<img width="729" alt="Screenshot 2023-06-26 at 11 04 13 AM" src="https://github.com/chatwoot/chatwoot/assets/64252451/0dd992b3-5aa9-4fca-9c6a-78dca90c23cf">

**After**
<img width="729" alt="Screenshot 2023-06-26 at 11 04 42 AM" src="https://github.com/chatwoot/chatwoot/assets/64252451/0e3d030f-a93c-4af5-99d8-b57aefe7eabf">


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
