### PR TITLE
fix: Start calender is not moving properly is last 30 days range

### DIFF
--- a/app/javascript/dashboard/components/ui/DatePicker/DatePicker.vue
+++ b/app/javascript/dashboard/components/ui/DatePicker/DatePicker.vue
@@ -31,7 +31,7 @@ import CalendarMonth from './components/CalendarMonth.vue';
 import CalendarWeek from './components/CalendarWeek.vue';
 import CalendarFooter from './components/CalendarFooter.vue';
 
-const { LAST_7_DAYS, CUSTOM_RANGE } = DATE_RANGE_TYPES;
+const { LAST_7_DAYS, LAST_30_DAYS, CUSTOM_RANGE } = DATE_RANGE_TYPES;
 const { START_CALENDAR, END_CALENDAR } = CALENDAR_TYPES;
 const { WEEK, MONTH, YEAR } = CALENDAR_PERIODS;
 
@@ -59,14 +59,16 @@ const emit = defineEmits(['change']);
 // Watcher will set the start and end dates based on the selected range
 watch(selectedRange, newRange => {
   if (newRange !== CUSTOM_RANGE) {
-    // If selecting a range other than last 7 days, set the start and end dates to the selected start and end dates
-    // If selecting last 7 days, set the start date to the selected start date
+    // If selecting a range other than last 7 days or last 30 days, set the start and end dates to the selected start and end dates
+    // If selecting last 7 days or last 30 days is, set the start date to the selected start date
     // and the end date to one month ahead of the start date if the start date and end date are in the same month
     // Otherwise set the end date to the selected end date
-    const isLast7days = newRange === LAST_7_DAYS;
+    const isLastSevenOrThirtyDays =
+      newRange === LAST_7_DAYS || newRange === LAST_30_DAYS;
     startCurrentDate.value = selectedStartDate.value;
     endCurrentDate.value =
-      isLast7days || isSameMonth(selectedStartDate.value, selectedEndDate.value)
+      isLastSevenOrThirtyDays &&
+      isSameMonth(selectedStartDate.value, selectedEndDate.value)
         ? startOfMonth(addMonths(selectedStartDate.value, 1))
         : selectedEndDate.value;
     selectingEndDate.value = false;

--- a/app/javascript/dashboard/components/ui/DatePicker/DatePicker.vue
+++ b/app/javascript/dashboard/components/ui/DatePicker/DatePicker.vue
@@ -66,7 +66,7 @@ watch(selectedRange, newRange => {
     const isLast7days = newRange === LAST_7_DAYS;
     startCurrentDate.value = selectedStartDate.value;
     endCurrentDate.value =
-      isLast7days && isSameMonth(selectedStartDate.value, selectedEndDate.value)
+      isLast7days || isSameMonth(selectedStartDate.value, selectedEndDate.value)
         ? startOfMonth(addMonths(selectedStartDate.value, 1))
         : selectedEndDate.value;
     selectingEndDate.value = false;


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will fix a small edge case(only for the last 7(already handled) and 30(In this PR) days) in which the start calendar view is not moving correctly in **the last 30 days range if it is the same month. For e.g., April 1 - April 30 case**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Before**

https://github.com/chatwoot/chatwoot/assets/64252451/c3a0539d-e638-441c-a975-306ac048f481

**After**

https://github.com/chatwoot/chatwoot/assets/64252451/b4290f1f-3e5e-406a-b2bd-51b6364d0dd9



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
