### PR TITLE
feat: Improve Report API performance

### DIFF
--- a/app/builders/v2/base_conversation_report_builder.rb
+++ b/app/builders/v2/base_conversation_report_builder.rb
@@ -1,0 +1,30 @@
+class V2::BaseConversationReportBuilder
+  pattr_initialize :account, :params
+
+  private
+
+  AVG_METRICS = %w[avg_first_response_time avg_resolution_time reply_time].freeze
+  COUNT_METRICS = %w[
+    conversations_count
+    incoming_messages_count
+    outgoing_messages_count
+    resolutions_count
+    bot_resolutions_count
+    bot_handoffs_count
+  ].freeze
+
+  def builder_class(metric)
+    case metric
+    when *AVG_METRICS
+      V2::Reports::Timeseries::AverageReportBuilder
+    when *COUNT_METRICS
+      V2::Reports::Timeseries::CountReportBuilder
+    end
+  end
+
+  def log_invalid_metric
+    Rails.logger.error "ReportBuilder: Invalid metric - #{params[:metric]}"
+
+    {}
+  end
+end

--- a/app/builders/v2/conversation_metric_builder.rb
+++ b/app/builders/v2/conversation_metric_builder.rb
@@ -1,0 +1,30 @@
+class V2::ConversationMetricBuilder < V2::BaseConversationReportBuilder
+  def summary
+    {
+      conversations_count: count('conversations_count'),
+      incoming_messages_count: count('incoming_messages_count'),
+      outgoing_messages_count: count('outgoing_messages_count'),
+      avg_first_response_time: count('avg_first_response_time'),
+      avg_resolution_time: count('avg_resolution_time'),
+      resolutions_count: count('resolutions_count'),
+      reply_time: count('reply_time')
+    }
+  end
+
+  def bot_summary
+    {
+      bot_resolutions_count: count('bot_resolutions_count'),
+      bot_handoffs_count: count('bot_handoffs_count')
+    }
+  end
+
+  private
+
+  def count(metric)
+    builder_class(metric).new(account, builder_params(metric)).aggregate_value
+  end
+
+  def builder_params(metric)
+    params.merge({ metric: metric })
+  end
+end

--- a/app/builders/v2/new_report_builder.rb
+++ b/app/builders/v2/new_report_builder.rb
@@ -1,47 +1,25 @@
-class V2::NewReportBuilder
+class V2::NewReportBuilder < V2::BaseConversationReportBuilder
   include DateRangeHelper
 
   pattr_initialize :account, :params
 
-  AVG_METRICS = %w[avg_first_response_time avg_resolution_time reply_time].freeze
-  COUNT_METRICS = %w[
-    conversations_count
-    incoming_messages_count
-    outgoing_messages_count
-    resolutions_count
-    bot_resolutions_count
-    bot_handoffs_count
-  ].freeze
-
-  DEFAULT_GROUP_BY = 'day'.freeze
-  AGENT_RESULTS_PER_PAGE = 25
-
   def timeseries
-    return builder_class.new(account, params).timeseries if builder_class.present?
-
-    log_invalid_metric
+    perform_action(:timeseries)
   end
 
   def aggregate_value
-    return builder_class.new(account, params).aggregate_value if builder_class.present?
-
-    log_invalid_metric
+    perform_action(:aggregate_value)
   end
 
   private
 
-  def builder_class
-    case params[:metric]
-    when *AVG_METRICS
-      V2::Reports::Timeseries::AverageReportBuilder
-    when *COUNT_METRICS
-      V2::Reports::Timeseries::MetricCountReportBuilder
-    end
+  def perform_action(method_name)
+    return builder.new(account, params).public_send(method_name) if builder.present?
+
+    log_invalid_metric
   end
 
-  def log_invalid_metric
-    Rails.logger.error "ReportBuilder: Invalid metric - #{params[:metric]}"
-
-    {}
+  def builder
+    builder_class(params[:metric])
   end
 end

--- a/app/builders/v2/new_report_builder.rb
+++ b/app/builders/v2/new_report_builder.rb
@@ -4,29 +4,44 @@ class V2::NewReportBuilder
   pattr_initialize :account, :params
 
   AVG_METRICS = %w[avg_first_response_time avg_resolution_time reply_time].freeze
