### PR TITLE
fix: outline color on login page

### DIFF
--- a/app/javascript/v3/components/Form/Input.vue
+++ b/app/javascript/v3/components/Form/Input.vue
@@ -23,7 +23,7 @@
         'px-3 py-2 mb-0': spacing === 'compact',
         'pl-9': icon,
       }"
-      class="block w-full border-none rounded-xl shadow-sm appearance-none outline outline-1 outline-slate-200 dark:outline-slate-800 focus:outline-none focus:outline-0 text-slate-900 dark:text-slate-100 placeholder:text-slate-400 focus:ring-2 focus:ring-woot-500 sm:text-sm sm:leading-6 dark:bg-slate-800"
+      class="block w-full border-none shadow-sm appearance-none rounded-xl outline outline-1 outline-slate-200 dark:outline-slate-200/20 focus:outline-none focus:outline-0 text-slate-900 dark:text-slate-100 placeholder:text-slate-400 focus:ring-2 focus:ring-woot-500 sm:text-sm sm:leading-6 dark:bg-slate-800"
       @input="onInput"
       @blur="$emit('blur')"
     />


### PR DESCRIPTION
The outline on inputs would not be visible when placed on a background color `slate-800`, this PR changes it to use a reduced opacity color of slate-200, this blends perfectly on signup and login page with different bg colors

#### Login Page [Before fix]
![CleanShot 2024-02-12 at 23 29 01@2x](https://github.com/chatwoot/chatwoot/assets/18097732/f5d5bafe-7481-41f0-b47d-7086c5949538)

#### Login Page [After fix]
![CleanShot 2024-02-12 at 23 29 42@2x](https://github.com/chatwoot/chatwoot/assets/18097732/e8729db9-a941-486c-a593-89db6cf02fe2)


#### Signup Page
![CleanShot 2024-02-12 at 23 27 27@2x](https://github.com/chatwoot/chatwoot/assets/18097732/9b2e232f-bab4-4b8a-9722-e272fe7968b1)
