### PR TITLE
chore: Increase the rate limit for contact search

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -149,7 +149,7 @@ class Rack::Attack
   end
 
   ## Prevent abuse of contact search api
-  throttle('/api/v1/accounts/:account_id/contacts/search', limit: 5, period: 1.minute) do |req|
+  throttle('/api/v1/accounts/:account_id/contacts/search', limit: ENV.fetch('RATE_LIMIT_CONTACT_SEARCH', '100').to_i, period: 1.minute) do |req|
     match_data = %r{/api/v1/accounts/(?<account_id>\d+)/contacts/search}.match(req.path)
     match_data[:account_id] if match_data.present?
   end


### PR DESCRIPTION
The rate limit of 5 on the contact search endpoint is too low. application. Allowing 100 to 200 shouldn't be a major issue, especially during high traffic times when search queries may increase.

