### PR TITLE
fix: Twilo attachment download fallback to the step where authorization headers are not passed.

### DIFF
--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -137,7 +137,9 @@ class Twilio::IncomingMessageService
     )
   end
 
+  # This is just a temporary workaround since some users have not yet enabled media protection. We will remove this in the future.
   def handle_download_attachment_error(error)
+    logger.info "Error downloading attachment from Twilio: #{error.message}"
     if error.message.include?('401 Unauthorized')
       Down.download(params[:MediaUrl0])
     else

--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -141,7 +141,7 @@ class Twilio::IncomingMessageService
     if error.message.include?('401 Unauthorized')
       Down.download(params[:MediaUrl0])
     else
-      ChatwootExceptionTracker.new(e, account: @inbox.account).capture_exception
+      ChatwootExceptionTracker.new(error, account: @inbox.account).capture_exception
     end
   end
 end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2911/downclienterror-400-bad-request-downclienterror

**Where did it impact, how much did it impact?**

In the previous release, we enabled "HTTP Basic Authentication" to ensure that all attachments requiring HTTP authentication are secured. This is particularly important for media files that may contain sensitive data, as recommended by Twilio. However, some users experienced issues because they did not enable this option, despite our alerts prompting them to do so. (There are 2.6K events in sentry).

**Solution**

If the authenticated attachment download call fails, add another call to download the attachment without authentication.