### PR TITLE
fix: Twilio channel attachment issues

### DIFF
--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -8,7 +8,7 @@ class Twilio::IncomingMessageService
 
     set_contact
     set_conversation
-    @message = @conversation.messages.create!(
+    @message = @conversation.messages.build(
       content: message_body,
       account_id: @inbox.account_id,
       inbox_id: @inbox.id,
@@ -17,6 +17,7 @@ class Twilio::IncomingMessageService
       source_id: params[:SmsSid]
     )
     attach_files
+    @message.save!
   end
 
   private
@@ -111,18 +112,15 @@ class Twilio::IncomingMessageService
 
     return if attachment_file.blank?
 
-    attachment = @message.attachments.new(
+    @message.attachments.new(
       account_id: @message.account_id,
-      file_type: file_type(params[:MediaContentType0])
+      file_type: file_type(params[:MediaContentType0]),
+      file: {
+        io: attachment_file,
+        filename: attachment_file.original_filename,
+        content_type: attachment_file.content_type
+      }
     )
-
-    attachment.file.attach(
-      io: attachment_file,
-      filename: attachment_file.original_filename,
-      content_type: attachment_file.content_type
-    )
-
-    @message.save!
   end
 
   def download_attachment_file


### PR DESCRIPTION
We received customer reports that attachments in Twilio messages required page reloads to appear. This issue occurred because in the old Twilio builder, we saved the message and attachment in two stages. The new builders follow a streamlined approach, where both are saved in a single transaction. This update aligns the Twilio channel with the new builder format and resolves the issue.

### Testing:

Tests cover the attachment cases, ensuring that all original tests pass with these changes.