### PR TITLE
docs: Add RepoCloud deployment option for Chatwoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Customer engagement suite, an open-source alternative to Intercom, Zendesk, Sale
   <a href="https://marketplace.digitalocean.com/apps/chatwoot?refcode=f2238426a2a8" alt="Deploy to DigitalOcean">
      <img width="200" alt="Deploy to DO" src="https://www.deploytodo.com/do-btn-blue.svg"/>
   </a>
+  <a href="https://repocloud.io/details/?app_id=202" alt="Deploy to RepoCloud">
+     <img width="200" alt="Deploy to RepoCloud" src="https://d16t0pc4846x52.cloudfront.net/deploy-md.png"/>
+  </a>
 </p>
+
 
 <p>
   <a href="https://codeclimate.com/github/chatwoot/chatwoot/maintainability"><img src="https://api.codeclimate.com/v1/badges/e6e3f66332c91e5a4c0c/maintainability" alt="Maintainability"></a>


### PR DESCRIPTION
## Description

This update introduces a new deployment option for our GitHub README page, specifically for RepoCloud. RepoCloud is an open source app cloud marketplace that enables users to deploy and scale applications effortlessly. By adding a RepoCloud deployment button alongside existing Heroku and DigitalOcean options, we provide users with a wider range of deployment choices, catering to different preferences and requirements.

This addition aims to enhance user experience by offering a cost-effective and simple deployment solution. RepoCloud's integration promises ease of use, affordability, and the flexibility to scale applications as needed.

No dependencies are introduced with this change, and it addresses the ongoing request for more diverse deployment options within our community. This update does not fix a specific issue but rather enhances the project's accessibility and deployment versatility.

Fixes # (issue) - Not applicable

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The added deployment option has been tested by manually navigating to the provided RepoCloud link. This ensures the link directs to the correct RepoCloud application page and functions as expected. Future tests will include monitoring user feedback and deployment success rates to ensure the integration maintains high usability and reliability.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
