### PR TITLE
feat: Add `notification_deleted` action cable event

### DIFF
--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -7,6 +7,12 @@ class ActionCableListener < BaseListener
     broadcast(account, tokens, NOTIFICATION_CREATED, { notification: notification.push_event_data, unread_count: unread_count, count: count })
   end
 
+  def notification_deleted(event)
+    notification, account, unread_count, count = extract_notification_and_account(event)
+    tokens = [event.data[:notification].user.pubsub_token]
+    broadcast(account, tokens, NOTIFICATION_DELETED, notification: notification.push_event_data, unread_count: unread_count, count: count)
+  end
+
   def account_cache_invalidated(event)
     account = event.data[:account]
     tokens = user_tokens(account, account.agents)

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -10,7 +10,7 @@ class ActionCableListener < BaseListener
   def notification_deleted(event)
     notification, account, unread_count, count = extract_notification_and_account(event)
     tokens = [event.data[:notification].user.pubsub_token]
-    broadcast(account, tokens, NOTIFICATION_DELETED, notification: notification.push_event_data, unread_count: unread_count, count: count)
+    broadcast(account, tokens, NOTIFICATION_DELETED, notification: notification, unread_count: unread_count, count: count)
   end
 
   def account_cache_invalidated(event)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -41,6 +41,7 @@ class Notification < ApplicationRecord
   enum notification_type: NOTIFICATION_TYPES
 
   after_create_commit :process_notification_delivery, :dispatch_create_event
+  after_destroy_commit :dispatch_destroy_event
 
   # TODO: Get rid of default scope
   # https://stackoverflow.com/a/1834250/939299
@@ -134,5 +135,9 @@ class Notification < ApplicationRecord
 
   def dispatch_create_event
     Rails.configuration.dispatcher.dispatch(NOTIFICATION_CREATED, Time.zone.now, notification: self)
+  end
+
+  def dispatch_destroy_event
+    Rails.configuration.dispatcher.dispatch(NOTIFICATION_DELETED, Time.zone.now, notification: self)
   end
 end

--- a/lib/events/types.rb
+++ b/lib/events/types.rb
@@ -48,6 +48,7 @@ module Events::Types
 
   # notification events
   NOTIFICATION_CREATED = 'notification.created'
+  NOTIFICATION_DELETED = 'notification.deleted'
 
   # agent events
   AGENT_ADDED = 'agent.added'

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -131,6 +131,27 @@ describe ActionCableListener do
     end
   end
 
+  describe '#notification_deleted' do
+    let(:event_name) { :'notification.deleted' }
+    let!(:notification) { create(:notification, account: account, user: agent) }
+    let!(:event) { Events::Base.new(event_name, Time.zone.now, notification: notification) }
+
+    it 'sends message to account admins, inbox agents' do
+      expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+        [agent.pubsub_token],
+        'notification.deleted',
+        {
+          account_id: notification.account_id,
+          notification: notification.push_event_data,
+          unread_count: 1,
+          count: 1
+        }
+      )
+
+      listener.notification_deleted(event)
+    end
+  end
+
   describe '#conversation_updated' do
     let(:event_name) { :'conversation.updated' }
     let!(:event) { Events::Base.new(event_name, Time.zone.now, conversation: conversation, user: agent, is_private: false) }

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -142,7 +142,7 @@ describe ActionCableListener do
         'notification.deleted',
         {
           account_id: notification.account_id,
-          notification: notification.push_event_data,
+          notification: notification,
           unread_count: 1,
           count: 1
         }

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -134,7 +134,7 @@ Hey @John, @Alisha Peter can you check this ticket?"
     end
   end
 
-  context 'when primary actory is deleted' do
+  context 'when primary actor is deleted' do
     let!(:conversation) { create(:conversation) }
 
     it 'clears notifications' do


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2774/websocket-events-for-notification-update-and-destroy


https://github.com/chatwoot/chatwoot/assets/12408980/68343366-28f7-4d5e-808a-239be0cb7369



