### PR TITLE
chore: Add a check to verify if the user exists before broadcasting the `notification_deleted` event.

### DIFF
--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -8,6 +8,8 @@ class ActionCableListener < BaseListener
   end
 
   def notification_deleted(event)
+    return if event.data[:notification].user.blank?
+
     notification, account, unread_count, count = extract_notification_and_account(event)
     tokens = [event.data[:notification].user.pubsub_token]
     broadcast(account, tokens, NOTIFICATION_DELETED, { notification: notification.push_event_data, unread_count: unread_count, count: count })


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2927/nomethoderror-undefined-method-notifications-meta-for-nilnilclass

**Where did it impact, how much did it impact?**

A total of 55 events have been reported in Sentry. This issue occurred after implementing the notification [deleted action cable event](https://github.com/chatwoot/chatwoot/pull/8431)

The main root cause of the issue is that when a user is deleted, all associated notifications are also deleted from the database. As a result, the user record becomes empty.

**Solution**

I have added a check whether the user is exist not nor before broadcasting the notification.deleted event.

