### PR TITLE
fix: nightly gh action build failure

### DIFF
--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -18,15 +18,15 @@ jobs:
   nightly:
     runs-on: ubuntu-20.04
     steps:
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      if: always()
-    ## temporary fix for gh actions since node 20 installed via script is not taking effect till 30june2024
-    ## https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
+    # - name: Setup tmate session
+    #   uses: mxschmitt/action-tmate@v3
+    #   if: always()
+    # ## temporary fix for gh actions since node 20 installed via script is not taking effect till 30june2024
+    # ## https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default
+    # - name: Setup Node.js
+    #   uses: actions/setup-node@v4
+    #   with:
+    #     node-version: '20'
 
     - name: get installer
       run: |
@@ -34,6 +34,7 @@ jobs:
         chmod +x install.sh
         #fix for postgtres not starting automatically in gh action env
         sed -i '/function configure_db() {/a sudo service postgresql start' install.sh
+        sed -i '/function setup_chatwoot() {/a export PATH="/usr/bin/:$PATH"' install.sh
 
     - name: create input file
       run: |

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -18,6 +18,9 @@ jobs:
   nightly:
     runs-on: ubuntu-20.04
     steps:
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: always()
     ## temporary fix for gh actions since node 20 installed via script is not taking effect till 30june2024
     ## https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default
     - name: Setup Node.js
@@ -50,9 +53,7 @@ jobs:
         #        sudo systemctl restart chatwoot.target
         #        curl http://localhost:3000/api
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      if: always()
+
 
     - name: Upload chatwoot setup log file as an artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -23,19 +23,22 @@ jobs:
     #   if: always()
     # ## temporary fix for gh actions since node 20 installed via script is not taking effect till 30june2024
     # ## https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default
-    # - name: Setup Node.js
-    #   uses: actions/setup-node@v4
-    #   with:
-    #     node-version: '20'
-
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - name: create input file
+      run: |
+        node --version
+        which node
     - name: get installer
       run: |
         wget https://get.chatwoot.app/linux/install.sh
         chmod +x install.sh
         #fix for postgtres not starting automatically in gh action env
         sed -i '/function configure_db() {/a sudo service postgresql start' install.sh
-        sed -i '/function setup_chatwoot() {/a export PATH="/usr/bin/:$PATH"' install.sh
-        sed -i '/git checkout "\$BRANCH"/a export PATH="/usr/bin/:$PATH"' install.sh
+        #sed -i '/function setup_chatwoot() {/a export PATH="/usr/bin/:$PATH"' install.sh
+        #sed -i '/git checkout "\$BRANCH"/a export PATH="/usr/bin/:$PATH"' install.sh
 
     - name: create input file
       run: |

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -35,6 +35,7 @@ jobs:
         #fix for postgtres not starting automatically in gh action env
         sed -i '/function configure_db() {/a sudo service postgresql start' install.sh
         sed -i '/function setup_chatwoot() {/a export PATH="/usr/bin/:$PATH"' install.sh
+        sed -i '/git checkout "\$BRANCH"/a export PATH="/usr/bin/:$PATH"' install.sh
 
     - name: create input file
       run: |

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -43,6 +43,7 @@ jobs:
         sed -i '/function configure_db() {/a sudo service postgresql start' install.sh
         #sed -i '/function setup_chatwoot() {/a export PATH="/usr/bin/:$PATH"' install.sh
         #sed -i '/git checkout "\$BRANCH"/a export PATH="/usr/bin/:$PATH"' install.sh
+        sed -i '/function setup_chatwoot() {/a sudo chown -R chatwoot:chatwoot /hom/runner/.config' install.sh
 
     - name: create input file
       run: |
@@ -65,7 +66,7 @@ jobs:
     - name: check node/yarn inside chatwoot
       run: | 
          sudo -iu chatwoot
-         cd chatwoot
+         ls
          node --version
          yarn --versio
          yarn

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -18,6 +18,13 @@ jobs:
   nightly:
     runs-on: ubuntu-20.04
     steps:
+    ## temporary fix for gh actions since node 20 installed via script is not taking effect till 30june2024
+    ## https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'yarn'
 
     - name: get installer
       run: |

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -73,7 +73,9 @@ jobs:
          yarn
          exit
       if: always()
-
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: always()
     - name: Upload chatwoot setup log file as an artifact
       uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -65,8 +65,9 @@ jobs:
 
     - name: check node/yarn inside chatwoot
       run: | 
