### PR TITLE
chore: Handle twillio `Down::ClientError`

### DIFF
--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -127,7 +127,7 @@ class Twilio::IncomingMessageService
 
   def download_attachment_file
     download_with_auth
-  rescue Down::Error => e
+  rescue Down::Error, Down::ClientError => e
     handle_download_attachment_error(e)
   end
 


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2992/downclienterror-400-bad-request-downclienterror