### PR TITLE
fix: reply_time report tooltip

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/report.json
+++ b/app/javascript/dashboard/i18n/locale/en/report.json
@@ -37,7 +37,7 @@
       },
       "REPLY_TIME": {
         "NAME": "Customer waiting time",
-        "TOOLTIP_TEXT": "Waiting time is %{metricValue} (based on %{conversationCount} conversations)"
+        "TOOLTIP_TEXT": "Waiting time is %{metricValue} (based on %{conversationCount} replies)"
       }
     },
     "DATE_RANGE_OPTIONS": {


### PR DESCRIPTION
- The count displayed is of reporting events, ie the number of responses. Instead we were showing the copy as conversations which would confuse users.


![chatwoot-report](https://github.com/chatwoot/chatwoot/assets/73185/00545d83-7de0-40d3-8e90-ad45c5e0c962)


ref: https://discord.com/channels/647412545203994635/1207337933854613595/1211654122974089216