### PR TITLE
feat: mutex for `InstagramEventsJob` [CW-2447]

### DIFF
--- a/app/jobs/webhooks/facebook_events_job.rb
+++ b/app/jobs/webhooks/facebook_events_job.rb
@@ -1,6 +1,6 @@
 class Webhooks::FacebookEventsJob < MutexApplicationJob
   queue_as :default
-  retry_on LockAcquisitionError, wait: 1.second, attempts: 6
+  retry_on LockAcquisitionError, wait: 1.second, attempts: 8
 
   def perform(message)
     response = ::Integrations::Facebook::MessageParser.new(message)

--- a/app/jobs/webhooks/instagram_events_job.rb
+++ b/app/jobs/webhooks/instagram_events_job.rb
@@ -30,14 +30,11 @@ class Webhooks::InstagramEventsJob < MutexApplicationJob
   private
 
   def ig_account_id
-    @entries.first[:id]
+    @entries&.first&.dig(:id)
   end
 
   def sender_id
-    return unless @entries.first[:messaging].presence
-
-    messaging = @entries.first[:messaging]
-    messaging.first[:sender][:id]
+    @entries&.dig(0, :messaging, 0, :sender, :id)
   end
 
   def event_name(messaging)

--- a/app/jobs/webhooks/instagram_events_job.rb
+++ b/app/jobs/webhooks/instagram_events_job.rb
@@ -18,7 +18,9 @@ class Webhooks::InstagramEventsJob < MutexApplicationJob
   end
 
   # @see https://developers.facebook.com/docs/messenger-platform/instagram/features/webhook
-  def process_entries
+  def process_entries(entries)
+    @entries = entries
+
     @entries.each do |entry|
       entry = entry.with_indifferent_access
       messages(entry).each do |messaging|

--- a/lib/redis/redis_keys.rb
+++ b/lib/redis/redis_keys.rb
@@ -37,6 +37,6 @@ module Redis::RedisKeys
   ## Sempahores / Locks
   # We don't want to process messages from the same sender concurrently to prevent creating double conversations
   FACEBOOK_MESSAGE_MUTEX = 'FB_MESSAGE_CREATE_LOCK::%<sender_id>s::%<recipient_id>s'.freeze
-  IG_MESSAGE_MUTEX = 'IG_MESSAGE_CREATE_LOCK::%<ig_account_id>s'.freeze
+  IG_MESSAGE_MUTEX = 'IG_MESSAGE_CREATE_LOCK::%<sender_id>s::%<ig_account_id>s'.freeze
   SLACK_MESSAGE_MUTEX = 'SLACK_MESSAGE_LOCK::%<conversation_id>s::%<reference_id>s'.freeze
 end

--- a/lib/redis/redis_keys.rb
+++ b/lib/redis/redis_keys.rb
@@ -37,5 +37,6 @@ module Redis::RedisKeys
   ## Sempahores / Locks
   # We don't want to process messages from the same sender concurrently to prevent creating double conversations
   FACEBOOK_MESSAGE_MUTEX = 'FB_MESSAGE_CREATE_LOCK::%<sender_id>s::%<recipient_id>s'.freeze
+  IG_MESSAGE_MUTEX = 'IG_MESSAGE_CREATE_LOCK::%<page_id>s'.freeze
   SLACK_MESSAGE_MUTEX = 'SLACK_MESSAGE_LOCK::%<sender_id>s::%<reference_id>s'.freeze
 end

--- a/lib/redis/redis_keys.rb
+++ b/lib/redis/redis_keys.rb
@@ -37,6 +37,6 @@ module Redis::RedisKeys
   ## Sempahores / Locks
   # We don't want to process messages from the same sender concurrently to prevent creating double conversations
   FACEBOOK_MESSAGE_MUTEX = 'FB_MESSAGE_CREATE_LOCK::%<sender_id>s::%<recipient_id>s'.freeze
-  IG_MESSAGE_MUTEX = 'IG_MESSAGE_CREATE_LOCK::%<page_id>s'.freeze
+  IG_MESSAGE_MUTEX = 'IG_MESSAGE_CREATE_LOCK::%<ig_account_id>s'.freeze
   SLACK_MESSAGE_MUTEX = 'SLACK_MESSAGE_LOCK::%<sender_id>s::%<reference_id>s'.freeze
 end


### PR DESCRIPTION
This PR adds a mutex for `InstagramEventsJob`; the key used is the ID of the users Instagram Professional account. 