### PR TITLE
fix: Dark mode color fixes

### DIFF
--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
@@ -142,7 +142,7 @@
         @apply text-black-900 dark:text-white relative border border-solid bg-yellow-100 dark:bg-yellow-700 border-yellow-200 dark:border-yellow-600/25;
 
         blockquote {
-          @apply dark:border-yellow-900 text-slate-800 dark:text-slate-300;
+          @apply border-slate-400 dark:border-slate-400 text-slate-800 dark:text-slate-300;
 
           p {
             @apply text-slate-600 dark:text-slate-300;

--- a/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_conversation-view.scss
@@ -140,6 +140,14 @@
 
       &.is-private {
         @apply text-black-900 dark:text-white relative border border-solid bg-yellow-100 dark:bg-yellow-700 border-yellow-200 dark:border-yellow-600/25;
+
+        blockquote {
+          @apply dark:border-yellow-900 text-slate-800 dark:text-slate-300;
+
+          p {
+            @apply text-slate-600 dark:text-slate-300;
+          }
+        }
       }
 
       &.is-image {

--- a/app/javascript/dashboard/modules/search/components/MessageContent.vue
+++ b/app/javascript/dashboard/modules/search/components/MessageContent.vue
@@ -1,7 +1,7 @@
 <template>
   <blockquote
     ref="messageContainer"
-    class="message border-l-2 border-slate-100 dark:border-slate-800"
+    class="message border-l-2 border-slate-100 dark:border-slate-700"
   >
     <p class="header">
       <strong class="text-slate-700 dark:text-slate-100">

--- a/app/javascript/dashboard/modules/search/components/ReadMore.vue
+++ b/app/javascript/dashboard/modules/search/components/ReadMore.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="read-more">
-    <div ref="content" :class="{ 'shrink-container': shrink }">
+    <div
+      ref="content"
+      :class="{
+        'shrink-container after:shrink-gradient-light dark:after:shrink-gradient-dark': shrink,
+      }"
+    >
       <slot />
       <woot-button
         v-if="shrink"
@@ -27,30 +32,32 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
+@tailwind components;
+@layer components {
+  .shrink-gradient-light {
+    background: linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0),
+      rgba(255, 255, 255, 1) 100%
+    );
+  }
+
+  .shrink-gradient-dark {
+    background: linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0),
+      rgb(21, 23, 24) 100%
+    );
+  }
+}
 .shrink-container {
-  max-height: 100px;
-  overflow: hidden;
-  position: relative;
+  @apply max-h-[100px] overflow-hidden relative;
 }
 .shrink-container::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 50px;
-  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), #fff 100%);
-  z-index: 4;
+  @apply content-[''] absolute bottom-0 left-0 right-0 h-[50px] z-10;
 }
 .read-more-button {
-  max-width: max-content;
-  position: absolute;
-  bottom: var(--space-small);
-  left: 0;
-  right: 0;
-  margin: 0 auto;
-  z-index: 5;
-  box-shadow: var(--box-shadow);
+  @apply max-w-max absolute bottom-2 left-0 right-0 mx-auto mt-0 z-20 shadow-sm;
 }
 </style>

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/SocialIcons.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/SocialIcons.vue
@@ -1,14 +1,17 @@
 <template>
-  <div v-if="availableProfiles.length" class="social--icons">
+  <div v-if="availableProfiles.length" class="flex items-end mx-0 my-2 gap-3">
     <a
       v-for="profile in availableProfiles"
       :key="profile.key"
       :href="`${profile.link}${socialProfiles[profile.key]}`"
       target="_blank"
       rel="noopener noreferrer nofollow"
-      class="contact--social-icon"
     >
-      <fluent-icon :icon="`brand-${profile.key}`" size="16" />
+      <fluent-icon
+        :icon="`brand-${profile.key}`"
+        size="16"
+        class="text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+      />
     </a>
   </div>
 </template>
@@ -41,16 +44,3 @@ export default {
   },
 };
 </script>
-
-<style scoped lang="scss">
-.social--icons {
-  align-items: flex-end;
-  display: flex;
-  margin: var(--space-small) 0 var(--space-smaller);
-}
-
-.contact--social-icon {
-  padding-right: var(--space-slab);
-  color: var(--color-body);
-}
-</style>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR includes following fixes,
1. Blockquote text is not visible in private notes.
2. Social profile icon is not visible in dark mode and added hover.
3. Search shrink container color issue.

Fixes 
https://linear.app/chatwoot/issue/CW-2354/dark-mode-fixes , 
https://linear.app/chatwoot/issue/CW-2359/breakage-in-search-page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Light mode**

| Blockquote   | Social profile icon  |  Search shrink container |
|------------|------------|------------|
| <img width="220" alt="Screenshot 2023-08-08 at 1 29 58 PM" src="https://github.com/chatwoot/chatwoot/assets/64252451/fa064bb5-4c8b-4e19-a6da-332bb45c0bac">  | <img width="220" alt="Screenshot 2023-08-08 at 1 22 54 PM" src="https://github.com/chatwoot/chatwoot/assets/64252451/e1da8a84-38ea-4a05-931e-87e88f62d217">  |  <img width="752" alt="Screenshot 2023-08-08 at 1 22 46 PM" src="https://github.com/chatwoot/chatwoot/assets/64252451/c15e7deb-c147-4546-928e-c5a9e55bcb99"> |

**Dark mode**


| Blockquote   | Social profile icon  |  Search shrink container |
|------------|------------|------------|
| <img width="220" alt="Screenshot 2023-08-08 at 1 29 40 PM" src="https://github.com/chatwoot/chatwoot/assets/64252451/4b2c63d1-1302-46d7-b20f-a8f1f903daa4">  | <img width="220" alt="Screenshot 2023-08-08 at 1 23 05 PM" src="https://github.com/chatwoot/chatwoot/assets/64252451/c662d1a8-1aad-4d30-b713-700810069892">  |  <img width="753" alt="Screenshot 2023-08-08 at 1 38 32 PM" src="https://github.com/chatwoot/chatwoot/assets/64252451/15478f2d-1a49-4a62-a03e-9af1f67e0abd"> |


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
