### PR TITLE
feat: Show notification last active time instead of  created time

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationPanelItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationPanelItem.vue
@@ -56,7 +56,7 @@
           <span
             class="mt-1 text-slate-500 dark:text-slate-400 text-xxs font-semibold flex"
           >
-            {{ dynamicTime(notificationItem.created_at) }}
+            {{ dynamicTime(notificationItem.last_activity_at) }}
           </span>
         </div>
       </div>

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
@@ -58,7 +58,7 @@
           <td>
             <div class="text-right timestamp--column">
               <span class="notification--created-at">
-                {{ dynamicTime(notificationItem.created_at) }}
+                {{ dynamicTime(notificationItem.last_activity_at) }}
               </span>
             </div>
           </td>

--- a/app/views/api/v1/accounts/notifications/index.json.jbuilder
+++ b/app/views/api/v1/accounts/notifications/index.json.jbuilder
@@ -19,6 +19,7 @@ json.data do
       json.secondary_actor notification.secondary_actor&.push_event_data
       json.user notification.user.push_event_data
       json.created_at notification.created_at.to_i
+      json.last_activity_at notification.last_activity_at.to_i
     end
   end
 end


### PR DESCRIPTION
We have updated the way notifications are displayed by using the last active time instead of the create time. Therefore, showing the "created at" information in the UI no longer makes sense for the user. This PR will resolve the issue.