### PR TITLE
chore: Remove adding an exception in message flooding

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -236,7 +236,6 @@ class Message < ApplicationRecord
     # there are cases where automations can result in message loops, we need to prevent such cases.
     if conversation.messages.where('created_at >= ?', 1.minute.ago).count >= Limits.conversation_message_per_minute_limit
       Rails.logger.error "Too many message: Account Id - #{account_id} : Conversation id - #{conversation_id}"
-      errors.add(:base, 'Too many messages')
     end
   end
 


### PR DESCRIPTION
We have introduced a [validation](https://github.com/chatwoot/chatwoot/pull/9254) to limit the number of messages sent per minute, which helps prevent message flooding. We are now handling this as an exception, which previously led to a multitude of sentry errors. Simply logging this error is sufficient.