### PR TITLE
feat: Add ActionMailbox config for Postal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,7 @@ MAILER_INBOUND_EMAIL_DOMAIN=
 # mandrill for Mandrill
 # postmark for Postmark
 # sendgrid for Sendgrid
+# postal for Postal
 RAILS_INBOUND_EMAIL_SERVICE=
 # Use one of the following based on the email ingress service
 # Ref: https://edgeguides.rubyonrails.org/action_mailbox_basics.html

--- a/app/controllers/action_mailbox/ingresses/postal/inbound_emails_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/postal/inbound_emails_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ActionMailbox::Ingresses::Postal::InboundEmailsController < ActionMailbox::BaseController
+  before_action :authenticate_by_password
+
+  def create
+    ActionMailbox::InboundEmails.create_and_extract_message_id! Base64.decode64(params.require('message'))
+  rescue ActionController::ParameterMissing => e
+    logger.error <<~MESSAGE
+      #{e.message}
+    MESSAGE
+    head :unprocessable_entity
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,6 +100,7 @@ Rails.application.configure do
   # :mandrill for Mandrill
   # :postmark for Postmark
   # :sendgrid for Sendgrid
+  # :postal for Postal
   config.action_mailbox.ingress = ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay').to_sym
 
   Rails.application.routes.default_url_options = { host: ENV['FRONTEND_URL'] }


### PR DESCRIPTION
# Pull Request Template

## Description

Added base ActionMailbox configuration for Postal as per [this article](https://lcx.wien/blog/rails-actionmailbox-with-postal/)
This allows users to self-host their own Postal server for handling email.

Fixes #1959

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Using the section "Configuring Postal" and the lines above for how to setup Chatwoot (in development mode) and Ngrok to test the feature.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
(n/a but can be determined by the reviewer)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules