### PR TITLE
fix: Update the in_reply_to to logic to use processed_mail

### DIFF
--- a/app/mailboxes/imap/imap_mailbox.rb
+++ b/app/mailboxes/imap/imap_mailbox.rb
@@ -56,7 +56,7 @@ class Imap::ImapMailbox
   end
 
   def in_reply_to
-    @inbound_mail.in_reply_to
+    @processed_mail.in_reply_to
   end
 
   def find_message_by_references

--- a/spec/mailboxes/imap/imap_mailbox_spec.rb
+++ b/spec/mailboxes/imap/imap_mailbox_spec.rb
@@ -171,5 +171,14 @@ RSpec.describe Imap::ImapMailbox do
         expect(references_email.mail.references).to include('test-reference-id-2')
       end
     end
+
+    context 'when a reply for a conversation has multiple in_reply_to' do
+      let(:multiple_in_reply_to_mail) { create_inbound_email_from_fixture('multiple_in_reply_to.eml').mail }
+
+      it 'creates conversation taking the first in_reply_to email' do
+        class_instance.process(multiple_in_reply_to_mail, channel)
+        expect(conversation.additional_attributes['in_reply_to']).to eq(multiple_in_reply_to_mail.in_reply_to.first)
+      end
+    end
   end
 end


### PR DESCRIPTION
The issue with the in-reply-to header containing multiple values has been fixed. While the email standard allows for multiple in-reply-to values, our system previously did not support this feature. We've implemented a solution [here](https://github.com/chatwoot/chatwoot/pull/7715) that considers the first in-reply-to value as the preferred one.

Instead of relying on the original mail object, we have to utilize the processed mail objects in most cases. This change prevents potential issues (like the reported sentry error) arising from using the wrong in-reply-to value and ensures more accurate handling of email conversations.

This PR changes the usage of in_reply_to in imap_mailbox. As followup, I will check other places where the in-reply-to header is used.