### PR TITLE
chore: Add rails_panel gem for query debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -200,6 +200,8 @@ group :development do
   # profiling
   gem 'rack-mini-profiler', '>= 3.1.1', require: false
   gem 'stackprof'
+  # Should install the associated chrome extension to view query logs
+  gem 'meta_request'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,6 +451,9 @@ GEM
     marcel (1.0.2)
     maxminddb (0.1.22)
     memoist (0.16.2)
+    meta_request (0.7.4)
+      rack-contrib (>= 1.1, < 3)
+      railties (>= 3.0.0, < 7.1)
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
@@ -559,6 +562,8 @@ GEM
     rack (2.2.8)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
+    rack-contrib (2.4.0)
+      rack (< 4)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
     rack-mini-profiler (3.1.1)
@@ -895,6 +900,7 @@ DEPENDENCIES
   listen
   lograge (~> 0.14.0)
   maxminddb
+  meta_request
   mock_redis
   neighbor
   newrelic-sidekiq-metrics (>= 1.6.2)


### PR DESCRIPTION
- `rails_panel` gem gives detailed query debugging for requests to the rails app
-  need to install the associated browser extension as well to see the details : https://github.com/dejan/rails_panel

<img width="1578" alt="Screenshot 2023-11-17 at 12 29 32 PM" src="https://github.com/chatwoot/chatwoot/assets/73185/07c9cbc1-ad9c-43f8-832d-5278a29ff0eb">
