### PR TITLE
feat: Extend `upload` API end point to support external images

### DIFF
--- a/app/controllers/api/v1/accounts/upload_controller.rb
+++ b/app/controllers/api/v1/accounts/upload_controller.rb
@@ -21,6 +21,7 @@ class Api::V1::Accounts::UploadController < Api::V1::Accounts::BaseController
 
   def create_from_url
     uri = parse_and_validate_uri(params[:external_url])
+    # Checks if a response has already been sent back to the client.
     return if performed?
 
     fetch_and_process_file_from_uri(uri)

--- a/app/controllers/api/v1/accounts/upload_controller.rb
+++ b/app/controllers/api/v1/accounts/upload_controller.rb
@@ -19,18 +19,23 @@ class Api::V1::Accounts::UploadController < Api::V1::Accounts::BaseController
   end
 
   def create_from_url
-    uri = parse_and_validate_uri(params[:external_url])
+    uri = parse_uri(params[:external_url])
     return if performed?
 
     fetch_and_process_file_from_uri(uri)
   end
 
-  def parse_and_validate_uri(url)
-    URI.parse(url).tap do |uri|
-      raise URI::InvalidURIError unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
-    end
+  def parse_uri(url)
+    uri = URI.parse(url)
+    validate_uri(uri)
+    uri
   rescue URI::InvalidURIError, SocketError
     render_error('Invalid URL provided', :unprocessable_entity)
+    nil
+  end
+
+  def validate_uri(uri)
+    raise URI::InvalidURIError unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
   end
 
   def fetch_and_process_file_from_uri(uri)

--- a/app/controllers/api/v1/accounts/upload_controller.rb
+++ b/app/controllers/api/v1/accounts/upload_controller.rb
@@ -1,13 +1,60 @@
 class Api::V1::Accounts::UploadController < Api::V1::Accounts::BaseController
   def create
+    if params[:attachment].present?
+      create_from_file
+    elsif params[:external_url].present?
+      create_from_url
+    else
+      render json: { error: 'No file or URL provided' }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def create_from_file
+    attachment = params[:attachment]
     file_blob = ActiveStorage::Blob.create_and_upload!(
       key: nil,
-      io: params[:attachment].tempfile,
-      filename: params[:attachment].original_filename,
-      content_type: params[:attachment].content_type
+      io: attachment.tempfile,
+      filename: attachment.original_filename,
+      content_type: attachment.content_type
     )
     file_blob.save!
 
+    render_success(file_blob)
+  end
+
+  def create_from_url
+    external_url = params[:external_url]
+
+    begin
+      uri = URI.parse(external_url)
+      raise URI::InvalidURIError unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+
+      uri.open do |file|
+        filename = File.basename(uri.path)
+        content_type = file.content_type
+
+        file_blob = ActiveStorage::Blob.create_and_upload!(
+          key: nil,
+          io: file,
+          filename: filename,
+          content_type: content_type
+        )
+        file_blob.save!
+
+        render_success(file_blob)
+      end
+    rescue URI::InvalidURIError, SocketError => e
+      render json: { error: 'Invalid URL provided' }, status: :unprocessable_entity
+    rescue OpenURI::HTTPError => e
+      render json: { error: "Failed to fetch file from URL: #{e.message}" }, status: :unprocessable_entity
+    rescue StandardError => e
+      render json: { error: 'An unexpected error occurred' }, status: :internal_server_error
+    end
+  end
+
+  def render_success(file_blob)
     render json: { file_url: url_for(file_blob), blob_key: file_blob.key, blob_id: file_blob.id }
   end
 end

--- a/app/controllers/api/v1/accounts/upload_controller.rb
+++ b/app/controllers/api/v1/accounts/upload_controller.rb
@@ -13,45 +13,50 @@ class Api::V1::Accounts::UploadController < Api::V1::Accounts::BaseController
 
   def create_from_file
     attachment = params[:attachment]
-    file_blob = ActiveStorage::Blob.create_and_upload!(
-      key: nil,
-      io: attachment.tempfile,
-      filename: attachment.original_filename,
-      content_type: attachment.content_type
-    )
+    file_blob = create_file_blob(attachment.tempfile, attachment.original_filename, attachment.content_type)
     file_blob.save!
 
     render_success(file_blob)
   end
 
   def create_from_url
