### PR TITLE
feat: log errors on automation filter

### DIFF
--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -27,10 +27,13 @@ class AutomationRules::ConditionsFilterService < FilterService
     end
 
     records = base_relation.where(@query_string, @filter_values.with_indifferent_access)
-
     records = perform_attribute_changed_filter(records) if @attribute_changed_query_filter.any?
 
     records.any?
+  rescue StandardError => e
+    Rails.logger.error "Error in AutomationRules::ConditionsFilterService: #{e.message}"
+    Rails.logger.info "AutomationRules::ConditionsFilterService failed while processing rule #{@rule.id} for conversation #{@conversation.id}"
+    false
   end
 
   def filter_operation(query_hash, current_index)


### PR DESCRIPTION
This PR adds a `rescue` block for the `perform` method. This ensures that any error is logged with more details about the failure.  

The function then returns false, this ensures that the automation rule is not triggered