### PR TITLE
fix: Remove unnecessary attributes from notification deleted action cable event payload

### DIFF
--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -18,7 +18,7 @@ class ActionCableListener < BaseListener
 
     notification, account, unread_count, count = extract_notification_and_account(event)
     tokens = [event.data[:notification].user.pubsub_token]
-    broadcast(account, tokens, NOTIFICATION_DELETED, { notification: notification.push_event_data, unread_count: unread_count, count: count })
+    broadcast(account, tokens, NOTIFICATION_DELETED, { notification: { id: notification.id }, unread_count: unread_count, count: count })
   end
 
   def account_cache_invalidated(event)

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -142,7 +142,9 @@ describe ActionCableListener do
         'notification.deleted',
         {
           account_id: notification.account_id,
-          notification: notification.push_event_data,
+          notification: {
+            id: notification.id
+          },
           unread_count: 1,
           count: 1
         }


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-3251/nomethoderror-undefined-method-display-id-for-nilnilclass