### PR TITLE
feat: add Google Email fetch and OAuth token refresh service

### DIFF
--- a/app/jobs/inboxes/fetch_imap_emails_job.rb
+++ b/app/jobs/inboxes/fetch_imap_emails_job.rb
@@ -30,6 +30,8 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
   def process_email_for_channel(channel, interval)
     inbound_emails = if channel.microsoft?
                        Imap::MicrosoftFetchEmailService.new(channel: channel, interval: interval).perform
+                     elsif channel.google?
+                       Imap::GoogleFetchEmailService.new(channel: channel, interval: interval).perform
                      else
                        Imap::FetchEmailService.new(channel: channel, interval: interval).perform
                      end

--- a/app/services/base_refresh_oauth_token_service.rb
+++ b/app/services/base_refresh_oauth_token_service.rb
@@ -1,0 +1,62 @@
+class BaseRefreshOauthTokenService
+  pattr_initialize [:channel!]
+
+  # Additional references: https://gitlab.com/gitlab-org/ruby/gems/gitlab-mail_room/-/blob/master/lib/mail_room/microsoft_graph/connection.rb
+  def access_token
+    return provider_config[:access_token] unless access_token_expired?
+
+    refreshed_tokens = refresh_tokens
+    refreshed_tokens[:access_token]
+  end
+
+  def access_token_expired?
+    expiry = provider_config[:expires_on]
+
+    return true if expiry.blank?
+
+    # Adding a 5 minute window to expiry check to avoid any race
+    # conditions during the fetch operation. This would assure that the
+    # tokens are updated when we fetch the emails.
+    Time.current.utc >= DateTime.parse(expiry) - 5.minutes
+  end
+
+  # Refresh the access tokens using the refresh token
+  # Refer: https://github.com/microsoftgraph/msgraph-sample-rubyrailsapp/tree/b4a6869fe4a438cde42b161196484a929f1bee46
+  def refresh_tokens
+    oauth_strategy = build_oauth_strategy
+    token_service = build_token_service(oauth_strategy)
+
+    new_tokens = token_service.refresh!.to_hash.slice(:access_token, :refresh_token, :expires_at)
+
+    update_channel_provider_config(new_tokens)
+    channel.reload.provider_config
+  end
+
+  def update_channel_provider_config(new_tokens)
+    channel.provider_config = {
+      access_token: new_tokens[:access_token],
+      refresh_token: new_tokens[:refresh_token],
+      expires_on: Time.at(new_tokens[:expires_at]).utc.to_s
+    }
+    channel.save!
+  end
+
+  private
+
+  def build_oauth_strategy
+    raise NotImplementedError
+  end
+
+  def provider_config
+    @provider_config ||= channel.provider_config.with_indifferent_access
+  end
+
+  # Builds the token service using OAuth2
+  def build_token_service(oauth_strategy)
+    OAuth2::AccessToken.new(
+      oauth_strategy.client,
+      provider_config[:access_token],
+      refresh_token: provider_config[:refresh_token]
+    )
+  end
+end

--- a/app/services/google/refresh_oauth_token_service.rb
+++ b/app/services/google/refresh_oauth_token_service.rb
@@ -1,0 +1,12 @@
+# Refer: https://learn.microsoft.com/en-us/entra/identity-platform/configurable-token-lifetimes
+class Google::RefreshOauthTokenService < BaseRefreshOauthTokenService
+  private
+
+  # Builds the OAuth strategy for Microsoft Graph
+  def build_oauth_strategy
+    app_id = GlobalConfigService.load('GOOGLE_OAUTH_CLIENT_ID', nil)
+    app_secret = GlobalConfigService.load('GOOGLE_OAUTH_CLIENT_SECRET', nil)
+
+    OmniAuth::Strategies::GoogleOauth2.new(nil, app_id, app_secret)
+  end
+end

--- a/app/services/imap/google_fetch_email_service.rb
+++ b/app/services/imap/google_fetch_email_service.rb
@@ -1,4 +1,4 @@
-class Imap::MicrosoftFetchEmailService < Imap::BaseFetchEmailService
+class Imap::GoogleFetchEmailService < Imap::BaseFetchEmailService
   def fetch_emails
     return if channel.provider_config['access_token'].blank?
 

--- a/app/services/imap/google_fetch_email_service.rb
+++ b/app/services/imap/google_fetch_email_service.rb
@@ -1,0 +1,17 @@
+class Imap::MicrosoftFetchEmailService < Imap::BaseFetchEmailService
+  def fetch_emails
+    return if channel.provider_config['access_token'].blank?
+
+    fetch_mail_for_channel
+  end
+
+  private
+
+  def authentication_type
+    'XOAUTH2'
+  end
+
+  def imap_password
+    Google::RefreshOauthTokenService.new(channel: channel).access_token
+  end
+end

