### PR TITLE
fix: Rescue InvalidAuth and mark integration as inactive

### DIFF
--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -80,7 +80,7 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
   def send_message
     post_message if message_content.present?
     upload_file if message.attachments.any?
-  rescue Slack::Web::Api::Errors::AccountInactive, Slack::Web::Api::Errors::MissingScope => e
+  rescue Slack::Web::Api::Errors::AccountInactive, Slack::Web::Api::Errors::MissingScope, Slack::Web::Api::Errors::InvalidAuth => e
     Rails.logger.error e
     hook.prompt_reauthorization!
     hook.disable


### PR DESCRIPTION
Some of the production app records don't have enough scope or have invalid credentials stored in their settings. This throws 
 an InvalidAuth error in the Slack API call. 

This PR would rescue the error and mark the integration as inactive rather than throwing errors again.

As per the Slack documentation: 

> `invalid_auth`: Some aspects of authentication cannot be validated. Either the provided token is invalid, or the request originates from an IP address disallowed from making the request.

In both these cases, we do not need to keep sending the messages to Slack.