### PR TITLE
fix: Log twillio attachment error

### DIFF
--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -139,7 +139,7 @@ class Twilio::IncomingMessageService
 
   # This is just a temporary workaround since some users have not yet enabled media protection. We will remove this in the future.
   def handle_download_attachment_error(error)
-    logger.info "Error downloading attachment from Twilio: #{error.message}"
+    Rails.logger.info "Error downloading attachment from Twilio: #{error.message}"
     if error.message.include?('401 Unauthorized')
       Down.download(params[:MediaUrl0])
     else


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2950/nameerror-undefined-local-variable-or-method-logger-for