### PR TITLE
fix: Token type `hr` not supported by Markdown parser

### DIFF
--- a/app/javascript/dashboard/helper/editorHelper.js
+++ b/app/javascript/dashboard/helper/editorHelper.js
@@ -3,6 +3,7 @@ import {
   MessageMarkdownTransformer,
   MessageMarkdownSerializer,
 } from '@chatwoot/prosemirror-schema';
+import * as Sentry from '@sentry/browser';
 
 window.messageSchema = messageSchema;
 window.MessageMarkdownTransformer = MessageMarkdownTransformer;
@@ -27,6 +28,7 @@ export function cleanSignature(signature) {
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(e);
+    Sentry.captureException(e);
     // The parser can break on some cases
     // for example, Token type `hr` not supported by Markdown parser
     return signature;

--- a/app/javascript/dashboard/helper/editorHelper.js
+++ b/app/javascript/dashboard/helper/editorHelper.js
@@ -5,9 +5,6 @@ import {
 } from '@chatwoot/prosemirror-schema';
 import * as Sentry from '@sentry/browser';
 
-window.messageSchema = messageSchema;
-window.MessageMarkdownTransformer = MessageMarkdownTransformer;
-window.MessageMarkdownSerializer = MessageMarkdownSerializer;
 /**
  * The delimiter used to separate the signature from the rest of the body.
  * @type {string}
@@ -38,8 +35,6 @@ export function cleanSignature(signature) {
     return signature;
   }
 }
-
-window.cleanSignature = cleanSignature;
 
 /**
  * Adds the signature delimiter to the beginning of the signature.

--- a/app/javascript/dashboard/helper/editorHelper.js
+++ b/app/javascript/dashboard/helper/editorHelper.js
@@ -5,6 +5,9 @@ import {
 } from '@chatwoot/prosemirror-schema';
 import * as Sentry from '@sentry/browser';
 
+window.messageSchema = messageSchema;
+window.MessageMarkdownTransformer = MessageMarkdownTransformer;
+window.MessageMarkdownSerializer = MessageMarkdownSerializer;
 /**
  * The delimiter used to separate the signature from the rest of the body.
  * @type {string}
@@ -16,6 +19,11 @@ export const SIGNATURE_DELIMITER = '--';
  */
 export function cleanSignature(signature) {
   try {
+    // remove any horizontal rule tokens
+    signature = signature
+      .replace(/^---+$/gm, '') // replace --- with empty string
+      .replace(/^___+$/gm, ''); // replace ___ with empty string
+
     // convert from markdown to common mark format
     const nodes = new MessageMarkdownTransformer(messageSchema).parse(
       signature
@@ -30,6 +38,8 @@ export function cleanSignature(signature) {
     return signature;
   }
 }
+
+window.cleanSignature = cleanSignature;
 
 /**
  * Adds the signature delimiter to the beginning of the signature.

--- a/app/javascript/dashboard/helper/editorHelper.js
+++ b/app/javascript/dashboard/helper/editorHelper.js
@@ -4,6 +4,10 @@ import {
   MessageMarkdownSerializer,
 } from '@chatwoot/prosemirror-schema';
 
+window.messageSchema = messageSchema;
+window.MessageMarkdownTransformer = MessageMarkdownTransformer;
+window.MessageMarkdownSerializer = MessageMarkdownSerializer;
+
 /**
  * The delimiter used to separate the signature from the rest of the body.
  * @type {string}
@@ -14,10 +18,22 @@ export const SIGNATURE_DELIMITER = '--';
  * Parse and Serialize the markdown text to remove any extra spaces or new lines
  */
 export function cleanSignature(signature) {
-  // convert from markdown to common mark format
-  const nodes = new MessageMarkdownTransformer(messageSchema).parse(signature);
-  return MessageMarkdownSerializer.serialize(nodes);
+  try {
+    // convert from markdown to common mark format
+    const nodes = new MessageMarkdownTransformer(messageSchema).parse(
+      signature
+    );
+    return MessageMarkdownSerializer.serialize(nodes);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+    // The parser can break on some cases
+    // for example, Token type `hr` not supported by Markdown parser
+    return signature;
+  }
 }
+
+window.cleanSignature = cleanSignature;
 
 /**
  * Adds the signature delimiter to the beginning of the signature.

--- a/app/javascript/dashboard/helper/editorHelper.js
+++ b/app/javascript/dashboard/helper/editorHelper.js
@@ -5,6 +5,9 @@ import {
 } from '@chatwoot/prosemirror-schema';
 import * as Sentry from '@sentry/browser';
 
+window.messageSchema = messageSchema;
+window.MessageMarkdownTransformer = MessageMarkdownTransformer;
+window.MessageMarkdownSerializer = MessageMarkdownSerializer;
 /**
  * The delimiter used to separate the signature from the rest of the body.
  * @type {string}
@@ -18,23 +21,25 @@ export function cleanSignature(signature) {
   try {
     // remove any horizontal rule tokens
     signature = signature
-      .replace(/^---+$/gm, '') // replace --- with empty string
-      .replace(/^___+$/gm, ''); // replace ___ with empty string
+      .replace(/^( *\* *){3,} *$/gm, '')
+      .replace(/^( *- *){3,} *$/gm, '')
+      .replace(/^( *_ *){3,} *$/gm, '');
 
-    // convert from markdown to common mark format
     const nodes = new MessageMarkdownTransformer(messageSchema).parse(
       signature
     );
     return MessageMarkdownSerializer.serialize(nodes);
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.error(e);
+    console.warn(e);
     Sentry.captureException(e);
     // The parser can break on some cases
     // for example, Token type `hr` not supported by Markdown parser
     return signature;
   }
 }
+
+window.cleanSignature = cleanSignature;
 
 /**
  * Adds the signature delimiter to the beginning of the signature.

--- a/app/javascript/dashboard/helper/editorHelper.js
+++ b/app/javascript/dashboard/helper/editorHelper.js
@@ -5,10 +5,6 @@ import {
 } from '@chatwoot/prosemirror-schema';
 import * as Sentry from '@sentry/browser';
 
-window.messageSchema = messageSchema;
-window.MessageMarkdownTransformer = MessageMarkdownTransformer;
-window.MessageMarkdownSerializer = MessageMarkdownSerializer;
-
 /**
  * The delimiter used to separate the signature from the rest of the body.
  * @type {string}
@@ -34,8 +30,6 @@ export function cleanSignature(signature) {
     return signature;
   }
 }
-
-window.cleanSignature = cleanSignature;
 
 /**
  * Adds the signature delimiter to the beginning of the signature.

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -85,6 +85,37 @@ describe('appendSignature', () => {
   });
 });
 
+describe('cleanSignature', () => {
+  it('removes any instance of horizontal rule', () => {
+    const options = [
+      '---',
+      '***',
+      '___',
+      '- - -',
+      '* * *',
+      '_ _ _',
+      ' ---',
+      '--- ',
+      ' --- ',
+      '-----',
+      '*****',
+      '_____',
+      '- - - -',
+      '* * * * *',
+      '_ _ _ _ _ _',
+      ' - - - - ',
+      ' * * * * * ',
+      ' _ _ _ _ _ _',
+      '- - - - -',
+      '* * * * * *',
+      '_ _ _ _ _ _ _',
+    ];
+    options.forEach(option => {
+      expect(cleanSignature(option)).toBe('');
+    });
+  });
+});
+
 describe('removeSignature', () => {
   it('does not remove signature if not present', () => {
     Object.keys(DOES_NOT_HAVE_SIGNATURE).forEach(key => {


### PR DESCRIPTION
For the message schema we provide, `---` which is a horizontal rule element is not handled. This results in an error. This PR adds a exception catch to ensure that the signatures continues to work


To test, update the signature from the DB console to the following

```
---

Signature
```

Try using the editor after that, the dashes should be gone without error