### PR TITLE
fix: Add a .present? check for sentiment file path to avoid false positives

### DIFF
--- a/enterprise/app/models/enterprise/message.rb
+++ b/enterprise/app/models/enterprise/message.rb
@@ -1,5 +1,5 @@
 module Enterprise::Message
   def update_message_sentiments
-    ::Enterprise::SentimentAnalysisJob.perform_later(self) if ENV.fetch('SENTIMENT_FILE_PATH', nil)
+    ::Enterprise::SentimentAnalysisJob.perform_later(self) if ENV.fetch('SENTIMENT_FILE_PATH', nil).present?
   end
 end


### PR DESCRIPTION
Consider a method as follows. 

```rb
def is_present?(value)
  value ? true : false
end
```

```rb
is_present?('') # => returns true
is_present?(nil) # => returns false
```

We have to add `.present?` to avoid false positives. 

Fixes https://github.com/chatwoot/chatwoot/issues/8347
