### PR TITLE
fix: Space key in input closing dropdown

### DIFF
--- a/app/javascript/dashboard/components/ui/Dropdown/DropdownSearch.vue
+++ b/app/javascript/dashboard/components/ui/Dropdown/DropdownSearch.vue
@@ -18,11 +18,11 @@ defineProps({
   <div
     class="flex items-center justify-between h-10 min-h-[40px] sticky top-0 bg-white z-10 dark:bg-slate-800 gap-2 px-3 border-b rounded-t-xl border-slate-50 dark:border-slate-700"
   >
-    <div class="flex items-center w-full gap-2">
+    <div class="flex items-center w-full gap-2" @keyup.space.prevent>
       <fluent-icon
         icon="search"
-        size="18"
-        class="text-slate-400 dark:text-slate-400"
+        size="16"
+        class="text-slate-400 dark:text-slate-400 flex-shrink-0"
       />
       <input
         type="text"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will fix an issue with the new filter dropdown. When the dropdown is active, we can search it and add space, but it gets closed.

**Reason for the issue**
The filter dropdown is done with the slot mechanism, so it is added inside the button. The button is active when the dropdown and its input are active. Then we click the space key, and on the key up, the dropdown is toggled.

**Solution**
I used the Vue native event `@keyup.space.prevent` to prevent the space key-up event in the dropdown search wrapper.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Screenrecording**

**Before**

https://github.com/chatwoot/chatwoot/assets/64252451/0c7b062a-bea1-48e5-b3af-1c5837876078

**After**

https://github.com/chatwoot/chatwoot/assets/64252451/121b8a11-7f79-4a26-ac61-42f5751cdfe4


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules



