### PR TITLE
fix: Fixed an issue where the 'Go To' table styling was not correctly being set

### DIFF
--- a/app/javascript/dashboard/assets/scss/widgets/_woot-tables.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_woot-tables.scss
@@ -76,13 +76,13 @@ table {
 
   .ve-pagination-goto {
     @apply text-slate-600 dark:text-slate-200;
+
+    .ve-pagination-goto-input {
+      @apply bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-200;
+    }
   }
 
   .ve-pagination-li {
     @apply bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-200 border-slate-75 dark:border-slate-700;
-  }
-
-  .ve-pagination-goto-input {
-    @apply bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-200;
   }
 }


### PR DESCRIPTION
## Description

This fixes an issue where 'Go To' input was not correctly being over ridden with our custom styling.
This is because the VE table plugin has a higher selector than our current styling.
<img width="1224" alt="Screenshot 2023-08-17 at 21 16 19" src="https://github.com/chatwoot/chatwoot/assets/43280985/5f87d366-6ad0-43d4-8e5e-81d36933a4aa">


Fixes #7752 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)=

## How Has This Been Tested?
By switching from light mode to dark mode noticing the 'Go To' input changing.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings=
