### PR TITLE
fix: Fix an issue where Chat Widget Unread Message is not correctly d…

### DIFF
--- a/app/javascript/widget/components/UnreadMessage.vue
+++ b/app/javascript/widget/components/UnreadMessage.vue
@@ -12,8 +12,8 @@
           :username="agentName"
           :status="availabilityStatus"
         />
-        <span class="agent--name">{{ agentName }}</span>
-        <span class="company--name"> {{ companyName }}</span>
+        <span v-dompurify-html="agentName" class="agent--name" />
+        <span v-dompurify-html="companyName" class="company--name" />
       </div>
       <div
         v-dompurify-html="formatMessage(message, false)"


### PR DESCRIPTION
## Description

This fixes an issue where the UnreadMessages in the Chat Widget was not correctly converting special characters.
See screenshot below of the issue:
<img width="391" alt="Screenshot 2023-10-29 at 20 38 54" src="https://github.com/chatwoot/chatwoot/assets/43280985/017887c0-7618-4871-9659-f3afc5f8249a">

Fixes #8244 8244

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested by creating a new web inbox and creating a new campaign, noticing the special characters being correctly decoded.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
