### PR TITLE
chore: bump up version

### DIFF
--- a/config/app.yml
+++ b/config/app.yml
@@ -1,5 +1,5 @@
 shared: &shared
-  version: '2.18.0'
+  version: '3.0.0'
 
 development:
   <<: *shared

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/chatwoot",
-  "version": "2.18.0",
+  "version": "3.0.0",
   "license": "MIT",
   "scripts": {
     "eslint": "eslint app/**/*.{js,vue}",


### PR DESCRIPTION
Bump the Chatwoot version to `3.0.0`

ref: https://github.com/orgs/chatwoot/discussions/7570