### PR TITLE
fix: Update the message status to `failed` if the outgoing Facebook message fails.

### DIFF
--- a/app/services/facebook/send_on_facebook_service.rb
+++ b/app/services/facebook/send_on_facebook_service.rb
@@ -11,6 +11,7 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
   rescue Facebook::Messenger::FacebookError => e
     # TODO : handle specific errors or else page will get disconnected
     handle_facebook_error(e)
+    message.update!(status: :failed, external_error: e.message)
   end
 
   def send_message_to_facebook(delivery_params)

--- a/spec/services/facebook/send_on_facebook_service_spec.rb
+++ b/spec/services/facebook/send_on_facebook_service_spec.rb
@@ -58,6 +58,8 @@ describe Facebook::SendOnFacebookService do
         described_class.new(message: message).perform
 
         expect(facebook_channel.authorization_error_count).to eq(1)
+        expect(message.reload.status).to eq('failed')
+        expect(message.reload.external_error).to eq('Error validating access token')
       end
 
       it 'if message with attachment is sent from chatwoot and is outgoing' do


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2708/facebookmessengerfacebookerror-2022-you-have-been-temporarily-blocked