### PR TITLE
feat: Inbox item header component

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/inbox/components/InboxItemHeader.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/components/InboxItemHeader.vue
@@ -1,0 +1,53 @@
+<script setup>
+import PaginationButton from './PaginationButton.vue';
+
+const props = defineProps({
+  totalLength: {
+    type: Number,
+    default: 0,
+  },
+  currentIndex: {
+    type: Number,
+    default: 0,
+  },
+});
+
+const onSnooze = () => {
+  // TODO: Implement snooze
+};
+
+const onDelete = () => {
+  // TODO: Implement delete
+};
+</script>
+
+<template>
+  <div
+    class="flex gap-2 py-2 pl-4 pr-2 justify-between items-center w-full border-b border-slate-200 dark:border-slate-500"
+  >
+    <pagination-button
+      :total-length="props.totalLength"
+      :current-index="props.currentIndex"
+    />
+    <div class="flex items-center gap-2">
+      <woot-button
+        variant="hollow"
+        size="small"
+        color-scheme="secondary"
+        icon="snooze"
+        @click="onSnooze"
+      >
+        Snooze
+      </woot-button>
+      <woot-button
+        icon="delete"
+        size="small"
+        color-scheme="secondary"
+        variant="hollow"
+        @click="onDelete"
+      >
+        Delete notification
+      </woot-button>
+    </div>
+  </div>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/inbox/components/PaginationButton.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/components/PaginationButton.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { ref, computed } from 'vue';
+
+const props = defineProps({
+  totalLength: {
+    type: Number,
+    default: 0,
+  },
+  currentIndex: {
+    type: Number,
+    default: 0,
+  },
+});
+
+const totalItems = ref(props.totalLength);
+const currentPage = ref(Math.floor(props.currentIndex / totalItems.value) + 1);
+
+const isUpDisabled = computed(() => currentPage.value === 1);
+
+const isDownDisabled = computed(
+  () => currentPage.value === totalItems.value || totalItems.value <= 1
+);
+
+const handleUpClick = () => {
+  if (currentPage.value > 1) {
+    currentPage.value -= 1;
+    // need to update it based on usage
+  }
+};
+const handleDownClick = () => {
+  if (currentPage.value < totalItems.value) {
+    currentPage.value += 1;
+    // need to update it based on usage
+  }
+};
+</script>
+
+<template>
+  <div class="flex gap-2 items-center">
+    <div class="flex gap-1 items-center">
+      <woot-button
+        size="tiny"
+        variant="hollow"
+        color-scheme="secondary"
+        icon="chevron-up"
+        :disabled="isUpDisabled"
+        @click="handleUpClick"
+      />
+      <woot-button
+        size="tiny"
+        variant="hollow"
+        color-scheme="secondary"
+        icon="chevron-down"
+        :disabled="isDownDisabled"
+        @click="handleDownClick"
+      />
+    </div>
+    <div class="flex items-center gap-1 whitespace-nowrap">
+      <span class="text-sm font-medium text-gray-600">
+        {{ totalItems <= 1 ? '1' : currentPage }}
+      </span>
+      <span
+        v-if="totalItems > 1"
+        class="text-sm text-slate-400 relative -top-px"
+      >
+        /
+      </span>
+      <span v-if="totalItems > 1" class="text-sm text-slate-400">
+        {{ totalItems }}
+      </span>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR includes a dummy component of the inbox item header with the pagination button for a new inbox view.
I used the existing `woot-button` as the buttons for this component, so it will not look the same as the design. And replaces the Unwatch button with Snooze button.

**Components**
1. Pagination buttons component
2. Inbox item header component

Fixes -
https://linear.app/chatwoot/issue/CW-2973/ui-inbox-pagination
https://linear.app/chatwoot/issue/CW-2968/ui-inbox-header

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?


**Screenshot**
![Screenshot 2024-01-29 at 10 02 47 PM](https://github.com/chatwoot/chatwoot/assets/64252451/01684d3a-1b1b-42d6-a1de-1683874840cb)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
