### PR TITLE
fix: Logos of integrations in dark mode in integrations

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/SingleIntegrationHooks.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/SingleIntegrationHooks.vue
@@ -2,13 +2,17 @@
   <div class="flex-shrink flex-grow overflow-auto p-4">
     <div class="flex flex-col">
       <div
-        class="bg-white dark:bg-slate-800 border border-solid border-slate-75 dark:border-slate-700/50 rounded-sm mb-4 p-4"
+        class="bg-white dark:bg-slate-800 border border-solid border-slate-75 dark:border-slate-700/50 rounded-xl mb-4 p-4"
       >
         <div class="flex">
           <div class="flex h-[6.25rem] w-[6.25rem]">
             <img
               :src="`/dashboard/images/integrations/${integration.id}.png`"
-              class="max-w-full p-6"
+              class="max-w-full rounded-md border border-slate-50 dark:border-slate-700/50 shadow-sm block dark:hidden bg-white dark:bg-slate-900"
+            />
+            <img
+              :src="`/dashboard/images/integrations/${integration.id}-dark.png`"
+              class="max-w-full rounded-md border border-slate-50 dark:border-slate-700/50 shadow-sm hidden dark:block bg-white dark:bg-slate-900"
             />
           </div>
           <div class="flex flex-col justify-center m-0 mx-4 flex-1">


### PR DESCRIPTION
# Pull Request Template

## Description
issue

I have made adjustments so that the integration logos can display correctly

before
![logo integraciones modo oscuro antes](https://github.com/user-attachments/assets/96e05da5-9e33-4bf0-9c03-34de35a8b236)

after
![logo integraciones modo oscuro despues](https://github.com/user-attachments/assets/82d2b775-c8b5-430a-806a-5d24fa555471)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
