### PR TITLE
chore: Add display manifest to whitelabel settings

### DIFF
--- a/app/controllers/super_admin/app_configs_controller.rb
+++ b/app/controllers/super_admin/app_configs_controller.rb
@@ -9,6 +9,9 @@ class SuperAdmin::AppConfigsController < SuperAdmin::ApplicationController
                                     .map { |name, serialized_value| [name, serialized_value['value']] }
                                     .to_h
     # rubocop:enable Style/HashTransformValues
+    @installation_configs = ConfigLoader.new.general_configs.each_with_object({}) do |config_hash, result|
+      result[config_hash['name']] = config_hash.except('name')
+    end
   end
 
   def create

--- a/app/views/super_admin/app_configs/show.html.erb
+++ b/app/views/super_admin/app_configs/show.html.erb
@@ -8,13 +8,26 @@
 </header>
 <section class="main-content__body">
   <%= form_with url: super_admin_app_config_url(config: @config) , method: :post do |form| %>
-    <% @allowed_configs.each do |c| %>
-      <div class="field-unit">
+    <% @allowed_configs.each do |key| %>
+      <div class="flex mb-8">
         <div class="field-unit__label">
-          <%= form.label "app_config[#{c}]", c %>
+          <%= form.label "app_config[#{key}]", @installation_configs[key].dig('display_title') || key %>
         </div>
-        <div class="field-unit__field">
-          <%= form.text_field "app_config[#{c}]", value: @app_config[c] %>
+        <div class="field-unit__field -mt-2 ">
+          <% if @installation_configs[key].dig('type') == 'boolean' %>
+<%= form.select "app_config[#{key}]", 
+      [["True", true], ["False", false]], 
+      { selected: ActiveModel::Type::Boolean.new.cast(@app_config[key]) },
+      class: "mt-2 border border-slate-100 p-1 rounded-md" 
+  %>
+          <% else %>
+            <%= form.text_field "app_config[#{key}]", value: @app_config[key] %>
+          <% end %>
+          <%if @installation_configs[key].dig('description').present? %>
+            <p class="text-slate-400 text-xs italic pt-2">
+              <%= @installation_configs[key].dig('description') %>
+            </p>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/app/views/super_admin/app_configs/show.html.erb
+++ b/app/views/super_admin/app_configs/show.html.erb
@@ -11,21 +11,21 @@
     <% @allowed_configs.each do |key| %>
       <div class="flex mb-8">
         <div class="field-unit__label">
-          <%= form.label "app_config[#{key}]", @installation_configs[key].dig('display_title') || key %>
+          <%= form.label "app_config[#{key}]", @installation_configs[key]&.dig('display_title') || key %>
         </div>
         <div class="field-unit__field -mt-2 ">
-          <% if @installation_configs[key].dig('type') == 'boolean' %>
-<%= form.select "app_config[#{key}]", 
-      [["True", true], ["False", false]], 
-      { selected: ActiveModel::Type::Boolean.new.cast(@app_config[key]) },
-      class: "mt-2 border border-slate-100 p-1 rounded-md" 
-  %>
+          <% if @installation_configs[key]&.dig('type') == 'boolean' %>
+            <%= form.select "app_config[#{key}]", 
+              [["True", true], ["False", false]], 
+              { selected: ActiveModel::Type::Boolean.new.cast(@app_config[key]) },
+              class: "mt-2 border border-slate-100 p-1 rounded-md" 
+            %>
           <% else %>
             <%= form.text_field "app_config[#{key}]", value: @app_config[key] %>
           <% end %>
-          <%if @installation_configs[key].dig('description').present? %>
+          <%if @installation_configs[key]&.dig('description').present? %>
             <p class="text-slate-400 text-xs italic pt-2">
-              <%= @installation_configs[key].dig('description') %>
+              <%= @installation_configs[key]&.dig('description') %>
             </p>
           <% end %>
         </div>

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -1,4 +1,4 @@
-# if you dont specify locked attribute, the default value will be true
+# if you don't specify locked attribute, the default value will be true
 # which means the particular config will be locked
 - name: INSTALLATION_NAME
   value: 'Chatwoot'

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -2,22 +2,45 @@
 # which means the particular config will be locked
 - name: INSTALLATION_NAME
   value: 'Chatwoot'
