### PR TITLE
fix: Change the message status to `failed` if the Twilio message delivery status is `undelivered`

### DIFF
--- a/app/services/twilio/delivery_status_service.rb
+++ b/app/services/twilio/delivery_status_service.rb
@@ -13,13 +13,17 @@ class Twilio::DeliveryStatusService
   private
 
   def process_statuses
-    @message.status = params[:MessageStatus]
+    @message.status = status
     @message.external_error = external_error if error_occurred?
     @message.save!
   end
 
   def supported_status?
     %w[sent delivered read failed undelivered].include?(params[:MessageStatus])
+  end
+
+  def status
+    params[:MessageStatus] == 'undelivered' ? 'failed' : params[:MessageStatus]
   end
 
   def external_error

--- a/spec/services/twilio/delivery_status_service_spec.rb
+++ b/spec/services/twilio/delivery_status_service_spec.rb
@@ -59,21 +59,24 @@ describe Twilio::DeliveryStatusService do
         expect(conversation.reload.messages.last.status).to eq('sent')
       end
 
-      it 'updates message status to failed if message status is failed' do
+      it 'updates message status to failed if message status is undelivered' do
         params = {
           SmsSid: 'SMxx',
           From: '+12345',
           AccountSid: 'ACxxx',
           MessagingServiceSid: twilio_channel.messaging_service_sid,
           MessageSid: conversation.messages.last.source_id,
-          MessageStatus: 'failed'
+          MessageStatus: 'undelivered',
+          ErrorCode: '30002',
+          ErrorMessage: 'Account suspended'
         }
 
         described_class.new(params: params).perform
         expect(conversation.reload.messages.last.status).to eq('failed')
+        expect(conversation.reload.messages.last.external_error).to eq('30002 - Account suspended')
       end
 
-      it 'updates message status to failed and updates the error message if message status is undelivered' do
+      it 'updates message status to failed and updates the error message if message status is failed' do
         params = {
           SmsSid: 'SMxx',
           From: '+12345',


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2648/argumenterror-undelivered-is-not-a-valid-status-argumenterror