### PR TITLE
feat: Convert `cached_label_list` to text

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -6,7 +6,7 @@
 #  additional_attributes  :jsonb
 #  agent_last_seen_at     :datetime
 #  assignee_last_seen_at  :datetime
-#  cached_label_list      :string
+#  cached_label_list      :text
 #  contact_last_seen_at   :datetime
 #  custom_attributes      :jsonb
 #  first_reply_created_at :datetime

--- a/db/migrate/20240322071629_convert_cached_label_list_to_text.rb
+++ b/db/migrate/20240322071629_convert_cached_label_list_to_text.rb
@@ -1,0 +1,32 @@
+class ConvertCachedLabelListToText < ActiveRecord::Migration[7.0]
+  def up
+    change_column :conversations, :cached_label_list, :text
+  end
+
+  def down
+    # This might cause data loss if the text is longer than 255 characters
+    # lets start by truncating the data to 255 characters
+    Conversation.where('LENGTH(cached_label_list) > 255').find_in_batches do |conversation_batch|
+      Conversation.transaction do
+        conversation_batch.each do |conversation|
+          conversation.update!(cached_label_list: truncate_list(conversation.cached_label_list))
+        end
+      end
+    end
+
+    change_column :conversations, :cached_label_list, :string
+  end
+
+  private
+
+  # Truncate the list to 255 characters or less
+  # by removing the last element until the length is less than 255
+  def truncate_list(label_list)
+    labels = label_list.split(',')
+
+    # we add the `labels.length - 1` to account for the commas
+    labels.pop while (labels.join(',').length + labels.length - 1) > 255
+
+    labels.join(',')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_19_062553) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_22_071629) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -472,7 +472,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_19_062553) do
     t.integer "priority"
     t.bigint "sla_policy_id"
     t.datetime "waiting_since"
-    t.string "cached_label_list"
+    t.text "cached_label_list"
     t.index ["account_id", "display_id"], name: "index_conversations_on_account_id_and_display_id", unique: true
     t.index ["account_id", "id"], name: "index_conversations_on_id_and_account_id"
     t.index ["account_id", "inbox_id", "status", "assignee_id"], name: "conv_acid_inbid_stat_asgnid_idx"


### PR DESCRIPTION
We use `cached_label_list` column to hold the list of labels attached to a conversation, however the column type for it was `string` with a limit of 255 chars, this is not sufficient, since a conversation can have virtually unlimited labels. 

This caused the addition of any new labels to break once the char count reached 255. This PR fixes that by changing the column type to text

Fixes: https://github.com/chatwoot/chatwoot/issues/9094


## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

Tested locally for up and down queries both

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
