### PR TITLE
feat: expiry for cache keys [CW-3038]

### DIFF
--- a/app/mailboxes/reply_mailbox.rb
+++ b/app/mailboxes/reply_mailbox.rb
@@ -6,11 +6,12 @@ class ReplyMailbox < ApplicationMailbox
   EMAIL_PART_PATTERN = /^reply\+([0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12})$/i
 
   before_processing :conversation_uuid_from_to_address,
-                    :find_relative_conversation,
-                    :verify_decoded_params,
-                    :decorate_mail
+                    :find_relative_conversation
 
   def process
+    return if @conversation.blank?
+
+    decorate_mail
     create_message
     add_attachments_to_message
   end
@@ -78,12 +79,8 @@ class ReplyMailbox < ApplicationMailbox
     find_conversation_by_message_id(in_reply_to_addresses) if @conversation.blank?
   end
 
-  def verify_decoded_params
-    raise 'Conversation uuid not found' if conversation_uuid.nil?
-  end
-
   def validate_resource(resource)
-    raise "Email conversation with uuid: #{conversation_uuid} not found" if resource.nil?
+    Rails.logger.error "[App::Mailboxes::ReplyMailbox] Email conversation with uuid: #{conversation_uuid} not found" if resource.nil?
 
     resource
   end

--- a/app/models/concerns/account_cache_revalidator.rb
+++ b/app/models/concerns/account_cache_revalidator.rb
@@ -2,7 +2,7 @@ module AccountCacheRevalidator
   extend ActiveSupport::Concern
 
   included do
-    after_commit :update_account_cache, on: [:create, :update]
+    after_commit :update_account_cache, on: [:create, :update, :destroy]
   end
 
   def update_account_cache

--- a/app/models/concerns/account_cache_revalidator.rb
+++ b/app/models/concerns/account_cache_revalidator.rb
@@ -3,6 +3,7 @@ module AccountCacheRevalidator
 
   included do
     after_commit :update_account_cache, on: [:create, :update, :destroy]
+    after_touch :update_account_cache
   end
 
   def update_account_cache

--- a/app/models/concerns/account_cache_revalidator.rb
+++ b/app/models/concerns/account_cache_revalidator.rb
@@ -3,7 +3,6 @@ module AccountCacheRevalidator
 
   included do
     after_commit :update_account_cache, on: [:create, :update, :destroy]
-    after_touch :update_account_cache
   end
 
   def update_account_cache

--- a/app/models/concerns/cache_keys.rb
+++ b/app/models/concerns/cache_keys.rb
@@ -4,7 +4,7 @@ module CacheKeys
   include CacheKeysHelper
   include Events::Types
 
-  CACHE_KEYS_EXPIRY = 24.hours
+  CACHE_KEYS_EXPIRY = 48.hours
 
   included do
     class_attribute :cacheable_models

--- a/app/models/concerns/cache_keys.rb
+++ b/app/models/concerns/cache_keys.rb
@@ -4,7 +4,7 @@ module CacheKeys
   include CacheKeysHelper
   include Events::Types
 
-  CACHE_KEYS_EXPIRY = 48.hours
+  CACHE_KEYS_EXPIRY = 72.hours
 
   included do
     class_attribute :cacheable_models

--- a/app/models/concerns/cache_keys.rb
+++ b/app/models/concerns/cache_keys.rb
@@ -21,13 +21,13 @@ module CacheKeys
   end
 
   def update_cache_key(key)
-    udpate_cache_key_for_account(id, key)
+    update_cache_key_for_account(id, key)
     dispatch_cache_update_event
   end
 
   def reset_cache_keys
     self.class.cacheable_models.each do |model|
-      udpate_cache_key_for_account(id, model.name.underscore)
+      update_cache_key_for_account(id, model.name.underscore)
     end
 
     dispatch_cache_update_event
@@ -35,7 +35,7 @@ module CacheKeys
 
   private
 
-  def udpate_cache_key_for_account(account_id, key)
+  def update_cache_key_for_account(account_id, key)
     prefixed_cache_key = get_prefixed_cache_key(account_id, key)
     Redis::Alfred.setex(prefixed_cache_key, Time.now.utc.to_i, CACHE_KEYS_EXPIRY)
   end

--- a/app/models/concerns/cache_keys.rb
+++ b/app/models/concerns/cache_keys.rb
@@ -18,24 +18,25 @@ module CacheKeys
     keys
   end
 
-  def invalidate_cache_key_for(key)
-    update_cache_key(key)
-    dispatch_cache_update_event
-  end
-
   def update_cache_key(key)
