### PR TITLE
fix: Location message name overflows

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Location.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Location.vue
@@ -1,15 +1,45 @@
+<script setup>
+import { computed, toRefs } from 'vue';
+
+const props = defineProps({
+  latitude: {
+    type: Number,
+    default: undefined,
+  },
+  longitude: {
+    type: Number,
+    default: undefined,
+  },
+  name: {
+    type: String,
+    default: '',
+  },
+});
+
+const { latitude, longitude, name } = toRefs(props);
+
+const mapUrl = computed(
+  () => `https://maps.google.com/?q=${latitude.value},${longitude.value}`
+);
+</script>
+
 <template>
-  <div class="location message-text__wrap">
-    <div class="icon-wrap">
-      <fluent-icon icon="location" class="file--icon" size="32" />
-    </div>
-    <div class="meta">
+  <div
+    class="location message-text__wrap flex flex-row items-center justify-start gap-1 w-full py-1 px-0 cursor-pointer overflow-hidden"
+  >
+    <fluent-icon
+      icon="location"
+      class="file--icon text-slate-600 dark:text-slate-200 leading-none my-0 flex items-center flex-shrink-0"
+      size="32"
+    />
+    <div class="flex flex-col items-start w-11/12">
       <h5
-        class="text-sm text-slate-800 dark:text-slate-100 overflow-hidden whitespace-nowrap text-ellipsis"
+        class="text-sm text-slate-800 dark:text-slate-100 overflow-hidden whitespace-nowrap text-ellipsis m-0 w-full"
+        :title="name"
       >
         {{ name }}
       </h5>
-      <div class="link-wrap">
+      <div class="flex items-center">
         <a
           class="download clear link button small"
           rel="noreferrer noopener nofollow"
@@ -22,49 +52,3 @@
     </div>
   </div>
 </template>
