### PR TITLE
feat: Delete notification by id API

### DIFF
--- a/app/controllers/api/v1/accounts/notifications_controller.rb
+++ b/app/controllers/api/v1/accounts/notifications_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::Accounts::NotificationsController < Api::V1::Accounts::BaseController
   RESULTS_PER_PAGE = 15
 
-  before_action :fetch_notification, only: [:update]
+  before_action :fetch_notification, only: [:update, :destroy]
   before_action :set_primary_actor, only: [:read_all]
   before_action :set_current_page, only: [:index]
 
@@ -26,6 +26,11 @@ class Api::V1::Accounts::NotificationsController < Api::V1::Accounts::BaseContro
   def update
     @notification.update(read_at: DateTime.now.utc)
     render json: @notification
+  end
+
+  def destroy
+    @notification.destroy
+    head :ok
   end
 
   def unread_count

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,7 +166,7 @@ Rails.application.routes.draw do
             end
           end
 
-          resources :notifications, only: [:index, :update] do
+          resources :notifications, only: [:index, :update, :destroy] do
             collection do
               post :read_all
               get :unread_count

--- a/spec/controllers/api/v1/accounts/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/notifications_controller_spec.rb
@@ -127,4 +127,30 @@ RSpec.describe 'Notifications API', type: :request do
       end
     end
   end
+
+  describe 'DELETE /api/v1/accounts/{account.id}/notifications/:id' do
+    let(:admin) { create(:user, account: account, role: :administrator) }
+    let!(:notification) { create(:notification, account: account, user: admin) }
+
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized' do
+        delete "/api/v1/accounts/#{account.id}/notifications/#{notification.id}"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an authenticated user' do
+      let(:admin) { create(:user, account: account, role: :administrator) }
+
+      it 'deletes the notification' do
+        delete "/api/v1/accounts/#{account.id}/notifications/#{notification.id}",
+               headers: admin.create_new_auth_token,
+               as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(Notification.count).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2776/add-api-to-delete-a-notification-object