### PR TITLE
feat: allow multiple files for FB and Insta [CW-3019]

### DIFF
--- a/app/services/instagram/send_on_instagram_service.rb
+++ b/app/services/instagram/send_on_instagram_service.rb
@@ -14,12 +14,12 @@ class Instagram::SendOnInstagramService < Base::SendOnChannelService
   end
 
   def perform_reply
+    send_to_facebook_page message_params
+
     if message.attachments.present?
       message.attachments.each do |attachment|
         send_to_facebook_page attachment_message_params(attachment)
       end
-    else
-      send_to_facebook_page message_params
     end
   rescue StandardError => e
     ChatwootExceptionTracker.new(e, account: message.account, user: message.sender).capture_exception

--- a/app/services/instagram/send_on_instagram_service.rb
+++ b/app/services/instagram/send_on_instagram_service.rb
@@ -38,7 +38,7 @@ class Instagram::SendOnInstagramService < Base::SendOnChannelService
     merge_human_agent_tag(params)
   end
 
-  def attachament_message_params(attachment)
+  def attachment_message_params(attachment)
     params = {
       recipient: { id: contact.get_source_id(inbox.id) },
       message: {

--- a/app/services/instagram/send_on_instagram_service.rb
+++ b/app/services/instagram/send_on_instagram_service.rb
@@ -20,7 +20,7 @@ class Instagram::SendOnInstagramService < Base::SendOnChannelService
       end
     end
 
-    send_to_facebook_page message_params
+    send_to_facebook_page message_params if message.content.present?
   rescue StandardError => e
     ChatwootExceptionTracker.new(e, account: message.account, user: message.sender).capture_exception
     # TODO : handle specific errors or else page will get disconnected

--- a/app/services/instagram/send_on_instagram_service.rb
+++ b/app/services/instagram/send_on_instagram_service.rb
@@ -14,8 +14,13 @@ class Instagram::SendOnInstagramService < Base::SendOnChannelService
   end
 
   def perform_reply
-    send_to_facebook_page attachament_message_params if message.attachments.present?
-    send_to_facebook_page message_params
+    if message.attachments.present?
+      message.attachments.each do |attachment|
+        send_to_facebook_page attachment_message_params(attachment)
+      end
+    else
+      send_to_facebook_page message_params
+    end
   rescue StandardError => e
     ChatwootExceptionTracker.new(e, account: message.account, user: message.sender).capture_exception
     # TODO : handle specific errors or else page will get disconnected
@@ -33,8 +38,7 @@ class Instagram::SendOnInstagramService < Base::SendOnChannelService
     merge_human_agent_tag(params)
   end
 
-  def attachament_message_params
-    attachment = message.attachments.first
+  def attachament_message_params(attachment)
     params = {
       recipient: { id: contact.get_source_id(inbox.id) },
       message: {

--- a/app/services/instagram/send_on_instagram_service.rb
+++ b/app/services/instagram/send_on_instagram_service.rb
@@ -14,13 +14,13 @@ class Instagram::SendOnInstagramService < Base::SendOnChannelService
   end
 
   def perform_reply
-    send_to_facebook_page message_params
-
     if message.attachments.present?
       message.attachments.each do |attachment|
         send_to_facebook_page attachment_message_params(attachment)
       end
     end
+
+    send_to_facebook_page message_params
   rescue StandardError => e
     ChatwootExceptionTracker.new(e, account: message.account, user: message.sender).capture_exception
     # TODO : handle specific errors or else page will get disconnected

--- a/spec/services/instagram/send_on_instagram_service_spec.rb
+++ b/spec/services/instagram/send_on_instagram_service_spec.rb
@@ -54,14 +54,14 @@ describe Instagram::SendOnInstagramService do
         end
 
         it 'if message is sent from chatwoot and is outgoing with multiple attachments' do
-          new_message = build(:message, content: nil, message_type: 'outgoing', inbox: instagram_inbox, account: account, conversation: conversation)
-          avatar = new_message.attachments.new(account_id: new_message.account_id, file_type: :image)
+          message = build(:message, content: nil, message_type: 'outgoing', inbox: instagram_inbox, account: account, conversation: conversation)
+          avatar = message.attachments.new(account_id: message.account_id, file_type: :image)
           avatar.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
-          sample = new_message.attachments.new(account_id: new_message.account_id, file_type: :image)
+          sample = message.attachments.new(account_id: message.account_id, file_type: :image)
           sample.file.attach(io: Rails.root.join('spec/assets/sample.png').open, filename: 'sample.png', content_type: 'image/png')
-          new_message.save!
+          message.save!
 
-          service = described_class.new(message: new_message)
+          service = described_class.new(message: message)
 
           # Stub the send_to_facebook_page method on the service instance
           allow(service).to receive(:send_to_facebook_page)

--- a/spec/services/instagram/send_on_instagram_service_spec.rb
+++ b/spec/services/instagram/send_on_instagram_service_spec.rb
@@ -50,7 +50,25 @@ describe Instagram::SendOnInstagramService do
 
           response = described_class.new(message: message).perform
 
-          expect(response).to eq({  message_id: 'anyrandommessageid1234567890' })
+          expect(response).to eq({ message_id: 'anyrandommessageid1234567890' })
+        end
+
+        it 'if message is sent from chatwoot and is outgoing with multiple attachments' do
+          new_message = build(:message, content: nil, message_type: 'outgoing', inbox: instagram_inbox, account: account, conversation: conversation)
+          avatar = new_message.attachments.new(account_id: new_message.account_id, file_type: :image)
+          avatar.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
+          sample = new_message.attachments.new(account_id: new_message.account_id, file_type: :image)
+          sample.file.attach(io: Rails.root.join('spec/assets/sample.png').open, filename: 'sample.png', content_type: 'image/png')
+          new_message.save!
+
+          service = described_class.new(message: new_message)
+
+          # Stub the send_to_facebook_page method on the service instance
+          allow(service).to receive(:send_to_facebook_page)
+          service.perform
+
+          # Now you can set expectations on the stubbed method for each attachment
+          expect(service).to have_received(:send_to_facebook_page).exactly(:twice)
         end
 
         it 'if message with attachment is sent from chatwoot and is outgoing' do


### PR DESCRIPTION
### Verified for FB

#### Chatwoot Dashboard

![CleanShot 2024-01-25 at 14 52 29@2x](https://github.com/chatwoot/chatwoot/assets/18097732/90235442-82f7-48f9-bae7-65d3423d8681)


#### Facebook Messenger
![CleanShot 2024-01-25 at 14 52 58@2x](https://github.com/chatwoot/chatwoot/assets/18097732/f2d171aa-8ec8-425f-8840-1dd01ec81439)

### Verified for Instagram

#### Chatwoot Dashboard

![CleanShot 2024-01-25 at 15 51 26@2x](https://github.com/chatwoot/chatwoot/assets/18097732/37e5a178-0b72-4da0-a03c-107bdae65725)

#### Instagram Messenger

![CleanShot 2024-01-25 at 15 51 03@2x](https://github.com/chatwoot/chatwoot/assets/18097732/7caf5f1e-c7e2-49b1-b0fc-7015f707beb9)
