### PR TITLE
chore: Use installation config URL for captain app URL

### DIFF
--- a/app/controllers/api/v1/accounts/integrations/captain_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/captain_controller.rb
@@ -8,7 +8,9 @@ class Api::V1::Accounts::Integrations::CaptainController < Api::V1::Accounts::Ba
       "&email=#{URI.encode_www_form_component(@hook['settings']['account_email'])}" \
       "&account_id=#{URI.encode_www_form_component(@hook['settings']['account_id'])}"
 
-    sso_url = "#{ENV.fetch('CAPTAIN_APP_URL', '')}/sso?#{params_string}"
+    installation_config = InstallationConfig.find_by(name: 'CAPTAIN_APP_URL')
+
+    sso_url = "#{installation_config.value}/sso?#{params_string}"
     render json: { sso_url: sso_url }, status: :ok
   end
 

--- a/spec/controllers/api/v1/accounts/integrations/captain_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/captain_controller_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe 'Captain Integrations API', type: :request do
       end
 
       it 'returns sso url if hook is available' do
+        InstallationConfig.where(name: 'CAPTAIN_APP_URL').first_or_create(value: 'https://app.chatwoot.com')
+
         hook = create(:integrations_hook, account: account, app_id: 'captain', settings: {
                         access_token: SecureRandom.hex,
                         account_email: Faker::Internet.email,
@@ -45,21 +47,19 @@ RSpec.describe 'Captain Integrations API', type: :request do
                         inbox_ids: '1'
                       })
 
-        with_modified_env CAPTAIN_APP_URL: 'https://app.example.com' do
-          get sso_url_api_v1_account_integrations_captain_url(account_id: account.id),
-              params: {},
-              headers: admin.create_new_auth_token,
-              as: :json
+        get sso_url_api_v1_account_integrations_captain_url(account_id: account.id),
+            params: {},
+            headers: admin.create_new_auth_token,
+            as: :json
 
-          expect(response).to have_http_status(:success)
-          data = response.parsed_body
-          params_string = "token=#{URI.encode_www_form_component(hook['settings']['access_token'])}" \
-                          "&email=#{URI.encode_www_form_component(hook['settings']['account_email'])}" \
-                          "&account_id=#{URI.encode_www_form_component(hook['settings']['account_id'])}"
+        expect(response).to have_http_status(:success)
+        data = response.parsed_body
+        params_string = "token=#{URI.encode_www_form_component(hook['settings']['access_token'])}" \
+                        "&email=#{URI.encode_www_form_component(hook['settings']['account_email'])}" \
+                        "&account_id=#{URI.encode_www_form_component(hook['settings']['account_id'])}"
 
-          sso_url = "https://app.example.com/sso?#{params_string}"
-          expect(data['sso_url']).to eq(sso_url)
-        end
+        sso_url = "https://app.chatwoot.com/sso?#{params_string}"
+        expect(data['sso_url']).to eq(sso_url)
       end
     end
   end


### PR DESCRIPTION
Use `InstallationConfig.where(name: 'CAPTAIN_APP_URL')` instead of `ENV.fetch('CAPTAIN_APP_URL', '')`