### PR TITLE
feat: Inbox options dropdown menu

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/inbox.json
+++ b/app/javascript/dashboard/i18n/locale/en/inbox.json
@@ -2,6 +2,7 @@
   "INBOX": {
     "LIST": {
       "TITLE": "Inbox",
+      "DISPLAY_DROPDOWN": "Display",
       "LOADING": "Fetching notifications",
       "EOF": "All notifications loaded 🎉",
       "404": "There are no active notifications in this group."
@@ -12,6 +13,15 @@
       "CONVERSATION_ASSIGNMENT": "A conversation has been assigned to you",
       "ASSIGNED_CONVERSATION_NEW_MESSAGE": "New message in an assigned conversation",
       "PARTICIPATING_CONVERSATION_NEW_MESSAGE": "New message in a conversation you are participating in"
+    },
+    "MENU_ITEM": {
+      "MARK_AS_READ": "Mark as read",
+      "MARK_AS_UNREAD": "Mark as unread",
+      "SNOOZE": "Snooze",
+      "DELETE": "Delete",
+      "MARK_ALL_READ": "Mark all as read",
+      "DELETE_ALL": "Delete all",
+      "DELETE_ALL_READ": "Delete all read"
     }
   }
 }

--- a/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
@@ -1,11 +1,13 @@
 <script>
 import { mapGetters } from 'vuex';
 import InboxCard from './components/InboxCard.vue';
