### PR TITLE
chore: upgrade to latest versions of gh helper actions

### DIFF
--- a/.github/workflows/logging_percentage_check.yml
+++ b/.github/workflows/logging_percentage_check.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check for log lines and calculate percentage
         run: |

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -4,7 +4,7 @@
 # # This action will try to install and setup
 # # chatwoot on an Ubuntu 20.04 machine using
 # # the linux installer script.
-# # 
+# #
 # # This is set to run daily at midnight.
 # #
 
@@ -35,7 +35,7 @@ jobs:
       run: |
         sudo ./install.sh --install < input
 
-        #  disabling http verify for now as http 
+        #  disabling http verify for now as http
         #  access to port 3000 fails in gh action env
         #    - name: Verify
         #      if: always()
@@ -45,7 +45,7 @@ jobs:
         #        curl http://localhost:3000/api
 
     - name: Upload chatwoot setup log file as an artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: chatwoot-setup-log-file

--- a/.github/workflows/publish_codespace_image.yml
+++ b/.github/workflows/publish_codespace_image.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1

--- a/.github/workflows/publish_foss_docker.yml
+++ b/.github/workflows/publish_foss_docker.yml
@@ -21,7 +21,7 @@ jobs:
       GIT_REF: ${{ github.head_ref || github.ref_name }} # ref_name to get tags/branches
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/run_foss_spec.yml
+++ b/.github/workflows/run_foss_spec.yml
@@ -41,7 +41,7 @@ jobs:
         options: --entrypoint redis-server
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -50,7 +50,7 @@ jobs:
       with:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 20
         cache: yarn
@@ -76,11 +76,11 @@ jobs:
     - name: Run backend tests
       run: |
         bundle exec rspec --profile=10 --format documentation
-      env: 
+      env:
         NODE_OPTIONS: --openssl-legacy-provider
 
     - name: Upload rails log folder
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: rails-log-folder

--- a/.github/workflows/run_response_bot_spec.yml
+++ b/.github/workflows/run_response_bot_spec.yml
@@ -40,7 +40,7 @@ jobs:
         options: --entrypoint redis-server
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -49,7 +49,7 @@ jobs:
       with:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 20
         cache: yarn
@@ -77,7 +77,7 @@ jobs:
           --format documentation
 
     - name: Upload rails log folder
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: rails-log-folder

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -19,7 +19,7 @@ jobs:
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'
@@ -31,7 +31,7 @@ jobs:
         run: |
           rm -rf enterprise
           rm -rf spec/enterprise
-          
+
       - name: Run asset compile
         run: bundle exec rake assets:precompile
         env:


### PR DESCRIPTION
# Pull Request Template

## Description

- Github helper actions depending on `node16` have been deprecated. Switch to the latest version of helper actions to use `node20`.

Fixes https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

<img width="1365" alt="image" src="https://github.com/chatwoot/chatwoot/assets/3526167/7ec31a77-c8c1-490e-84f0-5bed45df63e2">



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

- gh action tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
