### PR TITLE
Fix: Contact merge dropdowns with adjusted margins-[CW-3494]

### DIFF
--- a/app/javascript/dashboard/modules/contact/components/MergeContact.vue
+++ b/app/javascript/dashboard/modules/contact/components/MergeContact.vue
@@ -196,7 +196,11 @@ export default {
   }
 
   .multiselect__tags {
-    @apply h-[52px];
+    @apply h-auto;
+  }
+
+  .multiselect__select {
+    @apply mt-px mr-1;
   }
 }
 </style>


### PR DESCRIPTION
# Pull Request Template

## Description

Adjusts the margin for dropdown and sets the height to auto from hardcoded 52px.

Fixes CW-3494

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested locally, attached screenshot