### PR TITLE
fix: Migrate notes when merging the contacts

### DIFF
--- a/app/actions/contact_merge_action.rb
+++ b/app/actions/contact_merge_action.rb
@@ -12,6 +12,7 @@ class ContactMergeAction
       merge_conversations
       merge_messages
       merge_contact_inboxes
+      merge_contact_notes
       merge_and_remove_mergee_contact
     end
     @base_contact
@@ -31,6 +32,10 @@ class ContactMergeAction
 
   def merge_conversations
     Conversation.where(contact_id: @mergee_contact.id).update(contact_id: @base_contact.id)
+  end
+
+  def merge_contact_notes
+    Note.where(contact_id: @mergee_contact.id, account_id: @mergee_contact.account_id).update(contact_id: @base_contact.id)
   end
 
   def merge_messages

--- a/spec/actions/contact_merge_action_spec.rb
+++ b/spec/actions/contact_merge_action_spec.rb
@@ -18,6 +18,7 @@ describe ContactMergeAction do
       create(:conversation, contact: base_contact)
       create(:conversation, contact: mergee_contact)
       create(:message, sender: mergee_contact)
+      create(:note, contact: mergee_contact, account: mergee_contact.account)
     end
   end
 
@@ -65,6 +66,17 @@ describe ContactMergeAction do
       it 'moves the messages to base contact' do
         contact_merge
         expect(base_contact.messages.count).to be 2
+      end
+    end
+
+    context 'when mergee contact has notes' do
+      it 'moves the notes to base contact' do
+        expect(base_contact.notes.count).to be 0
+        expect(mergee_contact.notes.count).to be 2
+
+        contact_merge
+
+        expect(base_contact.reload.notes.count).to be 2
       end
     end
 


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2987/migrate-notes-of-the-secondary-contact-to-primary-contact-when-merging

As per [this discussion](https://discord.com/channels/647412545203994635/1197921664760041532/1197921664760041532), the contact notes were not migrated when the contacts were merged. This PR would fix this issue. 

- Added a new method merge_contact_notes and update the contact_id similar to messages and conversations. 
- Added a spec to cover the case.

I've tested this locally as well and it is working fine.