-    external_url = params[:external_url]
+    uri = parse_and_validate_uri(params[:external_url])
+    return if performed?
 
-    begin
-      uri = URI.parse(external_url)
-      raise URI::InvalidURIError unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+    fetch_and_process_file_from_uri(uri)
+  end
 
-      uri.open do |file|
-        filename = File.basename(uri.path)
-        content_type = file.content_type
+  def parse_and_validate_uri(url)
+    uri = URI.parse(url)
+    raise URI::InvalidURIError unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
 
-        file_blob = ActiveStorage::Blob.create_and_upload!(
-          key: nil,
-          io: file,
-          filename: filename,
-          content_type: content_type
-        )
-        file_blob.save!
+    uri
+  rescue URI::InvalidURIError, SocketError
+    render json: { error: 'Invalid URL provided' }, status: :unprocessable_entity
+    nil
+  end
 
-        render_success(file_blob)
-      end
-    rescue URI::InvalidURIError, SocketError => e
-      render json: { error: 'Invalid URL provided' }, status: :unprocessable_entity
-    rescue OpenURI::HTTPError => e
-      render json: { error: "Failed to fetch file from URL: #{e.message}" }, status: :unprocessable_entity
-    rescue StandardError => e
-      render json: { error: 'An unexpected error occurred' }, status: :internal_server_error
+  def fetch_and_process_file_from_uri(uri)
+    uri.open do |file|
+      file_blob = create_file_blob(file, File.basename(uri.path), file.content_type)
+      file_blob.save!
+      render_success(file_blob)
     end
+  rescue OpenURI::HTTPError => e
+    render json: { error: "Failed to fetch file from URL: #{e.message}" }, status: :unprocessable_entity
+  rescue SocketError
+    render json: { error: 'Invalid URL provided' }, status: :unprocessable_entity
+  rescue StandardError
+    render json: { error: 'An unexpected error occurred' }, status: :internal_server_error
+  end
+
+  def create_file_blob(io, filename, content_type)
+    ActiveStorage::Blob.create_and_upload!(
+      key: nil,
+      io: io,
+      filename: filename,
+      content_type: content_type
+    )
   end
 
   def render_success(file_blob)

