### PR TITLE
fix: Default timezone is not working

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WeeklyAvailability.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WeeklyAvailability.vue
@@ -85,8 +85,8 @@ import {
 } from '../helpers/businessHour';
 
 const DEFAULT_TIMEZONE = {
-  label: 'America/Los_Angeles',
-  key: 'America/Los_Angeles',
+  label: 'Pacific Time (US & Canada) (GMT-07:00)',
+  value: 'America/Los_Angeles',
 };
 
 export default {


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request addresses an issue where the default timezone was not working properly in the business hour section upon initial save.

Fixes https://linear.app/chatwoot/issue/CW-2357/default-timezone-in-the-business-hour-section-is-not-working

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

**Screencast**
https://www.loom.com/share/29d4be82033c4379bd750f28a9c99225?sid=055131d6-57fd-4787-b478-0659b196a656


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
