### PR TITLE
fix: translation payload for audit logs

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
@@ -35,13 +35,20 @@ const fetchAuditLogs = page => {
 };
 
 const generateLogText = auditLogItem => {
-  const translationPayload = generateTranslationPayload(
-    auditLogItem,
-    agentList.value
-  );
+  const payload = generateTranslationPayload(auditLogItem, agentList.value);
   const translationKey = generateLogActionKey(auditLogItem);
+  // payload.attributes and payload.values can be an array, if it is so, join them
 
-  return t(translationKey, translationPayload);
+  const joinIfArray = value => {
+    return Array.isArray(value) ? value.join(', ') : value;
+  };
+
+  const mergedPayload = {
+    ...payload,
+    attributes: joinIfArray(payload.attributes),
+    values: joinIfArray(payload.values),
+  };
+  return t(translationKey, mergedPayload);
 };
 
 const onPageChange = page => {

--- a/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
@@ -37,7 +37,6 @@ const fetchAuditLogs = page => {
 const generateLogText = auditLogItem => {
   const payload = generateTranslationPayload(auditLogItem, agentList.value);
   const translationKey = generateLogActionKey(auditLogItem);
-  // payload.attributes and payload.values can be an array, if it is so, join them
 
   const joinIfArray = value => {
     return Array.isArray(value) ? value.join(', ') : value;


### PR DESCRIPTION
Vue i18n would automatically merge arrays previously, it does not do so now. This PR fixes it by cleaning up the payload before passing it for translation

![CleanShot 2024-10-03 at 20 52 54@2x](https://github.com/user-attachments/assets/6c0880b9-2428-40f7-bbae-489d53cf75b6)
