### PR TITLE
feat: Add labels, status and priority in notification `push_event_data`

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -68,21 +68,10 @@ class Notification < ApplicationRecord
 
     }
     if primary_actor.present?
-      payload[:primary_actor] = primary_actor_data
+      payload[:primary_actor] = primary_actor&.push_event_data
       payload[:push_message_title] = push_message_title
     end
     payload
-  end
-
-  def primary_actor_data
-    {
-      id: primary_actor.push_event_data[:id],
-      meta: primary_actor.push_event_data[:meta],
-      inbox_id: primary_actor.push_event_data[:inbox_id],
-      priority: primary_actor.push_event_data[:priority],
-      status: primary_actor.push_event_data[:status],
-      labels: primary_actor.push_event_data[:labels]
-    }
   end
 
   def fcm_push_data

--- a/spec/controllers/api/v1/accounts/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/notifications_controller_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'Notifications API', type: :request do
         expect(response_json['data']['meta']['count']).to eq 2
         # notification appear in descending order
         expect(response_json['data']['payload'].first['id']).to eq notification2.id
+        expect(response_json['data']['payload'].first['primary_actor']).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-3097/add-labels-status-and-priority-in-notification-payload