### PR TITLE
chore: Rescue Oauth2::Error and mark the channel as inactive

### DIFF
--- a/app/jobs/inboxes/fetch_imap_emails_job.rb
+++ b/app/jobs/inboxes/fetch_imap_emails_job.rb
@@ -36,6 +36,9 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
     inbound_emails.map do |inbound_mail|
       process_mail(inbound_mail, channel)
     end
+  rescue OAuth2::Error => e
+    Rails.logger.error "Error for email channel - #{channel.inbox.id} : #{e.message}"
+    channel.authorization_error!
   end
 
   def process_mail(inbound_mail, channel)

--- a/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
+++ b/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Inboxes::FetchImapEmailsJob do
 
     context 'when IMAP OAuth errors out' do
       it 'marks the connection as requiring authorization' do
-        error_response = instance_double(OAuth2::ErrorResponse, error: 'invalid_grant')
+        error_response = double
         oauth_error = OAuth2::Error.new(error_response)
 
         allow(Imap::MicrosoftFetchEmailService).to receive(:new)

--- a/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
+++ b/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
@@ -71,9 +71,12 @@ RSpec.describe Inboxes::FetchImapEmailsJob do
 
     context 'when IMAP OAuth errors out' do
       it 'marks the connection as requiring authorization' do
+        error_response = instance_double(OAuth2::ErrorResponse, error: 'invalid_grant')
+        oauth_error = OAuth2::Error.new(error_response)
+
         allow(Imap::MicrosoftFetchEmailService).to receive(:new)
           .with(channel: microsoft_imap_email_channel, interval: 1)
-          .and_raise(OAuth2::Error.new)
+          .and_raise(oauth_error)
 
         allow(Redis::Alfred).to receive(:incr)
 

--- a/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
+++ b/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe Inboxes::FetchImapEmailsJob do
       end
     end
 
+    context 'when IMAP OAuth errors out' do
+      it 'marks the connection as requiring authorization' do
+        allow(Imap::MicrosoftFetchEmailService).to receive(:new)
+          .with(channel: microsoft_imap_email_channel, interval: 1)
+          .and_raise(OAuth2::Error.new)
+
+        allow(Redis::Alfred).to receive(:incr)
+
+        expect(Redis::Alfred).to receive(:incr)
+          .with("AUTHORIZATION_ERROR_COUNT:channel_email:#{microsoft_imap_email_channel.id}")
+
+        described_class.perform_now(microsoft_imap_email_channel)
+      end
+    end
+
     context 'when the fetch service returns the email objects' do
       let(:inbound_mail) {  create_inbound_email_from_fixture('welcome.eml').mail }
       let(:mailbox) { double }


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-2910/oauth2error-invalid-grant-aadsts50079-due-to-a-configuration-change