### PR TITLE
chore: Rescue `Slack::Web::Api::Errors::NotInChannel` error

### DIFF
--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -97,7 +97,7 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
     post_message if message_content.present?
     upload_file if message.attachments.any?
   rescue Slack::Web::Api::Errors::AccountInactive, Slack::Web::Api::Errors::MissingScope, Slack::Web::Api::Errors::InvalidAuth,
-         Slack::Web::Api::Errors::ChannelNotFound => e
+         Slack::Web::Api::Errors::ChannelNotFound, Slack::Web::Api::Errors::NotInChannel => e
     Rails.logger.error e
     hook.prompt_reauthorization!
     hook.disable


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2930/slackwebapierrorsnotinchannel-not-in-channel

**Where and how much impact did it have?**

There have been 8 incidents reported in the sentry error.

The primary cause of this issue is when Chatwoot sends a message to a channel that has either been deleted or is unauthorized.

I was able to reproduce the issue by sending a message after deleting the connected Slack channel.

![CleanShot 2024-01-09 at 13 39 03@2x](https://github.com/chatwoot/chatwoot/assets/12408980/093e64e1-4058-4037-8cf0-70293e0aec7d)


**Why is the change you made the right solution?**

The right solution is simply to ask for prompt_reauthorization. So next time when connecting to Slack, users will only see the valid channels. This time, it should work without any issues.