### PR TITLE
fix: Fixes #8904 Unable to build docker image on Macbook M1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
         RAILS_SERVE_STATIC_FILES: 'false'
     tty: true
     stdin_open: true
-    image: chatwoot:development
+    image: chatwoot/chatwoot:develop
     env_file: .env
 
   rails:

--- a/docker/dockerfiles/rails.Dockerfile
+++ b/docker/dockerfiles/rails.Dockerfile
@@ -1,4 +1,4 @@
-FROM chatwoot:development
+FROM chatwoot/chatwoot:develop
 
 RUN chmod +x docker/entrypoints/rails.sh
 

--- a/docker/dockerfiles/webpack.Dockerfile
+++ b/docker/dockerfiles/webpack.Dockerfile
@@ -1,4 +1,4 @@
-FROM chatwoot:development
+FROM chatwoot/chatwoot:develop
 
 RUN chmod +x docker/entrypoints/webpack.sh
 


### PR DESCRIPTION
## Description
fix: [#8904](https://github.com/chatwoot/chatwoot/issues/8904)

The problem is in the docker image. The image being used is chatwoot:development, I searched for this image on Docker Hub, and can only find [one](https://hub.docker.com/layers/umar482/chatwoot/development/images/sha256-cc01cfc8cf7c42bd18310520b7a8dd72204f3c3c3af649b9a4a1796370742042?context=explore) and is not from the user chatwoot.
To fix it, I change the image tag to develop and specify the user: [chatwoot/chatwoot:develop](https://hub.docker.com/layers/chatwoot/chatwoot/develop/images/sha256-b9430a2f18dc08b0ba1189a256bb7f147bcfe46e88a1ef7eb266f677a0642aba?context=explore).

I replace the image in these three files:
1-docker-compose.yml
2 - docker/dockerfiles/webpack.Dockerfile
3 - docker/dockerfiles/rails.Dockerfile

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
