### PR TITLE
chore: Fix for empty update case for messages

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -299,6 +299,10 @@ class Message < ApplicationRecord
   end
 
   def dispatch_update_event
+    # ref: https://github.com/rails/rails/issues/44500
+    # we want to skip the update event if the message is not updated
+    return if previous_changes.blank?
+
     Rails.configuration.dispatcher.dispatch(MESSAGE_UPDATED, Time.zone.now, message: self, performed_by: Current.executed_by,
                                                                             previous_changes: previous_changes)
   end


### PR DESCRIPTION
We observed an issue in production where the external webhook for an API inbox was failing. This, in turn, calls message update to update message status to `failed`. This causes a loop because rails trigger after_update callbacks even for empty commits.

Ref: https://github.com/rails/rails/issues/44500