### PR TITLE
fix: `support_email` and `inbound_email_domain` returning empty string

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -111,11 +111,12 @@ class Account < ApplicationRecord
   end
 
   def inbound_email_domain
-    domain || GlobalConfig.get('MAILER_INBOUND_EMAIL_DOMAIN')['MAILER_INBOUND_EMAIL_DOMAIN'] || ENV.fetch('MAILER_INBOUND_EMAIL_DOMAIN', false)
+    domain.presence || GlobalConfig.get('MAILER_INBOUND_EMAIL_DOMAIN')['MAILER_INBOUND_EMAIL_DOMAIN'] || ENV.fetch('MAILER_INBOUND_EMAIL_DOMAIN',
+                                                                                                                   false)
   end
 
   def support_email
-    super || ENV.fetch('MAILER_SENDER_EMAIL') { GlobalConfig.get('MAILER_SUPPORT_EMAIL')['MAILER_SUPPORT_EMAIL'] }
+    super.presence || ENV.fetch('MAILER_SENDER_EMAIL') { GlobalConfig.get('MAILER_SUPPORT_EMAIL')['MAILER_SUPPORT_EMAIL'] }
   end
 
   def usage_limits

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -47,6 +47,56 @@ RSpec.describe Account do
     end
   end
 
+  describe 'inbound_email_domain' do
+    let(:account) { create(:account) }
+
+    it 'returns the domain from inbox if inbox value is present' do
+      account.update(domain: 'test.com')
+      with_modified_env MAILER_INBOUND_EMAIL_DOMAIN: 'test2.com' do
+        expect(account.inbound_email_domain).to eq('test.com')
+      end
+    end
+
+    it 'returns the domain from ENV if inbox value is nil' do
+      account.update(domain: nil)
+      with_modified_env MAILER_INBOUND_EMAIL_DOMAIN: 'test.com' do
+        expect(account.inbound_email_domain).to eq('test.com')
+      end
+    end
+
+    it 'returns the domain from ENV if inbox value is empty string' do
+      account.update(domain: '')
+      with_modified_env MAILER_INBOUND_EMAIL_DOMAIN: 'test.com' do
+        expect(account.inbound_email_domain).to eq('test.com')
+      end
+    end
+  end
+
+  describe 'support_email' do
+    let(:account) { create(:account) }
+
+    it 'returns the support email from inbox if inbox value is present' do
+      account.update(support_email: 'support@chatwoot.com')
+      with_modified_env MAILER_SENDER_EMAIL: 'hello@chatwoot.com' do
+        expect(account.support_email).to eq('support@chatwoot.com')
+      end
+    end
+
+    it 'returns the support email from ENV if inbox value is nil' do
+      account.update(support_email: nil)
+      with_modified_env MAILER_SENDER_EMAIL: 'hello@chatwoot.com' do
+        expect(account.support_email).to eq('hello@chatwoot.com')
+      end
+    end
+
+    it 'returns the support email from ENV if inbox value is empty string' do
+      account.update(support_email: '')
+      with_modified_env MAILER_SENDER_EMAIL: 'hello@chatwoot.com' do
+        expect(account.support_email).to eq('hello@chatwoot.com')
+      end
+    end
+  end
+
   context 'when after_destroy is called' do
     it 'conv_dpid_seq and camp_dpid_seq_ are deleted' do
       account = create(:account)


### PR DESCRIPTION
- While debugging a prod issue, we notified that if someone enabled `custom_reply_email' or `custom_reply_email` email features and updated their account. The account's values for attributes `domain` and `support_email` will change to "" instead of nil, which causes issues with email sending. Hence adding appropriate fixes for the same.