### PR TITLE
feat: Use typing status from utils

### DIFF
--- a/app/javascript/shared/components/ResizableTextArea.vue
+++ b/app/javascript/shared/components/ResizableTextArea.vue
@@ -17,6 +17,7 @@ import {
   removeSignature,
   extractTextFromMarkdown,
 } from 'dashboard/helper/editorHelper';
+import { createTypingIndicator } from '@chatwoot/utils';
 
 const TYPING_INDICATOR_IDLE_TIME = 4000;
 export default {
@@ -54,7 +55,15 @@ export default {
   },
   data() {
     return {
-      idleTimer: null,
+      typingIndicator: createTypingIndicator(
+        () => {
+          this.$emit('typing-on');
+        },
+        () => {
+          this.$emit('typing-off');
+        },
+        TYPING_INDICATOR_IDLE_TIME
+      ),
     };
   },
   computed: {
@@ -137,28 +146,11 @@ export default {
       this.$emit('input', event.target.value);
       this.resizeTextarea();
     },
-    resetTyping() {
-      this.$emit('typing-off');
-      this.idleTimer = null;
-    },
-    turnOffIdleTimer() {
-      if (this.idleTimer) {
-        clearTimeout(this.idleTimer);
-      }
-    },
     onKeyup() {
-      if (!this.idleTimer) {
-        this.$emit('typing-on');
-      }
-      this.turnOffIdleTimer();
-      this.idleTimer = setTimeout(
-        () => this.resetTyping(),
-        TYPING_INDICATOR_IDLE_TIME
-      );
+      this.typingIndicator.start();
     },
     onBlur() {
-      this.turnOffIdleTimer();
-      this.resetTyping();
+      this.typingIndicator.stop();
       this.$emit('blur');
     },
     onFocus() {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@braid/vue-formulate": "^2.5.2",
     "@chatwoot/prosemirror-schema": "1.0.3",
-    "@chatwoot/utils": "^0.0.20",
+    "@chatwoot/utils": "^0.0.21",
     "@hcaptcha/vue-hcaptcha": "^0.3.2",
     "@june-so/analytics-next": "^1.36.5",
     "@radix-ui/colors": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3177,10 +3177,10 @@
     prosemirror-utils "^0.9.6"
     prosemirror-view "^1.17.2"
 
-"@chatwoot/utils@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@chatwoot/utils/-/utils-0.0.20.tgz#d7cb407da434efcce4262178dbef55441f218489"
-  integrity sha512-rChMLxxbtzDpS2wePhnsdu+NDfRWbV+9Jw9eZ34jQRxkQ4LYVUoj6z5gC7a5+3izZQZ1XEwDSPHIiIvIUX4tzg==
+"@chatwoot/utils@^0.0.21":
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/@chatwoot/utils/-/utils-0.0.21.tgz#f9116daac0514a8a8fa6ce594efff10062222be0"
+  integrity sha512-eUDJ1K5x1rFlBywRctU3hXXiJ1U0EZiklowNl/YJOh1/BWDns4It3DWrQmAcjvsNbEUNWMfY+ShJmjdeei71Cw==
   dependencies:
     date-fns "^2.29.1"
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR utilizes the typing status functionality from the utils. The `typing on` status is triggered only when typing begins, and the `typing off` status is activated after 4 seconds of inactivity or when the user stops typing and the input field loses focus (on input blur).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**Loom video**
Cases with the normal editor (includes widget also) and advanced editor
https://www.loom.com/share/c779e44aeb834826bb6d3f5257e98fdb?sid=07a54080-d068-4bbf-87de-2cc6d979208f


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
