### PR TITLE
chore: Disable archived channels from the slack integration

### DIFF
--- a/lib/integrations/slack/channel_builder.rb
+++ b/lib/integrations/slack/channel_builder.rb
@@ -24,7 +24,7 @@ class Integrations::Slack::ChannelBuilder
   end
 
   def channels
-    conversations_list = slack_client.conversations_list(types: 'public_channel, private_channel')
+    conversations_list = slack_client.conversations_list(types: 'public_channel, private_channel', exclude_archived: true)
     channel_list = conversations_list.channels
     while conversations_list.response_metadata.next_cursor.present?
       conversations_list = slack_client.conversations_list(cursor: conversations_list.response_metadata.next_cursor)


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2488/exclude-archived-channels-from-the-slack-integration