### PR TITLE
fix: TypeError cannot read properties of undefined (reading 'name')

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/overview/AgentTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/overview/AgentTable.vue
@@ -67,7 +67,7 @@ export default {
       return this.agentMetrics.map(agent => {
         const agentInformation = this.getAgentInformation(agent.id);
         return {
-          agent: agentInformation.name,
+          agent: agentInformation.name || agentInformation.available_name,
           email: agentInformation.email,
           thumbnail: agentInformation.thumbnail,
           open: agent.metric.open || 0,
@@ -130,7 +130,18 @@ export default {
       this.$emit('page-change', pageIndex);
     },
     getAgentInformation(id) {
-      return this.agents.find(agent => agent.id === Number(id));
+      const agentInformation = this.agents?.find(
+        agent => agent.id === Number(id)
+      );
+      if (!agentInformation) {
+        return {
+          name: '-',
+          email: '-',
+          thumbnail: '',
+          availability_status: 'offline',
+        };
+      }
+      return agentInformation;
     },
   },
 };

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/overview/AgentTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/overview/AgentTable.vue
@@ -64,17 +64,19 @@ export default {
   },
   computed: {
     tableData() {
-      return this.agentMetrics.map(agent => {
-        const agentInformation = this.getAgentInformation(agent.id);
-        return {
-          agent: agentInformation.name || agentInformation.available_name,
-          email: agentInformation.email,
-          thumbnail: agentInformation.thumbnail,
-          open: agent.metric.open || 0,
-          unattended: agent.metric.unattended || 0,
-          status: agentInformation.availability_status,
-        };
-      });
+      return this.agentMetrics
+        .filter(agentMetric => this.getAgentInformation(agentMetric.id))
+        .map(agent => {
+          const agentInformation = this.getAgentInformation(agent.id);
+          return {
+            agent: agentInformation.name || agentInformation.available_name,
+            email: agentInformation.email,
+            thumbnail: agentInformation.thumbnail,
+            open: agent.metric.open || 0,
+            unattended: agent.metric.unattended || 0,
+            status: agentInformation.availability_status,
+          };
+        });
     },
     columns() {
       return [
@@ -130,18 +132,7 @@ export default {
       this.$emit('page-change', pageIndex);
     },
     getAgentInformation(id) {
-      const agentInformation = this.agents?.find(
-        agent => agent.id === Number(id)
-      );
-      if (!agentInformation) {
-        return {
-          name: '-',
-          email: '-',
-          thumbnail: '',
-          availability_status: 'offline',
-        };
-      }
-      return agentInformation;
+      return this.agents?.find(agent => agent.id === Number(id));
     },
   },
 };


### PR DESCRIPTION
# Pull Request Template

## Description

**Cause of this issue**
I tried to replicate the issue by deleting the agent from super admin, but it didn't work. The error `"TypeError: Cannot read properties of undefined (reading 'name')"` suggests that `agentInformation` is `undefined` when accessing the name property. This likely occurs because the `getAgentInformation` method does not find an agent matching the given `id`, and thus returns `undefined`. 

**Solution**
To resolve this issue, I modified the `getAgentInformation` method to handle cases where no agent is found. And added a fallback to the `agent.name` with `agent.available_name`. This change ensures that `agentInformation` will always be an object with its properties

Fixes https://linear.app/chatwoot/issue/CW-3325/typeerror-cannot-read-properties-of-undefined-reading-name

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
