### PR TITLE
fix: Set date hours to 9 in snooze time

### DIFF
--- a/app/javascript/dashboard/helper/snoozeHelpers.js
+++ b/app/javascript/dashboard/helper/snoozeHelpers.js
@@ -8,6 +8,8 @@ import {
   isMonday,
   isToday,
   setHours,
+  setMinutes,
+  setSeconds,
 } from 'date-fns';
 import wootConstants from 'dashboard/constants/globals';
 
@@ -36,7 +38,7 @@ export const findNextDay = currentDate => {
 };
 
 export const setHoursToNine = date => {
-  return setHours(date, 9, 0, 0);
+  return setSeconds(setMinutes(setHours(date, 9), 0), 0);
 };
 
 export const findSnoozeTime = (snoozeType, currentDate = new Date()) => {

--- a/app/javascript/dashboard/helper/specs/snoozeHelpers.spec.js
+++ b/app/javascript/dashboard/helper/specs/snoozeHelpers.spec.js
@@ -40,6 +40,11 @@ describe('#Snooze Helpers', () => {
       nextDay.setHours(9, 0, 0, 0);
       expect(setHoursToNine(nextDay)).toEqual(nextDay);
     });
+    it('should return date with 9.00AM time if date with 10am is passes', () => {
+      const nextDay = new Date('06/17/2023 10:00:00');
+      nextDay.setHours(9, 0, 0, 0);
+      expect(setHoursToNine(nextDay)).toEqual(nextDay);
+    });
   });
 
   describe('findSnoozeTime', () => {


### PR DESCRIPTION
We are using the `setHoursToNine` method to set the time to 9:00 for the provided date. The method `setHoursToNine` uses the `setHours` function from the `date-fns` library.

However, the `setHours` function from `date-fns` only sets the hours of the given date object, and does not provide a way to directly set the minutes and seconds.

To set the minutes and seconds using `date-fns`, we need to use `setMinutes` and `setSeconds` in combination with `setHours`. This PR will address this issue.