### PR TITLE
fix: Handle all types of errors in API channel webhooks

### DIFF
--- a/lib/webhooks/trigger.rb
+++ b/lib/webhooks/trigger.rb
@@ -13,7 +13,7 @@ class Webhooks::Trigger
 
   def execute
     perform_request
-  rescue RestClient::Exceptions::Timeout, RestClient::ExceptionWithResponse => e
+  rescue StandardError => e
     handle_error(e)
     Rails.logger.warn "Exception: Invalid webhook URL #{@url} : #{e.message}"
   end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2751/socketerror-failed-to-open-tcp-connection-to-new-baileyssuperwaio443