### PR TITLE
chore: Campaign conversations should be created in open state

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -226,6 +226,10 @@ class Conversation < ApplicationRecord
   end
 
   def mark_conversation_pending_if_bot
+    # Message template hooks aren't executed for conversations from campaigns
+    # So making these conversations open for agent visibility
+    return if campaign.present?
+
     # TODO: make this an inbox config instead of assuming bot conversations should start as pending
     self.status = :pending if inbox.active_bot?
   end

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -556,6 +556,11 @@ RSpec.describe Conversation do
     it 'returns conversation status as pending' do
       expect(conversation.status).to eq('pending')
     end
+
+    it 'returns conversation as open if campaign is present' do
+      conversation = create(:conversation, inbox: bot_inbox.inbox, campaign: create(:campaign))
+      expect(conversation.status).to eq('open')
+    end
   end
 
   describe '#botintegration: when conversation created in inbox with dialogflow integration' do


### PR DESCRIPTION
- Ensure that conversations originating from campaigns are created in the open state.