### PR TITLE
ci: Add arm64 support to build FOS Image

### DIFF
--- a/.github/workflows/publish_foss_docker.yml
+++ b/.github/workflows/publish_foss_docker.yml
@@ -24,10 +24,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64,amd64'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Strip enterprise code
         run: |
@@ -54,10 +56,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.DOCKER_TAG }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,8 +44,8 @@ RUN bundle config set --local force_ruby_platform true
 
 # Do not install development or test gems in production
 RUN if [ "$RAILS_ENV" = "production" ]; then \
-  bundle config set without 'development test'; bundle install -j 4 -r 3; \
-  else bundle install -j 4 -r 3; \
+  bundle config set without 'development test'; bundle install -j $(nproc) -r 3; \
+  else bundle install -j $(nproc) -r 3; \
   fi
 
 COPY package.json yarn.lock ./


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes #9579 

Add support for Arm64 images to the chatwoot docker ce build. Takes a long time to complete build: est 3h45m++


## Type of change

Please delete options that are not relevant.

- [X ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

Ran the build test on my own fork. Just a note on this. Since this is using buildx arm64 emulator the total build time for the arm image is up to 4 hours. When Github GA native Arm64 workers this will be drasticly faster.




## Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [x ] I have commented on my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- x[ ] Any dependent changes have been merged and published in downstream modules
