### PR TITLE
fix: sentry issues [CW-2222][CW-2232]

### DIFF
--- a/app/javascript/dashboard/modules/search/components/MessageContent.vue
+++ b/app/javascript/dashboard/modules/search/components/MessageContent.vue
@@ -53,7 +53,7 @@ export default {
       return this.$refs.messageContainer;
     }, this.setOverflow);
 
-    this.$nextTick(() => this.setOverflow);
+    this.$nextTick(this.setOverflow);
   },
   methods: {
     setOverflow() {

--- a/app/javascript/dashboard/modules/search/components/MessageContent.vue
+++ b/app/javascript/dashboard/modules/search/components/MessageContent.vue
@@ -49,6 +49,10 @@ export default {
     },
   },
   mounted() {
+    this.$watch(() => {
+      return this.$refs.messageContainer;
+    }, this.setOverflow);
+
     this.$nextTick(() => this.setOverflow);
   },
   methods: {

--- a/app/javascript/dashboard/modules/search/components/MessageContent.vue
+++ b/app/javascript/dashboard/modules/search/components/MessageContent.vue
@@ -49,13 +49,16 @@ export default {
     },
   },
   mounted() {
-    this.$nextTick(() => {
-      const wrap = this.$refs.messageContainer;
-      const message = wrap.querySelector('.message-content');
-      this.isOverflowing = message.offsetHeight > 150;
-    });
+    this.$nextTick(() => this.setOverflow);
   },
   methods: {
+    setOverflow() {
+      const wrap = this.$refs.messageContainer;
+      if (wrap) {
+        const message = wrap.querySelector('.message-content');
+        this.isOverflowing = message.offsetHeight > 150;
+      }
+    },
     escapeHtml(html) {
       var text = document.createTextNode(html);
       var p = document.createElement('p');

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
@@ -242,7 +242,9 @@ export default {
       get() {
         const inboxList = this.contact.contactableInboxes || [];
         return (
-          inboxList.find(inbox => inbox.inbox?.id === this.targetInbox?.id) || {
+          inboxList.find(inbox => {
+            return inbox.inbox?.id && inbox.inbox?.id === this.targetInbox?.id;
+          }) || {
             inbox: {},
           }
         );

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
@@ -242,7 +242,7 @@ export default {
       get() {
         const inboxList = this.contact.contactableInboxes || [];
         return (
-          inboxList.find(inbox => inbox.inbox.id === this.targetInbox.id) || {
+          inboxList.find(inbox => inbox.inbox?.id === this.targetInbox?.id) || {
             inbox: {},
           }
         );


### PR DESCRIPTION
Fixes the following issues

#### Cannot read properties of null (reading 'id') 

[[Sentry Link](https://chatwoot-p3.sentry.io/issues/4285192034/)]

Couldn't find the root cause of this, but seems like the component handles empty data as well, so added null checks in the `Array.find`. The cause of this mostly the contact list not having the inbox property set. The fix should be good enough for now

#### TypeError: Cannot read properties of undefined (reading 'querySelector')
[[Sentry Link](https://chatwoot-p3.sentry.io/issues/4283480477/)]

The problem here is in the vue rendering lifecycle, it's a bit tricky to solve this, since `$refs` are not reactive in nature. But then, this can work. [stackoverflow](https://stackoverflow.com/questions/39035498/vuejs-watch-refs)

```js
this.$watch(() => {
    return this.$refs.messageContainer;
}, this.setOverflow);
```
