### PR TITLE
chore: Add permissions to auth data

### DIFF
--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -49,6 +49,10 @@ class AccountUser < ApplicationRecord
     ::Agents::DestroyJob.perform_later(account, user)
   end
 
+  def permissions
+    administrator? ? ['administrator'] : ['agent']
+  end
+
   def push_event_data
     {
       id: id,

--- a/app/views/api/v1/models/_user.json.jbuilder
+++ b/app/views/api/v1/models/_user.json.jbuilder
@@ -14,6 +14,7 @@ json.provider resource.provider
 json.pubsub_token resource.pubsub_token
 json.custom_attributes resource.custom_attributes if resource.custom_attributes.present?
 json.role resource.active_account_user&.role
+json.permissions resource.active_account_user&.permissions
 json.ui_settings resource.ui_settings
 json.uid resource.uid
 json.type resource.type
@@ -24,6 +25,7 @@ json.accounts do
     json.status account_user.account.status
     json.active_at account_user.active_at
     json.role account_user.role
+    json.permissions account_user.permissions
     # the actual availability user has configured
     json.availability account_user.availability
     # availability derived from presence

--- a/spec/controllers/devise/session_controller_spec.rb
+++ b/spec/controllers/devise/session_controller_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe 'Session', type: :request do
         expect(response).to have_http_status(:success)
         expect(response.body).to include(user_with_new_pwd.email)
       end
+
+      it 'returns the permission of the user' do
+        params = { email: user.email, password: 'Password1!' }
+
+        post new_user_session_url,
+             params: params,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['data']['permissions']).to eq(['agent'])
+      end
     end
 
     context 'when it is invalid sso auth token' do

--- a/spec/models/account_user_spec.rb
+++ b/spec/models/account_user_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe AccountUser do
     end
   end
 
+  describe 'permissions' do
+    it 'returns the right permissions' do
+      expect(account_user.permissions).to eq(['agent'])
+    end
+
+    it 'returns the right permissions for administrator' do
+      account_user.administrator!
+      expect(account_user.permissions).to eq(['administrator'])
+    end
+  end
+
   describe 'destroy call agent::destroy service' do
     it 'gets created with the right default settings' do
       create(:conversation, account: account_user.account, assignee: account_user.user, inbox: inbox)


### PR DESCRIPTION
This API change sets the foundation for an upcoming frontend update, transitioning from a role-based model to a permission-based model. This new approach will determine eligibility for various actions and UI elements based on specific permissions rather than roles, enhancing flexibility and security in user access management.