### PR TITLE
chore: Handle invalid email address in IMAP channel

### DIFF
--- a/spec/mailboxes/imap/imap_mailbox_spec.rb
+++ b/spec/mailboxes/imap/imap_mailbox_spec.rb
@@ -54,6 +54,16 @@ RSpec.describe Imap::ImapMailbox do
       end
     end
 
+    context 'when a new email with invalid from' do
+      let(:inbound_mail) { create_inbound_email_from_mail(from: 'invalidemail', to: 'imap@gmail.com', subject: 'Hello!') }
+
+      it 'does not create a new conversation' do
+        allow(Rails.logger).to receive(:error)
+        class_instance.process(inbound_mail.mail, channel)
+        expect(Rails.logger).to have_received(:error).with("Email from: invalidemail : inbox #{inbox.id} is invalid")
+      end
+    end
+
     context 'when a reply for existing email conversation' do
       let(:prev_conversation) { create(:conversation, account: account, inbox: channel.inbox, assignee: agent) }
       let(:reply_mail) do


### PR DESCRIPTION
We have observed in Sentry that sometimes `fetch_imap_emails_jobs` fails with a validation error when creating a contact. This happens when the `original_sender` isn't in a format supported by the Chatwoot contact model schema. Chatwoot validates contacts email with `Device.email_regexp`.

This PR will skip processing such emails. It also adds a log for each email processed in the email fetch job and an error for the ones we skip. 

Fixes: https://linear.app/chatwoot/issue/CW-3295/activerecordrecordinvalid-validation-failed-email-invalid-email