### PR TITLE
feat: Compute average response time of replies

### DIFF
--- a/app/listeners/reporting_event_listener.rb
+++ b/app/listeners/reporting_event_listener.rb
@@ -43,6 +43,26 @@ class ReportingEventListener < BaseListener
     reporting_event.save!
   end
 
+  def reply_created(event)
+    message = extract_message_and_account(event)[0]
+    conversation = message.conversation
+    waiting_since = event.data[:waiting_since]
+    reply_time = message.created_at.to_i - waiting_since.to_i
+
+    reporting_event = ReportingEvent.new(
+      name: 'reply_time',
+      value: reply_time,
+      value_in_business_hours: business_hours(conversation.inbox, waiting_since, message.created_at),
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      user_id: conversation.assignee_id,
+      conversation_id: conversation.id,
+      event_start_time: waiting_since,
+      event_end_time: message.created_at
+    )
+    reporting_event.save!
+  end
+
   def conversation_bot_handoff(event)
     conversation = extract_conversation_and_account(event)[0]
 

--- a/lib/events/types.rb
+++ b/lib/events/types.rb
@@ -33,6 +33,7 @@ module Events::Types
   # message events
   MESSAGE_CREATED = 'message.created'
   FIRST_REPLY_CREATED = 'first.reply.created'
+  REPLY_CREATED = 'reply.created'
   MESSAGE_UPDATED = 'message.updated'
 
   # contact events

--- a/spec/listeners/reporting_event_listener_spec.rb
+++ b/spec/listeners/reporting_event_listener_spec.rb
@@ -34,6 +34,17 @@ describe ReportingEventListener do
     end
   end
 
+  describe '#reply_created' do
+    it 'creates reply created event' do
+      event = Events::Base.new('reply.created', Time.zone.now, waiting_since: 2.hours.ago, message: message)
+      listener.reply_created(event)
+
+      events = account.reporting_events.where(name: 'reply_time', conversation_id: message.conversation_id)
+      expect(events.length).to be 1
+      expect(events.first.value).to eq 7200
+    end
+  end
+
   describe '#first_reply_created' do
     it 'creates first_response event' do
       previous_count = account.reporting_events.where(name: 'first_response').count


### PR DESCRIPTION
Calculate the average response time of replies. 

**Conditions:** 

- Added a `reply_time` event.
- Added a reporting event listener to compute time based on the REPLY_CREATED event.