### PR TITLE
fix: inline attachments not handled if tag was missing

### DIFF
--- a/app/mailboxes/mailbox_helper.rb
+++ b/app/mailboxes/mailbox_helper.rb
@@ -80,10 +80,15 @@ module MailboxHelper
 
   def embed_plain_text_email_with_inline_image(mail_attachment)
     attachment_name = mail_attachment[:original].filename
+    img_tag = "<img src=\"#{inline_image_url(mail_attachment[:blob])}\" alt=\"#{attachment_name}\">"
 
-    @text_content = @text_content.gsub(
-      "[image: #{attachment_name}]", "<img src=\"#{inline_image_url(mail_attachment[:blob])}\" alt=\"#{attachment_name}\">"
-    )
+    tag_to_replace = "[image: #{attachment_name}]"
+
+    if @text_content.include?(tag_to_replace)
+      @text_content = @text_content.gsub(tag_to_replace, img_tag)
+    else
+      @text_content += "\n\n#{img_tag}"
+    end
   end
 
   def inline_image_url(blob)

--- a/spec/mailboxes/mailbox_helper_spec.rb
+++ b/spec/mailboxes/mailbox_helper_spec.rb
@@ -48,4 +48,33 @@ RSpec.describe MailboxHelper do
       end
     end
   end
+
+  describe '#embed_plain_text_email_with_inline_image' do
+    let(:mail_attachment) do
+      {
+        original: OpenStruct.new(filename: 'image.png'),
+        blob: get_blob_for('spec/assets/avatar.png', 'image/png')
+      }
+    end
+
+    let(:helper_instance) { mailbox_helper_obj.new(conversation, processed_mail) }
+
+    it 'replaces the image tag in the text content' do
+      helper_instance.instance_variable_set(:@text_content, 'Hello [image: image.png] World')
+      helper_instance.send(:embed_plain_text_email_with_inline_image, mail_attachment)
+
+      text_content = helper_instance.instance_variable_get(:@text_content)
+
+      expect(text_content).to include(Rails.application.routes.url_helpers.url_for(mail_attachment[:blob]))
+      expect(text_content).not_to include('[image: avatar.png]')
+    end
+
+    it 'replaces the image tag in the text content even if there is not tag to replace' do
+      helper_instance.instance_variable_set(:@text_content, 'Hello World')
+      helper_instance.send(:embed_plain_text_email_with_inline_image, mail_attachment)
+
+      text_content = helper_instance.instance_variable_get(:@text_content)
+      expect(text_content).to include(Rails.application.routes.url_helpers.url_for(mail_attachment[:blob]))
+    end
+  end
 end


### PR DESCRIPTION
When processing inline images, `MailboxHelper` would find the image that looks like `[image: image.png]` and replace it with an `<img>` tag, however this search candidate is not present when the email is sent from Apple mail app (verified) or Yahoo mail (Yet to be verified).

This PR updates the method to handle both cases, in case the search candidate is not present, we simply append the image at the end