### PR TITLE
feat(perf): contact page loading speed

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -23,6 +23,7 @@
 #  index_contacts_on_name_email_phone_number_identifier  (name,email,phone_number,identifier) USING gin
 #  index_contacts_on_nonempty_fields                     (account_id,email,phone_number,identifier) WHERE (((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))
 #  index_contacts_on_phone_number_and_account_id         (phone_number,account_id)
+#  index_resolved_contact_account_id                     (account_id) WHERE (((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))
 #  uniq_email_per_account_contact                        (email,account_id) UNIQUE
 #  uniq_identifier_per_account_contact                   (identifier,account_id) UNIQUE
 #

--- a/db/migrate/20230727065605_add_partial_index_contact_account_id.rb
+++ b/db/migrate/20230727065605_add_partial_index_contact_account_id.rb
@@ -1,0 +1,8 @@
+class AddPartialIndexContactAccountId < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :contacts, [:account_id], where: "(email <> '' OR phone_number <> '' OR identifier <> '')",
+                                        name: 'index_resolved_contact_account_id', algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_14_054138) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_27_065605) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -408,6 +408,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_14_054138) do
     t.index "lower((email)::text), account_id", name: "index_contacts_on_lower_email_account_id"
     t.index ["account_id", "email", "phone_number", "identifier"], name: "index_contacts_on_nonempty_fields", where: "(((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))"
     t.index ["account_id"], name: "index_contacts_on_account_id"
+    t.index ["account_id"], name: "index_resolved_contact_account_id", where: "(((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))"
     t.index ["email", "account_id"], name: "uniq_email_per_account_contact", unique: true
     t.index ["identifier", "account_id"], name: "uniq_identifier_per_account_contact", unique: true
     t.index ["name", "email", "phone_number", "identifier"], name: "index_contacts_on_name_email_phone_number_identifier", opclass: :gin_trgm_ops, using: :gin


### PR DESCRIPTION
This PR adds a [partial index](https://www.postgresql.org/docs/current/indexes-partial.html) to the `contacts` very similar to the one added here: https://github.com/chatwoot/chatwoot/pull/7175

The main difference is the fields on which this index operates, in this case we only index the account_id field, this drastically helps in building the contact list query when loading the contact page

```sql
EXPLAIN (ANALYZE, COSTS, VERBOSE, BUFFERS, FORMAT JSON)
SELECT
  contacts.*,
  (
    SELECT
      COUNT(*)
    FROM
      "conversations"
    WHERE
      "conversations"."contact_id" = "contacts"."id"
  ) as conversations_count
FROM
  "contacts"
WHERE
  "contacts"."account_id" = 1
  AND (
    contacts.email <> ''
    OR contacts.phone_number <> ''
    OR contacts.identifier <> ''
  )
GROUP BY
  "contacts"."id"
ORDER BY
  "contacts"."last_activity_at" desc NULLS LAST
LIMIT
  20;
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This is tested on ChatwootQA DB. Overall the performance is higher for larger accounts, for smaller accounts the performance improvement is relatively smaller, but in all cases the query takes less than half of the original

The following are the links to the query plans

#### Account with 6K contacts

Unoptimized: https://explain.dalibo.com/plan/ed5fg23729d02c91
Optimized: https://explain.dalibo.com/plan/fdf16065ccg3ad85

Cuts query time by 85%

#### Account with 23K contacts

Unoptimized: https://explain.dalibo.com/plan/a1g0e8c9d699c7d6 
Optimized: https://explain.dalibo.com/plan/12b68b5h8h5399f1

Cuts query time by 96%

#### Account with 495K contacts

Unoptimized: https://explain.dalibo.com/plan/f45g344g7d7696g3
Optimized: https://explain.dalibo.com/plan/242bd6d1g83ac8f7

Cuts query time by 99%

#### Account with 2.9 M contacts

Unoptimized: https://explain.dalibo.com/plan/f2ef8467fa57b5e5
Optimized: https://explain.dalibo.com/plan/a58aa96e954b73g2

Cuts query time by 98%

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
