### PR TITLE
chore: Add indexes to improve reporting performance

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -24,6 +24,7 @@
 #
 # Indexes
 #
+#  index_messages_on_account_created_type               (account_id,created_at,message_type)
 #  index_messages_on_account_id                         (account_id)
 #  index_messages_on_account_id_and_inbox_id            (account_id,inbox_id)
 #  index_messages_on_additional_attributes_campaign_id  (((additional_attributes -> 'campaign_id'::text))) USING gin

--- a/db/migrate/20240516003531_add_index_for_message_type_account_date.rb
+++ b/db/migrate/20240516003531_add_index_for_message_type_account_date.rb
@@ -1,0 +1,7 @@
+class AddIndexForMessageTypeAccountDate < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :messages, [:account_id, :created_at, :message_type], name: 'index_messages_on_account_created_type', algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_15_201632) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_16_003531) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -696,6 +696,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_201632) do
     t.text "processed_message_content"
     t.jsonb "sentiment", default: {}
     t.index "((additional_attributes -> 'campaign_id'::text))", name: "index_messages_on_additional_attributes_campaign_id", using: :gin
+    t.index ["account_id", "created_at", "message_type"], name: "index_messages_on_account_created_type"
     t.index ["account_id", "inbox_id"], name: "index_messages_on_account_id_and_inbox_id"
     t.index ["account_id"], name: "index_messages_on_account_id"
     t.index ["content"], name: "index_messages_on_content", opclass: :gin_trgm_ops, using: :gin


### PR DESCRIPTION
- Adding a new index on (account_id,created_at,message_type) based on our performance improvement exercise. This index significantly improves the page load speeds of messaging reports. 