### PR TITLE
fix: Force account_id in message filters

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -170,7 +170,7 @@ class Conversation < ApplicationRecord
   end
 
   def unread_incoming_messages
-    unread_messages.incoming.last(10)
+    unread_messages.where(account_id: account_id).incoming.last(10)
   end
 
   def push_event_data

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -22,7 +22,7 @@ if conversation.messages.first.blank?
 else
   json.messages [
     conversation.messages.where(account_id: conversation.account_id)
-    .includes([{ attachments: [{ file_attachment: [:blob] }] }]).last.try(:push_event_data)
+                .includes([{ attachments: [{ file_attachment: [:blob] }] }]).last.try(:push_event_data)
   ]
 end
 

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -20,7 +20,10 @@ json.id conversation.display_id
 if conversation.messages.first.blank?
   json.messages []
 else
-  json.messages [conversation.messages.includes([{ attachments: [{ file_attachment: [:blob] }] }]).last.try(:push_event_data)]
+  json.messages [
+    conversation.messages.where(account_id: conversation.account_id)
+    .includes([{ attachments: [{ file_attachment: [:blob] }] }]).last.try(:push_event_data)
+  ]
 end
 
 json.account_id conversation.account_id
@@ -40,7 +43,7 @@ json.created_at conversation.created_at.to_i
 json.timestamp conversation.last_activity_at.to_i
 json.first_reply_created_at conversation.first_reply_created_at.to_i
 json.unread_count conversation.unread_incoming_messages.count
-json.last_non_activity_message conversation.messages.non_activity_messages.first.try(:push_event_data)
+json.last_non_activity_message conversation.messages.where(account_id: conversation.account_id).non_activity_messages.first.try(:push_event_data)
 json.last_activity_at conversation.last_activity_at.to_i
 json.priority conversation.priority
 json.waiting_since conversation.waiting_since.to_i.to_i


### PR DESCRIPTION
This PR is a hacky fix to include account_id in the queries. This PR would reduce the query timing if there are quite a lot of messages in the database.