### PR TITLE
fix: Update `permitted_attributes` to support the latest version of administrate 

### DIFF
--- a/app/dashboards/account_dashboard.rb
+++ b/app/dashboards/account_dashboard.rb
@@ -86,7 +86,10 @@ class AccountDashboard < Administrate::BaseDashboard
     "##{account.id} #{account.name}"
   end
 
-  def permitted_attributes
+  # We do not use the action parameter but we still need to define it
+  # to prevent an error from being raised (wrong number of arguments)
+  # Reference: https://github.com/thoughtbot/administrate/pull/2356/files#diff-4e220b661b88f9a19ac527c50d6f1577ef6ab7b0bed2bfdf048e22e6bfa74a05R204
+  def permitted_attributes(action)
     super + [limits: {}]
   end
 end


### PR DESCRIPTION
## Description

This fixes an issue where `permitted_attributes` throws an error of `ArgumentError (wrong number of arguments (given 1, expected 0)):`

This is because we now bring in the latest version of `administrate` and `administrate` changes the way `permitted_attributes` works, it now passes a action parameter to `permitted_attributes`. Which means we need to update `permitted_attributes` to accept that new parameter.

I talk about this more in the issue.

Fixes #7592 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

By updating the account through super admin portal.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
