### PR TITLE
fix: Terminate IMAP connection after the job is complete

### DIFF
--- a/app/services/imap/base_fetch_email_service.rb
+++ b/app/services/imap/base_fetch_email_service.rb
@@ -8,8 +8,10 @@ class Imap::BaseFetchEmailService
   end
 
   def perform
-    fetch_emails
+    inbound_emails = fetch_emails
     terminate_imap_connection
+
+    inbound_emails
   end
 
   private
@@ -111,10 +113,10 @@ class Imap::BaseFetchEmailService
   end
 
   def terminate_imap_connection
-    imap.logout # Attempt to logout gracefully
+    imap_client.logout
   rescue Net::IMAP::Error => e
     Rails.logger.info "Logout failed for #{channel.email} - #{e.message}."
-    imap.disconnect
+    imap_client.disconnect
   end
 
   def build_mail_from_string(raw_email_content)

--- a/app/services/imap/fetch_email_service.rb
+++ b/app/services/imap/fetch_email_service.rb
@@ -1,5 +1,5 @@
 class Imap::FetchEmailService < Imap::BaseFetchEmailService
-  def perform
+  def fetch_emails
     fetch_mail_for_channel
   end
 

--- a/app/services/imap/microsoft_fetch_email_service.rb
+++ b/app/services/imap/microsoft_fetch_email_service.rb
@@ -1,5 +1,5 @@
 class Imap::MicrosoftFetchEmailService < Imap::BaseFetchEmailService
-  def perform
+  def fetch_emails
     return if channel.provider_config['access_token'].blank?
 
     fetch_mail_for_channel

--- a/spec/services/imap/fetch_email_service_spec.rb
+++ b/spec/services/imap/fetch_email_service_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Imap::FetchEmailService do
           allow(imap).to receive(:search).with(%w[SINCE 25-Oct-2020]).and_return([1])
           allow(imap).to receive(:fetch).with([1], 'BODY.PEEK[HEADER]').and_return([email_header])
           allow(imap).to receive(:fetch).with(1, 'RFC822').and_return([imap_fetch_mail])
+          allow(imap).to receive(:logout)
 
           result = described_class.new(channel: imap_email_channel).perform
 
@@ -39,6 +40,7 @@ RSpec.describe Imap::FetchEmailService do
           expect(imap).to have_received(:fetch).with([1], 'BODY.PEEK[HEADER]')
           expect(imap).to have_received(:fetch).with(1, 'RFC822')
           expect(logger).to have_received(:info).with("[IMAP::FETCH_EMAIL_SERVICE] Fetching mails from #{imap_email_channel.email}, found 1.")
+          expect(imap).to have_received(:logout)
         end
       end
 
@@ -51,6 +53,7 @@ RSpec.describe Imap::FetchEmailService do
 
           allow(imap).to receive(:search).with(%w[SINCE 25-Oct-2020]).and_return([1])
           allow(imap).to receive(:fetch).with([1], 'BODY.PEEK[HEADER]').and_return([email_header])
+          allow(imap).to receive(:logout)
 
           result = described_class.new(channel: imap_email_channel).perform
 

--- a/spec/services/imap/microsoft_fetch_email_service_spec.rb
+++ b/spec/services/imap/microsoft_fetch_email_service_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Imap::MicrosoftFetchEmailService do
           allow(imap).to receive(:search).with(%w[SINCE 25-Oct-2020]).and_return([1])
           allow(imap).to receive(:fetch).with([1], 'BODY.PEEK[HEADER]').and_return([email_header])
           allow(imap).to receive(:fetch).with(1, 'RFC822').and_return([imap_fetch_mail])
+          allow(imap).to receive(:logout)
 
           result = described_class.new(channel: microsoft_channel).perform
 


### PR DESCRIPTION
Fixes https://github.com/chatwoot/chatwoot/issues/8968

The existing IMAP connections were not immediately terminated after the job completion. This delay could lead to some providers throttling connections, ultimately causing the "Connection reset by peer - SSL_connect" error.

In this PR, I've introduced an option to log out from the IMAP server. If we fail to logout properly, a forced disconnect will occur. 

The underlying method that was overridden was `perform`, it has been changed to `fetch_emails`. The `perform` method remains the same—it accepts no input and returns the same list of inbound email, while also terminating the connection.

The suggestion [here](https://github.com/chatwoot/chatwoot/issues/8968#issuecomment-1977618980) made sense, however I've used `logout` in place of `close` and used the `disconnect` as a fallback.