### PR TITLE
fix: logic error when setting new relic logging forwarding

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -30,7 +30,7 @@ common: &default_settings
     enabled: <%= ENV.fetch('NEW_RELIC_APPLICATION_LOGGING_ENABLED', false) %>
     forwarding:
       # If `true`, the agent captures log records emitted by this application.
-      enabled: <%= ENV.fetch('NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED', true) %>
+      enabled: <%= ENV.fetch('NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED', true) == "false" ? false : true %>
       # Defines the maximum number of log records to buffer in memory at a time.
       max_samples_stored: 30000
     metrics:

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -29,7 +29,7 @@ common: &default_settings
     # independently. If `false`, all logging-related features are disabled.
     enabled: <%= ENV.fetch('NEW_RELIC_APPLICATION_LOGGING_ENABLED', false) %>
     forwarding:
-      # If `true`, the agent captures log records emitted by this application.
+      # If `true`, the agent captures log records emitted by this application
       enabled: <%= ENV.fetch('NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED', true) == "false" ? false : true %>
       # Defines the maximum number of log records to buffer in memory at a time.
       max_samples_stored: 30000


### PR DESCRIPTION


## Description
ENV.fetch coerces all values to strings, setting `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=false` yields the string "false" which is interpreted as `true`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

Tested locally

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
