### PR TITLE
chore: Add account_id scope for conversation.messages

### DIFF
--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -17,7 +17,7 @@ json.meta do
 end
 
 json.id conversation.display_id
-if conversation.messages.first.blank?
+if conversation.messages.where(account_id: conversation.account_id).first.blank?
   json.messages []
 else
   json.messages [


### PR DESCRIPTION
Force account_id scope to conversation.message to include account id in queries.