### PR TITLE
feat: Save sort Conversations filter

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -207,6 +207,7 @@ import DeleteCustomViews from 'dashboard/routes/dashboard/customviews/DeleteCust
 import ConversationBulkActions from './widgets/conversation/conversationBulkActions/Index.vue';
 import alertMixin from 'shared/mixins/alertMixin';
 import filterMixin from 'shared/mixins/filterMixin';
+import uiSettingsMixin from 'dashboard/mixins/uiSettings';
 import languages from 'dashboard/components/widgets/conversation/advancedFilterItems/languages';
 import countries from 'shared/constants/countries';
 import { generateValuesForEditCustomViews } from 'dashboard/helper/customViewsHelper';
@@ -238,6 +239,7 @@ export default {
     eventListenerMixins,
     alertMixin,
     filterMixin,
+    uiSettingsMixin,
   ],
   props: {
     conversationInbox: {
@@ -320,6 +322,9 @@ export default {
     },
     hasAppliedFiltersOrActiveFolders() {
       return this.hasAppliedFilters || this.hasActiveFolders;
+    },
+    savedSortByFilter() {
+      return this.uiSettings?.conversations_filter_by;
     },
     savedFoldersValue() {
       if (this.hasActiveFolders) {
@@ -514,6 +519,9 @@ export default {
       this.chatsOnView = this.conversationList;
     },
   },
+  created() {
+    this.setSavedSortByFilter();
+  },
   mounted() {
     this.$store.dispatch('setChatStatusFilter', this.activeStatus);
     this.$store.dispatch('setChatSortFilter', this.activeSortBy);
@@ -543,6 +551,11 @@ export default {
       };
       this.$store.dispatch('customViews/update', payloadData);
       this.closeAdvanceFiltersModal();
+    },
+    setSavedSortByFilter() {
+      const { status, order_by: orderBy } = this.savedSortByFilter || {};
+      this.activeStatus = status || this.activeStatus;
+      this.activeSortBy = orderBy || this.activeSortBy;
     },
     onClickOpenAddFoldersModal() {
       this.showAddFoldersModal = true;

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -554,8 +554,8 @@ export default {
     },
     setSavedSortByFilter() {
       const { status, order_by: orderBy } = this.savedSortByFilter || {};
-      this.activeStatus = status || this.activeStatus;
-      this.activeSortBy = orderBy || this.activeSortBy;
+      this.activeStatus = status || wootConstants.STATUS_TYPE.OPEN;
+      this.activeSortBy = orderBy || wootConstants.SORT_BY_TYPE.LATEST;
     },
     onClickOpenAddFoldersModal() {
       this.showAddFoldersModal = true;

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -323,9 +323,6 @@ export default {
     hasAppliedFiltersOrActiveFolders() {
       return this.hasAppliedFilters || this.hasActiveFolders;
     },
-    savedSortByFilter() {
-      return this.uiSettings?.conversations_filter_by;
-    },
     savedFoldersValue() {
       if (this.hasActiveFolders) {
         const payload = this.activeFolder.query;
@@ -520,7 +517,7 @@ export default {
     },
   },
   created() {
-    this.setSavedSortByFilter();
+    this.setFiltersFromUISettings();
   },
   mounted() {
     this.$store.dispatch('setChatStatusFilter', this.activeStatus);
@@ -552,8 +549,9 @@ export default {
       this.$store.dispatch('customViews/update', payloadData);
       this.closeAdvanceFiltersModal();
     },
-    setSavedSortByFilter() {
-      const { status, order_by: orderBy } = this.savedSortByFilter || {};
+    setFiltersFromUISettings() {
+      const { status, order_by: orderBy } =
+        this.uiSettings.conversations_filter_by;
       this.activeStatus = status || wootConstants.STATUS_TYPE.OPEN;
       this.activeSortBy = orderBy || wootConstants.SORT_BY_TYPE.LATEST;
     },

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
@@ -66,9 +66,6 @@ export default {
       chatStatusFilter: 'getChatStatusFilter',
       chatSortFilter: 'getChatSortFilter',
     }),
-    savedSortByFilter() {
-      return this.uiSettings.conversations_filter_by;
-    },
     chatStatus() {
       return this.chatStatusFilter || wootConstants.STATUS_TYPE.OPEN;
     },

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
@@ -32,7 +32,7 @@
         }}</span>
         <filter-item
           type="sort"
-          :selected-value="chatSortFilter"
+          :selected-value="sortFilter"
           :items="chatSortItems"
           path-prefix="CHAT_LIST.CHAT_SORT_FILTER_ITEMS"
           @onChangeFilter="onChangeFilter"
@@ -47,12 +47,13 @@ import wootConstants from 'dashboard/constants/globals';
 import { mapGetters } from 'vuex';
 import { mixin as clickaway } from 'vue-clickaway';
 import FilterItem from './FilterItem.vue';
+import uiSettingsMixin from 'dashboard/mixins/uiSettings';
 
 export default {
   components: {
     FilterItem,
   },
-  mixins: [clickaway],
+  mixins: [clickaway, uiSettingsMixin],
   data() {
     return {
       showActionsDropdown: false,
@@ -65,6 +66,9 @@ export default {
       chatStatusFilter: 'getChatStatusFilter',
       chatSortFilter: 'getChatSortFilter',
     }),
+    savedSortByFilter() {
+      return this.uiSettings.conversations_filter_by;
+    },
     chatStatus() {
       return this.chatStatusFilter || wootConstants.STATUS_TYPE.OPEN;
     },
@@ -85,6 +89,15 @@ export default {
     },
     onChangeFilter(type, value) {
       this.$emit('changeFilter', type, value);
+      this.saveSelectedFilter(type, value);
+    },
+    saveSelectedFilter(type, value) {
+      this.updateUISettings({
+        conversations_filter_by: {
+          status: value === 'status' ? type : this.chatStatus,
+          order_by: value === 'sort' ? type : this.sortFilter,
+        },
+      });
     },
   },
 };

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
@@ -87,15 +87,15 @@ export default {
     closeDropdown() {
       this.showActionsDropdown = false;
     },
-    onChangeFilter(type, value) {
-      this.$emit('changeFilter', type, value);
+    onChangeFilter(value, type) {
+      this.$emit('changeFilter', value, type);
       this.saveSelectedFilter(type, value);
     },
     saveSelectedFilter(type, value) {
       this.updateUISettings({
         conversations_filter_by: {
-          status: value === 'status' ? type : this.chatStatus,
-          order_by: value === 'sort' ? type : this.sortFilter,
+          status: type === 'status' ? value : this.chatStatus,
+          order_by: type === 'sort' ? value : this.sortFilter,
         },
       });
     },


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will save the last sort value to the UI setting and retain the previous selection after reloading.

Fixes https://linear.app/chatwoot/issue/CW-2662/sort-conversations-by-creation-date-for-fair-client-handling

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**Loom video**
https://www.loom.com/share/932370d0a19e4f538fc2b8693f8d9b05?sid=f7f85fde-e81d-4d21-aa5e-fe4de9d91737



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
