### PR TITLE
fix: Limit count query to return only 10 values

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -45,7 +45,7 @@
       />
       <li v-show="unreadMessageCount != 0" class="unread--toast">
         <span>
-          {{ unreadMessageCount }}
+          {{ unreadMessageCount > 9 ? '9+' : unreadMessageCount }}
           {{
             unreadMessageCount > 1
               ? $t('CONVERSATION.UNREAD_MESSAGES')
@@ -314,7 +314,7 @@ export default {
       return '';
     },
     unreadMessageCount() {
-      return this.currentChat.unread_count;
+      return this.currentChat.unread_count || 0;
     },
   },
 

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -170,7 +170,7 @@ class Conversation < ApplicationRecord
   end
 
   def unread_incoming_messages
-    unread_messages.incoming
+    unread_messages.incoming.last(10)
   end
 
   def push_event_data

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -19,10 +19,8 @@ end
 json.id conversation.display_id
 if conversation.messages.first.blank?
   json.messages []
-elsif conversation.unread_incoming_messages.count.zero?
-  json.messages [conversation.messages.includes([{ attachments: [{ file_attachment: [:blob] }] }]).last.try(:push_event_data)]
 else
-  json.messages conversation.unread_messages.includes([{ attachments: [{ file_attachment: [:blob] }] }]).last(10).map(&:push_event_data)
+  json.messages [conversation.messages.includes([{ attachments: [{ file_attachment: [:blob] }] }]).last.try(:push_event_data)]
 end
 
 json.account_id conversation.account_id


### PR DESCRIPTION
The "unread count" feature provides the exact number of unread messages in a conversation at any given moment. However, we do not currently display this count on the dashboard. Instead, the conversation list displays "9+" for any number greater than 9 of unread messages.

If there are many unread messages, the query can become heavy. The additional computation doesn't add much value, so it may not be necessary. 

This PR limits the query to take only last 10 unread messages.

Fix https://linear.app/chatwoot/issue/CW-2384/dashboard-should-load-even-if-there-are-thousands-of-unread-messages