### PR TITLE
fix: Enable edit option for custom attributes if value is present

### DIFF
--- a/app/javascript/dashboard/components/CustomAttribute.vue
+++ b/app/javascript/dashboard/components/CustomAttribute.vue
@@ -100,7 +100,7 @@
             @click="onCopy"
           />
           <woot-button
-            v-if="showEditButton"
+            v-if="showActions"
             v-tooltip.right="$t('CUSTOM_ATTRIBUTES.ACTIONS.EDIT')"
             variant="link"
             size="small"
@@ -176,9 +176,6 @@ export default {
   computed: {
     showCopyAndDeleteButton() {
       return this.value && this.showActions;
-    },
-    showEditButton() {
-      return !this.value && this.showActions;
     },
     displayValue() {
       if (this.isAttributeTypeDate) {

--- a/app/javascript/dashboard/components/CustomAttribute.vue
+++ b/app/javascript/dashboard/components/CustomAttribute.vue
@@ -27,7 +27,7 @@
             />
           </span>
           <woot-button
-            v-if="showCopyAndDeleteButton"
+            v-if="showActions && value"
             v-tooltip.left="$t('CUSTOM_ATTRIBUTES.ACTIONS.DELETE')"
             variant="link"
             size="medium"
@@ -90,7 +90,7 @@
         </p>
         <div class="flex max-w-[2rem] gap-1 ml-1 rtl:mr-1 rtl:ml-0">
           <woot-button
-            v-if="showCopyAndDeleteButton"
+            v-if="showActions && value"
             v-tooltip="$t('CUSTOM_ATTRIBUTES.ACTIONS.COPY')"
             variant="link"
             size="small"
@@ -174,9 +174,6 @@ export default {
     };
   },
   computed: {
-    showCopyAndDeleteButton() {
-      return this.value && this.showActions;
-    },
     displayValue() {
       if (this.isAttributeTypeDate) {
         return this.value


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will enable a back edit option for custom attributes if there is the value present, which is removed by this [PR](https://github.com/chatwoot/chatwoot/pull/9070/files#diff-fe9b82bbef1da31faa513332ed6015c0ed23765a6368832137a5408547da8938R172)

Fixes https://linear.app/chatwoot/issue/CW-3345/edit-attribute-does-not-work-anymore

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Screenrecordings**

**Before**


https://github.com/chatwoot/chatwoot/assets/64252451/ab89e087-d919-404d-90a9-17982b425dc3



**After**

https://github.com/chatwoot/chatwoot/assets/64252451/98d8b0b2-2f8f-46ec-ace5-b3e2a721623e



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
