### PR TITLE
fix: use safe nav when downcasing email in from_email

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -169,7 +169,7 @@ class Contact < ApplicationRecord
   end
 
   def self.from_email(email)
-    find_by(email: email.downcase)
+    find_by(email: email&.downcase)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -157,7 +157,7 @@ class User < ApplicationRecord
   end
 
   def self.from_email(email)
-    find_by(email: email.downcase)
+    find_by(email: email&.downcase)
   end
 
   private


### PR DESCRIPTION
# Pull Request Template

## Description

I used the safe navigation operator to avoid a `NoMethodError`, bringing behavior of the `from_email` method in line with `find_by` and previous behavior of Chatwoot.

Fixes #9138

## Type of change

Please delete options that are not relevant.

- [✅] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've verified that the previous working behavior via Slack bot response no longer crashes and makes its way into Chatwoot.

## Checklist:

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my code
- [N/A] I have commented on my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [❌] I have added tests that prove my fix is effective or that my feature works
- [✅] New and existing unit tests pass locally with my changes
- [N/A] Any dependent changes have been merged and published in downstream modules
