### PR TITLE
feat: Conversation API to return applied_sla and sla_events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,3 +25,4 @@ class ApplicationController < ActionController::Base
     }
   end
 end
+ApplicationController.include_mod_with('Concerns::ApplicationControllerConcern')

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -163,10 +163,14 @@ class ConversationFinder
     params[:page] || 1
   end
 
-  def conversations
-    @conversations = @conversations.includes(
+  def conversations_base_query
+    @conversations.includes(
       :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox
     )
+  end
+
+  def conversations
+    @conversations = conversations_base_query
 
     sort_by, sort_order = SORT_OPTIONS[params[:sort_by]] || SORT_OPTIONS['last_activity_at_desc']
     @conversations = @conversations.send(sort_by, sort_order)
@@ -178,3 +182,4 @@ class ConversationFinder
     end
   end
 end
+ConversationFinder.prepend_mod_with('ConversationFinder')

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -312,5 +312,5 @@ class Conversation < ApplicationRecord
   end
 end
 
-Conversation.include_mod_with('EnterpriseConversationConcern')
+Conversation.include_mod_with('Concerns::Conversation')
 Conversation.include_mod_with('SentimentAnalysisHelper')

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -45,3 +45,4 @@ class Conversations::EventDataPresenter < SimpleDelegator
     }
   end
 end
+Conversations::EventDataPresenter.prepend_mod_with('Conversations::EventDataPresenter')

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -1,3 +1,7 @@
+# TODO: Move this into models jbuilder
+# Currently the file there is used only for search endpoint. 
+# Everywhere else we use this
+
 json.meta do
   json.sender do
     json.partial! 'api/v1/models/contact', formats: [:json], resource: conversation.contact
@@ -48,3 +52,6 @@ json.last_activity_at conversation.last_activity_at.to_i
 json.priority conversation.priority
 json.waiting_since conversation.waiting_since.to_i.to_i
 json.sla_policy_id conversation.sla_policy_id
+if ChatwootApp.enterprise? 
+  json.partial! 'enterprise/api/v1/conversations/partials/conversation', conversation: conversation
+end

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -1,5 +1,5 @@
 # TODO: Move this into models jbuilder
-# Currently the file there is used only for search endpoint. 
+# Currently the file there is used only for search endpoint.
 # Everywhere else we use conversation builder in partials folder
 
 json.meta do
@@ -52,6 +52,4 @@ json.last_activity_at conversation.last_activity_at.to_i
 json.priority conversation.priority
 json.waiting_since conversation.waiting_since.to_i.to_i
 json.sla_policy_id conversation.sla_policy_id
-if ChatwootApp.enterprise? 
-  json.partial! 'enterprise/api/v1/conversations/partials/conversation', conversation: conversation
-end
+json.partial! 'enterprise/api/v1/conversations/partials/conversation', conversation: conversation if ChatwootApp.enterprise?

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -1,6 +1,6 @@
 # TODO: Move this into models jbuilder
 # Currently the file there is used only for search endpoint. 
-# Everywhere else we use this
+# Everywhere else we use conversation builder in partials folder
 
 json.meta do
   json.sender do

--- a/app/views/api/v1/models/_conversation.json.jbuilder
+++ b/app/views/api/v1/models/_conversation.json.jbuilder
@@ -1,3 +1,5 @@
+# This file is used to render conversation data search API response.
+
 json.id conversation.display_id
 json.uuid conversation.uuid
 json.created_at conversation.created_at.to_i

--- a/enterprise/app/controllers/api/v1/accounts/enterprise_accounts_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/enterprise_accounts_controller.rb
@@ -1,8 +1,2 @@
 class Api::V1::Accounts::EnterpriseAccountsController < Api::V1::Accounts::BaseController
-  before_action :prepend_view_paths
-
-  # Prepend the view path to the enterprise/app/views won't be available by default
-  def prepend_view_paths
-    prepend_view_path 'enterprise/app/views/'
-  end
 end

