### PR TITLE
chore: Change the `RemoveMessageNotifications` job implementation.

### DIFF
--- a/app/jobs/migration/remove_message_notifications.rb
+++ b/app/jobs/migration/remove_message_notifications.rb
@@ -3,6 +3,6 @@ class Migration::RemoveMessageNotifications < ApplicationJob
   queue_as :scheduled_jobs
 
   def perform
-    Notification.where(primary_actor_type: 'Message').in_batches(of: 100).each_record(&:destroy)
+    Notification.where(primary_actor_type: 'Message').in_batches(of: 100).delete_all
   end
 end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2883/change-the-removemessagenotifications-job-implementation
We use `destroy` to clear primary actor message notifications. However, this approach triggers `after_destroy_commit` every time, creating many unnecessary jobs in the queue, as we call `notification_deleted` on delete. This Pull Request will essentially replace `delete` with `destroy`.