### PR TITLE
fix: Change the column identifier from string to text to avoid overflow

### DIFF
--- a/app/models/notification_subscription.rb
+++ b/app/models/notification_subscription.rb
@@ -3,7 +3,7 @@
 # Table name: notification_subscriptions
 #
 #  id                      :bigint           not null, primary key
-#  identifier              :string
+#  identifier              :text
 #  subscription_attributes :jsonb            not null
 #  subscription_type       :integer          not null
 #  created_at              :datetime         not null

--- a/db/migrate/20240306201954_change_identifier_type_in_notifications_subscriptions.rb
+++ b/db/migrate/20240306201954_change_identifier_type_in_notifications_subscriptions.rb
@@ -1,0 +1,9 @@
+class ChangeIdentifierTypeInNotificationsSubscriptions < ActiveRecord::Migration[7.0]
+  def up
+    change_column :notification_subscriptions, :identifier, :text
+  end
+
+  def down
+    change_column :notification_subscriptions, :identifier, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema[7.0].define(version: 2024_02_16_055809) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_06_201954) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -736,7 +735,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_16_055809) do
     t.jsonb "subscription_attributes", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "identifier"
+    t.text "identifier"
     t.index ["identifier"], name: "index_notification_subscriptions_on_identifier", unique: true
     t.index ["user_id"], name: "index_notification_subscriptions_on_user_id"
   end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-3118/cannot-subscribe-to-notifications-on-microsoft-edge

Fix the issue with notifications in Microsoft Edge. The identifier generated from the Edge push notification payload has more than 255 characters. The API calls were failing due to this. This PR would fix the issue.