### PR TITLE
fix: Add reset password for edit agent screen

### DIFF
--- a/app/javascript/dashboard/api/auth.js
+++ b/app/javascript/dashboard/api/auth.js
@@ -84,6 +84,11 @@ export default {
     return axios.delete(endPoints('deleteAvatar').url);
   },
 
+  resetPassword({ email }) {
+    const urlData = endPoints('resetPassword');
+    return axios.post(urlData.url, { email });
+  },
+
   setActiveAccount({ accountId }) {
     const urlData = endPoints('setActiveAccount');
     return axios.put(urlData.url, {


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2657/cannot-reset-password-from-the-dashboard