### PR TITLE
fix: Delete attachments when removing them from Instagram in real-time

### DIFF
--- a/app/services/instagram/message_text.rb
+++ b/app/services/instagram/message_text.rb
@@ -83,6 +83,7 @@ class Instagram::MessageText < Instagram::WebhooksBaseService
     )
     return if message_to_delete.blank?
 
+    message_to_delete.attachments.destroy_all
     message_to_delete.update!(content: I18n.t('conversations.messages.deleted'), deleted: true)
   end
 

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -81,9 +81,7 @@ describe Webhooks::InstagramEventsJob do
       end
 
       it 'handle instagram unsend message event' do
-        create(:message,
-               source_id: 'message-id-to-delete',
-               inbox_id: instagram_inbox.id)
+        message = create(:message, inbox_id: instagram_inbox.id, source_id: 'message-id-to-delete')
         allow(Koala::Facebook::API).to receive(:new).and_return(fb_object)
         allow(fb_object).to receive(:get_object).and_return(
           {
@@ -93,7 +91,10 @@ describe Webhooks::InstagramEventsJob do
             profile_pic: 'https://chatwoot-assets.local/sample.png'
           }.with_indifferent_access
         )
+        message.attachments.new(file_type: :image, external_url: 'https://www.example.com/test.jpeg')
+
         expect(instagram_inbox.messages.count).to be 1
+
         instagram_webhook.perform_now(unsend_event[:entry])
 
         expect(instagram_inbox.messages.last.content).to eq 'This message was deleted'

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -97,6 +97,8 @@ describe Webhooks::InstagramEventsJob do
         instagram_webhook.perform_now(unsend_event[:entry])
 
         expect(instagram_inbox.messages.last.content).to eq 'This message was deleted'
+        expect(instagram_inbox.messages.last.deleted).to be true
+        expect(instagram_inbox.messages.last.attachments.count).to be 0
         expect(instagram_inbox.messages.last.reload.deleted).to be true
       end
 


### PR DESCRIPTION
Fixes https://github.com/chatwoot/chatwoot/issues/9963

This PR will fix the issue of removing attachments in real-time when someone unsends media (images, videos, and audio) from Instagram.