### PR TITLE
feat: store sent emails with IMAP sent folder

### DIFF
--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -36,6 +36,8 @@ class ConversationReplyMailer < ApplicationMailer
     @message = message
     reply_mail_object = prepare_mail(true)
     message.update(source_id: reply_mail_object.message_id)
+    # Store in IMAP after preparing the mail
+    store_in_imap(reply_mail_object)
   end
 
   def conversation_transcript(conversation, to_email)
@@ -197,5 +199,18 @@ class ConversationReplyMailer < ApplicationMailer
     return false if action_name == 'reply_without_summary' || action_name == 'email_reply'
 
     'mailer/base'
+  end
+
+  def store_in_imap(mail_object)
+    if @channel.microsoft?
+      imap_service = Imap::MicrosoftFetchEmailService.new(channel: @channel)
+    elsif @channel.google?
+      imap_service = Imap::GoogleFetchEmailService.new(channel: @channel)
+    else
+      imap_service = Imap::FetchEmailService.new(channel: @channel)
+    end
+    imap_service.store_in_imap(mail_object)
+  rescue => e
+    Rails.logger.error "Failed to store email in IMAP: #{e.message}"
   end
 end

--- a/app/services/imap/fetch_email_service.rb
+++ b/app/services/imap/fetch_email_service.rb
@@ -3,6 +3,15 @@ class Imap::FetchEmailService < Imap::BaseFetchEmailService
     fetch_mail_for_channel
   end
 
+  def store_in_imap(mail_object)
+    imap = Net::IMAP.new(channel.imap_address, port: channel.imap_port, ssl: true)
+    imap.authenticate(authentication_type, channel.imap_login, imap_password)
+    imap.select('INBOX.Sent')
+    imap_email = mail_object.encoded
+    imap.append('INBOX.Sent', imap_email, [:Seen], Time.now)
+    terminate_imap_connection
+  end
+
   private
 
   def authentication_type

--- a/app/services/imap/google_fetch_email_service.rb
+++ b/app/services/imap/google_fetch_email_service.rb
@@ -5,6 +5,15 @@ class Imap::GoogleFetchEmailService < Imap::BaseFetchEmailService
     fetch_mail_for_channel
   end
 
+  def store_in_imap(mail_object)
+    imap = Net::IMAP.new(channel.imap_address, port: channel.imap_port, ssl: true)
+    imap.authenticate(authentication_type, channel.imap_login, imap_password)
+    imap.select('[Gmail]/Sent Mail')
+    imap_email = mail_object.encoded
+    imap.append('[Gmail]/Sent Mail', imap_email, [:Seen], Time.now)
+    terminate_imap_connection
+  end
+
   private
 
   def authentication_type

--- a/app/services/imap/microsoft_fetch_email_service.rb
+++ b/app/services/imap/microsoft_fetch_email_service.rb
@@ -5,6 +5,15 @@ class Imap::MicrosoftFetchEmailService < Imap::BaseFetchEmailService
     fetch_mail_for_channel
   end
 
+  def store_in_imap(mail_object)
+    imap = Net::IMAP.new(channel.imap_address, port: channel.imap_port, ssl: true)
+    imap.authenticate(authentication_type, channel.imap_login, imap_password)
+    imap.select('INBOX.Sent')
+    imap_email = mail_object.encoded
+    imap.append('INBOX.Sent', imap_email, [:Seen], Time.now)
+    terminate_imap_connection
+  end
+
   private
 
   def authentication_type


### PR DESCRIPTION
# Store sent emails with IMAP sent folder

## Description

Store Sent emails in IMAP email account when using SMTP for email Channel
Fixes https://github.com/chatwoot/chatwoot/issues/7606

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Built self-host version, send email and check if it was saved in imap server in INBOX.Sent folder.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
