### PR TITLE
feat: remove stale ONLINE_PRESENCE contact keys in redis

### DIFF
--- a/app/jobs/internal/process_stale_redis_keys_job.rb
+++ b/app/jobs/internal/process_stale_redis_keys_job.rb
@@ -1,0 +1,11 @@
+# housekeeping
+# remove contact inboxes that does not have any conversations
+# and are older than 3 months
+
+class Internal::ProcessStaleRedisKeysJob < ApplicationJob
+  queue_as :low
+
+  def perform(account)
+    Internal::RemoveStaleRedisKeysService.new(account_id: account.id).perform
+  end
+end

--- a/app/jobs/internal/remove_stale_redis_keys_job.rb
+++ b/app/jobs/internal/remove_stale_redis_keys_job.rb
@@ -1,0 +1,14 @@
+# housekeeping
+# ensure stale ONLINE PRESENCE KEYS for contacts are removed periodically
+# should result in 50% redis mem size reduction
+
+class Internal::RemoveStaleRedisKeysJob < ApplicationJob
+  queue_as :scheduled_jobs
+
+  def perform
+    Account.find_each do |account|
+      Rails.logger.info "Enqueuing ProcessStaleRedisKeysJob for account #{account.id}"
+      Internal::ProcessStaleRedisKeysJob.perform_later(account)
+    end
+  end
+end

--- a/app/services/internal/remove_stale_redis_keys_service.rb
+++ b/app/services/internal/remove_stale_redis_keys_service.rb
@@ -1,0 +1,10 @@
+class Internal::RemoveStaleRedisKeysService
+  pattr_initialize [:account_id!]
+
+  def perform(account_id)
+    range_start = (Time.zone.now - PRESENCE_DURATION).to_i
+    # exclusive minimum score is specified by prefixing (
+    # we are clearing old records because this could clogg up the sorted set
+    ::Redis::Alfred.zremrangebyscore(presence_key(account_id, 'Contact'), '-inf', "(#{range_start}")
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -26,3 +26,10 @@ remove_stale_contact_inboxes_job.rb:
   cron: '30 22 * * *'
   class: 'Internal::RemoveStaleContactInboxesJob'
   queue: scheduled_jobs
+
+# executed daily at 2230 UTC
+# which is our lowest traffic time
+remove_stale_redis_keys_job.rb:
+  cron: '30 22 * * *'
+  class: 'Internal::RemoveStaleRedisKeysJob'
+  queue: scheduled_jobs


### PR DESCRIPTION
# Pull Request Template

## Description

50% of Redis memory size comes from ONLINE_PRESENCE keys. This PR adds a periodic job to remove stale keys from all accounts.

![image](https://github.com/chatwoot/chatwoot/assets/3526167/89d1ee63-e614-4401-8d6e-973303f7a522)

Fixes https://linear.app/chatwoot/issue/CW-3231/investigate-appropriate-strategy-for-redis-key-expiry

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