-    prefixed_cache_key = get_prefixed_cache_key(id, key)
-    Redis::Alfred.setex(prefixed_cache_key, Time.now.utc.to_i, 72.hours)
+    udpate_cache_key_for_account(id, key)
     dispatch_cache_update_event
   end
 
   def reset_cache_keys
     self.class.cacheable_models.each do |model|
-      invalidate_cache_key_for(model.name.underscore)
+      udpate_cache_key_for_account(id, model.name.underscore)
     end
+
+    dispatch_cache_update_event
   end
 
   private
+
+  def udpate_cache_key_for_account(account_id, key)
+    prefixed_cache_key = get_prefixed_cache_key(account_id, key)
+    Redis::Alfred.setex(prefixed_cache_key, Time.now.utc.to_i, 72.hours)
+  end
 
   def dispatch_cache_update_event
     Rails.configuration.dispatcher.dispatch(ACCOUNT_CACHE_INVALIDATED, Time.zone.now, cache_keys: cache_keys, account: self)

--- a/app/models/concerns/cache_keys.rb
+++ b/app/models/concerns/cache_keys.rb
@@ -19,8 +19,7 @@ module CacheKeys
   end
 
   def invalidate_cache_key_for(key)
-    prefixed_cache_key = get_prefixed_cache_key(id, key)
-    Redis::Alfred.delete(prefixed_cache_key)
+    update_cache_key(key)
     dispatch_cache_update_event
   end
 

--- a/app/models/concerns/cache_keys.rb
+++ b/app/models/concerns/cache_keys.rb
@@ -26,7 +26,7 @@ module CacheKeys
 
   def update_cache_key(key)
     prefixed_cache_key = get_prefixed_cache_key(id, key)
-    Redis::Alfred.set(prefixed_cache_key, Time.now.utc.to_i)
+    Redis::Alfred.setex(prefixed_cache_key, Time.now.utc.to_i, 72.hours)
     dispatch_cache_update_event
   end
 

--- a/app/models/concerns/cache_keys.rb
+++ b/app/models/concerns/cache_keys.rb
@@ -4,6 +4,8 @@ module CacheKeys
   include CacheKeysHelper
   include Events::Types
 
+  CACHE_KEYS_EXPIRY = 24.hours
+
   included do
     class_attribute :cacheable_models
     self.cacheable_models = [Label, Inbox, Team]
@@ -35,7 +37,7 @@ module CacheKeys
 
   def udpate_cache_key_for_account(account_id, key)
     prefixed_cache_key = get_prefixed_cache_key(account_id, key)
-    Redis::Alfred.setex(prefixed_cache_key, Time.now.utc.to_i, 72.hours)
+    Redis::Alfred.setex(prefixed_cache_key, Time.now.utc.to_i, CACHE_KEYS_EXPIRY)
   end
 
   def dispatch_cache_update_event

--- a/spec/controllers/super_admin/accounts_controller_spec.rb
+++ b/spec/controllers/super_admin/accounts_controller_spec.rb
@@ -43,10 +43,13 @@ RSpec.describe 'Super Admin accounts API', type: :request do
       it 'shows the list of accounts' do
         expect(account.cache_keys.keys).to contain_exactly(:inbox, :label, :team)
         sign_in(super_admin, scope: :super_admin)
+
+        now_timestamp = Time.now.utc.to_i
         post "/super_admin/accounts/#{account.id}/reset_cache"
         expect(response).to have_http_status(:redirect)
         expect(flash[:notice]).to eq('Cache keys cleared')
-        expect(account.reload.cache_keys.values.map(&:to_i)).to eq([0, 0, 0])
+
+        expect(account.reload.cache_keys.values.all? { |v| v.to_i == now_timestamp }).to be(true)
       end
     end
   end

--- a/spec/models/concerns/cache_keys_spec.rb
+++ b/spec/models/concerns/cache_keys_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe CacheKeys do
   before do
     allow(Redis::Alfred).to receive(:delete)
     allow(Redis::Alfred).to receive(:set)
+    allow(Redis::Alfred).to receive(:setex)
     allow(Rails.configuration.dispatcher).to receive(:dispatch)
   end
 
@@ -27,28 +28,11 @@ RSpec.describe CacheKeys do
     end
   end
 
-  describe '#invalidate_cache_key_for' do
-    it 'deletes the cache key' do
-      test_model.invalidate_cache_key_for('label')
-      expect(Redis::Alfred).to have_received(:delete).with('idb-cache-key-account-1-label')
-    end
-
-    it 'dispatches a cache update event' do
-      test_model.invalidate_cache_key_for('label')
-      expect(Rails.configuration.dispatcher).to have_received(:dispatch).with(
-        CacheKeys::ACCOUNT_CACHE_INVALIDATED,
-        kind_of(ActiveSupport::TimeWithZone),
-        cache_keys: test_model.cache_keys,
-        account: test_model
-      )
-    end
-  end
-
   describe '#update_cache_key' do
     it 'updates the cache key' do
       allow(Time).to receive(:now).and_return(Time.parse('2023-05-29 00:00:00 UTC'))
       test_model.update_cache_key('label')
