### PR TITLE
chore: Improved indexes for Conversations & Contacts [CW-3300]

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -25,6 +25,7 @@
 # Indexes
 #
 #  index_contacts_on_account_id                          (account_id)
+#  index_contacts_on_account_id_and_last_activity_at     (account_id,last_activity_at DESC NULLS LAST)
 #  index_contacts_on_blocked                             (blocked)
 #  index_contacts_on_lower_email_account_id              (lower((email)::text), account_id)
 #  index_contacts_on_name_email_phone_number_identifier  (name,email,phone_number,identifier) USING gin

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -41,7 +41,6 @@
 #  index_conversations_on_first_reply_created_at      (first_reply_created_at)
 #  index_conversations_on_id_and_account_id           (account_id,id)
 #  index_conversations_on_inbox_id                    (inbox_id)
-#  index_conversations_on_last_activity_at            (last_activity_at)
 #  index_conversations_on_priority                    (priority)
 #  index_conversations_on_status_and_account_id       (status,account_id)
 #  index_conversations_on_status_and_priority         (status,priority)

--- a/db/migrate/20240515201632_index_improvements_conversations_contacts.rb
+++ b/db/migrate/20240515201632_index_improvements_conversations_contacts.rb
@@ -1,0 +1,11 @@
+class IndexImprovementsConversationsContacts < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :conversations, :last_activity_at
+    add_index :contacts, [:account_id, :last_activity_at],
+              order: { last_activity_at: 'DESC NULLS LAST' },
+              algorithm: :concurrently,
+              name: 'index_contacts_on_account_id_and_last_activity_at'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_15_210313) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_15_201632) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -426,6 +426,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_15_210313) do
     t.boolean "blocked", default: false, null: false
     t.index "lower((email)::text), account_id", name: "index_contacts_on_lower_email_account_id"
     t.index ["account_id", "email", "phone_number", "identifier"], name: "index_contacts_on_nonempty_fields", where: "(((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))"
+    t.index ["account_id", "last_activity_at"], name: "index_contacts_on_account_id_and_last_activity_at", order: { last_activity_at: "DESC NULLS LAST" }
     t.index ["account_id"], name: "index_contacts_on_account_id"
     t.index ["account_id"], name: "index_resolved_contact_account_id", where: "(((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))"
     t.index ["blocked"], name: "index_contacts_on_blocked"
@@ -483,7 +484,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_15_210313) do
     t.index ["contact_inbox_id"], name: "index_conversations_on_contact_inbox_id"
     t.index ["first_reply_created_at"], name: "index_conversations_on_first_reply_created_at"
     t.index ["inbox_id"], name: "index_conversations_on_inbox_id"
-    t.index ["last_activity_at"], name: "index_conversations_on_last_activity_at"
     t.index ["priority"], name: "index_conversations_on_priority"
     t.index ["status", "account_id"], name: "index_conversations_on_status_and_account_id"
     t.index ["status", "priority"], name: "index_conversations_on_status_and_priority"


### PR DESCRIPTION
Based on our recent performant optimisation exercises, We have identified a better indexing strategy for conversations and contacts. The previous index on `last_activity_at` for conversations significantly slowed down conversation filters. Similarly, the new index on Contacts will allow the page rendering to improve for accounts with many contacts. 

fixes: https://linear.app/chatwoot/issue/CW-3300/db-improvements