### PR TITLE
chore: Disable message hooks for conversations without incoming message

### DIFF
--- a/app/services/facebook/send_on_facebook_service.rb
+++ b/app/services/facebook/send_on_facebook_service.rb
@@ -60,11 +60,7 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
 
   def sent_first_outgoing_message_after_24_hours?
     # we can send max 1 message after 24 hour window
-    conversation.messages.outgoing.where('id > ?', last_incoming_message.id).count == 1
-  end
-
-  def last_incoming_message
-    conversation.messages.incoming.last
+    conversation.messages.outgoing.where('id > ?', conversation.last_incoming_message.id).count == 1
   end
 
   def handle_facebook_error(exception)

--- a/app/services/instagram/send_on_instagram_service.rb
+++ b/app/services/instagram/send_on_instagram_service.rb
@@ -90,11 +90,7 @@ class Instagram::SendOnInstagramService < Base::SendOnChannelService
 
   def sent_first_outgoing_message_after_24_hours?
     # we can send max 1 message after 24 hour window
-    conversation.messages.outgoing.where('id > ?', last_incoming_message.id).count == 1
-  end
-
-  def last_incoming_message
-    conversation.messages.incoming.last
+    conversation.messages.outgoing.where('id > ?', conversation.last_incoming_message.id).count == 1
   end
 
   def config

--- a/app/services/message_templates/hook_execution_service.rb
+++ b/app/services/message_templates/hook_execution_service.rb
@@ -3,6 +3,7 @@ class MessageTemplates::HookExecutionService
 
   def perform
     return if conversation.campaign.present?
+    return if conversation.last_incoming_message.blank?
 
     trigger_templates
   end


### PR DESCRIPTION
> Customer  is facing some issues with the welcome and out of office messages
> 
> Based on the investigation,  we believe the problem is the flow of how messages are created when using the API 
> 
> - The way Chatwoot creates conversations using the widget API is along with a first message. 
> 
> - But in this case of creating a conversation using the Application API, mostly the conversation and messages are created in subsequent requests, which messes up the logic for welcome messages / other automated messages. 
> 
>    ie 
> 
>     - The conversation is created, and this triggers automation which creates the assignment message. 
> 
>     - which in turn triggers the welcome message and subsequent automated messages
> 
> We will add a fix for the same where we will skip triggering automated messages unless there is incoming messages in the conversation. 

Fixes: https://linear.app/chatwoot/issue/CW-2187