### PR TITLE
feat: allow bulk invite create via email

### DIFF
--- a/app/builders/agent_builder.rb
+++ b/app/builders/agent_builder.rb
@@ -17,9 +17,9 @@ class AgentBuilder
     ActiveRecord::Base.transaction do
       @user = find_or_create_user
       send_confirmation_if_required
-      create_account_user
+      @account_user = create_account_user
     end
-    @user
+    [@user, @account_user]
   end
 
   private

--- a/app/builders/agent_builder.rb
+++ b/app/builders/agent_builder.rb
@@ -6,10 +6,10 @@ class AgentBuilder
   # @param email [String] the email of the user.
   # @param name [String] the name of the user.
   # @param role [String] the role of the user, defaults to 'agent' if not provided.
-  # @param current_user [User] the current user.
+  # @param inviter [User] the current user.
   # @param availability [String] the availability status of the user, defaults to 'offline' if not provided.
   # @param auto_offline [Boolean] the auto offline status of the user.
-  pattr_initialize [:email, { name: '' }, :current_user, :account, { role: :agent }, { availability: :offline }, { auto_offline: false }]
+  pattr_initialize [:email, { name: '' }, :inviter, :account, { role: :agent }, { availability: :offline }, { auto_offline: false }]
 
   # Creates a user and account user in a transaction.
   # @return [User] the created user.
@@ -50,7 +50,7 @@ class AgentBuilder
     AccountUser.create!({
       account_id: account.id,
       user_id: @user.id,
-      inviter_id: current_user.id
+      inviter_id: inviter.id
     }.merge({
       role: role,
       availability: availability,

--- a/app/builders/agent_builder.rb
+++ b/app/builders/agent_builder.rb
@@ -17,9 +17,9 @@ class AgentBuilder
     ActiveRecord::Base.transaction do
       @user = find_or_create_user
       send_confirmation_if_required
-      @account_user = create_account_user
+      create_account_user
     end
-    [@user, @account_user]
+    @user
   end
 
   private

--- a/app/builders/agent_builder.rb
+++ b/app/builders/agent_builder.rb
@@ -1,0 +1,60 @@
+# The AgentBuilder class is responsible for creating a new agent.
+# It initializes with necessary attributes and provides a perform method
+# to create a user and account user in a transaction.
+class AgentBuilder
+  # Initializes an AgentBuilder with necessary attributes.
+  # @param email [String] the email of the user.
+  # @param name [String] the name of the user.
+  # @param role [String] the role of the user, defaults to 'agent' if not provided.
+  # @param current_user [User] the current user.
+  # @param availability [String] the availability status of the user, defaults to 'offline' if not provided.
+  # @param auto_offline [Boolean] the auto offline status of the user.
+  pattr_initialize [:email, { name: '' }, :current_user, :account, { role: :agent }, { availability: :offline }, { auto_offline: false }]
+
+  # Creates a user and account user in a transaction.
+  # @return [User] the created user.
+  def perform
+    ActiveRecord::Base.transaction do
+      @user = find_or_create_user
+      send_confirmation_if_required
+      create_account_user
+    end
+    @user
+  end
+
+  private
+
+  # Finds a user by email or creates a new one with a temporary password.
+  # @return [User] the found or created user.
+  def find_or_create_user
+    user = User.find_by(email: email)
+    return user if user
+
+    temp_password = "1!aA#{SecureRandom.alphanumeric(12)}"
+    User.create!(email: email, name: name, password: temp_password, password_confirmation: temp_password)
+  end
+
+  # Sends confirmation instructions if the user is persisted and not confirmed.
+  def send_confirmation_if_required
+    @user.send_confirmation_instructions if user_needs_confirmation?
+  end
+
+  # Checks if the user needs confirmation.
+  # @return [Boolean] true if the user is persisted and not confirmed, false otherwise.
+  def user_needs_confirmation?
+    @user.persisted? && !@user.confirmed?
+  end
+
+  # Creates an account user linking the user to the current account.
+  def create_account_user
+    AccountUser.create!({
+      account_id: account.id,
+      user_id: @user.id,
+      inviter_id: current_user.id
+    }.merge({
+      role: role,
+      availability: availability,
+      auto_offline: auto_offline
+    }.compact))
+  end
+end

--- a/app/builders/agent_builder.rb
+++ b/app/builders/agent_builder.rb
@@ -6,7 +6,7 @@ class AgentBuilder
   # @param email [String] the email of the user.
   # @param name [String] the name of the user.
   # @param role [String] the role of the user, defaults to 'agent' if not provided.
-  # @param inviter [User] the current user.
+  # @param inviter [User] the user who is inviting the agent (Current.user in most cases).
   # @param availability [String] the availability status of the user, defaults to 'offline' if not provided.
   # @param auto_offline [Boolean] the auto offline status of the user.
   pattr_initialize [:email, { name: '' }, :inviter, :account, { role: :agent }, { availability: :offline }, { auto_offline: false }]

--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
-  before_action :fetch_agent, except: [:create, :index]
+  before_action :fetch_agent, except: [:create, :index, :bulk_create]
   before_action :check_authorization
   before_action :validate_limit, only: [:create]
   before_action :validate_limit_for_bulk_create, only: [:bulk_create]

--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
       role: new_agent_params['role'],
       availability: new_agent_params['availability'],
       auto_offline: new_agent_params['auto_offline'],
-      current_user: current_user,
+      inviter: current_user,
       account: Current.account
     )
     @user = builder.perform
@@ -41,7 +41,7 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
       builder = AgentBuilder.new(
         email: email,
         name: email.split('@').first,
-        current_user: current_user,
+        inviter: current_user,
         account: Current.account
       )
       builder.perform

--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -18,9 +18,9 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
       inviter: current_user,
       account: Current.account
     )
-    @user = builder.perform
+    @user, account_user = builder.perform
 
-    head :ok
+    render json: account_user, status: :created
   end
 
   def update

--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -18,9 +18,9 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
       inviter: current_user,
       account: Current.account
     )
