### PR TITLE
feat: Add support for API key authentication in Twilio

### DIFF
--- a/app/controllers/api/v1/accounts/channels/twilio_channels_controller.rb
+++ b/app/controllers/api/v1/accounts/channels/twilio_channels_controller.rb
@@ -18,7 +18,11 @@ class Api::V1::Accounts::Channels::TwilioChannelsController < Api::V1::Accounts:
   end
 
   def authenticate_twilio
-    client = Twilio::REST::Client.new(permitted_params[:account_sid], permitted_params[:auth_token])
+    client = if permitted_params[:api_key_sid].present?
+               Twilio::REST::Client.new(permitted_params[:api_key_sid], permitted_params[:auth_token], permitted_params[:account_sid])
+             else
+               Twilio::REST::Client.new(permitted_params[:account_sid], permitted_params[:auth_token])
+             end
     client.messages.list(limit: 1)
   end
 
@@ -40,6 +44,7 @@ class Api::V1::Accounts::Channels::TwilioChannelsController < Api::V1::Accounts:
     @twilio_channel = Current.account.twilio_sms.create!(
       account_sid: permitted_params[:account_sid],
       auth_token: permitted_params[:auth_token],
+      api_key_sid: permitted_params[:api_key_sid],
       messaging_service_sid: permitted_params[:messaging_service_sid].presence,
       phone_number: phone_number,
       medium: medium
@@ -52,7 +57,7 @@ class Api::V1::Accounts::Channels::TwilioChannelsController < Api::V1::Accounts:
 
   def permitted_params
     params.require(:twilio_channel).permit(
-      :account_id, :messaging_service_sid, :phone_number, :account_sid, :auth_token, :name, :medium
+      :account_id, :messaging_service_sid, :phone_number, :account_sid, :auth_token, :name, :medium, :api_key_sid
     )
   end
 end

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -111,6 +111,17 @@
           "PLACEHOLDER": "Please enter your Twilio Account SID",
           "ERROR": "This field is required"
         },
+        "API_KEY": {
+          "USE_API_KEY": "Use API Key Authentication",
+          "LABEL": "API Key SID",
+          "PLACEHOLDER": "Please enter your API Key SID",
+          "ERROR": "This field is required"
+        },
+        "API_KEY_SECRET": {
+          "LABEL": "API Key Secret",
+          "PLACEHOLDER": "Please enter your API Key Secret",
+          "ERROR": "This field is required"
+        },
         "MESSAGING_SERVICE_SID": {
           "LABEL": "Messaging Service SID",
           "PLACEHOLDER": "Please enter your Twilio Messaging Service SID",

--- a/app/models/channel/twilio_sms.rb
+++ b/app/models/channel/twilio_sms.rb
@@ -4,6 +4,7 @@
 #
 #  id                    :bigint           not null, primary key
 #  account_sid           :string           not null
+#  api_key_sid           :string
 #  auth_token            :string           not null
 #  medium                :integer          default("sms")
 #  messaging_service_sid :string
@@ -25,6 +26,7 @@ class Channel::TwilioSms < ApplicationRecord
   self.table_name = 'channel_twilio_sms'
 
   validates :account_sid, presence: true
+  # The same parameter is used to store api_key_secret if api_key authentication is opted
   validates :auth_token, presence: true
 
   # Must have _one_ of messaging_service_sid _or_ phone_number, and messaging_service_sid is preferred
@@ -51,7 +53,11 @@ class Channel::TwilioSms < ApplicationRecord
   private
 
   def client
-    ::Twilio::REST::Client.new(account_sid, auth_token)
+    if api_key_sid.present?
+      Twilio::REST::Client.new(api_key_sid, auth_token, account_sid)
+    else
+      Twilio::REST::Client.new(account_sid, auth_token)
+    end
   end
 
   def send_message_from

--- a/db/migrate/20230714054138_add_api_key_sid_to_twilio_sms.rb
+++ b/db/migrate/20230714054138_add_api_key_sid_to_twilio_sms.rb
@@ -1,0 +1,5 @@
+class AddApiKeySidToTwilioSms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :channel_twilio_sms, :api_key_sid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_06_090122) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_14_054138) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -330,6 +330,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_06_090122) do
     t.datetime "updated_at", null: false
     t.integer "medium", default: 0
     t.string "messaging_service_sid"
+    t.string "api_key_sid"
     t.index ["account_sid", "phone_number"], name: "index_channel_twilio_sms_on_account_sid_and_phone_number", unique: true
     t.index ["messaging_service_sid"], name: "index_channel_twilio_sms_on_messaging_service_sid", unique: true
     t.index ["phone_number"], name: "index_channel_twilio_sms_on_phone_number", unique: true


### PR DESCRIPTION
We use Account SID and Account Auth token for Twilio SMS authentication. One user had their Account Auth token leaked (conversation [here](https://app.chatwoot.com/app/accounts/1/conversations/26054)), which prompted them to switch to API Key authentication. API Key authentication is a better option as it reduces the privileges of the key and enables revocation whenever needed.

The changes are straightforward.

- Added a migration to include api_key_sid 
- Use auth_token for storing both api_key_secret and account_auth_token
- Update the UI to include the API Key SID changes.

<img width="587" alt="Screenshot 2023-07-13 at 11 10 13 PM" src="https://github.com/chatwoot/chatwoot/assets/2246121/8dba4c65-0017-4dab-96b1-b382f39fec05">

I've tested this locally. It seems to be working without issues.