### PR TITLE
fix: Return 404 if conversation is nil

### DIFF
--- a/app/controllers/api/v1/widget/conversations_controller.rb
+++ b/app/controllers/api/v1/widget/conversations_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Widget::ConversationsController < Api::V1::Widget::BaseController
   include Events::Types
+  before_action :render_not_found_if_empty, only: [:toggle_typing, :toggle_status, :set_custom_attributes, :destroy_custom_attributes]
 
   def index
     @conversation = conversation
@@ -41,8 +42,6 @@ class Api::V1::Widget::ConversationsController < Api::V1::Widget::BaseController
   end
 
   def toggle_typing
-    head :ok && return if conversation.nil?
-
     case permitted_params[:typing_status]
     when 'on'
       trigger_typing_event(CONVERSATION_TYPING_ON)
@@ -54,8 +53,6 @@ class Api::V1::Widget::ConversationsController < Api::V1::Widget::BaseController
   end
 
   def toggle_status
-    return head :not_found if conversation.nil?
-
     return head :forbidden unless @web_widget.end_conversation?
 
     unless conversation.resolved?
@@ -79,6 +76,10 @@ class Api::V1::Widget::ConversationsController < Api::V1::Widget::BaseController
 
   def trigger_typing_event(event)
     Rails.configuration.dispatcher.dispatch(event, Time.zone.now, conversation: conversation, user: @contact)
+  end
+
+  def render_not_found_if_empty
+    return head :not_found if conversation.nil?
   end
 
   def permitted_params


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2649/nomethoderror-undefined-method-update-for-nilnilclass-nomethoderror