### PR TITLE
fix: Improve the contrast for the code snippet on the Widget Builder page.

### DIFF
--- a/app/javascript/dashboard/assets/scss/_foundation-custom.scss
+++ b/app/javascript/dashboard/assets/scss/_foundation-custom.scss
@@ -26,7 +26,7 @@ code {
     background: $color-background;
     border-radius: var(--border-radius-large);
     padding: $space-two;
-    @apply bg-slate-50 dark:bg-slate-600 text-slate-800 dark:text-slate-100;
+    @apply bg-slate-50 dark:bg-slate-700 text-slate-800 dark:text-slate-100;
   }
 }
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/WidgetBuilder.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/WidgetBuilder.vue
@@ -455,9 +455,7 @@ export default {
     }
   }
   .widget-script {
-    margin: 0 var(--space-two);
-    padding: var(--space-one);
-    background: var(--s-50);
+    @apply mx-5 p-2.5 bg-slate-50 dark:bg-slate-700;
   }
 }
 </style>


### PR DESCRIPTION
## Description
Before:
<img width="1262" alt="Screenshot 2023-08-17 at 22 34 13" src="https://github.com/chatwoot/chatwoot/assets/43280985/a0ea5a78-8261-44bf-b594-d20599cac441">

After:
<img width="1224" alt="Screenshot 2023-08-17 at 22 42 26" src="https://github.com/chatwoot/chatwoot/assets/43280985/94f50bac-e008-48d3-a330-b7886d0b3b2a">

Fixes #7757 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
By creating an inbox and going to the Widget Builder page.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
