### PR TITLE
fix: Handle `Twilio::REST::RestError`

### DIFF
--- a/app/services/twilio/send_on_twilio_service.rb
+++ b/app/services/twilio/send_on_twilio_service.rb
@@ -8,8 +8,9 @@ class Twilio::SendOnTwilioService < Base::SendOnChannelService
   def perform_reply
     begin
       twilio_message = channel.send_message(**message_params)
-    rescue Twilio::REST::TwilioError => e
+    rescue Twilio::REST::TwilioError, Twilio::REST::RestError => e
       ChatwootExceptionTracker.new(e, user: message.sender, account: message.account).capture_exception
+      message.update!(status: :failed, external_error: e.message)
     end
     message.update!(source_id: twilio_message.sid) if twilio_message
   end

--- a/spec/services/twilio/send_on_twilio_service_spec.rb
+++ b/spec/services/twilio/send_on_twilio_service_spec.rb
@@ -96,5 +96,15 @@ describe Twilio::SendOnTwilioService do
       described_class.new(message: message).perform
       expect(messages_double).to have_received(:create).with(hash_including(media_url: [anything]))
     end
+
+    it 'if message is sent from chatwoot fails' do
+      allow(messages_double).to receive(:create).and_raise(Twilio::REST::TwilioError)
+
+      outgoing_message = create(
+        :message, message_type: 'outgoing', inbox: twilio_inbox, account: account, conversation: conversation
+      )
+      described_class.new(message: outgoing_message).perform
+      expect(outgoing_message.reload.status).to eq('failed')
+    end
   end
 end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2235/twiliorestresterror-[http-400]-21211-unable-to-create-record

<img width="688" alt="CleanShot 2023-10-31 at 13 02 38@2x" src="https://github.com/chatwoot/chatwoot/assets/12408980/10bec540-5a3f-4687-8b35-04ac8f327f14">
