### PR TITLE
fix: TypeError cannot read properties of undefined (reading 'status')

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/agents/AddAgent.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agents/AddAgent.vue
@@ -1,13 +1,13 @@
 <template>
   <woot-modal :show.sync="show" :on-close="onClose">
-    <div class="h-auto overflow-auto flex flex-col">
+    <div class="flex flex-col h-auto overflow-auto">
       <woot-modal-header
         :header-title="$t('AGENT_MGMT.ADD.TITLE')"
         :header-content="$t('AGENT_MGMT.ADD.DESC')"
       />
 
       <form
-        class="flex flex-col w-full items-start"
+        class="flex flex-col items-start w-full"
         @submit.prevent="addAgent()"
       >
         <div class="w-full">
@@ -45,7 +45,7 @@
             />
           </label>
         </div>
-        <div class="flex flex-row justify-end gap-2 py-2 px-0 w-full">
+        <div class="flex flex-row justify-end w-full gap-2 px-0 py-2">
           <div class="w-full">
             <woot-submit-button
               :disabled="
@@ -140,7 +140,7 @@ export default {
         } = error;
 
         let errorMessage = '';
-        if (error.response.status === 422 && !attributes.includes('base')) {
+        if (error?.response?.status === 422 && !attributes.includes('base')) {
           errorMessage = this.$t('AGENT_MGMT.ADD.API.EXIST_MESSAGE');
         } else {
           errorMessage = this.$t('AGENT_MGMT.ADD.API.ERROR_MESSAGE');


### PR DESCRIPTION
# Pull Request Template

## Description

**Issue**
The error `Cannot read properties of undefined (reading 'status')` occurs because the `error.response.status` is accessed without checking if `error.response` is present.

I can't able to reproduce this issue.

**Solution**
To resolve this issue, I added a check to ensure that this `error.response` is defined before accessing the `error.response.status`

Fixes https://linear.app/chatwoot/issue/CW-3322/typeerror-cannot-read-properties-of-undefined-reading-status

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
