### PR TITLE
fix: Use native a tag for https URL in the sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,10 @@ master.key
 .env
 
 public/uploads
-public/packs*
+/packs/*
+!/packs/js/
+/packs/js/*
+!/packs/js/sdk.js
 public/assets/administrate*
 public/assets/action*.js
 public/assets/activestorage*.js

--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,7 @@ master.key
 .env
 
 public/uploads
-/packs/*
-!/packs/js/
-/packs/js/*
-!/packs/js/sdk.js
+public/packs*
 public/assets/administrate*
 public/assets/action*.js
 public/assets/activestorage*.js

--- a/app/javascript/dashboard/components/layout/sidebarComponents/Primary.vue
+++ b/app/javascript/dashboard/components/layout/sidebarComponents/Primary.vue
@@ -90,13 +90,17 @@ export default {
       />
     </div>
     <div class="flex flex-col items-center justify-end pb-6">
-      <PrimaryNavItem
+      <a
         v-if="!isACustomBrandedInstance"
-        icon="book-open-globe"
-        name="DOCS"
-        open-in-new-page
-        :to="helpDocsURL"
-      />
+        v-tooltip.right="$t(`SIDEBAR.DOCS`)"
+        :href="helpDocsURL"
+        class="text-slate-700 dark:text-slate-100 w-10 h-10 my-2 flex items-center justify-center rounded-lg hover:bg-slate-25 dark:hover:bg-slate-700 dark:hover:text-slate-100 hover:text-slate-600 relative"
+        rel="noopener noreferrer nofollow"
+        target="_blank"
+      >
+        <fluent-icon icon="book-open-globe" />
+        <span class="sr-only">{{ $t(`SIDEBAR.DOCS`) }}</span>
+      </a>
       <NotificationBell @open-notification-panel="openNotificationPanel" />
       <AgentDetails @toggle-menu="toggleOptions" />
       <OptionsMenu

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,11 @@ if (isLibraryMode) {
   plugins = [vue(vueOptions)];
 }
 
+const esbuildOptions = {
+  minifyIdentifiers: false,
+  keepNames: true,
+};
+
 export default defineConfig({
   plugins: plugins,
   build: {
@@ -107,4 +112,5 @@ export default defineConfig({
     mockReset: true,
     clearMocks: true,
   },
+  esbuild: isLibraryMode ? esbuildOptions : undefined,
 });


### PR DESCRIPTION
This PR updates the sidebar component to use a native <a> tag for the Help Center URL component. It also updates the build pipeline to use the esbuild options minifyIdentifiers and keepNames set to true.