### PR TITLE
fix: Cookies.set does not stringify JSON

### DIFF
--- a/app/javascript/dashboard/store/utils/api.js
+++ b/app/javascript/dashboard/store/utils/api.js
@@ -12,6 +12,8 @@ import { LocalStorage } from 'shared/helpers/localStorage';
 
 Cookies.defaults = { sameSite: 'Lax' };
 
+window.cck = Cookies;
+
 export const getLoadingStatus = state => state.fetchAPIloadingStatus;
 export const setLoadingStatus = (state, status) => {
   state.fetchAPIloadingStatus = status;
@@ -27,7 +29,7 @@ export const getHeaderExpiry = response =>
 
 export const setAuthCredentials = response => {
   const expiryDate = getHeaderExpiry(response);
-  Cookies.set('cw_d_session_info', response.headers, {
+  Cookies.set('cw_d_session_info', JSON.stringify(response.headers), {
     expires: differenceInDays(expiryDate, new Date()),
   });
   setUser(response.data.data, expiryDate);

--- a/app/javascript/sdk/cookieHelpers.js
+++ b/app/javascript/sdk/cookieHelpers.js
@@ -34,5 +34,12 @@ export const setCookieWithDomain = (
     domain: baseDomain,
   };
 
+  // if type of value is object, stringify it
+  // this is because js-cookies 3.0 removed builtin json support
+  // ref: https://github.com/js-cookie/js-cookie/releases/tag/v3.0.0
+  if (typeof value === 'object') {
+    value = JSON.stringify(value);
+  }
+
   Cookies.set(name, value, cookieOptions);
 };


### PR DESCRIPTION
In a previous PR https://github.com/chatwoot/chatwoot/pull/8799 `js-cookies` lib was updated to 3.0, however we missed updating the `set` implementation, since it does not stringify by default. This PR fixes it