### PR TITLE
fix: Update the default status of the hooks to enabled

### DIFF
--- a/app/models/integrations/hook.rb
+++ b/app/models/integrations/hook.rb
@@ -6,7 +6,7 @@
 #  access_token :string
 #  hook_type    :integer          default("account")
 #  settings     :jsonb
-#  status       :integer          default("disabled")
+#  status       :integer          default("enabled")
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  account_id   :integer

--- a/db/migrate/20230801180936_update_default_status_in_hooks.rb
+++ b/db/migrate/20230801180936_update_default_status_in_hooks.rb
@@ -1,0 +1,17 @@
+class UpdateDefaultStatusInHooks < ActiveRecord::Migration[7.0]
+  def up
+    change_column_default :integrations_hooks, :status, 1
+
+    update_default_status
+  end
+
+  def down
+    change_column_default :integrations_hooks, :status, 0
+  end
+
+  private
+
+  def update_default_status
+    Integrations::Hook.where(app_id: %w[dialogflow google_translate dyte]).all
+  end
+end

--- a/db/migrate/20230801180936_update_default_status_in_hooks.rb
+++ b/db/migrate/20230801180936_update_default_status_in_hooks.rb
@@ -12,6 +12,6 @@ class UpdateDefaultStatusInHooks < ActiveRecord::Migration[7.0]
   private
 
   def update_default_status
-    Integrations::Hook.where(app_id: %w[dialogflow google_translate dyte]).all
+    Integrations::Hook.all.update(status: 'enabled')
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_065605) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_01_180936) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -604,7 +604,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_065605) do
   end
 
   create_table "integrations_hooks", force: :cascade do |t|
-    t.integer "status", default: 0
+    t.integer "status", default: 1
     t.integer "inbox_id"
     t.integer "account_id"
     t.string "app_id"


### PR DESCRIPTION
In the recent Slack integration update, we made changes to how hooks are handled. Now, hooks require an additional check to be enabled. By default, new hooks are created in a disabled state, which might lead to issues with the hooks not being executed as expected. 

This migration updates the status attribute of hooks to have 'enabled' as the default value, ensuring that new hooks are enabled by default and can function properly.