### PR TITLE
fix: Use message sender ID in the analytics for first response time

### DIFF
--- a/app/listeners/reporting_event_listener.rb
+++ b/app/listeners/reporting_event_listener.rb
@@ -34,7 +34,7 @@ class ReportingEventListener < BaseListener
                                               message.created_at),
       account_id: conversation.account_id,
       inbox_id: conversation.inbox_id,
-      user_id: conversation.assignee_id,
+      user_id: message.sender_id,
       conversation_id: conversation.id,
       event_start_time: last_non_human_activity(conversation),
       event_end_time: message.created_at

--- a/spec/listeners/reporting_event_listener_spec.rb
+++ b/spec/listeners/reporting_event_listener_spec.rb
@@ -101,7 +101,7 @@ describe ReportingEventListener do
         listener.first_reply_created(event)
         reporting_event = account.reporting_events.where(name: 'first_response').first
         expect(reporting_event.value_in_business_hours).to be 144_000.0
-        expect(reporting_event.user_id).to be user.sender_id
+        expect(reporting_event.user_id).to be new_message.sender_id
       end
     end
 

--- a/spec/listeners/reporting_event_listener_spec.rb
+++ b/spec/listeners/reporting_event_listener_spec.rb
@@ -99,7 +99,9 @@ describe ReportingEventListener do
       it 'creates first_response event with business hour value' do
         event = Events::Base.new('first.reply.created', Time.zone.now, message: new_message)
         listener.first_reply_created(event)
-        expect(account.reporting_events.where(name: 'first_response')[0]['value_in_business_hours']).to be 144_000.0
+        reporting_event = account.reporting_events.where(name: 'first_response').first
+        expect(reporting_event.value_in_business_hours).to be 144_000.0
+        expect(reporting_event.user_id).to be user.sender_id
       end
     end
 


### PR DESCRIPTION
`conversation.assignee_id` was taken into consideration for first response time calculation. There was one flaw in this approach. A lot of customer support agents respond to the conversation first before assigning it to themselves. This makes the analytics broken.

To fix this, we will take the message sender instead of assignee in calculations, which should solve the issue with metric.

Fixes https://linear.app/chatwoot/issue/CW-3375/first-response-reporting-events-use-assignee-id-instead-of-agent-who