### PR TITLE
fix: Instagram outgoing attachments

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -81,7 +81,7 @@ class Attachment < ApplicationRecord
       height: file.metadata[:height]
     }
 
-    metadata[:data_url] = metadata[:thumb_url] = external_url if message.inbox.instagram?
+    metadata[:data_url] = metadata[:thumb_url] = external_url if message.inbox.instagram? && message.incoming?
     metadata
   end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -48,5 +48,10 @@ RSpec.describe Attachment do
       external_url = instagram_message.attachments.first.external_url
       expect(instagram_message.attachments.first.push_event_data[:data_url]).to eq external_url
     end
+
+    it 'returns data url as data if the message is outgoing' do
+      message = create(:message, :instagram_story_mention, message_type: :outgoing)
+      expect(message.attachments.first.push_event_data[:data_url]).not_to eq message.attachments.first.external_url
+    end
   end
 end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -44,12 +44,12 @@ RSpec.describe Attachment do
       }.to_json, headers: {})
     end
 
-    it 'returns external url as data and thumb urls' do
+    it 'returns external url as data and thumb urls when message is incoming' do
       external_url = instagram_message.attachments.first.external_url
       expect(instagram_message.attachments.first.push_event_data[:data_url]).to eq external_url
     end
 
-    it 'returns data url as data if the message is outgoing' do
+    it 'returns original attachment url as data url if the message is outgoing' do
       message = create(:message, :instagram_story_mention, message_type: :outgoing)
       expect(message.attachments.first.push_event_data[:data_url]).not_to eq message.attachments.first.external_url
     end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-3497/instagram-outgoing-attachments-are-not-rendering

It seems like Instagram outgoing attachment rendering has been broken for a long time. We couldn't identify the issue because the check below only inspects Instagram mentions.
```
metadata[:data_url] = metadata[:thumb_url] = external_url if message.instagram_story_mention?
```
We recently worked on adding the [Instagram CDN URL for attachments.](https://github.com/chatwoot/chatwoot/pull/9287) 

After that, it started using external URLs as attachment data URLs for both outgoing and incoming attachments. The rendering broken for all the outgoing attachments since there were no external URLs, making the data URL empty. Adding an incoming message check will solve the issue.