### PR TITLE
fix: Vector search breaking widget hc integration

### DIFF
--- a/enterprise/app/controllers/enterprise/public/api/v1/portals/articles_controller.rb
+++ b/enterprise/app/controllers/enterprise/public/api/v1/portals/articles_controller.rb
@@ -3,7 +3,7 @@ module Enterprise::Public::Api::V1::Portals::ArticlesController
 
   def search_articles
     if @portal.account.feature_enabled?('help_center_embedding_search')
-      @articles = @articles.vector_search(list_params) if list_params.present?
+      @articles = @articles.vector_search(list_params) if list_params[:query].present?
     else
       super
     end


### PR DESCRIPTION
- Enabling vector search was breaking the widget help center integration [ Helpcenter articles were not being displayed on welcome screen ]