### PR TITLE
fix: Remove draft articles from the help center search

### DIFF
--- a/app/controllers/public/api/v1/portals/articles_controller.rb
+++ b/app/controllers/public/api/v1/portals/articles_controller.rb
@@ -6,7 +6,7 @@ class Public::Api::V1::Portals::ArticlesController < Public::Api::V1::Portals::B
   layout 'portal'
 
   def index
-    @articles = @portal.articles
+    @articles = @portal.articles.published
     search_articles
     order_by_sort_param
     @articles.page(list_params[:page]) if list_params[:page].present?

--- a/spec/controllers/public/api/v1/portals/articles_controller_spec.rb
+++ b/spec/controllers/public/api/v1/portals/articles_controller_spec.rb
@@ -17,13 +17,20 @@ RSpec.describe 'Public Articles API', type: :request do
     create(:article, category: category, portal: portal, account_id: account.id, author_id: agent.id, associated_article_id: article.id, views: 1)
     create(:article, category: category_2, portal: portal, account_id: account.id, author_id: agent.id, associated_article_id: article.id, views: 5)
     create(:article, category: category_2, portal: portal, account_id: account.id, author_id: agent.id, views: 4)
+    create(:article, category: category_2, portal: portal, account_id: account.id, author_id: agent.id, status: :draft)
   end
 
   describe 'GET /public/api/v1/portals/:slug/articles' do
     it 'Fetch all articles in the portal' do
       get "/hc/#{portal.slug}/#{category.locale}/categories/#{category.slug}/articles"
-
       expect(response).to have_http_status(:success)
+    end
+
+    it 'Fetches only the published articles in the portal' do
+      get "/hc/#{portal.slug}/#{category_2.locale}/categories/#{category.slug}/articles.json"
+      expect(response).to have_http_status(:success)
+      response_data = JSON.parse(response.body, symbolize_names: true)[:payload]
+      expect(response_data.length).to eq(2)
     end
 
     it 'get all articles with searched text query' do


### PR DESCRIPTION
Limit the API to return only the published articles in public help center API.

Fixes https://github.com/chatwoot/chatwoot/issues/10026