### PR TITLE
chore: Unset Redis config after spec

### DIFF
--- a/spec/lib/redis/config_spec.rb
+++ b/spec/lib/redis/config_spec.rb
@@ -42,6 +42,11 @@ describe Redis::Config do
       end
     end
 
+    after do
+      # ensuring the redis config is unset and won't affect other tests
+      described_class.instance_variable_set(:@config, nil)
+    end
+
     it 'checks for app redis config' do
       expect(described_class.app.keys).to contain_exactly(:url, :password, :sentinels, :timeout, :reconnect_attempts, :ssl_params)
       expect(described_class.app[:url]).to eq("redis://#{redis_master_name}")
@@ -57,6 +62,11 @@ describe Redis::Config do
                           REDIS_SENTINEL_MASTER_NAME: redis_master_name, REDIS_SENTINEL_PASSWORD: redis_sentinel_password do
           described_class.config
         end
+      end
+
+      after do
+        # ensuring the redis config is unset and won't affect other tests
+        described_class.instance_variable_set(:@config, nil)
       end
 
       it 'checks for app redis config and sentinel passwords will be empty' do
@@ -75,6 +85,11 @@ describe Redis::Config do
                           REDIS_SENTINEL_MASTER_NAME: redis_master_name, REDIS_SENTINEL_PASSWORD: redis_sentinel_password do
           described_class.config
         end
+      end
+
+      after do
+        # ensuring the redis config is unset and won't affect other tests
+        described_class.instance_variable_set(:@config, nil)
       end
 
       it 'checks for app redis config and redis password is replaced in sentinel config' do


### PR DESCRIPTION
- The sentinel configuration set in this specification seems to be affecting other specifications. So let's ensure that the memoised config variable gets unset after execution of the spec.