--- a/enterprise/app/controllers/enterprise/concerns/application_controller_concern.rb
+++ b/enterprise/app/controllers/enterprise/concerns/application_controller_concern.rb
@@ -1,0 +1,12 @@
+module Enterprise::Concerns::ApplicationControllerConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :prepend_view_paths
+  end
+
+  # Prepend the view path to the enterprise/app/views won't be available by default
+  def prepend_view_paths
+    prepend_view_path 'enterprise/app/views/'
+  end
+end

--- a/enterprise/app/finders/enterprise/conversation_finder.rb
+++ b/enterprise/app/finders/enterprise/conversation_finder.rb
@@ -1,0 +1,5 @@
+module Enterprise::ConversationFinder
+  def conversations_base_query
+    current_account.feature_enabled?('sla') ? super.includes(:applied_sla, :sla_events) : super
+  end
+end

--- a/enterprise/app/models/applied_sla.rb
+++ b/enterprise/app/models/applied_sla.rb
@@ -40,6 +40,23 @@ class AppliedSla < ApplicationRecord
                                         end
                                       }
   scope :missed, -> { where(sla_status: :missed) }
+
+  def push_event_data
+    {
+      id: id,
+      sla_id: sla_policy_id,
+      sla_status: sla_status,
+      created_at: created_at.to_i,
+      updated_at: updated_at.to_i,
+      sla_description: sla_policy.description,
+      sla_name: sla_policy.name,
+      sla_first_response_time_threshold: sla_policy.first_response_time_threshold,
+      sla_next_response_time_threshold: sla_policy.next_response_time_threshold,
+      sla_only_during_business_hours: sla_policy.only_during_business_hours,
+      sla_resolution_time_threshold: sla_policy.resolution_time_threshold
+    }
+  end
+
   private
 
   def ensure_account_id

--- a/enterprise/app/models/enterprise/concerns/conversation.rb
+++ b/enterprise/app/models/enterprise/concerns/conversation.rb
@@ -1,9 +1,10 @@
-module Enterprise::EnterpriseConversationConcern
+module Enterprise::Concerns::Conversation
   extend ActiveSupport::Concern
 
   included do
     belongs_to :sla_policy, optional: true
-    has_one :applied_sla, dependent: :destroy
+    has_one :applied_sla, dependent: :destroy_async
+    has_many :sla_events, dependent: :destroy_async
     before_validation :validate_sla_policy, if: -> { sla_policy_id_changed? }
     around_save :ensure_applied_sla_is_created, if: -> { sla_policy_id_changed? }
   end

--- a/enterprise/app/models/sla_event.rb
+++ b/enterprise/app/models/sla_event.rb
@@ -32,6 +32,16 @@ class SlaEvent < ApplicationRecord
 
   before_validation :ensure_applied_sla_id, :ensure_account_id, :ensure_inbox_id, :ensure_sla_policy_id
 
+  def push_event_data
+    {
+      id: id,
+      event_type: event_type,
+      meta: meta,
+      created_at: created_at.to_i,
+      updated_at: updated_at.to_i
+    }
+  end
+
   private
 
   def ensure_applied_sla_id

--- a/enterprise/app/presenters/enterprise/conversations/event_data_presenter.rb
+++ b/enterprise/app/presenters/enterprise/conversations/event_data_presenter.rb
@@ -1,0 +1,8 @@
+module Enterprise::Conversations::EventDataPresenter
+  def push_data
+    super.merge(
+      applied_sla: applied_sla&.push_event_data,
+      sla_events: sla_events.map(&:push_event_data)
+    )
+  end
+end

--- a/enterprise/app/presenters/enterprise/conversations/event_data_presenter.rb
+++ b/enterprise/app/presenters/enterprise/conversations/event_data_presenter.rb
@@ -1,8 +1,12 @@
 module Enterprise::Conversations::EventDataPresenter
   def push_data
-    super.merge(
-      applied_sla: applied_sla&.push_event_data,
-      sla_events: sla_events.map(&:push_event_data)
-    )
+    if account.feature_enabled?('sla')
+      super.merge(
+        applied_sla: applied_sla&.push_event_data,
+        sla_events: sla_events.map(&:push_event_data)
+      )
+    else
+      super
+    end
   end
 end

