### PR TITLE
chore: Move EnterprisePricing validation to on create

### DIFF
--- a/enterprise/app/models/enterprise/concerns/user.rb
+++ b/enterprise/app/models/enterprise/concerns/user.rb
@@ -2,7 +2,7 @@ module Enterprise::Concerns::User
   extend ActiveSupport::Concern
 
   included do
-    before_validation :ensure_installation_pricing_plan_quantity
+    before_validation :ensure_installation_pricing_plan_quantity, on: :create
   end
 
   def ensure_installation_pricing_plan_quantity

--- a/spec/enterprise/models/user_spec.rb
+++ b/spec/enterprise/models/user_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  let(:user) { create(:user) }
+  let!(:user) { create(:user) }
 
   describe 'before validation for pricing plans' do
+    let!(:existing_user) { create(:user) }
     let(:new_user) { build(:user) }
 
     context 'when pricing plan is not premium' do
@@ -26,17 +27,24 @@ RSpec.describe User do
       end
 
       context 'when the user limit is reached' do
-        it 'adds an error to the user' do
+        it 'adds an error when trying to create a user' do
           allow(ChatwootHub).to receive(:pricing_plan_quantity).and_return(1)
-          user.valid?
-          expect(user.errors[:base]).to include('User limit reached. Please purchase more licenses from super admin')
+          new_user.valid?
+          expect(new_user.errors[:base]).to include('User limit reached. Please purchase more licenses from super admin')
+        end
+
+        it 'will not add error when trying to update a existing user' do
+          allow(ChatwootHub).to receive(:pricing_plan_quantity).and_return(1)
+          # since there is user and existing user, we are already over limits
+          existing_user.valid?
+          expect(existing_user.errors[:base]).to be_empty
         end
       end
 
       context 'when the user limit is not reached' do
         it 'does not add an error to the user' do
-          allow(ChatwootHub).to receive(:pricing_plan_quantity).and_return(2)
-          user.valid?
+          allow(ChatwootHub).to receive(:pricing_plan_quantity).and_return(3)
+          new_user.valid?
           expect(user.errors[:base]).to be_empty
         end
       end
@@ -44,6 +52,10 @@ RSpec.describe User do
   end
 
   describe 'audit log' do
+    before do
+      create(:user)
+    end
+
     context 'when user is created' do
       it 'has no associated audit log created' do
         expect(Audited::Audit.where(auditable_type: 'User', action: 'create').count).to eq 0


### PR DESCRIPTION
The previous validation was getting triggered on all transactions; this would prevent login to existing users as session data needed to be updated. So opting for a less intrusive approach and display warning only when trying to create new users.

