### PR TITLE
fix: TypeError undefined is not an object `(evaluating 'this.features.inbound_emails')`

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -200,7 +200,7 @@ export default {
     },
 
     featureInboundEmailEnabled() {
-      return !!this.features.inbound_emails;
+      return !!this.features?.inbound_emails;
     },
 
     featureCustomReplyDomainEnabled() {


### PR DESCRIPTION
# Pull Request Template

## Description

**Cause of this issue**
I tried replicating the issue by toggling the feature flags from the super admin, but it didn't work. The error `TypeError: undefined, is not an object (evaluating 'this.features.inbound_emails')`. It's because `this.features` is undefined when `featureInboundEmailEnabled` is called. This can happen if `this.features` is not properly initialized before this method is accessed. The `features` are set on mounted. 

 **Solution**
To resolve this issue, you should ensure that `this.features` is defined before any computations or methods that rely on it are executed. So, I added a check in the `featureInboundEmailEnabled` method to handle cases where `features` might be undefined.

Fixes https://linear.app/chatwoot/issue/CW-3341/typeerror-undefined-is-not-an-object-evaluating-thisfeaturesinbound

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