--- a/app/javascript/dashboard/store/modules/helpCenterArticles/specs/action.spec.js
+++ b/app/javascript/dashboard/store/modules/helpCenterArticles/specs/action.spec.js
@@ -187,30 +187,25 @@ describe('#actions', () => {
 
   describe('attachImage', () => {
     it('should upload the file and return the fileUrl', async () => {
-      // Given
       const mockFile = new Blob(['test'], { type: 'image/png' });
       mockFile.name = 'test.png';
 
       const mockFileUrl = 'https://test.com/test.png';
       uploadFile.mockResolvedValueOnce({ fileUrl: mockFileUrl });
 
-      // When
       const result = await actions.attachImage({}, { file: mockFile });
 
-      // Then
       expect(uploadFile).toHaveBeenCalledWith(mockFile);
       expect(result).toBe(mockFileUrl);
     });
 
     it('should throw an error if the upload fails', async () => {
-      // Given
       const mockFile = new Blob(['test'], { type: 'image/png' });
       mockFile.name = 'test.png';
 
       const mockError = new Error('Upload failed');
       uploadFile.mockRejectedValueOnce(mockError);
 
-      // When & Then
       await expect(actions.attachImage({}, { file: mockFile })).rejects.toThrow(
         'Upload failed'
       );

--- a/spec/controllers/api/v1/upload_controller_spec.rb
+++ b/spec/controllers/api/v1/upload_controller_spec.rb
@@ -1,42 +1,112 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Accounts::UploadController', type: :request do
-  describe 'POST /api/v1/account/1/upload/' do
-    let(:account) { create(:account) }
-    let(:user) { create(:user, account: account) }
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
+  let(:upload_url) { "/api/v1/accounts/#{account.id}/upload/" }
 
-    it 'uploads the image when authorized' do
-      file = fixture_file_upload(Rails.root.join('spec/assets/avatar.png'), 'image/png')
+  describe 'POST /api/v1/accounts/:account_id/upload/' do
+    context 'when uploading a file' do
+      let(:file) { fixture_file_upload(Rails.root.join('spec/assets/avatar.png'), 'image/png') }
 
-      post "/api/v1/accounts/#{account.id}/upload/",
-           headers: user.create_new_auth_token,
-           params: { attachment: file }
+      it 'uploads the image when authorized' do
+        post upload_url,
+             headers: user.create_new_auth_token,
+             params: { attachment: file }
 
-      expect(response).to have_http_status(:success)
-      blob = response.parsed_body
+        expect(response).to have_http_status(:success)
+        blob = response.parsed_body
+        expect(blob['errors']).to be_nil
+        expect(blob['file_url']).to be_present
+        expect(blob['blob_key']).to be_present
+        expect(blob['blob_id']).to be_present
+      end
 
-      expect(blob['errors']).to be_nil
+      it 'does not upload when unauthorized' do
+        post upload_url,
+             headers: {},
+             params: { attachment: file }
 
-      expect(blob['file_url']).to be_present
-      expect(blob['blob_key']).to be_present
-      expect(blob['blob_id']).to be_present
+        expect(response).to have_http_status(:unauthorized)
+        blob = response.parsed_body
+        expect(blob['errors']).to be_present
+        expect(blob['file_url']).to be_nil
+        expect(blob['blob_key']).to be_nil
+        expect(blob['blob_id']).to be_nil
+      end
     end
 
-    it 'does not upload when un-authorized' do
-      file = fixture_file_upload(Rails.root.join('spec/assets/avatar.png'), 'image/png')
+    context 'when uploading from a URL' do
+      let(:valid_external_url) { 'http://example.com/image.jpg' }
 
-      post "/api/v1/accounts/#{account.id}/upload/",
-           headers: {},
-           params: { attachment: file }
+      before do
+        stub_request(:get, valid_external_url)
+          .to_return(status: 200, body: File.new(Rails.root.join('spec/assets/avatar.png')), headers: { 'Content-Type' => 'image/png' })
+      end
 
-      expect(response).to have_http_status(:unauthorized)
-      blob = response.parsed_body
+      it 'uploads the image from URL when authorized' do
+        post upload_url,
+             headers: user.create_new_auth_token,
+             params: { external_url: valid_external_url }
 
-      expect(blob['errors']).to be_present
+        expect(response).to have_http_status(:success)
+        blob = response.parsed_body
+        expect(blob['error']).to be_nil
+        expect(blob['file_url']).to be_present
+        expect(blob['blob_key']).to be_present
+        expect(blob['blob_id']).to be_present
+      end
 
-      expect(blob['file_url']).to be_nil
-      expect(blob['blob_key']).to be_nil
-      expect(blob['blob_id']).to be_nil
+      it 'handles invalid URL format' do
+        post upload_url,
+             headers: user.create_new_auth_token,
+             params: { external_url: 'not_a_url' }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to eq('Invalid URL provided')
+      end
+
+      it 'handles URL with unsupported protocol' do
+        post upload_url,
+             headers: user.create_new_auth_token,
+             params: { external_url: 'ftp://example.com/image.jpg' }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to eq('Invalid URL provided')
+      end
+
+      it 'handles unreachable URLs' do
+        stub_request(:get, 'http://nonexistent.example.com')
+          .to_raise(SocketError.new('Failed to open TCP connection'))
+
+        post upload_url,
+             headers: user.create_new_auth_token,
+             params: { external_url: 'http://nonexistent.example.com' }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to eq('Invalid URL provided')
+      end
+
+      it 'handles HTTP errors' do
+        stub_request(:get, 'http://error.example.com')
+          .to_return(status: 404)
+
+        post upload_url,
+             headers: user.create_new_auth_token,
+             params: { external_url: 'http://error.example.com' }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to start_with('Failed to fetch file from URL')
+      end
+    end
+
+    it 'returns an error when no file or URL is provided' do
+      post upload_url,
+           headers: user.create_new_auth_token,
+           params: {}
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['error']).to eq('No file or URL provided')
     end
   end
 end


### PR DESCRIPTION
We're adding support for copying and pasting images directly into the editor. Users can copy images from any platform and paste them seamlessly. These images will be stored in Chatwoot's storage, reducing reliance on external servers. This ensures that all images remain accessible even if the original source becomes unavailable. This PR extend the `upload` endpoint to support external URLs.