### PR TITLE
fix: message signature default value

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/profile/MessageSignature.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/profile/MessageSignature.vue
@@ -38,7 +38,7 @@ const signature = ref(props.messageSignature);
 const emit = defineEmits(['update-signature']);
 
 watch(
-  () => props.messageSignature,
+  () => props.messageSignature ?? '',
   newValue => {
     signature.value = newValue;
   }


### PR DESCRIPTION
The `messageSignature` props has a default value of `''` however this is only selected when the value passed is undefined, in a case where `null` is passed, it is consumed as it is.

This value further propagates to the `Editor.vue` component where it fails in `createState` method at `MessageMarkdownTransformer(messageSchema).parse(content)`

This PR fixes it