### PR TITLE
fix: Contacts page sort by created_at [CW-2262]

### DIFF
--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -4,6 +4,7 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   sort_on :name, internal_name: :order_on_name, type: :scope, scope_params: [:direction]
   sort_on :phone_number, type: :string
   sort_on :last_activity_at, internal_name: :order_on_last_activity_at, type: :scope, scope_params: [:direction]
+  sort_on :created_at, internal_name: :order_on_created_at, type: :scope, scope_params: [:direction]
   sort_on :company, internal_name: :order_on_company_name, type: :scope, scope_params: [:direction]
   sort_on :city, internal_name: :order_on_city, type: :scope, scope_params: [:direction]
   sort_on :country, internal_name: :order_on_country_name, type: :scope, scope_params: [:direction]

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -62,6 +62,14 @@ class Contact < ApplicationRecord
       )
     )
   }
+  scope :order_on_created_at, lambda { |direction|
+    order(
+      Arel::Nodes::SqlLiteral.new(
+        sanitize_sql_for_order("\"contacts\".\"created_at\" #{direction}
+          NULLS LAST")
+      )
+    )
+  }
   scope :order_on_company_name, lambda { |direction|
     order(
       Arel::Nodes::SqlLiteral.new(


### PR DESCRIPTION
## Description

Fixes the contacts page sort by `created_at`.
fixes: https://github.com/chatwoot/chatwoot/issues/7577

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

By sorting.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
