### PR TITLE
refactor: remove exception tracker

### DIFF
--- a/app/helpers/api/v1/inboxes_helper.rb
+++ b/app/helpers/api/v1/inboxes_helper.rb
@@ -53,7 +53,7 @@ module Api::V1::InboxesHelper
   rescue StandardError => e
     raise StandardError, e.message
   ensure
-    Rails.logger.error "Check IMAP Connect Failed with #{e.message}" if e.present?
+    Rails.logger.error "[Api::V1::InboxesHelper] check_imap_connection failed with #{e.message}" if e.present?
   end
 
   def check_smtp_connection(channel_data, smtp)

--- a/app/helpers/api/v1/inboxes_helper.rb
+++ b/app/helpers/api/v1/inboxes_helper.rb
@@ -53,7 +53,7 @@ module Api::V1::InboxesHelper
   rescue StandardError => e
     raise StandardError, e.message
   ensure
-    Rails.logger.error e
+    Rails.logger.error "Check IMAP Connect Failed with #{e.message}" if e.present?
   end
 
   def check_smtp_connection(channel_data, smtp)

--- a/app/helpers/api/v1/inboxes_helper.rb
+++ b/app/helpers/api/v1/inboxes_helper.rb
@@ -53,7 +53,7 @@ module Api::V1::InboxesHelper
   rescue StandardError => e
     raise StandardError, e.message
   ensure
-    ChatwootExceptionTracker.new(e).capture_exception if e.present?
+    Rails.logger.error e
   end
 
   def check_smtp_connection(channel_data, smtp)


### PR DESCRIPTION
The Mail connection error can happen for a myriad of reasons. This PR removes the exception tracker and adds a more straightforward log instead.