### PR TITLE
fix: set size limit to 300KB

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "size-limit": [
     {
       "path": "public/packs/js/widget-*.js",
-      "limit": "281 KB"
+      "limit": "300 KB"
     },
     {
       "path": "public/packs/js/sdk.js",


### PR DESCRIPTION
Setting the size limit for the widget bundle to be 300KB, this is the max we should let it allow to grow. Once exceeded we can explore options to reduce this