### PR TITLE
feat: Inbox email domain preference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,9 +78,12 @@ SMTP_OPENSSL_VERIFY_MODE=peer
 # SMTP_TLS=
 # SMTP_SSL=
 
+
 # Mail Incoming
 # This is the domain set for the reply emails when conversation continuity is enabled
 MAILER_INBOUND_EMAIL_DOMAIN=
+# Gives preference to the inbox email domain over MAILER_INBOUND_EMAIL_DOMAIN. It allows you to have different domains per inbox.
+MAILER_INBOUND_INBOX_PREFERENCE=false
 # Set this to the appropriate ingress channel with regards to incoming emails
 # Possible values are :
 # relay for Exim, Postfix, Qmail

--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,8 @@ RAILS_MAX_THREADS=5
 # The email from which all outgoing emails are sent
 # could user either  `email@yourdomain.com` or `BrandName <email@yourdomain.com>`
 MAILER_SENDER_EMAIL=Chatwoot <accounts@chatwoot.com>
+# Gives preference to the inbox email over MAILER_SENDER_EMAIL. It allows you to have different sender per inbox.
+MAILER_SENDER_INBOX_PREFERENCE=false
 
 #SMTP domain key is set up for HELO checking
 SMTP_DOMAIN=chatwoot.com
@@ -77,7 +79,6 @@ SMTP_OPENSSL_VERIFY_MODE=peer
 # Comment out the following environment variables if required by your SMTP server
 # SMTP_TLS=
 # SMTP_SSL=
-
 
 # Mail Incoming
 # This is the domain set for the reply emails when conversation continuity is enabled

--- a/app/mailboxes/application_mailbox.rb
+++ b/app/mailboxes/application_mailbox.rb
@@ -21,7 +21,7 @@ class ApplicationMailbox < ActionMailbox::Base
 
   class << self
     # checks if follow this pattern then send it to reply_mailbox
-    # <account/#{@account.id}/conversation/#{@conversation.uuid}@#{@account.inbound_email_domain}>
+    # <account/#{@account.id}/conversation/#{@conversation.uuid}@#{channel_email_domain}>
     def in_reply_to_mail?(inbound_mail)
       in_reply_to = inbound_mail.mail.in_reply_to
 

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -118,7 +118,7 @@ class ConversationReplyMailer < ApplicationMailer
 
   def reply_email
     if should_use_conversation_email_address?
-      sender_name("reply+#{@conversation.uuid}@#{@account.inbound_email_domain}")
+      sender_name("reply+#{@conversation.uuid}@#{channel_email_domain}")
     else
       @inbox.email_address || @agent&.email
     end

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -101,7 +101,10 @@ class ConversationReplyMailer < ApplicationMailer
   end
 
   def from_email
-    should_use_conversation_email_address? ? parse_email(@account.support_email) : parse_email(inbox_from_email_address)
+    sender_inbox_preference = ENV.fetch('MAILER_SENDER_INBOX_PREFERENCE', 'false') == 'true'
+    return parse_email(@account.support_email) if should_use_conversation_email_address? && !sender_inbox_preference
+
+    parse_email(inbox_from_email_address)
   end
 
   def mail_subject
@@ -137,9 +140,7 @@ class ConversationReplyMailer < ApplicationMailer
   end
 
   def inbox_from_email_address
-    return @inbox.email_address if @inbox.email_address
-
-    @account.support_email
+    @inbox.email_address || @account.support_email
   end
 
   def custom_message_id

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -67,6 +67,10 @@ class ConversationReplyMailer < ApplicationMailer
     @inbox.inbox_type == 'Email' || inbound_email_enabled?
   end
 
+  def should_use_inbox_from?
+    ENV['MAILER_SENDER_INBOX_PREFERENCE'] == 'true'
+  end
+
   def conversation_already_viewed?
     # whether contact already saw the message on widget
     return unless @conversation.contact_last_seen_at
@@ -101,8 +105,7 @@ class ConversationReplyMailer < ApplicationMailer
   end
 
   def from_email
-    sender_inbox_preference = ENV.fetch('MAILER_SENDER_INBOX_PREFERENCE', 'false') == 'true'
-    return parse_email(@account.support_email) if should_use_conversation_email_address? && !sender_inbox_preference
+    return parse_email(@account.support_email) if should_use_conversation_email_address? && !should_use_inbox_from?
 
     parse_email(inbox_from_email_address)
   end

