### PR TITLE
chore: Upgrade csv-safe to the latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    csv-safe (3.2.1)
+    csv (3.3.0)
+    csv-safe (3.3.1)
+      csv (~> 3.0)
     cypress-on-rails (1.16.0)
       rack
     database_cleaner (2.0.2)


### PR DESCRIPTION
The following error starting is shown on the console after the ruby upgrade.

csv.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of csv-safe-3.2.1 to add csv into its gemspec.


Csv-safe has already added a patch via https://github.com/zvory/csv-safe/pull/20. 

This PR updates the version to the latest version of csv-safe (3.3.1)