### PR TITLE
chore: Temp support for 360DialogV2

### DIFF
--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -44,7 +44,7 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
     channel = Channel::Whatsapp.find_by(phone_number: phone_number)
 
     # TODO: Remove this in future when we deprecate the 360Dialog Provider
-    return channel unless channel.provider == 'whatsapp_cloud'
+    return channel unless channel&.provider == 'whatsapp_cloud'
     # validate to ensure the phone number id matches the whatsapp channel
     return channel if channel && channel.provider_config['phone_number_id'] == phone_number_id
   end

--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -6,7 +6,7 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
     return if channel_is_inactive?(channel)
 
     case channel.provider
-    when 'whatsapp_cloud'
+    when 'whatsapp_cloud', '360dialog_v2'
       Whatsapp::IncomingMessageWhatsappCloudService.new(inbox: channel.inbox, params: params).perform
     else
       Whatsapp::IncomingMessageService.new(inbox: channel.inbox, params: params).perform
@@ -42,6 +42,8 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
     phone_number = "+#{wb_params[:entry].first[:changes].first.dig(:value, :metadata, :display_phone_number)}"
     phone_number_id = wb_params[:entry].first[:changes].first.dig(:value, :metadata, :phone_number_id)
     channel = Channel::Whatsapp.find_by(phone_number: phone_number)
+
+    return channel unless channel.provider == 'whatsapp_cloud'
     # validate to ensure the phone number id matches the whatsapp channel
     return channel if channel && channel.provider_config['phone_number_id'] == phone_number_id
   end

--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -43,6 +43,7 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
     phone_number_id = wb_params[:entry].first[:changes].first.dig(:value, :metadata, :phone_number_id)
     channel = Channel::Whatsapp.find_by(phone_number: phone_number)
 
+    # TODO: Remove this in future when we deprecate the 360Dialog Provider
     return channel unless channel.provider == 'whatsapp_cloud'
     # validate to ensure the phone number id matches the whatsapp channel
     return channel if channel && channel.provider_config['phone_number_id'] == phone_number_id

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -25,7 +25,7 @@ class Channel::Whatsapp < ApplicationRecord
   EDITABLE_ATTRS = [:phone_number, :provider, { provider_config: {} }].freeze
 
   # default at the moment is 360dialog lets change later.
-  PROVIDERS = %w[default whatsapp_cloud].freeze
+  PROVIDERS = %w[default whatsapp_cloud 360dialog_v2].freeze
   before_validation :ensure_webhook_verify_token
 
   validates :provider, inclusion: { in: PROVIDERS }
@@ -41,6 +41,8 @@ class Channel::Whatsapp < ApplicationRecord
   def provider_service
     if provider == 'whatsapp_cloud'
       Whatsapp::Providers::WhatsappCloudService.new(whatsapp_channel: self)
+    elsif provider == '360dialog_v2'
+      Whatsapp::Providers::Whatsapp360DialogV2Service.new(whatsapp_channel: self)
     else
       Whatsapp::Providers::Whatsapp360DialogService.new(whatsapp_channel: self)
     end

--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -12,6 +12,9 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
     url_response = HTTParty.get(inbox.channel.media_url(attachment_payload[:id]), headers: inbox.channel.api_headers)
     # This url response will be failure if the access token has expired.
     inbox.channel.authorization_error! if url_response.unauthorized?
-    Down.download(url_response.parsed_response['url'], headers: inbox.channel.api_headers) if url_response.success?
+
+    download_url = url_response.parsed_response['url']
+    download_url.gsub!('https://lookaside.fbsbx.com', 'https://waba-v2.360dialog.io') if inbox.channel.provider == '360dialog_v2'
+    Down.download(download_url, headers: inbox.channel.api_headers) if url_response.success?
   end
 end

--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -13,9 +13,11 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
     # This url response will be failure if the access token has expired.
     inbox.channel.authorization_error! if url_response.unauthorized?
 
+    return unless url_response.success?
+
     download_url = url_response.parsed_response['url']
     # TODO: Remove this in future when we deprecate the 360Dialog Provider
     download_url.gsub!('https://lookaside.fbsbx.com', 'https://waba-v2.360dialog.io') if inbox.channel.provider == '360dialog_v2'
-    Down.download(download_url, headers: inbox.channel.api_headers) if url_response.success?
+    Down.download(download_url, headers: inbox.channel.api_headers)
   end
 end

--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -14,6 +14,7 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
     inbox.channel.authorization_error! if url_response.unauthorized?
 
     download_url = url_response.parsed_response['url']
+    # TODO: Remove this in future when we deprecate the 360Dialog Provider
     download_url.gsub!('https://lookaside.fbsbx.com', 'https://waba-v2.360dialog.io') if inbox.channel.provider == '360dialog_v2'
     Down.download(download_url, headers: inbox.channel.api_headers) if url_response.success?
   end

