### PR TITLE
feat: filtering by private messages optionally

### DIFF
--- a/app/finders/message_finder.rb
+++ b/app/finders/message_finder.rb
@@ -15,8 +15,10 @@ class MessageFinder
   end
 
   def messages
+    if @params[:private].present?
+      return conversation_messages.where(private: true)
+    end
     return conversation_messages if @params[:filter_internal_messages].blank?
-
     conversation_messages.where.not('private = ? OR message_type = ?', true, 2)
   end
 

--- a/spec/finders/message_finder_spec.rb
+++ b/spec/finders/message_finder_spec.rb
@@ -73,5 +73,18 @@ describe MessageFinder do
         expect(result.last.id).to be conversation.messages[-2].id
       end
     end
+
+    context 'with private attribute' do
+      let(:params) do
+        {
+          private: true
+        }
+      end
+
+      it 'filter conversations by private' do
+        result = message_finder.perform
+        expect(result.count).to be 0
+      end
+    end
   end
 end


### PR DESCRIPTION
# Pull Request Template

## Description
Checking for private parameter in order to filter private messages at the API messages endpoint.
It closes the issue #9034
Fixes # (issue)

## Type of change

Please delete options that are not relevant.
 
- [x] New feature (non-breaking change which adds functionality) 
- [x] This change requires a documentation update

## How Has This Been Tested?

I created a new test at `messages_finder_spec.rb`. Also the remaining tests ran just fine.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
