### PR TITLE
feat: Add inbox webhook events

### DIFF
--- a/app/listeners/base_listener.rb
+++ b/app/listeners/base_listener.rb
@@ -24,6 +24,11 @@ class BaseListener
     [contact, contact.account]
   end
 
+  def extract_inbox_and_account(event)
+    inbox = event.data[:inbox]
+    [inbox, inbox.account]
+  end
+
   def extract_changed_attributes(event)
     changed_attributes = event.data[:changed_attributes]
 

--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -66,6 +66,23 @@ class WebhookListener < BaseListener
     deliver_account_webhooks(payload, account)
   end
 
+  def inbox_created(event)
+    inbox, account = extract_inbox_and_account(event)
+    inbox_webhook_data = Inbox::EventDataPresenter.new(inbox).push_data
+    payload = inbox_webhook_data.merge(event: __method__.to_s)
+    deliver_account_webhooks(payload, account)
+  end
+
+  def inbox_updated(event)
+    inbox, account = extract_inbox_and_account(event)
+    changed_attributes = extract_changed_attributes(event)
+    return if changed_attributes.blank?
+
+    inbox_webhook_data = Inbox::EventDataPresenter.new(inbox).push_data
+    payload = inbox_webhook_data.merge(event: __method__.to_s, changed_attributes: changed_attributes)
+    deliver_account_webhooks(payload, account)
+  end
+
   private
 
   def deliver_account_webhooks(payload, account)

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -26,7 +26,7 @@ class Webhook < ApplicationRecord
   enum webhook_type: { account_type: 0, inbox_type: 1 }
 
   ALLOWED_WEBHOOK_EVENTS = %w[conversation_status_changed conversation_updated conversation_created contact_created contact_updated
-                              message_created message_updated webwidget_triggered].freeze
+                              message_created message_updated webwidget_triggered inbox_created inbox_updated].freeze
 
   private
 

--- a/app/presenters/inbox/event_data_presenter.rb
+++ b/app/presenters/inbox/event_data_presenter.rb
@@ -1,0 +1,35 @@
+class Inbox::EventDataPresenter < SimpleDelegator
+  def push_data
+    {
+      # Conversation thread config
+      allow_messages_after_resolved: allow_messages_after_resolved,
+      lock_to_single_conversation: lock_to_single_conversation,
+
+      # Auto Assignment config
+      auto_assignment_config: auto_assignment_config,
+      enable_auto_assignment: enable_auto_assignment,
+
+      # Feature flag for message events
+      enable_email_collect: enable_email_collect,
+      greeting_enabled: greeting_enabled,
+      greeting_message: greeting_message,
+      csat_survey_enabled: csat_survey_enabled,
+
+      # Outbound email sender config
+      business_name: business_name,
+      sender_name_type: sender_name_type,
+
+      # Business hour config
+      timezone: timezone,
+      out_of_office_message: out_of_office_message,
+      working_hours_enabled: working_hours_enabled,
+      working_hours: working_hours,
+
+      created_at: created_at,
+      updated_at: updated_at,
+
+      # Associated channel attributes
+      channel: channel
+    }
+  end
+end

--- a/lib/events/types.rb
+++ b/lib/events/types.rb
@@ -42,6 +42,10 @@ module Events::Types
   CONTACT_MERGED = 'contact.merged'
   CONTACT_DELETED = 'contact.deleted'
 
+  # contact events
+  INBOX_CREATED = 'inbox.created'
+  INBOX_UPDATED = 'inbox.updated'
+
   # notification events
   NOTIFICATION_CREATED = 'notification.created'
 

--- a/spec/models/inbox_spec.rb
+++ b/spec/models/inbox_spec.rb
@@ -210,6 +210,34 @@ RSpec.describe Inbox do
       expect(inbox.portal).to eq(portal)
     end
 
+    it 'sends the inbox_created event if ENABLE_INBOX_EVENTS is true' do
+      with_modified_env ENABLE_INBOX_EVENTS: 'true' do
+        channel = inbox.channel
+        channel.update(widget_color: '#fff')
+
+        expect(Rails.configuration.dispatcher).to have_received(:dispatch)
+          .with(
+            'inbox.updated',
+            kind_of(Time),
+            inbox: inbox,
+            changed_attributes: kind_of(Object)
+          )
+      end
+    end
+
+    it 'sends the inbox_created event if ENABLE_INBOX_EVENTS is false' do
+      channel = inbox.channel
+      channel.update(widget_color: '#fff')
+
+      expect(Rails.configuration.dispatcher).not_to have_received(:dispatch)
+        .with(
+          'inbox.updated',
+          kind_of(Time),
+          inbox: inbox,
+          changed_attributes: kind_of(Object)
+        )
+    end
+
     it 'resets cache key if there is an update in the channel' do
       channel = inbox.channel
       channel.update(widget_color: '#fff')


### PR DESCRIPTION
- Add webhook events for inbox creation / updation.
- Right now, the feature is added under a feature_flag. It is not available by default on all installations.
