### PR TITLE
fix: Cannot read properties of undefined (reading 'toLowerCase')

### DIFF
--- a/app/javascript/dashboard/mixins/uiSettings.js
+++ b/app/javascript/dashboard/mixins/uiSettings.js
@@ -15,7 +15,7 @@ export const DEFAULT_CONTACT_SIDEBAR_ITEMS_ORDER = [
 ];
 
 const slugifyChannel = name =>
-  name.toLowerCase().replace(' ', '_').replace('-', '_').replace('::', '_');
+  name?.toLowerCase().replace(' ', '_').replace('-', '_').replace('::', '_');
 
 export const isEditorHotKeyEnabled = (uiSettings, key) => {
   const {

--- a/app/javascript/dashboard/mixins/uiSettings.js
+++ b/app/javascript/dashboard/mixins/uiSettings.js
@@ -70,6 +70,8 @@ export default {
       this.updateUISettings({ [key]: !this.isContactSidebarItemOpen(key) });
     },
     setSignatureFlagForInbox(channelType, value) {
+      if (!channelType) return;
+
       channelType = slugifyChannel(channelType);
       this.updateUISettings({
         [`${channelType}_signature_enabled`]: value,


### PR DESCRIPTION
Tried to replicate the issue, but Sentry didn't have enough information. `toggleMessageSignature` is a user triggered action in `ReplyBottomPanel.vue`, the value for `channelType` is provided from `inboxMixin`. The error will occur if either `inbox` is an empty object `{}` or `channel_type` in `inbox` object is undefined.

I couldn't find any instance where this could be the case. The PR has a stop gap solution that ensures that no action is triggered