### PR TITLE
chore: Remove sentry exceptions for the message status failed errors

### DIFF
--- a/app/services/facebook/send_on_facebook_service.rb
+++ b/app/services/facebook/send_on_facebook_service.rb
@@ -76,10 +76,8 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
 
   def handle_facebook_error(exception)
     # Refer: https://github.com/jgorset/facebook-messenger/blob/64fe1f5cef4c1e3fca295b205037f64dfebdbcab/lib/facebook/messenger/error.rb
-    if exception.to_s.include?('The session has been invalidated') || exception.to_s.include?('Error validating access token')
-      channel.authorization_error!
-    else
-      ChatwootExceptionTracker.new(exception, account: message.account, user: message.sender).capture_exception
-    end
+    return unless exception.to_s.include?('The session has been invalidated') || exception.to_s.include?('Error validating access token')
+
+    channel.authorization_error!
   end
 end

--- a/app/services/twilio/send_on_twilio_service.rb
+++ b/app/services/twilio/send_on_twilio_service.rb
@@ -9,7 +9,6 @@ class Twilio::SendOnTwilioService < Base::SendOnChannelService
     begin
       twilio_message = channel.send_message(**message_params)
     rescue Twilio::REST::TwilioError, Twilio::REST::RestError => e
-      ChatwootExceptionTracker.new(e, user: message.sender, account: message.account).capture_exception
       message.update!(status: :failed, external_error: e.message)
     end
     message.update!(source_id: twilio_message.sid) if twilio_message


### PR DESCRIPTION
- Remove sending exceptions to Sentry after capturing the message failed errors.