### PR TITLE
fix: add missing 'one' translations for time units in agent-reports

### DIFF
--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -262,10 +262,14 @@ id:
     button: Buka percakapan
   time_units:
     days:
+      one: "%{count} day"
       other: "%{count} days"
     hours:
+      one: "%{count} hour"
       other: "%{count} hours"
     minutes:
+      one: "%{count} minute"
       other: "%{count} minutes"
     seconds:
+      one: "%{count} second"
       other: "%{count} seconds"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -262,10 +262,14 @@ ja:
     button: Open conversation
   time_units:
     days:
+      one: "%{count} day"
       other: "%{count} days"
     hours:
+      one: "%{count} hour"
       other: "%{count} hours"
     minutes:
+      one: "%{count} minute"
       other: "%{count} minutes"
     seconds:
+      one: "%{count} second"
       other: "%{count} seconds"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -262,10 +262,14 @@ ko:
     button: Open conversation
   time_units:
     days:
+      one: "%{count} day"
       other: "%{count} days"
     hours:
+      one: "%{count} hour"
       other: "%{count} hours"
     minutes:
+      one: "%{count} minute"
       other: "%{count} minutes"
     seconds:
+      one: "%{count} second"
       other: "%{count} seconds"

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -262,10 +262,14 @@ ms:
     button: Open conversation
   time_units:
     days:
+      one: "%{count} day"
       other: "%{count} days"
     hours:
+      one: "%{count} hour"
       other: "%{count} hours"
     minutes:
+      one: "%{count} minute"
       other: "%{count} minutes"
     seconds:
+      one: "%{count} second"
       other: "%{count} seconds"

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -262,10 +262,14 @@ th:
     button: เปิดดูการสนทนา
   time_units:
     days:
+      one: "%{count} day"
       other: "%{count} days"
     hours:
+      one: "%{count} hour"
       other: "%{count} hours"
     minutes:
+      one: "%{count} minute"
       other: "%{count} minutes"
     seconds:
+      one: "%{count} second"
       other: "%{count} seconds"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -262,10 +262,14 @@ vi:
     button: Mở cuộc trò chuyện
   time_units:
     days:
+      one: "%{count} day"
       other: "%{count} days"
     hours:
+      one: "%{count} hour"
       other: "%{count} hours"
     minutes:
+      one: "%{count} minute"
       other: "%{count} minutes"
     seconds:
+      one: "%{count} second"
       other: "%{count} seconds"

--- a/config/locales/zh_CN.yml
+++ b/config/locales/zh_CN.yml
@@ -262,10 +262,14 @@ zh_CN:
     button: 重新打开会话
   time_units:
     days:
+      one: "%{count} day"
       other: "%{count} days"
     hours:
+      one: "%{count} hour"
       other: "%{count} hours"
     minutes:
+      one: "%{count} minute"
       other: "%{count} minutes"
     seconds:
+      one: "%{count} second"
       other: "%{count} seconds"

--- a/config/locales/zh_TW.yml
+++ b/config/locales/zh_TW.yml
@@ -262,10 +262,14 @@ zh_TW:
     button: 開啟對話
   time_units:
     days:
+      one: "%{count} day"
       other: "%{count} days"
     hours:
+      one: "%{count} hour"
       other: "%{count} hours"
     minutes:
+      one: "%{count} minute"
       other: "%{count} minutes"
     seconds:
+      one: "%{count} second"
       other: "%{count} seconds"


### PR DESCRIPTION
# Pull Request Template

## Description

- add missing 'one' translations for time units in agent reports 

Fixes https://github.com/chatwoot/chatwoot/issues/10220

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
