### PR TITLE
feat: Add attachments in email reply

### DIFF
--- a/app/views/mailers/conversation_reply_mailer/conversation_transcript.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/conversation_transcript.html.erb
@@ -34,7 +34,8 @@
       <% end %>
       <% if message.attachments %>
         <% message.attachments.each do |attachment| %>
-          Attachment [<a href="<%= attachment.file_url %>" _target="blank">Click here to view</a>]
+          Attachment 
+          <p>[<a href="<%= attachment.file_url %>" _target="blank"><%= attachment.file.filename.to_s %></a>]</p>
         <% end %>
       <% end %>
       <p style="font-size: 90%; font-size: 90%;color: #899096;margin-top: -8px; margin-bottom: 0px;">

--- a/app/views/mailers/conversation_reply_mailer/email_reply.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/email_reply.html.erb
@@ -1,8 +1,9 @@
 <% if @message.content %>
   <%= ChatwootMarkdownRenderer.new(@message.content).render_message %>
 <% end %>
-<% if @message.attachments %>
+<% if @message.attachments && !defined?(@options[:attachments]) %>
   <% @message.attachments.each do |attachment| %>
-    attachment [<a href="<%= attachment.file_url %>" _target="blank">click here to view</a>]
+    <p>attachment</p> 
+    <p>[<a href="<%= attachment.file_url %>" _target="blank"><%= attachment.file.filename.to_s %></a>]</p>
   <% end %>
 <% end %>


### PR DESCRIPTION
# Add attachments in email reply

## Description

Add ability to send files as attachments instead of links

Fixes https://github.com/chatwoot/chatwoot/issues/1074 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Send email replies with attachments, notice that files are sent as attachments in the received email reply.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
