### PR TITLE
feat: Add loom video embed support for help center articles

### DIFF
--- a/lib/custom_markdown_renderer.rb
+++ b/lib/custom_markdown_renderer.rb
@@ -73,14 +73,14 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
   def make_youtube_embed(youtube_match)
     video_id = youtube_match[1]
     %(
-      <iframe
-        width="560"
-        height="315"
+      <div style="position: relative; padding-bottom: 62.5%; height: 0;">
+       <iframe
         src="https://www.youtube.com/embed/#{video_id}"
         frameborder="0"
+        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-      ></iframe>
+        allowfullscreen></iframe>
+      </div>
     )
   end
 
@@ -88,7 +88,7 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
     video_id = loom_match[1]
     %(
       <div style="position: relative; padding-bottom: 62.5%; height: 0;">
-      <iframe
+        <iframe
          src="https://www.loom.com/embed/#{video_id}"
          frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen
          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
@@ -99,14 +99,15 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
   def make_vimeo_embed(vimeo_match)
     video_id = vimeo_match[1]
     %(
-      <iframe
+      <div style="position: relative; padding-bottom: 62.5%; height: 0;">
+       <iframe
         src="https://player.vimeo.com/video/#{video_id}"
-        width="640"
-        height="360"
         frameborder="0"
         allow="autoplay; fullscreen; picture-in-picture"
         allowfullscreen
-      ></iframe>
+        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+       ></iframe>
+       </div>
     )
   end
 

--- a/lib/custom_markdown_renderer.rb
+++ b/lib/custom_markdown_renderer.rb
@@ -105,7 +105,7 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
         frameborder="0"
         allow="autoplay; fullscreen; picture-in-picture"
         allowfullscreen
-        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">></iframe>
+        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
        </div>
     )
   end

--- a/lib/custom_markdown_renderer.rb
+++ b/lib/custom_markdown_renderer.rb
@@ -87,15 +87,12 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
   def make_loom_embed(loom_match)
     video_id = loom_match[1]
     %(
+      <div style="position: relative; padding-bottom: 62.5%; height: 0;">
       <iframe
-        src="https://www.loom.com/embed/#{video_id}"
-        width="640"
-        height="360"
-        frameborder="0"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen
-      ></iframe>
+         src="https://www.loom.com/embed/#{video_id}"
+         frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen
+         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+      </div>
     )
   end
 

--- a/lib/custom_markdown_renderer.rb
+++ b/lib/custom_markdown_renderer.rb
@@ -105,8 +105,7 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
         frameborder="0"
         allow="autoplay; fullscreen; picture-in-picture"
         allowfullscreen
-        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
-       ></iframe>
+        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">></iframe>
        </div>
     )
   end

--- a/spec/lib/custom_markdown_renderer_spec.rb
+++ b/spec/lib/custom_markdown_renderer_spec.rb
@@ -68,6 +68,20 @@ describe CustomMarkdownRenderer do
       end
     end
 
+    context 'when link is a Loom URL' do
+      let(:loom_url) { 'https://www.loom.com/share/VIDEO_ID' }
+
+      it 'renders an iframe with Loom embed code' do
+        output = render_markdown_link(loom_url)
+        expect(output).to include(`
+          <iframe
+            width="640"
+            height="360"
+            src="https://www.loom.com/embed/VIDEO_ID"
+        `)
+      end
+    end
+
     context 'when link is a Vimeo URL' do
       let(:vimeo_url) { 'https://vimeo.com/1234567' }
 


### PR DESCRIPTION
Added support for embedding loom videos in help center articles.

**Preview**
![CleanShot 2024-04-24 at 10 33 50@2x](https://github.com/chatwoot/chatwoot/assets/12408980/7d2e9fd6-23a5-4dc9-8514-a5dcb6d79d01)