-  COUNT_METRICS = %w[conversations_count incoming_messages_count outgoing_messages_count resolutions_count bot_resolutions_count
-                     bot_handoffs_count].freeze
+  COUNT_METRICS = %w[
+    conversations_count
+    incoming_messages_count
+    outgoing_messages_count
+    resolutions_count
+    bot_resolutions_count
+    bot_handoffs_count
+  ].freeze
 
   DEFAULT_GROUP_BY = 'day'.freeze
   AGENT_RESULTS_PER_PAGE = 25
 
-  def build
-    builder_class = case params[:metric]
-                    when *AVG_METRICS
-                      V2::Reports::Timeseries::AverageReportBuilder
-                    when *COUNT_METRICS
-                      V2::Reports::Timeseries::MetricCountReportBuilder
-                    else
-                      log_invalid_metric
-                      return {}
-                    end
+  def timeseries
+    return builder_class.new(account, params).timeseries if builder_class.present?
 
-    builder_class.new(account, params).build
+    log_invalid_metric
+  end
+
+  def aggregate_value
+    return builder_class.new(account, params).aggregate_value if builder_class.present?
+
+    log_invalid_metric
   end
 
   private
 
+  def builder_class
+    case params[:metric]
+    when *AVG_METRICS
+      V2::Reports::Timeseries::AverageReportBuilder
+    when *COUNT_METRICS
+      V2::Reports::Timeseries::MetricCountReportBuilder
+    end
+  end
+
   def log_invalid_metric
     Rails.logger.error "ReportBuilder: Invalid metric - #{params[:metric]}"
+
+    {}
   end
 end

--- a/app/builders/v2/new_report_builder.rb
+++ b/app/builders/v2/new_report_builder.rb
@@ -1,0 +1,32 @@
+class V2::NewReportBuilder
+  include DateRangeHelper
+
+  pattr_initialize :account, :params
+
+  AVG_METRICS = %w[avg_first_response_time avg_resolution_time reply_time].freeze
+  COUNT_METRICS = %w[conversations_count incoming_messages_count outgoing_messages_count resolutions_count bot_resolutions_count
+                     bot_handoffs_count].freeze
+
+  DEFAULT_GROUP_BY = 'day'.freeze
+  AGENT_RESULTS_PER_PAGE = 25
+
+  def build
+    builder_class = case params[:metric]
+                    when *AVG_METRICS
+                      V2::Reports::Timeseries::AverageReportBuilder
+                    when *COUNT_METRICS
+                      V2::Reports::Timeseries::MetricCountReportBuilder
+                    else
+                      log_invalid_metric
+                      return {}
+                    end
+
+    builder_class.new(account, params).build
+  end
+
+  private
+
+  def log_invalid_metric
+    Rails.logger.error "ReportBuilder: Invalid metric - #{params[:metric]}"
+  end
+end

--- a/app/builders/v2/report_builder.rb
+++ b/app/builders/v2/report_builder.rb
@@ -46,27 +46,11 @@ class V2::ReportBuilder
     }
   end
 
-  def short_summary
-    {
-      conversations_count: conversations.count,
-      avg_first_response_time: avg_first_response_time_summary,
-      avg_resolution_time: avg_resolution_time_summary
-    }
-  end
-
   def bot_summary
     {
       bot_resolutions_count: bot_resolutions.count,
       bot_handoffs_count: bot_handoffs.count
     }
-  end
-
-  def conversation_metrics
-    if params[:type].equal?(:account)
-      live_conversations
-    else
-      agent_metrics.sort_by { |hash| hash[:metric][:open] }.reverse
-    end
   end
 
   private
@@ -108,31 +92,5 @@ class V2::ReportBuilder
       permit: %w[day week month year hour],
       time_zone: @timezone
     )
-  end
-
-  def agent_metrics
-    account_users = @account.account_users.page(params[:page]).per(AGENT_RESULTS_PER_PAGE)
-    account_users.each_with_object([]) do |account_user, arr|
-      @user = account_user.user
-      arr << {
-        id: @user.id,
-        name: @user.name,
-        email: @user.email,
-        thumbnail: @user.avatar_url,
-        availability: account_user.availability_status,
-        metric: live_conversations
-      }
-    end
-  end
-
-  def live_conversations
-    @open_conversations = scope.conversations.where(account_id: @account.id).open
-    metric = {
-      open: @open_conversations.count,
-      unattended: @open_conversations.unattended.count
-    }
-    metric[:unassigned] = @open_conversations.unassigned.count if params[:type].equal?(:account)
-    metric[:pending] = @open_conversations.pending.count if params[:type].equal?(:account)
-    metric
   end
 end

