### PR TITLE
feat: disable upload after one file for IG and FB messenger

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
@@ -13,12 +13,17 @@
       />
       <file-upload
         ref="upload"
-        v-tooltip.top-end="$t('CONVERSATION.REPLYBOX.TIP_ATTACH_ICON')"
+        v-tooltip.top-end="
+          disableFileUpload
+            ? $t('CONVERSATION.REPLYBOX.TIP_ATTACHMENT_LIMIT_FB')
+            : $t('CONVERSATION.REPLYBOX.TIP_ATTACH_ICON')
+        "
         input-id="conversationAttachment"
+        :disabled="disableFileUpload"
         :size="4096 * 4096"
         :accept="allowedFileTypes"
         :multiple="enableMultipleFileUpload"
-        :drop="enableDragAndDrop"
+        :drop="disableFileUpload ? false : enableDragAndDrop"
         :drop-directory="false"
         :data="{
           direct_upload_url: '/rails/active_storage/direct_uploads',
@@ -29,7 +34,12 @@
         <woot-button
           v-if="showAttachButton"
           class-names="button--upload"
-          :title="$t('CONVERSATION.REPLYBOX.TIP_ATTACH_ICON')"
+          :disabled="disableFileUpload"
+          :title="
+            disableFileUpload
+              ? $t('CONVERSATION.REPLYBOX.TIP_ATTACHMENT_LIMIT_FB')
+              : $t('CONVERSATION.REPLYBOX.TIP_ATTACH_ICON')
+          "
           icon="attach"
           emoji="📎"
           color-scheme="secondary"
@@ -247,6 +257,10 @@ export default {
     portalSlug: {
       type: String,
       required: true,
+    },
+    disableFileUpload: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -109,6 +109,7 @@
     <reply-bottom-panel
       :conversation-id="conversationId"
       :enable-multiple-file-upload="enableMultipleFileUpload"
+      :disable-file-upload="disableFileUpload"
       :has-whatsapp-templates="hasWhatsappTemplates"
       :inbox="inbox"
       :is-on-private-note="isOnPrivateNote"
@@ -464,6 +465,13 @@ export default {
     },
     showReplyHead() {
       return !this.isOnPrivateNote && this.isAnEmailChannel;
+    },
+    disableFileUpload() {
+      if (this.isAFacebookInbox) {
+        return this.hasAttachments > 0;
+      }
+
+      return false;
     },
     enableMultipleFileUpload() {
       return (

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -148,6 +148,7 @@
       "TIP_FORMAT_ICON": "Show rich text editor",
       "TIP_EMOJI_ICON": "Show emoji selector",
       "TIP_ATTACH_ICON": "Attach files",
+      "TIP_ATTACHMENT_LIMIT_FB": "You cannot attach more files to this message",
       "TIP_AUDIORECORDER_ICON": "Record audio",
       "TIP_AUDIORECORDER_PERMISSION": "Allow access to audio",
       "TIP_AUDIORECORDER_ERROR": "Could not open the audio",


### PR DESCRIPTION
It seems like it's not possible to send multiple files in a single message via the instagram API. This PR disables the file upload once a single attachment is added.

The actual fix to this would be to update `SendOnInstagramService` and `SendOnFacebookService` to send these attachments as multiple different messages, but this may take some time, the UI change is a stopgap solution for now