### PR TITLE
fix: Always reset CC/BCC emails when switching conversations

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -511,6 +511,8 @@ export default {
     currentChat(conversation) {
       const { can_reply: canReply } = conversation;
 
+      this.setCCAndToEmailsFromLastChat();
+
       if (this.isOnPrivateNote) {
         return;
       }
@@ -521,7 +523,6 @@ export default {
         this.replyType = REPLY_EDITOR_MODES.NOTE;
       }
 
-      this.setCCAndToEmailsFromLastChat();
       this.fetchAndSetReplyTo();
     },
     conversationIdByRoute(conversationId, oldConversationId) {


### PR DESCRIPTION
## Description

Fixes #6391. Even when we're on the `Private Note` tab, when switching conversations, we need to update the To/CC/BCC values of the component, otherwise the values of the previous conversation will persist when switching from `Private Note` to `Reply`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually tested.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
