### PR TITLE
feat: add reauthorization banner for Facebook

### DIFF
--- a/app/javascript/dashboard/components/layout/sidebarComponents/SecondaryChildNavItem.vue
+++ b/app/javascript/dashboard/components/layout/sidebarComponents/SecondaryChildNavItem.vue
@@ -65,11 +65,11 @@
         </div>
         <span
           v-if="warningIcon"
-          class="inline-flex rounded-sm mr-1 bg-slate-100"
+          class="inline-flex mr-1 bg-red-50 dark:bg-red-900 p-0.5 rounded-sm"
         >
           <fluent-icon
-            v-tooltip.top-end="$t('SIDEBAR.FACEBOOK_REAUTHORIZE')"
-            class="text-xxs"
+            v-tooltip.top-end="$t('SIDEBAR.REAUTHORIZE')"
+            class="text-xxs text-red-500 dark:text-red-300"
             :icon="warningIcon"
             size="12"
           />

--- a/app/javascript/dashboard/helper/inbox.js
+++ b/app/javascript/dashboard/helper/inbox.js
@@ -87,7 +87,8 @@ export const getInboxClassByType = (type, phoneNumber) => {
 };
 
 export const getInboxWarningIconClass = (type, reauthorizationRequired) => {
-  if (type === INBOX_TYPES.FB && reauthorizationRequired) {
+  const allowedInboxTypes = [INBOX_TYPES.FB, INBOX_TYPES.EMAIL];
+  if (allowedInboxTypes.includes(type) && reauthorizationRequired) {
     return 'warning';
   }
   return '';

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -274,7 +274,7 @@
     "SLA": "SLA",
     "BETA": "Beta",
     "REPORTS_OVERVIEW": "Overview",
-    "REAUTHORIZE": "Your inbox connection has expired, please reconnect\n your inbox to continue receiving and sending messages",
+    "REAUTHORIZE": "Your inbox connection has expired, please reconnect\n to continue receiving and sending messages",
     "HELP_CENTER": {
       "TITLE": "Help Center",
       "ALL_ARTICLES": "All Articles",

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -274,7 +274,7 @@
     "SLA": "SLA",
     "BETA": "Beta",
     "REPORTS_OVERVIEW": "Overview",
-    "FACEBOOK_REAUTHORIZE": "Your Facebook connection has expired, please reconnect your Facebook page to continue services",
+    "REAUTHORIZE": "Your inbox connection has expired, please reconnect\n your inbox to continue receiving and sending messages",
     "HELP_CENTER": {
       "TITLE": "Help Center",
       "ALL_ARTICLES": "All Articles",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -22,6 +22,7 @@
     </setting-intro-banner>
 
     <microsoft-reauthorize v-if="microsoftUnauthorized" :inbox="inbox" />
+    <facebook-reauthorize v-if="facebookUnauthorized" :inbox="inbox" />
 
     <div v-if="selectedTabKey === 'inbox_settings'" class="mx-8">
       <settings-section
@@ -399,7 +400,6 @@
           @click="updateInbox"
         />
       </settings-section>
-      <facebook-reauthorize v-if="isAFacebookInbox" :inbox-id="inbox.id" />
     </div>
 
     <div v-if="selectedTabKey === 'collaborators'" class="mx-8">
@@ -620,6 +620,9 @@ export default {
     },
     microsoftUnauthorized() {
       return this.isAMicrosoftInbox && this.inbox.reauthorization_required;
+    },
+    facebookUnauthorized() {
+      return this.isAFacebookInbox && this.inbox.reauthorization_required;
     },
   },
   watch: {

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -619,7 +619,7 @@ export default {
       return false;
     },
     microsoftUnauthorized() {
-      return this.inbox.microsoft_reauthorization;
+      return this.isAMicrosoftInbox && this.inbox.reauthorization_required;
     },
   },
   watch: {

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/facebook/Reauthorize.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/facebook/Reauthorize.vue
@@ -19,7 +19,7 @@ export default {
     },
   },
   computed: {
-    inboxId: () => {
+    inboxId() {
       return this.inbox.id;
     },
   },

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/facebook/Reauthorize.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/facebook/Reauthorize.vue
@@ -1,38 +1,32 @@
 <template>
-  <settings-section
-    :title="$t('INBOX_MGMT.FACEBOOK_REAUTHORIZE.TITLE')"
-    :sub-title="$t('INBOX_MGMT.FACEBOOK_REAUTHORIZE.SUBTITLE')"
-  >
-    <a class="fb--login" href="#" @click="tryFBlogin">
-      <img
-        src="~dashboard/assets/images/channels/facebook_login.png"
-        alt="Facebook-logo"
-      />
-    </a>
-  </settings-section>
+  <inbox-reconnection-required class="mx-8 mt-5" @reauthorize="tryFBlogin" />
 </template>
 
 <script>
 /* global FB */
-import SettingsSection from '../../../../../components/SettingsSection.vue';
+import InboxReconnectionRequired from '../components/InboxReconnectionRequired';
 import alertMixin from 'shared/mixins/alertMixin';
 
 export default {
   components: {
-    SettingsSection,
+    InboxReconnectionRequired,
   },
   mixins: [alertMixin],
   props: {
-    inboxId: {
-      type: Number,
+    inbox: {
+      type: Object,
       required: true,
+    },
+  },
+  computed: {
+    inboxId: () => {
+      return this.inbox.id;
     },
   },
   mounted() {
     this.initFB();
     this.loadFBsdk();
   },
-
   methods: {
     initFB() {
       if (window.fbSDKLoaded === undefined) {

--- a/app/javascript/shared/mixins/inboxMixin.js
+++ b/app/javascript/shared/mixins/inboxMixin.js
@@ -44,6 +44,9 @@ export default {
     whatsAppAPIProvider() {
       return this.inbox.provider || '';
     },
+    isAMicrosoftInbox() {
+      return this.isAnEmailChannel && this.inbox.provider === 'microsoft';
+    },
     isAPIInbox() {
       return this.channelType === INBOX_TYPES.API;
     },

--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -48,7 +48,6 @@ if resource.web_widget?
   json.continuity_via_email resource.channel.try(:continuity_via_email)
 end
 
-
 ## Facebook Attributes
 if resource.facebook?
   json.page_id resource.channel.try(:page_id)

--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -48,10 +48,13 @@ if resource.web_widget?
   json.continuity_via_email resource.channel.try(:continuity_via_email)
 end
 
+
 ## Facebook Attributes
 if resource.facebook?
   json.page_id resource.channel.try(:page_id)
+
   json.reauthorization_required resource.channel.try(:reauthorization_required?)
+  json.facebook_reauthorization resource.channel.try(:reauthorization_required?)
 end
 
 ## Twilio Attributes
@@ -74,7 +77,7 @@ if resource.email?
     json.imap_enable_ssl resource.channel.try(:imap_enable_ssl)
 
     if resource.channel.try(:microsoft?)
-      json.microsoft_reauthorization resource.channel.try(:provider_config).empty? || resource.channel.try(:reauthorization_required?)
+      json.reauthorization_required resource.channel.try(:provider_config).empty? || resource.channel.try(:reauthorization_required?)
     end
   end
 

--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -52,9 +52,7 @@ end
 ## Facebook Attributes
 if resource.facebook?
   json.page_id resource.channel.try(:page_id)
-
   json.reauthorization_required resource.channel.try(:reauthorization_required?)
-  json.facebook_reauthorization resource.channel.try(:reauthorization_required?)
 end
 
 ## Twilio Attributes


### PR DESCRIPTION
This PR has the following changes

1. Use `reauthorization_required` as standard instead of inbox specific flags
1. Show alert on the sidebar along with a tooltip for Microsoft and Facebook both
1. Update  `facebook/Reauthorize.vue` component to use the banner UI instead of the form
1. Update alert icon layout on the sidebar to make it more prominent

#### Updated tooltip on the sidebar

![CleanShot 2024-05-28 at 12 49 32@2x](https://github.com/chatwoot/chatwoot/assets/18097732/8f5a24dd-635b-4f3c-85ec-3a584e6d5da4)

#### Updated facebook page

![CleanShot 2024-05-28 at 12 51 30@2x](https://github.com/chatwoot/chatwoot/assets/18097732/3f7597c5-d356-4d10-8edc-7f9d47f74020)

