### PR TITLE
fix: Get online status from db when not present in cache [CW-3233]

### DIFF
--- a/lib/online_status_tracker.rb
+++ b/lib/online_status_tracker.rb
@@ -57,7 +57,13 @@ class OnlineStatusTracker
     return {} if user_ids.blank?
 
     user_availabilities = ::Redis::Alfred.hmget(status_key(account_id), user_ids)
-    user_ids.map.with_index { |id, index| [id, (user_availabilities[index] || 'online')] }.to_h
+    user_ids.map.with_index { |id, index| [id, (user_availabilities[index] || get_availability_from_db(account_id, id))] }.to_h
+  end
+
+  def self.get_availability_from_db(account_id, user_id)
+    availability = Account.find(account_id).account_users.find_by(user_id: user_id).availability
+    set_status(account_id, user_id, availability)
+    availability
   end
 
   def self.get_available_user_ids(account_id)

--- a/spec/lib/online_status_tracker_spec.rb
+++ b/spec/lib/online_status_tracker_spec.rb
@@ -13,7 +13,7 @@ describe OnlineStatusTracker do
     end
 
     it 'returns only the online user ids with presence' do
-      expect(described_class.get_available_users(account.id).keys).to contain_exactly(user1.id.to_s)
+      expect(described_class.get_available_users(account.id).keys).to contain_exactly(user1.id.to_s, user2.id.to_s)
       expect(described_class.get_available_users(account.id).values).not_to include(user3.id)
     end
 

--- a/spec/lib/online_status_tracker_spec.rb
+++ b/spec/lib/online_status_tracker_spec.rb
@@ -9,6 +9,7 @@ describe OnlineStatusTracker do
   context 'when get_available_users' do
     before do
       described_class.update_presence(account.id, 'User', user1.id)
+      described_class.update_presence(account.id, 'User', user2.id)
     end
 
     it 'returns only the online user ids with presence' do
@@ -19,6 +20,17 @@ describe OnlineStatusTracker do
     it 'returns agents who have auto offline configured false' do
       user2.account_users.first.update(auto_offline: false)
       expect(described_class.get_available_users(account.id).keys).to contain_exactly(user1.id.to_s, user2.id.to_s)
+    end
+
+    it 'returns the availability from the db if it is not present in redis and set it in redis' do
+      user2.account_users.find_by(account_id: account.id).update!(availability: 'offline')
+      # clear the redis cache to ensure values are fetched from db
+      Redis::Alfred.delete(format(Redis::Alfred::ONLINE_STATUS, account_id: account.id))
+      expect(described_class.get_available_users(account.id)[user1.id.to_s]).to eq('online')
+      expect(described_class.get_available_users(account.id)[user2.id.to_s]).to eq('offline')
+      # ensure online status is also set
+      expect(Redis::Alfred.hmget(format(Redis::Alfred::ONLINE_STATUS, account_id: account.id),
+                                 [user1.id.to_s, user2.id.to_s])).to eq(%w[online offline])
     end
   end
 


### PR DESCRIPTION
Previously, we returned the static value 'online' when the status was not present in the Redis cache. This PR changes it to fall back to the DB value and updates the cache in such cases.

fixes: https://linear.app/chatwoot/issue/CW-3233/write-a-back-up-for-online-status-in-case-if-redis-keys-are-not
