### PR TITLE
fix: Handle PermissionDeniedError for Dialogflow processor

### DIFF
--- a/app/mailers/administrator_notifications/channel_notifications_mailer.rb
+++ b/app/mailers/administrator_notifications/channel_notifications_mailer.rb
@@ -7,6 +7,13 @@ class AdministratorNotifications::ChannelNotificationsMailer < ApplicationMailer
     send_mail_with_liquid(to: admin_emails, subject: subject) and return
   end
 
+  def dialogflow_disconnect
+    return unless smtp_config_set_or_development?
+
+    subject = 'Your Dialogflow integration was disconnected'
+    send_mail_with_liquid(to: admin_emails, subject: subject) and return
+  end
+
   def facebook_disconnect(inbox)
     return unless smtp_config_set_or_development?
 

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -129,7 +129,7 @@ class Inbox < ApplicationRecord
   end
 
   def active_bot?
-    agent_bot_inbox&.active? || hooks.pluck(:app_id).include?('dialogflow')
+    agent_bot_inbox&.active? || hooks.where(app_id: 'dialogflow', status: 'enabled').count.positive?
   end
 
   def inbox_type

--- a/app/models/integrations/hook.rb
+++ b/app/models/integrations/hook.rb
@@ -43,6 +43,10 @@ class Integrations::Hook < ApplicationRecord
     app_id == 'slack'
   end
 
+  def dialogflow?
+    app_id == 'dialogflow'
+  end
+
   def disable
     update(status: 'disabled')
   end

--- a/app/views/mailers/administrator_notifications/channel_notifications_mailer/dialogflow_disconnect.liquid
+++ b/app/views/mailers/administrator_notifications/channel_notifications_mailer/dialogflow_disconnect.liquid
@@ -1,0 +1,3 @@
+<p>Hello there,</p>
+
+<p>Your Dialogflow integration was disconnected because of permission issues. To resolve this, please delete the integration from Chatwoot and reconnect it using new credentials.</p>

--- a/app/views/mailers/administrator_notifications/channel_notifications_mailer/dialogflow_disconnect.liquid
+++ b/app/views/mailers/administrator_notifications/channel_notifications_mailer/dialogflow_disconnect.liquid
@@ -1,3 +1,3 @@
 <p>Hello there,</p>
 
-<p>Your Dialogflow integration was disconnected because of permission issues. To resolve this, please delete the integration from Chatwoot and reconnect it using new credentials.</p>
+<p>Your Dialogflow integration was disconnected because of permission issues. To resolve this, please delete the integration from the admin dashboard and reconnect it using new credentials.</p>

--- a/spec/lib/integrations/dialogflow/processor_service_spec.rb
+++ b/spec/lib/integrations/dialogflow/processor_service_spec.rb
@@ -162,10 +162,17 @@ describe Integrations::Dialogflow::ProcessorService do
       allow(session_client).to receive(:detect_intent).and_return({ session: session, query_input: query_input })
     end
 
-    it 'returns indented response' do
+    it 'returns intended response' do
       response = processor.send(:get_response, conversation.contact_inbox.source_id, message.content)
       expect(response[:query_input][:text][:text]).to eq(message)
       expect(response[:query_input][:text][:language_code]).to eq('en-US')
+    end
+
+    it 'disables the hook if permission errors are thrown' do
+      allow(session_client).to receive(:detect_intent).and_raise(Google::Cloud::PermissionDeniedError)
+
+      expect { processor.send(:get_response, conversation.contact_inbox.source_id, message.content) }
+        .to change(hook, :status).from('enabled').to('disabled')
     end
   end
 end

--- a/spec/mailers/administrator_notifications/channel_notifications_mailer_spec.rb
+++ b/spec/mailers/administrator_notifications/channel_notifications_mailer_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe AdministratorNotifications::ChannelNotificationsMailer do
     end
   end
 
+  describe 'dialogflow disconnect' do
+    let(:mail) { described_class.with(account: account).dialogflow_disconnect.deliver_now }
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq('Your Dialogflow integration was disconnected')
+    end
+
+    it 'renders the content' do
+      expect(mail.body).to include('Your Dialogflow integration was disconnected because of permission issues.')
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([administrator.email])
+    end
+  end
+
   describe 'facebook_disconnect' do
     before do
       stub_request(:post, /graph.facebook.com/)


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2699/googlecloudpermissiondeniederror-7iam-permission
