### PR TITLE
fix: Template sync issue for older Whatsapp channels

### DIFF
--- a/app/jobs/channels/whatsapp/templates_sync_scheduler_job.rb
+++ b/app/jobs/channels/whatsapp/templates_sync_scheduler_job.rb
@@ -2,8 +2,10 @@ class Channels::Whatsapp::TemplatesSyncSchedulerJob < ApplicationJob
   queue_as :low
 
   def perform
-    Channel::Whatsapp.where('message_templates_last_updated <= ? OR message_templates_last_updated IS NULL',
-                            3.hours.ago).limit(Limits::BULK_EXTERNAL_HTTP_CALLS_LIMIT).all.each do |channel|
+    Channel::Whatsapp.order(Arel.sql('message_templates_last_updated IS NULL DESC, message_templates_last_updated ASC'))
+                     .where('message_templates_last_updated <= ? OR message_templates_last_updated IS NULL', 3.hours.ago)
+                     .limit(Limits::BULK_EXTERNAL_HTTP_CALLS_LIMIT)
+                     .each do |channel|
       Channels::Whatsapp::TemplatesSyncJob.perform_later(channel)
     end
   end

--- a/spec/jobs/channels/whatsapp/templates_sync_scheduler_job_spec.rb
+++ b/spec/jobs/channels/whatsapp/templates_sync_scheduler_job_spec.rb
@@ -23,5 +23,23 @@ RSpec.describe Channels::Whatsapp::TemplatesSyncSchedulerJob do
         have_been_enqueued.with(non_synced).on_queue('low')
       )
     end
+
+    it 'schedules templates_sync_job for oldest synced channels first' do
+      stub_const('Limits::BULK_EXTERNAL_HTTP_CALLS_LIMIT', 2)
+      stub_request(:post, 'https://waba.360dialog.io/v1/configs/webhook')
+      non_synced = create(:channel_whatsapp, sync_templates: false, message_templates_last_updated: nil)
+      synced_recently = create(:channel_whatsapp, sync_templates: false, message_templates_last_updated: 4.hours.ago)
+      synced_old = create(:channel_whatsapp, sync_templates: false, message_templates_last_updated: 6.hours.ago)
+      described_class.perform_now
+      expect(Channels::Whatsapp::TemplatesSyncJob).not_to(
+        have_been_enqueued.with(synced_recently).on_queue('low')
+      )
+      expect(Channels::Whatsapp::TemplatesSyncJob).to(
+        have_been_enqueued.with(synced_old).on_queue('low')
+      )
+      expect(Channels::Whatsapp::TemplatesSyncJob).to(
+        have_been_enqueued.with(non_synced).on_queue('low')
+      )
+    end
   end
 end


### PR DESCRIPTION
### Summary

This PR introduces a modification to the channel fetching logic, ensuring that channels with older `message_template_last_updated` timestamps are prioritized during synchronization. 

### Background

Currently, our system is designed to handle a limit of 25 bulk API calls every 5 minutes. This results in a total of 300 API calls per hour. Over a span of 3 hours, we approach nearly 900 API calls. However, there's an observation that after 3 hours, we might be re-fetching the same channels repeatedly.

### Changes

To address this, the PR implements an ordering mechanism for fetching channels. The channels are now ordered by `message_template_last_updated` with `NULL` values being given the highest priority, followed by the oldest update dates (ascending order). This ensures that channels which haven't been synced recently (or ever) are processed first, improving the efficiency of our synchronization process.

### Impact

This change is expected to enhance the efficiency of channel synchronization by prioritizing channels that are most in need of updates, thereby optimizing our API call usage and ensuring a more evenly distributed update process across all channels.
