### PR TITLE
fix: TypeError cannot read properties of undefined (reading 'id')

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/conversationCardComponents/CardLabels.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/conversationCardComponents/CardLabels.vue
@@ -13,9 +13,9 @@ export default {
     const accountLabels = useMapGetter('labels/getLabels');
 
     const activeLabels = computed(() => {
-      return props.conversationLabels
-        .map(label => accountLabels.value.find(l => l.title === label))
-        .filter(label => label !== undefined); // Filter out undefined labels, which can happen if the label is deleted
+      return accountLabels.value.filter(({ title }) =>
+        props.conversationLabels.includes(title)
+      );
     });
 
     return {

--- a/app/javascript/dashboard/components/widgets/conversation/conversationCardComponents/CardLabels.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/conversationCardComponents/CardLabels.vue
@@ -15,7 +15,7 @@ export default {
     const activeLabels = computed(() => {
       return props.conversationLabels
         .map(label => accountLabels.value.find(l => l.title === label))
-        .filter(label => label !== undefined);
+        .filter(label => label !== undefined); // Filter out undefined labels, which can happen if the label is deleted
     });
 
     return {

--- a/app/javascript/dashboard/components/widgets/conversation/conversationCardComponents/CardLabels.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/conversationCardComponents/CardLabels.vue
@@ -13,9 +13,9 @@ export default {
     const accountLabels = useMapGetter('labels/getLabels');
 
     const activeLabels = computed(() => {
-      return props.conversationLabels.map(label =>
-        accountLabels.value.find(l => l.title === label)
-      );
+      return props.conversationLabels
+        .map(label => accountLabels.value.find(l => l.title === label))
+        .filter(label => label !== undefined);
     });
 
     return {

--- a/app/javascript/dashboard/components/widgets/conversation/conversationCardComponents/CardLabels.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/conversationCardComponents/CardLabels.vue
@@ -83,7 +83,7 @@ export default {
       <slot name="before" />
       <woot-label
         v-for="(label, index) in activeLabels"
-        :key="label.id"
+        :key="label ? label.id : index"
         :title="label.title"
         :description="label.description"
         :color="label.color"


### PR DESCRIPTION
# Pull Request Template

## Description
**Issue**
This PR will fix an issue with the `CardLabels` component, which throws these type errors: `TypeError: Cannot read properties of undefined (reading 'id')` and `TypeError: n is undefined`. It seems that `label` in the `v-for` directive is `undefined` at some point, or it happens because `activelabels` becomes undefined, which can occur if the assigned label is deleted.

Previously, it would try to find a matching label in `accountLabels` for each label in `props.conversationLabels`. For the deleted label, it would return `undefined`.

**Solution**
Now, we filter `accountLabels` based on whether their title is included in the `props.conversationLabels` array.

Fixes 
1. https://chatwoot-p3.sentry.io/issues/5707611629/?project=4507182691975168&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=2
2. https://chatwoot-p3.sentry.io/issues/5707611526/?project=4507182691975168&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=1

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Steps to reproduce**
1. Assign an existing label to conversation.
2. Delete the assigned label from label settings page
3. Now you can see these errors.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
