### PR TITLE
fix: Editor menu option is not showing

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -51,6 +51,7 @@ import uiSettingsMixin from 'dashboard/mixins/uiSettings';
 import { isEditorHotKeyEnabled } from 'dashboard/mixins/uiSettings';
 import { replaceVariablesInMessage } from '@chatwoot/utils';
 import { CONVERSATION_EVENTS } from '../../../helper/AnalyticsHelper/events';
+import { MESSAGE_EDITOR_MENU_OPTIONS } from 'dashboard/constants/editor';
 
 const createState = (
   content,
@@ -110,6 +111,11 @@ export default {
       return (
         this.enableCannedResponses && this.showCannedMenu && !this.isPrivate
       );
+    },
+    editorMenuOptions() {
+      return this.enabledMenuOptions.length
+        ? this.enabledMenuOptions
+        : MESSAGE_EDITOR_MENU_OPTIONS;
     },
     plugins() {
       if (!this.enableSuggestions) {
@@ -249,7 +255,7 @@ export default {
       this.value,
       this.placeholder,
       this.plugins,
-      this.enabledMenuOptions
+      this.editorMenuOptions
     );
   },
   mounted() {
@@ -263,7 +269,7 @@ export default {
         content,
         this.placeholder,
         this.plugins,
-        this.enabledMenuOptions
+        this.editorMenuOptions
       );
       this.editorView.updateState(this.state);
       this.focusEditorInputField();

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -69,7 +69,6 @@
         :min-height="4"
         :enable-variables="true"
         :variables="messageVariables"
-        :enabled-menu-options="customEditorMenuOptions"
         @typing-off="onTypingOff"
         @typing-on="onTypingOn"
         @focus="onFocus"
@@ -185,7 +184,6 @@ import wootConstants from 'dashboard/constants/globals';
 import { isEditorHotKeyEnabled } from 'dashboard/mixins/uiSettings';
 import { CONVERSATION_EVENTS } from '../../../helper/AnalyticsHelper/events';
 import rtlMixin from 'shared/mixins/rtlMixin';
-import { MESSAGE_EDITOR_MENU_OPTIONS } from 'dashboard/constants/editor';
 
 const EmojiInput = () => import('shared/components/emoji/EmojiInput');
 
@@ -228,7 +226,6 @@ export default {
   data() {
     return {
       message: '',
-      customEditorMenuOptions: MESSAGE_EDITOR_MENU_OPTIONS,
       isFocused: false,
       showEmojiPicker: false,
       attachedFiles: [],


### PR DESCRIPTION
# Pull Request Template

## Description

This PR includes a hotfix: the editor menu is not visible in other editors except the message editor. For example, in campaigns, new conversation editor. etc

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Loom video
https://www.loom.com/share/8c89cf4d40974355b12e28096f152c6c?sid=7f099830-885c-4b18-9f2d-a7070927954b

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
