### PR TITLE
fix: Temporarily fix text/plain email rendering

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -257,7 +257,16 @@ export default {
         html_content: { full: fullHTMLContent } = {},
         text_content: { full: fullTextContent } = {},
       } = this.contentAttributes.email || {};
-      return fullHTMLContent || fullTextContent || '';
+
+      if (fullHTMLContent) {
+        return fullHTMLContent;
+      }
+
+      if (fullTextContent) {
+        return fullTextContent.replace(/\n/g, '<br>');
+      }
+
+      return '';
     },
     displayQuotedButton() {
       if (this.emailMessageContent.includes('<blockquote')) {

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -68,7 +68,7 @@ class Rack::Attack
   end
 
   # ### Prevent Brute-Force Login Attacks ###
-  throttle('login/ip', limit: 20, period: 5.minutes) do |req|
+  throttle('login/ip', limit: 5, period: 5.minutes) do |req|
     req.ip if req.path_without_extentions == '/auth/sign_in' && req.post?
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -68,7 +68,7 @@ class Rack::Attack
   end
 
   # ### Prevent Brute-Force Login Attacks ###
-  throttle('login/ip', limit: 5, period: 5.minutes) do |req|
+  throttle('login/ip', limit: 20, period: 5.minutes) do |req|
     req.ip if req.path_without_extentions == '/auth/sign_in' && req.post?
   end
 


### PR DESCRIPTION
This is hacky fix for plain text email rendering. The issue happens only for the text/plain only emails. If there was an HTML component, then the rendering works fine.

**How was this tested?**

Mac Email client allows you to send text/plain emails. I've sent one to myself and imported it on Chatwoot. I've also verified that the email contains only text/plain part.

Sample rendered email below.

<img width="476" alt="Screenshot 2024-06-18 at 8 15 10 PM" src="https://github.com/chatwoot/chatwoot/assets/2246121/0c3c07f6-c49d-401a-bba5-a79e82b57bd6">

Fixes https://github.com/chatwoot/chatwoot/issues/9649
Fixes https://github.com/chatwoot/chatwoot/issues/9480