### PR TITLE
feat: handle already invited user

### DIFF
--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -43,7 +43,11 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
         inviter: current_user,
         account: Current.account
       )
-      builder.perform
+      begin
+        builder.perform
+      rescue ActiveRecord::RecordInvalid => e
+        Rails.logger.info "[Agent#bulk_create] ignoring email #{email}, errors: #{e.record.errors}"
+      end
     end
     head :ok
   end

--- a/spec/controllers/api/v1/accounts/agents_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/agents_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Agents API', type: :request do
 
   let(:account) { create(:account) }
   let!(:admin) { create(:user, custom_attributes: { test: 'test' }, account: account, role: :administrator) }
-  let!(:agent) { create(:user, account: account, role: :agent) }
+  let!(:agent) { create(:user, account: account, email: 'exists@example.com', role: :agent) }
 
   describe 'GET /api/v1/accounts/{account.id}/agents' do
     context 'when it is an unauthenticated user' do
@@ -193,6 +193,17 @@ RSpec.describe 'Agents API', type: :request do
         expect do
           post "/api/v1/accounts/#{account.id}/agents/bulk_create", params: bulk_create_params, headers: admin.create_new_auth_token
         end.to change(User, :count).by(3)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'ignores errors if account_user already exists' do
+        params = { emails: ['exists@example.com', 'test1@example.com', 'test2@example.com'] }
+
+        expect do
+          post "/api/v1/accounts/#{account.id}/agents/bulk_create", params: params,
+                                                                    headers: admin.create_new_auth_token
+        end.to change(User, :count).by(2)
 
         expect(response).to have_http_status(:ok)
       end


### PR DESCRIPTION
This PR adds a `rescue` block for the `perform` method, this is to ignore any errors if the AgentUser already exists. This behaviour only affects the bulk create API