### PR TITLE
feat: trigger handoff when agent bot is the actor

### DIFF
--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -72,7 +72,7 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def pending_to_open_by_bot?
-    @conversation.status == 'pending' && params[:status] == 'open' && Current.user.nil?
+    @conversation.status == 'pending' && params[:status] == 'open' && Current.user.nil? && Current.executed_by.is_a?(AgentBot)
   end
 
   def should_assign_conversation?

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -60,6 +60,7 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def toggle_status
+    # FIXME: move this logic into a service object
     if pending_to_open_by_bot?
       @conversation.bot_handoff!
     elsif params[:status].present?
@@ -72,7 +73,9 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def pending_to_open_by_bot?
-    @conversation.status == 'pending' && params[:status] == 'open' && Current.user.nil? && Current.executed_by.is_a?(AgentBot)
+    return false unless Current.user.is_a?(AgentBot)
+
+    @conversation.status == 'pending' && params[:status] == 'open'
   end
 
   def should_assign_conversation?

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -61,7 +61,7 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
 
   def toggle_status
     if pending_to_open_by_bot?
-      @conversation.handoff
+      @conversation.bot_handoff!
     elsif params[:status].present?
       set_conversation_status
       @status = @conversation.save!

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -72,7 +72,7 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def pending_to_open_by_bot?
-    @conversation.status == 'pending' && params[:status] == 'open' && Current.user.is_a?(AgentBot)
+    @conversation.status == 'pending' && params[:status] == 'open' && Current.user.nil?
   end
 
   def should_assign_conversation?

--- a/app/controllers/concerns/access_token_auth_helper.rb
+++ b/app/controllers/concerns/access_token_auth_helper.rb
@@ -15,6 +15,7 @@ module AccessTokenAuthHelper
 
     @resource = @access_token.owner
     Current.user = @resource if current_user.is_a?(User)
+    Current.executed_by = @resource
   end
 
   def validate_bot_access_token!

--- a/app/controllers/concerns/access_token_auth_helper.rb
+++ b/app/controllers/concerns/access_token_auth_helper.rb
@@ -14,8 +14,7 @@ module AccessTokenAuthHelper
     render_unauthorized('Invalid Access Token') && return if @access_token.blank?
 
     @resource = @access_token.owner
-    Current.user = @resource if current_user.is_a?(User)
-    Current.executed_by = @resource
+    Current.user = @resource if [User, AgentBot].include?(@resource.class)
   end
 
   def validate_bot_access_token!

--- a/app/policies/inbox_policy.rb
+++ b/app/policies/inbox_policy.rb
@@ -21,7 +21,7 @@ class InboxPolicy < ApplicationPolicy
 
   def show?
     # FIXME: for agent bots, lets bring this validation to policies as well in future
-    return true if @user.blank?
+    return true if @user.is_a?(AgentBot)
 
     Current.user.assigned_inboxes.include? record
   end

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -538,7 +538,6 @@ RSpec.describe 'Conversations API', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(Rails.configuration.dispatcher).to have_received(:dispatch)
-          .with
           .with(Conversation::CONVERSATION_TYPING_ON, kind_of(Time), { conversation: conversation, user: agent, is_private: false })
       end
 
@@ -551,7 +550,6 @@ RSpec.describe 'Conversations API', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(Rails.configuration.dispatcher).to have_received(:dispatch)
-          .with
           .with(Conversation::CONVERSATION_TYPING_ON, kind_of(Time), { conversation: conversation, user: agent, is_private: true })
       end
     end


### PR DESCRIPTION
This PR adds a feature to auto-trigger handoff events when an Agent bot toggles a conversation status from `Pending` to `Open`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests, covers enough cases

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
