### PR TITLE
fix: Cannot read properties of undefined (reading '$touch')

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/DashboardApps/DashboardAppModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/DashboardApps/DashboardAppModal.vue
@@ -125,7 +125,7 @@ export default {
           "
           data-testid="app-title"
           @input="v$.app.title.$touch"
-          @blur="v$.slug.$touch"
+          @blur="v$.app.title.$touch"
         />
         <woot-input
           v-model="app.content.url"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will fix this sentry issue `Cannot read properties of undefined (reading '$touch')`, which has been separated from this PR: https://github.com/chatwoot/chatwoot/pull/10262

Fixes https://chatwoot-p3.sentry.io/issues/5966555379?project=4507182691975168

**Loom video**

**Before**
https://www.loom.com/share/71cd2191135c48e792b2c6d5976f4e58?sid=7f4a811e-8930-4af9-a01d-3fe13944e0fc

**After**
https://www.loom.com/share/de1e127e532549ee90b9724a2c21de98?sid=e7f71f58-ef73-41d7-af1c-72c1dc106b21


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