--- a/app/builders/v2/reports/live_reports/account_reports_builder.rb
+++ b/app/builders/v2/reports/live_reports/account_reports_builder.rb
@@ -1,0 +1,14 @@
+class V2::LiveReports::AccountReportsBuilder
+  pattr_initialize :account
+
+  def build
+    open_conversations = account.conversations.open
+    metric = {
+      open: open_conversations.count,
+      unattended: open_conversations.unattended.count
+    }
+    metric[:unassigned] = open_conversations.unassigned.count
+    metric[:pending] = open_conversations.pending.count
+    metric
+  end
+end

--- a/app/builders/v2/reports/live_reports/account_reports_builder.rb
+++ b/app/builders/v2/reports/live_reports/account_reports_builder.rb
@@ -1,4 +1,4 @@
-class V2::LiveReports::AccountReportsBuilder
+class V2::Reports::LiveReports::AccountReportsBuilder
   pattr_initialize :account
 
   def build

--- a/app/builders/v2/reports/live_reports/agent_reports_builder.rb
+++ b/app/builders/v2/reports/live_reports/agent_reports_builder.rb
@@ -1,4 +1,4 @@
-class V2::LiveReports::AgentReportsBuilder
+class V2::Reports::LiveReports::AgentReportsBuilder
   pattr_initialize :account, :params
   AGENT_RESULTS_PER_PAGE = 25
 

--- a/app/builders/v2/reports/live_reports/agent_reports_builder.rb
+++ b/app/builders/v2/reports/live_reports/agent_reports_builder.rb
@@ -1,0 +1,29 @@
+class V2::LiveReports::AgentReportsBuilder
+  pattr_initialize :account, :params
+  AGENT_RESULTS_PER_PAGE = 25
+
+  def build
+    account_users = account.account_users.page(params[:page]).per(AGENT_RESULTS_PER_PAGE)
+    account_users.each_with_object([]) do |account_user, arr|
+      user = account_user.user
+      arr << {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        thumbnail: user.avatar_url,
+        availability: account_user.availability_status,
+        metric: live_conversations(user)
+      }
+    end
+  end
+
+  private
+
+  def live_conversations(user)
+    open_conversations = user.conversations.where(account_id: @account.id).open
+    {
+      open: open_conversations.count,
+      unattended: open_conversations.unattended.count
+    }
+  end
+end

--- a/app/builders/v2/reports/timeseries/average_report_builder.rb
+++ b/app/builders/v2/reports/timeseries/average_report_builder.rb
@@ -27,8 +27,11 @@ class V2::Reports::Timeseries::AverageReportBuilder < V2::Reports::Timeseries::B
     metric_to_event_name[params[:metric].to_sym]
   end
 
+  def object_scope
+    scope.reporting_events.where(name: event_name, created_at: range)
+  end
+
   def reporting_events
-    object_scope = scope.reporting_events.where(name: event_name)
     @grouped_values = object_scope.group_by_period(
       group_by,
       :created_at,

--- a/app/builders/v2/reports/timeseries/average_report_builder.rb
+++ b/app/builders/v2/reports/timeseries/average_report_builder.rb
@@ -1,5 +1,5 @@
 class V2::Reports::Timeseries::AverageReportBuilder < V2::Reports::Timeseries::BaseTimeseriesBuilder
-  def build
+  def timeseries
     grouped_average_time = reporting_events.average(average_value_key)
     grouped_event_count = reporting_events.count
     grouped_average_time.each_with_object([]) do |element, arr|
@@ -10,6 +10,10 @@ class V2::Reports::Timeseries::AverageReportBuilder < V2::Reports::Timeseries::B
         count: grouped_event_count[event_date]
       }
     end
+  end
+
+  def aggregate_value
+    object_scope.average(average_value_key)
   end
 
   private

--- a/app/builders/v2/reports/timeseries/average_report_builder.rb
+++ b/app/builders/v2/reports/timeseries/average_report_builder.rb
@@ -29,6 +29,7 @@ class V2::Reports::Timeseries::AverageReportBuilder < V2::Reports::Timeseries::B
       group_by,
       :created_at,
       default_value: 0,
+      range: range,
       permit: %w[day week month year hour],
       time_zone: timezone
     )

