### PR TITLE
chore: Component changes for bot reports

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/reports/ReportContainer.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/ReportContainer.vue
@@ -37,15 +37,6 @@ import format from 'date-fns/format';
 import { formatTime } from '@chatwoot/utils';
 import reportMixin from 'dashboard/mixins/reportMixin';
 import ChartStats from './components/ChartElements/ChartStats.vue';
-const REPORTS_KEYS = {
-  CONVERSATIONS: 'conversations_count',
-  INCOMING_MESSAGES: 'incoming_messages_count',
-  OUTGOING_MESSAGES: 'outgoing_messages_count',
-  FIRST_RESPONSE_TIME: 'avg_first_response_time',
-  RESOLUTION_TIME: 'avg_resolution_time',
-  RESOLUTION_COUNT: 'resolutions_count',
-  REPLY_TIME: 'reply_time',
-};
 
 export default {
   components: { ChartStats },
@@ -55,18 +46,22 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    reportKeys: {
+      type: Object,
+      default: () => ({
+        CONVERSATIONS: 'conversations_count',
+        INCOMING_MESSAGES: 'incoming_messages_count',
+        OUTGOING_MESSAGES: 'outgoing_messages_count',
+        FIRST_RESPONSE_TIME: 'avg_first_response_time',
+        RESOLUTION_TIME: 'avg_resolution_time',
+        RESOLUTION_COUNT: 'resolutions_count',
+        REPLY_TIME: 'reply_time',
+      }),
+    },
   },
   computed: {
     metrics() {
-      const reportKeys = [
-        'CONVERSATIONS',
-        'FIRST_RESPONSE_TIME',
-        'REPLY_TIME',
-        'RESOLUTION_TIME',
-        'RESOLUTION_COUNT',
-        'INCOMING_MESSAGES',
-        'OUTGOING_MESSAGES',
-      ];
+      const reportKeys = Object.keys(this.reportKeys);
       const infoText = {
         FIRST_RESPONSE_TIME: this.$t(
           `REPORT.METRICS.FIRST_RESPONSE_TIME.INFO_TEXT`
@@ -75,11 +70,11 @@ export default {
       };
       return reportKeys.map(key => ({
         NAME: this.$t(`REPORT.METRICS.${key}.NAME`),
-        KEY: REPORTS_KEYS[key],
+        KEY: this.reportKeys[key],
         DESC: this.$t(`REPORT.METRICS.${key}.DESC`),
         INFO_TEXT: infoText[key],
         TOOLTIP_TEXT: `REPORT.METRICS.${key}.TOOLTIP_TEXT`,
-        trend: this.calculateTrend(REPORTS_KEYS[key]),
+        trend: this.calculateTrend(this.reportKeys[key]),
       }));
     },
   },

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatMetrics.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatMetrics.vue
@@ -42,7 +42,7 @@
 </template>
 <script>
 import { mapGetters } from 'vuex';
-import CsatMetricCard from './CsatMetricCard.vue';
+import CsatMetricCard from './ReportMetricCard.vue';
 import { CSAT_RATINGS } from 'shared/constants/messages';
 
 export default {

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatMetrics.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatMetrics.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex flex-wrap mx-0 bg-white dark:bg-slate-800 rounded-[4px] p-4 mb-5 border border-solid border-slate-75 dark:border-slate-700"
+    class="flex-col lg:flex-row flex flex-wrap mx-0 bg-white dark:bg-slate-800 rounded-[4px] p-4 mb-5 border border-solid border-slate-75 dark:border-slate-700"
   >
     <csat-metric-card
       :label="$t('CSAT_REPORTS.METRIC.TOTAL_RESPONSES.LABEL')"
@@ -18,16 +18,19 @@
       :info-text="$t('CSAT_REPORTS.METRIC.RESPONSE_RATE.TOOLTIP')"
       :value="formatToPercent(responseRate)"
     />
+
     <div
       v-if="metrics.totalResponseCount && !ratingFilterEnabled"
-      class="w-[50%] max-w-[50%] flex-[50%] report-card rtl:[direction:initial]"
+      class="w-full md:w-1/2 md:max-w-[50%] flex-1 rtl:[direction:initial] p-4"
     >
-      <h3 class="heading text-slate-800 dark:text-slate-100">
+      <h3
+        class="flex items-center text-xs md:text-sm font-medium m-0 text-slate-800 dark:text-slate-100"
+      >
         <div class="flex justify-end flex-row-reverse">
           <div
             v-for="(rating, key, index) in ratingPercentage"
             :key="rating + key + index"
-            class="pl-4"
+            class="pr-4 rtl:pl-4"
           >
             <span class="my-0 mx-0.5">{{ ratingToEmoji(key) }}</span>
             <span>{{ formatToPercent(rating) }}</span>

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportMetricCard.stories.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportMetricCard.stories.js
@@ -1,12 +1,12 @@
 import Vue from 'vue';
 import VTooltip from 'v-tooltip';
-import CsatMetricCard from './CsatMetricCard';
+import ReportMetricCard from './ReportMetricCard';
 
 Vue.use(VTooltip, { defaultHtml: false });
 
 export default {
   title: 'Components/CSAT/Metrics Card',
-  component: CsatMetricCard,
+  component: ReportMetricCard,
   argTypes: {
     label: {
       defaultValue: '',
@@ -31,12 +31,12 @@ export default {
 
 const Template = (_, { argTypes }) => ({
   props: Object.keys(argTypes),
-  components: { CsatMetricCard },
-  template: '<csat-metric-card v-bind="$props" />',
+  components: { ReportMetricCard },
+  template: '<report-metric-card v-bind="$props" />',
 });
 
-export const CsatMetricCardTemplate = Template.bind({});
-CsatMetricCardTemplate.args = {
+export const ReportMetricCardTemplate = Template.bind({});
+ReportMetricCardTemplate.args = {
   infoText: 'No. of responses / No. of survey messages sent * 100',
   label: 'Satisfaction Score',
   value: '98.5',

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportMetricCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportMetricCard.vue
@@ -1,77 +1,43 @@
+<script setup>
+defineProps({
+  label: {
+    type: String,
+    required: true,
+  },
+  value: {
+    type: String,
+    required: true,
+  },
+  infoText: {
+    type: String,
+    required: true,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+});
+</script>
 <template>
   <div
-    class="md:w-[16%] sm:w-[50%] sm:max-w-[50%] md:max-w-[16%] report-metric--card"
+    class="xs:w-full sm:max-w-[50%] lg:w-1/6 lg:max-w-[16%] m-0 p-4"
     :class="{
-      disabled: disabled,
+      'grayscale pointer-events-none opacity-30': disabled,
     }"
   >
-    <h3 class="heading">
+    <h3
+      class="flex items-center text-sm font-medium m-0 text-slate-800 dark:text-slate-100"
+    >
       <span>{{ label }}</span>
       <fluent-icon
         v-tooltip="infoText"
         size="14"
         icon="info"
-        class="report-metric--icon"
+        class="text-slate-500 dark:text-slate-200 my-0 mx-1 mt-0.5"
       />
     </h3>
-    <h4 class="metric">
+    <h4 class="text-slate-700 dark:text-slate-100 mb-0 mt-1 font-thin text-3xl">
       {{ value }}
     </h4>
   </div>
 </template>
-<script>
-export default {
-  props: {
-    label: {
-      type: String,
-      required: true,
-    },
-    value: {
-      type: String,
-      required: true,
-    },
-    infoText: {
-      type: String,
-      required: true,
-    },
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
-  },
-};
-</script>
-<style lang="scss" scoped>
-.report-metric--card {
-  margin: 0;
-  padding: var(--space-normal);
-
-  &.disabled {
-    // grayscale everything
-    filter: grayscale(100%);
-    opacity: 0.3;
-    pointer-events: none;
-  }
-
-  .heading {
-    align-items: center;
-    display: flex;
-    font-size: var(--font-size-small);
-    font-weight: var(--font-weight-bold);
-    margin: 0;
-    @apply text-slate-800 dark:text-slate-100;
-  }
-
-  .metric {
-    font-size: var(--font-size-bigger);
-    font-weight: var(--font-weight-feather);
-    margin-bottom: 0;
-    margin-top: var(--space-smaller);
-    @apply text-slate-700 dark:text-slate-100;
-  }
-}
-
-.report-metric--icon {
-  @apply text-slate-500 dark:text-slate-200 my-0 mx-0.5;
-}
-</style>

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportMetricCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportMetricCard.vue
@@ -20,6 +20,7 @@ defineProps({
 </script>
 <template>
   <div
+    ref="reportMetricContainer"
     class="xs:w-full sm:max-w-[50%] lg:w-1/6 lg:max-w-[16%] m-0 p-4"
     :class="{
       'grayscale pointer-events-none opacity-30': disabled,
@@ -28,15 +29,19 @@ defineProps({
     <h3
       class="flex items-center text-sm font-medium m-0 text-slate-800 dark:text-slate-100"
     >
-      <span>{{ label }}</span>
+      <span ref="reportMetricLabel">{{ label }}</span>
       <fluent-icon
+        ref="reportMetricInfo"
         v-tooltip="infoText"
         size="14"
         icon="info"
         class="text-slate-500 dark:text-slate-200 my-0 mx-1 mt-0.5"
       />
     </h3>
-    <h4 class="text-slate-700 dark:text-slate-100 mb-0 mt-1 font-thin text-3xl">
+    <h4
+      ref="reportMetricValue"
+      class="text-slate-700 dark:text-slate-100 mb-0 mt-1 font-thin text-3xl"
+    >
       {{ value }}
     </h4>
   </div>

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportMetricCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportMetricCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="md:w-[16%] sm:w-[50%] sm:max-w-[50%] md:max-w-[16%] csat--metric-card"
+    class="md:w-[16%] sm:w-[50%] sm:max-w-[50%] md:max-w-[16%] report-metric--card"
     :class="{
       disabled: disabled,
     }"
@@ -11,7 +11,7 @@
         v-tooltip="infoText"
         size="14"
         icon="info"
-        class="csat--icon"
+        class="report-metric--icon"
       />
     </h3>
     <h4 class="metric">
@@ -42,7 +42,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-.csat--metric-card {
+.report-metric--card {
   margin: 0;
   padding: var(--space-normal);
 
@@ -71,7 +71,7 @@ export default {
   }
 }
 
-.csat--icon {
+.report-metric--icon {
   @apply text-slate-500 dark:text-slate-200 my-0 mx-0.5;
 }
 </style>

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/ReportMetricCard.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/ReportMetricCard.spec.js
@@ -1,17 +1,17 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
-import CsatMetricCard from '../CsatMetricCard.vue';
+import ReportMetricCard from '../ReportMetricCard.vue';
 
 import VTooltip from 'v-tooltip';
 
 const localVue = createLocalVue();
 localVue.use(VTooltip);
 
-describe('CsatMetricCard.vue', () => {
+describe('ReportMetricCard.vue', () => {
   it('renders props correctly', () => {
     const label = 'Total Responses';
     const value = '100';
     const infoText = 'Total number of responses';
-    const wrapper = shallowMount(CsatMetricCard, {
+    const wrapper = shallowMount(ReportMetricCard, {
       propsData: { label, value, infoText },
       localVue,
       stubs: ['fluent-icon'],
@@ -19,27 +19,31 @@ describe('CsatMetricCard.vue', () => {
 
     expect(wrapper.find('.heading span').text()).toMatch(label);
     expect(wrapper.find('.metric').text()).toMatch(value);
-    expect(wrapper.find('.csat--icon').classes()).toContain('has-tooltip');
+    expect(wrapper.find('.report-metric--icon').classes()).toContain(
+      'has-tooltip'
+    );
   });
 
   it('adds disabled class when disabled prop is true', () => {
-    const wrapper = shallowMount(CsatMetricCard, {
+    const wrapper = shallowMount(ReportMetricCard, {
       propsData: { label: '', value: '', infoText: '', disabled: true },
       localVue,
       stubs: ['fluent-icon'],
     });
 
-    expect(wrapper.find('.csat--metric-card').classes()).toContain('disabled');
+    expect(wrapper.find('.report--metric-card').classes()).toContain(
+      'disabled'
+    );
   });
 
   it('does not add disabled class when disabled prop is false', () => {
-    const wrapper = shallowMount(CsatMetricCard, {
+    const wrapper = shallowMount(ReportMetricCard, {
       propsData: { label: '', value: '', infoText: '', disabled: false },
       localVue,
       stubs: ['fluent-icon'],
     });
 
-    expect(wrapper.find('.csat--metric-card').classes()).not.toContain(
+    expect(wrapper.find('.report--metric-card').classes()).not.toContain(
       'disabled'
     );
   });

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/ReportMetricCard.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/ReportMetricCard.spec.js
@@ -17,9 +17,9 @@ describe('ReportMetricCard.vue', () => {
       stubs: ['fluent-icon'],
     });
 
-    expect(wrapper.find('.heading span').text()).toMatch(label);
-    expect(wrapper.find('.metric').text()).toMatch(value);
-    expect(wrapper.find('.report-metric--icon').classes()).toContain(
+    expect(wrapper.find({ ref: 'reportMetricLabel' }).text()).toMatch(label);
+    expect(wrapper.find({ ref: 'reportMetricValue' }).text()).toMatch(value);
+    expect(wrapper.find({ ref: 'reportMetricInfo' }).classes()).toContain(
       'has-tooltip'
     );
   });
@@ -31,8 +31,8 @@ describe('ReportMetricCard.vue', () => {
       stubs: ['fluent-icon'],
     });
 
-    expect(wrapper.find('.report--metric-card').classes()).toContain(
-      'disabled'
+    expect(wrapper.classes().join(' ')).toContain(
+      'grayscale pointer-events-none opacity-30'
     );
   });
 
@@ -43,8 +43,8 @@ describe('ReportMetricCard.vue', () => {
       stubs: ['fluent-icon'],
     });
 
-    expect(wrapper.find('.report--metric-card').classes()).not.toContain(
-      'disabled'
-    );
+    expect(
+      wrapper.find({ ref: 'reportMetricContainer' }).classes().join(' ')
+    ).not.toContain('grayscale pointer-events-none opacity-30');
   });
 });


### PR DESCRIPTION
We want to reuse the existing reporting components for our upcoming bot reports. Hence, making the required changes and cleaning up existing components.


- `ReportContainer.vue` to accept report keys via prompts ( We will be using different report keys in bot reports )
-  `CsatMetricCard` to `ReportMetricCard`  for generic use since we are using it also for the bot reports.

----

<img width="1564" alt="Screenshot 2024-02-27 at 7 02 38 PM" src="https://github.com/chatwoot/chatwoot/assets/73185/9ac825bc-ca55-4c80-bacb-d8c2facb29a6">
