### PR TITLE
feat: toggle typing and update last seen endpoints for client apis

### DIFF
--- a/app/controllers/public/api/v1/inboxes/conversations_controller.rb
+++ b/app/controllers/public/api/v1/inboxes/conversations_controller.rb
@@ -1,4 +1,7 @@
 class Public::Api::V1::Inboxes::ConversationsController < Public::Api::V1::InboxesController
+  include Events::Types
+  before_action :set_conversation, only: [:toggle_typing, :update_last_seen]
+
   def index
     @conversations = @contact_inbox.hmac_verified? ? @contact.conversations : @contact_inbox.conversations
   end
@@ -7,10 +10,34 @@ class Public::Api::V1::Inboxes::ConversationsController < Public::Api::V1::Inbox
     @conversation = create_conversation
   end
 
+  def toggle_typing
+    case params[:typing_status]
+    when 'on'
+      trigger_typing_event(CONVERSATION_TYPING_ON)
+    when 'off'
+      trigger_typing_event(CONVERSATION_TYPING_OFF)
+    end
+    head :ok
+  end
+
+  def update_last_seen
+    @conversation.contact_last_seen_at = DateTime.now.utc
+    @conversation.save!
+    head :ok
+  end
+
   private
+
+  def set_conversation
+    @conversation = @contact_inbox.contact.conversations.find_by!(display_id: params[:id])
+  end
 
   def create_conversation
     ::Conversation.create!(conversation_params)
+  end
+
+  def trigger_typing_event(event)
+    Rails.configuration.dispatcher.dispatch(event, Time.zone.now, conversation: @conversation, user: @conversation.contact)
   end
 
   def conversation_params

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -233,7 +233,7 @@ export default {
         return false;
       }
 
-      if (this.isAWebWidgetInbox) {
+      if (this.isAWebWidgetInbox || this.isAPIInbox) {
         const { contact_last_seen_at: contactLastSeenAt } = this.currentChat;
         return contactLastSeenAt >= this.createdAt;
       }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -337,6 +337,11 @@ Rails.application.routes.draw do
           scope module: :inboxes do
             resources :contacts, only: [:create, :show, :update] do
               resources :conversations, only: [:index, :create] do
+                member do
+                  post :toggle_typing
+                  post :update_last_seen
+                end
+
                 resources :messages, only: [:index, :create, :update]
               end
             end

--- a/spec/controllers/public/api/v1/inbox/conversations_controller_spec.rb
+++ b/spec/controllers/public/api/v1/inbox/conversations_controller_spec.rb
@@ -45,4 +45,35 @@ RSpec.describe 'Public Inbox Contact Conversations API', type: :request do
       expect(data['id']).not_to be_nil
     end
   end
+
+  describe 'POST /public/api/v1/inboxes/{identifier}/contact/{source_id}/conversations/{conversation_id}/toggle_typing' do
+    let!(:conversation) { create(:conversation, contact_inbox: contact_inbox, contact: contact) }
+    let(:toggle_typing_path) do
+      "/public/api/v1/inboxes/#{api_channel.identifier}/contacts/#{contact_inbox.source_id}/conversations/#{conversation.display_id}/toggle_typing"
+    end
+
+    it 'dispatches the correct typing status' do
+      allow(Rails.configuration.dispatcher).to receive(:dispatch)
+      post toggle_typing_path, params: { typing_status: 'on' }
+
+      expect(response).to have_http_status(:success)
+      expect(Rails.configuration.dispatcher).to have_received(:dispatch)
+        .with(Conversation::CONVERSATION_TYPING_ON, kind_of(Time), { conversation: conversation, user: contact })
+    end
+  end
+
+  describe 'POST /public/api/v1/inboxes/{identifier}/contact/{source_id}/conversations/{conversation_id}/update_last_seen' do
+    let!(:conversation) { create(:conversation, contact_inbox: contact_inbox, contact: contact) }
+    let(:update_last_seen_path) do
+      "/public/api/v1/inboxes/#{api_channel.identifier}/contacts/#{contact_inbox.source_id}/conversations/#{conversation.display_id}/update_last_seen"
+    end
+
+    it 'updates the last seen of the conversation contact' do
+      contact_last_seen_at = conversation.contact_last_seen_at
+      post update_last_seen_path
+
+      expect(response).to have_http_status(:success)
+      expect(conversation.reload.contact_last_seen_at).not_to eq contact_last_seen_at
+    end
+  end
 end


### PR DESCRIPTION
- Add toggle_typing endpoint for client APIs : 
```
curl --location 'http://localhost:3000/public/api/v1/inboxes/7mXPYawhiZPG2ooE5ZkC4vaJ/contacts/9b9d46b9-8542-43f5-8077-082d54682581/conversations/21/toggle_typing' \
--header 'Content-Type: application/json' \
--data '{ "typing_status": "on" }'
```

- Add update_contact_last_seen endpoint for client APIs: 
```
curl --location 'http://localhost:3000/public/api/v1/inboxes/7mXPYawhiZPG2ooE5ZkC4vaJ/contacts/9b9d46b9-8542-43f5-8077-082d54682581/conversations/21/update_last_seen' \
--header 'Content-Type: application/json' 
```

Fixes: https://github.com/chatwoot/chatwoot/issues/7581