### PR TITLE
fix: Conversation assignment notification title

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -106,8 +106,10 @@ class Notification < ApplicationRecord
     case notification_type
     when 'conversation_creation'
       message_body(conversation.messages.first)
-    when 'assigned_conversation_new_message', 'participating_conversation_new_message', 'conversation_assignment', 'conversation_mention'
+    when 'assigned_conversation_new_message', 'participating_conversation_new_message', 'conversation_mention'
       message_body(secondary_actor)
+    when 'conversation_assignment'
+      message_body(conversation.messages.incoming.last)
     else
       ''
     end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -76,6 +76,13 @@ has been assigned to you"
       expect(notification.push_message_body).to eq "#{message.sender.name}: #{message.content.truncate_words(10)}"
     end
 
+    it 'returns appropriate body suited for the notification type conversation_assignment' do
+      conversation = create(:conversation)
+      message = create(:message, sender: create(:user), content: Faker::Lorem.paragraphs(number: 2), conversation: conversation)
+      notification = create(:notification, notification_type: 'conversation_assignment', primary_actor: conversation, secondary_actor: message)
+      expect(notification.push_message_body).to eq "#{message.sender.name}: #{message.content.truncate_words(10)}"
+    end
+
     it 'returns appropriate body suited for the notification type assigned_conversation_new_message' do
       conversation = create(:conversation)
       message = create(:message, sender: create(:user), content: Faker::Lorem.paragraphs(number: 2), conversation: conversation)


### PR DESCRIPTION
As per the latest update, we display message content for all notifications. But In conversation assignments, the last message is an activity message, which isn't useful for the user. This PR resolves this issue by selecting the last incoming message.