### PR TITLE
feat: use of imap login as default if present

### DIFF
--- a/app/controllers/google/callbacks_controller.rb
+++ b/app/controllers/google/callbacks_controller.rb
@@ -1,6 +1,15 @@
 class Google::CallbacksController < OauthCallbackController
   include GoogleConcern
 
+  def find_channel_by_email
+    # find by imap_login first, and then by email
+    # this ensures the legacy users can migrate correctly even if main email address doesn't
+    imap_channel = Channel::Email.find_by(imap_login: users_data['email'], account: account)
+    return imap_channel if imap_channel
+
+    Channel::Email.find_by(email: users_data['email'], account: account)
+  end
+
   private
 
   def provider_name

--- a/app/controllers/google/callbacks_controller.rb
+++ b/app/controllers/google/callbacks_controller.rb
@@ -3,7 +3,7 @@ class Google::CallbacksController < OauthCallbackController
 
   def find_channel_by_email
     # find by imap_login first, and then by email
-    # this ensures the legacy users can migrate correctly even if main email address doesn't
+    # this ensures the legacy users can migrate correctly even if inbox email address doesn't match
     imap_channel = Channel::Email.find_by(imap_login: users_data['email'], account: account)
     return imap_channel if imap_channel
 

--- a/app/controllers/oauth_callback_controller.rb
+++ b/app/controllers/oauth_callback_controller.rb
@@ -25,7 +25,7 @@ class OauthCallbackController < ApplicationController
   end
 
   def find_or_create_inbox
-    channel_email = Channel::Email.find_by(email: users_data['email'], account: account)
+    channel_email = find_channel_by_email
     # we need this value to know where to redirect on sucessful processing of the callback
     channel_exists = channel_email.present?
 
@@ -37,6 +37,10 @@ class OauthCallbackController < ApplicationController
     channel_email.reauthorized!
 
     [channel_email.inbox, channel_exists]
+  end
+
+  def find_channel_by_email
+    Channel::Email.find_by(email: users_data['email'], account: account)
   end
 
   def update_channel(channel_email)

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Email.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Email.vue
@@ -47,7 +47,7 @@ const emailProviderList = computed(() => {
 
 function onClick(emailProvider) {
   if (emailProvider.isEnabled) {
-    this.provider = emailProvider.key;
+    provider.value = emailProvider.key;
   }
 }
 </script>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/google/Reauthorize.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/google/Reauthorize.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import InboxReconnectionRequired from '../../components/InboxReconnectionRequired.vue';
 import googleClient from 'dashboard/api/channel/googleClient';
 
@@ -17,11 +17,18 @@ const { t } = useI18n();
 
 const isRequestingAuthorization = ref(false);
 
+const inboxEmail = computed(() => {
+  if (props.inbox.imap_login && props.inbox.imap_enabled) {
+    return props.inbox.imap_login;
+  }
+  return props.inbox.email;
+});
+
 async function requestAuthorization() {
   try {
     isRequestingAuthorization.value = true;
     const response = await googleClient.generateAuthorization({
-      email: props.inbox.email,
+      email: inboxEmail.value,
     });
 
     const {


### PR DESCRIPTION
When moving form using Gmail Legacy auth to using OAuth, we need the email address that will be used to connect. This is because we need to store this email address in the cache and reuse when we get the callback to find the associated inbox. 

However there are cases where the imap login might be `support@company.com` and the email used to communicate will be `contact@company.com` (Probably an alias) In that case, we need to send the correct email address to Chatwoot when re-authenticating

At the moment, we used the inbox email. This PR adds a check that defaults to to `imap_login` if that is available and imap is enabled

This PR also fixes an unrelated problem where the email inbox creation flow was not working

---

Tested it, it is working correctly

![CleanShot 2024-10-09 at 14 23 47@2x](https://github.com/user-attachments/assets/0e2cb6c8-1224-4b45-b34a-7b19611249bc)
