### PR TITLE
fix: Fixes overlapping issue with local selector dropdown in portal header

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/Header/ArticleHeader.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/Header/ArticleHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex px-4 items-center justify-between w-full h-16 pt-2 sticky top-0 z-10 bg-white dark:bg-slate-900"
+    class="flex px-4 items-center justify-between w-full h-16 pt-2 sticky top-0 z-50 bg-white dark:bg-slate-900"
   >
     <div class="flex items-center">
       <woot-sidemenu-icon />


### PR DESCRIPTION

**Before**
<img width="473" alt="image" src="https://github.com/chatwoot/chatwoot/assets/1277421/8994354d-a957-4119-a86d-8dce6de2067a">

**After**
<img width="473" alt="image" src="https://github.com/chatwoot/chatwoot/assets/1277421/94880743-f20b-4eda-8f52-70ff1d194182">