--- a/app/mailers/conversation_reply_mailer_helper.rb
+++ b/app/mailers/conversation_reply_mailer_helper.rb
@@ -79,11 +79,14 @@ module ConversationReplyMailerHelper
     email_imap_enabled ? @channel.email : reply_email
   end
 
-  # Use channel email domain in case of account email domain is not set for custom message_id and in_reply_to
+  # Use channel email domain or account email domain depending on preference configuration for custom message_id and in_reply_to
   def channel_email_domain
-    return @account.inbound_email_domain if @account.inbound_email_domain.present?
+    email_domain = @inbox.channel&.email&.split('@')&.last
+    fallback_domain = @account.inbound_email_domain
 
-    email = @inbox.channel.try(:email)
-    email.present? ? email.split('@').last : raise(StandardError, 'Channel email domain not present.')
+    domain = (ENV['MAILER_INBOUND_INBOX_PREFERENCE'] == 'true' ? email_domain : fallback_domain).presence || email_domain.presence
+    raise(StandardError, 'Account inbound email domain and channel email domain not present.') unless domain
+
+    domain
   end
 end

--- a/app/mailers/conversation_reply_mailer_helper.rb
+++ b/app/mailers/conversation_reply_mailer_helper.rb
@@ -81,12 +81,15 @@ module ConversationReplyMailerHelper
 
   # Use channel email domain or account email domain depending on preference configuration for custom message_id and in_reply_to
   def channel_email_domain
-    use_inbox_email = ENV['MAILER_INBOUND_INBOX_PREFERENCE'] == 'true'
     inbox_email_domain = @inbox.channel.try(:email)&.split('@')&.last
-    return inbox_email_domain if inbox_email_domain.present? && use_inbox_email
+    return inbox_email_domain if inbox_email_domain.present? && should_use_channel_domain?
     return @account.inbound_email_domain if @account.inbound_email_domain.present?
     return inbox_email_domain if inbox_email_domain.present?
 
     raise(StandardError, 'Account inbound email domain and channel email domain not present.')
+  end
+
+  def should_use_channel_domain?
+    ENV['MAILER_INBOUND_INBOX_PREFERENCE'] == 'true'
   end
 end

--- a/app/mailers/conversation_reply_mailer_helper.rb
+++ b/app/mailers/conversation_reply_mailer_helper.rb
@@ -81,12 +81,12 @@ module ConversationReplyMailerHelper
 
   # Use channel email domain or account email domain depending on preference configuration for custom message_id and in_reply_to
   def channel_email_domain
-    email_domain = @inbox.channel&.email&.split('@')&.last
-    fallback_domain = @account.inbound_email_domain
+    use_inbox_email = ENV['MAILER_INBOUND_INBOX_PREFERENCE'] == 'true'
+    inbox_email_domain = @inbox.channel.try(:email)&.split('@')&.last
+    return inbox_email_domain if inbox_email_domain.present? && use_inbox_email
+    return @account.inbound_email_domain if @account.inbound_email_domain.present?
+    return inbox_email_domain if inbox_email_domain.present?
 
-    domain = (ENV['MAILER_INBOUND_INBOX_PREFERENCE'] == 'true' ? email_domain : fallback_domain).presence || email_domain.presence
-    raise(StandardError, 'Account inbound email domain and channel email domain not present.') unless domain
-
-    domain
+    raise(StandardError, 'Account inbound email domain and channel email domain not present.')
   end
 end

--- a/app/models/channel/email.rb
+++ b/app/models/channel/email.rb
@@ -61,6 +61,9 @@ class Channel::Email < ApplicationRecord
   private
 
   def ensure_forward_to_email
-    self.forward_to_email ||= "#{SecureRandom.hex}@#{account.inbound_email_domain}"
+    inbox_preference = ENV.fetch('MAILER_INBOUND_INBOX_PREFERENCE', 'false') == 'true'
+    email_domain = inbox_preference && email&.split('@')&.last
+
+    self.forward_to_email ||= "#{SecureRandom.hex}@#{email_domain || account.inbound_email_domain}"
   end
 end

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -383,5 +383,37 @@ RSpec.describe ConversationReplyMailer do
         expect(mail.in_reply_to).to eq("account/#{conversation.account.id}/conversation/#{conversation.uuid}@#{domain}")
       end
     end
