### PR TITLE
feat(message-bubble): add timestamps to messages in client

### DIFF
--- a/app/javascript/dashboard/mixins/time.js
+++ b/app/javascript/dashboard/mixins/time.js
@@ -28,6 +28,34 @@ export default {
       const unixTime = fromUnixTime(time);
       return format(unixTime, dateFormat);
     },
+    /**
+     * Custom timestamp function to display time in a more readable format
+     * @param {number} timestamp unix epoch timestamp
+     * @param {*} hoursThreshold number of hours to consider as a day
+     * @returns string
+     */
+    customTimestamp(timestamp, hoursThreshold = 12) {
+      const messageTime = fromUnixTime(timestamp);
+      const now = new Date();
+      const timeDiff = (now - messageTime) / 1000 / 60; // time difference in minutes
+
+      let timeString = messageTime.toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+
+      // Convert hoursThreshold to minutes and check if the time difference exceeds it
+      if (timeDiff > hoursThreshold * 60) {
+        const dateString = messageTime.toLocaleDateString([], {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+        });
+        timeString += ` ${dateString}`;
+      }
+
+      return timeString;
+    },
     shortTimestamp(time, withAgo = false) {
       // This function takes a time string and converts it to a short time string
       // with the following format: 1m, 1h, 1d, 1mo, 1y

--- a/app/javascript/widget/components/AgentMessage.vue
+++ b/app/javascript/widget/components/AgentMessage.vue
@@ -24,6 +24,7 @@
               v-if="shouldDisplayAgentMessage"
               :content-type="contentType"
               :message-content-attributes="messageContentAttributes"
+              :message-created-at="message.created_at"
               :message-id="message.id"
               :message-type="messageType"
               :message="message.content"

--- a/app/javascript/widget/components/AgentMessageBubble.vue
+++ b/app/javascript/widget/components/AgentMessageBubble.vue
@@ -9,6 +9,7 @@
     >
       <div
         v-dompurify-html="formatMessage(message, false)"
+        :data-time="readableTime"
         class="message-content text-slate-900 dark:text-slate-50"
       />
       <email-input
@@ -69,6 +70,7 @@ import EmailInput from './template/EmailInput.vue';
 import CustomerSatisfaction from 'shared/components/CustomerSatisfaction.vue';
 import darkModeMixin from 'widget/mixins/darkModeMixin.js';
 import IntegrationCard from './template/IntegrationCard.vue';
+import timeMixin from '../../dashboard/mixins/time';
 
 export default {
   name: 'AgentMessageBubble',
@@ -81,11 +83,12 @@ export default {
     CustomerSatisfaction,
     IntegrationCard,
   },
-  mixins: [messageFormatterMixin, darkModeMixin],
+  mixins: [messageFormatterMixin, darkModeMixin, timeMixin],
   props: {
     message: { type: String, default: null },
     contentType: { type: String, default: null },
     messageType: { type: Number, default: null },
+    messageCreatedAt: { type: Number, default: null },
     messageId: { type: Number, default: null },
     messageContentAttributes: {
       type: Object,
@@ -93,6 +96,11 @@ export default {
     },
   },
   computed: {
+    readableTime() {
+      if (!this.messageCreatedAt) return '';
+
+      return this.customTimestamp(this.messageCreatedAt);
+    },
     isTemplate() {
       return this.messageType === 3;
     },
@@ -141,3 +149,12 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+.message-content::after {
+  content: attr(data-time);
+  font-size: 0.625rem;
+  color: hsl(206 6% 63% / 1);
+  font-family: monospace;
+}
+</style>

--- a/app/javascript/widget/components/ImageBubble.vue
+++ b/app/javascript/widget/components/ImageBubble.vue
@@ -71,8 +71,9 @@ export default {
     bottom: $space-smaller;
     color: $color-white;
     position: absolute;
-    right: $space-slab;
+    left: $space-slab;
     white-space: nowrap;
+    font-family: monospace;
   }
 }
 </style>

--- a/app/javascript/widget/components/UserMessage.vue
+++ b/app/javascript/widget/components/UserMessage.vue
@@ -20,6 +20,7 @@
             <user-message-bubble
               v-if="showTextBubble"
               :message="message.content"
+              :readable-time="readableMessageTimestamp"
               :status="message.status"
               :widget-color="widgetColor"
             />
@@ -36,7 +37,7 @@
                   v-if="attachment.file_type === 'image' && !hasImageError"
                   :url="attachment.data_url"
                   :thumb="attachment.data_url"
-                  :readable-time="readableTime"
+                  :readable-time="readableMessageTimestamp"
                   @error="onImageLoadError"
                 />
 
@@ -136,6 +137,11 @@ export default {
     readableTime() {
       const { created_at: createdAt = '' } = this.message;
       return this.messageStamp(createdAt);
+    },
+    readableMessageTimestamp() {
+      const { created_at: createdAt = '' } = this.message;
+      if (!createdAt) return '';
+      return this.customTimestamp(createdAt);
     },
     isFailed() {
       const { status = '' } = this.message;

--- a/app/javascript/widget/components/UserMessageBubble.vue
+++ b/app/javascript/widget/components/UserMessageBubble.vue
@@ -2,6 +2,7 @@
   <div
     v-dompurify-html="formatMessage(message, false)"
     class="chat-bubble user"
+    :data-time="readableTime"
     :style="{ background: widgetColor, color: textColor }"
   />
 </template>
@@ -23,6 +24,10 @@ export default {
       default: '',
     },
     widgetColor: {
+      type: String,
+      default: '',
+    },
+    readableTime: {
       type: String,
       default: '',
     },
@@ -64,5 +69,12 @@ export default {
       color: var(--s-800);
     }
   }
+}
+
+.chat-bubble::after {
+  content: attr(data-time);
+  font-size: 0.625rem;
+  color: hsl(209 95% 90.1% / 1);
+  font-family: monospace;
 }
 </style>


### PR DESCRIPTION
# Pull Request Template

## Description

We want to know when message was sent from the user for troubleshooting.

![image](https://github.com/chatwoot/chatwoot/assets/13982649/1bf72043-459e-407b-857e-059248295a4c)
<img width="826" alt="image" src="https://github.com/chatwoot/chatwoot/assets/13982649/392de04a-a84a-42c1-9dd8-e5970e0dbad4">


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Linked issues

Closes #11372
Closes #12987
