### PR TITLE
docs: Update .env.example for clearer inbound Postmark instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,7 +81,7 @@ SMTP_OPENSSL_VERIFY_MODE=peer
 # Mail Incoming
 # This is the domain set for the reply emails when conversation continuity is enabled
 MAILER_INBOUND_EMAIL_DOMAIN=
-# Set this to appropriate ingress channel with regards to incoming emails
+# Set this to the appropriate ingress channel with regards to incoming emails
 # Possible values are :
 # relay for Exim, Postfix, Qmail
 # mailgun for Mailgun
@@ -91,9 +91,19 @@ MAILER_INBOUND_EMAIL_DOMAIN=
 RAILS_INBOUND_EMAIL_SERVICE=
 # Use one of the following based on the email ingress service
 # Ref: https://edgeguides.rubyonrails.org/action_mailbox_basics.html
+# Set this to a password of your choice and use it in the Inbound webhook
 RAILS_INBOUND_EMAIL_PASSWORD=
+
 MAILGUN_INGRESS_SIGNING_KEY=
 MANDRILL_INGRESS_API_KEY=
+
+# Creating Your Inbound Webhook Instructions for Postmark and Sendgrid:
+# Inbound webhook URL format:
+#    https://actionmailbox:[YOUR_RAILS_INBOUND_EMAIL_PASSWORD]@[YOUR_CHATWOOT_DOMAIN.COM]/rails/action_mailbox/[RAILS_INBOUND_EMAIL_SERVICE]/inbound_emails
+# Note: Replace the values inside the brackets; do not include the brackets themselves.
+# Example: https://actionmailbox:mYRandomPassword3@chatwoot.example.com/rails/action_mailbox/postmark/inbound_emails
+# For Postmark
+# Ensure the 'Include raw email content in JSON payload' checkbox is selected in the inbound webhook section.
 
 # Storage
 ACTIVE_STORAGE_SERVICE=local


### PR DESCRIPTION
# Pull Request Template

## Description

Updated the `.env.example` file to provide clearer instructions for setting up the Postmark inbound webhook. Many users, including myself, found the initial instructions ambiguous, leading to difficulties during setup. This change aims to simplify the process for future users by providing clearer instructions and examples. 

Fixes #8234

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The updated instructions were tested during my personal setup of Chatwoot with Postmark. However, please note that these are documentation changes and do not directly affect the software's functionality.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (This may not be applicable since it's a documentation change)
- [x] New and existing unit tests pass locally with my changes (Again, this is more for code than documentation)
- [ ] Any dependent changes have been merged and published in downstream modules (If there are dependent changes, you can check this)