### PR TITLE
fix: Missing mitt.js in vue 3 instance of app

### DIFF
--- a/app/javascript/packs/v3app.js
+++ b/app/javascript/packs/v3app.js
@@ -14,6 +14,7 @@ import App from '../v3/App.vue';
 import router, { initalizeRouter } from '../v3/views/index';
 import store from '../v3/store';
 import FluentIcon from 'shared/components/FluentIcon/DashboardIcon';
+import { emitter } from '../shared/helpers/mitt';
 
 Vue.config.env = process.env;
 
@@ -45,11 +46,11 @@ Vue.use(VueRouter);
 Vue.use(VueI18n);
 Vue.use(Vuelidate);
 Vue.use(AnalyticsPlugin);
+Vue.prototype.$emitter = emitter;
 Vue.component('fluent-icon', FluentIcon);
 
 const i18nConfig = new VueI18n({ locale: 'en', messages: i18n });
 
-window.bus = new Vue();
 initializeChatwootEvents();
 initializeAnalyticsEvents();
 initalizeRouter();


### PR DESCRIPTION
# Pull Request Template

## Description

Vue 3 instance of the pages missed the emitter initialization, this PR fixes this issue

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update