### PR TITLE
fix: handling markdown before replacing or appending signature [CW-2532]

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
@@ -218,7 +218,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '@chatwoot/prosemirror-schema/src/styles/article.scss';
+@import '~@chatwoot/prosemirror-schema/src/styles/article.scss';
 
 .ProseMirror-menubar-wrapper {
   display: flex;

--- a/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
@@ -218,7 +218,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~@chatwoot/prosemirror-schema/src/styles/article.scss';
+@import '@chatwoot/prosemirror-schema/src/styles/article.scss';
 
 .ProseMirror-menubar-wrapper {
   display: flex;

--- a/app/javascript/dashboard/helper/editorHelper.js
+++ b/app/javascript/dashboard/helper/editorHelper.js
@@ -11,29 +11,12 @@ import {
 export const SIGNATURE_DELIMITER = '--';
 
 /**
- * Remove trailing spaces from each line in a markdown text
- * @param {string} markdownText
- * @returns
- */
-function removeTrailingSpaces(markdownText) {
-  return markdownText
-    .split('\n')
-    .map(line => line.replace(/\s+$/, ''))
-    .join('\n');
-}
-
-/**
- * Trim the signature and remove all " \r" from the signature
- * 1. Trim any extra lines or spaces at the start or end of the string
- * 2. Converts all \r or \r\n to \f
+ * Parse and Serialize the markdown text to remove any extra spaces or new lines
  */
 export function cleanSignature(signature) {
   // convert from markdown to common mark format
   const nodes = new MessageMarkdownTransformer(messageSchema).parse(signature);
-  const md = MessageMarkdownSerializer.serialize(nodes);
-
-  const cleaned = md.trim().replace(/\r\n?/g, '\n');
-  return removeTrailingSpaces(cleaned);
+  return MessageMarkdownSerializer.serialize(nodes);
 }
 
 /**

--- a/app/javascript/dashboard/helper/editorHelper.js
+++ b/app/javascript/dashboard/helper/editorHelper.js
@@ -1,3 +1,9 @@
+import {
+  messageSchema,
+  MessageMarkdownTransformer,
+  MessageMarkdownSerializer,
+} from '@chatwoot/prosemirror-schema';
+
 /**
  * The delimiter used to separate the signature from the rest of the body.
  * @type {string}
@@ -22,7 +28,11 @@ function removeTrailingSpaces(markdownText) {
  * 2. Converts all \r or \r\n to \f
  */
 export function cleanSignature(signature) {
-  const cleaned = signature.trim().replace(/\r\n?/g, '\n');
+  // convert from markdown to common mark format
+  const nodes = new MessageMarkdownTransformer(messageSchema).parse(signature);
+  const md = MessageMarkdownSerializer.serialize(nodes);
+
+  const cleaned = md.trim().replace(/\r\n?/g, '\n');
   return removeTrailingSpaces(cleaned);
 }
 

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -6,48 +6,6 @@ import {
   extractTextFromMarkdown,
 } from '../editorHelper';
 
-// 🚨 Why mock @chatwoot/prosemirror-schema?
-// If we don't mock it we will get an error like this
-//     SyntaxError: Cannot use import statement outside a module
-// This is because one of the imports inside @prosemirror/schema is not a module
-// It's prosemirror-history, it is written in typescript, but seems like it's not exported properly
-// We cannot do much about it, except mock it
-//
-// Including `ts-jest` and `typescript` should potentially fix it
-// but a problem exists with babel and jest versions, babel uses core-js 3,
-// which has a conflict with the browser name for `opera_mobile`,
-// this breaks the build
-// the best solution in that case is to mock the function with a closest implementation
-//
-// In the future, we could also mock this using MarkdownIt and TurnDown
-// import MarkdownIt from "markdown-it";
-// import Turndown from "turndown";
-//
-// const forward = new MarkdownIt("commonmark");
-// const reverse = new Turndown()
-// const commonMark = reverse.turndown(forward.render(signature))
-//
-// At the moment it's not necessary, but if we need to do more complex
-// transformations, we can use the above approach
-jest.mock('@chatwoot/prosemirror-schema', () => ({
-  messageSchema: 'mocked messageSchema',
-  MessageMarkdownTransformer: () => {
-    return {
-      parse: jest.fn().mockImplementation(candidate => {
-        return candidate
-          .trim()
-          .replace(/\r\n?/g, '\n')
-          .split('\n')
-          .map(line => line.replace(/\s+$/, ''))
-          .join('\n');
-      }),
-    };
-  },
-  MessageMarkdownSerializer: {
-    serialize: candidate => candidate,
-  },
-}));
-
 const NEW_SIGNATURE = 'This is a new signature';
 
 const DOES_NOT_HAVE_SIGNATURE = {

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -20,7 +20,7 @@ const DOES_NOT_HAVE_SIGNATURE = {
   signature_has_images: {
     body: 'This is a test',
     signature:
-      'Testing\n![](http://localhost:3000/rails/active_storage/blobs/redirect/some-hash/image.png)',
+      'Testing \n![](http://localhost:3000/rails/active_storage/blobs/redirect/some-hash/image.png)',
   },
 };
 

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -6,6 +6,48 @@ import {
   extractTextFromMarkdown,
 } from '../editorHelper';
 
+// 🚨 Why mock @chatwoot/prosemirror-schema?
+// If we don't mock it we will get an error like this
+//     SyntaxError: Cannot use import statement outside a module
+// This is because one of the imports inside @prosemirror/schema is not a module
+// It's prosemirror-history, it is written in typescript, but seems like it's not exported properly
+// We cannot do much about it, except mock it
+//
+// Including `ts-jest` and `typescript` should potentially fix it
+// but a problem exists with babel and jest versions, babel uses core-js 3,
+// which has a conflict with the browser name for `opera_mobile`,
+// this breaks the build
+// the best solution in that case is to mock the function with a closest implementation
+//
+// In the future, we could also mock this using MarkdownIt and TurnDown
+// import MarkdownIt from "markdown-it";
+// import Turndown from "turndown";
+//
+// const forward = new MarkdownIt("commonmark");
+// const reverse = new Turndown()
+// const commonMark = reverse.turndown(forward.render(signature))
+//
+// At the moment it's not necessary, but if we need to do more complex
+// transformations, we can use the above approach
+jest.mock('@chatwoot/prosemirror-schema', () => ({
+  messageSchema: 'mocked messageSchema',
+  MessageMarkdownTransformer: () => {
+    return {
+      parse: jest.fn().mockImplementation(candidate => {
+        return candidate
+          .trim()
+          .replace(/\r\n?/g, '\n')
+          .split('\n')
+          .map(line => line.replace(/\s+$/, ''))
+          .join('\n');
+      }),
+    };
+  },
+  MessageMarkdownSerializer: {
+    serialize: candidate => candidate,
+  },
+}));
+
 const NEW_SIGNATURE = 'This is a new signature';
 
 const DOES_NOT_HAVE_SIGNATURE = {
@@ -20,7 +62,7 @@ const DOES_NOT_HAVE_SIGNATURE = {
   signature_has_images: {
     body: 'This is a test',
     signature:
-      'Testing \n![](http://localhost:3000/rails/active_storage/blobs/redirect/some-hash/image.png)',
+      'Testing\n![](http://localhost:3000/rails/active_storage/blobs/redirect/some-hash/image.png)',
   },
 };
 

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -18,10 +18,14 @@ const DOES_NOT_HAVE_SIGNATURE = {
     body: 'This is a test\n\n--\n\nThis is a signature\n\nThis is more text',
     signature: 'This is a signature',
   },
-  signature_has_images: {
+  'signature has images': {
     body: 'This is a test',
     signature:
-      'Testing\n![](http://localhost:3000/rails/active_storage/blobs/redirect/some-hash/image.png)',
+      'Testing \n![](http://localhost:3000/rails/active_storage/blobs/redirect/some-hash/image.png)',
+  },
+  'signature has non commonmark syntax': {
+    body: 'This is a test',
+    signature: '- Shivam',
   },
 };
 
@@ -37,6 +41,10 @@ const HAS_SIGNATURE = {
   'no text before signature': {
     body: '\n\n--\n\nThis is a signature',
     signature: 'This is a signature',
+  },
+  'signature has non-commonmark syntax': {
+    body: '\n\n--\n\n* Signature',
+    signature: '- Signature',
   },
 };
 

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -25,7 +25,11 @@ const DOES_NOT_HAVE_SIGNATURE = {
   },
   'signature has non commonmark syntax': {
     body: 'This is a test',
-    signature: '- Shivam',
+    signature: '- Signature',
+  },
+  'signature has trailing spaces': {
+    body: 'This is a test',
+    signature: '**hello**      \n**world**',
   },
 };
 

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -3,6 +3,7 @@ import {
   appendSignature,
   removeSignature,
   replaceSignature,
+  cleanSignature,
   extractTextFromMarkdown,
 } from '../editorHelper';
 
@@ -20,7 +21,7 @@ const DOES_NOT_HAVE_SIGNATURE = {
   signature_has_images: {
     body: 'This is a test',
     signature:
-      'Testing \n![](http://localhost:3000/rails/active_storage/blobs/redirect/some-hash/image.png)',
+      'Testing\n![](http://localhost:3000/rails/active_storage/blobs/redirect/some-hash/image.png)',
   },
 };
 
@@ -58,9 +59,10 @@ describe('appendSignature', () => {
   it('appends the signature if it is not present', () => {
     Object.keys(DOES_NOT_HAVE_SIGNATURE).forEach(key => {
       const { body, signature } = DOES_NOT_HAVE_SIGNATURE[key];
-      expect(appendSignature(body, signature)).toBe(
-        `${body}\n\n--\n\n${signature}`
-      );
+      const cleanedSignature = cleanSignature(signature);
+      expect(
+        appendSignature(body, signature).includes(cleanedSignature)
+      ).toBeTruthy();
     });
   });
   it('does not append signature if already present', () => {

--- a/app/javascript/shared/components/ResizableTextArea.vue
+++ b/app/javascript/shared/components/ResizableTextArea.vue
@@ -113,7 +113,6 @@ export default {
       });
     },
     setCursor() {
-      const textarea = this.$refs.textarea;
       const bodyWithoutSignature = removeSignature(
         this.value,
         this.cleanedSignature
@@ -121,9 +120,12 @@ export default {
 
       // only trim at end, so if there are spaces at the start, those are not removed
       const bodyEndsAt = bodyWithoutSignature.trimEnd().length;
+      const textarea = this.$refs.textarea;
 
-      textarea.focus();
-      textarea.setSelectionRange(bodyEndsAt, bodyEndsAt);
+      if (textarea) {
+        textarea.focus();
+        textarea.setSelectionRange(bodyEndsAt, bodyEndsAt);
+      }
     },
     onInput(event) {
       this.$emit('input', event.target.value);

--- a/app/javascript/shared/components/ResizableTextArea.vue
+++ b/app/javascript/shared/components/ResizableTextArea.vue
@@ -159,7 +159,7 @@ export default {
       this.$emit('focus');
     },
     focus() {
-      this.$refs.textarea.focus();
+      if (this.$refs.textarea) this.$refs.textarea.focus();
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@braid/vue-formulate": "^2.5.2",
-    "@chatwoot/prosemirror-schema": "https://github.com/chatwoot/prosemirror-schema.git#825755b53f1ef4ae14fac2393b53a02e14ce21e0",
+    "@chatwoot/prosemirror-schema": "^1.0.1",
     "@chatwoot/utils": "^0.0.16",
     "@hcaptcha/vue-hcaptcha": "^0.3.2",
     "@june-so/analytics-next": "^1.36.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,9 +2994,10 @@
     is-url "^1.2.4"
     nanoid "^2.1.11"
 
-"@chatwoot/prosemirror-schema@https://github.com/chatwoot/prosemirror-schema.git#825755b53f1ef4ae14fac2393b53a02e14ce21e0":
-  version "1.0.0"
-  resolved "https://github.com/chatwoot/prosemirror-schema.git#825755b53f1ef4ae14fac2393b53a02e14ce21e0"
+"@chatwoot/prosemirror-schema@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@chatwoot/prosemirror-schema/-/prosemirror-schema-1.0.1.tgz#7beb7a9303fbf5281d3a7e6c470ac78cce21be04"
+  integrity sha512-fnT2zSzAmiAh1ElEWqBhISavGZF73DLUzQyml0iiXDy6IU7HS3TtQPI/AGoCK3CkCxvoqBtzhRLGZrHsftoQ9w==
   dependencies:
     markdown-it-sup "^1.0.0"
     prosemirror-commands "^1.1.4"


### PR DESCRIPTION
This PR fixes an issue where a signature would not be replaced properly in the editor.  The problem is that when a signature reached our editor, which looks like the following `- Jane Doe`, it is fed to the editor, which converts it to commonmark, which looks like the following `* Jane Doe` 

The problem arises when we try to look for the signature, since the output and input don't match, the program concludes that there is no signature in the body, and we simply append it again. On every mount this happens and here we have it, infinite signature glitch

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
