### PR TITLE
fix: TypeError cannot read properties of undefined (reading '$store')

### DIFF
--- a/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js
@@ -52,6 +52,10 @@ class DashboardAudioNotificationHelper {
   };
 
   executeRecurringNotification = () => {
+    if (!window.WOOT || !window.WOOT.$store) {
+      this.clearSetTimeout();
+      return;
+    }
     const mineConversation = window.WOOT.$store.getters.getMineChats({
       assigneeType: 'me',
       status: 'open',


### PR DESCRIPTION
# Pull Request Template

## Description

**Cases**
https://linear.app/chatwoot/issue/CW-3396/typeerror-cannot-read-properties-of-undefined-reading-dollarstore#comment-f018b29c

Fixes https://linear.app/chatwoot/issue/CW-3396/typeerror-cannot-read-properties-of-undefined-reading-dollarstore


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
