### PR TITLE
fix: open conversation too many cause db io crush

### DIFF
--- a/app/builders/v2/report_builder.rb
+++ b/app/builders/v2/report_builder.rb
@@ -96,12 +96,13 @@ class V2::ReportBuilder
   end
 
   def live_conversations
-    @open_conversations = scope.conversations.where(account_id: @account.id).open
+    open_conversations_count = scope.conversations.where(account_id: @account.id).open.count
+    open_unattended_conversations_count = scope.conversations.where(account_id: @account.id).open.unattended.count
     metric = {
-      open: @open_conversations.count,
-      unattended: @open_conversations.unattended.count
+      open: open_conversations_count,
+      unattended: open_unattended_conversations_count
     }
-    metric[:unassigned] = @open_conversations.unassigned.count if params[:type].equal?(:account)
+    metric[:unassigned] = scope.conversations.where(account_id: @account.id).open.unassigned.count if params[:type].equal?(:account)
     metric
   end
 end


### PR DESCRIPTION
# Pull Request Template

## Description

When account has too many open conversation(in my case, the number over 500k), this query(`scope.conversations.where(account_id: @account.id).open`) will cause db io crush, and db will no response until it recover(in my case, db has shut down for 30s).

Fixes # (issue)

## Type of change

- [ ] Bug fix 

## How Has This Been Tested?

Page "/app/accounts/:account_id/reports/overview" shows same data.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
