### PR TITLE
chore: Support for updated_within in ConverationFinder

### DIFF
--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -168,11 +168,13 @@ class ConversationFinder
       :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox
     )
 
+    sort_by, sort_order = SORT_OPTIONS[params[:sort_by]] || SORT_OPTIONS['last_activity_at_desc']
+    @conversations = @conversations.send(sort_by, sort_order)
+
     if params[:updated_within].present?
-      @conversations = @conversations.where('conversations.updated_at > ?', Time.zone.now - params[:updated_within].to_i.seconds)
+      @conversations.where('conversations.updated_at > ?', Time.zone.now - params[:updated_within].to_i.seconds)
     else
-      sort_by, sort_order = SORT_OPTIONS[params[:sort_by]] || SORT_OPTIONS['last_activity_at_desc']
-      @conversations.send(sort_by, sort_order).page(current_page).per(ENV.fetch('CONVERSATION_RESULTS_PER_PAGE', '25').to_i)
+      @conversations.page(current_page).per(ENV.fetch('CONVERSATION_RESULTS_PER_PAGE', '25').to_i)
     end
   end
 end

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -168,7 +168,11 @@ class ConversationFinder
       :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox
     )
 
-    sort_by, sort_order = SORT_OPTIONS[params[:sort_by]] || SORT_OPTIONS['last_activity_at_desc']
-    @conversations.send(sort_by, sort_order).page(current_page).per(ENV.fetch('CONVERSATION_RESULTS_PER_PAGE', '25').to_i)
+    if params[:updated_within].present?
+      @conversations = @conversations.where('conversations.updated_at > ?', Time.zone.now - params[:updated_within].to_i.seconds)
+    else
+      sort_by, sort_order = SORT_OPTIONS[params[:sort_by]] || SORT_OPTIONS['last_activity_at_desc']
+      @conversations.send(sort_by, sort_order).page(current_page).per(ENV.fetch('CONVERSATION_RESULTS_PER_PAGE', '25').to_i)
+    end
   end
 end

--- a/spec/finders/conversation_finder_spec.rb
+++ b/spec/finders/conversation_finder_spec.rb
@@ -147,9 +147,9 @@ describe ConversationFinder do
     end
 
     context 'with updated_within' do
-      let(:params) { { updated_within: 20, assignee_type: 'unassigned' } }
+      let(:params) { { updated_within: 20, assignee_type: 'unassigned', sort_by: 'created_at_asc' } }
 
-      it 'filters based on params but returns all conversations without pagination with in time range' do
+      it 'filters based on params, sort order but returns all conversations without pagination with in time range' do
         # value of updated_within is in seconds
         # write spec based on that
         conversations = create_list(:conversation, 50, account: account,
@@ -165,6 +165,8 @@ describe ConversationFinder do
         # filters are applied
         # modified conversations + 1 conversation created during set up
         expect(result[:conversations].length).to be 29
+        # ensure that the conversations are sorted by created_at
+        expect(result[:conversations].first.created_at).to be < result[:conversations].last.created_at
       end
     end
 

--- a/spec/finders/conversation_finder_spec.rb
+++ b/spec/finders/conversation_finder_spec.rb
@@ -146,6 +146,28 @@ describe ConversationFinder do
       end
     end
 
+    context 'with updated_within' do
+      let(:params) { { updated_within: 20, assignee_type: 'unassigned' } }
+
+      it 'filters based on params but returns all conversations without pagination with in time range' do
+        # value of updated_within is in seconds
+        # write spec based on that
+        conversations = create_list(:conversation, 50, account: account,
+                                                       inbox: inbox, assignee: nil,
+                                                       updated_at: Time.now.utc - 30.seconds,
+                                                       created_at: Time.now.utc - 30.seconds)
+        # update updated_at of 27 conversations to be with in 20 seconds
+        conversations[0..27].each do |conversation|
+          conversation.update(updated_at: Time.now.utc - 10.seconds)
+        end
+        result = conversation_finder.perform
+        # pagination is not applied
+        # filters are applied
+        # modified conversations + 1 conversation created during set up
+        expect(result[:conversations].length).to be 29
+      end
+    end
+
     context 'with pagination' do
       let(:params) { { status: 'open', assignee_type: 'me', page: 1 } }
 


### PR DESCRIPTION
- `updated_within' accepts value in seconds and returns all conversations updated in the given period with out pagination. This API will assist in our refetch logic on socket disconnect  

ref: https://github.com/chatwoot/chatwoot/issues/8888