### PR TITLE
fix: bug with loading images from external S3 in chat

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/bubble/ImageAudioVideo.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/ImageAudioVideo.vue
@@ -25,6 +25,9 @@ export default {
     return {
       show: false,
       isImageError: false,
+      retryCount: 0,
+      maxRetries: 5,
+      retryDelay: 500,
     };
   },
   computed: {
@@ -84,9 +87,17 @@ export default {
       }
       this.show = true;
     },
-    onImgError() {
-      this.isImageError = true;
-      this.$emit('error');
+    onImgError(e) {
+      if (this.retryCount < this.maxRetries) {
+        setTimeout(() => {
+          e.target.src = this.attachment.data_url;
+          this.retryCount++;
+        }, this.retryDelay);
+      } else {
+        console.error(`Failed to load image after ${this.maxRetries} attempts.`);
+        this.isImageError = true;
+        this.$emit('error');
+      }
     },
   },
 };


### PR DESCRIPTION
PR fixes this #7453 issue (https://github.com/chatwoot/chatwoot/issues/7453#issuecomment-2373687646)
I added five retries after getting an image loading error. Only when five tries failed it emit an error.