### PR TITLE
fix: Resizable textarea height issue

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleEditor.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleEditor.vue
@@ -4,6 +4,7 @@
       v-model="articleTitle"
       type="text"
       rows="1"
+      :min-height="6"
       class="article-heading"
       :placeholder="$t('HELP_CENTER.EDIT_ARTICLE.TITLE_PLACEHOLDER')"
       @focus="onFocus"

--- a/app/javascript/shared/components/GreetingsEditor.vue
+++ b/app/javascript/shared/components/GreetingsEditor.vue
@@ -19,6 +19,7 @@
       v-model="greetingsMessage"
       rows="4"
       type="text"
+      :min-height="6"
       class="greetings--textarea"
       :label="label"
       :placeholder="placeholder"

--- a/app/javascript/shared/components/ResizableTextArea.vue
+++ b/app/javascript/shared/components/ResizableTextArea.vue
@@ -1,6 +1,7 @@
 <template>
   <textarea
     ref="textarea"
+    :style="{ height: textareaHeight }"
     :placeholder="placeholder"
     :value="value"
     @input="onInput"
@@ -18,6 +19,7 @@ import {
 } from 'dashboard/helper/editorHelper';
 
 const TYPING_INDICATOR_IDLE_TIME = 4000;
+const PIXELS_PER_REM = 16;
 export default {
   props: {
     placeholder: {
@@ -50,6 +52,7 @@ export default {
   data() {
     return {
       idleTimer: null,
+      textareaHeight: `${this.minHeight * PIXELS_PER_REM}px`,
     };
   },
   computed: {
@@ -91,12 +94,16 @@ export default {
   },
   methods: {
     resizeTextarea() {
-      this.$el.style.height = 'auto';
-      if (!this.value) {
-        this.$el.style.height = `${this.minHeight}rem`;
-      } else {
-        this.$el.style.height = `${this.$el.scrollHeight}px`;
-      }
+      const textarea = this.$refs.textarea;
+      if (!textarea || !this.value) return;
+      // Reset the height to the minimum first to allow shrinking
+      const minHeightPx = this.minHeight * PIXELS_PER_REM;
+      this.textareaHeight = `${minHeightPx}px`;
+
+      this.$nextTick(() => {
+        const newHeight = Math.max(textarea.scrollHeight, minHeightPx);
+        this.textareaHeight = `${newHeight}px`; // Update the height
+      });
     },
     // The toggleSignatureInEditor gets the new value from the
     // watcher, this means that if the value is true, the signature


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will solve the resizable textarea height issue that adds space.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

Please test this issue also. I made some changes. https://linear.app/chatwoot/issue/CW-2438/messenger-editor-break-on-chatwoot-cloud . 

**Loom video**
https://www.loom.com/share/bfde46ef8d1c41a2a8f3a64bb8ecf47e?sid=7de50b6b-e36d-4577-b0ee-f6211dd93fe7


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
