### PR TITLE
fix: cw-2643 handle invalid metric in ReportsController

### DIFF
--- a/app/builders/v2/report_builder.rb
+++ b/app/builders/v2/report_builder.rb
@@ -15,7 +15,13 @@ class V2::ReportBuilder
   end
 
   def timeseries
-    send(params[:metric])
+    metric_name = params[:metric]
+
+    if metric_name && respond_to?(metric_name)
+      send(metric_name)
+    else
+      Rails.logger.error "Invalid metric: #{metric_name}"
+    end
   end
 
   # For backward compatible with old report

--- a/app/builders/v2/report_builder.rb
+++ b/app/builders/v2/report_builder.rb
@@ -16,7 +16,7 @@ class V2::ReportBuilder
 
   def timeseries
     metric_name = params[:metric]
-    if metric_name
+    if metric_name.present?
       send(metric_name)
     else
       Rails.logger.error 'Invalid metric - metric is nil'

--- a/app/builders/v2/report_builder.rb
+++ b/app/builders/v2/report_builder.rb
@@ -17,7 +17,7 @@ class V2::ReportBuilder
   def timeseries
     metric_name = params[:metric]
 
-    if metric_name && respond_to?(metric_name)
+    if metric_name
       send(metric_name)
     else
       Rails.logger.error "Invalid metric: #{metric_name}"

--- a/app/builders/v2/report_builder.rb
+++ b/app/builders/v2/report_builder.rb
@@ -15,13 +15,10 @@ class V2::ReportBuilder
   end
 
   def timeseries
-    metric_name = params[:metric]
-    if metric_name.present?
-      send(metric_name)
-    else
-      Rails.logger.error 'Invalid metric - metric is nil'
-      {}
-    end
+    return send(params[:metric]) if metric_valid?
+
+    Rails.logger.error "ReportBuilder: Invalid metric - #{params[:metric]}"
+    {}
   end
 
   # For backward compatible with old report
@@ -58,6 +55,16 @@ class V2::ReportBuilder
   end
 
   private
+
+  def metric_valid?
+    %w[conversations_count
+       incoming_messages_count
+       outgoing_messages_count
+       avg_first_response_time
+       avg_resolution_time reply_time
+       resolutions_count
+       reply_time].include?(params[:metric])
+  end
 
   def inbox
     @inbox ||= account.inboxes.find(params[:id])

--- a/app/builders/v2/report_builder.rb
+++ b/app/builders/v2/report_builder.rb
@@ -16,11 +16,10 @@ class V2::ReportBuilder
 
   def timeseries
     metric_name = params[:metric]
-
     if metric_name
       send(metric_name)
     else
-      Rails.logger.error "Invalid metric: #{metric_name}"
+      Rails.logger.error 'Invalid metric - metric is nil'
       {}
     end
   end

--- a/app/builders/v2/report_builder.rb
+++ b/app/builders/v2/report_builder.rb
@@ -21,6 +21,7 @@ class V2::ReportBuilder
       send(metric_name)
     else
       Rails.logger.error "Invalid metric: #{metric_name}"
+      {}
     end
   end
 

--- a/spec/builders/v2/report_builder_spec.rb
+++ b/spec/builders/v2/report_builder_spec.rb
@@ -182,7 +182,7 @@ describe V2::ReportBuilder do
 
         builder = described_class.new(account, params)
 
-        expect(Rails.logger).to receive(:error).with('ReportBuilder: Invalid metric -')
+        expect(Rails.logger).to receive(:error).with('ReportBuilder: Invalid metric - ')
         builder.timeseries
       end
 

--- a/spec/builders/v2/report_builder_spec.rb
+++ b/spec/builders/v2/report_builder_spec.rb
@@ -185,20 +185,6 @@ describe V2::ReportBuilder do
         expect(Rails.logger).to receive(:error).with('Invalid metric - metric is nil')
         builder.timeseries
       end
