### PR TITLE
feat: Add a migration to update all the `contact_type` from visitor to lead for all the contacts

### DIFF
--- a/app/builders/contact_inbox_with_contact_builder.rb
+++ b/app/builders/contact_inbox_with_contact_builder.rb
@@ -55,7 +55,8 @@ class ContactInboxWithContactBuilder
       email: contact_attributes[:email],
       identifier: contact_attributes[:identifier],
       additional_attributes: contact_attributes[:additional_attributes],
-      custom_attributes: contact_attributes[:custom_attributes]
+      custom_attributes: contact_attributes[:custom_attributes],
+      contact_type: contact_attributes[:type]
     )
   end
 

--- a/app/models/channel/web_widget.rb
+++ b/app/models/channel/web_widget.rb
@@ -101,7 +101,7 @@ class Channel::WebWidget < ApplicationRecord
   def create_contact_inbox(additional_attributes = {})
     ::ContactInboxWithContactBuilder.new({
                                            inbox: inbox,
-                                           contact_attributes: { additional_attributes: additional_attributes }
+                                           contact_attributes: { additional_attributes: additional_attributes, type: 'visitor' }
                                          }).perform
   end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -7,7 +7,7 @@
 #  id                    :integer          not null, primary key
 #  additional_attributes :jsonb
 #  blocked               :boolean          default(FALSE), not null
-#  contact_type          :integer          default("visitor")
+#  contact_type          :integer          default("lead")
 #  country_code          :string           default("")
 #  custom_attributes     :jsonb
 #  email                 :string
@@ -57,7 +57,7 @@ class Contact < ApplicationRecord
   has_many :inboxes, through: :contact_inboxes
   has_many :messages, as: :sender, dependent: :destroy_async
   has_many :notes, dependent: :destroy_async
-  before_validation :prepare_contact_attributes
+  before_validation :prepare_contact_attributes, :set_default_contact_type
   after_create_commit :dispatch_create_event, :ip_lookup
   after_update_commit :dispatch_update_event
   after_destroy_commit :dispatch_destroy_event
@@ -195,6 +195,10 @@ class Contact < ApplicationRecord
   def prepare_contact_attributes
     prepare_email_attribute
     prepare_jsonb_attributes
+  end
+
+  def set_default_contact_type
+    self.contact_type ||= :lead
   end
 
   def prepare_email_attribute

--- a/app/services/contacts/sync_attributes.rb
+++ b/app/services/contacts/sync_attributes.rb
@@ -7,7 +7,7 @@ class Contacts::SyncAttributes
 
   def perform
     update_contact_location_and_country_code
-    # set_contact_type
+    set_contact_type
   end
 
   private

--- a/app/services/contacts/sync_attributes.rb
+++ b/app/services/contacts/sync_attributes.rb
@@ -7,7 +7,7 @@ class Contacts::SyncAttributes
 
   def perform
     update_contact_location_and_country_code
-    set_contact_type
+    # set_contact_type
   end
 
   private

--- a/db/migrate/20240318111131_change_default_contact_type_in_contacts.rb
+++ b/db/migrate/20240318111131_change_default_contact_type_in_contacts.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultContactTypeInContacts < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :contacts, :contact_type, from: 0, to: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_06_201954) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_18_111131) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -418,7 +418,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_06_201954) do
     t.string "identifier"
     t.jsonb "custom_attributes", default: {}
     t.datetime "last_activity_at", precision: nil
-    t.integer "contact_type", default: 0
+    t.integer "contact_type", default: 1
     t.string "middle_name", default: ""
     t.string "last_name", default: ""
     t.string "location", default: ""

--- a/spec/builders/contact_inbox_with_contact_builder_spec.rb
+++ b/spec/builders/contact_inbox_with_contact_builder_spec.rb
@@ -96,4 +96,18 @@ describe ContactInboxWithContactBuilder do
       expect(contact_inbox.contact.id).to be(contact.id)
     end
   end
+
+  it 'creates contact type as visitor by default' do
+    contact_inbox = described_class.new(
+      source_id: '123456',
+      inbox: inbox,
+      contact_attributes: {
+        name: 'Contact',
+        phone_number: '',
+        type: 'visitor'
+      }
+    ).perform
+
+    expect(contact_inbox.contact.contact_type).to eq('visitor')
+  end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Contact do
     it 'sets email to nil when empty string' do
       contact = create(:contact, email: '')
       expect(contact.email).to be_nil
-      expect(contact.contact_type).to eq('visitor')
+      expect(contact.contact_type).to eq('lead')
     end
 
     it 'sets custom_attributes to {} when nil' do
@@ -87,9 +87,9 @@ RSpec.describe Contact do
   end
 
   context 'when a contact is created' do
-    it 'has contact type "visitor" by default' do
+    it 'has contact type "lead" by default' do
       contact = create(:contact)
-      expect(contact.contact_type).to eq 'visitor'
+      expect(contact.contact_type).to eq 'lead'
     end
 
     it 'has contact type "lead" when email is present' do

--- a/spec/services/contacts/sync_attributes_spec.rb
+++ b/spec/services/contacts/sync_attributes_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Contacts::SyncAttributes do
     context 'when contact has neither email/phone number nor social details' do
       it 'does not change contact type' do
         described_class.new(contact).perform
-        expect(contact.reload.contact_type).to eq('visitor')
+        expect(contact.reload.contact_type).to eq('lead')
       end
     end
 


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-3027/add-a-migration-to-update-the-contact-type-for-all-the-existing.
- Set default `contact_type` will be lead.
- Set `contact_type` visitor default for live chat contacts.
