### PR TITLE
fix: install node 20.x in non-production docker (#8441)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -104,7 +104,7 @@ RUN apk update && apk add --no-cache \
   && gem install bundler
 
 RUN if [ "$RAILS_ENV" != "production" ]; then \
-  apk add --no-cache nodejs yarn; \
+  apk add --no-cache nodejs-current yarn; \
   fi
 
 COPY --from=pre-builder /gems/ /gems/


### PR DESCRIPTION
## Description

The specified node version in package.json is listed as 20.x.
`apk add nodejs` installs node version 18.x, nodejs-current with the used alpine version installs version 20.x which is the one needed.

Fixes #8441

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Rebuild the images with `docker-compose build --no-cache` and start with `docker-compose up`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