-    @user, account_user = builder.perform
+    @user = builder.perform
 
-    render json: account_user, status: :created
+    head :ok
   end
 
   def update

--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -78,7 +78,7 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
   end
 
   def can_add_agent?
-    available_agent_count >= 0
+    available_agent_count.positive?
   end
 
   def delete_user_record(agent)

--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -18,9 +18,8 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
       inviter: current_user,
       account: Current.account
     )
-    @user = builder.perform
 
-    head :ok
+    builder.perform
   end
 
   def update

--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -1,16 +1,26 @@
 class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
   before_action :fetch_agent, except: [:create, :index]
   before_action :check_authorization
-  before_action :find_user, only: [:create]
   before_action :validate_limit, only: [:create]
-  before_action :create_user, only: [:create]
-  before_action :save_account_user, only: [:create]
 
   def index
     @agents = agents
   end
 
-  def create; end
+  def create
+    builder = AgentBuilder.new(
+      email: new_agent_params['email'],
+      name: new_agent_params['name'],
+      role: new_agent_params['role'],
+      availability: new_agent_params['availability'],
+      auto_offline: new_agent_params['auto_offline'],
+      current_user: current_user,
+      account: Current.account
+    )
+    @user = builder.perform
+
+    head :ok
+  end
 
   def update
     @agent.update!(agent_params.slice(:name).compact)
@@ -33,39 +43,12 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
     @agent = agents.find(params[:id])
   end
 
-  def find_user
-    @user =  User.find_by(email: new_agent_params[:email])
-  end
-
-  # TODO: move this to a builder and combine the save account user method into a builder
-  # ensure the account user association is also created in a single transaction
-  def create_user
-    return @user.send_confirmation_instructions if @user
-
-    @user = User.create!(new_agent_params.slice(:email, :name, :password, :password_confirmation))
-  end
-
-  def save_account_user
-    AccountUser.create!({
-      account_id: Current.account.id,
-      user_id: @user.id,
-      inviter_id: current_user.id
-    }.merge({
-      role: new_agent_params[:role],
-      availability: new_agent_params[:availability],
-      auto_offline: new_agent_params[:auto_offline]
-    }.compact))
-  end
-
   def agent_params
     params.require(:agent).permit(:name, :email, :name, :role, :availability, :auto_offline)
   end
 
   def new_agent_params
-    # intial string ensures the password requirements are met
-    temp_password = "1!aA#{SecureRandom.alphanumeric(12)}"
     params.require(:agent).permit(:email, :name, :role, :availability, :auto_offline)
-          .merge!(password: temp_password, password_confirmation: temp_password, inviter: current_user)
   end
 
   def agents

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,4 +14,8 @@ class UserPolicy < ApplicationPolicy
   def destroy?
     @account_user.administrator?
   end
+
+  def bulk_create?
+    @account_user.administrator?
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,9 @@ Rails.application.routes.draw do
             resource :contact_merge, only: [:create]
           end
           resource :bulk_actions, only: [:create]
