### PR TITLE
feature: Implement then functionality of allowing an agent to delete a message or not

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -12,6 +12,8 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
   end
 
   def destroy
+    return head :bad_request unless message.can_delete_message?
+
     ActiveRecord::Base.transaction do
       message.update!(content: I18n.t('conversations.messages.deleted'), content_attributes: { deleted: true })
       message.attachments.destroy_all

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -124,7 +124,7 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   def inbox_attributes
     [:name, :avatar, :greeting_enabled, :greeting_message, :enable_email_collect, :csat_survey_enabled,
      :enable_auto_assignment, :working_hours_enabled, :out_of_office_message, :timezone, :allow_messages_after_resolved,
-     :lock_to_single_conversation, :portal_id, :sender_name_type, :business_name]
+     :lock_to_single_conversation, :portal_id, :sender_name_type, :business_name, :allow_agent_to_delete_message]
   end
 
   def permitted_params(channel_attributes = [])

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -513,7 +513,11 @@
       "WHATSAPP_SECTION_UPDATE_BUTTON": "Update",
       "WHATSAPP_WEBHOOK_TITLE": "Webhook Verify Token",
       "WHATSAPP_WEBHOOK_SUBHEADER": "This token is used to verify the authenticity of the webhook endpoint.",
-      "UPDATE_PRE_CHAT_FORM_SETTINGS": "Update Pre Chat Form Settings"
+      "UPDATE_PRE_CHAT_FORM_SETTINGS": "Update Pre Chat Form Settings",
+      "AGENT_PERMISSIONS": "Agent Permissions",
+      "AGENT_PERMISSIONS_SUB_TEXT": "Update agent permissions for this inbox",
+      "AGENT_ALLOW_TO_DELETE_MESSAGE": "Allow an agent to delete a message",
+      "AGENT_ALLOW_TO_DELETE_MESSAGE_SUB_TEXT": "Allow an agent to delete a message from a conversation."
     },
     "HELP_CENTER": {
       "LABEL": "Help Center",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CollaboratorsPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CollaboratorsPage.vue
@@ -73,6 +73,33 @@
         />
       </div>
     </settings-section>
+
+    <settings-section
+      :title="$t('INBOX_MGMT.SETTINGS_POPUP.AGENT_PERMISSIONS')"
+      :sub-title="$t('INBOX_MGMT.SETTINGS_POPUP.AGENT_PERMISSIONS_SUB_TEXT')"
+    >
+      <label class="w-[75%] settings-item">
+        <div>
+          <input
+            id="allowAgentToDeleteMessage"
+            v-model="allowAgentToDeleteMessage"
+            type="checkbox"
+            @change="handleAllowAgentToDeleteMessage"
+          />
+          <label for="allowAgentToDeleteMessage">
+            {{ $t('INBOX_MGMT.SETTINGS_POPUP.AGENT_ALLOW_TO_DELETE_MESSAGE') }}
+          </label>
+        </div>
+
+        <p class="text-slate-600 dark:text-slate-400 pb-1 text-sm not-italic">
+          {{
+            $t(
+              'INBOX_MGMT.SETTINGS_POPUP.AGENT_ALLOW_TO_DELETE_MESSAGE_SUB_TEXT'
+            )
+          }}
+        </p>
+      </label>
+    </settings-section>
   </div>
 </template>
 
@@ -99,6 +126,7 @@ export default {
       selectedAgents: [],
       isAgentListUpdating: false,
       enableAutoAssignment: false,
+      allowAgentToDeleteMessage: false,
       maxAssignmentLimit: null,
     };
   },
@@ -128,6 +156,7 @@ export default {
       this.enableAutoAssignment = this.inbox.enable_auto_assignment;
       this.maxAssignmentLimit =
         this.inbox.auto_assignment_config.max_assignment_limit || null;
+      this.allowAgentToDeleteMessage = this.inbox.allow_agent_to_delete_message;
       this.fetchAttachedAgents();
     },
     async fetchAttachedAgents() {
@@ -144,6 +173,9 @@ export default {
       }
     },
     handleEnableAutoAssignment() {
+      this.updateInbox();
+    },
+    handleAllowAgentToDeleteMessage() {
       this.updateInbox();
     },
     async updateAgents() {
@@ -169,6 +201,7 @@ export default {
           auto_assignment_config: {
             max_assignment_limit: this.maxAssignmentLimit,
           },
+          allow_agent_to_delete_message: this.allowAgentToDeleteMessage,
         };
         await this.$store.dispatch('inboxes/updateInbox', payload);
         this.showAlert(this.$t('INBOX_MGMT.EDIT.API.SUCCESS_MESSAGE'));

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -5,6 +5,7 @@
 # Table name: inboxes
 #
 #  id                            :integer          not null, primary key
+#  allow_agent_to_delete_message :boolean          default(TRUE)
 #  allow_messages_after_resolved :boolean          default(TRUE)
 #  auto_assignment_config        :jsonb
 #  business_name                 :string

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -223,6 +223,12 @@ class Message < ApplicationRecord
     save!
   end
 
+  def can_delete_message?
+    return false if !inbox.allow_agent_to_delete_message && !Current.user&.administrator?
+
+    true
+  end
+
   private
 
   def ensure_processed_message_content

--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -18,6 +18,7 @@ json.allow_messages_after_resolved resource.allow_messages_after_resolved
 json.lock_to_single_conversation resource.lock_to_single_conversation
 json.sender_name_type resource.sender_name_type
 json.business_name resource.business_name
+json.allow_agent_to_delete_message resource.allow_agent_to_delete_message
 
 if resource.portal.present?
   json.help_center do

--- a/db/migrate/20230726203159_add_allow_agent_to_delete_message_to_inboxes.rb
+++ b/db/migrate/20230726203159_add_allow_agent_to_delete_message_to_inboxes.rb
@@ -1,0 +1,5 @@
+class AddAllowAgentToDeleteMessageToInboxes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :inboxes, :allow_agent_to_delete_message, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -588,6 +588,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_065605) do
     t.bigint "portal_id"
     t.integer "sender_name_type", default: 0, null: false
     t.string "business_name"
+    t.boolean "allow_agent_to_delete_message", default: true
     t.index ["account_id"], name: "index_inboxes_on_account_id"
     t.index ["channel_id", "channel_type"], name: "index_inboxes_on_channel_id_and_channel_type"
     t.index ["portal_id"], name: "index_inboxes_on_portal_id"


### PR DESCRIPTION
## Description

This feature request implements the functionality of allowing an agent to delete a conversation message or not.

I've added this on a per inbox level, this feature can be accessed under inbox > Collaborators.

Implements feature #5950 

## Type of change

- [x] New feature (non-breaking change which adds functionality

## How Has This Been Tested?

Creating two users; administrator and agent - then toggling the 'Allow agent to delete message...' and observing the message 'Delete' button appearing/disappearing.

I've also created a API unit test.

I am not convinced I have covered all testing areas. There may be a few caveats I am not aware of e.g public API and also possibly updating the mobile app to be aware of this flag.

Additionally documentation needs to be updated: [Documentation](https://www.chatwoot.com/docs/product/channels/live-chat/create-website-channel#collaborators-tab)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
