### PR TITLE
fix: Stop overwritting contact avatars unneccesarily 

### DIFF
--- a/app/actions/contact_identify_action.rb
+++ b/app/actions/contact_identify_action.rb
@@ -104,7 +104,7 @@ class ContactIdentifyAction
     # TODO: replace reject { |_k, v| v.blank? } with compact_blank when rails is upgraded
     @contact.discard_invalid_attrs if discard_invalid_attrs
     @contact.save!
-    Avatar::AvatarFromUrlJob.perform_later(@contact, params[:avatar_url]) if params[:avatar_url].present?
+    Avatar::AvatarFromUrlJob.perform_later(@contact, params[:avatar_url]) if params[:avatar_url].present? && !@contact.avatar.attached?
   end
 
   def merge_contact(base_contact, merge_contact)

--- a/spec/actions/contact_identify_action_spec.rb
+++ b/spec/actions/contact_identify_action_spec.rb
@@ -22,6 +22,12 @@ describe ContactIdentifyAction do
       expect(contact.reload.identifier).to eq 'test_id'
     end
 
+    it 'will not call avatar job if avatar is already attached' do
+      contact.avatar.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
+      expect(Avatar::AvatarFromUrlJob).not_to receive(:perform_later).with(contact, params[:avatar_url])
+      contact_identify
+    end
+
     it 'merge deeply nested additional attributes' do
       create(:contact, account: account, identifier: '', email: 'test@test.com',
                        additional_attributes: { location: 'Bengaulru', company_name: 'Meta', social_profiles: { linkedin: 'saras' } })


### PR DESCRIPTION
While debugging a sentry error for "ActiveRecord::InvalidForeignKey ActiveStorage::Representations::RedirectController", it was noticed that we enqueue a `Avatar::AvatarFromUrlJob` for each `setUser` call, which is unnecessary. Hence making this call only if the contact doesn't have an existing avatar. 

If one needs to have this avatar updated, they can go to the contacts tab and delete the current avatar, Chatwoot will pick up the new avatar in subsequent API call. 