-          resources :agents, only: [:index, :create, :update, :destroy]
+          resources :agents, only: [:index, :create, :update, :destroy] do
+            post :bulk_create, on: :collection
+          end
           resources :agent_bots, only: [:index, :create, :show, :update, :destroy] do
             delete :avatar, on: :member
           end

--- a/spec/builders/agent_builder_spec.rb
+++ b/spec/builders/agent_builder_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe AgentBuilder, type: :model do
+  subject(:agent_builder) { described_class.new(params) }
+
+  let(:account) { create(:account) }
+  let!(:current_user) { create(:user, account: account) }
+  let(:email) { 'test@example.com' }
+  let(:name) { 'Test User' }
+  let(:role) { 'agent' }
+  let(:availability) { 'offline' }
+  let(:auto_offline) { false }
+  let(:params) do
+    {
+      email: email,
+      name: name,
+      current_user: current_user,
+      account: account,
+      role: role,
+      availability: availability,
+      auto_offline: auto_offline
+    }
+  end
+
+  describe '#perform' do
+    context 'when user does not exist' do
+      it 'creates a new user' do
+        expect { agent_builder.perform }.to change(User, :count).by(1)
+      end
+
+      it 'creates a new account user' do
+        expect { agent_builder.perform }.to change(AccountUser, :count).by(1)
+      end
+
+      it 'returns a user' do
+        expect(agent_builder.perform).to be_a(User)
+      end
+    end
+
+    context 'when user exists' do
+      before do
+        create(:user, email: email)
+      end
+
+      it 'does not create a new user' do
+        expect { agent_builder.perform }.not_to change(User, :count)
+      end
+
+      it 'creates a new account user' do
+        expect { agent_builder.perform }.to change(AccountUser, :count).by(1)
+      end
+    end
+
+    context 'when only email is provided' do
+      let(:params) { { email: email, current_user: current_user, account: account } }
+
+      it 'creates a user with default values' do
+        user = agent_builder.perform
+        expect(user.name).to eq('')
+        expect(AccountUser.find_by(user: user).role).to eq('agent')
+      end
+    end
+
+    context 'when a temporary password is generated' do
+      it 'sets a temporary password for the user' do
+        user = agent_builder.perform
+        expect(user.encrypted_password).not_to be_empty
+      end
+    end
+
+    context 'with confirmation required' do
+      let(:unconfirmed_user) { create(:user, email: email) }
+
+      before do
+        unconfirmed_user.confirmed_at = nil
+        unconfirmed_user.save(validate: false)
+        allow(unconfirmed_user).to receive(:confirmed?).and_return(false)
+      end
+
+      it 'sends confirmation instructions' do
+        user = agent_builder.perform
+        expect(user).to receive(:send_confirmation_instructions)
+        agent_builder.send(:send_confirmation_if_required)
+      end
+    end
+  end
+end

--- a/spec/builders/agent_builder_spec.rb
+++ b/spec/builders/agent_builder_spec.rb
@@ -33,10 +33,7 @@ RSpec.describe AgentBuilder, type: :model do
       end
 
       it 'returns a user' do
-        # response is a User and AccountUser object
-        result = agent_builder.perform
-        expect(result.first).to be_a(User)
-        expect(result.second).to be_a(AccountUser)
+        expect(agent_builder.perform).to be_a(User)
       end
     end
 
@@ -58,15 +55,15 @@ RSpec.describe AgentBuilder, type: :model do
       let(:params) { { email: email, inviter: current_user, account: account } }
 
       it 'creates a user with default values' do
-        user, account_user = agent_builder.perform
+        user = agent_builder.perform
         expect(user.name).to eq('')
-        expect(AccountUser.find_by(user: user).id).to eq(account_user.id)
+        expect(AccountUser.find_by(user: user).role).to eq('agent')
       end
     end
 
     context 'when a temporary password is generated' do
       it 'sets a temporary password for the user' do
-        user, _account_user = agent_builder.perform
+        user = agent_builder.perform
         expect(user.encrypted_password).not_to be_empty
       end
     end
@@ -81,7 +78,7 @@ RSpec.describe AgentBuilder, type: :model do
       end
 
       it 'sends confirmation instructions' do
-        user, _account_user = agent_builder.perform
+        user = agent_builder.perform
         expect(user).to receive(:send_confirmation_instructions)
         agent_builder.send(:send_confirmation_if_required)
       end

