### PR TITLE
fix: Removed author section from public help center

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleTable.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="w-full">
     <div
-      class="my-0 py-0 px-4 grid grid-cols-6 md:grid-cols-7 lg:grid-cols-8 gap-4 border-b border-slate-100 dark:border-slate-700 sticky top-16 bg-white dark:bg-slate-900"
+      class="my-0 py-0 px-4 grid grid-cols-6 z-10 md:grid-cols-7 lg:grid-cols-8 gap-4 border-b border-slate-100 dark:border-slate-700 sticky top-16 bg-white dark:bg-slate-900"
       :class="{ draggable: onCategoryPage }"
     >
       <div

--- a/app/views/public/api/v1/portals/articles/_article_header.html.erb
+++ b/app/views/public/api/v1/portals/articles/_article_header.html.erb
@@ -30,9 +30,8 @@
 </h1>
 <div class="flex flex-col items-start justify-between w-full pt-6 md:flex-row md:items-center">
   <div class="flex items-start space-x-1">
-    <div class="pr-px mt-0.5 min-w-[20px] min-h-[20px]">
-      <%= render "public/api/v1/portals/thumbnail", author: article.author, size: 5 %>
-    </div>
-    <span class="flex items-center text-base font-medium text-slate-600 dark:text-slate-400"><%= "#{I18n.t('public_portal.common.by')} #{article.author&.available_name || article.author&.name || ''}" %> • <%= I18n.t('public_portal.common.last_updated_on', last_updated_on: article.updated_at.strftime("%b %d, %Y")) %></span>
+    <span class="flex items-center text-base font-medium text-slate-600 dark:text-slate-400">
+     <%= I18n.t('public_portal.common.last_updated_on', last_updated_on: article.updated_at.strftime("%b %d, %Y")) %>
+    </span>
   </div>
 </div>

--- a/app/views/public/api/v1/portals/categories/show.html.erb
+++ b/app/views/public/api/v1/portals/categories/show.html.erb
@@ -32,17 +32,7 @@
             <h3 id="<%= !@is_plain_layout_enabled ? 'category-name' : '' %>" class="text-lg text-slate-900 tracking-[0.28px] dark:text-slate-50 font-semibold <%= @is_plain_layout_enabled ? 'group-hover:underline' : '' %>"><%= article.title %></h3>
             <p class="text-base font-normal text-slate-600 dark:text-slate-200 line-clamp-1 break-all"><%= render_category_content(article.content) %></p>
           </div>
-          <div class="flex flex-row items-center gap-1">
-            <div class="flex flex-row items-center gap-1">
-              <% author = article.author %>
-              <%= render "public/api/v1/portals/thumbnail", author: author, size: 5 %>
-              <% if author&.name.present? %>
-                <span class="text-sm text-slate-600 dark:text-slate-400 font-medium flex items-center"><%= "#{I18n.t('public_portal.common.by')} #{author&.name}" %></span>
-              <% end %>
-            </div>
-            <span class="text-slate-600 dark:text-slate-400">•</span>
-            <span class="text-sm text-slate-600 dark:text-slate-400 font-medium flex items-center"><%= I18n.t('public_portal.common.last_updated_on', last_updated_on: article.updated_at.strftime("%b %d, %Y")) %></span>
-          </div>
+          <span class="text-sm text-slate-600 dark:text-slate-400 font-medium flex items-center"><%= I18n.t('public_portal.common.last_updated_on', last_updated_on: article.updated_at.strftime("%b %d, %Y")) %></span>
         </div>
       </a>
     </div>  


### PR DESCRIPTION
# Pull Request Template

## Description

Please refer to this PR https://github.com/chatwoot/chatwoot/pull/8756

This PR includes:
1. Removed the author section from the article header and the category article list block
2. Fix an overflow issue in the help center dashboard occurred from this PR https://github.com/chatwoot/chatwoot/pull/8756

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Screenshots**

**Category list article block**
<img width="988" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/21a9f551-ff21-4da7-ab0f-63c0690ee229">

**Article header**
<img width="988" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/c9968cdb-5112-48b3-9abc-3c24a3b242a4">



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
