### PR TITLE
chore: Remove unused attribute imap_inbox_synced_at

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/ImapSettings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/ImapSettings.vue
@@ -143,9 +143,6 @@ export default {
             imap_login: this.login,
             imap_password: this.password,
             imap_enable_ssl: this.isSSLEnabled,
-            imap_inbox_synced_at: this.isIMAPEnabled
-              ? new Date().toISOString()
-              : undefined,
           },
         };
 

--- a/app/models/channel/email.rb
+++ b/app/models/channel/email.rb
@@ -8,7 +8,6 @@
 #  imap_address              :string           default("")
 #  imap_enable_ssl           :boolean          default(TRUE)
 #  imap_enabled              :boolean          default(FALSE)
-#  imap_inbox_synced_at      :datetime
 #  imap_login                :string           default("")
 #  imap_password             :string           default("")
 #  imap_port                 :integer          default(0)
@@ -41,7 +40,7 @@ class Channel::Email < ApplicationRecord
   AUTHORIZATION_ERROR_THRESHOLD = 10
 
   self.table_name = 'channel_email'
-  EDITABLE_ATTRS = [:email, :imap_enabled, :imap_login, :imap_password, :imap_address, :imap_port, :imap_enable_ssl, :imap_inbox_synced_at,
+  EDITABLE_ATTRS = [:email, :imap_enabled, :imap_login, :imap_password, :imap_address, :imap_port, :imap_enable_ssl,
                     :smtp_enabled, :smtp_login, :smtp_password, :smtp_address, :smtp_port, :smtp_domain, :smtp_enable_starttls_auto,
                     :smtp_enable_ssl_tls, :smtp_openssl_verify_mode, :smtp_authentication, :provider].freeze
 

--- a/db/migrate/20240131040316_remove_imap_inbox_syned_at_from_channel_email.rb
+++ b/db/migrate/20240131040316_remove_imap_inbox_syned_at_from_channel_email.rb
@@ -1,0 +1,5 @@
+class RemoveImapInboxSynedAtFromChannelEmail < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :channel_email, :imap_inbox_synced_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_29_080827) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_31_040316) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -276,7 +276,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_29_080827) do
     t.string "imap_login", default: ""
     t.string "imap_password", default: ""
     t.boolean "imap_enable_ssl", default: true
-    t.datetime "imap_inbox_synced_at", precision: nil
     t.boolean "smtp_enabled", default: false
     t.string "smtp_address", default: ""
     t.integer "smtp_port", default: 0

--- a/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
+++ b/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Inboxes::FetchImapEmailsJob do
   let(:account) { create(:account) }
   let(:imap_email_channel) do
     create(:channel_email, imap_enabled: true, imap_address: 'imap.gmail.com', imap_port: 993, imap_login: 'imap@gmail.com',
-                           imap_password: 'password', imap_inbox_synced_at: Time.now.utc, account: account)
+                           imap_password: 'password', account: account)
   end
   let(:microsoft_imap_email_channel) do
     create(:channel_email, provider: 'microsoft', imap_enabled: true, imap_address: 'outlook.office365.com',


### PR DESCRIPTION
imap_inbox_synced_at is no longer used, this PR removes all the references to the same.