### PR TITLE
fix: cwctl upgrade in ubuntu 24.04

### DIFF
--- a/deployment/setup_20.04.sh
+++ b/deployment/setup_20.04.sh
@@ -804,9 +804,12 @@ function upgrade_node() {
 function get_pnpm() {
   # if pnpm is already installed, return
   if command -v pnpm &> /dev/null; then
+    echo "pnpm is already installed. Skipping installation."
     return
   fi
+  echo "pnpm is not installed. Installing pnpm..."
   npm install -g pnpm
+  echo "Cleaning up existing node_modules directory..."
   sudo -i -u chatwoot << "EOF"
   cd chatwoot
   rm -rf node_modules
@@ -992,7 +995,7 @@ function cwctl_upgrade_check() {
     # Check if packaging library is installed, and install it if not
     if ! python3 -c "import packaging.version" &> /dev/null; then
         echo "Installing packaging library..."
-        python3 -m pip install packaging
+        install_packaging
     fi
 
     needs_update=$(python3 -c "from packaging import version; v1 = version.parse('$CWCTL_VERSION'); v2 = version.parse('$remote_version'); print(1 if v2 > v1 else 0)")
@@ -1008,6 +1011,27 @@ function cwctl_upgrade_check() {
     fi
 
 }
+
+##############################################################################
+# Check for PEP 668 restrictions and install packaging accordingly
+# Globals:
+#   None
+# Arguments:
+#   None
+# Outputs:
+#   None
+##############################################################################
+function install_packaging() {
+  ubuntu_version=$(lsb_release -r | awk '{print $2}')
+  if [[ "$ubuntu_version" == "24.04" ]]; then
+    echo "Detected Ubuntu 24.04. Installing packaging library using apt."
+    apt install -y python3-packaging
+  else
+    echo "Installing packaging library using pip."
+    python3 -m pip install packaging
+  fi
+}
+
 
 
 ##############################################################################

--- a/deployment/setup_20.04.sh
+++ b/deployment/setup_20.04.sh
@@ -850,7 +850,7 @@ function upgrade() {
 
   # Update dependencies
   bundle
-  pnpm -i
+  pnpm i
 
   # Recompile the assets
   rake assets:precompile RAILS_ENV=production NODE_OPTIONS="--max-old-space-size=4096 --openssl-legacy-provider"


### PR DESCRIPTION
# Pull Request Template

## Description
- fix pip install during cwctl upgrade in `ubuntu 24.04`
- add logs during pnpm installation
- fix `pnpm` installation during upgrade

Ref
> PEP 668 specification in Ubuntu 24.04, which marks the Python environment as "externally managed." This means it restricts using pip for system-wide package installations to avoid conflicts with system-managed packages.



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested on Ubuntu 20.04, 22.04, 24.04

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
