### PR TITLE
fix: Fixes wrong page size in category filter in articles page 

### DIFF
--- a/app/controllers/api/v1/accounts/articles_controller.rb
+++ b/app/controllers/api/v1/accounts/articles_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::Accounts::ArticlesController < Api::V1::Accounts::BaseController
     @articles_count = @all_articles.count
 
     @articles = if list_params[:category_slug].present?
-                  @all_articles.order_by_position.page(@current_page).per(50)
+                  @all_articles.order_by_position.page(@current_page)
                 else
                   @all_articles.order_by_updated_at.page(@current_page)
                 end


### PR DESCRIPTION


## Description

When I select the category from the sidebar, the API returns more articles than the expected page size 25. Thereby breaking the pagination.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
