### PR TITLE
chore: Support multiple values for automation message content

### DIFF
--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -47,8 +47,6 @@ class FilterService
       query_hash['values'].map { |x| Conversation.statuses[x.to_sym] }
     when 'message_type'
       query_hash['values'].map { |x| Message.message_types[x.to_sym] }
-    when 'content'
-      string_filter_values(query_hash)
     else
       case_insensitive_values(query_hash)
     end


### PR DESCRIPTION
This change will allow automation rules with `message -> content` `equal` or `not equal` rules to accept an array of values. 
example rule 

```
#<AutomationRule:0x0000000107db6408
 id: 3,
 account_id: 1,
 name: "hello",
 description: "hello",
 event_name: "message_created",
 conditions:
  [{"values"=>["hi", "test", "Test", "magic"],
    "attribute_key"=>"content",
    "filter_operator"=>"equal_to",
    "custom_attribute_type"=>""}],
 actions:
  [{"action_name"=>"send_message", "action_params"=>["automation working"]}],
 created_at: Thu, 07 Sep 2023 00:19:49.873168000 UTC +00:00,
 updated_at: Thu, 07 Sep 2023 00:42:11.988807000 UTC +00:00,
 active: true>
```