### PR TITLE
fix: Consider the emails where in-reply-to header has multiple values

### DIFF
--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -106,6 +106,15 @@ class MailPresenter < SimpleDelegator
     }
   end
 
+  def in_reply_to
+    return if @mail.in_reply_to.blank?
+
+    # Although the "in_reply_to" field in the email can potentially hold multiple values,
+    # our current system does not have the capability to handle this.
+    # FIX ME: Address this issue by returning the complete results and utilizing them for querying conversations.
+    @mail.in_reply_to.is_a?(Array) ? @mail.in_reply_to.first : @mail.in_reply_to
+  end
+
   def from
     # changing to downcase to avoid case mismatch while finding contact
     (@mail.reply_to.presence || @mail.from).map(&:downcase)

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -17,7 +17,7 @@ json.meta do
 end
 
 json.id conversation.display_id
-if conversation.messages.where(account_id: conversation.account_id).first.blank?
+if conversation.messages.where(account_id: conversation.account_id).last.blank?
   json.messages []
 else
   json.messages [

--- a/enterprise/app/services/enterprise/message_templates/response_bot_service.rb
+++ b/enterprise/app/services/enterprise/message_templates/response_bot_service.rb
@@ -61,7 +61,7 @@ class Enterprise::MessageTemplates::ResponseBotService
   end
 
   def create_messages(response, conversation)
-    response = process_response_content(response)
+    response = process_response_content(response).first
     create_outgoing_message(response, conversation)
   end
 

--- a/spec/fixtures/files/multiple_in_reply_to.eml
+++ b/spec/fixtures/files/multiple_in_reply_to.eml
@@ -1,0 +1,18 @@
+From: Sony Mathew <Sony@chatwoot.com>
+Mime-Version: 1.0 (Apple Message framework v1244.3)
+Content-Type: multipart/alternative; boundary="Apple-Mail=_33A037C7-4BB3-4772-AE52-FCF2D7535F74"
+Subject: Discussion: Let's debate these attachments
+Date: Tue, 20 Apr 2020 04:20:20 -0400
+In-Reply-To: <4e6e35f5a38b4_479f13bb90078171@small-app-01.mail>
+  <4e6e35f5a38b4_479f13bb90078131@small-app-01.mail>
+To: "Replies" <replies@example.com>
+References: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
+Message-Id: <0CB459E0-0336-41DA-BC88-E6E28C697DDB@chatwoot.com>
+X-Mailer: Apple Mail (2.1244.3)
+
+--Apple-Mail=_33A037C7-4BB3-4772-AE52-FCF2D7535F74
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain;
+  charset=utf-8
+
+Let's talk about these images

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe MailPresenter do
 
   describe 'parsed mail decorator' do
     let(:mail) { create_inbound_email_from_fixture('welcome.eml').mail }
+    let(:multiple_in_reply_to_mail) { create_inbound_email_from_fixture('multiple_in_reply_to.eml').mail }
+    let(:mail_without_in_reply_to) { create_inbound_email_from_fixture('reply_cc.eml').mail }
     let(:html_mail) { create_inbound_email_from_fixture('welcome_html.eml').mail }
     let(:ascii_mail) { create_inbound_email_from_fixture('non_utf_encoded_mail.eml').mail }
     let(:decorated_mail) { described_class.new(mail) }
@@ -73,6 +75,29 @@ RSpec.describe MailPresenter do
       expect(decorated_html_mail.text_content[:reply][0..70]).to eq(
         'أنظروا، أنا أحتاجها فقط لتقوم بالتدقيق في مقالتي الشخصية'
       )
+    end
+
+    describe '#in_reply_to' do
+      context 'when "in_reply_to" is an array' do
+        it 'returns the first value from the array' do
+          mail_presenter = described_class.new(multiple_in_reply_to_mail)
+          expect(mail_presenter.in_reply_to).to eq('4e6e35f5a38b4_479f13bb90078171@small-app-01.mail')
+        end
+      end
+
+      context 'when "in_reply_to" is not an array' do
+        it 'returns the value as is' do
+          mail_presenter = described_class.new(mail)
+          expect(mail_presenter.in_reply_to).to eq('4e6e35f5a38b4_479f13bb90078178@small-app-01.mail')
+        end
+      end
+
+      context 'when "in_reply_to" is blank' do
+        it 'returns nil' do
+          mail_presenter = described_class.new(mail_without_in_reply_to)
+          expect(mail_presenter.in_reply_to).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- Return the first message id for now to avoid the errors and subsequently missing the message.
- Use .last instead of .first to avoid expensive query.
- Fix array response in response bot.

Fixes https://linear.app/chatwoot/issue/CW-2358/activerecordstatementinvalid-pgdatatypemismatch-error-argument-of-and