--- a/app/builders/v2/reports/timeseries/average_report_builder.rb
+++ b/app/builders/v2/reports/timeseries/average_report_builder.rb
@@ -1,0 +1,40 @@
+class V2::Reports::Timeseries::AverageReportBuilder < V2::Reports::Timeseries::BaseTimeseriesBuilder
+  def build
+    grouped_average_time = reporting_events.average(average_value_key)
+    grouped_event_count = reporting_events.count
+    grouped_average_time.each_with_object([]) do |element, arr|
+      event_date, average_time = element
+      arr << {
+        value: average_time,
+        timestamp: event_date.to_time.to_i,
+        count: grouped_event_count[event_date]
+      }
+    end
+  end
+
+  private
+
+  def event_name
+    metric_to_event_name = {
+      avg_first_response_time: :first_response,
+      avg_resolution_time: :conversation_resolved,
+      reply_time: :reply_time
+    }
+    metric_to_event_name[params[:metric].to_sym]
+  end
+
+  def reporting_events
+    object_scope = scope.reporting_events.where(name: event_name)
+    @grouped_values = object_scope.group_by_period(
+      group_by,
+      :created_at,
+      default_value: 0,
+      permit: %w[day week month year hour],
+      time_zone: timezone
+    )
+  end
+
+  def average_value_key
+    @average_value_key ||= params[:business_hours].present? ? :value_in_business_hours : :value
+  end
+end

--- a/app/builders/v2/reports/timeseries/base_timeseries_builder.rb
+++ b/app/builders/v2/reports/timeseries/base_timeseries_builder.rb
@@ -1,0 +1,49 @@
+class V2::Reports::Timeseries::BaseTimeseriesBuilder
+  include DateRangeHelper
+  DEFAULT_GROUP_BY = 'day'.freeze
+
+  pattr_initialize :account, :params
+
+  def scope
+    case params[:type]
+    when :account
+      account
+    when :inbox
+      inbox
+    when :agent
+      user
+    when :label
+      label
+    when :team
+      team
+    end
+  end
+
+  def inbox
+    @inbox ||= account.inboxes.find(params[:id])
+  end
+
+  def user
+    @user ||= account.users.find(params[:id])
+  end
+
+  def label
+    @label ||= account.labels.find(params[:id])
+  end
+
+  def team
+    @team ||= account.teams.find(params[:id])
+  end
+
+  def group_by
+    @group_by ||= params[:group_by] || DEFAULT_GROUP_BY
+  end
+
+  def timezone
+    @timezone ||= ActiveSupport::TimeZone[timezone_offset]&.name
+  end
+
+  def timezone_offset
+    @timezone_offset ||= params.fetch(:timezone_offset, 0).to_f
+  end
+end

--- a/app/builders/v2/reports/timeseries/count_report_builder.rb
+++ b/app/builders/v2/reports/timeseries/count_report_builder.rb
@@ -1,4 +1,4 @@
-class V2::Reports::Timeseries::MetricCountReportBuilder < V2::Reports::Timeseries::BaseTimeseriesBuilder
+class V2::Reports::Timeseries::CountReportBuilder < V2::Reports::Timeseries::BaseTimeseriesBuilder
   def timeseries
     grouped_count.each_with_object([]) do |element, arr|
       event_date, event_count = element

--- a/app/builders/v2/reports/timeseries/metric_count_report_builder.rb
+++ b/app/builders/v2/reports/timeseries/metric_count_report_builder.rb
@@ -1,9 +1,13 @@
 class V2::Reports::Timeseries::MetricCountReportBuilder < V2::Reports::Timeseries::BaseTimeseriesBuilder
-  def build
+  def timeseries
     grouped_count.each_with_object([]) do |element, arr|
       event_date, event_count = element
       arr << { value: event_count, timestamp: event_date.to_time.to_i }
     end
+  end
+
+  def aggregate_value
+    object_scope.count
   end
 
   private

--- a/app/builders/v2/reports/timeseries/metric_count_report_builder.rb
+++ b/app/builders/v2/reports/timeseries/metric_count_report_builder.rb
@@ -54,6 +54,7 @@ class V2::Reports::Timeseries::MetricCountReportBuilder < V2::Reports::Timeserie
       group_by,
       :created_at,
       default_value: 0,
+      range: range,
       permit: %w[day week month year hour],
       time_zone: timezone
     ).count