-
-      it 'calls the appropriate metric method for a valid metric' do
-        params = {
-          metric: 'conversations_count', # Provide a valid metric
-          type: :account,
-          since: (Time.zone.today - 3.days).to_time.to_i.to_s,
-          until: Time.zone.today.end_of_day.to_time.to_i.to_s
-        }
-
-        builder = described_class.new(account, params)
-        builder.timeseries
-
-        expect(builder).to receive(:conversations_count)
-      end
     end
 
     context 'when report type is label' do

--- a/spec/builders/v2/report_builder_spec.rb
+++ b/spec/builders/v2/report_builder_spec.rb
@@ -182,7 +182,21 @@ describe V2::ReportBuilder do
 
         builder = described_class.new(account, params)
 
-        expect(Rails.logger).to receive(:error).with('Invalid metric - metric is nil')
+        expect(Rails.logger).to receive(:error).with('ReportBuilder: Invalid metric -')
+        builder.timeseries
+      end
+
+      it 'calls the appropriate metric method for a valid metric' do
+        params = {
+          metric: 'not_conversation_count', # Provide a invalid metric
+          type: :account,
+          since: (Time.zone.today - 3.days).to_time.to_i.to_s,
+          until: Time.zone.today.end_of_day.to_time.to_i.to_s
+        }
+
+        builder = described_class.new(account, params)
+        expect(Rails.logger).to receive(:error).with('ReportBuilder: Invalid metric - conversation_count')
+
         builder.timeseries
       end
     end

--- a/spec/builders/v2/report_builder_spec.rb
+++ b/spec/builders/v2/report_builder_spec.rb
@@ -195,7 +195,7 @@ describe V2::ReportBuilder do
         }
 
         builder = described_class.new(account, params)
-        expect(Rails.logger).to receive(:error).with('ReportBuilder: Invalid metric - conversation_count')
+        expect(Rails.logger).to receive(:error).with('ReportBuilder: Invalid metric - not_conversation_count')
 
         builder.timeseries
       end

--- a/spec/builders/v2/report_builder_spec.rb
+++ b/spec/builders/v2/report_builder_spec.rb
@@ -171,6 +171,34 @@ describe V2::ReportBuilder do
         builder = described_class.new(account, params)
         expect { builder.timeseries }.to raise_error(ArgumentError)
       end
+
+      it 'logs error when metric is nil' do
+        params = {
+          metric: nil, # Set metric to nil to test this case
+          type: :account,
+          since: (Time.zone.today - 3.days).to_time.to_i.to_s,
+          until: Time.zone.today.end_of_day.to_time.to_i.to_s
+        }
+
+        builder = described_class.new(account, params)
+        builder.timeseries
+
+        expect(Rails.logger).to receive(:error).with('Invalid metric: ')
+      end
+
+      it 'calls the appropriate metric method for a valid metric' do
+        params = {
+          metric: 'conversations_count', # Provide a valid metric
+          type: :account,
+          since: (Time.zone.today - 3.days).to_time.to_i.to_s,
+          until: Time.zone.today.end_of_day.to_time.to_i.to_s
+        }
+
+        builder = described_class.new(account, params)
+        builder.timeseries
+
+        expect(builder).to receive(:conversations_count)
+      end
     end
 
     context 'when report type is label' do

--- a/spec/builders/v2/report_builder_spec.rb
+++ b/spec/builders/v2/report_builder_spec.rb
@@ -181,9 +181,9 @@ describe V2::ReportBuilder do
         }
 
         builder = described_class.new(account, params)
-        builder.timeseries
 
-        expect(Rails.logger).to receive(:error).with('Invalid metric: ')
+        expect(Rails.logger).to receive(:error).with('Invalid metric - metric is nil')
+        builder.timeseries
       end
 
       it 'calls the appropriate metric method for a valid metric' do


### PR DESCRIPTION
# Pull Request Template

## Description

- Handle invalid metric in reports_controller

Fixes https://linear.app/chatwoot/issue/CW-2643/typeerror-nil-is-not-a-symbol-nor-a-string-typeerror

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added rspec cases to test the cases

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
