### PR TITLE
chore: Migration status in super admin

### DIFF
--- a/app/controllers/super_admin/instance_statuses_controller.rb
+++ b/app/controllers/super_admin/instance_statuses_controller.rb
@@ -6,6 +6,7 @@ class SuperAdmin::InstanceStatusesController < SuperAdmin::ApplicationController
     postgres_status
     redis_metrics
     chatwoot_edition
+    instance_meta
   end
 
   def chatwoot_edition
@@ -16,6 +17,10 @@ class SuperAdmin::InstanceStatusesController < SuperAdmin::ApplicationController
                                    else
                                      'Community'
                                    end
+  end
+
+  def instance_meta
+    @metrics['Database Migrations'] = ActiveRecord::Base.connection.migration_context.needs_migration? ? 'pending' : 'completed'
   end
 
   def chatwoot_version


### PR DESCRIPTION
Pending migrations are often cause for issues in Chatwoot self-hosted installation. This feature should help to identify such issues easily


<img width="1433" alt="Screenshot 2023-09-18 at 8 32 00 PM" src="https://github.com/chatwoot/chatwoot/assets/73185/66c1ce48-e1a6-4d89-868f-00b9625b6176">