+import InboxListHeader from './components/InboxListHeader.vue';
 import { ACCOUNT_EVENTS } from '../../../helper/AnalyticsHelper/events';
 import IntersectionObserver from 'dashboard/components/IntersectionObserver.vue';
 export default {
   components: {
     InboxCard,
+    InboxListHeader,
     IntersectionObserver,
   },
   data() {
@@ -70,11 +72,7 @@ export default {
   <div
     class="flex flex-col min-w-[360px] w-full max-w-[360px] h-full ltr:border-r border-slate-50 dark:border-slate-800/50"
   >
-    <div
-      class="flex text-xl w-full pl-5 pr-3 py-2 h-14 items-center font-medium text-slate-900 dark:text-slate-25 border-b border-slate-50 dark:border-slate-800/50"
-    >
-      {{ $t('INBOX.LIST.TITLE') }}
-    </div>
+    <inbox-list-header />
     <div
       ref="notificationList"
       class="flex flex-col w-full h-full overflow-x-hidden overflow-y-auto"

--- a/app/javascript/dashboard/routes/dashboard/inbox/components/InboxListHeader.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/components/InboxListHeader.vue
@@ -4,7 +4,7 @@
   >
     <div class="flex items-center gap-1.5">
       <h1 class="font-medium text-slate-900 dark:text-slate-25 text-xl">
-        Inbox
+        {{ $t('INBOX.LIST.TITLE') }}
       </h1>
       <div
         role="button"
@@ -14,7 +14,7 @@
         <span
           class="text-slate-600 relative -top-px dark:text-slate-200 text-xs text-center font-medium"
         >
-          Display
+          {{ $t('INBOX.LIST.DISPLAY_DROPDOWN') }}
         </span>
         <fluent-icon
           icon="chevron-down"
@@ -23,14 +23,14 @@
         />
       </div>
     </div>
-    <div class="flex gap-1 items-center">
-      <woot-button
+    <div class="flex relative gap-1 items-center">
+      <!-- <woot-button
         variant="clear"
         size="small"
         color-scheme="secondary"
         icon="filter"
         @click="openInboxFilter"
-      />
+      /> -->
       <woot-button
         variant="clear"
         size="small"
@@ -38,21 +38,34 @@
         icon="mail-inbox"
         @click="openInboxOptionsMenu"
       />
+      <inbox-option-menu
+        v-if="showInboxOptionMenu"
+        v-on-clickaway="openInboxOptionsMenu"
+        class="absolute top-9"
+      />
     </div>
   </div>
 </template>
 
 <script>
+import { mixin as clickaway } from 'vue-clickaway';
+import InboxOptionMenu from './InboxOptionMenu.vue';
 export default {
+  components: {
+    InboxOptionMenu,
+  },
+  mixins: [clickaway],
+  data() {
+    return {
+      showInboxOptionMenu: false,
+    };
+  },
   methods: {
     openInboxDisplayMenu() {
       this.$emit('open-display-menu');
     },
-    openInboxFilter() {
-      this.$emit('open-filter');
-    },
     openInboxOptionsMenu() {
-      this.$emit('open-options-menu');
+      this.showInboxOptionMenu = !this.showInboxOptionMenu;
     },
   },
 };

--- a/app/javascript/dashboard/routes/dashboard/inbox/components/InboxOptionMenu.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/components/InboxOptionMenu.vue
@@ -1,0 +1,72 @@
+<template>
+  <div
+    class="flex flex-col gap-1 bg-white z-50 dark:bg-slate-900 w-40 py-1 border shadow-md border-slate-100 dark:border-slate-500 rounded-xl divide-y divide-slate-100 dark:divide-slate-700/50"
+  >
+    <div class="flex flex-col">
+      <menu-item
+        v-for="item in menuItems"
+        :key="item.key"
+        :label="item.label"
+        @click="onMenuItemClick(item.key)"
+      />
+    </div>
+    <div class="flex flex-col">
+      <menu-item
+        v-for="item in commonMenuItems"
+        :key="item.key"
+        :label="item.label"
+        @click="onMenuItemClick(item.key)"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import MenuItem from './MenuItem.vue';
+export default {
+  components: {
+    MenuItem,
+  },
+  data() {
+    return {
+      menuItems: [
+        {
+          key: 'mark_as_read',
+          label: this.$t('INBOX.MENU_ITEM.MARK_AS_READ'),
+        },
+        {
+          key: 'mark_as_unread',
+          label: this.$t('INBOX.MENU_ITEM.MARK_AS_UNREAD'),
+        },
+        {
+          key: 'snooze',
+          label: this.$t('INBOX.MENU_ITEM.SNOOZE'),
+        },
+        {
+          key: 'delete',
+          label: this.$t('INBOX.MENU_ITEM.DELETE'),
+        },
+      ],
+      commonMenuItems: [
+        {
+          key: 'mark_all_read',
+          label: this.$t('INBOX.MENU_ITEM.MARK_ALL_READ'),
+        },
+        {
+          key: 'delete_all',
+          label: this.$t('INBOX.MENU_ITEM.DELETE_ALL'),
+        },
+        {
+          key: 'delete_all_read',
+          label: this.$t('INBOX.MENU_ITEM.DELETE_ALL_READ'),
+        },
+      ],
+    };
+  },
+  methods: {
+    onMenuItemClick(key) {
+      this.$emit('option-click', key);
+    },
+  },
+};
+</script>

--- a/app/javascript/dashboard/routes/dashboard/inbox/components/MenuItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/components/MenuItem.vue
@@ -1,0 +1,25 @@
+<script setup>
+import { defineProps, defineEmits } from 'vue';
+
+defineProps({
+  label: {
+    type: String,
+    default: '',
+  },
+});
+
+const emits = defineEmits(['click']);
+
+const onMenuItemClick = () => {
+  emits('click');
+};
+</script>
+<template>
+  <div
+    role="button"
+    class="py-1 px-2 w-full h-8 font-medium text-xs text-slate-800 dark:text-slate-100 flex items-center whitespace-nowrap text-ellipsis overflow-hidden hover:text-woot-600 dark:hover:text-woot-500 cursor-pointer rounded-md"
+    @click.stop="onMenuItemClick"
+  >
+    {{ label }}
+  </div>
+</template>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR includes a dummy component of the new inbox view's inbox list header options menu. 

Fixes https://linear.app/chatwoot/issue/CW-2966/ui-inbox-options

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**Screenshot**
<img width="502" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/67885a12-ed54-40fd-90f0-77c306e0bef1">



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
