### PR TITLE
chore: Fix agent API returning 500 error

### DIFF
--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
       account: Current.account
     )
 
-    builder.perform
+    @agent = builder.perform
   end
 
   def update

--- a/app/views/api/v1/accounts/agents/create.json.jbuilder
+++ b/app/views/api/v1/accounts/agents/create.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'api/v1/models/agent', formats: [:json], resource: @user
+json.partial! 'api/v1/models/agent', formats: [:json], resource: @agent

--- a/spec/controllers/api/v1/accounts/agents_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/agents_controller_spec.rb
@@ -171,6 +171,7 @@ RSpec.describe 'Agents API', type: :request do
              as: :json
 
         expect(response).to have_http_status(:success)
+        expect(response.parsed_body['email']).to eq(params[:email])
         expect(account.users.last.name).to eq('NewUser')
       end
     end


### PR DESCRIPTION
- We were using the `@user` object in the view, which wasn't available when using api_access_token.  
- Also replaced the object to `@agent` and added additional specs to confirm the right object

fixes: https://linear.app/chatwoot/issue/CW-3185/agent-create-api-throwing-500-response
ref: https://discord.com/channels/647412545203994635/1219928138163949568/1219928138163949568