### PR TITLE
chore: Handle conversation participation creation race condition error

### DIFF
--- a/app/listeners/participation_listener.rb
+++ b/app/listeners/participation_listener.rb
@@ -3,6 +3,11 @@ class ParticipationListener < BaseListener
 
   def assignee_changed(event)
     conversation, _account = extract_conversation_and_account(event)
-    conversation.conversation_participants.find_or_create_by!(user_id: conversation.assignee_id) if conversation.assignee_id.present?
+    return if conversation.assignee_id.blank?
+
+    conversation.conversation_participants.find_or_create_by!(user_id: conversation.assignee_id)
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+    Rails.logger.warn "Failed to create conversation participant for account #{conversation.account.id} " \
+                      ": user #{conversation.assignee_id} : conversation #{conversation.id}"
   end
 end

--- a/app/listeners/participation_listener.rb
+++ b/app/listeners/participation_listener.rb
@@ -6,6 +6,8 @@ class ParticipationListener < BaseListener
     return if conversation.assignee_id.blank?
 
     conversation.conversation_participants.find_or_create_by!(user_id: conversation.assignee_id)
+  # We have observed race conditions triggering these errors
+  # example: Assignment happening via automation, while auto assignment is also configured.
   rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
     Rails.logger.warn "Failed to create conversation participant for account #{conversation.account.id} " \
                       ": user #{conversation.assignee_id} : conversation #{conversation.id}"

--- a/app/models/concerns/assignment_handler.rb
+++ b/app/models/concerns/assignment_handler.rb
@@ -32,7 +32,7 @@ module AssignmentHandler
       ASSIGNEE_CHANGED => -> { saved_change_to_assignee_id? },
       TEAM_CHANGED => -> { saved_change_to_team_id? }
     }.each do |event, condition|
-      condition.call && dispatcher_dispatch(event)
+      condition.call && dispatcher_dispatch(event, previous_changes)
     end
   end
 

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Conversation do
                                                                  changed_attributes: nil, performed_by: nil)
       expect(Rails.configuration.dispatcher).to have_received(:dispatch)
         .with(described_class::ASSIGNEE_CHANGED, kind_of(Time), conversation: conversation, notifiable_assignee_change: true,
-                                                                changed_attributes: nil, performed_by: nil)
+                                                                changed_attributes: changed_attributes, performed_by: nil)
       expect(Rails.configuration.dispatcher).to have_received(:dispatch)
         .with(described_class::CONVERSATION_UPDATED, kind_of(Time), conversation: conversation, notifiable_assignee_change: true,
                                                                     changed_attributes: changed_attributes, performed_by: nil)


### PR DESCRIPTION
We observed some race condition errors in the conversation participation listner while trying to create a conversation participation assignment.  This PR handles this error and also adds additional debug information for future


fixes: https://linear.app/chatwoot/issue/CW-3296/activerecordrecordnotunique-pguniqueviolation-error-duplicate-key


## Changelog

- handles `ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvald` errors so that they won't polite sentry
- Adds a debug statement to log the cases
- Add `previous_changes` into the dispatcher so that we know the exact attribute changes  which trigger `assignee_changed, team_changed` events ( would be handy in future )