--- a/app/services/microsoft/refresh_oauth_token_service.rb
+++ b/app/services/microsoft/refresh_oauth_token_service.rb
@@ -1,64 +1,9 @@
 # Refer: https://learn.microsoft.com/en-us/entra/identity-platform/configurable-token-lifetimes
-class Microsoft::RefreshOauthTokenService
-  pattr_initialize [:channel!]
-
-  # Additional references: https://gitlab.com/gitlab-org/ruby/gems/gitlab-mail_room/-/blob/master/lib/mail_room/microsoft_graph/connection.rb
-  def access_token
-    return provider_config[:access_token] unless access_token_expired?
-
-    refreshed_tokens = refresh_tokens
-    refreshed_tokens[:access_token]
-  end
-
-  def access_token_expired?
-    expiry = provider_config[:expires_on]
-
-    return true if expiry.blank?
-
-    # Adding a 5 minute window to expiry check to avoid any race
-    # conditions during the fetch operation. This would assure that the
-    # tokens are updated when we fetch the emails.
-    Time.current.utc >= DateTime.parse(expiry) - 5.minutes
-  end
-
-  # Refresh the access tokens using the refresh token
-  # Refer: https://github.com/microsoftgraph/msgraph-sample-rubyrailsapp/tree/b4a6869fe4a438cde42b161196484a929f1bee46
-  def refresh_tokens
-    oauth_strategy = build_oauth_strategy
-    token_service = build_token_service(oauth_strategy)
-
-    new_tokens = token_service.refresh!.to_hash.slice(:access_token, :refresh_token, :expires_at)
-
-    update_channel_provider_config(new_tokens)
-    channel.reload.provider_config
-  end
-
-  def update_channel_provider_config(new_tokens)
-    channel.provider_config = {
-      access_token: new_tokens[:access_token],
-      refresh_token: new_tokens[:refresh_token],
-      expires_on: Time.at(new_tokens[:expires_at]).utc.to_s
-    }
-    channel.save!
-  end
-
+class Microsoft::RefreshOauthTokenService < BaseRefreshOauthTokenService
   private
-
-  def provider_config
-    @provider_config ||= channel.provider_config.with_indifferent_access
-  end
 
   # Builds the OAuth strategy for Microsoft Graph
   def build_oauth_strategy
     ::MicrosoftGraphAuth.new(nil, GlobalConfigService.load('AZURE_APP_ID', ''), GlobalConfigService.load('AZURE_APP_SECRET', ''))
-  end
-
-  # Builds the token service using OAuth2
-  def build_token_service(oauth_strategy)
-    OAuth2::AccessToken.new(
-      oauth_strategy.client,
-      provider_config[:access_token],
-      refresh_token: provider_config[:refresh_token]
-    )
   end
 end

--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -73,7 +73,7 @@ if resource.email?
     json.imap_enabled resource.channel.try(:imap_enabled)
     json.imap_enable_ssl resource.channel.try(:imap_enable_ssl)
 
-    if resource.channel.try(:microsoft?)
+    if resource.channel.try(:microsoft?) || resource.channel.try(:google?)
       json.reauthorization_required resource.channel.try(:provider_config).empty? || resource.channel.try(:reauthorization_required?)
     end
   end

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -283,6 +283,22 @@ RSpec.describe ConversationReplyMailer do
       end
     end
 
+    context 'when smtp enabled for google email channel' do
+      let(:ms_smtp_email_channel) do
+        create(:channel_email, imap_login: 'smtp@gmail.com',
+                               imap_enabled: true, account: account, provider: 'google', provider_config: { access_token: 'access_token' })
+      end
+      let(:conversation) { create(:conversation, assignee: agent, inbox: ms_smtp_email_channel.inbox, account: account).reload }
+      let(:message) { create(:message, conversation: conversation, account: account, message_type: 'outgoing', content: 'Outgoing Message 2') }
+
+      it 'use smtp mail server' do
+        mail = described_class.email_reply(message)
+        expect(mail.delivery_method.settings.empty?).to be false
+        expect(mail.delivery_method.settings[:address]).to eq 'smtp.gmail.com'
+        expect(mail.delivery_method.settings[:port]).to eq 587
+      end
+    end
+
     context 'when smtp disabled for email channel', :test do
       let(:conversation) { create(:conversation, assignee: agent, inbox: email_channel.inbox, account: account).reload }
       let(:message) { create(:message, conversation: conversation, account: account, message_type: 'outgoing', content: 'Outgoing Message 2') }

--- a/spec/models/channel/email_spec.rb
+++ b/spec/models/channel/email_spec.rb
@@ -35,4 +35,15 @@ RSpec.describe Channel::Email do
       expect(channel.microsoft?).to be(true)
     end
   end
+
+  context 'when google?' do
+    it 'returns false' do
+      expect(channel.google?).to be(false)
+    end
+
+    it 'returns true' do
+      channel.provider = 'google'
+      expect(channel.google?).to be(true)
+    end
+  end
 end

