### PR TITLE
fix: Handle Net::IMAP::InvalidResponseError Exception bad response type "ESMTP"

### DIFF
--- a/app/jobs/inboxes/fetch_imap_emails_job.rb
+++ b/app/jobs/inboxes/fetch_imap_emails_job.rb
@@ -12,7 +12,7 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
   rescue *ExceptionList::IMAP_EXCEPTIONS => e
     Rails.logger.error e
     channel.authorization_error!
-  rescue EOFError, OpenSSL::SSL::SSLError, Net::IMAP::NoResponseError, Net::IMAP::BadResponseError => e
+  rescue EOFError, OpenSSL::SSL::SSLError, Net::IMAP::NoResponseError, Net::IMAP::BadResponseError, Net::IMAP::InvalidResponseError => e
     Rails.logger.error e
   rescue LockAcquisitionError
     Rails.logger.error "Lock failed for #{channel.inbox.id}"


### PR DESCRIPTION
> This error typically occurs when you're trying to connect to an SMTP server using IMAP protocol, or there's a misconfiguration in the server settings you are trying to connect to.

While further investigating this error, we ignore it from the sentry since it unnecessarily exhausts the quota. 