### PR TITLE
feat(perf): update query to do a simpler search [CW-2997]

### DIFF
--- a/app/jobs/inboxes/fetch_imap_emails_job.rb
+++ b/app/jobs/inboxes/fetch_imap_emails_job.rb
@@ -137,7 +137,7 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
   end
 
   def email_already_present?(channel, message_id)
-    Message.find_by(source_id: message_id, inbox_id: channel.inbox).present?
+    channel.inbox.messages.find_by(source_id: message_id).present?
   end
 
   def build_mail_from_string(raw_email_content)

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -66,7 +66,7 @@ class Inbox < ApplicationRecord
   has_many :inbox_members, dependent: :destroy_async
   has_many :members, through: :inbox_members, source: :user
   has_many :conversations, dependent: :destroy_async
-  has_many :messages, through: :conversations
+  has_many :messages, dependent: :destroy_async
 
   has_one :agent_bot_inbox, dependent: :destroy_async
   has_one :agent_bot, through: :agent_bot_inbox

--- a/spec/mailboxes/imap/imap_mailbox_spec.rb
+++ b/spec/mailboxes/imap/imap_mailbox_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Imap::ImapMailbox do
                              imap_port: 993, imap_login: 'imap@gmail.com', imap_password: 'password',
                              account: account)
     end
-    let(:inbox) { create(:inbox, channel: channel, account: account) }
+    let(:inbox) { channel.inbox }
     let!(:contact) { create(:contact, email: 'email@gmail.com', phone_number: '+919584546666', account: account, identifier: '123') }
     let(:conversation) { Conversation.where(inbox_id: channel.inbox).last }
     let(:class_instance) { described_class.new }

--- a/spec/models/inbox_spec.rb
+++ b/spec/models/inbox_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Inbox do
 
     it { is_expected.to have_many(:conversations).dependent(:destroy_async) }
 
-    it { is_expected.to have_many(:messages).through(:conversations) }
+    it { is_expected.to have_many(:messages).dependent(:destroy_async) }
 
     it { is_expected.to have_one(:agent_bot_inbox) }
 


### PR DESCRIPTION
Message search would frequently timeout. The reason was that query would join conversation too, the new query searches the message table directly


#### Old Query

Explain: https://explain.dalibo.com/plan/ba6d2g39c441edca
Duration: `365ms`

```sql
SELECT
  messages.*
FROM
  messages
  INNER JOIN conversations ON messages.conversation_id = conversations.id
WHERE
  conversations.inbox_id = 123
  AND messages.source_id = 'conversation/some-id'
ORDER BY
  messages.created_at ASC
LIMIT 1;
```

#### New Query

Explain: https://explain.dalibo.com/plan/34c9423c61515g73
Duration: `1.7ms`

```sql
SELECT
  messages.*
FROM
  messages
WHERE
  messages.inbox_id = 123
  AND messages.source_id = 'conversation/some-id'
ORDER BY
  messages.created_at ASC
LIMIT 1;
```

For previous instance, the messages was accessed via the conversation association, the new one skips conversation all-together. 

### Notes

We could further speed this up significantly with a index on `created_at`, `inbox_id` and `source_id` on the messages table. However it's best to add it only if this occurs again, any new index added an overhead our insert and update performance as well.

> The fastest query is the one that's not executed
> ~ Shivam Mishra