### PR TITLE
feat: don't show widget on plain layout

### DIFF
--- a/app/views/layouts/portal.html.erb
+++ b/app/views/layouts/portal.html.erb
@@ -128,7 +128,7 @@ By default, it renders:
       tocHeader: '<%= I18n.t('public_portal.toc_header') %>'
     };
   </script>
-  <% if @portal.channel_web_widget.present? %>
+  <% if @portal.channel_web_widget.present? && !@is_plain_layout_enabled %>
   <%= @portal.channel_web_widget.web_widget_script.html_safe %>
   <% end %>
 </html>


### PR DESCRIPTION
The portal was rendering the widget inside the widget, this is because the widget script was getting injected even when the portal was rendered in plain layout. This PR fixes that

Fixes: https://github.com/chatwoot/chatwoot/issues/9274