### PR TITLE
feat: Adds business name field for sender name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -441,7 +441,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
-    minitest (5.18.0)
+    minitest (5.18.1)
     mock_redis (0.36.0)
       ruby2_keywords
     msgpack (1.7.0)
@@ -450,7 +450,7 @@ GEM
     multipart-post (2.3.0)
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
-    net-imap (0.3.4)
+    net-imap (0.3.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -525,7 +525,7 @@ GEM
     pundit (2.3.0)
       activesupport (>= 3.0.0)
     raabro (1.4.0)
-    racc (1.7.0)
+    racc (1.7.1)
     rack (2.2.7)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
@@ -731,7 +731,7 @@ GEM
     time_diff (0.3.0)
       activesupport
       i18n
-    timeout (0.3.2)
+    timeout (0.4.0)
     trailblazer-option (0.1.2)
     twilio-ruby (5.77.0)
       faraday (>= 0.9, < 3.0)

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -402,6 +402,11 @@
         "PROFESSIONAL": {
           "TITLE": "Professional",
           "SUBTITLE": "Use only the configured business name as the sender name in the email header."
+        },
+        "BUSINESS_NAME": {
+          "BUTTON_TEXT": "+ Configure your business name",
+          "PLACEHOLDER": "Enter your business name",
+          "SAVE_BUTTON_TEXT": "Save"
         }
       },
       "ALLOW_MESSAGES_AFTER_RESOLVED": {

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -394,6 +394,7 @@
       "ENABLE_AGENT_NAME": {
         "TITLE": "Sender name",
         "SUB_TEXT": "Select the name shown to the your customer when they receive emails from your agents.",
+        "FOR_EG": "For eg:",
         "FRIENDLY": {
           "TITLE": "Friendly",
           "FROM": "from",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -380,7 +380,6 @@
                   )
                 "
                 type="text"
-                class="business-name"
               />
               <woot-button color-scheme="primary" @click="updateInbox">
                 {{

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -358,6 +358,34 @@
             :custom-sender-name-enabled="customSenderNameEnabled"
             @update="toggleCustomSenderName"
           />
+          <div class="business-section">
+            <woot-button
+              variant="clear"
+              color-scheme="primary"
+              @click="onClickShowBusinessNameInput"
+            >
+              {{
+                $t(
+                  'INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.BUSINESS_NAME.BUTTON_TEXT'
+                )
+              }}
+            </woot-button>
+            <div v-if="showBusinessNameInput" class="business-name-input">
+              <input
+                ref="businessNameInput"
+                v-model="businessName"
+                type="text"
+                class="business-name"
+              />
+              <woot-button color-scheme="primary" @click="updateInbox">
+                {{
+                  $t(
+                    'INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.BUSINESS_NAME.SAVE_BUTTON_TEXT'
+                  )
+                }}
+              </woot-button>
+            </div>
+          </div>
         </div>
       </settings-section>
       <settings-section :show-border="false">
@@ -446,6 +474,7 @@ export default {
       emailCollectEnabled: false,
       csatSurveyEnabled: false,
       customSenderNameEnabled: false,
+      businessName: '',
       locktoSingleConversation: false,
       allowMessagesAfterResolved: true,
       continuityViaEmail: true,
@@ -458,6 +487,7 @@ export default {
       replyTime: '',
       selectedTabIndex: 0,
       selectedPortalSlug: '',
+      showBusinessNameInput: false,
     };
   },
   computed: {
@@ -639,6 +669,7 @@ export default {
         this.emailCollectEnabled = this.inbox.enable_email_collect;
         this.csatSurveyEnabled = this.inbox.csat_survey_enabled;
         this.customSenderNameEnabled = this.inbox.custom_sender_name_enabled;
+        this.businessName = this.inbox.business_name;
         this.allowMessagesAfterResolved = this.inbox.allow_messages_after_resolved;
         this.continuityViaEmail = this.inbox.continuity_via_email;
         this.channelWebsiteUrl = this.inbox.website_url;
@@ -669,6 +700,7 @@ export default {
             : null,
           lock_to_single_conversation: this.locktoSingleConversation,
           custom_sender_name_enabled: this.customSenderNameEnabled,
+          business_name: this.businessName,
           channel: {
             widget_color: this.inbox.widget_color,
             website_url: this.channelWebsiteUrl,
@@ -716,6 +748,14 @@ export default {
     toggleCustomSenderName(value) {
       this.customSenderNameEnabled = value;
     },
+    onClickShowBusinessNameInput() {
+      this.showBusinessNameInput = !this.showBusinessNameInput;
+      if (this.showBusinessNameInput) {
+        this.$nextTick(() => {
+          this.$refs.businessNameInput.focus();
+        });
+      }
+    },
   },
   validations: {
     webhookUrl: {
@@ -756,6 +796,24 @@ export default {
     font-style: normal;
     color: var(--b-500);
     padding-bottom: var(--space-smaller);
+  }
+}
+
+.business-section {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-small);
+  margin-top: var(--space-small);
+
+  .business-name-input {
+    display: flex;
+    gap: var(--space-small);
+    width: 80%;
+
+    input {
+      margin-bottom: 0;
+    }
   }
 }
 </style>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -374,6 +374,11 @@
               <input
                 ref="businessNameInput"
                 v-model="businessName"
+                :placeholder="
+                  $t(
+                    'INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.BUSINESS_NAME.PLACEHOLDER'
+                  )
+                "
                 type="text"
                 class="business-name"
               />

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -704,7 +704,7 @@ export default {
             : null,
           lock_to_single_conversation: this.locktoSingleConversation,
           custom_sender_name_enabled: this.customSenderNameEnabled,
-          business_name: this.businessName,
+          business_name: this.businessName || null,
           channel: {
             widget_color: this.inbox.widget_color,
             website_url: this.channelWebsiteUrl,

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
@@ -12,7 +12,9 @@
         :active="keyOption.value === customSenderNameEnabled"
       >
         <div class="sender-name--preview-content">
-          <span class="text">For eg:</span>
+          <span class="text">
+            {{ $t('INBOX_MGMT.EDIT.ENABLE_AGENT_NAME.FOR_EG') }}
+          </span>
           <div class="sender-name--preview">
             <thumbnail :username="userName(keyOption)" size="32px" />
             <div class="preview-card--content">


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds the ability to update the business name.

Fixes https://linear.app/chatwoot/issue/CW-2124/add-business-name-field-for-professional-sender-name

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<img width="1210" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/ac46ccc2-595c-419e-80b0-0939b8ed5f18">



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