--- a/spec/builders/agent_builder_spec.rb
+++ b/spec/builders/agent_builder_spec.rb
@@ -33,7 +33,10 @@ RSpec.describe AgentBuilder, type: :model do
       end
 
       it 'returns a user' do
-        expect(agent_builder.perform).to be_a(User)
+        # response is a User and AccountUser object
+        result = agent_builder.perform
+        expect(result.first).to be_a(User)
+        expect(result.second).to be_a(AccountUser)
       end
     end
 
@@ -55,15 +58,15 @@ RSpec.describe AgentBuilder, type: :model do
       let(:params) { { email: email, inviter: current_user, account: account } }
 
       it 'creates a user with default values' do
-        user = agent_builder.perform
+        user, account_user = agent_builder.perform
         expect(user.name).to eq('')
-        expect(AccountUser.find_by(user: user).role).to eq('agent')
+        expect(AccountUser.find_by(user: user).id).to eq(account_user.id)
       end
     end
 
     context 'when a temporary password is generated' do
       it 'sets a temporary password for the user' do
-        user = agent_builder.perform
+        user, _account_user = agent_builder.perform
         expect(user.encrypted_password).not_to be_empty
       end
     end
@@ -78,7 +81,7 @@ RSpec.describe AgentBuilder, type: :model do
       end
 
       it 'sends confirmation instructions' do
-        user = agent_builder.perform
+        user, _account_user = agent_builder.perform
         expect(user).to receive(:send_confirmation_instructions)
         agent_builder.send(:send_confirmation_if_required)
       end

--- a/spec/builders/agent_builder_spec.rb
+++ b/spec/builders/agent_builder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AgentBuilder, type: :model do
     {
       email: email,
       name: name,
-      current_user: current_user,
+      inviter: current_user,
       account: account,
       role: role,
       availability: availability,
@@ -52,7 +52,7 @@ RSpec.describe AgentBuilder, type: :model do
     end
 
     context 'when only email is provided' do
-      let(:params) { { email: email, current_user: current_user, account: account } }
+      let(:params) { { email: email, inviter: current_user, account: account } }
 
       it 'creates a user with default values' do
         user = agent_builder.perform

--- a/spec/enterprise/controllers/api/v1/accounts/agents_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/agents_controller_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'Agents API', type: :request do
+  include ActiveJob::TestHelper
+
+  let(:account) { create(:account) }
+  let!(:admin) { create(:user, custom_attributes: { test: 'test' }, account: account, role: :administrator) }
+
+  describe 'POST /api/v1/accounts/{account.id}/agents' do
+    context 'when the account has reached its agent limit' do
+      params = { name: 'NewUser', email: Faker::Internet.email, role: :agent }
+
+      before do
+        account.update(limits: { agents: 4 })
+        create_list(:user, 4, account: account, role: :agent)
+      end
+
+      it 'prevents adding a new agent and returns a payment required status' do
+        post "/api/v1/accounts/#{account.id}/agents", params: params, headers: admin.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:payment_required)
+        expect(response.body).to include('Account limit exceeded. Please purchase more licenses')
+      end
+    end
+  end
+
+  describe 'POST /api/v1/accounts/{account.id}/agents/bulk_create' do
+    let(:emails) { ['test1@example.com', 'test2@example.com', 'test3@example.com'] }
+    let(:bulk_create_params) { { emails: emails } }
+
+    context 'when exceeding agent limit' do
+      it 'prevents creating agents and returns a payment required status' do
+        # Set the limit to be less than the number of emails
+        account.update(limits: { agents: 2 })
+
+        expect do
+          post "/api/v1/accounts/#{account.id}/agents/bulk_create", params: bulk_create_params, headers: admin.create_new_auth_token
+        end.not_to change(User, :count)
+
+        expect(response).to have_http_status(:payment_required)
+        expect(response.body).to include('Account limit exceeded. Please purchase more licenses')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR allows creating bulk invites via email. A `POST` request to `/api/v1/accounts/{account.id}/agents/bulk_create` with `{ emails: ['test1@example.com', 'test2@example.com'] }` will allow creation of multiple invites. This will also validate the agents limits before creating any users

This PR has the following changes

1. New `AgentBuilder` this creates the agent and associates it with the account in a single transaction.
2. Refactor `AgentsController` to use the new `AgentBuilder`
3. Add `bulk_create` endpoint to allow creation of multiple agents during onboarding

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests
- [ ] Manual Testing on staging

