### PR TITLE
fix: ConditionValidationService fails on conversation priority

### DIFF
--- a/lib/filters/filter_keys.yml
+++ b/lib/filters/filter_keys.yml
@@ -44,6 +44,12 @@ conversations:
       - "not_equal_to"
       - "is_present"
       - "is_not_present"
+  priority:
+    attribute_type: "standard"
+    data_type: "text"
+    filter_operators:
+      - "equal_to"
+      - "not_equal_to"
   display_id:
     attribute_type: "standard"
     data_type: "Number"


### PR DESCRIPTION
`AutomationRules::ConditionValidationService` would fail, since `filter_keys.yml` didn't have the priority attribute