### PR TITLE
fix: Cannot read properties of undefined (reading 'filter')

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/getters.js
+++ b/app/javascript/dashboard/store/modules/conversations/getters.js
@@ -49,8 +49,7 @@ const getters = {
   },
   getSelectedChatAttachments: (_state, _getters) => {
     const selectedChat = _getters.getSelectedChat;
-    const { attachments } = selectedChat;
-    return attachments;
+    return selectedChat.attachments || [];
   },
   getLastEmailInSelectedChat: (stage, _getters) => {
     const selectedChat = _getters.getSelectedChat;


### PR DESCRIPTION
Fix https://linear.app/chatwoot/issue/CW-2216/typeerror-cannot-read-properties-of-undefined-reading-filter