### PR TITLE
Fix transparent background issue

### DIFF
--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -68,6 +68,7 @@ export const IFrameHelper = {
       'camera;microphone;fullscreen;display-capture;picture-in-picture;clipboard-write;';
     iframe.id = 'chatwoot_live_chat_widget';
     iframe.style.visibility = 'hidden';
+    iframe.style.colorScheme = 'normal';
 
     let holderClassName = `woot-widget-holder woot--hide woot-elements--${window.$chatwoot.position}`;
     if (window.$chatwoot.hideMessageBubble) {


### PR DESCRIPTION
Solution based on https://stackoverflow.com/a/70119968

# Pull Request Template

## Description

Chrome makes the background of the iframe white:
<img width="450" alt="Screenshot 2024-03-21 at 12 44 42" src="https://github.com/chatwoot/chatwoot/assets/1109982/a4189b4b-0a9c-4084-9830-1fce0d1442a0">


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested it manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
