### PR TITLE
chore: Make super admin auth error readable

### DIFF
--- a/app/controllers/super_admin/devise/sessions_controller.rb
+++ b/app/controllers/super_admin/devise/sessions_controller.rb
@@ -27,7 +27,8 @@ class SuperAdmin::Devise::SessionsController < Devise::SessionsController
 
     true
   rescue StandardError => e
-    @error_message = e.message
+    Rails.logger.error e.message
+    @error_message = 'Invalid credentials. Please try again.'
     false
   end
 end


### PR DESCRIPTION
- Remove the cryptic error for super admin auth and make it more readable. 