### PR TITLE
fix: Fixes textarea with empty lines changing height while typing [CW-2438]

### DIFF
--- a/app/javascript/shared/components/ResizableTextArea.vue
+++ b/app/javascript/shared/components/ResizableTextArea.vue
@@ -91,6 +91,7 @@ export default {
   },
   methods: {
     resizeTextarea() {
+      this.$el.style.height = 'auto';
       if (!this.value) {
         this.$el.style.height = `${this.minHeight}rem`;
       } else {


### PR DESCRIPTION

## Description
Fixes the issue with textarea shifting height when user types something in between last empty lines.

Fixes # (issue)
https://linear.app/chatwoot/issue/CW-2438/messenger-editor-break-on-chatwoot-cloud


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
