### PR TITLE
feat: use composables that automatically cleanup listeners on the `onBeforeUnmount` hook

### DIFF
--- a/app/javascript/dashboard/composables/emitter.js
+++ b/app/javascript/dashboard/composables/emitter.js
@@ -1,0 +1,20 @@
+import { emitter } from 'shared/helpers/mitt';
+import { onMounted, onBeforeUnmount } from 'vue';
+
+// this will automatically add event listeners to the emitter
+// and remove them when the component is destroyed
+const useEmitter = (eventName, callback) => {
+  const cleanup = () => {
+    emitter.off(eventName, callback);
+  };
+
+  onMounted(() => {
+    emitter.on(eventName, callback);
+  });
+
+  onBeforeUnmount(cleanup);
+
+  return cleanup;
+};
+
+export { useEmitter };

--- a/app/javascript/dashboard/composables/spec/emitter.spec.js
+++ b/app/javascript/dashboard/composables/spec/emitter.spec.js
@@ -1,0 +1,51 @@
+import { shallowMount } from '@vue/test-utils';
+import { emitter } from 'shared/helpers/mitt';
+import { useEmitter } from '../emitter';
+
+jest.mock('shared/helpers/mitt', () => ({
+  emitter: {
+    on: jest.fn(),
+    off: jest.fn(),
+  },
+}));
+
+describe('useEmitter', () => {
+  let wrapper;
+  const eventName = 'my-event';
+  const callback = jest.fn();
+
+  beforeEach(() => {
+    wrapper = shallowMount({
+      template: `
+        <div>
+          Hello world
+        </div>
+      `,
+      setup() {
+        return {
+          cleanup: useEmitter(eventName, callback),
+        };
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should add an event listener on mount', () => {
+    expect(emitter.on).toHaveBeenCalledWith(eventName, callback);
+  });
+
+  it('should remove the event listener when the component is unmounted', () => {
+    wrapper.destroy();
+    expect(emitter.off).toHaveBeenCalledWith(eventName, callback);
+  });
+
+  it('should return the cleanup function', () => {
+    const cleanup = wrapper.vm.cleanup;
+    expect(typeof cleanup).toBe('function');
+    cleanup();
+    expect(emitter.off).toHaveBeenCalledWith(eventName, callback);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@tailwindcss/typography": "^0.5.9",
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.4",
+    "@vueuse/core": "^10.10.0",
     "activestorage": "^5.2.6",
     "autoprefixer": "^10.4.14",
     "axios": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6550,6 +6550,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
+"@types/web-bluetooth@^0.0.20":
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz#f066abfcd1cbe66267cdbbf0de010d8a41b41597"
+  integrity sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==
+
 "@types/webpack-env@^1.16.0":
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.18.1.tgz#49699bb508961e14a3bfb68c78cd87b296889d1d"
@@ -6817,6 +6822,28 @@
   integrity sha512-odTxtUZ2JpwwiQ10t0QWYJkkYrfd0SyFYhdHH44QQ1jDatlZgTh/KRzrWVmn/ib9Gq7H4hFD4e8ahoo5YlUlDw==
   dependencies:
     vue-demi "^0.13.11"
+
+"@vueuse/core@^10.10.0":
+  version "10.10.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-10.10.0.tgz#05a98d3c5674762455a2c552c915d461d83e6490"
+  integrity sha512-vexJ/YXYs2S42B783rI95lMt3GzEwkxzC8Hb0Ndpd8rD+p+Lk/Za4bd797Ym7yq4jXqdSyj3JLChunF/vyYjUw==
+  dependencies:
+    "@types/web-bluetooth" "^0.0.20"
+    "@vueuse/metadata" "10.10.0"
+    "@vueuse/shared" "10.10.0"
+    vue-demi ">=0.14.7"
+
+"@vueuse/metadata@10.10.0":
+  version "10.10.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-10.10.0.tgz#53e61e9380670e342cbe6e03d852f3319308cb5b"
+  integrity sha512-UNAo2sTCAW5ge6OErPEHb5z7NEAg3XcO9Cj7OK45aZXfLLH1QkexDcZD77HBi5zvEiLOm1An+p/4b5K3Worpug==
+
+"@vueuse/shared@10.10.0":
+  version "10.10.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-10.10.0.tgz#93f7c2210151ff43c2c7677963f7aa3aef5d9896"
+  integrity sha512-2aW33Ac0Uk0U+9yo3Ypg9s5KcR42cuehRWl7vnUHadQyFvCktseyxxEPBi1Eiq4D2yBGACOnqLZpx1eMc7g5Og==
+  dependencies:
+    vue-demi ">=0.14.7"
 
 "@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
   version "1.11.6"
@@ -20596,6 +20623,11 @@ vue-color@2.8.1:
     lodash.throttle "^4.0.0"
     material-colors "^1.0.0"
     tinycolor2 "^1.1.2"
+
+vue-demi@>=0.14.7:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.8.tgz#00335e9317b45e4a68d3528aaf58e0cec3d5640a"
+  integrity sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==
 
 vue-demi@^0.13.11:
   version "0.13.11"


### PR DESCRIPTION
This PR makes the following changes

1. Add `@vueuse/core` package, it supports Vue 2.7, we should start using this across the board
2. Add `useEmitter` composable, this adds a listener on the emitter on `onMounted` and automatically removes it on `onBeforeUnmount`
3. Use `useEmitter` & `useEventListener` from in `NetworkNotification.vue` 