### PR TITLE
fix: Incorrect error response for reset password

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/profile/ChangePassword.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/profile/ChangePassword.vue
@@ -125,10 +125,9 @@ export default {
         });
         this.errorMessage = this.$t('PROFILE_SETTINGS.PASSWORD_UPDATE_SUCCESS');
       } catch (error) {
-        this.errorMessage = this.$t('RESET_PASSWORD.API.ERROR_MESSAGE');
-        if (error?.response?.data?.message) {
-          this.errorMessage = error.response.data.message;
-        }
+        this.errorMessage =
+          error?.response?.data?.error ||
+          this.$t('RESET_PASSWORD.API.ERROR_MESSAGE');
       } finally {
         this.isPasswordChanging = false;
         this.showAlert(this.errorMessage);

--- a/app/javascript/dashboard/routes/dashboard/settings/profile/ChangePassword.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/profile/ChangePassword.vue
@@ -74,6 +74,7 @@
 import { required, minLength } from 'vuelidate/lib/validators';
 import { mapGetters } from 'vuex';
 import alertMixin from 'shared/mixins/alertMixin';
+import { parseAPIErrorResponse } from 'dashboard/store/utils/api';
 
 export default {
   mixins: [alertMixin],
@@ -126,7 +127,7 @@ export default {
         this.errorMessage = this.$t('PROFILE_SETTINGS.PASSWORD_UPDATE_SUCCESS');
       } catch (error) {
         this.errorMessage =
-          error?.response?.data?.error ||
+          parseAPIErrorResponse(error) ||
           this.$t('RESET_PASSWORD.API.ERROR_MESSAGE');
       } finally {
         this.isPasswordChanging = false;


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will fix showing an incorrect error response message when resetting the password.

Fixes https://linear.app/chatwoot/issue/CW-3105/incorrect-error-response-for-reset-password

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Loom video**
https://www.loom.com/share/7d32d34bd44f4a678a6f9ef2a64c5122?sid=c6d67478-65d7-441f-bc99-4967a9c76556


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
