### PR TITLE
feat: use better loading state

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/SettingsLayout.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/SettingsLayout.vue
@@ -1,6 +1,23 @@
+<script setup>
+defineProps({
+  isLoading: {
+    type: Boolean,
+    default: false,
+  },
+  loadingMessage: {
+    type: String,
+    default: '',
+  },
+});
+</script>
 <template>
   <div class="flex flex-col w-full h-full gap-10 font-inter">
     <slot name="header" />
-    <slot name="body" />
+    <div>
+      <slot v-if="isLoading" name="loading">
+        <woot-loading-state :message="loadingMessage" />
+      </slot>
+      <slot v-else name="body" />
+    </div>
   </div>
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/components/BaseSettingsListItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/components/BaseSettingsListItem.vue
@@ -12,7 +12,7 @@ defineProps({
 </script>
 <template>
   <div
-    class="flex relative flex-col sm:flex-row p-4 gap-4 sm:p-6 justify-between shadow-sm sm:divide-x sm:divide-slate-75 sm:dark:divide-slate-700/50 group bg-white border border-solid rounded-xl dark:bg-slate-800 border-slate-75 dark:border-slate-700/50 max-w-[900px] w-full"
+    class="flex relative flex-col sm:flex-row p-4 gap-4 sm:p-6 justify-between shadow-sm group bg-white border border-solid rounded-xl dark:bg-slate-800 border-slate-75 dark:border-slate-700/50 max-w-[900px] w-full"
   >
     <!-- left side section -->
     <slot name="leftSection">

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/Index.vue
@@ -7,7 +7,7 @@
       <SLA-header @click="openAddPopup" />
     </template>
     <template #loading>
-      <SLAListItemLoading v-for="ii in 3" :key="ii" class="mb-3" />
+      <SLAListItemLoading v-for="ii in 2" :key="ii" class="mb-3" />
     </template>
     <template #body>
       <p

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/Index.vue
@@ -1,23 +1,22 @@
 <template>
-  <settings-layout>
+  <settings-layout
+    :is-loading="uiFlags.isFetching"
+    :loading-message="$t('SLA.LOADING')"
+  >
     <template #header>
       <SLA-header @click="openAddPopup" />
     </template>
+    <template #loading>
+      <SLAListItemLoading v-for="ii in 3" :key="ii" class="mb-3" />
+    </template>
     <template #body>
       <p
-        v-if="!uiFlags.isFetching && !records.length"
+        v-if="!records.length"
         class="flex flex-col items-center justify-center h-full"
       >
         {{ $t('SLA.LIST.404') }}
       </p>
-      <woot-loading-state
-        v-if="uiFlags.isFetching"
-        :message="$t('SLA.LOADING')"
-      />
-      <div
-        v-if="!uiFlags.isFetching && records.length"
-        class="flex flex-col w-full h-full gap-3"
-      >
+      <div v-if="records.length" class="flex flex-col w-full h-full gap-3">
         <SLA-list-item
           v-for="sla in records"
           :key="sla.title"
@@ -53,6 +52,7 @@
 import SettingsLayout from '../SettingsLayout.vue';
 import SLAHeader from './components/SLAHeader.vue';
 import SLAListItem from './components/SLAListItem.vue';
+import SLAListItemLoading from './components/SLAListItemLoading.vue';
 import { mapGetters } from 'vuex';
 import { convertSecondsToTimeUnit } from '@chatwoot/utils';
 
@@ -64,6 +64,7 @@ export default {
     AddSLA,
     SLAHeader,
     SLAListItem,
+    SLAListItemLoading,
     SettingsLayout,
   },
   mixins: [alertMixin],

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/components/SLAListItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/components/SLAListItem.vue
@@ -35,7 +35,11 @@ defineProps({
 });
 </script>
 <template>
-  <base-settings-list-item :title="slaName" :description="description">
+  <base-settings-list-item
+    class="sm:divide-x sm:divide-slate-75 sm:dark:divide-slate-700/50"
+    :title="slaName"
+    :description="description"
+  >
     <template #label>
       <SLA-business-hours-label :has-business-hours="hasBusinessHours" />
     </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/components/SLAListItemLoading.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/components/SLAListItemLoading.vue
@@ -21,13 +21,11 @@ import BaseSettingsListItem from '../../components/BaseSettingsListItem.vue';
       <div
         class="flex items-center sm:rtl:!border-l-0 sm:rtl:!border-r sm:rtl:border-solid sm:rtl:border-slate-75 sm:rtl:dark:border-slate-700/50 gap-1.5 w-fit sm:w-full sm:gap-0 sm:justify-between"
       >
-        <div class="flex justify-end w-1/3 h-full px-4">
-          <div class="w-20 h-full rounded-md bg-slate-50 animate-pulse" />
-        </div>
-        <div class="flex justify-end w-1/3 h-full px-4">
-          <div class="w-20 h-full rounded-md bg-slate-50 animate-pulse" />
-        </div>
-        <div class="flex justify-end w-1/3 h-full px-4">
+        <div
+          v-for="ii in 3"
+          :key="ii"
+          class="flex justify-end w-1/3 h-full px-4"
+        >
           <div class="w-20 h-full rounded-md bg-slate-50 animate-pulse" />
         </div>
       </div>

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/components/SLAListItemLoading.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/components/SLAListItemLoading.vue
@@ -22,7 +22,7 @@ import BaseSettingsListItem from '../../components/BaseSettingsListItem.vue';
           :key="ii"
           class="flex justify-end w-1/3 h-full px-4"
         >
-          <div class="w-20 h-full rounded-md bg-slate-50 animate-pulse" />
+          <div class="w-32 h-full rounded-md bg-slate-50 animate-pulse" />
         </div>
       </div>
     </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/components/SLAListItemLoading.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/components/SLAListItemLoading.vue
@@ -2,11 +2,7 @@
 import BaseSettingsListItem from '../../components/BaseSettingsListItem.vue';
 </script>
 <template>
-  <base-settings-list-item
-    :title="slaName"
-    :description="description"
-    class="opacity-50"
-  >
+  <base-settings-list-item class="opacity-50">
     <template #title>
       <div class="w-24 h-[26px] rounded-md bg-slate-50 animate-pulse" />
     </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/components/SLAListItemLoading.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/components/SLAListItemLoading.vue
@@ -1,0 +1,36 @@
+<script setup>
+import BaseSettingsListItem from '../../components/BaseSettingsListItem.vue';
+</script>
+<template>
+  <base-settings-list-item
+    :title="slaName"
+    :description="description"
+    class="opacity-50"
+  >
+    <template #title>
+      <div class="w-24 h-[26px] rounded-md bg-slate-50 animate-pulse" />
+    </template>
+    <template #description>
+      <div class="w-64 h-4 mb-0.5 rounded-md bg-slate-50 animate-pulse" />
+      <div class="w-48 h-4 rounded-md bg-slate-50 animate-pulse" />
+    </template>
+    <template #label>
+      <div class="w-32 h-[26px] bg-slate-50 animate-pulse rounded-md" />
+    </template>
+    <template #rightSection>
+      <div
+        class="flex items-center sm:rtl:!border-l-0 sm:rtl:!border-r sm:rtl:border-solid sm:rtl:border-slate-75 sm:rtl:dark:border-slate-700/50 gap-1.5 w-fit sm:w-full sm:gap-0 sm:justify-between"
+      >
+        <div class="flex justify-end w-1/3 h-full px-4">
+          <div class="w-20 h-full rounded-md bg-slate-50 animate-pulse" />
+        </div>
+        <div class="flex justify-end w-1/3 h-full px-4">
+          <div class="w-20 h-full rounded-md bg-slate-50 animate-pulse" />
+        </div>
+        <div class="flex justify-end w-1/3 h-full px-4">
+          <div class="w-20 h-full rounded-md bg-slate-50 animate-pulse" />
+        </div>
+      </div>
+    </template>
+  </base-settings-list-item>
+</template>


### PR DESCRIPTION
This PR has the following changes

1. Handle loading state in the `SettingsLayout` with default loader and message spinner
2. Create loading state using `BaseSettingsListItem`

https://github.com/chatwoot/chatwoot/assets/18097732/bc29f2de-036e-47ba-82b1-c4019e7852b7

