### PR TITLE
feat(perf): sla-9 improve perf of TriggerSlasForAccountsJob

### DIFF
--- a/app/javascript/shared/mixins/specs/automationMixin.spec.js
+++ b/app/javascript/shared/mixins/specs/automationMixin.spec.js
@@ -13,7 +13,6 @@ import {
   inboxes,
   languages,
   countries,
-  sla_policies,
   MESSAGE_CONDITION_VALUES,
   automationToSubmit,
   savedAutomation,
@@ -89,9 +88,6 @@ const generateComputedProperties = () => {
     },
     countries() {
       return countries;
-    },
-    sla_policies() {
-      return sla_policies;
     },
     MESSAGE_CONDITION_VALUES() {
       return MESSAGE_CONDITION_VALUES;
@@ -354,9 +350,6 @@ describe('automationMethodsMixin', () => {
       teams() {
         return teams;
       },
-      sla_policies() {
-        return sla_policies;
-      },
     };
 
     const methods = {
@@ -439,9 +432,6 @@ describe('automationMethodsMixin', () => {
       },
       teams() {
         return teams;
-      },
-      sla_policies() {
-        return sla_policies;
       },
     };
     const expectedActionDropdownValues = [

--- a/app/javascript/shared/mixins/specs/automationMixin.spec.js
+++ b/app/javascript/shared/mixins/specs/automationMixin.spec.js
@@ -13,6 +13,7 @@ import {
   inboxes,
   languages,
   countries,
+  sla_policies,
   MESSAGE_CONDITION_VALUES,
   automationToSubmit,
   savedAutomation,
@@ -88,6 +89,9 @@ const generateComputedProperties = () => {
     },
     countries() {
       return countries;
+    },
+    sla_policies() {
+      return sla_policies;
     },
     MESSAGE_CONDITION_VALUES() {
       return MESSAGE_CONDITION_VALUES;
@@ -350,6 +354,9 @@ describe('automationMethodsMixin', () => {
       teams() {
         return teams;
       },
+      sla_policies() {
+        return sla_policies;
+      },
     };
 
     const methods = {
@@ -432,6 +439,9 @@ describe('automationMethodsMixin', () => {
       },
       teams() {
         return teams;
+      },
+      sla_policies() {
+        return sla_policies;
       },
     };
     const expectedActionDropdownValues = [

--- a/enterprise/app/jobs/sla/trigger_slas_for_accounts_job.rb
+++ b/enterprise/app/jobs/sla/trigger_slas_for_accounts_job.rb
@@ -2,7 +2,7 @@ class Sla::TriggerSlasForAccountsJob < ApplicationJob
   queue_as :scheduled_jobs
 
   def perform
-    Account.find_each do |account|
+    Account.joins(:sla_policies).distinct.find_each do |account|
       Rails.logger.info "Enqueuing ProcessAccountAppliedSlasJob for account #{account.id}"
       Sla::ProcessAccountAppliedSlasJob.perform_later(account)
     end

--- a/spec/enterprise/jobs/sla/trigger_slas_for_accounts_job_spec.rb
+++ b/spec/enterprise/jobs/sla/trigger_slas_for_accounts_job_spec.rb
@@ -1,16 +1,25 @@
 require 'rails_helper'
-
 RSpec.describe Sla::TriggerSlasForAccountsJob do
   context 'when perform is called' do
-    let(:account) { create(:account) }
+    let(:account_with_sla) { create(:account) }
+    let(:account_without_sla) { create(:account) }
+
+    before do
+      create(:sla_policy, account: account_with_sla)
+    end
 
     it 'enqueues the job' do
       expect { described_class.perform_later }.to have_enqueued_job(described_class)
         .on_queue('scheduled_jobs')
     end
 
-    it 'calls the ProcessAccountAppliedSlasJob' do
-      expect(Sla::ProcessAccountAppliedSlasJob).to receive(:perform_later).with(account).and_call_original
+    it 'calls the ProcessAccountAppliedSlasJob for accounts with SLA' do
+      expect(Sla::ProcessAccountAppliedSlasJob).to receive(:perform_later).with(account_with_sla).and_call_original
+      described_class.perform_now
+    end
+
+    it 'does not call the ProcessAccountAppliedSlasJob for accounts without SLA' do
+      expect(Sla::ProcessAccountAppliedSlasJob).not_to receive(:perform_later).with(account_without_sla)
       described_class.perform_now
     end
   end


### PR DESCRIPTION
# Pull Request Template

## Description

- Schedule `ProcessAccountAppliedSlasJob` only for `accounts` that have one or more sla_policy created against it 

Fixes https://linear.app/chatwoot/issue/CW-3095/perf-schedule-account-sla-job-only-for-accounts-with-sla-policy

## Type of change

Please delete options that are not relevant.
- [ ] Perf (non-breaking change which improves performance)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
