### PR TITLE
fix:  Notification count is incorrect when the number of notifications exceeds the page size.

### DIFF
--- a/app/controllers/api/v1/accounts/notifications_controller.rb
+++ b/app/controllers/api/v1/accounts/notifications_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::Accounts::NotificationsController < Api::V1::Accounts::BaseContro
   def index
     @unread_count = notification_finder.unread_count
     @notifications = notification_finder.perform
-    @count = @notifications.count
+    @count = notification_finder.count
   end
 
   def read_all

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationsView.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationsView.vue
@@ -11,6 +11,7 @@
       <table-footer
         :current-page="Number(meta.currentPage)"
         :total-count="meta.count"
+        :page-size="15"
         @page-change="onPageChange"
       />
     </div>


### PR DESCRIPTION
The notification count is incorrect when the number of notifications exceeds the page size.