### PR TITLE
fix: SQL error when rules with missing attributes is triggered

### DIFF
--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -20,7 +20,7 @@ class AutomationRules::ConditionsFilterService < FilterService
     @message_filters = @filters['messages']
     @attribute_changed_query_filter = []
 
-    @rule.conditions.each_with_index do |query_hash, current_index|
+    valid_rule_conditions.each_with_index do |query_hash, current_index|
       @attribute_changed_query_filter << query_hash and next if query_hash['filter_operator'] == 'attribute_changed'
 
       apply_filter(query_hash, current_index)
@@ -31,6 +31,28 @@ class AutomationRules::ConditionsFilterService < FilterService
     records = perform_attribute_changed_filter(records) if @attribute_changed_query_filter.any?
 
     records.any?
+  end
+
+  def valid_rule_conditions
+    filtered_rules = []
+    @rule.conditions.each do |query_hash|
+      filtered_rules << query_hash if valid_filter?(query_hash)
+    end
+
+    # [{"values"=>["open"], "attribute_key"=>"status", "query_operator"=>"and", "filter_operator"=>"equal_to", "custom_attribute_type"=>""}]
+    # go to the last condition and remove the `query_operator` key
+    filtered_rules.last.delete('query_operator')
+
+    filtered_rules
+  end
+
+  def valid_filter?(query_hash)
+    conversation_filter = @conversation_filters[query_hash['attribute_key']]
+    contact_filter = @contact_filters[query_hash['attribute_key']]
+    message_filter = @message_filters[query_hash['attribute_key']]
+
+    conversation_filter || contact_filter || message_filter ||
+      custom_attribute(query_hash['attribute_key'], @account, query_hash['custom_attribute_type'])
   end
 
   def filter_operation(query_hash, current_index)

--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -39,7 +39,6 @@ class AutomationRules::ConditionsFilterService < FilterService
       filtered_rules << query_hash if valid_filter?(query_hash)
     end
 
-    # [{"values"=>["open"], "attribute_key"=>"status", "query_operator"=>"and", "filter_operator"=>"equal_to", "custom_attribute_type"=>""}]
     # go to the last condition and remove the `query_operator` key
     filtered_rules.last.delete('query_operator')
 


### PR DESCRIPTION
Suppose we have a condition in an automation rule with a custom attribute, if that attribute it deleted, there can arise a condition when the generated query string can be malformed.

Suppose we have a filter on `conversation.created` event. And the rule looks like the following 

```json
[
  {
    "values": [
      "open"
    ],
    "attribute_key": "status",
    "query_operator": "and",
    "filter_operator": "equal_to",
    "custom_attribute_type": ""
  },
  {
    "values": [
      "true"
    ],
    "attribute_key": "missing_attribute",
    "filter_operator": "equal_to",
    "custom_attribute_type": "conversation_attribute"
  }
]
```

- When the first condition is parsed, and `apply_filter` appends to an empty query string, since there is a `query_operator` an `AND` is appended too. So for the first pass, the query string looks like `conversations.status IN (0) and`
- Now when the `apply_filter` is run for the second condition, [this line](https://github.com/chatwoot/chatwoot/blob/046ce68a45063436a3a4c7e82aeb91e0fa612eaf/app/services/automation_rules/conditions_filter_service.rb#L56C6-L56C6) evaluates to nil, causing the condition to break

This PR runs adds a sanitation step that ensures any rules without the said custom attribute is removed.

---

P.S. I tried a hack to fix this, Spoiler alert, it failed hilariously. But I'll document it anyway.

We can update the `apply_filter` method to add a final else condition `1 = 1`, so instead of appending nothing, it appends a blank condition. But then this only works for `AND` condition. 

```rb
  def apply_filter(query_hash, current_index)
    conversation_filter = @conversation_filters[query_hash['attribute_key']]
    contact_filter = @contact_filters[query_hash['attribute_key']]
    message_filter = @message_filters[query_hash['attribute_key']]

    @query_string += if conversation_filter
                       conversation_query_string('conversations', conversation_filter, query_hash.with_indifferent_access, current_index)
                     elsif contact_filter
                       contact_query_string(contact_filter, query_hash.with_indifferent_access, current_index)
                     elsif message_filter
                       message_query_string(message_filter, query_hash.with_indifferent_access, current_index)
                     elsif custom_attribute(query_hash['attribute_key'], @account, query_hash['custom_attribute_type'])
                       # send table name according to attribute key right now we are supporting contact based custom attribute filter
                       custom_attribute_query(query_hash.with_indifferent_access, query_hash['custom_attribute_type'], current_index)
                     else
                       '1 = 1'
                     end
  end
```