+  display_title: 'Installation Name'
+  description: 'The installation wide name that would be used in the dashboard, title etc.'
 - name: LOGO_THUMBNAIL
   value: '/brand-assets/logo_thumbnail.svg'
+  display_title: 'Logo Thumbnail'
+  description: 'The thumbnail that would be used for favicon (512px X 512px)'
 - name: LOGO
   value: '/brand-assets/logo.svg'
+  display_title: 'Logo'
+  description: 'The logo that would be used on the dashboard, login page etc.'
+- name: LOGO_DARK
+  value: '/brand-assets/logo_dark.svg'
+  display_title: 'Logo Dark Mode'
+  description: 'The logo that would be used on the dashboard, login page etc. for dark mode'
 - name: BRAND_URL
   value: 'https://www.chatwoot.com'
+  display_title: 'Brand URL'
+  description: 'The URL that would be used in emails under the section “Powered By”'
 - name: WIDGET_BRAND_URL
   value: 'https://www.chatwoot.com'
+  display_title: 'Widget Brand URL'
+  description: 'The URL that would be used in the widget under the section “Powered By”'
 - name: BRAND_NAME
   value: 'Chatwoot'
+  display_title: 'Brand Name'
+  description: 'The name that would be used in emails and the widget'
 - name: TERMS_URL
   value: 'https://www.chatwoot.com/terms-of-service'
+  display_title: 'Terms URL'
+  description: 'The terms of service URL displayed in Signup Page'
 - name: PRIVACY_URL
   value: 'https://www.chatwoot.com/privacy-policy'
+  display_title: 'Privacy URL'
+  description: 'The privacy policy URL displayed in the app'
 - name: DISPLAY_MANIFEST
   value: true
+  display_title: 'Chatwoot Metadata'
+  description: 'Display default Chatwoot metadata like favicons and upgrade warnings'
+  type: boolean
 - name: MAILER_INBOUND_EMAIL_DOMAIN
   value:
   locked: false
@@ -72,8 +95,6 @@
   value: self-hosted
 - name: CSML_EDITOR_HOST
   value:
-- name: LOGO_DARK
-  value: '/brand-assets/logo_dark.svg'
 - name: INSTALLATION_PRICING_PLAN
   value: 'community'
 - name: INSTALLATION_PRICING_PLAN_QUANTITY

--- a/enterprise/app/controllers/enterprise/super_admin/app_configs_controller.rb
+++ b/enterprise/app/controllers/enterprise/super_admin/app_configs_controller.rb
@@ -16,6 +16,7 @@ module Enterprise::SuperAdmin::AppConfigsController
         WIDGET_BRAND_URL
         TERMS_URL
         PRIVACY_URL
+        DISPLAY_MANIFEST
       ]
     else
       super

--- a/lib/config_loader.rb
+++ b/lib/config_loader.rb
@@ -26,11 +26,12 @@ class ConfigLoader
     reconcile_feature_config
   end
 
-  private
-
   def general_configs
+    @config_path ||= Rails.root.join('config')
     @general_configs ||= YAML.safe_load(File.read("#{@config_path}/installation_config.yml")).freeze
   end
+
+  private
 
   def account_features
     @account_features ||= YAML.safe_load(File.read("#{@config_path}/features.yml")).freeze

--- a/lib/global_config.rb
+++ b/lib/global_config.rb
@@ -12,6 +12,7 @@ class GlobalConfig
         config[config_key] = load_from_cache(config_key)
       end
 
+      typecast_config(config)
       config.with_indifferent_access
     end
 
@@ -27,6 +28,14 @@ class GlobalConfig
     end
 
     private
+
+    def typecast_config(config)
+      general_configs = ConfigLoader.new.general_configs
+      config.each do |config_key, config_value|
+        config_type = general_configs.find { |c| c['name'] == config_key }&.dig('type')
+        config[config_key] = ActiveRecord::Type::Boolean.new.cast(config_value) if config_type == 'boolean'
+      end
+    end
 
     def load_from_cache(config_key)
       cache_key = "#{VERSION}:#{KEY_PREFIX}:#{config_key}"


### PR DESCRIPTION
- adds display manifest to white label settings
- Improve the app config rendering with options for display name and description 

<img width="1197" alt="Screenshot 2024-01-15 at 10 15 48 PM" src="https://github.com/chatwoot/chatwoot/assets/73185/d68f781f-29d0-4540-940a-2e13c1c0c327">
