### PR TITLE
fix: Update unread_count being 0 if agent has not seen the conversation

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -166,11 +166,11 @@ class Conversation < ApplicationRecord
   end
 
   def unread_messages
-    messages.created_since(agent_last_seen_at)
+    agent_last_seen_at ? messages.created_since(agent_last_seen_at) : messages
   end
 
   def unread_incoming_messages
-    messages.incoming.created_since(agent_last_seen_at)
+    unread_messages.incoming
   end
 
   def push_event_data

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -166,7 +166,7 @@ class Conversation < ApplicationRecord
   end
 
   def unread_messages
-    agent_last_seen_at ? messages.created_since(agent_last_seen_at) : messages
+    agent_last_seen_at.present? ? messages.created_since(agent_last_seen_at) : messages
   end
 
   def unread_incoming_messages

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -497,6 +497,12 @@ RSpec.describe Conversation do
     it 'returns unread incoming messages' do
       expect(unread_incoming_messages).to contain_exactly(message)
     end
+
+    it 'returns unread incoming messages even if the agent has not seen the conversation' do
+      conversation.update!(agent_last_seen_at: nil)
+
+      expect(unread_incoming_messages).to contain_exactly(message)
+    end
   end
 
   describe '#push_event_data' do


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2360/new-conversations-are-created-with-unread-count-=-0


This PR https://github.com/chatwoot/chatwoot/pull/7267 introduced a bug. When a conversation is created, the agent_last_seen_at would not be available. Querying created_at > nil returned empty results. A case where agent_last_seen_at being empty should have been added. The spec was also missing to validate this case.

This PR would check for the existence of agent_last_seen_at attribute. If present, it would return all the message since the time, otherwise it would return all the messages.

