### PR TITLE
chore(migration): Re-run database migration job for caching.

### DIFF
--- a/app/jobs/migration/conversation_batch_cache_label_job.rb
+++ b/app/jobs/migration/conversation_batch_cache_label_job.rb
@@ -1,0 +1,14 @@
+class Migration::ConversationBatchCacheLabelJob < ApplicationJob
+  queue_as :async_database_migration
+
+  # To cache the label, we simply access it from the object and save it. Anytime the object is
+  # saved in the future, ActsAsTaggable will automatically recompute it. This process is done
+  # initially when the user has not performed any action.
+  # Reference: https://github.com/mbleigh/acts-as-taggable-on/wiki/Caching
+  def perform(conversation_batch)
+    conversation_batch.each do |conversation|
+      conversation.label_list
+      conversation.save!
+    end
+  end
+end

--- a/db/migrate/20231211010807_add_cached_labels_list.rb
+++ b/db/migrate/20231211010807_add_cached_labels_list.rb
@@ -3,17 +3,5 @@ class AddCachedLabelsList < ActiveRecord::Migration[7.0]
     add_column :conversations, :cached_label_list, :string
     Conversation.reset_column_information
     ActsAsTaggableOn::Taggable::Cache.included(Conversation)
-
-    update_exisiting_conversations
-  end
-
-  private
-
-  def update_exisiting_conversations
-    ::Account.find_in_batches do |account_batch|
-      account_batch.each do |account|
-        Migration::ConversationCacheLabelJob.perform_later(account)
-      end
-    end
   end
 end

--- a/db/migrate/20231219000743_re_run_cache_label_job.rb
+++ b/db/migrate/20231219000743_re_run_cache_label_job.rb
@@ -1,0 +1,16 @@
+class ReRunCacheLabelJob < ActiveRecord::Migration[7.0]
+  def change
+    update_exisiting_conversations
+  end
+
+  private
+
+  def update_exisiting_conversations
+    # Run label migrations on the accounts that are not suspended
+    ::Account.active.find_in_batches do |account_batch|
+      account_batch.each do |account|
+        Migration::ConversationCacheLabelJob.perform_later(account)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_11_010807) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_19_000743) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"


### PR DESCRIPTION
A support request that came to Chatwoot Cloud revealed that the job was timed prematurely. The default timeout for Sidekiq queues was set as 25 minutes in sidekiq.yml file. The cache was not created properly for the accounts with more than 100k conversations.

This change removes the cache logic in the previous migration and creates a new migration with a new job which processes conversations in batch.
