### PR TITLE
chore: Render timestamp in a better format in conversation traffic export

### DIFF
--- a/app/helpers/api/v2/accounts/heatmap_helper.rb
+++ b/app/helpers/api/v2/accounts/heatmap_helper.rb
@@ -15,8 +15,8 @@ module Api::V2::Accounts::HeatmapHelper
     dates = data.pluck(:date).uniq.sort
 
     # add the dates as the first row, leave an empty cell for the hour column
-    # e.g. [nil, '2023-01-01', '2023-1-02', '2023-01-03']
-    result_arr << ([nil] + dates)
+    # e.g. ['Start of the hour', '2023-01-01', '2023-1-02', '2023-01-03']
+    result_arr << (['Start of the hour'] + dates)
 
     # group the data by hour, we do not need to sort it, because the data is already sorted
     # given it starts from the beginning of the day
@@ -25,7 +25,7 @@ module Api::V2::Accounts::HeatmapHelper
     # value = [{date: 2023-01-01, value: 1}, {date: 2023-01-02, value: 1}, {date: 2023-01-03, value: 1}, ...]
     data.group_by { |d| d[:hour] }.each do |hour, items|
       # create a new row for each hour
-      row = [hour]
+      row = [format('%02d:00', hour)]
 
       # group the items by date, so we can easily access the value for each date
       # grouped values will be a hasg with the date as the key, and the value as the value
@@ -37,7 +37,7 @@ module Api::V2::Accounts::HeatmapHelper
         row << (grouped_values[date][0][:value] if grouped_values[date].is_a?(Array))
       end
 
-      # row will look like [22, 0, 0, 1, 4, 6, 7, 4]
+      # row will look like ['22:00', 0, 0, 1, 4, 6, 7, 4]
       # add the row to the result array
 
       result_arr << row
@@ -46,12 +46,12 @@ module Api::V2::Accounts::HeatmapHelper
     # return the resultant array
     # the result looks like this
     # [
-    #   [nil, '2023-01-01', '2023-1-02', '2023-01-03'],
-    #   [0, 0, 0, 0],
-    #   [1, 0, 0, 0],
-    #   [2, 0, 0, 0],
-    #   [3, 0, 0, 0],
-    #   [4, 0, 0, 0],
+    #   ['Start of the hour', '2023-01-01', '2023-1-02', '2023-01-03'],
+    #   ['00:00', 0, 0, 0],
+    #   ['01:00', 0, 0, 0],
+    #   ['02:00', 0, 0, 0],
+    #   ['03:00', 0, 0, 0],
+    #   ['04:00', 0, 0, 0],
     # ]
     result_arr
   end

--- a/app/views/api/v2/accounts/reports/conversation_traffic.erb
+++ b/app/views/api/v2/accounts/reports/conversation_traffic.erb
@@ -1,4 +1,4 @@
-<%= CSVSafe.generate_line [I18n.t('reports.conversation_traffic_csv.timezone'), @timezone] %>
+<%= CSV.generate_line [I18n.t('reports.conversation_traffic_csv.timezone'), @timezone] %>
 <% @report_data.each do |row| %>
 <%= CSVSafe.generate_line row -%>
 <% end %>


### PR DESCRIPTION
| Before | After |
| -- | -- |
| <img width="555" alt="Screenshot 2024-02-09 at 12 28 26 AM" src="https://github.com/chatwoot/chatwoot/assets/2246121/18756988-d52c-4125-ada3-d02bd7063ec9"> | <img width="524" alt="Screenshot 2024-02-09 at 12 28 07 AM" src="https://github.com/chatwoot/chatwoot/assets/2246121/47f58df8-26e4-4dd9-a453-a8472456670a"> |


Fixes https://linear.app/chatwoot/issue/CW-3068/update-the-heatmap-time-display-format