### PR TITLE
fix: Erase null bytes from incoming Twilio messages

### DIFF
--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -9,7 +9,7 @@ class Twilio::IncomingMessageService
     set_contact
     set_conversation
     @message = @conversation.messages.create!(
-      content: params[:Body],
+      content: message_body,
       account_id: @inbox.account_id,
       inbox_id: @inbox.id,
       message_type: :incoming,
@@ -44,6 +44,10 @@ class Twilio::IncomingMessageService
 
   def formatted_phone_number
     TelephoneNumber.parse(phone_number).international_number
+  end
+
+  def message_body
+    params[:Body].delete("\u0000")
   end
 
   def set_contact

--- a/spec/services/twilio/incoming_message_service_spec.rb
+++ b/spec/services/twilio/incoming_message_service_spec.rb
@@ -24,6 +24,19 @@ describe Twilio::IncomingMessageService do
       expect(conversation.reload.messages.last.content).to eq('testing3')
     end
 
+    it 'removes null bytes' do
+      params = {
+        SmsSid: 'SMxx',
+        From: '+12345',
+        AccountSid: 'ACxxx',
+        MessagingServiceSid: twilio_channel.messaging_service_sid,
+        Body: "remove\u0000 null bytes\u0000"
+      }
+
+      described_class.new(params: params).perform
+      expect(conversation.reload.messages.last.content).to eq('remove null bytes')
+    end
+
     it 'creates a new conversation' do
       params = {
         SmsSid: 'SMxx',


### PR DESCRIPTION
We've had some messages come in from a few different phone numbers that had null bytes in them. I don't know how this happens. They don't seem to be malicious.

They currently cause the Postgres gem to raise an error when Chatwoot attempts to save the message body to the database:
> ArgumentError (string contains null byte)

Related Rails GitHub issue: https://github.com/rails/rails/issues/26891