### PR TITLE
fix: Delete agent bots without deleting the messages

### DIFF
--- a/app/models/agent_bot.rb
+++ b/app/models/agent_bot.rb
@@ -23,7 +23,7 @@ class AgentBot < ApplicationRecord
 
   has_many :agent_bot_inboxes, dependent: :destroy_async
   has_many :inboxes, through: :agent_bot_inboxes
-  has_many :messages, as: :sender, dependent: :restrict_with_exception
+  has_many :messages, as: :sender, dependent: :nullify
   belongs_to :account, optional: true
   enum bot_type: { webhook: 0, csml: 1 }
 

--- a/spec/models/agent_bot_spec.rb
+++ b/spec/models/agent_bot_spec.rb
@@ -27,4 +27,16 @@ RSpec.describe AgentBot do
       expect(agent_bot.errors[:outgoing_url]).to include("is too long (maximum is #{Limits::URL_LENGTH_LIMIT} characters)")
     end
   end
+
+  context 'when agent bot is deleted' do
+    let(:agent_bot) { create(:agent_bot) }
+    let(:message) { create(:message, sender: agent_bot) }
+
+    it 'nullifies the message sender key' do
+      expect(message.sender).to eq agent_bot
+      agent_bot.destroy!
+
+      expect(message.reload.sender).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
The agent bot which has sent a message was not deleted due to `ActiveRecord::DeleteRestrictionError:  Cannot delete record because of dependent messages`

This PR fixes the issue.