--- a/app/services/whatsapp/providers/whatsapp_360_dialog_v2_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_360_dialog_v2_service.rb
@@ -1,0 +1,136 @@
+class Whatsapp::Providers::Whatsapp360DialogV2Service < Whatsapp::Providers::BaseService
+  def send_message(phone_number, message)
+    if message.attachments.present?
+      send_attachment_message(phone_number, message)
+    elsif message.content_type == 'input_select'
+      send_interactive_text_message(phone_number, message)
+    else
+      send_text_message(phone_number, message)
+    end
+  end
+
+  def send_template(phone_number, template_info)
+    response = HTTParty.post(
+      "#{api_base_path}/messages",
+      headers: api_headers,
+      body: {
+        to: phone_number,
+        template: template_body_parameters(template_info),
+        type: 'template'
+      }.to_json
+    )
+
+    process_response(response)
+  end
+
+  def sync_templates
+    # ensuring that channels with wrong provider config wouldn't keep trying to sync templates
+    whatsapp_channel.mark_message_templates_updated
+    response = HTTParty.get("#{api_base_path}/configs/templates", headers: api_headers)
+    whatsapp_channel.update(message_templates: response['waba_templates'], message_templates_last_updated: Time.now.utc) if response.success?
+  end
+
+  def validate_provider_config?
+    response = HTTParty.post(
+      "#{api_base_path}/v1/configs/webhook",
+      headers: { 'D360-API-KEY': whatsapp_channel.provider_config['api_key'], 'Content-Type': 'application/json' },
+      body: {
+        url: "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/whatsapp/#{whatsapp_channel.phone_number}"
+      }.to_json
+    )
+    response.success?
+  end
+
+  def api_headers
+    { 'D360-API-KEY' => whatsapp_channel.provider_config['api_key'], 'Content-Type' => 'application/json' }
+  end
+
+  def media_url(media_id)
+    "#{api_base_path}/#{media_id}"
+  end
+
+  private
+
+  def api_base_path
+    # provide the environment variable when testing against sandbox : 'https://waba-sandbox.360dialog.io/v1'
+    ENV.fetch('360DIALOG_V2_BASE_URL', 'https://waba-v2.360dialog.io')
+  end
+
+  def send_text_message(phone_number, message)
+    response = HTTParty.post(
+      "#{api_base_path}/messages",
+      headers: api_headers,
+      body: {
+        messaging_product: 'whatsapp',
+        to: phone_number,
+        text: { body: message.content },
+        type: 'text'
+      }.to_json
+    )
+
+    process_response(response)
+  end
+
+  def send_attachment_message(phone_number, message)
+    attachment = message.attachments.first
+    type = %w[image audio video].include?(attachment.file_type) ? attachment.file_type : 'document'
+    type_content = {
+      'link': attachment.download_url
+    }
+    type_content['caption'] = message.content unless %w[audio sticker].include?(type)
+    type_content['filename'] = attachment.file.filename if type == 'document'
+    response = HTTParty.post(
+      "#{api_base_path}/messages",
+      headers: api_headers,
+      body: {
+        'messaging_product' => 'whatsapp',
+        'to' => phone_number,
+        'type' => type,
+        type.to_s => type_content
+      }.to_json
+    )
+
+    process_response(response)
+  end
+
+  def process_response(response)
+    if response.success?
+      response['messages'].first['id']
+    else
+      Rails.logger.error response.body
+      nil
+    end
+  end
+
+  def template_body_parameters(template_info)
+    {
+      name: template_info[:name],
+      namespace: template_info[:namespace],
+      language: {
+        policy: 'deterministic',
+        code: template_info[:lang_code]
+      },
+      components: [{
+        type: 'body',
+        parameters: template_info[:parameters]
+      }]
+    }
+  end
+
+  def send_interactive_text_message(phone_number, message)
+    payload = create_payload_based_on_items(message)
+
+    response = HTTParty.post(
+      "#{api_base_path}/messages",
+      headers: api_headers,
+      body: {
+        messaging_product: 'whatsapp',
+        to: phone_number,
+        interactive: payload,
+        type: 'interactive'
+      }.to_json
+    )
+
+    process_response(response)
+  end
+end

--- a/app/services/whatsapp/providers/whatsapp_360_dialog_v2_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_360_dialog_v2_service.rb
@@ -1,3 +1,4 @@
+# TODO: Remove this in future when we deprecate the 360Dialog Provider
 class Whatsapp::Providers::Whatsapp360DialogV2Service < Whatsapp::Providers::BaseService
   def send_message(phone_number, message)
     if message.attachments.present?


### PR DESCRIPTION
Before sunsetting the 360Dialog Provider, we will temporarily support the V2 URL in response to requests from some enterprise clients. However, we advise against creating new inboxes with this configuration due to its impending deprecation. We recommend using or transitioning to the WhatsApp Cloud Provider for the WhatsApp channel.