### PR TITLE
fix: TypeError cannot read properties of undefined (reading 'data')

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/EditWebHook.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/EditWebHook.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-auto overflow-auto flex flex-col">
+  <div class="flex flex-col h-auto overflow-auto">
     <woot-modal-header
       :header-title="$t('INTEGRATION_SETTINGS.WEBHOOK.EDIT.TITLE')"
     />
@@ -51,7 +51,7 @@ export default {
         this.onClose();
       } catch (error) {
         const alertMessage =
-          error.response.data.message ||
+          error?.response?.data?.message ||
           this.$t('INTEGRATION_SETTINGS.WEBHOOK.EDIT.API.ERROR_MESSAGE');
         this.showAlert(alertMessage);
       }


### PR DESCRIPTION
# Pull Request Template

## Description

**Issue**
The error `Cannot read properties of undefined (reading 'data')` occurs because the `error.response.data` is accessed without checking if `error.response` is present.

I can able to reproduce this issue.

**Solution**
To resolve this issue, I can add a check to ensure that this `error.response` is defined before accessing the `error.response.data`

Fixes https://linear.app/chatwoot/issue/CW-3406/typeerror-cannot-read-properties-of-undefined-reading-data

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
