### PR TITLE
Chore(Translation): Label from "login" to "Login" in Login page

### DIFF
--- a/app/javascript/dashboard/i18n/locale/pt_BR/login.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/login.json
@@ -2,7 +2,7 @@
   "LOGIN": {
     "TITLE": "Entrar no Chatwoot",
     "EMAIL": {
-      "LABEL": "e-mail",
+      "LABEL": "E-mail",
       "PLACEHOLDER": "exemplo@nomedaempresa.com",
       "ERROR": "Por favor, insira um endereço de e-mail válido"
     },


### PR DESCRIPTION
1 letter change in PT_BR translation.
Its seems like that translation are not present in https://chatwoot.crowdin.com/

From:
![image](https://github.com/chatwoot/chatwoot/assets/8796757/74b34034-ace7-4286-b69d-ee2f60840c4b)
To:
![image](https://github.com/chatwoot/chatwoot/assets/8796757/d6c14530-4064-4d29-bc8a-521ebcb0e0c7)
