### PR TITLE
feat: Add the support for custom attributes in message variables

### DIFF
--- a/app/drops/contact_drop.rb
+++ b/app/drops/contact_drop.rb
@@ -18,4 +18,9 @@ class ContactDrop < BaseDrop
   def last_name
     @obj.try(:name).try(:split).try(:last).try(:capitalize) if @obj.try(:name).try(:split).try(:size) > 1
   end
+
+  def custom_attribute
+    custom_attributes = @obj.try(:custom_attributes) || {}
+    custom_attributes.transform_keys(&:to_s)
+  end
 end

--- a/app/drops/conversation_drop.rb
+++ b/app/drops/conversation_drop.rb
@@ -19,6 +19,11 @@ class ConversationDrop < BaseDrop
     end
   end
 
+  def custom_attribute
+    custom_attributes = @obj.try(:custom_attributes) || {}
+    custom_attributes.transform_keys(&:to_s)
+  end
+
   private
 
   def message_sender_name(sender)

--- a/spec/drops/contact_drop_spec.rb
+++ b/spec/drops/contact_drop_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ContactDrop do
   subject(:contact_drop) { described_class.new(contact) }
 
-  let!(:contact) { create(:contact) }
+  let!(:contact) { create(:contact, custom_attributes: { car_model: 'Tesla Model S', car_year: '2022' }) }
 
   context 'when first name' do
     it 'returns first name' do
@@ -36,6 +36,21 @@ describe ContactDrop do
     it('return the capitalized last name') do
       contact.update!(name: 'john doe')
       expect(subject.last_name).to eq 'Doe'
+    end
+  end
+
+  context 'when accessing custom attributes' do
+    it 'returns the correct car model from custom attributes' do
+      expect(contact_drop.custom_attribute['car_model']).to eq 'Tesla Model S'
+    end
+
+    it 'returns the correct car year from custom attributes' do
+      expect(contact_drop.custom_attribute['car_year']).to eq '2022'
+    end
+
+    it 'returns empty hash when there are no custom attributes' do
+      contact.update!(custom_attributes: nil)
+      expect(contact_drop.custom_attribute).to eq({})
     end
   end
 end

--- a/spec/models/concerns/liquidable_shared.rb
+++ b/spec/models/concerns/liquidable_shared.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 shared_examples_for 'liqudable' do
   context 'when liquid is present in content' do
-    let(:contact) { create(:contact, name: 'john', phone_number: '+912883') }
+    let(:contact) { create(:contact, name: 'john', phone_number: '+912883', custom_attributes: { customer_type: 'platinum' }) }
     let(:conversation) { create(:conversation, id: 1, contact: contact) }
 
     context 'when message is incoming' do
@@ -22,6 +22,12 @@ shared_examples_for 'liqudable' do
         message.content = 'hey {{contact.name}} how are you?'
         message.save!
         expect(message.content).to eq 'hey John how are you?'
+      end
+
+      it 'set replaces liquid custom attributes in message' do
+        message.content = 'Are you a {{contact.custom_attribute.customer_type}} customer'
+        message.save!
+        expect(message.content).to eq 'Are you a platinum customer'
       end
 
       it 'process liquid operators like default value' do

--- a/spec/models/concerns/liquidable_shared.rb
+++ b/spec/models/concerns/liquidable_shared.rb
@@ -28,7 +28,8 @@ shared_examples_for 'liqudable' do
         message.content = 'Are you a {{contact.custom_attribute.customer_type}} customer,
         If yes then the priority is {{conversation.custom_attribute.priority}}'
         message.save!
-        expect(message.content).to eq 'Are you a platinum customer,If yes then the priority is high'
+        expect(message.content).to eq 'Are you a platinum customer,
+        If yes then the priority is high'
       end
 
       it 'process liquid operators like default value' do

--- a/spec/models/concerns/liquidable_shared.rb
+++ b/spec/models/concerns/liquidable_shared.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 shared_examples_for 'liqudable' do
   context 'when liquid is present in content' do
     let(:contact) { create(:contact, name: 'john', phone_number: '+912883', custom_attributes: { customer_type: 'platinum' }) }
-    let(:conversation) { create(:conversation, id: 1, contact: contact) }
+    let(:conversation) { create(:conversation, id: 1, contact: contact, custom_attributes: { priority: 'high' }) }
 
     context 'when message is incoming' do
       let(:message) { build(:message, conversation: conversation, message_type: 'incoming') }
@@ -25,9 +25,10 @@ shared_examples_for 'liqudable' do
       end
 
       it 'set replaces liquid custom attributes in message' do
-        message.content = 'Are you a {{contact.custom_attribute.customer_type}} customer'
+        message.content = 'Are you a {{contact.custom_attribute.customer_type}} customer,
+        If yes then the priority is {{conversation.custom_attribute.priority}}'
         message.save!
-        expect(message.content).to eq 'Are you a platinum customer'
+        expect(message.content).to eq 'Are you a platinum customer,If yes then the priority is high'
       end
 
       it 'process liquid operators like default value' do


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2881/backend-add-the-support-for-custom-attributes-in-liquid-templates