--- a/enterprise/app/views/api/v1/models/_applied_sla.json.jbuilder
+++ b/enterprise/app/views/api/v1/models/_applied_sla.json.jbuilder
@@ -1,0 +1,11 @@
+json.id resource.id
+json.sla_id resource.sla_policy_id
+json.sla_status resource.sla_status
+json.created_at resource.created_at.to_i
+json.updated_at resource.updated_at.to_i
+json.sla_description resource.sla_policy.description
+json.sla_name resource.sla_policy.name
+json.sla_first_response_time_threshold resource.sla_policy.first_response_time_threshold
+json.sla_next_response_time_threshold resource.sla_policy.next_response_time_threshold
+json.sla_only_during_business_hours resource.sla_policy.only_during_business_hours
+json.sla_resolution_time_threshold resource.sla_policy.resolution_time_threshold

--- a/enterprise/app/views/enterprise/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/enterprise/app/views/enterprise/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -1,8 +1,8 @@
 if conversation.account.feature_enabled?('sla')
-  json.applied_sla do 
+  json.applied_sla do
     json.partial! 'api/v1/models/applied_sla', formats: [:json], resource: conversation.applied_sla if conversation.applied_sla.present?
   end
-  json.sla_events do 
+  json.sla_events do
     json.array! conversation.sla_events do |sla_event|
       json.partial! 'api/v1/models/sla_event', formats: [:json], sla_event: sla_event
     end

--- a/enterprise/app/views/enterprise/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/enterprise/app/views/enterprise/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -1,0 +1,10 @@
+if conversation.account.feature_enabled?('sla')
+  json.applied_sla do 
+    json.partial! 'api/v1/models/applied_sla', formats: [:json], resource: conversation.applied_sla if conversation.applied_sla.present?
+  end
+  json.sla_events do 
+    json.array! conversation.sla_events do |sla_event|
+      json.partial! 'api/v1/models/sla_event', formats: [:json], sla_event: sla_event
+    end
+  end
+end

--- a/spec/enterprise/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Conversations API', type: :request do
+  let(:account) { create(:account) }
+  let(:administrator) { create(:user, account: account, role: :administrator) }
+
+  describe 'GET /api/v1/accounts/{account.id}/conversations/:id' do
+    it 'returns SLA data for the conversation if the feature is enabled' do
+      account.enable_features!('sla')
+      conversation = create(:conversation, account: account)
+      applied_sla = create(:applied_sla, conversation: conversation)
+      sla_event = create(:sla_event, conversation: conversation, applied_sla: applied_sla)
+
+      get "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}", headers: administrator.create_new_auth_token
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['applied_sla']['id']).to eq(applied_sla.id)
+      expect(response.parsed_body['sla_events'].first['id']).to eq(sla_event.id)
+    end
+
+    it 'does not return SLA data for the conversation if the feature is disabled' do
+      account.disable_features!('sla')
+      conversation = create(:conversation, account: account)
+      create(:applied_sla, conversation: conversation)
+      create(:sla_event, conversation: conversation)
+
+      get "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}", headers: administrator.create_new_auth_token
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.keys).not_to include('applied_sla')
+      expect(response.parsed_body.keys).not_to include('sla_events')
+    end
+  end
+end

--- a/spec/enterprise/models/applied_sla_spec.rb
+++ b/spec/enterprise/models/applied_sla_spec.rb
@@ -7,6 +7,27 @@ RSpec.describe AppliedSla, type: :model do
     it { is_expected.to belong_to(:conversation) }
   end
 
