### PR TITLE
fix: Enable cmd bar actions for all conversation routes

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/commands/conversationHotKeys.js
+++ b/app/javascript/dashboard/routes/dashboard/commands/conversationHotKeys.js
@@ -38,6 +38,9 @@ export const isAConversationRoute = routeName =>
     'conversation_through_inbox',
     'conversations_through_label',
     'conversations_through_team',
+    'conversations_through_folders',
+    'conversation_through_unattended',
+    'conversation_through_participating',
   ].includes(routeName);
 
 export default {


### PR DESCRIPTION
This pull request resolves the issue of being unable to access conversation actions via the command bar in certain conversation URLs.