### PR TITLE
feat: more email info in Send Transcript Email-Type Inbox

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -223,6 +223,10 @@ class Message < ApplicationRecord
     save!
   end
 
+  def sender_name
+    (sender.try(:available_name) || sender&.name).to_s
+  end
+
   private
 
   def ensure_processed_message_content

--- a/app/views/mailers/conversation_reply_mailer/conversation_transcript.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/conversation_transcript.html.erb
@@ -1,7 +1,12 @@
 <% @messages.each do |message| %>
   <tr>
     <td>
-      <b><%= message.sender&.try(:available_name) || message.sender&.name || '' %></b>
+      <% if @inbox.email? %>
+        <b>From:</b> <%= message.sender_name %> <%= "<#{message.sender&.email}>" %><br>
+        <b>Subject:</b> <%= message.conversation.additional_attributes&.dig('mail_subject') %><br>
+      <% else %>
+        <b><%= message.sender_name %></b>
+      <% end %>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will add the email subject, from, and sent date in the send transcript email body. This is only applied to the email type inboxes.

Fixes #5474 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Verification Steps
- Generate a few messages in an email-type inbox
- Send Transcript to any recipient
- verify that the email received contains the messages in conversation with the subject, from and date sent.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
