### PR TITLE
fix: Editor hyperlink popup is hidden under modal

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -753,7 +753,7 @@ export default {
 }
 
 .ProseMirror-prompt {
-  @apply z-50 bg-slate-25 dark:bg-slate-700 rounded-md border border-solid border-slate-75 dark:border-slate-800;
+  @apply z-[9999] bg-slate-25 dark:bg-slate-700 rounded-md border border-solid border-slate-75 dark:border-slate-800 shadow-lg;
 
   h5 {
     @apply dark:text-slate-25 text-slate-800;


### PR DESCRIPTION
# Pull Request Template

## Description

This PR addresses an issue where the hyperlink popup in the editor is hidden under the modal component.

Fixes https://linear.app/chatwoot/issue/CW-3093/cant-hyperlink-text-on-new-conversation-started-from-contacts

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Loom video**
https://www.loom.com/share/4248e18112804df085a0c167d3fccedb?sid=cf1d2cb2-2958-42da-b8de-7b5de60e6913


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
