### PR TITLE
docs: added missing type text

### DIFF
--- a/swagger/definitions/request/conversation/create_message.yml
+++ b/swagger/definitions/request/conversation/create_message.yml
@@ -13,7 +13,7 @@ properties:
     description: Flag to identify if it is a private note
   content_type:
     type: string
-    enum: ['input_email', 'cards', 'input_select', 'form' , 'article']
+    enum: ['text', 'input_email', 'cards', 'input_select', 'form' , 'article']
     example: 'cards'
     description: 'if you want to create custom message types'
   content_attributes:

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -6509,6 +6509,7 @@
         "content_type": {
           "type": "string",
           "enum": [
+            "text",
             "input_email",
             "cards",
             "input_select",


### PR DESCRIPTION
# Pull Request Template

## Description

It adds the **text** type of message which is missing on the documentation, here a code that uses the text type:
```ruby
  # lib/integrations/csml/processor_service.rb
  def process_image_messages(message_payload, conversation)
    message = conversation.messages.new(
      {
        message_type: :outgoing,
        account_id: conversation.account_id,
        inbox_id: conversation.inbox_id,
        content: '',
        content_type: 'text',
        sender: agent_bot
      }
    )

    prepare_attachment(message_payload, message, conversation.account_id)
    message.save!
  end
```
Fixes # (issue)

## Type of change
Documentation


## How Has This Been Tested?

Pretty much doc updates


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
