### PR TITLE
perf:  Resloved green badge issue

### DIFF
--- a/app/javascript/widget/components/ChatHeader.vue
+++ b/app/javascript/widget/components/ChatHeader.vue
@@ -23,12 +23,7 @@
           :class="$dm('text-black-900', 'dark:text-slate-50')"
         >
           <span v-dompurify-html="title" class="mr-1" />
-          <div
-            :class="
-              `h-2 w-2 rounded-full
-              ${isOnline ? 'bg-green-500' : 'hidden'}`
-            "
-          />
+          <div v-if="isOnline" class="h-2 w-2 rounded-full bg-green-500" />
         </div>
         <div
           class="text-xs mt-1 leading-3"
@@ -85,12 +80,12 @@ export default {
     ...mapGetters({
       widgetColor: 'appConfig/getWidgetColor',
     }),
-    isOnline() {
+     isOnline() {
       const { workingHoursEnabled } = this.channelConfig;
       const anyAgentOnline = this.availableAgents.length > 0;
 
       if (workingHoursEnabled) {
-        return this.isInBetweenTheWorkingHours;
+        return this.isInBetweenTheWorkingHours && anyAgentOnline;
       }
       return anyAgentOnline;
     },


### PR DESCRIPTION

CHANGES MADE:-

1)In the template section:

a)Inside the <div> with the class font-medium text-base leading-4 flex items-center, the following changes were made:
b)Removed the conditional class binding for the Green badge's background color (bg-green-500).
c)Instead, added a v-if="isOnline" directive to conditionally render the Green badge.
d)Inside the conditional rendering, added the class h-2 w-2 rounded-full bg-green-500 to apply the background color when the user is online.
2)In the computed property isOnline:

a)Added const anyAgentOnline = this.availableAgents.length > 0; to check if there are any available agents.
b)Updated the return statement inside the if (workingHoursEnabled) block to return this.isInBetweenTheWorkingHours && anyAgentOnline;.
c)This change ensures that the Green badge is displayed only when the user is within the working hours and there is at least one available agent.
