### PR TITLE
fix: API error when using SuperAdmin token

### DIFF
--- a/app/controllers/concerns/access_token_auth_helper.rb
+++ b/app/controllers/concerns/access_token_auth_helper.rb
@@ -14,7 +14,14 @@ module AccessTokenAuthHelper
     render_unauthorized('Invalid Access Token') && return if @access_token.blank?
 
     @resource = @access_token.owner
-    Current.user = @resource if [User, AgentBot].include?(@resource.class)
+    Current.user = @resource if allowed_current_user_type?(@resource)
+  end
+
+  def allowed_current_user_type?(resource)
+    return true if resource.is_a?(User)
+    return true if resource.is_a?(AgentBot)
+
+    false
   end
 
   def validate_bot_access_token!

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -29,6 +29,25 @@ RSpec.describe 'API Base', type: :request do
     end
   end
 
+  describe 'request with api_access_token for a super admin' do
+    before do
+      user.update!(type: 'SuperAdmin')
+    end
+
+    context 'when its a valid api_access_token' do
+      it 'returns current user information' do
+        get '/api/v1/profile',
+            headers: { api_access_token: user.access_token.token },
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        json_response = response.parsed_body
+        expect(json_response['id']).to eq(user.id)
+        expect(json_response['email']).to eq(user.email)
+      end
+    end
+  end
+
   describe 'request with api_access_token for bot' do
     let!(:agent_bot) { create(:agent_bot) }
     let!(:inbox) { create(:inbox, account: account) }


### PR DESCRIPTION
- Fixes the issue in release 3.5.0 which causes `SuperAdmin` tokens throwing error during API calls 

fixes: #8719 