### PR TITLE
fix: Disable predictions if model is absent

### DIFF
--- a/enterprise/app/jobs/enterprise/sentiment_analysis_job.rb
+++ b/enterprise/app/jobs/enterprise/sentiment_analysis_job.rb
@@ -17,6 +17,8 @@ class Enterprise::SentimentAnalysisJob < ApplicationJob
     # While gathering the maningfull node the Array/tensor index is going out of bound
 
     text = message.content&.truncate(2900)
+    return if model.blank?
+
     sentiment = model.predict(text)
     message.sentiment = sentiment.merge(value: label_val(sentiment))
 


### PR DESCRIPTION
Fix https://linear.app/chatwoot/issue/CW-2214/nomethoderror-undefined-method-predict-for-nilnilclass-nomethoderror
