### PR TITLE
chore: Switch to Markdown instead of MarkdownV2 for telegram channel

### DIFF
--- a/app/models/channel/telegram.rb
+++ b/app/models/channel/telegram.rb
@@ -150,17 +150,12 @@ class Channel::Telegram < ApplicationRecord
   end
 
   def convert_markdown_to_telegram(text)
+    ## supported characters : https://core.telegram.org/bots/api#markdown-style
+    ## To implement MarkdownV2, we will need to do a lot of escaping
+
     # Convert bold - double asterisks to single asterisk in Telegram
+    # Chatwoot uses double asterisks for bold, while telegram used single asterisk
     text.gsub!(/\*\*(.*?)\*\*/, '*\1*')
-
-    # Convert italics - single underscore (same in both CommonMark and Telegram)
-    # No conversion needed for italics as both use _text_
-
-    # Convert underline - not typically used in CommonMark, so we'll leave it as is
-
-    # Convert strikethrough - double tilde to single tilde in Telegram
-    text.gsub!(/~~(.*?)~~/, '~\1~')
-
     text
   end
 
@@ -171,7 +166,7 @@ class Channel::Telegram < ApplicationRecord
                     chat_id: chat_id,
                     text: text_to_md,
                     reply_markup: reply_markup,
-                    parse_mode: 'MarkdownV2',
+                    parse_mode: 'Markdown',
                     reply_to_message_id: reply_to_message_id
                   })
   end

--- a/spec/models/channel/telegram_spec.rb
+++ b/spec/models/channel/telegram_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Channel::Telegram do
 
       stub_request(:post, "https://api.telegram.org/bot#{telegram_channel.bot_token}/sendMessage")
         .with(
-          body: 'chat_id=123&text=test&reply_markup=&parse_mode=MarkdownV2&reply_to_message_id='
+          body: 'chat_id=123&text=test&reply_markup=&parse_mode=Markdown&reply_to_message_id='
         )
         .to_return(
           status: 200,
@@ -22,12 +22,12 @@ RSpec.describe Channel::Telegram do
     end
 
     it 'send message with markdown converted to telegram markdown' do
-      message = create(:message, message_type: :outgoing, content: '**test** ~~test~~ *test* ~test~',
+      message = create(:message, message_type: :outgoing, content: '**test** *test* ~test~',
                                  conversation: create(:conversation, inbox: telegram_channel.inbox, additional_attributes: { 'chat_id' => '123' }))
 
       stub_request(:post, "https://api.telegram.org/bot#{telegram_channel.bot_token}/sendMessage")
         .with(
-          body: "chat_id=123&text=#{ERB::Util.url_encode('*test* ~test~ *test* ~test~')}&reply_markup=&parse_mode=MarkdownV2&reply_to_message_id="
+          body: "chat_id=123&text=#{ERB::Util.url_encode('*test* *test* ~test~')}&reply_markup=&parse_mode=Markdown&reply_to_message_id="
         )
         .to_return(
           status: 200,
@@ -49,7 +49,7 @@ RSpec.describe Channel::Telegram do
         .with(
           body: 'chat_id=123&text=test' \
                 '&reply_markup=%7B%22one_time_keyboard%22%3Atrue%2C%22inline_keyboard%22%3A%5B%5B%7B%22text%22%3A%22test%22%2C%22' \
-                'callback_data%22%3A%22test%22%7D%5D%5D%7D&parse_mode=MarkdownV2&reply_to_message_id='
+                'callback_data%22%3A%22test%22%7D%5D%5D%7D&parse_mode=Markdown&reply_to_message_id='
         )
         .to_return(
           status: 200,
@@ -66,7 +66,7 @@ RSpec.describe Channel::Telegram do
 
       stub_request(:post, "https://api.telegram.org/bot#{telegram_channel.bot_token}/sendMessage")
         .with(
-          body: 'chat_id=123&text=test&reply_markup=&parse_mode=MarkdownV2&reply_to_message_id='
+          body: 'chat_id=123&text=test&reply_markup=&parse_mode=Markdown&reply_to_message_id='
         )
         .to_return(
           status: 403,


### PR DESCRIPTION
https://github.com/chatwoot/chatwoot/pull/8640 Introduced using `MarkdownV2` rendering for telegram Channel. But using this format caused breakages since this format requires escaping of a lot of special characters
> In all other places characters '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!' must be escaped with the preceding character '\'.

ref: https://core.telegram.org/bots/api#markdownv2-style

Hence, switching to the `Markdown` format doesn't require as much complexity. We will evaluate `MarkdownV2` later in future. 
ref: https://core.telegram.org/bots/api#markdown-style 

the caveat is that `Markdown` only supports a limited set of blocks, like bold, italics and code