### PR TITLE
feat: Use CJS build for SDK

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
     lib: isLibraryMode
       ? {
           entry: path.resolve(__dirname, './app/javascript/entrypoints/sdk.js'),
-          formats: ['umd'], // UMD format for single file
+          formats: ['cjs'], // UMD format for single file
           name: 'sdk',
         }
       : undefined,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
     lib: isLibraryMode
       ? {
           entry: path.resolve(__dirname, './app/javascript/entrypoints/sdk.js'),
-          formats: ['cjs'], // UMD format for single file
+          formats: ['cjs'], // CJS format for single file
           name: 'sdk',
         }
       : undefined,


### PR DESCRIPTION
The UMD build was causing issues for a few customers, this PR reverts to using CJS like used in Webpack 4 before the vite migration