### PR TITLE
fix: Mark notification as unread after the un-snooze

### DIFF
--- a/app/jobs/notification/reopen_snoozed_notifications_job.rb
+++ b/app/jobs/notification/reopen_snoozed_notifications_job.rb
@@ -4,7 +4,7 @@ class Notification::ReopenSnoozedNotificationsJob < ApplicationJob
   def perform
     # rubocop:disable Rails/SkipsModelValidations
     Notification.where(snoozed_until: 3.days.ago..Time.current)
-                .update_all(snoozed_until: nil, updated_at: Time.current, last_activity_at: Time.current)
+                .update_all(snoozed_until: nil, updated_at: Time.current, last_activity_at: Time.current, read_at: nil)
     # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/spec/jobs/notification/reopen_snoozed_notifications_job_spec.rb
+++ b/spec/jobs/notification/reopen_snoozed_notifications_job_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Notification::ReopenSnoozedNotificationsJob do
       expect(snoozed_till_5_minutes_ago.reload.snoozed_until).to be_nil
       expect(snoozed_till_tomorrow.reload.snoozed_until.to_date).to eq 1.day.from_now.to_date
       expect(snoozed_indefinitely.reload.snoozed_until).to be_nil
+      expect(snoozed_indefinitely.reload.read_at).to be_nil
     end
   end
 end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-3089/mark-notification-as-unread-after-the-unsnooze