### PR TITLE
feat: Add ability to sort canned responses

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/canned/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/canned/Index.vue
@@ -32,9 +32,25 @@
             <th
               v-for="thHeader in $t('CANNED_MGMT.LIST.TABLE_HEADER')"
               :key="thHeader"
-              class="last:text-right"
+              class="last:text-right first:m-0 first:p-0"
             >
-              {{ thHeader }}
+              <p v-if="thHeader !== $t('CANNED_MGMT.LIST.TABLE_HEADER[0]')">
+                {{ thHeader }}
+              </p>
+
+              <button
+                v-if="thHeader === $t('CANNED_MGMT.LIST.TABLE_HEADER[0]')"
+                class="cursor-pointer flex items-center p-0"
+                @click="toggleSort"
+              >
+                <p class="uppercase">
+                  {{ thHeader }}
+                </p>
+                <fluent-icon
+                  class="mb-2 ml-2"
+                  :icon="sortOrder === 'asc' ? 'chevron-up' : 'chevron-down'"
+                />
+              </button>
             </th>
           </thead>
           <tbody>
@@ -132,6 +148,7 @@ export default {
       cannedResponseAPI: {
         message: '',
       },
+      sortOrder: 'asc',
     };
   },
   computed: {
@@ -156,9 +173,23 @@ export default {
   },
   mounted() {
     // Fetch API Call
-    this.$store.dispatch('getCannedResponse');
+    this.$store.dispatch('getCannedResponse').then(() => {
+      this.toggleSort();
+    });
   },
   methods: {
+    toggleSort() {
+      if (!this.records.length) return;
+
+      this.records.sort((a, b) => {
+        if (this.sortOrder === 'asc') {
+          return a.short_code.localeCompare(b.short_code);
+        }
+        return b.short_code.localeCompare(a.short_code);
+      });
+
+      this.sortOrder = this.sortOrder === 'asc' ? 'desc' : 'asc';
+    },
     showAlert(message) {
       // Reset loading, current selected agent
       this.loading[this.selectedResponse.id] = false;


### PR DESCRIPTION
# Pull Request Template

## Description
This change gives users the ability to sort their canned responses by `short_code` the motivation here was multiple complaints from our customers that they have a hard time finding canned responses when the list is very large.

Fixes #9329 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
