### PR TITLE
fix: Avoid joining tables to fix the distinct value query

### DIFF
--- a/app/services/contacts/filter_service.rb
+++ b/app/services/contacts/filter_service.rb
@@ -6,7 +6,7 @@ class Contacts::FilterService < FilterService
 
     {
       contacts: @contacts,
-      count: @contacts.count
+      count: @contacts.distinct.count
     }
   end
 
@@ -35,7 +35,7 @@ class Contacts::FilterService < FilterService
       " (contacts.#{attribute_key})::#{current_filter['data_type']} #{filter_operator_value}#{current_filter['data_type']} #{query_operator} "
     when 'standard'
       if attribute_key == 'labels'
-        " tags.id #{filter_operator_value} #{query_operator} "
+        tag_filter_query('Contact', 'contacts', query_hash, current_index)
       else
         " LOWER(contacts.#{attribute_key}) #{filter_operator_value} #{query_operator} "
       end
@@ -54,7 +54,7 @@ class Contacts::FilterService < FilterService
   end
 
   def base_relation
-    Current.account.contacts.distinct(:id).left_outer_joins(:labels)
+    Current.account.contacts
   end
 
   private

--- a/app/services/contacts/filter_service.rb
+++ b/app/services/contacts/filter_service.rb
@@ -6,7 +6,7 @@ class Contacts::FilterService < FilterService
 
     {
       contacts: @contacts,
-      count: @contacts.distinct.count
+      count: @contacts.count
     }
   end
 

--- a/app/services/conversations/filter_service.rb
+++ b/app/services/conversations/filter_service.rb
@@ -46,7 +46,7 @@ class Conversations::FilterService < FilterService
       " (conversations.#{attribute_key})::#{current_filter['data_type']} #{filter_operator_value}#{current_filter['data_type']} #{query_operator} "
     when 'standard'
       if attribute_key == 'labels'
-        " tags.name #{filter_operator_value} #{query_operator} "
+        tag_filter_query('Conversation', 'conversations', query_hash, current_index)
       else
         " conversations.#{attribute_key} #{filter_operator_value} #{query_operator} "
       end
@@ -54,7 +54,9 @@ class Conversations::FilterService < FilterService
   end
 
   def base_relation
-    @account.conversations.left_outer_joins(:labels)
+    @account.conversations.includes(
+      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox
+    )
   end
 
   def current_page

--- a/app/services/conversations/filter_service.rb
+++ b/app/services/conversations/filter_service.rb
@@ -55,7 +55,7 @@ class Conversations::FilterService < FilterService
 
   def base_relation
     @account.conversations.includes(
-      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox
+      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :messages, :contact_inbox
     )
   end
 
@@ -64,10 +64,6 @@ class Conversations::FilterService < FilterService
   end
 
   def conversations
-    @conversations = @conversations.includes(
-      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :messages, :contact_inbox
-    )
-
     @conversations.latest.page(current_page)
   end
 end

--- a/spec/services/contacts/filter_service_spec.rb
+++ b/spec/services/contacts/filter_service_spec.rb
@@ -84,7 +84,7 @@ describe Contacts::FilterService do
       end
 
       it 'filter contact by tags' do
