### PR TITLE
fix: Filter dropdown alignment issue in reports page

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/FilterSelector.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/FilterSelector.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col md:flex-row justify-between mb-4">
-    <div class="md:grid flex flex-col filter-container gap-3 w-full">
+    <div class="md:grid flex flex-col filter-container gap-3 w-full items-end">
       <reports-filters-date-range @on-range-change="onDateRangeChange" />
       <woot-date-range-picker
         v-if="isDateRangeSelected"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will fix the alignment issue with the filter dropdown on the reports page. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Before**
<img width="850" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/5915cbe1-24cf-4cd6-8427-dddba72ce13a">


**After**
<img width="850" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/9c9cd683-72d7-40c4-9d4d-d79c58b6b60f">



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
