### PR TITLE
feat: Update the `location` and `country_code` when creating or updating the contact.

### DIFF
--- a/app/builders/contact_inbox_with_contact_builder.rb
+++ b/app/builders/contact_inbox_with_contact_builder.rb
@@ -49,14 +49,35 @@ class ContactInboxWithContactBuilder
   end
 
   def create_contact
-    account.contacts.create!(
-      name: contact_attributes[:name] || ::Haikunator.haikunate(1000),
+    contact_params = build_contact_params
+    account.contacts.create!(contact_params)
+  end
+
+  def build_contact_params
+    {
+      name: contact_name,
       phone_number: contact_attributes[:phone_number],
       email: contact_attributes[:email],
       identifier: contact_attributes[:identifier],
+      location: contact_location,
+      country_code: contact_country_code,
       additional_attributes: contact_attributes[:additional_attributes],
       custom_attributes: contact_attributes[:custom_attributes]
-    )
+    }
+  end
+
+  def contact_name
+    contact_attributes[:name] || ::Haikunator.haikunate(1000)
+  end
+
+  def contact_location
+    # TODO: Deprecate the additional_attributes['city'] in favor of country_code
+    contact_attributes[:location] || contact_attributes.dig(:additional_attributes, 'city')
+  end
+
+  def contact_country_code
+    # TODO: Deprecate the additional_attributes['country_code'] in favor of country_code
+    contact_attributes[:country_code] || contact_attributes.dig(:additional_attributes, 'country_code')
   end
 
   def find_contact

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -89,6 +89,9 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
   def update
     @contact.assign_attributes(contact_update_params)
+    # TODO: Remove this once we standardize the location field across the app
+    @contact.country_code = params[:country_code] || params.dig(:additional_attributes, 'country_code')
+    @contact.location = params[:location] || params.dig(:additional_attributes, 'city')
     @contact.save!
     process_avatar_from_url
   end
@@ -148,7 +151,8 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def permitted_params
-    params.permit(:name, :identifier, :email, :phone_number, :avatar, :blocked, :avatar_url, additional_attributes: {}, custom_attributes: {})
+    params.permit(:name, :identifier, :email, :phone_number, :avatar, :location, :country_code, :blocked, :avatar_url, additional_attributes: {},
+                                                                                                                       custom_attributes: {})
   end
 
   def contact_custom_attributes

--- a/app/controllers/api/v1/widget/contacts_controller.rb
+++ b/app/controllers/api/v1/widget/contacts_controller.rb
@@ -70,7 +70,18 @@ class Api::V1::Widget::ContactsController < Api::V1::Widget::BaseController
   end
 
   def permitted_params
-    params.permit(:website_token, :identifier, :identifier_hash, :email, :name, :avatar_url, :phone_number, custom_attributes: {},
-                                                                                                            additional_attributes: {})
+    params.permit(
+      :website_token,
+      :identifier,
+      :identifier_hash,
+      :email,
+      :name,
+      :avatar_url,
+      :location,
+      :country_code,
+      :phone_number,
+      custom_attributes: {},
+      additional_attributes: {}
+    )
   end
 end

--- a/app/controllers/public/api/v1/inboxes/contacts_controller.rb
+++ b/app/controllers/public/api/v1/inboxes/contacts_controller.rb
@@ -43,6 +43,6 @@ class Public::Api::V1::Inboxes::ContactsController < Public::Api::V1::InboxesCon
   end
 
   def permitted_params
-    params.permit(:identifier, :identifier_hash, :email, :name, :avatar_url, :phone_number, custom_attributes: {})
+    params.permit(:identifier, :identifier_hash, :email, :name, :avatar_url, :location, :city, :phone_number, custom_attributes: {})
   end
 end

--- a/app/jobs/contact_ip_lookup_job.rb
+++ b/app/jobs/contact_ip_lookup_job.rb
@@ -14,9 +14,12 @@ class ContactIpLookupJob < ApplicationJob
     return unless geocoder_result
 
     contact.additional_attributes ||= {}
+    # TODO: Deprecate these fields in favor of the new location field
     contact.additional_attributes['city'] = geocoder_result.city
     contact.additional_attributes['country'] = geocoder_result.country
     contact.additional_attributes['country_code'] = geocoder_result.country_code
+    contact.country_code = geocoder_result.country_code
+    contact.location = geocoder_result.city
     contact.save!
   end
 

--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -60,9 +60,15 @@ class DataImport::ContactManager
 
   def update_contact_attributes(params, contact)
     contact.name = params[:name] if params[:name].present?
+    update_additional_attributes(params, contact)
+    contact.country_code = params[:country_code] if params[:country_code].present?
+    contact.location = params[:location] if params[:location].present?
+    contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number)))
+  end
+
+  def update_additional_attributes(params, contact)
     contact.additional_attributes ||= {}
     contact.additional_attributes[:company] = params[:company] if params[:company].present?
     contact.additional_attributes[:city] = params[:city] if params[:city].present?
-    contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number)))
   end
 end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-3014/update-the-location-and-country-code-when-the-contact-createdupdated