### PR TITLE
feat: fallback to DB localStorage for idb names

### DIFF
--- a/app/javascript/dashboard/helper/CacheHelper/DataManager.js
+++ b/app/javascript/dashboard/helper/CacheHelper/DataManager.js
@@ -10,6 +10,7 @@ export class DataManager {
 
   async initDb() {
     if (this.db) return this.db;
+    const dbName = `cw-store-${this.accountId}`;
     this.db = await openDB(`cw-store-${this.accountId}`, DATA_VERSION, {
       upgrade(db) {
         db.createObjectStore('cache-keys');
@@ -18,6 +19,13 @@ export class DataManager {
         db.createObjectStore('team', { keyPath: 'id' });
       },
     });
+
+    // Store the database name in LocalStorage
+    const dbNames = JSON.parse(localStorage.getItem('cw-idb-names') || '[]');
+    if (!dbNames.includes(dbName)) {
+      dbNames.push(dbName);
+      localStorage.setItem('dbNames', JSON.stringify(dbNames));
+    }
 
     return this.db;
   }

--- a/app/javascript/dashboard/helper/CacheHelper/DataManager.js
+++ b/app/javascript/dashboard/helper/CacheHelper/DataManager.js
@@ -24,7 +24,7 @@ export class DataManager {
     const dbNames = JSON.parse(localStorage.getItem('cw-idb-names') || '[]');
     if (!dbNames.includes(dbName)) {
       dbNames.push(dbName);
-      localStorage.setItem('dbNames', JSON.stringify(dbNames));
+      localStorage.setItem('cw-idb-names', JSON.stringify(dbNames));
     }
 
     return this.db;

--- a/app/javascript/dashboard/store/utils/api.js
+++ b/app/javascript/dashboard/store/utils/api.js
@@ -49,7 +49,7 @@ export const deleteIndexedDBOnLogout = async () => {
     dbs = await window.indexedDB.databases();
     dbs = dbs.map(db => db.name);
   } catch (e) {
-    dbs = JSON.parse(localStorage.getItem('dbNames') || '[]');
+    dbs = JSON.parse(localStorage.getItem('cw-idb-names') || '[]');
   }
 
   dbs.forEach(dbName => {

--- a/app/javascript/dashboard/store/utils/api.js
+++ b/app/javascript/dashboard/store/utils/api.js
@@ -44,10 +44,29 @@ export const clearLocalStorageOnLogout = () => {
 };
 
 export const deleteIndexedDBOnLogout = async () => {
-  const dbs = await window.indexedDB.databases();
-  dbs.forEach(db => {
-    window.indexedDB.deleteDatabase(db.name);
+  let dbs = [];
+  try {
+    dbs = await window.indexedDB.databases();
+    dbs = dbs.map(db => db.name);
+  } catch (e) {
+    dbs = JSON.parse(localStorage.getItem('dbNames') || '[]');
+  }
+
+  dbs.forEach(dbName => {
+    const deleteRequest = window.indexedDB.deleteDatabase(dbName);
+
+    deleteRequest.onerror = event => {
+      // eslint-disable-next-line no-console
+      console.error(`Error deleting database ${dbName}.`, event);
+    };
+
+    deleteRequest.onsuccess = () => {
+      // eslint-disable-next-line no-console
+      console.log(`Database ${dbName} deleted successfully.`);
+    };
   });
+
+  localStorage.removeItem('cw-idb-names');
 };
 
 export const clearCookiesOnLogout = () => {


### PR DESCRIPTION
The `window.indexedDB.databases()` function is not available in all browsers. It's a non-standard method that's currently only supported in Chrome and Opera. This method returns a promise that resolves to a list of all database names associated with the origin of the calling script.

On Firefox, we won't be able to use this method as it's not supported. Instead, we will need to keep track of your database names in another way. One common approach is to store the names of your databases in a separate IndexedDB database or LocalStorage. This PR implements exactly that!

