### PR TITLE
fix: Update the suspended page to show the chat bubble

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/suspended/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/suspended/Index.vue
@@ -1,24 +1,30 @@
+<script setup>
+import EmptyState from 'dashboard/components/widgets/EmptyState.vue';
+import { onMounted } from 'vue';
+
+const toggleSupportWidgetVisibility = () => {
+  if (window.$chatwoot) {
+    window.$chatwoot.toggleBubbleVisibility('show');
+  }
+};
+
+const setupListenerForWidgetEvent = () => {
+  window.addEventListener('chatwoot:on-message', () => {
+    toggleSupportWidgetVisibility();
+  });
+};
+
+onMounted(() => {
+  toggleSupportWidgetVisibility();
+  setupListenerForWidgetEvent();
+});
+</script>
+
 <template>
-  <div class="suspended-page">
+  <div class="items-center bg-slate-50 flex justify-center h-full w-full">
     <empty-state
       :title="$t('APP_GLOBAL.ACCOUNT_SUSPENDED.TITLE')"
       :message="$t('APP_GLOBAL.ACCOUNT_SUSPENDED.MESSAGE')"
     />
   </div>
 </template>
-<script>
-import EmptyState from 'dashboard/components/widgets/EmptyState.vue';
-export default {
-  components: { EmptyState },
-};
-</script>
-<style scoped>
-.suspended-page {
-  align-items: center;
-  background: var(--s-50);
-  display: flex;
-  justify-content: center;
-  height: 100%;
-  width: 100%;
-}
-</style>


### PR DESCRIPTION
<img width="1457" alt="Screenshot 2024-06-06 at 4 09 23 PM" src="https://github.com/chatwoot/chatwoot/assets/2246121/50e78a10-96e0-42e9-ad0f-91471285f878">

This PR updates the implementation of chat bubble on suspended account. 