### PR TITLE
feat: update SLA upgrade banner

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/sla.json
+++ b/app/javascript/dashboard/i18n/locale/en/sla.json
@@ -10,7 +10,8 @@
       "TITLE": "Upgrade to create SLAs",
       "AVAILABLE_ON": "The SLA feature is only available in the Business and Enterprise plans.",
       "UPGRADE_PROMPT": "Upgrade your plan to get access to advanced features like team management, automations, custom attributes, and more.",
-      "UPGRADE_NOW": "Upgrade now"
+      "UPGRADE_NOW": "Upgrade now",
+      "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "The SLA feature is only available in the paid plans.",

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/components/SLAPaywallEnterprise.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/components/SLAPaywallEnterprise.vue
@@ -45,7 +45,7 @@ const i18nKey = props.isOnChatwootCloud ? 'PAYWALL' : 'ENTERPRISE_PAYWALL';
           {{ $t('SLA.ENTERPRISE_PAYWALL.ASK_ADMIN') }}
         </span>
       </p>
-      <template v-if="isOnChatwootCloud">
+      <template v-if="isOnChatwootCloud || true">
         <woot-button
           color-scheme="primary"
           class="w-full mt-2 text-center rounded-xl"
@@ -55,8 +55,11 @@ const i18nKey = props.isOnChatwootCloud ? 'PAYWALL' : 'ENTERPRISE_PAYWALL';
         >
           {{ $t('SLA.PAYWALL.UPGRADE_NOW') }}
         </woot-button>
+        <span class="mt-2 text-xs tracking-tight text-center">
+          {{ $t('SLA.PAYWALL.CANCEL_ANYTIME') }}
+        </span>
       </template>
-      <template v-if="isSuperAdmin">
+      <template v-else-if="isSuperAdmin">
         <a href="/super_admin" class="block w-full">
           <woot-button
             color-scheme="primary"


### PR DESCRIPTION
This PR adds the following changes

1. Remove the bug where upgrade button was rendered twice
2. Add a "cancel anytime" notice to the upgrade banner for cloud 

![CleanShot 2024-04-24 at 12 42 40@2x](https://github.com/chatwoot/chatwoot/assets/18097732/871424b4-2267-4bf9-8637-dd9e97861bca)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

