### PR TITLE
fix: Fixed an issue where the Widget Builder was not correctly being in sync with the Welcome Header input

### DIFF
--- a/app/javascript/dashboard/modules/widget-preview/components/WidgetHead.vue
+++ b/app/javascript/dashboard/modules/widget-preview/components/WidgetHead.vue
@@ -36,8 +36,10 @@ export default {
     isDefaultScreen() {
       return (
         this.config.isDefaultScreen &&
-        (this.config.welcomeHeading.length !== 0 ||
-          this.config.welcomeTagline.length !== 0)
+        ((this.config.welcomeHeading &&
+          this.config.welcomeHeading.length !== 0) ||
+          (this.config.welcomeTagLine &&
+            this.config.welcomeTagline.length !== 0))
       );
     },
   },


### PR DESCRIPTION
## Description
This fixed an issue as described in the video below:
The problem occurs when the welcomeHeading and welcomeTagLine is not always a string.
[Chatwoot - 17 August 2023 - Watch Video](https://www.loom.com/share/f364167f7c9346c79c6de1450ebee9b8)

Fixes #7755 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

By observing the Welcome Headline input being in sync with the Widget.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code=
- [x] My changes generate no new warnings
