### PR TITLE
fix: Attachment sent from slack doesn't reach to chatwoot

### DIFF
--- a/app/models/concerns/slack_message_creation.rb
+++ b/app/models/concerns/slack_message_creation.rb
@@ -10,11 +10,11 @@ module SlackMessageCreation
     @message.save!
     { status: 'success' }
   rescue Slack::Web::Api::Errors::MissingScope => e
-    handle_missing_scope_error(e)
+    ChatwootExceptionTracker.new(e, account: conversation.account).capture_exception
+    disable_and_reauthorize
   end
 
-  def handle_missing_scope_error(_error)
-    Rails.logger.error e
+  def disable_and_reauthorize
     integration_hook.prompt_reauthorization!
     integration_hook.disable
   end

--- a/app/models/concerns/slack_message_creation.rb
+++ b/app/models/concerns/slack_message_creation.rb
@@ -1,0 +1,69 @@
+module SlackMessageCreation
+  extend ActiveSupport::Concern
+
+  private
+
+  def create_message
+    return unless conversation
+
+    build_message
+    @message.save!
+    { status: 'success' }
+  rescue Slack::Web::Api::Errors::MissingScope => e
+    handle_missing_scope_error(e)
+  end
+
+  def handle_missing_scope_error(_error)
+    Rails.logger.error e
+    integration_hook.prompt_reauthorization!
+    integration_hook.disable
+  end
+
+  def build_message
+    @message = conversation.messages.build(
+      message_type: :outgoing,
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      content: Slack::Messages::Formatting.unescape(params[:event][:text] || ''),
+      external_source_id_slack: params[:event][:ts],
+      private: private_note?,
+      sender: sender
+    )
+    process_attachments(params[:event][:files]) if attachments_present?
+  end
+
+  def attachments_present?
+    params[:event][:files].present?
+  end
+
+  def process_attachments(attachments)
+    attachments.each do |attachment|
+      tempfile = Down::NetHttp.download(attachment[:url_private], headers: { 'Authorization' => "Bearer #{integration_hook.access_token}" })
+
+      attachment_params = {
+        file_type: file_type(attachment),
+        account_id: @message.account_id,
+        external_url: attachment[:url_private],
+        file: {
+          io: tempfile,
+          filename: tempfile.original_filename,
+          content_type: tempfile.content_type
+        }
+      }
+
+      attachment_obj = @message.attachments.new(attachment_params)
+      attachment_obj.file.content_type = attachment[:mimetype]
+    end
+  end
+
+  def file_type(attachment)
+    return if attachment[:mimetype] == 'text/plain'
+
+    case attachment[:filetype]
+    when 'png', 'jpeg', 'gif', 'bmp', 'tiff', 'jpg'
+      :image
+    when 'pdf'
+      :file
+    end
+  end
+end

--- a/config/integration/apps.yml
+++ b/config/integration/apps.yml
@@ -13,7 +13,7 @@ slack:
   id: slack
   logo: slack.png
   i18n_key: slack
-  action: https://slack.com/oauth/v2/authorize?scope=commands,chat:write,channels:read,channels:manage,channels:join,groups:read,groups:write,im:write,mpim:write,users:read,users:read.email,chat:write.customize,channels:history,groups:history,mpim:history,im:history
+  action: https://slack.com/oauth/v2/authorize?scope=commands,chat:write,channels:read,channels:manage,channels:join,groups:read,groups:write,im:write,mpim:write,users:read,users:read.email,chat:write.customize,channels:history,groups:history,mpim:history,im:history,files:read,files:write
   hook_type: account
   allow_multiple_hooks: false
 webhooks:

--- a/lib/integrations/slack/incoming_message_builder.rb
+++ b/lib/integrations/slack/incoming_message_builder.rb
@@ -1,4 +1,5 @@
 class Integrations::Slack::IncomingMessageBuilder
+  include SlackMessageCreation
   attr_reader :params
 
   SUPPORTED_EVENT_TYPES = %w[event_callback url_verification].freeze
@@ -36,7 +37,11 @@ class Integrations::Slack::IncomingMessageBuilder
   def should_process_event?
     return true if params[:type] != 'event_callback'
 
-    params[:event][:user].present? && params[:event][:subtype].blank?
+    params[:event][:user].present? && valid_event_subtype?
+  end
+
+  def valid_event_subtype?
+    params[:event][:subtype].blank? || params[:event][:subtype] == 'file_share'
   end
 
   def supported_event?
@@ -90,60 +95,8 @@ class Integrations::Slack::IncomingMessageBuilder
     params[:event][:text].strip.downcase.starts_with?('note:', 'private:')
   end
 
-  def create_message
-    return unless conversation
-
-    @message = conversation.messages.create!(
-      message_type: :outgoing,
-      account_id: conversation.account_id,
-      inbox_id: conversation.inbox_id,
-      content: Slack::Messages::Formatting.unescape(params[:event][:text] || ''),
-      external_source_id_slack: params[:event][:ts],
-      private: private_note?,
-      sender: sender
-    )
-
-    process_attachments(params[:event][:files]) if params[:event][:files].present?
-
-    { status: 'success' }
-  end
-
   def slack_client
     @slack_client ||= Slack::Web::Client.new(token: @integration_hook.access_token)
-  end
-
-  # TODO: move process attachment for facebook instagram and slack in one place
-  # https://api.slack.com/messaging/files
-  def process_attachments(attachments)
-    attachments.each do |attachment|
-      tempfile = Down::NetHttp.download(attachment[:url_private], headers: { 'Authorization' => "Bearer #{integration_hook.access_token}" })
-
-      attachment_params = {
-        file_type: file_type(attachment),
-        account_id: @message.account_id,
-        external_url: attachment[:url_private],
-        file: {
-          io: tempfile,
-          filename: tempfile.original_filename,
-          content_type: tempfile.content_type
-        }
-      }
-
-      attachment_obj = @message.attachments.new(attachment_params)
-      attachment_obj.file.content_type = attachment[:mimetype]
-      attachment_obj.save!
-    end
-  end
-
-  def file_type(attachment)
-    return if attachment[:mimetype] == 'text/plain'
-
-    case attachment[:filetype]
-    when 'png', 'jpeg', 'gif', 'bmp', 'tiff', 'jpg'
-      :image
-    when 'pdf'
-      :file
-    end
   end
 
   # Ignoring the changes added here https://github.com/chatwoot/chatwoot/blob/5b5a6d89c0cf7f3148a1439d6fcd847784a79b94/lib/integrations/slack/send_on_slack_service.rb#L69


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2366/files-sent-from-slack-doesnt-reach-the-customer

https://www.loom.com/share/a606c17136284ec68e51a059508615e7