### PR TITLE
chore: Add an API to find the contacts using contact inbox sourceId

### DIFF
--- a/app/controllers/api/v1/accounts/contact_inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/contact_inboxes_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::Accounts::ContactInboxesController < Api::V1::Accounts::BaseController
+  before_action :ensure_inbox
+
+  def filter
+    contact_inbox = @inbox.contact_inboxes.where(inbox_id: permitted_params[:inbox_id], source_id: permitted_params[:source_id])
+    return head :not_found if contact_inbox.empty?
+
+    @contact = contact_inbox.first.contact
+  end
+
+  private
+
+  def ensure_inbox
+    @inbox = Current.account.inboxes.find(permitted_params[:inbox_id])
+    authorize @inbox, :show?
+  end
+
+  def permitted_params
+    params.permit(:inbox_id, :source_id)
+  end
+end

--- a/app/views/api/v1/accounts/contact_inboxes/filter.json.jbuilder
+++ b/app/views/api/v1/accounts/contact_inboxes/filter.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,11 @@ Rails.application.routes.draw do
           resource :bulk_actions, only: [:create]
           resources :agents, only: [:index, :create, :update, :destroy]
           resources :agent_bots, only: [:index, :create, :show, :update, :destroy]
+          resources :contact_inboxes, only: [] do
+            collection do
+              post :filter
+            end
+          end
           resources :assignable_agents, only: [:index]
           resource :audit_logs, only: [:show]
           resources :callbacks, only: [] do

--- a/spec/controllers/api/v1/accounts/contact_inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contact_inboxes_controller_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe 'Contact Inboxes API', type: :request do
+  let(:account) { create(:account) }
+
+  let(:inbox) { create(:inbox, account: account) }
+  let(:contact) { create(:contact, account: account) }
+  let!(:contact_inbox) { create(:contact_inbox, contact: contact, inbox: inbox) }
+
+  describe 'POST /api/v1/accounts/{account.id}/contact_inboxes/filter' do
+    let(:admin) { create(:user, account: account, role: :administrator) }
+
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized' do
+        post "/api/v1/accounts/#{account.id}/contact_inboxes/filter"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an authenticated admin user' do
+      it 'returns not found if the params are invalid' do
+        post "/api/v1/accounts/#{account.id}/contact_inboxes/filter",
+             headers: admin.create_new_auth_token,
+             params: { inbox_id: inbox.id, source_id: 'random_source_id' },
+             as: :json
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'returns the contact if the params are valid' do
+        post "/api/v1/accounts/#{account.id}/contact_inboxes/filter",
+             headers: admin.create_new_auth_token,
+             params: { inbox_id: inbox.id, source_id: contact_inbox.source_id },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        response_body = response.parsed_body
+        expect(response_body['id']).to eq(contact.id)
+        expect(response_body['contact_inboxes'].first['source_id']).to eq(contact_inbox.source_id)
+      end
+    end
+
+    context 'when it is an authenticated agent user' do
+      let(:agent_with_inbox_access) { create(:user, account: account, role: :agent) }
+      let(:agent_without_inbox_access) { create(:user, account: account, role: :agent) }
+
+      before do
+        create(:inbox_member, user: agent_with_inbox_access, inbox: inbox)
+      end
+
+      it 'returns unauthorized if agent does not have inbox access' do
+        post "/api/v1/accounts/#{account.id}/contact_inboxes/filter",
+             headers: agent_without_inbox_access.create_new_auth_token,
+             params: { inbox_id: inbox.id, source_id: contact_inbox.source_id },
+             as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns success if agent have inbox access' do
+        post "/api/v1/accounts/#{account.id}/contact_inboxes/filter",
+             headers: agent_with_inbox_access.create_new_auth_token,
+             params: { inbox_id: inbox.id, source_id: contact_inbox.source_id },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2578/search-by-facebook-id