### PR TITLE
fix: Use installation locale if configured

### DIFF
--- a/app/javascript/v3/App.vue
+++ b/app/javascript/v3/App.vue
@@ -15,6 +15,7 @@ export default {
   mounted() {
     this.setColorTheme();
     this.listenToThemeChanges();
+    this.setLocale(window.chatwootConfig.selectedLocale);
   },
   methods: {
     setColorTheme() {
@@ -34,6 +35,9 @@ export default {
           this.theme = 'light';
         }
       };
+    },
+    setLocale(locale) {
+      this.$root.$i18n.locale = locale;
     },
   },
 };


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2487/default-locale=pt-br-in-the-environment-variables 
Fixes #7894 


--- 

To test:

- Set DEFAULT_LOCALE = pt_BR in .env file
- Restart the application and see if the login / signup / reset password / set new password pages have the locale changed.
