### PR TITLE
chore: Make IP_LOOKUP_BASE_URL configurable

### DIFF
--- a/lib/tasks/ip_lookup.rake
+++ b/lib/tasks/ip_lookup.rake
@@ -13,7 +13,7 @@ namespace :ip_lookup do
     Rails.logger.info '[rake ip_lookup:setup] Fetch GeoLite2-City database'
 
     begin
-      base_url = 'https://download.maxmind.com/app/geoip_download'
+      base_url = ENV.fetch('IP_LOOKUP_BASE_URL', 'https://download.maxmind.com/app/geoip_download')
       source_file = Down.download(
         "#{base_url}?edition_id=GeoLite2-City&suffix=tar.gz&license_key=#{ip_lookup_api_key}"
       )


### PR DESCRIPTION
Since we download the GeoIP database during worker/server initialization, there is a high chance of spamming the server with too many requests for downloads, especially if the number of web and worker nodes is high. This PR provides the ability to specify a custom URL for the GeoLite database download, configurable via an environment variable. This helps in distributing the load and avoiding server overload during the initialization process