### PR TITLE
8249

### DIFF
--- a/app/javascript/dashboard/assets/scss/_date-picker.scss
+++ b/app/javascript/dashboard/assets/scss/_date-picker.scss
@@ -1,9 +1,5 @@
 @import '~vue2-datepicker/scss/index';
 
-.mx-datepicker-popup {
-  @apply z-[99999];
-}
-
 .date-picker {
   &.no-margin {
     .mx-input {
@@ -29,10 +25,38 @@
   .mx-input[readonly] {
     @apply bg-white dark:bg-slate-900 cursor-pointer;
   }
+
+  .mx-icon-calendar {
+    @apply dark:text-slate-500;
+  }
 }
 
-.mx-calendar-content .cell:hover {
-  @apply bg-slate-75 dark:bg-slate-700 text-slate-900 dark:text-slate-100;
+.mx-datepicker-main {
+  @apply border-0 bg-white dark:bg-slate-800;
+
+  .cell {
+    &.disabled {
+      @apply bg-slate-25 dark:bg-slate-900 text-slate-200 dark:text-slate-300;
+    }
+
+    &:hover,
+    &.hover-in-range,
+    &.in-range {
+      @apply bg-slate-75 dark:bg-slate-700 text-slate-900 dark:text-slate-100;
+    }
+  }
+
+  .mx-time {
+    @apply border-0 bg-white dark:bg-slate-800;
+  }
+
+  .today {
+    @apply font-semibold;
+  }
+}
+
+.mx-datepicker-popup {
+  @apply z-[99999];
 }
 
 .mx-datepicker-inline {
@@ -40,25 +64,5 @@
 
   .mx-calendar {
     @apply w-full;
-  }
-
-  .cell.disabled {
-    @apply bg-slate-25 dark:bg-slate-900 text-slate-200 dark:text-slate-300;
-  }
-
-  .mx-time-item.disabled {
-    @apply bg-slate-25 dark:bg-slate-900;
-  }
-
-  .today {
-    @apply font-semibold;
-  }
-
-  .mx-datepicker-main {
-    @apply border-0 bg-white dark:bg-slate-800;
-  }
-
-  .mx-time-header {
-    @apply border-0;
   }
 }

--- a/app/javascript/dashboard/assets/scss/_date-picker.scss
+++ b/app/javascript/dashboard/assets/scss/_date-picker.scss
@@ -48,6 +48,20 @@
 
   .mx-time {
     @apply border-0 bg-white dark:bg-slate-800;
+
+    .mx-time-header {
+      @apply border-0;
+    }
+
+    .mx-time-item {
+      &.disabled {
+        @apply bg-slate-25 dark:bg-slate-900;
+      }
+
+      &:hover {
+        @apply bg-slate-75 dark:bg-slate-700;
+      }
+    }
   }
 
   .today {


### PR DESCRIPTION
## Description

This add dark mode support for the calendars (date and time picker).
<img width="304" alt="Screenshot 2023-10-30 at 13 57 35" src="https://github.com/chatwoot/chatwoot/assets/43280985/5d917e2f-3a3e-4a6d-914e-23948d74f9f8">
<img width="291" alt="Screenshot 2023-10-30 at 13 57 27" src="https://github.com/chatwoot/chatwoot/assets/43280985/abd84727-9b09-4c04-84f8-52313c09a16a">
<img width="536" alt="Screenshot 2023-10-30 at 13 56 56" src="https://github.com/chatwoot/chatwoot/assets/43280985/e41c7bcd-1f19-4a93-b1f8-bc190d0ed75a">

Fixes #8249
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested by switching to light/dark mode theme and noticing the calendar changing the colors.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
