### PR TITLE
feat: Creates 404 page for public portal [CW-2727]

### DIFF
--- a/app/controllers/public/api/v1/portals/articles_controller.rb
+++ b/app/controllers/public/api/v1/portals/articles_controller.rb
@@ -1,8 +1,8 @@
 class Public::Api::V1::Portals::ArticlesController < Public::Api::V1::Portals::BaseController
   before_action :ensure_custom_domain_request, only: [:show, :index]
   before_action :portal
-  before_action :set_category, except: [:index, :show]
   before_action :set_article, only: [:show]
+  before_action :set_category, except: [:index, :show]
   layout 'portal'
 
   def index
@@ -37,10 +37,6 @@ class Public::Api::V1::Portals::ArticlesController < Public::Api::V1::Portals::B
       slug: permitted_params[:category_slug],
       locale: permitted_params[:locale]
     )
-  end
-
-  def portal
-    @portal ||= Portal.find_by!(slug: permitted_params[:slug], archived: false)
   end
 
   def list_params

--- a/app/controllers/public/api/v1/portals/articles_controller.rb
+++ b/app/controllers/public/api/v1/portals/articles_controller.rb
@@ -1,8 +1,8 @@
 class Public::Api::V1::Portals::ArticlesController < Public::Api::V1::Portals::BaseController
   before_action :ensure_custom_domain_request, only: [:show, :index]
   before_action :portal
-  before_action :set_article, only: [:show]
   before_action :set_category, except: [:index, :show]
+  before_action :set_article, only: [:show]
   layout 'portal'
 
   def index

--- a/app/controllers/public/api/v1/portals/base_controller.rb
+++ b/app/controllers/public/api/v1/portals/base_controller.rb
@@ -19,7 +19,7 @@ class Public::Api::V1::Portals::BaseController < PublicController
   end
 
   def portal
-    @portal ||= Portal.find_by!(slug: permitted_params[:slug], archived: false)
+    @portal ||= Portal.find_by!(slug: params[:slug], archived: false)
   end
 
   def set_locale(&)

--- a/app/controllers/public/api/v1/portals/base_controller.rb
+++ b/app/controllers/public/api/v1/portals/base_controller.rb
@@ -18,6 +18,10 @@ class Public::Api::V1::Portals::BaseController < PublicController
              end
   end
 
+  def portal
+    @portal ||= Portal.find_by!(slug: permitted_params[:slug], archived: false)
+  end
+
   def set_locale(&)
     switch_locale_with_portal(&) if params[:locale].present?
     switch_locale_with_article(&) if params[:article_slug].present?
@@ -40,6 +44,8 @@ class Public::Api::V1::Portals::BaseController < PublicController
 
   def switch_locale_with_article(&)
     article = Article.find_by(slug: params[:article_slug])
+    Rails.logger.info "Article: not found for slug: #{params[:article_slug]}"
+    render_404 && return if article.blank?
 
     @locale = if article.category.present?
                 article.category.locale
@@ -52,5 +58,10 @@ class Public::Api::V1::Portals::BaseController < PublicController
 
   def allow_iframe_requests
     response.headers.delete('X-Frame-Options') if @is_plain_layout_enabled
+  end
+
+  def render_404
+    portal
+    render 'public/api/v1/portals/error/404', status: :not_found
   end
 end

--- a/app/controllers/public/api/v1/portals/categories_controller.rb
+++ b/app/controllers/public/api/v1/portals/categories_controller.rb
@@ -15,8 +15,4 @@ class Public::Api::V1::Portals::CategoriesController < Public::Api::V1::Portals:
   def set_category
     @category = @portal.categories.find_by!(locale: params[:locale], slug: params[:category_slug])
   end
-
-  def portal
-    @portal ||= Portal.find_by!(slug: params[:slug], archived: false)
-  end
 end

--- a/app/controllers/public/api/v1/portals/categories_controller.rb
+++ b/app/controllers/public/api/v1/portals/categories_controller.rb
@@ -13,6 +13,9 @@ class Public::Api::V1::Portals::CategoriesController < Public::Api::V1::Portals:
   private
 
   def set_category
-    @category = @portal.categories.find_by!(locale: params[:locale], slug: params[:category_slug])
+    @category = @portal.categories.find_by(locale: params[:locale], slug: params[:category_slug])
+
+    Rails.logger.info "Category: not found for slug: #{params[:category_slug]}"
+    render_404 && return if @category.blank?
   end
 end

--- a/app/views/public/api/v1/portals/error/404.html.erb
+++ b/app/views/public/api/v1/portals/error/404.html.erb
@@ -2,8 +2,8 @@
     <div class="text-center mb-12">
         <span class="text-8xl">🔍</span>
     </div>
-    <h1 class="text-6xl text-center font-semibold text-slate-800 leading-relaxed"><%= I18n.t('public_portal.404.title') %></h1>
-    <p class="text-center text-slate-700 my-1"><%= I18n.t('public_portal.404.description') %></p>
+    <h1 class="text-6xl text-center font-semibold text-slate-800 dark:text-slate-100 leading-relaxed"><%= I18n.t('public_portal.404.title') %></h1>
+    <p class="text-center text-slate-700 dark:text-slate-300 my-1"><%= I18n.t('public_portal.404.description') %></p>
     <div class="text-center my-8">
         <a href="/hc/<%= @portal.slug %>/<%= @portal.config['default_locale'] || params[:locale] %>/<%= @theme.present? ? '?theme='+@theme : ''  %>" class="text-woot-500 font-semibold underline">
             <%= I18n.t('public_portal.404.back_to_home') %>

--- a/app/views/public/api/v1/portals/error/404.html.erb
+++ b/app/views/public/api/v1/portals/error/404.html.erb
@@ -1,0 +1,12 @@
+<div class="max-w-6xl h-full w-full flex-grow flex flex-col items-center justify-center mx-auto py-16 px-4 relative">
+    <div class="text-center mb-12">
+        <span class="text-8xl">🔍</span>
+    </div>
+    <h1 class="text-6xl text-center font-semibold text-slate-800 leading-relaxed"><%= I18n.t('public_portal.404.title') %></h1>
+    <p class="text-center text-slate-700 my-1"><%= I18n.t('public_portal.404.description') %></p>
+    <div class="text-center my-8">
+        <a href="/hc/<%= @portal.slug %>/<%= @portal.config['default_locale'] || params[:locale] %>/<%= @theme.present? ? '?theme='+@theme : ''  %>" class="text-woot-500 font-semibold underline">
+            <%= I18n.t('public_portal.404.back_to_home') %>
+        </a>
+    </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,6 +220,10 @@ en:
       made_with: Made with
     header:
       go_to_homepage: Go to the main site
+    404:
+      title: Page not found
+      description: We couldn't find the page you were looking for.
+      back_to_home: Go to home page
   slack_unfurl:
     fields:
      name: Name


### PR DESCRIPTION
## Description

- Refactors the repeated portal method definition 
- 404 page for wrong category and article links

<img width="1792" alt="image" src="https://github.com/chatwoot/chatwoot/assets/1277421/2724f580-16a5-45cc-bd97-777a784a253e">

Fixes # (issue)
https://linear.app/chatwoot/issue/CW-2727/create-404-page-for-public-portal

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
