### PR TITLE
fix: initOnEvents not removed [CW-3594]

### DIFF
--- a/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js
@@ -22,6 +22,21 @@ class DashboardAudioNotificationHelper {
     this.currentUser = null;
     this.currentUserId = null;
     this.audioAlertTone = 'ding';
+
+    this.onAudioListenEvent = async () => {
+      try {
+        await getAlertAudio('', {
+          type: 'dashboard',
+          alertTone: this.audioAlertTone,
+        });
+        initOnEvents.forEach(event => {
+          document.removeEventListener(event, this.onAudioListenEvent, false);
+        });
+        this.playAudioEvery30Seconds();
+      } catch (error) {
+        // Ignore audio fetch errors
+      }
+    };
   }
 
   setInstanceValues({
@@ -44,21 +59,6 @@ class DashboardAudioNotificationHelper {
     });
     initFaviconSwitcher();
   }
-
-  onAudioListenEvent = async () => {
-    try {
-      await getAlertAudio('', {
-        type: 'dashboard',
-        alertTone: this.audioAlertTone,
-      });
-      initOnEvents.forEach(event => {
-        document.removeEventListener(event, this.onAudioListenEvent, false);
-      });
-      this.playAudioEvery30Seconds();
-    } catch (error) {
-      // Ignore audio fetch errors
-    }
-  };
 
   executeRecurringNotification() {
     if (!window.WOOT_STORE) {

--- a/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js
@@ -38,12 +38,14 @@ class DashboardAudioNotificationHelper {
     this.currentUserId = currentUser.id;
     this.audioAlertTone = audioAlertTone;
     initOnEvents.forEach(e => {
-      document.addEventListener(e, this.onAudioListenEvent, false);
+      document.addEventListener(e, this.onAudioListenEvent, {
+        once: true,
+      });
     });
     initFaviconSwitcher();
   }
 
-  async onAudioListenEvent() {
+  onAudioListenEvent = async () => {
     try {
       await getAlertAudio('', {
         type: 'dashboard',
@@ -56,7 +58,7 @@ class DashboardAudioNotificationHelper {
     } catch (error) {
       // Ignore audio fetch errors
     }
-  }
+  };
 
   executeRecurringNotification() {
     if (!window.WOOT_STORE) {


### PR DESCRIPTION
The `initOnEvents` was used to get the notification sound file and trigger the 30 second loop, but since the function was replaced to using class syntax, the removeEvent listener was not working. This PR fixes it by reverting to the old syntax but moving it inside the constructor instead and also adding a `once: true` to ensure it is always removed automatically