### PR TITLE
fix: modify exception tracker to log even if sentry configured

### DIFF
--- a/lib/chatwoot_exception_tracker.rb
+++ b/lib/chatwoot_exception_tracker.rb
@@ -12,11 +12,8 @@ class ChatwootExceptionTracker
   end
 
   def capture_exception
-    if ENV['SENTRY_DSN'].present?
-      capture_exception_with_sentry
-    else
-      Rails.logger.error @exception
-    end
+    capture_exception_with_sentry if ENV['SENTRY_DSN'].present?
+    Rails.logger.error @exception
   end
 
   private


### PR DESCRIPTION
# Pull Request Template

## Description

Right now, if sentry is configured exception won't be logged. This results in the log management tool missing every error captured with ChatwootExceptionTracker. This change logs the exception, even if Sentry is configured or not.

Fixes https://linear.app/chatwoot/issue/CW-2145/improve-logging-info-debug-trace

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
