### PR TITLE
fix: TypeError: t.messages.at is not a function

### DIFF
--- a/app/javascript/dashboard/helper/conversationHelper.js
+++ b/app/javascript/dashboard/helper/conversationHelper.js
@@ -47,12 +47,13 @@ export const filterDuplicateSourceMessages = (messages = []) => {
  * @returns {Object} The last message of the conversation.
  */
 export const getLastMessage = m => {
-  const lastMessageIncludingActivity = m.messages.at(-1);
+  const lastMessageIncludingActivity = m.messages[m.messages.length - 1];
 
   const nonActivityMessages = m.messages.filter(
     message => message.message_type !== 2
   );
-  const lastNonActivityMessageInStore = nonActivityMessages.at(-1);
+  const lastNonActivityMessageInStore =
+    nonActivityMessages[nonActivityMessages.length - 1];
 
   const lastNonActivityMessageFromAPI = m.last_non_activity_message;
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will fix the type error related to `getLastMessage` to retrieve the last message and display it in the conversation card.

**Issue**
This method is part of newer JavaScript versions and might not be supported in all browsers.
<img width="331" alt="image" src="https://github.com/user-attachments/assets/6def714a-b442-40fa-bbe2-d4b6983cbcb8">
<img width="221" alt="image" src="https://github.com/user-attachments/assets/2eebe892-0547-4719-91f5-57fa995758b9">


Fixes https://chatwoot-p3.sentry.io/issues/5708410274/?alert_rule_id=15157525&alert_timestamp=1723552508790&alert_type=email&environment=production&notification_uuid=be5966b2-f17d-4273-8709-98e3322f1f6f&project=4507182691975168&referrer=alert_email

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
