### PR TITLE
feat(perf): Cache labels on the conversation model

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
@@ -14,7 +14,8 @@ class Api::V1::Accounts::Conversations::AssignmentsController < Api::V1::Account
 
   def set_agent
     @agent = Current.account.users.find_by(id: params[:assignee_id])
-    @conversation.update_assignee(@agent)
+    @conversation.assignee = @agent
+    @conversation.save!
     render_agent
   end
 

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -110,8 +110,8 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def assign_conversation
-    @agent = Current.account.users.find(current_user.id)
-    @conversation.update_assignee(@agent)
+    @conversation.assignee = current_user
+    @conversation.save!
   end
 
   def conversation

--- a/app/jobs/migration/conversation_cache_label_job.rb
+++ b/app/jobs/migration/conversation_cache_label_job.rb
@@ -1,0 +1,16 @@
+class Migration::ConversationCacheLabelJob < ApplicationJob
+  queue_as :async_database_migration
+
+  # To cache the label, we simply access it from the object and save it. Anytime the object is
+  # saved in the future, ActsAsTaggable will automatically recompute it. This process is done
+  # initially when the user has not performed any action.
+  # Reference: https://github.com/mbleigh/acts-as-taggable-on/wiki/Caching
+  def perform(account)
+    account.conversations.find_in_batches do |conversation_batch|
+      conversation_batch.each do |conversation|
+        conversation.label_list
+        conversation.save!
+      end
+    end
+  end
+end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -145,10 +145,6 @@ class Conversation < ApplicationRecord
     end
   end
 
-  def update_assignee(agent = nil)
-    update!(assignee: agent)
-  end
-
   def toggle_status
     # FIXME: implement state machine with aasm
     self.status = open? ? :resolved : :open

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -6,6 +6,7 @@
 #  additional_attributes  :jsonb
 #  agent_last_seen_at     :datetime
 #  assignee_last_seen_at  :datetime
+#  cached_label_list      :string
 #  contact_last_seen_at   :datetime
 #  custom_attributes      :jsonb
 #  first_reply_created_at :datetime
@@ -183,6 +184,10 @@ class Conversation < ApplicationRecord
 
   def webhook_data
     Conversations::EventDataPresenter.new(self).push_data
+  end
+
+  def cached_label_list_array
+    (cached_label_list || '').split(',')
   end
 
   def notifiable_assignee_change?

--- a/app/views/api/v1/accounts/conversations/messages/index.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/messages/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.meta do
-  json.labels @conversation.label_list
+  json.labels @conversation.cached_label_list_array
   json.additional_attributes @conversation.additional_attributes
   json.contact @conversation.contact.push_event_data
   json.assignee @conversation.assignee.push_event_data if @conversation.assignee.present?

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -35,7 +35,7 @@ json.can_reply conversation.can_reply?
 json.contact_last_seen_at conversation.contact_last_seen_at.to_i
 json.custom_attributes conversation.custom_attributes
 json.inbox_id conversation.inbox_id
-json.labels conversation.label_list
+json.labels conversation.cached_label_list_array
 json.muted conversation.muted?
 json.snoozed_until conversation.snoozed_until
 json.status conversation.status

--- a/db/migrate/20231211010807_add_cached_labels_list.rb
+++ b/db/migrate/20231211010807_add_cached_labels_list.rb
@@ -1,0 +1,19 @@
+class AddCachedLabelsList < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversations, :cached_label_list, :string
+    Conversation.reset_column_information
+    ActsAsTaggableOn::Taggable::Cache.included(Conversation)
+
+    update_exisiting_conversations
+  end
+
+  private
+
+  def update_exisiting_conversations
+    ::Account.find_in_batches do |account_batch|
+      account_batch.each do |account|
+        Migration::ConversationCacheLabelJob.perform_later(account)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_01_014644) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_11_010807) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -453,6 +453,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_01_014644) do
     t.integer "priority"
     t.bigint "sla_policy_id"
     t.datetime "waiting_since"
+    t.string "cached_label_list"
     t.index ["account_id", "display_id"], name: "index_conversations_on_account_id_and_display_id", unique: true
     t.index ["account_id", "id"], name: "index_conversations_on_id_and_account_id"
     t.index ["account_id", "inbox_id", "status", "assignee_id"], name: "conv_acid_inbid_stat_asgnid_idx"


### PR DESCRIPTION
I began by #8525, which increases the conversation page size to 100. However, this can't be reliably sent to all self-hosted instances because the response time is higher than the 25 items. (It took 6 seconds on my machine). 

This PR could decrease one query in the conversation jbuilder. Currently, we fetch those during runtime, which increases the API response time. In this PR, 

- Add an attribute `cached_label_list` on the conversation table to store the cached list of labels. 
- Run a migration to touch all the conversations to generate the cache for the first time.