### PR TITLE
chore: Update the filter for articles in the widget

### DIFF
--- a/app/controllers/public/api/v1/portals/articles_controller.rb
+++ b/app/controllers/public/api/v1/portals/articles_controller.rb
@@ -44,7 +44,7 @@ class Public::Api::V1::Portals::ArticlesController < Public::Api::V1::Portals::B
   end
 
   def list_params
-    params.permit(:query, :locale, :sort)
+    params.permit(:query, :locale, :sort, :status)
   end
 
   def permitted_params

--- a/app/javascript/widget/api/endPoints.js
+++ b/app/javascript/widget/api/endPoints.js
@@ -98,6 +98,7 @@ const getMostReadArticles = (slug, locale) => ({
   params: {
     page: 1,
     sort: 'views',
+    status: 1,
   },
 });
 


### PR DESCRIPTION
Avoid displaying the draft articles in the help center.