### PR TITLE
feat: Add `last_activity_at` field to Notification model

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -41,6 +41,7 @@ class Notification < ApplicationRecord
 
   enum notification_type: NOTIFICATION_TYPES
 
+  before_create :set_last_activity_at
   after_create_commit :process_notification_delivery, :dispatch_create_event
   after_destroy_commit :dispatch_destroy_event
 
@@ -136,5 +137,9 @@ class Notification < ApplicationRecord
 
   def dispatch_destroy_event
     Rails.configuration.dispatcher.dispatch(NOTIFICATION_DELETED, Time.zone.now, notification: self)
+  end
+
+  def set_last_activity_at
+    self.last_activity_at = created_at
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,6 +3,7 @@
 # Table name: notifications
 #
 #  id                   :bigint           not null, primary key
+#  last_activity_at     :datetime
 #  notification_type    :integer          not null
 #  primary_actor_type   :string           not null
 #  read_at              :datetime
@@ -18,6 +19,7 @@
 # Indexes
 #
 #  index_notifications_on_account_id               (account_id)
+#  index_notifications_on_last_activity_at         (last_activity_at)
 #  index_notifications_on_user_id                  (user_id)
 #  uniq_primary_actor_per_account_notifications    (primary_actor_type,primary_actor_id)
 #  uniq_secondary_actor_per_account_notifications  (secondary_actor_type,secondary_actor_id)

--- a/db/migrate/20231219073832_add_last_activity_at_to_notifications.rb
+++ b/db/migrate/20231219073832_add_last_activity_at_to_notifications.rb
@@ -1,0 +1,6 @@
+class AddLastActivityAtToNotifications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :notifications, :last_activity_at, :datetime, default: nil
+    add_index :notifications, :last_activity_at
+  end
+end

--- a/db/migrate/20231219073832_add_last_activity_at_to_notifications.rb
+++ b/db/migrate/20231219073832_add_last_activity_at_to_notifications.rb
@@ -1,6 +1,6 @@
 class AddLastActivityAtToNotifications < ActiveRecord::Migration[7.0]
   def change
-    add_column :notifications, :last_activity_at, :datetime, default: nil
+    add_column :notifications, :last_activity_at, :datetime, default: -> { 'CURRENT_TIMESTAMP' }
     add_index :notifications, :last_activity_at
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -731,7 +731,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_19_073832) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "snoozed_until"
-    t.datetime "last_activity_at"
+    t.datetime "last_activity_at", default: -> { "CURRENT_TIMESTAMP" }
     t.index ["account_id"], name: "index_notifications_on_account_id"
     t.index ["last_activity_at"], name: "index_notifications_on_last_activity_at"
     t.index ["primary_actor_type", "primary_actor_id"], name: "uniq_primary_actor_per_account_notifications"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_19_000743) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_19_073832) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -731,7 +731,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_19_000743) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "snoozed_until"
+    t.datetime "last_activity_at"
     t.index ["account_id"], name: "index_notifications_on_account_id"
+    t.index ["last_activity_at"], name: "index_notifications_on_last_activity_at"
     t.index ["primary_actor_type", "primary_actor_id"], name: "uniq_primary_actor_per_account_notifications"
     t.index ["secondary_actor_type", "secondary_actor_id"], name: "uniq_secondary_actor_per_account_notifications"
     t.index ["user_id"], name: "index_notifications_on_user_id"


### PR DESCRIPTION
This PR will introduce a `last_activity_at` date-time field to the Notification model for ordering notifications by their snooze time. This means if a notification is snoozed, the last_activity_at field will update, bringing the notification to the top.