### PR TITLE
fix: Change the route from `inbox` to `inbox-view`

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -306,7 +306,7 @@ export default {
           });
         } else if (isAInboxViewRoute(this.$route.name)) {
           this.$router.push({
-            name: 'inbox',
+            name: 'inbox-view',
           });
         } else if (this.$route.name !== 'contacts_dashboard') {
           this.$router.push({

--- a/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
@@ -6,7 +6,7 @@ const InboxView = () => import('../inbox/InboxView.vue');
 export default {
   routes: [
     {
-      path: frontendURL('accounts/:accountId/inbox'),
+      path: frontendURL('accounts/:accountId/inbox-view'),
       name: 'inbox',
       roles: ['administrator', 'agent'],
       component: InboxView,
@@ -15,7 +15,7 @@ export default {
       },
     },
     {
-      path: frontendURL('accounts/:accountId/inbox/:conversation_id'),
+      path: frontendURL('accounts/:accountId/inbox-view/:conversation_id'),
       name: 'inbox_view_conversation',
       roles: ['administrator', 'agent'],
       component: InboxView,

--- a/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
@@ -7,7 +7,7 @@ export default {
   routes: [
     {
       path: frontendURL('accounts/:accountId/inbox-view'),
-      name: 'inbox',
+      name: 'inbox_view',
       roles: ['administrator', 'agent'],
       component: InboxView,
       props: () => {

--- a/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
@@ -97,8 +97,8 @@ export default {
   methods: {
     redirectToInbox() {
       if (!this.conversationId) return;
-      if (this.$route.name === 'inbox') return;
-      this.$router.push({ name: 'inbox' });
+      if (this.$route.name === 'inbox-view') return;
+      this.$router.push({ name: 'inbox-view' });
     },
     loadMoreNotifications() {
       if (this.uiFlags.isAllNotificationsLoaded) return;

--- a/app/javascript/dashboard/routes/dashboard/inbox/components/InboxItemHeader.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/components/InboxItemHeader.vue
@@ -132,7 +132,7 @@ export default {
         .then(() => {
           this.showAlert(this.$t('INBOX.ALERTS.DELETE'));
         });
-      this.$router.push({ name: 'inbox' });
+      this.$router.push({ name: 'inbox-view' });
     },
     onClickNext() {
       this.$emit('next');


### PR DESCRIPTION
We already have a route named "inbox" when clicking on "inbox" from the sidebar, which is conflicting with the new inbox view. For now, I have renamed it to "inbox-view" until we find a better route name.