### PR TITLE
fix: Lograge issue on non api pages

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -5,8 +5,9 @@ if ActiveModel::Type::Boolean.new.cast(ENV.fetch('LOGRAGE_ENABLED', false)).pres
     config.lograge.enabled = true
     config.lograge.formatter = Lograge::Formatters::Json.new
     config.lograge.custom_payload do |controller|
-      # Fixes https://github.com/chatwoot/chatwoot/issues/6922
-      user_id = controller.try(:current_user).try(:id) unless controller.is_a?(SuperAdmin::Devise::SessionsController)
+      # We only need user_id for API requests
+      # might error out for other controller - ref: https://github.com/chatwoot/chatwoot/issues/6922
+      user_id = controller&.try(:current_user)&.id if controller.is_a?(Api::BaseController) && controller&.try(:current_user).is_a?(User)
       {
         host: controller.request.host,
         remote_ip: controller.request.remote_ip,

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,6 +9,8 @@ end
 Sidekiq.configure_server do |config|
   config.logger.formatter = Sidekiq::Logger::Formatters::JSON.new
   config.redis = Redis::Config.app
+  # skip the default start stop logging
+  config[:skip_default_job_logging] = true
   config.logger.level = Logger.const_get(ENV.fetch('LOG_LEVEL', 'info').upcase.to_s)
 end
 


### PR DESCRIPTION
This PR addresses several issues related to logging:

- Enabling Lograge broke certain non-API URLs, such as password reset. This occurred due to the user ID tagging we had in Lograge, which has now been limited to API pages only.
- Disabled the start and done logs in Sidekiq.
- Investigated why Sidekiq logs weren’t being output as JSON. This is due to the use of ActiveJob instead of Sidekiq for the job base classes.

**Potential Options for Converting ActiveJob Logs to JSON:**
- https://glozer.rocks/ojb
- https://learnedreverie.medium.com/activejob-logs-as-json-6912403d8c81
- https://github.com/roidrage/lograge/pull/226
