### PR TITLE
Update setup_20.04.sh

### DIFF
--- a/deployment/setup_20.04.sh
+++ b/deployment/setup_20.04.sh
@@ -191,7 +191,7 @@ function install_dependencies() {
       postgresql-client redis-tools \
       nodejs yarn patch ruby-dev zlib1g-dev liblzma-dev \
       libgmp-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev sudo \
-      libvips python3-pip
+      libvips python3-pip python3-packaging
 }
 
 ##############################################################################
@@ -971,7 +971,7 @@ function cwctl_upgrade_check() {
     # Check if packaging library is installed, and install it if not
     if ! python3 -c "import packaging.version" &> /dev/null; then
         echo "Installing packaging library..."
-        python3 -m pip install packaging
+        sudo apt install python3-packaging
     fi
 
     needs_update=$(python3 -c "from packaging import version; v1 = version.parse('$CWCTL_VERSION'); v2 = version.parse('$remote_version'); print(1 if v2 > v1 else 0)")


### PR DESCRIPTION
The reason why the pip install command doesn’t work in Ubuntu 23.04 is down to an intentional shift in policy (also taken in Ubuntu’s upstream, Debian) to avoid conflicts between the Python package manager and Ubuntu’s underlying APT.

Basically, you can’t run pip install outside a virtual environment in Ubuntu 23.04. If you try to, you get a “externally managed environment” error https://peps.python.org/pep-0668/#implementation-notes

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
