### PR TITLE
fix: TypeError: Cannot read properties of undefined (reading 'emoji')

### DIFF
--- a/app/javascript/dashboard/components/widgets/forms/PhoneInput.vue
+++ b/app/javascript/dashboard/components/widgets/forms/PhoneInput.vue
@@ -5,8 +5,8 @@
         class="cursor-pointer py-2 pr-1.5 pl-2 rounded-tl-md rounded-bl-md flex items-center justify-center gap-1.5 bg-slate-25 dark:bg-slate-700 h-10 w-14"
         @click="toggleCountryDropdown"
       >
-        <h5 v-if="activeCountryEmoji" class="mb-0">
-          {{ activeCountryEmoji }}
+        <h5 v-if="activeCountry" class="mb-0">
+          {{ activeCountry.emoji }}
         </h5>
         <fluent-icon v-else icon="globe" class="fluent-icon" size="16" />
         <fluent-icon icon="chevron-down" class="fluent-icon" size="12" />
@@ -143,9 +143,6 @@ export default {
         );
       }
       return '';
-    },
-    activeCountryEmoji() {
-      return this.activeCountry?.emoji || '';
     },
   },
   watch: {


### PR DESCRIPTION
# Pull Request Template

## Description

**Why? And how much it impacted**

**NB**: Please refer to this old PR https://github.com/chatwoot/chatwoot/pull/8747 

We use a package called `libphonenumber-js` in our codebase that helps us in identifying the dialing and country codes based on the phone number. It's important for our `phoneInput.vue` component, which serves a dual purpose, not only saving the phone numbers with country codes but also helping to display the saved phone numbers and country codes accurately.

For this issue it may happen if the phone number is not valid, which may cause the error `TypeError: Cannot read properties of undefined (reading 'emoji')`. According to Sentry, there are 2 events reported in the last 30 days, marking its first occurrence.

This problem was due to a missing validation check. Previously, our code attempted to access `activeCountry.emoji` without confirming if an active country was actually selected.

**Solution**

I've updated the `phoneInput.vue` component. The v-if statement within the `h5` tag now includes a check for `activeCountry`. With this change, the emoji will only be displayed if an active country is present, it will resolve the issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
