### PR TITLE
fix: Error ResizeObserver loop completed with undelivered notifications.

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -51,6 +51,9 @@ if (window.errorLoggingConfig) {
       /safari-extension:/i,
     ],
     integrations: [new Integrations.BrowserTracing()],
+    ignoreErrors: [
+      'ResizeObserver loop completed with undelivered notifications',
+    ],
   });
 }
 

--- a/app/javascript/packs/v3app.js
+++ b/app/javascript/packs/v3app.js
@@ -35,6 +35,9 @@ if (window.errorLoggingConfig) {
       /safari-extension:/i,
     ],
     integrations: [new Integrations.BrowserTracing()],
+    ignoreErrors: [
+      'ResizeObserver loop completed with undelivered notifications',
+    ],
   });
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This ResizeObserver issue is happening on the dashboard's chat list screen, and we aren't using ResizeObserver there. After an investigation, the problem might come from the `vue-resize` package used in `vue-tooltip`. And we couldn't find any issue created on their repo. Right now, there doesn't seem to be a straightforward way to fix this issue. 

So, I tried to ignore the ResizeObserver error from the sentry.

```
ignoreErrors: [
 'ResizeObserver loop limit exceeded',
 'ResizeObserver loop completed with undelivered notifications',
],
```

Fixes https://linear.app/chatwoot/issue/CW-2924/error-resizeobserver-loop-completed-with-undelivered-notifications

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
