### PR TITLE
feat: handle unsupported media on the backend

### DIFF
--- a/app/builders/messages/instagram/message_builder.rb
+++ b/app/builders/messages/instagram/message_builder.rb
@@ -48,6 +48,10 @@ class Messages::Instagram::MessageBuilder < Messages::Messenger::MessageBuilder
     @outgoing_echo ? recipient_id : sender_id
   end
 
+  def message_is_unsupported?
+    message[:is_unsupported].present? && @messaging[:message][:is_unsupported] == true
+  end
+
   def sender_id
     @messaging[:sender][:id]
   end
@@ -126,7 +130,8 @@ class Messages::Instagram::MessageBuilder < Messages::Messenger::MessageBuilder
       content: message_content,
       sender: @outgoing_echo ? nil : contact,
       content_attributes: {
-        in_reply_to_external_id: message_reply_attributes
+        in_reply_to_external_id: message_reply_attributes,
+        is_unsupported: message_is_unsupported?
       }
     }
   end

--- a/app/builders/messages/instagram/message_builder.rb
+++ b/app/builders/messages/instagram/message_builder.rb
@@ -122,7 +122,7 @@ class Messages::Instagram::MessageBuilder < Messages::Messenger::MessageBuilder
   end
 
   def message_params
-    {
+    params = {
       account_id: conversation.account_id,
       inbox_id: conversation.inbox_id,
       message_type: message_type,
@@ -130,10 +130,12 @@ class Messages::Instagram::MessageBuilder < Messages::Messenger::MessageBuilder
       content: message_content,
       sender: @outgoing_echo ? nil : contact,
       content_attributes: {
-        in_reply_to_external_id: message_reply_attributes,
-        is_unsupported: message_is_unsupported?
+        in_reply_to_external_id: message_reply_attributes
       }
     }
+
+    params[:content_attributes][:is_unsupported] = true if message_is_unsupported?
+    params
   end
 
   def already_sent_from_chatwoot?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -101,7 +101,7 @@ class Message < ApplicationRecord
   # [:external_error : Can specify if the message creation failed due to an error at external API
   store :content_attributes, accessors: [:submitted_email, :items, :submitted_values, :email, :in_reply_to, :deleted,
                                          :external_created_at, :story_sender, :story_id, :external_error,
-                                         :translations, :in_reply_to_external_id], coder: JSON
+                                         :translations, :in_reply_to_external_id, :is_unsupported], coder: JSON
 
   store :external_source_ids, accessors: [:slack], coder: JSON, prefix: :external_source_id
 

--- a/spec/factories/instagram/instagram_message_create_event.rb
+++ b/spec/factories/instagram/instagram_message_create_event.rb
@@ -273,6 +273,33 @@ FactoryBot.define do
     initialize_with { attributes }
   end
 
+  factory :instagram_message_unsupported_event, class: Hash do
+    entry do
+      [
+        {
+          'id': 'instagram-message-unsupported-id-123',
+          'time': '2021-09-08T06:34:04+0000',
+          'messaging': [
+            {
+              'sender': {
+                'id': 'Sender-id-1'
+              },
+              'recipient': {
+                'id': 'chatwoot-app-user-id-1'
+              },
+              'timestamp': '2021-09-08T06:34:04+0000',
+              'message': {
+                'mid': 'unsupported-message-id-1',
+                'is_unsupported': true
+              }
+            }
+          ]
+        }
+      ]
+    end
+    initialize_with { attributes }
+  end
+
   factory :messaging_seen_event, class: Hash do
     entry do
       [

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -46,6 +46,7 @@ describe Webhooks::InstagramEventsJob do
         expect(instagram_inbox.contacts.last.additional_attributes['social_profiles']['instagram']).to eq 'some_user_name'
         expect(instagram_inbox.conversations.count).to be 1
         expect(instagram_inbox.messages.count).to be 1
+        expect(instagram_inbox.messages.last.content_attributes['is_unsupported']).to be_nil
       end
 
       it 'creates standby message in the instagram inbox' do

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -28,6 +28,7 @@ describe Webhooks::InstagramEventsJob do
   let!(:story_mention_params) { build(:instagram_story_mention_event).with_indifferent_access }
   let!(:story_mention_echo_params) { build(:instagram_story_mention_event_with_echo).with_indifferent_access }
   let!(:messaging_seen_event) { build(:messaging_seen_event).with_indifferent_access }
+  let!(:unsupported_message_event) { build(:instagram_message_unsupported_event).with_indifferent_access }
   let(:fb_object) { double }
 
   describe '#perform' do
@@ -156,6 +157,22 @@ describe Webhooks::InstagramEventsJob do
       it 'handle messaging_seen callback' do
         expect(Instagram::ReadStatusService).to receive(:new).with(params: messaging_seen_event[:entry][0][:messaging][0]).and_call_original
         instagram_webhook.perform_now(messaging_seen_event[:entry])
+      end
+
+      it 'handles unsupported message' do
+        allow(Koala::Facebook::API).to receive(:new).and_return(fb_object)
+        allow(fb_object).to receive(:get_object).and_return(
+          return_object.with_indifferent_access
+        )
+
+        instagram_webhook.perform_now(unsupported_message_event[:entry])
+        instagram_inbox.reload
+
+        expect(instagram_inbox.contacts.count).to be 1
+        expect(instagram_inbox.contacts.last.additional_attributes['social_profiles']['instagram']).to eq 'some_user_name'
+        expect(instagram_inbox.conversations.count).to be 1
+        expect(instagram_inbox.messages.count).to be 1
+        expect(instagram_inbox.messages.last.content_attributes['is_unsupported']).to be true
       end
     end
   end


### PR DESCRIPTION
This PR logs additional information in `content_attributes` of a message in case it is unsupported. This info can be used by the client to render a fresh UI

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
