### PR TITLE
fix: Disable the password section is the admin has disabled user profile update

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/profile/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/profile/Index.vue
@@ -229,8 +229,11 @@ export default {
         </button>
       </div>
     </FormSection>
-    <FormSection :title="$t('PROFILE_SETTINGS.FORM.PASSWORD_SECTION.TITLE')">
-      <ChangePassword v-if="!globalConfig.disableUserProfileUpdate" />
+    <FormSection
+      v-if="!globalConfig.disableUserProfileUpdate"
+      :title="$t('PROFILE_SETTINGS.FORM.PASSWORD_SECTION.TITLE')"
+    >
+      <ChangePassword />
     </FormSection>
     <FormSection
       :title="$t('PROFILE_SETTINGS.FORM.AUDIO_NOTIFICATIONS_SECTION.TITLE')"


### PR DESCRIPTION
This PR updates the profile settings page to completely disable the password section, including the heading, if the admin has disabled user profile updates. Previously, the section heading was shown with empty content, which caused confusion.

| Before | After |
| -- | -- |
| <img width="813" alt="Screenshot 2024-08-07 at 9 36 24 AM" src="https://github.com/user-attachments/assets/120efab0-0094-4141-b23c-5103596a187e"> | <img width="805" alt="Screenshot 2024-08-07 at 9 36 35 AM" src="https://github.com/user-attachments/assets/35e2c76b-e8f5-4c6f-a51e-7c30b882cd9c"> | 
