### PR TITLE
feat: Update the `location` and `country_code` when creating or updating the contact

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -209,7 +209,7 @@ class Contact < ApplicationRecord
 
   def update_contact_location_and_country_code
     # TODO: Ensure that location and country_code are updated from additional_attributes.
-    # we will remove this after all contacts have been updated and the location field has been standardized across the app.
+    # We will remove this once all contacts are updated and both the location and country_code fields are standardized throughout the app.
     self.location = additional_attributes['city']
     self.country_code = additional_attributes['country']
   end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -61,6 +61,7 @@ class Contact < ApplicationRecord
   after_create_commit :dispatch_create_event, :ip_lookup
   after_update_commit :dispatch_update_event
   after_destroy_commit :dispatch_destroy_event
+  before_save :update_contact_location_and_country_code
 
   enum contact_type: { visitor: 0, lead: 1, customer: 2 }
 
@@ -204,6 +205,13 @@ class Contact < ApplicationRecord
   def prepare_jsonb_attributes
     self.additional_attributes = {} if additional_attributes.blank?
     self.custom_attributes = {} if custom_attributes.blank?
+  end
+
+  def update_contact_location_and_country_code
+    # TODO: Ensure that location and country_code are updated from additional_attributes.
+    # we will remove this after all contacts have been updated and the location field has been standardized across the app.
+    self.location = additional_attributes['city']
+    self.country_code = additional_attributes['country']
   end
 
   def dispatch_create_event

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -75,4 +75,12 @@ RSpec.describe Contact do
       expect(contact.email).to eq 'test@test.com'
     end
   end
+
+  context 'when city and country code passed in additional attributes' do
+    it 'updates location and country code' do
+      contact = create(:contact, additional_attributes: { city: 'New York', country: 'US' })
+      expect(contact.location).to eq 'New York'
+      expect(contact.country_code).to eq 'US'
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-3014/update-the-location-and-country-code-when-the-contact-createdupdated