### PR TITLE
chore: Handle stripe events without plan data

### DIFF
--- a/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
+++ b/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
@@ -14,7 +14,8 @@ class Enterprise::Billing::HandleStripeEventService
   private
 
   def process_subscription_updated
-    plan = find_plan(subscription['plan']['product'])
+    plan = find_plan(subscription['plan']['product']) if subscription['plan'].present?
+
     # skipping self hosted plan events
     return if plan.blank? || account.blank?
 


### PR DESCRIPTION
`plan` isn't a guaranteed object in stripe `customer.subscription.updated` events.  It can be null for cases like `send_invoice` for `past_due` event as seen in the payload shown in sentry error.

fixes: https://linear.app/chatwoot/issue/CW-2925/nomethoderror-undefined-method-[]-for-nilnilclass-nomethoderror