### PR TITLE
fix: set virtualListExtraProps

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -554,6 +554,15 @@ export default {
       this.$store.dispatch('campaigns/get');
     }
 
+    this.virtualListExtraProps = {
+      label: this.label,
+      teamId: this.teamId,
+      foldersId: this.foldersId,
+      conversationType: this.conversationType,
+      showAssignee: false,
+      isConversationSelected: this.isConversationSelected,
+    };
+
     bus.$on('fetch_conversation_stats', () => {
       this.$store.dispatch('conversationStats/get', this.conversationFilters);
     });


### PR DESCRIPTION
# Pull Request Template

## Description

Props appear after data, and because of this, all data is empty and everything works incorrectly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
