### PR TITLE
fix: Add webhook string to the zh_CN to fix missing webhook feature

### DIFF
--- a/config/locales/zh_CN.yml
+++ b/config/locales/zh_CN.yml
@@ -199,7 +199,7 @@ zh_CN:
       name: "Slack"
       description: "Integrate Chatwoot with Slack to keep your team in sync. This integration allows you to receive notifications for new conversations and respond to them directly within Slack's interface."
     webhooks:
-      name: ""
+      name: "Webhooks"
       description: "Webhook events provide real-time updates about activities in your Chatwoot account. You can subscribe to your preferred events, and Chatwoot will send you HTTP callbacks with the updates."
     dialogflow:
       name: "Dialogflow"


### PR DESCRIPTION
The integrations are displayed based on whether the integration object is available on the API. Since there are chances where empty objects can be returned, the check for the presence was done based on the "integration.name". The name was empty (this should be investigated) in the zh_CN locale, which led to the feature being disabled for a user.

In this PR, I just added the string which should enable the feature. In the followups, I will add a better check for the presence of the integration object.