### PR TITLE
fix: throttle conversation search endpoint to prevent abuse

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -154,6 +154,12 @@ class Rack::Attack
     match_data[:account_id] if match_data.present?
   end
 
+  # Prevent abuse of conversation search api
+  throttle('/api/v1/accounts/:account_id/conversations/search', limit: 5, period: 1.minute) do |req|
+    match_data = %r{/api/v1/accounts/(?<account_id>\d+)/conversations/search}.match(req.path)
+    match_data[:account_id] if match_data.present?
+  end
+
   ## ----------------------------------------------- ##
 end
 


### PR DESCRIPTION
Throttle conversation search endpoint to prevent abuse/maintain db perf

ref: https://discord.com/channels/897869226579222540/1206919316402999326/1206953097444720711