### PR TITLE
feat: Sort articles based on views

### DIFF
--- a/app/controllers/public/api/v1/portals/articles_controller.rb
+++ b/app/controllers/public/api/v1/portals/articles_controller.rb
@@ -8,12 +8,21 @@ class Public::Api::V1::Portals::ArticlesController < Public::Api::V1::Portals::B
   def index
     @articles = @portal.articles
     @articles = @articles.search(list_params) if list_params.present?
-    @articles.order(position: :asc)
+    order_by_sort_param
+    @articles.page(list_params[:page]) if list_params[:page].present?
   end
 
   def show; end
 
   private
+
+  def order_by_sort_param
+    @articles = if list_params[:sort].present? && list_params[:sort] == 'views'
+                  @articles.order_by_views
+                else
+                  @articles.order_by_position
+                end
+  end
 
   def set_article
     @article = @portal.articles.find_by(slug: permitted_params[:article_slug])
@@ -35,7 +44,7 @@ class Public::Api::V1::Portals::ArticlesController < Public::Api::V1::Portals::B
   end
 
   def list_params
-    params.permit(:query, :locale)
+    params.permit(:query, :locale, :sort)
   end
 
   def permitted_params

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -65,6 +65,7 @@ class Article < ApplicationRecord
   scope :search_by_status, ->(status) { where(status: status) if status.present? }
   scope :order_by_updated_at, -> { reorder(updated_at: :desc) }
   scope :order_by_position, -> { reorder(position: :asc) }
+  scope :order_by_views, -> { reorder(views: :desc) }
 
   # TODO: if text search slows down https://www.postgresql.org/docs/current/textsearch-features.html#TEXTSEARCH-UPDATE-TRIGGERS
   pg_search_scope(

--- a/app/views/public/api/v1/models/hc/_associated_article.json.jbuilder
+++ b/app/views/public/api/v1/models/hc/_associated_article.json.jbuilder
@@ -10,6 +10,6 @@ json.views article.views
 
 if article.author.present?
   json.author do
-    json.partial! 'public/api/v1/models/portal/author', formats: [:json], resource: article.author
+    json.partial! 'public/api/v1/models/hc/author', formats: [:json], resource: article.author
   end
 end

--- a/app/views/public/api/v1/portals/index.json.jbuilder
+++ b/app/views/public/api/v1/portals/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @portals, partial: 'public/api/v1/models/portal', formats: [:json], as: :portal
+json.array! @portals, partial: 'public/api/v1/models/hc/portal', formats: [:json], as: :portal

--- a/app/views/public/api/v1/portals/show.json.jbuilder
+++ b/app/views/public/api/v1/portals/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'public/api/v1/models/portal', formats: [:json], portal: @portal
+json.partial! 'public/api/v1/models/hc/portal', formats: [:json], portal: @portal


### PR DESCRIPTION
Fix https://linear.app/chatwoot/issue/CW-2283/api-to-list-top-articles-from-the-connected-help-center

Additions: 

- Added param for sort. Default sort = sort_by_position
- Added page param.
- Fix issues with the partials rendering