+  describe 'push_event_data' do
+    it 'returns the correct hash' do
+      applied_sla = create(:applied_sla)
+      expect(applied_sla.push_event_data).to eq(
+        {
+          id: applied_sla.id,
+          sla_id: applied_sla.sla_policy_id,
+          sla_status: applied_sla.sla_status,
+          created_at: applied_sla.created_at.to_i,
+          updated_at: applied_sla.updated_at.to_i,
+          sla_description: applied_sla.sla_policy.description,
+          sla_name: applied_sla.sla_policy.name,
+          sla_first_response_time_threshold: applied_sla.sla_policy.first_response_time_threshold,
+          sla_next_response_time_threshold: applied_sla.sla_policy.next_response_time_threshold,
+          sla_only_during_business_hours: applied_sla.sla_policy.only_during_business_hours,
+          sla_resolution_time_threshold: applied_sla.sla_policy.resolution_time_threshold
+        }
+      )
+    end
+  end
+
   describe 'validates_factory' do
     it 'creates valid applied sla policy object' do
       applied_sla = create(:applied_sla)

--- a/spec/enterprise/models/sla_event_spec.rb
+++ b/spec/enterprise/models/sla_event_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe SlaEvent, type: :model do
     it { is_expected.to belong_to(:inbox) }
   end
 
+  describe 'push_event_data' do
+    it 'returns the correct hash' do
+      sla_event = create(:sla_event)
+      expect(sla_event.push_event_data).to eq(
+        {
+          id: sla_event.id,
+          event_type: 'frt',
+          meta: sla_event.meta,
+          created_at: sla_event.created_at.to_i,
+          updated_at: sla_event.updated_at.to_i
+        }
+      )
+    end
+  end
+
   describe 'validates_factory' do
     it 'creates valid sla event object' do
       sla_event = create(:sla_event)

--- a/spec/enterprise/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/enterprise/presenters/conversations/event_data_presenter_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Conversations::EventDataPresenter do
+  let(:presenter) { described_class.new(conversation) }
+  let(:conversation) { create(:conversation) }
+
+  describe '#push_data' do
+    it 'returns push event payload with applied sla & sla events' do
+      applied_sla = create(:applied_sla, conversation: conversation)
+      sla_event = create(:sla_event, conversation: conversation, applied_sla: applied_sla)
+      conversation.reload
+
+      expect(presenter.push_data).to include(
+        {
+          applied_sla: applied_sla.push_event_data,
+          sla_events: [sla_event.push_event_data]
+        }
+      )
+    end
+  end
+end

--- a/spec/enterprise/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/enterprise/presenters/conversations/event_data_presenter_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe Conversations::EventDataPresenter do
-  let(:presenter) { described_class.new(conversation) }
-  let(:conversation) { create(:conversation) }
+  let!(:presenter) { described_class.new(conversation) }
+  let!(:conversation) { create(:conversation) }
+  let!(:applied_sla) { create(:applied_sla, conversation: conversation) }
+  let!(:sla_event) { create(:sla_event, conversation: conversation, applied_sla: applied_sla) }
 
   describe '#push_data' do
-    it 'returns push event payload with applied sla & sla events' do
-      applied_sla = create(:applied_sla, conversation: conversation)
-      sla_event = create(:sla_event, conversation: conversation, applied_sla: applied_sla)
-      conversation.reload
+    it 'returns push event payload with applied sla & sla events if the feature is enabled' do
+      conversation.account.enable_features!('sla')
 
       expect(presenter.push_data).to include(
         {
@@ -18,6 +18,12 @@ RSpec.describe Conversations::EventDataPresenter do
           sla_events: [sla_event.push_event_data]
         }
       )
+    end
+
+    it 'returns push event payload without applied sla & sla events if the feature is disabled' do
+      conversation.account.disable_features!('sla')
+
+      expect(presenter.push_data).not_to include(:applied_sla, :sla_events)
     end
   end
 end

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Conversations::EventDataPresenter do
     end
 
     it 'returns push event payload' do
-      expect(presenter.push_data).to eq(expected_data)
+      # the exceptions are the values that would be added in enterprise edition.
+      expect(presenter.push_data.except(:applied_sla, :sla_events)).to include(expected_data)
     end
   end
 end


### PR DESCRIPTION
- Include applied_sla and sla_events in conversation api endpoints
- Include applied_sla and sla_events in conversation push_data

fixes: https://linear.app/chatwoot/issue/CW-3143/update-the-conversation-api-to-return-the-sla-policy-breached-sla