--- a/spec/services/google/refresh_oauth_token_service_spec.rb
+++ b/spec/services/google/refresh_oauth_token_service_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe Google::RefreshOauthTokenService do
+  let!(:google_channel) { create(:channel_email, :microsoft_email) }
+  let!(:google_channel_with_expired_token) do
+    create(
+      :channel_email, :microsoft_email, provider_config: {
+        expires_on: Time.zone.now - 3600,
+        access_token: SecureRandom.hex,
+        refresh_token: SecureRandom.hex
+      }
+    )
+  end
+
+  let(:new_tokens) do
+    {
+      access_token: SecureRandom.hex,
+      refresh_token: SecureRandom.hex,
+      expires_at: (Time.zone.now + 3600).to_i,
+      token_type: 'bearer'
+    }
+  end
+
+  context 'when token is not expired' do
+    it 'returns the existing access token' do
+      service = described_class.new(channel: google_channel)
+
+      expect(service.access_token).to eq(google_channel.provider_config['access_token'])
+      expect(google_channel.reload.provider_config['refresh_token']).to eq(google_channel.provider_config['refresh_token'])
+    end
+  end
+
+  describe 'on expired token or invalid expiry' do
+    before do
+      stub_request(:post, 'https://oauth2.googleapis.com/token').with(
+        body: { 'grant_type' => 'refresh_token', 'refresh_token' => google_channel_with_expired_token.provider_config['refresh_token'] }
+      ).to_return(status: 200, body: new_tokens.to_json, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    context 'when token is invalid' do
+      it 'fetches new access token and refresh tokens' do
+        with_modified_env GOOGLE_OAUTH_CLIENT_ID: SecureRandom.uuid, GOOGLE_OAUTH_CLIENT_SECRET: SecureRandom.hex do
+          provider_config = google_channel_with_expired_token.provider_config
+          service = described_class.new(channel: google_channel_with_expired_token)
+          expect(service.access_token).not_to eq(provider_config['access_token'])
+
+          new_provider_config = google_channel_with_expired_token.reload.provider_config
+          expect(new_provider_config['access_token']).to eq(new_tokens[:access_token])
+          expect(new_provider_config['refresh_token']).to eq(new_tokens[:refresh_token])
+          expect(new_provider_config['expires_on']).to eq(Time.at(new_tokens[:expires_at]).utc.to_s)
+        end
+      end
+    end
+
+    context 'when expiry time is missing' do
+      it 'fetches new access token and refresh tokens' do
+        with_modified_env GOOGLE_OAUTH_CLIENT_ID: SecureRandom.uuid, GOOGLE_OAUTH_CLIENT_SECRET: SecureRandom.hex do
+          google_channel_with_expired_token.provider_config['expires_on'] = nil
+          google_channel_with_expired_token.save!
+          provider_config = google_channel_with_expired_token.provider_config
+          service = described_class.new(channel: google_channel_with_expired_token)
+          expect(service.access_token).not_to eq(provider_config['access_token'])
+
+          new_provider_config = google_channel_with_expired_token.reload.provider_config
+          expect(new_provider_config['access_token']).to eq(new_tokens[:access_token])
+          expect(new_provider_config['refresh_token']).to eq(new_tokens[:refresh_token])
+          expect(new_provider_config['expires_on']).to eq(Time.at(new_tokens[:expires_at]).utc.to_s)
+        end
+      end
+    end
+  end
+
+  context 'when refresh token is not present in provider config and access token is expired' do
+    it 'throws an error' do
+      with_modified_env GOOGLE_OAUTH_CLIENT_ID: SecureRandom.uuid, GOOGLE_OAUTH_CLIENT_SECRET: SecureRandom.hex do
+        google_channel.update(
+          provider_config: {
+            access_token: SecureRandom.hex,
+            expires_on: Time.zone.now - 3600
+          }
+        )
+
+        expect do
+          described_class.new(channel: google_channel).access_token
+        end.to raise_error(RuntimeError, 'A refresh_token is not available')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the following changes

1. Add `Imap::GoogleFetchEmailService` and `Google::RefreshOauthTokenService`. The `Google::RefreshOauthTokenService` uses `OmniAuth::Strategies::GoogleOauth2` which is already added as a packge
2. Update `Inboxes::FetchImapEmailsJob` to handle Google inboxes
3. Add SMTP settings for Google in `ConversationReplyMailerHelper` to allow sending emails


## Preview

#### Incoming emails

![CleanShot 2024-06-06 at 17 17 22@2x](https://github.com/chatwoot/chatwoot/assets/18097732/9d7d70d1-68e3-4c16-b1ca-e5a2e6f890e8)

#### Outgoing email

![CleanShot 2024-06-06 at 17 18 05@2x](https://github.com/chatwoot/chatwoot/assets/18097732/1b4abf0e-e311-493e-bdc8-386886afbb25)
