### PR TITLE
feat: Added support for copying and pasting images in article editor

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
@@ -173,6 +173,13 @@ export default {
           blur: () => {
             this.onBlur();
           },
+          paste: (view, event) => {
+            const data = event.clipboardData.files;
+            if (data.length > 0) {
+              data.forEach(file => this.uploadImageToStorage(file));
+              event.preventDefault();
+            }
+          },
         },
       });
     },

--- a/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
@@ -120,7 +120,6 @@ export default {
         if (fileUrl) {
           this.onImageUploadStart(fileUrl);
         }
-        useAlert(this.$t('HELP_CENTER.ARTICLE_EDITOR.IMAGE_UPLOAD.SUCCESS'));
       } catch (error) {
         useAlert(this.$t('HELP_CENTER.ARTICLE_EDITOR.IMAGE_UPLOAD.ERROR'));
       }


### PR DESCRIPTION
- Added the ability to copy images from the system and paste them into the editor.
- Removed the success message as it's unnecessary; users will know when the image appears in the editor.