### PR TITLE
refactor: UI flags for Reply To

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -292,7 +292,7 @@ export default {
     },
     inboxSupportsReplyTo() {
       return (
-        this.inboxHasFeature(INBOX_FEATURES.REPLY_TO) &&
+        this.inboxHasFeature(INBOX_FEATURES.REPLY_TO_OUTGOING) &&
         this.isFeatureEnabledonAccount(
           this.accountId,
           FEATURE_FLAGS.MESSAGE_REPLY_TO

--- a/app/javascript/shared/mixins/inboxMixin.js
+++ b/app/javascript/shared/mixins/inboxMixin.js
@@ -13,16 +13,24 @@ export const INBOX_TYPES = {
 
 export const INBOX_FEATURES = {
   REPLY_TO: 'replyTo',
+  REPLY_TO_OUTGOING: 'replyToOutgoing',
 };
 
 // This is a single source of truth for inbox features
 // This is used to check if a feature is available for a particular inbox or not
 export const INBOX_FEATURE_MAP = {
   [INBOX_FEATURES.REPLY_TO]: [
+    INBOX_TYPES.FB,
     INBOX_TYPES.WEB,
     INBOX_TYPES.TWITTER,
     INBOX_TYPES.WHATSAPP,
-    INBOX_TYPES.LINE,
+    INBOX_TYPES.TELEGRAM,
+    INBOX_TYPES.API,
+  ],
+  [INBOX_FEATURES.REPLY_TO_OUTGOING]: [
+    INBOX_TYPES.WEB,
+    INBOX_TYPES.TWITTER,
+    INBOX_TYPES.WHATSAPP,
     INBOX_TYPES.TELEGRAM,
     INBOX_TYPES.API,
   ],


### PR DESCRIPTION
Facebook does not support `ReplyTo` via their API, so we have to disable that explicitly for them. This PR handles that