### PR TITLE
fix: Fix typo in the font for portals

### DIFF
--- a/app/javascript/portal/application.scss
+++ b/app/javascript/portal/application.scss
@@ -11,7 +11,7 @@
 
 html,
 body {
-  font-family: 'Inter Display', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
+  font-family: 'InterDisplay', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   height: 100%;


### PR DESCRIPTION
The fonts on the portal were not loaded properly before due to a typo in the stylesheet. The font that is shown on the public portal is ui-sans right now. This PR fixes it. 