### PR TITLE
fix: cw2644 handle empty status in conversation controller

### DIFF
--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -6,8 +6,6 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   before_action :conversation, except: [:index, :meta, :search, :create, :filter]
   before_action :inbox, :contact, :contact_inbox, only: [:create]
 
-  rescue_from PG::NotNullViolation, with: :handle_not_null_violation
-
   def index
     result = conversation_finder.perform
     @conversations = result[:conversations]
@@ -62,7 +60,7 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def toggle_status
-    if params[:status]
+    if params[:status].present?
       set_conversation_status
       @status = @conversation.save!
     else
@@ -98,11 +96,6 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   private
-
-  # Handle PG::NotNullViolation exceptions
-  def handle_not_null_violation(exception)
-    render json: { error: "Database not null violation: #{exception.message}" }, status: :unprocessable_entity
-  end
 
   def update_last_seen_on_conversation(last_seen_at, update_assignee)
     # rubocop:disable Rails/SkipsModelValidations

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -6,6 +6,8 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   before_action :conversation, except: [:index, :meta, :search, :create, :filter]
   before_action :inbox, :contact, :contact_inbox, only: [:create]
 
+  rescue_from PG::NotNullViolation, with: :handle_not_null_violation
+
   def index
     result = conversation_finder.perform
     @conversations = result[:conversations]
@@ -96,6 +98,11 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   private
+
+  # Handle PG::NotNullViolation exceptions
+  def handle_not_null_violation(exception)
+    render json: { error: "Database not null violation: #{exception.message}" }, status: :unprocessable_entity
+  end
 
   def update_last_seen_on_conversation(last_seen_at, update_assignee)
     # rubocop:disable Rails/SkipsModelValidations

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -340,11 +340,12 @@ RSpec.describe 'Conversations API', type: :request do
         create(:inbox_member, user: agent, inbox: conversation.inbox)
       end
 
-      it 'toggles the conversation status' do
+      it 'toggles the conversation status if status is empty' do
         expect(conversation.status).to eq('open')
 
         post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_status",
              headers: agent.create_new_auth_token,
+             params: { status: '' },
              as: :json
 
         expect(response).to have_http_status(:success)
@@ -360,18 +361,6 @@ RSpec.describe 'Conversations API', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(conversation.reload.status).to eq('open')
-      end
-
-      it 'handles PG::NotNullViolation gracefully' do
-        post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_status",
-             headers: agent.create_new_auth_token,
-             params: { status: '' },
-             as: :json
-
-        expect(response).to have_http_status(:unprocessable_entity)
-        response_body = response.parsed_body
-
-        expect(response_body['error']).to include('Database not null violation')
       end
 
       it 'self assign if agent changes the conversation status to open' do

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -362,6 +362,18 @@ RSpec.describe 'Conversations API', type: :request do
         expect(conversation.reload.status).to eq('open')
       end
 
+      it 'handles PG::NotNullViolation gracefully' do
+        post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_status",
+             headers: agent.create_new_auth_token,
+             params: { status: '' },
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        response_body = response.parsed_body
+
+        expect(response_body['error']).to include('Database not null violation')
+      end
+
       it 'self assign if agent changes the conversation status to open' do
         conversation.update!(status: 'pending')
         post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_status",


### PR DESCRIPTION
# Pull Request Template

## Description

- Handle empty status in `convesation_controller`

Fixes https://linear.app/chatwoot/issue/CW-2644/activerecordnotnullviolation-pgnotnullviolation-error-null-value-in

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added new specs

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
