### PR TITLE
feat: set lock timeout to 1 second

### DIFF
--- a/app/jobs/send_on_slack_job.rb
+++ b/app/jobs/send_on_slack_job.rb
@@ -1,6 +1,6 @@
 class SendOnSlackJob < MutexApplicationJob
   queue_as :medium
-  retry_on LockAcquisitionError, wait: 1.second, attempts: 6
+  retry_on LockAcquisitionError, wait: 1.second, attempts: 8
 
   def perform(message, hook)
     with_lock(::Redis::Alfred::SLACK_MESSAGE_MUTEX, conversation_id: message.conversation_id, reference_id: hook.reference_id) do

--- a/lib/redis/lock_manager.rb
+++ b/lib/redis/lock_manager.rb
@@ -12,10 +12,10 @@
 # end
 #
 class Redis::LockManager
-  # Default lock timeout set to 2 seconds. This means that if the lock isn't released
-  # within 2 seconds, it will automatically expire.
+  # Default lock timeout set to 1 second. This means that if the lock isn't released
+  # within 1 second, it will automatically expire.
   # This helps to avoid deadlocks in case the process holding the lock crashes or fails to release it.
-  LOCK_TIMEOUT = 2.seconds
+  LOCK_TIMEOUT = 1.second
 
   # Attempts to acquire a lock for the given key.
   #


### PR DESCRIPTION
We notice a lot of `MutexApplicationJob::LockAcquisitionError` especially for high velocity instances. This PR attempts to address that

- Reducing the default timeout to 1 second instead 2. Theoretically this should release the lock faster, given that the wait time in all cases is 1 second, having a lock timeout more than that does not make sense. Beside for us, the Mutex providing a 1 second delay is sufficient to handle concurrency issues
- Increase the attempt count for slack to 8, previously this has shown to improve delivery for FB and Insta