### PR TITLE
fix: Widget iFrame is adding a white background

### DIFF
--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -23,6 +23,7 @@ export const SDK_CSS = `
 
 .woot-widget-holder iframe {
   border: 0;
+  color-scheme: normal;
   height: 100% !important;
   width: 100% !important;
   max-height: 100vh !important;


### PR DESCRIPTION
# Pull Request Template

## Description

This PR includes a fix to solve iFrame, adding a white color as the background.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

**Screenshot**
**Before** without adding `color-scheme: normal` in `iFrame`
<img width="528" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/cac7d7b1-1be9-4355-bb56-f6bcee575ade">
**After** adding `color-scheme: normal` in `iFrame`
<img width="528" alt="image" src="https://github.com/chatwoot/chatwoot/assets/64252451/a10ffafd-ee46-496c-9237-9afe9fe3461e">



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