+
+    context 'when prefer inbox emails configured' do
+      let(:new_account) { create(:account, domain: 'example.com') }
+      let!(:email_channel) { create(:channel_email, account: new_account, email: 'testing@channel.com') }
+      let!(:inbox) { create(:inbox, channel: email_channel, account: new_account, email_address: 'testing@inbox.com') }
+      let(:inbox_member) { create(:inbox_member, user: agent, inbox: inbox) }
+      let(:conversation) { create(:conversation, assignee: agent, inbox: inbox_member.inbox, account: new_account) }
+      let!(:message) { create(:message, conversation: conversation, account: new_account) }
+      let(:mail) { described_class.reply_with_summary(message.conversation, message.id).deliver_now }
+      let(:domain) { inbox.channel.email.split('@').last }
+
+      before do
+        allow(class_instance).to receive(:should_use_channel_domain?).and_return(true)
+        allow(class_instance).to receive(:should_use_inbox_from?).and_return(true)
+      end
+
+      it 'sets the correct custom message id' do
+        expect(mail.message_id).to eq("conversation/#{conversation.uuid}/messages/#{message.id}@#{domain}")
+      end
+
+      it 'sets the correct in reply to id' do
+        expect(mail.in_reply_to).to eq("account/#{conversation.account.id}/conversation/#{conversation.uuid}@#{domain}")
+      end
+
+      it 'sets reply to email to be based on the inbox domain' do
+        expect(mail.reply_to).to eq(["reply+#{message.conversation.uuid}@#{domain}"])
+      end
+
+      it 'sets from email to the inbox email address' do
+        expect(mail.from).to eq([inbox.email_address])
+      end
+    end
   end
 end


### PR DESCRIPTION
# Inbox email domain preference

## Description

As of today, `MAILER_INBOUND_EMAIL_DOMAIN` and `MAILER_SENDER_EMAIL` have preference over Email inbox configuration for inbound domain and sender. This is not very intuitive and too rigid if you want to have multiple email inboxes, and inconsistent if these inboxes are for different domains (i.e support different brands).

Since changing this behaviour would add breaking changes, our proposal is to allow configuring the order of preference by setting two new env vars that default to the current behaviour:

```bash
# Gives preference to the inbox email over MAILER_SENDER_EMAIL. It allows you to have different sender per inbox.
# Only changes the `from_email` logic
MAILER_SENDER_INBOX_PREFERENCE=false

# Gives preference to the inbox email domain over MAILER_INBOUND_EMAIL_DOMAIN. It allows you to have different domains per inbox.
MAILER_INBOUND_INBOX_PREFERENCE=false
```

The reason behind defining two different vars is to be more consistent and give more flexibility to cover a wider range of use cases:

```bash
# I want to always reply from my support email ignoring any inbox config (as it is today)
# doesn't keep consistency between inbox domain and reply-to domain
# (From: sender@a.tld <> inbox1@b.tld <> reply-to: hex@a.tld)
MAILER_SENDER_EMAIL=sender@a.tld
MAILER_SENDER_INBOX_PREFERENCE=false
MAILER_INBOUND_EMAIL_DOMAIN=a.tld
MAILER_INBOUND_INBOX_PREFERENCE=false

# I have multiple inboxes for different domains but always want to reply from "mother-company" (a.tld) domain sender account.
# (From: sender@a.tld <> inbox1@b.tld <> reply-to: hex@b.tld)
# (From: sender@a.tld <> inbox2@c.tld <> reply-to: hex@c.tld)
MAILER_SENDER_EMAIL=sender@a.tld
MAILER_SENDER_INBOX_PREFERENCE=false
MAILER_INBOUND_EMAIL_DOMAIN=a.tld
MAILER_INBOUND_INBOX_PREFERENCE=true

# I have different brands and want to reply from the same inbox email
# Sender and inbound domain are consistent per inbox (always same domain from sender, inbound and reply-to)
# (From: inbox1@b.tld <> inbox1@b.tld <> reply-to: hex@b.tld)
# (From: inbox2@c.tld <> inbox2@c.tld <> reply-to: hex@c.tld)
MAILER_SENDER_EMAIL=sender@a.tld
MAILER_SENDER_INBOX_PREFERENCE=true
MAILER_INBOUND_EMAIL_DOMAIN=a.tld
MAILER_INBOUND_INBOX_PREFERENCE=true
```

Fixes #5178

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- Doesn't change the current behaviour if the new ENV vars are missing or set to `false`.
- TBD


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
