### PR TITLE
fix: Create new thread if thread identifier changes in slack

### DIFF
--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -128,7 +128,8 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
   end
 
   def update_reference_id
-    return if conversation.identifier
+    # If the conversation identifier is present and conversation identifier is not equal to slack message ts, then do nothing
+    return if conversation.identifier && conversation.identifier == @slack_message['ts']
 
     conversation.update!(identifier: @slack_message['ts'])
   end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-1324/if-a-conversation-doesnt-have-a-thread-id-new-message-would-appear

This pull request addresses an issue in which messages were being sent directly to a channel if the conversation did not have a saved thread_id (which can occur if the conversation was created before connecting to Slack in Chatwoot). This behavior is unexpected and has been corrected.

**QA Check List**

**Case 1**

1. Create a new conversation.
2. Connect the Slack integration.
3. Check that sending more messages creates the Slack thread properly.

**Case 2**

1. Connect the Slack integration.
2. Create a new conversation and send more messages. Check that the thread is created properly in Slack.
3. Delete the Slack integration.
4. Connect Slack again.
5. Connect Slack with the same channel. Check that new messages are sent to the previously created thread.

**Case 3**

1. Connect the Slack integration.
2. Create a new conversation from the widget and send more messages. Verify that the Slack thread is created properly without any issues.
3. Delete the Slack integration.
4. Connect Slack again.
5. Connect Slack with a different channel. Send messages from the same conversation and check that the first message appears in the new channel and subsequent messages are creating under the thread.
