### PR TITLE
fix: TypeError cannot read property 'focus' of undefined

### DIFF
--- a/app/javascript/shared/components/emoji/EmojiInput.vue
+++ b/app/javascript/shared/components/emoji/EmojiInput.vue
@@ -4,12 +4,12 @@
     class="emoji-dialog bg-white shadow-lg dark:bg-slate-900 rounded-md border border-solid border-slate-75 dark:border-slate-800/50 box-content h-[300px] absolute right-0 -top-[95px] w-80 z-20"
   >
     <div class="flex flex-col">
-      <div class="emoji-search--wrap flex gap-2">
+      <div class="flex gap-2 emoji-search--wrap">
         <input
           ref="searchbar"
           v-model="search"
           type="text"
-          class="emoji-search--input focus:box-shadow-blue dark:focus:box-shadow-dark"
+          class="emoji-search--input focus:box-shadow-blue dark:focus:box-shadow-dark !mb-0"
           :placeholder="$t('EMOJI.PLACEHOLDER')"
         />
         <woot-button
@@ -174,7 +174,7 @@ export default {
       return categoryItem ? categoryItem.emojis[0].emoji : '';
     },
     focusSearchInput() {
-      this.$refs.searchbar.focus();
+      this.$refs.searchbar?.focus();
     },
   },
 };

--- a/app/javascript/shared/components/emoji/EmojiInput.vue
+++ b/app/javascript/shared/components/emoji/EmojiInput.vue
@@ -174,7 +174,9 @@ export default {
       return categoryItem ? categoryItem.emojis[0].emoji : '';
     },
     focusSearchInput() {
-      this.$refs.searchbar?.focus();
+      this.$nextTick(() => {
+        this.$refs.searchbar.focus();
+      });
     },
   },
 };


### PR DESCRIPTION
# Pull Request Template

## Description

**Issue**
The error `Cannot read property 'focus' of undefined`occurs because the `this.$refs.searchbar` is undefined at the time `focusSearchInput()` method is called. This can happen if the method is called before the component has fully mounted or if the `ref="searchbar"` is not correctly attached to any element. 

I tried multiple ways to reproduce this issue, but none worked.

**Solution**
To resolve this issue, I can add a check to ensure that `this.$refs.searchbar` is defined before calling `focus()` method.

Fixes https://linear.app/chatwoot/issue/CW-3405/typeerror-cannot-read-property-focus-of-undefined

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
