### PR TITLE
fix: Update query to support multiple tag conditions

### DIFF
--- a/app/services/contacts/filter_service.rb
+++ b/app/services/contacts/filter_service.rb
@@ -35,7 +35,7 @@ class Contacts::FilterService < FilterService
       " (contacts.#{attribute_key})::#{current_filter['data_type']} #{filter_operator_value}#{current_filter['data_type']} #{query_operator} "
     when 'standard'
       if attribute_key == 'labels'
-        tag_filter_query('Contact', 'contacts', query_hash, current_index)
+        " #{tag_filter_query('Contact', 'contacts', query_hash, current_index)} "
       else
         " LOWER(contacts.#{attribute_key}) #{filter_operator_value} #{query_operator} "
       end

--- a/app/services/conversations/filter_service.rb
+++ b/app/services/conversations/filter_service.rb
@@ -46,7 +46,7 @@ class Conversations::FilterService < FilterService
       " (conversations.#{attribute_key})::#{current_filter['data_type']} #{filter_operator_value}#{current_filter['data_type']} #{query_operator} "
     when 'standard'
       if attribute_key == 'labels'
-        tag_filter_query('Conversation', 'conversations', query_hash, current_index)
+        " #{tag_filter_query('Conversation', 'conversations', query_hash, current_index)} "
       else
         " conversations.#{attribute_key} #{filter_operator_value} #{query_operator} "
       end

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -140,19 +140,20 @@ describe Conversations::FilterService do
           {
             attribute_key: 'assignee_id',
             filter_operator: 'equal_to',
-            values: [
-              user_1.id,
-              user_2.id
-            ],
-            query_operator: 'AND',
-            custom_attribute_type: ''
+            values: [user_1.id, user_2.id],
+            query_operator: 'AND'
           }.with_indifferent_access,
           {
             attribute_key: 'labels',
             filter_operator: 'equal_to',
             values: ['support'],
-            query_operator: nil,
-            custom_attribute_type: ''
+            query_operator: 'AND'
+          }.with_indifferent_access,
+          {
+            attribute_key: 'labels',
+            filter_operator: 'not_equal_to',
+            values: ['random-label'],
+            query_operator: nil
           }.with_indifferent_access
         ]
         result = filter_service.new(params, user_1).perform


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2628/activerecordstatementinvalid-when-applying-tag-queries