-         sudo -iu chatwoot
+         sudo -i -u chatwoot
          ls
+         cd chatwoot
          node --version
          yarn --versio
          yarn

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -50,6 +50,10 @@ jobs:
         #        sudo systemctl restart chatwoot.target
         #        curl http://localhost:3000/api
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: always()
+
     - name: Upload chatwoot setup log file as an artifact
       uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -43,7 +43,7 @@ jobs:
         sed -i '/function configure_db() {/a sudo service postgresql start' install.sh
         #sed -i '/function setup_chatwoot() {/a export PATH="/usr/bin/:$PATH"' install.sh
         #sed -i '/git checkout "\$BRANCH"/a export PATH="/usr/bin/:$PATH"' install.sh
-        sed -i '/function setup_chatwoot() {/a sudo chown -R chatwoot:chatwoot /hom/runner/.config' install.sh
+        sed -i '/function setup_chatwoot() {/a sudo chown -R chatwoot:chatwoot /home/runner/.config' install.sh
 
     - name: create input file
       run: |

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         node --version
         which node
-   - name: check yarn version
+    - name: check yarn version
       run: |
         yarn --version
         which yarn
@@ -62,15 +62,15 @@ jobs:
         #        sudo systemctl restart chatwoot.target
         #        curl http://localhost:3000/api
 
-   - name: check node/yarn inside chatwoot
-     run: | 
-       sudo -iu chatwoot
-       cd chatwoot
-       node --version
-       yarn --versio
-       yarn
-       exit
-    if: always()
+    - name: check node/yarn inside chatwoot
+      run: | 
+         sudo -iu chatwoot
+         cd chatwoot
+         node --version
+         yarn --versio
+         yarn
+         exit
+      if: always()
 
     - name: Upload chatwoot setup log file as an artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -24,7 +24,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-        cache: 'yarn'
 
     - name: get installer
       run: |

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   nightly:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     # - name: Setup tmate session
     #   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -22,11 +22,11 @@ jobs:
     #   uses: mxschmitt/action-tmate@v3
     #   if: always()
     # ## temporary fix for gh actions since node 20 installed via script is not taking effect till 30june2024
-    # ## https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
+    # # ## https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default
+    # - name: Setup Node.js
+    #   uses: actions/setup-node@v4
+    #   with:
+    #     node-version: '20'
     - name: check node version
       run: |
         node --version
@@ -43,7 +43,7 @@ jobs:
         sed -i '/function configure_db() {/a sudo service postgresql start' install.sh
         #sed -i '/function setup_chatwoot() {/a export PATH="/usr/bin/:$PATH"' install.sh
         #sed -i '/git checkout "\$BRANCH"/a export PATH="/usr/bin/:$PATH"' install.sh
-        sed -i '/function setup_chatwoot() {/a sudo chown -R chatwoot:chatwoot /home/runner/.config' install.sh
+        # sed -i '/function setup_chatwoot() {/a sudo chown -R chatwoot:chatwoot /home/runner/.config' install.sh
 
     - name: create input file
       run: |
@@ -65,13 +65,13 @@ jobs:
 
     - name: check node/yarn inside chatwoot
       run: | 
-         sudo -i -u chatwoot
+         sudo -i -u chatwoot << EOF
          ls
          cd chatwoot
          node --version
          yarn --versio
          yarn
-         exit
+         EOF
       if: always()
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -27,10 +27,14 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-    - name: create input file
+    - name: check node version
       run: |
         node --version
         which node
+   - name: check yarn version
+      run: |
+        yarn --version
+        which yarn
     - name: get installer
       run: |
         wget https://get.chatwoot.app/linux/install.sh
@@ -58,7 +62,15 @@ jobs:
         #        sudo systemctl restart chatwoot.target
         #        curl http://localhost:3000/api
 
-
+   - name: check node/yarn inside chatwoot
+     run: | 
+       sudo -iu chatwoot
+       cd chatwoot
+       node --version
+       yarn --versio
+       yarn
+       exit
+    if: always()
 
     - name: Upload chatwoot setup log file as an artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION


# Pull Request Template

## Description

 - nightly gh action is failing due to mismatched node version 18/20 when running inside gh runners
 - setup node 20 via `setup-node@v4` action for now
 - remove once https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default is live

Fixes https://linear.app/chatwoot/issue/CW-3373/fix-gh-action-nightly-build-failure

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- test via gh action run

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
