### PR TITLE
fix: Add `last_activity_at` to notification push event data

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -60,6 +60,7 @@ class Notification < ApplicationRecord
       secondary_actor: secondary_actor&.push_event_data,
       user: user&.push_event_data,
       created_at: created_at.to_i,
+      last_activity_at: last_activity_at.to_i,
       account_id: account_id
 
     }


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-3010/rangeerror-invalid-time-value

**Where and how much impact did it have?**

There have been 500+ incidents reported in the sentry error.

In the previous release, we enabled `last_activity_at` in the notification item instead of `created_at` and made the necessary changes.

However, we missed to add `last_activity_at` to the action cable event (`notification_created`). As a result, in the front end, the `last_activity_at` will be empty, causing the `dynamicTime` function to be called without a value and resulting in a **RangeError**.

**Solution**

The right solution is simply add the `last_activity_at` to push event data.