### PR TITLE
fix: Editor add link modal header dark mode issue

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -670,6 +670,10 @@ export default {
 
 .ProseMirror-prompt {
   @apply z-50 bg-slate-25 dark:bg-slate-700 rounded-md border border-solid border-slate-75 dark:border-slate-800;
+
+  h5 {
+    @apply dark:text-slate-25 text-slate-800;
+  }
 }
 
 .is-private {


### PR DESCRIPTION
# Pull Request Template

## Description

This PR includes a fix for the editor add link modal header issue.

Fixes https://linear.app/chatwoot/issue/CW-2529/dark-mode-issues

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

|  Dark mode  |  Light mode  |
|---|---|
| <img width="229" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/a9980130-7c28-4dca-8afb-c92eeba5b231"> |  <img width="229" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/b5a94378-ffc2-4bd8-97fe-a3ef0dd69104"> |  







## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