-      expect(Redis::Alfred).to have_received(:set).with('idb-cache-key-account-1-label', Time.now.utc.to_i)
+      expect(Redis::Alfred).to have_received(:setex).with('idb-cache-key-account-1-label', kind_of(Integer), 72.hours)
     end
 
     it 'dispatches a cache update event' do
@@ -66,8 +50,19 @@ RSpec.describe CacheKeys do
     it 'invalidates all cache keys for cacheable models' do
       test_model.reset_cache_keys
       test_model.class.cacheable_models.each do |model|
-        expect(Redis::Alfred).to have_received(:delete).with("idb-cache-key-account-1-#{model.name.underscore}")
+        expect(Redis::Alfred).to have_received(:setex).with("idb-cache-key-account-1-#{model.name.underscore}", kind_of(Integer), 72.hours)
       end
+    end
+
+    it 'dispatches a cache update event' do
+      test_model.reset_cache_keys
+
+      expect(Rails.configuration.dispatcher).to have_received(:dispatch).with(
+        CacheKeys::ACCOUNT_CACHE_INVALIDATED,
+        kind_of(ActiveSupport::TimeWithZone),
+        cache_keys: test_model.cache_keys,
+        account: test_model
+      )
     end
   end
 end

--- a/spec/models/concerns/cache_keys_spec.rb
+++ b/spec/models/concerns/cache_keys_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CacheKeys do
     it 'updates the cache key' do
       allow(Time).to receive(:now).and_return(Time.parse('2023-05-29 00:00:00 UTC'))
       test_model.update_cache_key('label')
-      expect(Redis::Alfred).to have_received(:setex).with('idb-cache-key-account-1-label', kind_of(Integer), 72.hours)
+      expect(Redis::Alfred).to have_received(:setex).with('idb-cache-key-account-1-label', kind_of(Integer), CacheKeys::CACHE_KEYS_EXPIRY)
     end
 
     it 'dispatches a cache update event' do
@@ -50,7 +50,8 @@ RSpec.describe CacheKeys do
     it 'invalidates all cache keys for cacheable models' do
       test_model.reset_cache_keys
       test_model.class.cacheable_models.each do |model|
-        expect(Redis::Alfred).to have_received(:setex).with("idb-cache-key-account-1-#{model.name.underscore}", kind_of(Integer), 72.hours)
+        expect(Redis::Alfred).to have_received(:setex).with("idb-cache-key-account-1-#{model.name.underscore}", kind_of(Integer),
+                                                            CacheKeys::CACHE_KEYS_EXPIRY)
       end
     end
 

--- a/spec/models/inbox_spec.rb
+++ b/spec/models/inbox_spec.rb
@@ -250,5 +250,15 @@ RSpec.describe Inbox do
           cache_keys: inbox.account.cache_keys
         )
     end
+
+    it 'updates the cache key after update' do
+      expect(inbox.account).to receive(:update_cache_key).with('inbox')
+      inbox.update(name: 'New Name')
+    end
+
+    it 'updates the cache key after touch' do
+      expect(inbox.account).to receive(:update_cache_key).with('inbox').at_least(:once)
+      inbox.touch # rubocop:disable Rails/SkipsModelValidations
+    end
   end
 end

--- a/spec/models/inbox_spec.rb
+++ b/spec/models/inbox_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Inbox do
     end
 
     it 'updates the cache key after touch' do
-      expect(inbox.account).to receive(:update_cache_key).with('inbox').at_least(:once)
+      expect(inbox.account).to receive(:update_cache_key).with('inbox')
       inbox.touch # rubocop:disable Rails/SkipsModelValidations
     end
   end


### PR DESCRIPTION
This PR tackles to problems with current implementation

1. In a rare case, the cache might show stale data, this means unless something changes for that model, or someone resets the cache keys manually, it will continue to show stale data
2. The value `0000000000` also is a valid key, this means when someone reset the cache from superadmin, it won't reset the cache for someone holding the cache key `0000000000`
3. Destroy event didn't update cache

This PR addresses this with the following changes
1. Set a default expiry of 72 hours for the cache keys, this can be changed to a higher number, this ensures that new data is fetched after every 3 days
2. When reseting the cache, we set the value to the latest timestamp, that way the conflict for the `zero` epoch is solved
3. Trigger `update_account_cache` on `destroy`


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

