### PR TITLE
fix: Variant success button in dark mode

### DIFF
--- a/app/javascript/dashboard/assets/scss/widgets/_buttons.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_buttons.scss
@@ -52,11 +52,7 @@ button {
   }
 
   &.success {
-    @apply bg-[#44ce4b] text-white dark:text-white;
-
-    &:hover {
-      @apply bg-[#3dbb45];
-    }
+    @apply bg-[#44ce4b] dark:bg-[#44ce4b] text-white dark:text-white;
   }
 
   &.secondary {

--- a/app/javascript/dashboard/assets/scss/widgets/_buttons.scss
+++ b/app/javascript/dashboard/assets/scss/widgets/_buttons.scss
@@ -53,6 +53,10 @@ button {
 
   &.success {
     @apply bg-[#44ce4b] text-white dark:text-white;
+
+    &:hover {
+      @apply bg-[#3dbb45];
+    }
   }
 
   &.secondary {


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the issue of the success button displaying the wrong color in dark mode when we hover it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Before**

https://github.com/chatwoot/chatwoot/assets/64252451/5342666d-2826-4029-973d-f3d8627c33b8



**After**

https://github.com/chatwoot/chatwoot/assets/64252451/357a4c3b-dd9d-43eb-86b8-f5658caf5068




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
