### PR TITLE
chore: Move line attachment creation to a single db commit

### DIFF
--- a/app/services/line/incoming_message_service.rb
+++ b/app/services/line/incoming_message_service.rb
@@ -25,13 +25,14 @@ class Line::IncomingMessageService
       next unless message_created? event
 
       attach_files event['message']
+      @message.save!
     end
   end
 
   def message_created?(event)
     return unless event_type_message?(event)
 
-    @message = @conversation.messages.create!(
+    @message = @conversation.messages.build(
       content: message_content(event),
       account_id: @inbox.account_id,
       content_type: message_content_type(event),
@@ -90,7 +91,6 @@ class Line::IncomingMessageService
         content_type: response.content_type
       }
     )
-    @message.save!
   end
 
   def event_type_message?(event)


### PR DESCRIPTION
Similar to the work we did with the legacy code of other channels like Twilio, we need to move the message creation and attachment creation to be under a single db commit for the line channel. Otherwise, the emitted webhook events for message creation will miss the attachment payload. 


ref: https://github.com/orgs/chatwoot/discussions/7546#discussioncomment-10814495
ref: https://github.com/chatwoot/chatwoot/pull/10167
