### PR TITLE
fix: Add a DISCONNECT_DELAY_THRESHOLD while fetching the conversations

### DIFF
--- a/app/javascript/dashboard/helper/ReconnectService.js
+++ b/app/javascript/dashboard/helper/ReconnectService.js
@@ -9,6 +9,11 @@ import {
 
 const MAX_DISCONNECT_SECONDS = 10800;
 
+// The disconnect delay threshold is added to account for delays in identifying
+// disconnections (for example, the websocket disconnection takes up to 3 seconds)
+// while fetching the latest updated conversations or messages.
+const DISCONNECT_DELAY_THRESHOLD = 15;
+
 class ReconnectService {
   constructor(store, router) {
     this.store = store;
@@ -47,7 +52,8 @@ class ReconnectService {
   fetchConversations = async () => {
     await this.store.dispatch('updateChatListFilters', {
       page: null,
-      updatedWithin: this.getSecondsSinceDisconnect(),
+      updatedWithin:
+        this.getSecondsSinceDisconnect() + DISCONNECT_DELAY_THRESHOLD,
     });
     await this.store.dispatch('fetchAllConversations');
     // Reset the updatedWithin in the store chat list filter after fetching conversations when the user is reconnected

--- a/app/javascript/dashboard/helper/specs/ReconnectService.spec.js
+++ b/app/javascript/dashboard/helper/specs/ReconnectService.spec.js
@@ -102,7 +102,7 @@ describe('ReconnectService', () => {
       expect(reconnectService.getSecondsSinceDisconnect()).toBe(0);
     });
 
-    it('should return the number of seconds since disconnect', () => {
+    it('should return the number of seconds + threshold since disconnect', () => {
       reconnectService.disconnectTime = new Date();
       differenceInSeconds.mockReturnValue(100);
       expect(reconnectService.getSecondsSinceDisconnect()).toBe(100);
@@ -128,12 +128,21 @@ describe('ReconnectService', () => {
   });
 
   describe('fetchConversations', () => {
+    it('should update the filters with disconnected time and the threshold', async () => {
+      reconnectService.getSecondsSinceDisconnect = vi.fn().mockReturnValue(100);
+      await reconnectService.fetchConversations();
+      expect(storeMock.dispatch).toHaveBeenCalledWith('updateChatListFilters', {
+        page: null,
+        updatedWithin: 115,
+      });
+    });
+
     it('should dispatch updateChatListFilters and fetchAllConversations', async () => {
       reconnectService.getSecondsSinceDisconnect = vi.fn().mockReturnValue(100);
       await reconnectService.fetchConversations();
       expect(storeMock.dispatch).toHaveBeenCalledWith('updateChatListFilters', {
         page: null,
-        updatedWithin: 100,
+        updatedWithin: 115,
       });
       expect(storeMock.dispatch).toHaveBeenCalledWith('fetchAllConversations');
     });


### PR DESCRIPTION
The disconnect threshold is added to account for delays in identifying disconnections (for example, the websocket disconnection takes up to 3 seconds) while fetching the latest updated conversations or messages.

In this case, the cable disconnection event takes about 3 seconds to fire. If there was a conversation which was created in this 3 second, it would not be displayed in the UI until the refresh. 

