### PR TITLE
feat: Slack link unfurling

### DIFF
--- a/config/initializers/monkey_patches/chat.rb
+++ b/config/initializers/monkey_patches/chat.rb
@@ -1,0 +1,21 @@
+module Slack
+  module Web
+    module Api
+      module Endpoints
+        module Chat
+          # TODO: Remove this monkey patch when PR for this issue https://github.com/slack-ruby/slack-ruby-client/issues/388 is merged
+          def chat_unfurl(options = {})
+            if (options[:channel].nil? || options[:ts].nil?) && (options[:unfurl_id].nil? || options[:source].nil?)
+              raise ArgumentError, 'Either a combination of :channel and :ts or :unfurl_id and :source is required'
+            end
+
+            raise ArgumentError, 'Required arguments :unfurls missing' if options[:unfurls].nil?
+
+            options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
+            post('chat.unfurl', options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/integrations/slack/link_unfurl_helper.rb
+++ b/lib/integrations/slack/link_unfurl_helper.rb
@@ -1,0 +1,53 @@
+module Integrations::Slack::LinkUnfurlHelper
+  def generate_unfurls(url, user_info)
+    {
+      url => {
+        'blocks' => user_info_blocks(user_info) +
+          open_conversation_button(url)
+      }
+    }
+  end
+
+  private
+
+  def user_info_blocks(user_info)
+    [
+      {
+        'type' => 'section',
+        'fields' => [
+          user_info_field('Name', user_info[:user_name]),
+          user_info_field('Email', user_info[:email]),
+          user_info_field('Phone', user_info[:phone_number]),
+          user_info_field('Company', user_info[:company_name])
+        ]
+      }
+    ]
+  end
+
+  def user_info_field(label, value)
+    {
+      'type' => 'mrkdwn',
+      'text' => "*#{label}:*\n#{value}"
+    }
+  end
+
+  def open_conversation_button(url)
+    [
+      {
+        'type' => 'actions',
+        'elements' => [
+          {
+            'type' => 'button',
+            'text' => {
+              'type' => 'plain_text',
+              'text' => 'Open conversation',
+              'emoji' => true
+            },
+            'url' => url,
+            'action_id' => 'button-action'
+          }
+        ]
+      }
+    ]
+  end
+end

--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -14,6 +14,12 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
     perform_reply
   end
 
+  def link_unfurl(event)
+    slack_client.chat_unfurl(
+      event
+    )
+  end
+
   private
 
   def valid_channel_for_slack?

--- a/lib/integrations/slack/slack_message_helper.rb
+++ b/lib/integrations/slack/slack_message_helper.rb
@@ -62,4 +62,27 @@ module Integrations::Slack::SlackMessageHelper
       :file
     end
   end
+
+  def conversation
+    @conversation ||= Conversation.where(identifier: params[:event][:thread_ts]).first
+  end
+
+  def sender
+    user_email = slack_client.users_info(user: params[:event][:user])[:user][:profile][:email]
+    conversation.account.users.find_by(email: user_email)
+  end
+
+  def private_note?
+    params[:event][:text].strip.downcase.starts_with?('note:', 'private:')
+  end
+
+  def extract_conversation_id(url)
+    conversation_id_regex = %r{/conversations/(\d+)}
+    match_data = url.match(conversation_id_regex)
+    match_data[1] if match_data
+  end
+
+  def find_conversation_by_id(conversation_id)
+    Conversation.find_by(display_id: conversation_id)
+  end
 end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2369/render-private-information-in-the-metadata-if-slack-app-is-connected

## How Has This Been Tested?

## Configuring your app 

To support custom app unfurling, your app needs to have the permissions to listen to links posted into Slack and unfurl those links.

### Scopes and token types 

Navigate to your [app configuration](https://api.slack.com/apps) and choose the OAuth & Permissions sidebar to select scopes.

Add the [links:read](https://api.slack.com/scopes/links:read) & [links:write](https://api.slack.com/scopes/links:write) scopes under **Bot Token Scopes*.

### Events 

Navigate to the Event Subscriptions sidebar.

Under Subscribe to bot events, add the [link_shared event](https://api.slack.com/events/link_shared) to receive information about links posted into Slack that are associated with your app.

The [link_shared](https://api.slack.com/events/link_shared) event will dispatch for all channels in each workspace it is installed in.

### Register your domain(s) 

On the same Event Subscriptions page, click App unfurl domains near the bottom of the page. Your app can register up to five domains, and will only receive [link_shared](https://api.slack.com/events/link_shared) events for URLs that match your registered domains.

More details can be found [here](https://api.slack.com/reference/messaging/link-unfurling#setup).