### PR TITLE
feat: use `short_summary` for downloading reports [CW-2962]

### DIFF
--- a/app/builders/v2/report_builder.rb
+++ b/app/builders/v2/report_builder.rb
@@ -46,6 +46,14 @@ class V2::ReportBuilder
     }
   end
 
+  def short_summary
+    {
+      conversations_count: conversations.count,
+      avg_first_response_time: avg_first_response_time_summary,
+      avg_resolution_time: avg_resolution_time_summary
+    }
+  end
+
   def conversation_metrics
     if params[:type].equal?(:account)
       live_conversations

--- a/app/helpers/api/v2/accounts/reports_helper.rb
+++ b/app/helpers/api/v2/accounts/reports_helper.rb
@@ -37,7 +37,7 @@ module Api::V2::Accounts::ReportsHelper
           business_hours: ActiveModel::Type::Boolean.new.cast(params[:business_hours])
         }
       )
-    ).summary
+    ).short_summary
   end
 
   private


### PR DESCRIPTION
This PR removes redundant queries that are made when downloading reports.

The `generate_readable_report_metrics` method only returned three metrics, so there is no point in calculating the rest. This should significantly speed up report generation for downloads

```rb
  def generate_readable_report_metrics(report_metric)
    [
      report_metric[:conversations_count],
      time_to_minutes(report_metric[:avg_first_response_time]),
      time_to_minutes(report_metric[:avg_resolution_time])
    ]
  end
```

## Results

#### Before Fix

![CleanShot 2024-01-18 at 13 08 42@2x](https://github.com/chatwoot/chatwoot/assets/18097732/6d6262c1-098b-4b8c-a5e2-5c3705080f6e)


#### After Fix

![CleanShot 2024-01-18 at 13 08 39@2x](https://github.com/chatwoot/chatwoot/assets/18097732/a18a0dde-99d2-4156-a374-f9b203298004)
