### PR TITLE
fix: TypeError cannot read properties of undefined (reading 'click')

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -118,25 +118,37 @@ export default {
       };
     };
     const handlePreviousConversation = () => {
+      // Retrieve conversation parameters
       const { allConversations, activeConversationIndex } =
         getKeyboardListenerParams();
-      if (activeConversationIndex === -1) {
-        allConversations[0].click();
-      }
-      if (activeConversationIndex >= 1) {
+
+      // Check if there are conversations and the active index is valid for a previous conversation
+      if (allConversations.length > 0 && activeConversationIndex > 0) {
+        // Click the previous conversation
         allConversations[activeConversationIndex - 1].click();
+      } else if (allConversations.length > 0) {
+        // If no valid previous index, click the first conversation
+        allConversations[0].click();
       }
     };
     const handleNextConversation = () => {
+      // Retrieve conversation parameters
       const {
         allConversations,
         activeConversationIndex,
         lastConversationIndex,
       } = getKeyboardListenerParams();
-      if (activeConversationIndex === -1) {
-        allConversations[lastConversationIndex].click();
-      } else if (activeConversationIndex < lastConversationIndex) {
+
+      // Check if there are conversations and the active index is valid for a next conversation
+      if (
+        allConversations.length > 0 &&
+        activeConversationIndex < lastConversationIndex
+      ) {
+        // Click the next conversation
         allConversations[activeConversationIndex + 1].click();
+      } else if (allConversations.length > 0) {
+        // If no valid next index, click the last conversation
+        allConversations[lastConversationIndex].click();
       }
     };
     const keyboardEvents = {

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -117,47 +117,41 @@ export default {
         lastConversationIndex,
       };
     };
-    const handlePreviousConversation = () => {
-      // Retrieve conversation parameters
-      const { allConversations, activeConversationIndex } =
-        getKeyboardListenerParams();
-
-      // Check if there are conversations and the active index is valid for a previous conversation
-      if (allConversations.length > 0 && activeConversationIndex > 0) {
-        // Click the previous conversation
-        allConversations[activeConversationIndex - 1].click();
-      } else if (allConversations.length > 0) {
-        // If no valid previous index, click the first conversation
-        allConversations[0].click();
-      }
-    };
-    const handleNextConversation = () => {
-      // Retrieve conversation parameters
+    const handleConversationNavigation = direction => {
       const {
         allConversations,
         activeConversationIndex,
         lastConversationIndex,
       } = getKeyboardListenerParams();
 
-      // Check if there are conversations and the active index is valid for a next conversation
+      // Determine the new index based on the direction
+      const newIndex =
+        direction === 'previous'
+          ? activeConversationIndex - 1
+          : activeConversationIndex + 1;
+
+      // Check if the new index is within the valid range
       if (
         allConversations.length > 0 &&
-        activeConversationIndex < lastConversationIndex
+        newIndex >= 0 &&
+        newIndex <= lastConversationIndex
       ) {
-        // Click the next conversation
-        allConversations[activeConversationIndex + 1].click();
+        // Click the conversation at the new index
+        allConversations[newIndex].click();
       } else if (allConversations.length > 0) {
-        // If no valid next index, click the last conversation
-        allConversations[lastConversationIndex].click();
+        // If the new index is out of range, click the first or last conversation based on the direction
+        const fallbackIndex =
+          direction === 'previous' ? 0 : lastConversationIndex;
+        allConversations[fallbackIndex].click();
       }
     };
     const keyboardEvents = {
       'Alt+KeyJ': {
-        action: () => handlePreviousConversation(),
+        action: () => handleConversationNavigation('previous'),
         allowOnFocusedInput: true,
       },
       'Alt+KeyK': {
-        action: () => handleNextConversation(),
+        action: () => handleConversationNavigation('next'),
         allowOnFocusedInput: true,
       },
     };


### PR DESCRIPTION
# Pull Request Template

## Description

**Issue**
This PR addresses an sentry issue in the `ChatList.vue` component, where a `TypeError: Cannot read properties of undefined (reading 'click')` was thrown when navigating through the chat list using keyboard shortcuts. The error occurred because the code attempted to invoke the `click()` method on elements that were not present, typically happening when the chat list is empty.


**Solution**
I updated the keyboard navigation functions to include checks for the `allConversations` array's length, ensuring that `click()` actions are only attempted when the array contains elements. Additionally, I added comments to the code to improve clarity and maintainability.

Fixes https://linear.app/chatwoot/issue/CW-3535/typeerror-cannot-read-properties-of-undefined-reading-click

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Open dashboard
2. Clear the chats under mine or unassigned or all.
3. Then try to click `Alt+KeyJ` or `Alt+KeyK`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
