### PR TITLE
fix: Update the label name to use .strip to avoid unnecessary whitespace characters

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -183,7 +183,7 @@ class Conversation < ApplicationRecord
   end
 
   def cached_label_list_array
-    (cached_label_list || '').split(',')
+    (cached_label_list || '').split(',').map(&:strip)
   end
 
   def notifiable_assignee_change?

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -831,4 +831,14 @@ RSpec.describe Conversation do
       end
     end
   end
+
+  describe 'cached_label_list_array' do
+    let(:conversation) { create(:conversation) }
+
+    it 'returns the correct list of labels' do
+      conversation.update(label_list: %w[customer-support enterprise paid-customer])
+
+      expect(conversation.cached_label_list_array).to eq %w[customer-support enterprise paid-customer]
+    end
+  end
 end


### PR DESCRIPTION
The cache stores the labels as `label1, label2`. Without removing the whitespace, the output of cached_label_list_array would be [`label1`,  `[whitespace]label2`], which doesn't match with the existing labels. This list is returned with proper label names.