### PR TITLE
fix: Backdrop color for insert article modal in dark mode

### DIFF
--- a/app/javascript/dashboard/assets/scss/widgets/_modal.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_modal.scss
@@ -1,7 +1,7 @@
 .modal-mask {
   // @include flex;
   // @include flex-align(center, middle);
-  @apply flex items-center justify-center bg-modal dark:bg-modal z-[9990] h-full left-0 fixed top-0 w-full;
+  @apply flex items-center justify-center bg-modal-backdrop-light dark:bg-modal-backdrop-dark  z-[9990] h-full left-0 fixed top-0 w-full;
 }
 
 .page-top-bar {

--- a/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
@@ -101,10 +101,10 @@
       <transition name="modal-fade">
         <div
           v-show="$refs.upload && $refs.upload.dropActive"
-          class="fixed top-0 bottom-0 left-0 right-0 z-20 flex flex-col items-center justify-center w-full h-full gap-2 text-slate-600 dark:text-slate-200 bg-white_transparent dark:bg-black_transparent"
+          class="fixed top-0 bottom-0 left-0 right-0 z-20 flex flex-col items-center justify-center w-full h-full gap-2 text-slate-900 dark:text-slate-50 bg-modal-backdrop-light dark:bg-modal-backdrop-dark"
         >
           <fluent-icon icon="cloud-backup" size="40" />
-          <h4 class="page-sub-title text-slate-600 dark:text-slate-200">
+          <h4 class="page-sub-title text-slate-900 dark:text-slate-50">
             {{ $t('CONVERSATION.REPLYBOX.DRAG_DROP') }}
           </h4>
         </div>

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleSearch/SearchPopover.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleSearch/SearchPopover.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="fixed flex items-center justify-center w-screen h-screen bg-white/70 top-0 left-0 z-50"
+    class="fixed flex items-center justify-center w-screen h-screen bg-modal-backdrop-light dark:bg-modal-backdrop-dark top-0 left-0 z-50"
   >
     <div
       v-on-clickaway="onClose"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,9 +32,8 @@ module.exports = {
     colors: {
       transparent: 'transparent',
       white: '#fff',
-      white_transparent: 'rgba(255, 255, 255, 0.9)',
-      black_transparent: 'rgba(0, 0, 0, 0.9)',
-      modal: 'rgba(0, 0, 0, 0.4)',
+      'modal-backdrop-light': 'rgba(0, 0, 0, 0.4)',
+      'modal-backdrop-dark': 'rgba(0, 0, 0, 0.6)',
       current: 'currentColor',
       woot: {
         25: blue.blue2,


### PR DESCRIPTION
# Pull Request Template

## Description

This PR includes a fix to support backdrop color for insert the article modal in dark mode.

Fixes https://linear.app/chatwoot/issue/CW-2954/fix-backdrop-color-for-insert-article-modal-in-dark-mode

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Loom video**
https://www.loom.com/share/c2945162be644896b475488cc5bdb516?sid=c0fd30e1-0df4-4f8f-bc94-2a18ed51950e

**Screens to be tested for both dark and light mode**
1. Insert article modal
2. Drag and drop
3. All other modals


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
