### PR TITLE
fix: Links are not readable in private notes dark mode

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -552,7 +552,7 @@ export default {
     }
 
     &.is-private.is-text > .message-text__wrap .link {
-      @apply text-woot-700 dark:text-woot-700;
+      @apply text-woot-600 dark:text-woot-200;
     }
     &.is-private.is-text > .message-text__wrap .prosemirror-mention-node {
       @apply font-bold bg-none rounded-sm p-0 bg-yellow-100 dark:bg-yellow-700 text-slate-700 dark:text-slate-25 underline;


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes issues with links that are not readable in private notes dark mode

Fixes https://linear.app/chatwoot/issue/CW-2347/links-are-not-readable-in-private-notes-dark-mode
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Screenshot**

| Before   | After   |
|------------|------------|
| <img width="763" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/b621981b-1642-4d19-af27-9a72359b8b7e">  | <img width="763" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/cf9162fe-23f0-4c7b-beb0-227c8f854f12">  |




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