-        label_id = cs_contact.labels.last.id
+        label_id = cs_contact.labels.last.name
         params[:payload] = [
           {
             attribute_key: 'labels',
@@ -101,7 +101,7 @@ describe Contacts::FilterService do
       end
 
       it 'filter by custom_attributes and labels' do
-        label_id = cs_contact.labels.last.id
+        label_id = cs_contact.labels.last.name
         params[:payload] = [
           {
             attribute_key: 'customer_type',

--- a/spec/services/contacts/filter_service_spec.rb
+++ b/spec/services/contacts/filter_service_spec.rb
@@ -15,7 +15,7 @@ describe Contacts::FilterService do
     create(:inbox_member, user: first_user, inbox: inbox)
     create(:inbox_member, user: second_user, inbox: inbox)
     create(:conversation, account: account, inbox: inbox, assignee: first_user, contact: en_contact)
-    create(:conversation, account: account, inbox: inbox)
+    create(:conversation, account: account, inbox: inbox, contact: el_contact)
     Current.account = account
 
     create(:custom_attribute_definition,
@@ -38,8 +38,7 @@ describe Contacts::FilterService do
 
   describe '#perform' do
     before do
-      en_contact.add_labels(%w[random_label support])
-      el_contact.update_labels('random_label')
+      en_contact.update_labels(%w[random_label support])
       cs_contact.update_labels('support')
 
       en_contact.update!(custom_attributes: { contact_additional_information: 'test custom data' })
@@ -58,6 +57,70 @@ describe Contacts::FilterService do
             query_operator: nil
           }.with_indifferent_access
         ]
+      end
+
+      context 'with label filter' do
+        it 'returns equal_to filter results properly' do
+          params[:payload] = [
+            {
+              attribute_key: 'labels',
+              filter_operator: 'equal_to',
+              values: ['support'],
+              query_operator: nil
+            }.with_indifferent_access
+          ]
+
+          result = filter_service.new(params, first_user).perform
+          expect(result[:contacts].length).to be 2
+          expect(result[:contacts].first.label_list).to include('support')
+          expect(result[:contacts].last.label_list).to include('support')
+        end
+
+        it 'returns not_equal_to filter results properly' do
+          params[:payload] = [
+            {
+              attribute_key: 'labels',
+              filter_operator: 'not_equal_to',
+              values: ['support'],
+              query_operator: nil
+            }.with_indifferent_access
+          ]
+
+          result = filter_service.new(params, first_user).perform
+          expect(result[:contacts].length).to be 1
+          expect(result[:contacts].first.id).to eq el_contact.id
+        end
+
+        it 'returns is_present filter results properly' do
+          params[:payload] = [
+            {
+              attribute_key: 'labels',
+              filter_operator: 'is_present',
+              values: [],
+              query_operator: nil
+            }.with_indifferent_access
+          ]
+
+          result = filter_service.new(params, first_user).perform
+          expect(result[:contacts].length).to be 2
+          expect(result[:contacts].first.label_list).to include('support')
+          expect(result[:contacts].last.label_list).to include('support')
+        end
+
+        it 'returns is_not_present filter results properly' do
+          params[:payload] = [
+            {
+              attribute_key: 'labels',
+              filter_operator: 'is_not_present',
+              values: [],
+              query_operator: nil
+            }.with_indifferent_access
+          ]
+
+          result = filter_service.new(params, first_user).perform
+          expect(result[:contacts].length).to be 1
+          expect(result[:contacts].first.id).to eq el_contact.id
+        end
       end
 
       it 'filter contacts by additional_attributes' do
@@ -83,25 +146,7 @@ describe Contacts::FilterService do
         expect(result[:contacts].first.name).to eq(en_contact.name)
       end
 
-      it 'filter contact by tags' do
-        label_id = cs_contact.labels.last.name
-        params[:payload] = [
-          {
-            attribute_key: 'labels',
-            filter_operator: 'equal_to',
-            values: [label_id],
-            query_operator: nil
-          }.with_indifferent_access
-        ]
-
-        result = filter_service.new(params, first_user).perform
-        expect(result[:contacts].length).to be 2
-        expect(result[:contacts].first.label_list).to include('support')
-        expect(result[:contacts].last.label_list).to include('support')
-      end
-
       it 'filter by custom_attributes and labels' do
-        label_id = cs_contact.labels.last.name
         params[:payload] = [
           {
             attribute_key: 'customer_type',
@@ -112,7 +157,7 @@ describe Contacts::FilterService do
           {
             attribute_key: 'labels',
             filter_operator: 'equal_to',
-            values: [label_id],
+            values: ['support'],
             query_operator: 'AND'
           }.with_indifferent_access,
           {


### PR DESCRIPTION
DISTINCT query with custom attributes return an error. To avoid the error, this PR refactors the query to include tags only when it is required.

Fixes https://github.com/chatwoot/chatwoot/issues/7931
Fixes https://github.com/chatwoot/chatwoot/issues/7836