### PR TITLE
chore: Fix twilio inbox create transaction rollback

### DIFF
--- a/app/controllers/api/v1/accounts/channels/twilio_channels_controller.rb
+++ b/app/controllers/api/v1/accounts/channels/twilio_channels_controller.rb
@@ -2,19 +2,23 @@ class Api::V1::Accounts::Channels::TwilioChannelsController < Api::V1::Accounts:
   before_action :authorize_request
 
   def create
-    ActiveRecord::Base.transaction do
-      authenticate_twilio
-      build_inbox
-      setup_webhooks if @twilio_channel.sms?
-    rescue StandardError => e
-      render_could_not_create_error(e.message)
-    end
+    process_create
+  rescue StandardError => e
+    render_could_not_create_error(e.message)
   end
 
   private
 
   def authorize_request
     authorize ::Inbox
+  end
+
+  def process_create
+    ActiveRecord::Base.transaction do
+      authenticate_twilio
+      build_inbox
+      setup_webhooks if @twilio_channel.sms?
+    end
   end
 
   def authenticate_twilio


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2902/bug-twilio-incorrect-error-toast-message-during-inbox-creation

**Problem**
In Twilio channels, we set up the webhooks after creating the inbox. We manage this within a transaction block to handle any potential issues with the webhook setup.

```ruby
  def create
    ActiveRecord::Base.transaction do
      authenticate_twilio
      build_inbox
      setup_webhooks if @twilio_channel.sms?
    rescue StandardError => e
      render_could_not_create_error(e.message)
    end
  end
```

The `rescue` block catches and deals with the error, so it doesn't affect the rest of the program. This means, even if there's an issue, the inbox is created successfully. At first, you might see an error in front end, but if you refresh the inbox list, you'll see the new inbox.

**Solution**

```ruby
 def create
  process_create
  rescue StandardError => e
    render_could_not_create_error(e.message)
  end

  private
  
  def process_create
    ActiveRecord::Base.transaction do
      authenticate_twilio
      build_inbox
      setup_webhooks if @twilio_channel.sms?
    end
  end
```

The error blocks the transaction and it can't be completed. Then, the `rescue` command finds the error and fixes it.