### PR TITLE
fix: Check body exists before deleting null bytes in Twilio

### DIFF
--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -47,7 +47,7 @@ class Twilio::IncomingMessageService
   end
 
   def message_body
-    params[:Body].delete("\u0000")
+    params[:Body]&.delete("\u0000")
   end
 
   def set_contact

--- a/spec/services/twilio/incoming_message_service_spec.rb
+++ b/spec/services/twilio/incoming_message_service_spec.rb
@@ -37,6 +37,18 @@ describe Twilio::IncomingMessageService do
       expect(conversation.reload.messages.last.content).to eq('remove null bytes')
     end
 
+    it 'wont throw error when the body is empty' do
+      params = {
+        SmsSid: 'SMxx',
+        From: '+12345',
+        AccountSid: 'ACxxx',
+        MessagingServiceSid: twilio_channel.messaging_service_sid
+      }
+
+      described_class.new(params: params).perform
+      expect(conversation.reload.messages.last.content).to be_nil
+    end
+
     it 'creates a new conversation' do
       params = {
         SmsSid: 'SMxx',


### PR DESCRIPTION
This PR will add the fix for checking body exist or not before deleting the null bytes in Twilio payload.

Reference https://github.com/chatwoot/chatwoot/pull/7901