### PR TITLE
fix: `message_type` in widget conversation create end point

### DIFF
--- a/app/controllers/api/v1/widget/conversations_controller.rb
+++ b/app/controllers/api/v1/widget/conversations_controller.rb
@@ -11,6 +11,8 @@ class Api::V1::Widget::ConversationsController < Api::V1::Widget::BaseController
       process_update_contact
       @conversation = create_conversation
       conversation.messages.create!(message_params)
+      # TODO: Temporary fix for message type cast issue, since message_type is returning as string instead of integer
+      conversation.reload
     end
   end
 

--- a/app/views/api/v1/models/_widget_message.json.jbuilder
+++ b/app/views/api/v1/models/_widget_message.json.jbuilder
@@ -1,7 +1,6 @@
 json.id resource.id
 json.content resource.content
-# TODO: Temporary fix for message type cast issue, since message_type is returning as string instead of integer
-json.message_type resource.reload.message_type_before_type_cast
+json.message_type resource.message_type_before_type_cast
 json.content_type resource.content_type
 json.content_attributes resource.content_attributes
 json.created_at resource.created_at.to_i

--- a/app/views/api/v1/models/_widget_message.json.jbuilder
+++ b/app/views/api/v1/models/_widget_message.json.jbuilder
@@ -1,6 +1,7 @@
 json.id resource.id
 json.content resource.content
-json.message_type resource.message_type_before_type_cast
+# TODO: Temporary fix for message type cast issue, since message_type is returning as string instead of integer
+json.message_type resource.reload.message_type_before_type_cast
 json.content_type resource.content_type
 json.content_attributes resource.content_attributes
 json.created_at resource.created_at.to_i

--- a/spec/controllers/api/v1/widget/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/conversations_controller_spec.rb
@@ -13,6 +13,21 @@ RSpec.describe '/api/v1/widget/conversations/toggle_typing', type: :request do
     Widget::TokenService.new(payload: { source_id: second_session.source_id, inbox_id: web_widget.inbox.id }).generate_token
   end
 
+  def conversation_params
+    {
+      website_token: web_widget.website_token,
+      contact: {
+        name: 'contact-name',
+        email: 'contact-email@chatwoot.com',
+        phone_number: '+919745313456'
+      },
+      message: {
+        content: 'This is a test message'
+      },
+      custom_attributes: { order_id: '12345' }
+    }
+  end
+
   describe 'GET /api/v1/widget/conversations' do
     context 'with a conversation' do
       it 'returns the correct conversation params' do
@@ -47,21 +62,10 @@ RSpec.describe '/api/v1/widget/conversations/toggle_typing', type: :request do
   end
 
   describe 'POST /api/v1/widget/conversations' do
-    it 'creates a conversation' do
+    it 'creates a conversation with correct details' do
       post '/api/v1/widget/conversations',
            headers: { 'X-Auth-Token' => token },
-           params: {
-             website_token: web_widget.website_token,
-             contact: {
-               name: 'contact-name',
-               email: 'contact-email@chatwoot.com',
-               phone_number: '+919745313456'
-             },
-             message: {
-               content: 'This is a test message'
-             },
-             custom_attributes: { order_id: '12345' }
-           },
+           params: conversation_params,
            as: :json
 
       expect(response).to have_http_status(:success)
@@ -70,8 +74,19 @@ RSpec.describe '/api/v1/widget/conversations/toggle_typing', type: :request do
       expect(json_response['contact']['email']).to eq 'contact-email@chatwoot.com'
       expect(json_response['contact']['phone_number']).to eq '+919745313456'
       expect(json_response['contact']['name']).to eq 'contact-name'
+    end
+
+    it 'creates a conversation with correct message and custom attributes' do
+      post '/api/v1/widget/conversations',
+           headers: { 'X-Auth-Token' => token },
+           params: conversation_params,
+           as: :json
+
+      expect(response).to have_http_status(:success)
+      json_response = response.parsed_body
       expect(json_response['custom_attributes']['order_id']).to eq '12345'
       expect(json_response['messages'][0]['content']).to eq 'This is a test message'
+      expect(json_response['messages'][0]['message_type']).to eq 0
     end
 
     it 'create a conversation with a name and without an email' do


### PR DESCRIPTION
The `before_type_cast` method sometimes returns a string for `message_type`, creating inconsistencies in conversation create API response.