-
-<script>
-export default {
-  props: {
-    latitude: {
-      type: Number,
-      default: undefined,
-    },
-    longitude: {
-      type: Number,
-      default: undefined,
-    },
-    name: {
-      type: String,
-      default: '',
-    },
-  },
-  computed: {
-    mapUrl() {
-      return `https://maps.google.com/?q=${this.latitude},${this.longitude}`;
-    },
-  },
-};
-</script>
-
-<style lang="scss" scoped>
-.location {
-  @apply flex flex-row py-1 px-0 cursor-pointer;
-
-  .icon-wrap {
-    @apply text-slate-600 dark:text-slate-200 leading-none my-0 mx-1;
-  }
-
-  .text-block-title {
-    @apply m-0 text-slate-800 dark:text-slate-100 break-words;
-  }
-
-  .meta {
-    @apply flex flex-col items-center pr-4;
-  }
-
-  .link-wrap {
-    @apply flex;
-  }
-}
-</style>

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Location.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Location.vue
@@ -23,11 +23,11 @@ const mapUrl = computed(
 
 <template>
   <div
-    class="location message-text__wrap flex flex-row items-center justify-start gap-1 w-full py-1 px-0 cursor-pointer overflow-hidden"
+    class="flex flex-row items-center justify-start gap-1 w-full py-1 px-0 cursor-pointer overflow-hidden"
   >
     <fluent-icon
       icon="location"
-      class="file--icon text-slate-600 dark:text-slate-200 leading-none my-0 flex items-center flex-shrink-0"
+      class="text-slate-600 dark:text-slate-200 leading-none my-0 flex items-center flex-shrink-0"
       size="32"
     />
     <div class="flex flex-col items-start flex-1 min-w-0">
@@ -39,7 +39,7 @@ const mapUrl = computed(
       </h5>
       <div class="flex items-center">
         <a
-          class="download clear link button small"
+          class="text-woot-600 dark:text-woot-600 text-xs underline"
           rel="noreferrer noopener nofollow"
           target="_blank"
           :href="mapUrl"

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Location.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Location.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, toRefs } from 'vue';
+import { computed } from 'vue';
 
 const props = defineProps({
   latitude: {
@@ -16,10 +16,8 @@ const props = defineProps({
   },
 });
 
-const { latitude, longitude, name } = toRefs(props);
-
 const mapUrl = computed(
-  () => `https://maps.google.com/?q=${latitude.value},${longitude.value}`
+  () => `https://maps.google.com/?q=${props.latitude},${props.longitude}`
 );
 </script>
 
@@ -32,9 +30,9 @@ const mapUrl = computed(
       class="file--icon text-slate-600 dark:text-slate-200 leading-none my-0 flex items-center flex-shrink-0"
       size="32"
     />
-    <div class="flex flex-col items-start w-11/12">
+    <div class="flex flex-col items-start flex-1 min-w-0">
       <h5
-        class="text-sm text-slate-800 dark:text-slate-100 overflow-hidden whitespace-nowrap text-ellipsis m-0 w-full"
+        class="text-sm text-slate-800 dark:text-slate-100 truncate m-0 w-full"
         :title="name"
       >
         {{ name }}

--- a/app/services/telegram/incoming_message_service.rb
+++ b/app/services/telegram/incoming_message_service.rb
@@ -130,6 +130,7 @@ class Telegram::IncomingMessageService
     @message.attachments.new(
       account_id: @message.account_id,
       file_type: :location,
+      fallback_title: location_fallback_title,
       coordinates_lat: location['latitude'],
       coordinates_long: location['longitude']
     )
@@ -137,6 +138,16 @@ class Telegram::IncomingMessageService
 
   def file
     @file ||= visual_media_params || params[:message][:voice].presence || params[:message][:audio].presence || params[:message][:document].presence
+  end
+
+  def location_fallback_title
+    return '' if venue.blank?
+
+    venue[:title] || ''
+  end
+
+  def venue
+    @venue ||= params.dig(:message, :venue).presence
   end
 
   def location

--- a/spec/services/telegram/incoming_message_service_spec.rb
+++ b/spec/services/telegram/incoming_message_service_spec.rb
@@ -255,6 +255,30 @@ describe Telegram::IncomingMessageService do
         expect(Contact.all.first.name).to eq('Sojan Jose')
         expect(telegram_channel.inbox.messages.first.attachments.first.file_type).to eq('location')
       end
+
+      it 'creates appropriate conversations, message and contacts if venue is present' do
+        params = {
+          'update_id' => 2_342_342_343_242,
+          'message' => {
+            'location': {
+              'latitude': 37.7893768,
+              'longitude': -122.3895553
+            },
+            venue: {
+              title: 'San Francisco'
+            }
+          }.merge(message_params)
+        }.with_indifferent_access
+        described_class.new(inbox: telegram_channel.inbox, params: params).perform
+        expect(telegram_channel.inbox.conversations.count).not_to eq(0)
+        expect(Contact.all.first.name).to eq('Sojan Jose')
+
+        attachment = telegram_channel.inbox.messages.first.attachments.first
+        expect(attachment.file_type).to eq('location')
+        expect(attachment.coordinates_lat).to eq(37.7893768)
+        expect(attachment.coordinates_long).to eq(-122.3895553)
+        expect(attachment.fallback_title).to eq('San Francisco')
+      end
     end
 
     context 'when valid callback_query params' do


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will fix text overflow in the location message. And moved to composition API

Fixes https://linear.app/chatwoot/issue/CW-3123/location-message-text-is-not-wrapped

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Before** 
<image width="500" src="https://github.com/chatwoot/chatwoot/assets/64252451/f46ceb85-2b10-4f30-b308-8bfb3c70a7d7"><image/>

<img width="216" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/d1bb66b8-a543-4858-8f67-cbca4e133494">


**After**
<image width="500" src="https://github.com/chatwoot/chatwoot/assets/64252451/ab333b8e-fbd9-451a-9275-8b6d6d2fa244"><image/>

<img width="216" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/a42886b4-762e-4d44-ac41-24556cae9973">




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
