### PR TITLE
fix: Removes default slot for right of label

### DIFF
--- a/app/javascript/v3/components/Form/WithLabel.vue
+++ b/app/javascript/v3/components/Form/WithLabel.vue
@@ -9,9 +9,7 @@
       <slot name="label">
         {{ label }}
       </slot>
-      <slot name="rightOfLabel">
-        {{ label }}
-      </slot>
+      <slot name="rightOfLabel" />
     </label>
     <div class="w-full">
       <div class="flex items-center relative w-full">


### PR DESCRIPTION

## Description
**Before**
<img width="919" alt="image" src="https://github.com/chatwoot/chatwoot/assets/1277421/3f901985-f4af-4989-9e0b-911698e0ca29">


**After**
<img width="919" alt="image" src="https://github.com/chatwoot/chatwoot/assets/1277421/cb762407-c4d7-4aa1-8ec8-26bb3e676412">

The label was appearing twice on all with-label used forms. This would remove the default 
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] 