--- a/app/builders/v2/reports/timeseries/metric_count_report_builder.rb
+++ b/app/builders/v2/reports/timeseries/metric_count_report_builder.rb
@@ -1,0 +1,61 @@
+class V2::Reports::Timeseries::MetricCountReportBuilder < V2::Reports::Timeseries::BaseTimeseriesBuilder
+  def build
+    grouped_count.each_with_object([]) do |element, arr|
+      event_date, event_count = element
+      arr << { value: event_count, timestamp: event_date.to_time.to_i }
+    end
+  end
+
+  private
+
+  def metric
+    @metric ||= params[:metric]
+  end
+
+  def object_scope
+    send("scope_for_#{metric}")
+  end
+
+  def scope_for_conversations_count
+    scope.conversations.where(account_id: account.id, created_at: range)
+  end
+
+  def scope_for_incoming_messages_count
+    scope.messages.where(account_id: account.id, created_at: range).incoming.unscope(:order)
+  end
+
+  def scope_for_outgoing_messages_count
+    scope.messages.where(account_id: account.id, created_at: range).outgoing.unscope(:order)
+  end
+
+  def scope_for_resolutions_count
+    scope.reporting_events.joins(:conversation).select(:conversation_id).where(
+      name: :conversation_resolved,
+      conversations: { status: :resolved }, created_at: range
+    ).distinct
+  end
+
+  def scope_for_bot_resolutions_count
+    scope.reporting_events.joins(:conversation).select(:conversation_id).where(
+      name: :conversation_bot_resolved,
+      conversations: { status: :resolved }, created_at: range
+    ).distinct
+  end
+
+  def scope_for_bot_handoffs_count
+    scope.reporting_events.joins(:conversation).select(:conversation_id).where(
+      name: :conversation_bot_handoff,
+      created_at: range
+    ).distinct
+  end
+
+  def grouped_count
+    @grouped_values = object_scope.group_by_period(
+      group_by,
+      :created_at,
+      default_value: 0,
+      permit: %w[day week month year hour],
+      time_zone: timezone
+    ).count
+  end
+end

--- a/app/controllers/api/v2/accounts/reports_controller.rb
+++ b/app/controllers/api/v2/accounts/reports_controller.rb
@@ -5,7 +5,7 @@ class Api::V2::Accounts::ReportsController < Api::V1::Accounts::BaseController
   before_action :check_authorization
 
   def index
-    builder = V2::ReportBuilder.new(Current.account, report_params)
+    builder = V2::NewReportBuilder.new(Current.account, report_params)
     data = builder.build
     render json: data
   end

--- a/app/helpers/api/v2/accounts/heatmap_helper.rb
+++ b/app/helpers/api/v2/accounts/heatmap_helper.rb
@@ -66,18 +66,17 @@ module Api::V2::Accounts::HeatmapHelper
   end
 
   def generate_heatmap_data(date, offset)
-    report_params = {
-      type: :account,
-      group_by: 'hour',
-      metric: 'conversations_count',
-      business_hours: false
-    }
-
-    V2::ReportBuilder.new(Current.account, report_params.merge({
-                                                                 since: since_timestamp(date),
-                                                                 until: until_timestamp(date),
-                                                                 timezone_offset: offset
-                                                               })).build
+    V2::NewReportBuilder.new(
+      Current.account, {
+        type: :account,
+        group_by: 'hour',
+        metric: 'conversations_count',
+        business_hours: false,
+        since: since_timestamp(date),
+        until: until_timestamp(date),
+        timezone_offset: offset
+      }
+    ).timeseries
   end
 
   def transform_data(data, zone_transform)
@@ -94,7 +93,7 @@ module Api::V2::Accounts::HeatmapHelper
   end
 
   def since_timestamp(date)
-    (date - 6.days).to_i.to_s
+    (date - 100.days).to_i.to_s
   end
 
   def until_timestamp(date)

--- a/app/helpers/api/v2/accounts/reports_helper.rb
+++ b/app/helpers/api/v2/accounts/reports_helper.rb
@@ -41,7 +41,12 @@ module Api::V2::Accounts::ReportsHelper
   end
 
   def generate_report(report_params)
-    report_builder(report_params).short_summary
+    builder = V2::NewReportBuilder
+    {
+      conversations_count: builder.new(account, report_params.merge(metric: :conversations_count)),
+      avg_first_response_time: builder.new(account, report_params.merge(metric: :avg_first_response_time)),
+      avg_resolution_time: builder.new(account, report_params.merge(metric: :avg_resolution_time))
+    }
   end
 
   private


### PR DESCRIPTION
- Re-write the methods for clarity
- Remove the dependency on the ReportHelper class.
- Remove n+1 queries in the average metric time series data.