### PR TITLE
fix: parsing of `@` in i18n values

### DIFF
--- a/app/javascript/dashboard/i18n/locale/ar/login.json
+++ b/app/javascript/dashboard/i18n/locale/ar/login.json
@@ -3,7 +3,7 @@
     "TITLE": "تسجيل الدخول إلى Chatwoot",
     "EMAIL": {
       "LABEL": "البريد الإلكتروني",
-      "PLACEHOLDER": "مثلاً: someone@example.com",
+      "PLACEHOLDER": "مثلاً: someone{'@'}example.com",
       "ERROR": "الرجاء إدخال عنوان بريد إلكتروني صحيح"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/bg/login.json
+++ b/app/javascript/dashboard/i18n/locale/bg/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Login to Chatwoot",
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "Email eg: someone@example.com",
+      "PLACEHOLDER": "Email eg: someone{'@'}example.com",
       "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/ca/login.json
+++ b/app/javascript/dashboard/i18n/locale/ca/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Entra a Chatwoot",
     "EMAIL": {
       "LABEL": "Correu electrònic",
-      "PLACEHOLDER": "exemple@nomdelacompanyia.com",
+      "PLACEHOLDER": "exemple{'@'}nomdelacompanyia.com",
       "ERROR": "Introduïu una adreça de correu electrònic vàlida"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/cs/login.json
+++ b/app/javascript/dashboard/i18n/locale/cs/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Přihlásit se do Chatwoot",
     "EMAIL": {
       "LABEL": "E-mailová adresa",
-      "PLACEHOLDER": "E-mail např: někdo@example.com",
+      "PLACEHOLDER": "E-mail např: někdo{'@'}example.com",
       "ERROR": "Zadejte prosím platnou e-mailovou adresu"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/cs/signup.json
+++ b/app/javascript/dashboard/i18n/locale/cs/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Pracovní e-mail",
-      "PLACEHOLDER": "Zadejte svou pracovní e-mailovou adresu. např.: jan@novak.spolecnost",
+      "PLACEHOLDER": "Zadejte svou pracovní e-mailovou adresu. např.: jan{'@'}novak.spolecnost",
       "ERROR": "Please enter a valid work email address"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/da/login.json
+++ b/app/javascript/dashboard/i18n/locale/da/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Log ind på Chatwoot",
     "EMAIL": {
       "LABEL": "E-mail",
-      "PLACEHOLDER": "E-mail, fx: navn@eksempel.dk",
+      "PLACEHOLDER": "E-mail, fx: navn{'@'}eksempel.dk",
       "ERROR": "Indtast venligst en gyldig e-mailadresse"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/de/login.json
+++ b/app/javascript/dashboard/i18n/locale/de/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Melden Sie sich bei Chatwoot an",
     "EMAIL": {
       "LABEL": "E-Mail",
-      "PLACEHOLDER": "E-Mail zB: jemand@example.com",
+      "PLACEHOLDER": "E-Mail zB: jemand{'@'}example.com",
       "ERROR": "Bitte geben Sie eine gültige E-Mail-Adresse ein"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/el/login.json
+++ b/app/javascript/dashboard/i18n/locale/el/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Είσοδος στο Chatwoot",
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "Email π.χ.: someone@example.com",
+      "PLACEHOLDER": "Email π.χ.: someone{'@'}example.com",
       "ERROR": "Παρακαλώ εισάγετε μια έγκυρη διεύθυνση email"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/el/signup.json
+++ b/app/javascript/dashboard/i18n/locale/el/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "email εργασίας",
-      "PLACEHOLDER": "συμπληρώστε το email εργασίας πχ: papadopoulos@wyane.com",
+      "PLACEHOLDER": "συμπληρώστε το email εργασίας πχ: papadopoulos{'@'}wyane.com",
       "ERROR": "Παρακαλώ εισάγετε μια έγκυρη διεύθυνση email"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/es/login.json
+++ b/app/javascript/dashboard/i18n/locale/es/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Iniciar sesión en Chatwoot",
     "EMAIL": {
       "LABEL": "E-mail",
-      "PLACEHOLDER": "Email por ejemplo: alguien@ejemplo.com",
+      "PLACEHOLDER": "Email por ejemplo: alguien{'@'}ejemplo.com",
       "ERROR": "Por favor, introduzca una dirección de correo válida"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/es/signup.json
+++ b/app/javascript/dashboard/i18n/locale/es/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "E-mail",
-      "PLACEHOLDER": "bruce@wayne.empresas",
+      "PLACEHOLDER": "bruce{'@'}wayne.empresas",
       "ERROR": "Por favor, introduzca una dirección de correo válida"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/fa/login.json
+++ b/app/javascript/dashboard/i18n/locale/fa/login.json
@@ -3,7 +3,7 @@
     "TITLE": "ورود به چت ووت",
     "EMAIL": {
       "LABEL": "ایمیل",
-      "PLACEHOLDER": "ایمیل به عنوان مثال: someone@example.com",
+      "PLACEHOLDER": "ایمیل به عنوان مثال: someone{'@'}example.com",
       "ERROR": "لطفا ایمیل خود را به شکل صحیح وارد کنید"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/fa/signup.json
+++ b/app/javascript/dashboard/i18n/locale/fa/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "ایمیل کاری",
-      "PLACEHOLDER": "ایمیل کاری خود را وارد کنید به عنوان مثال: jafari@wayne.enterprises",
+      "PLACEHOLDER": "ایمیل کاری خود را وارد کنید به عنوان مثال: jafari{'@'}wayne.enterprises",
       "ERROR": "لطفا یک آدرس ایمیل کاری معتبر وارد کنید"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/fi/login.json
+++ b/app/javascript/dashboard/i18n/locale/fi/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Kirjaudu sisään Chatwootiin",
     "EMAIL": {
       "LABEL": "Sähköposti",
-      "PLACEHOLDER": "Sähköposti, esim: someone@example.fi",
+      "PLACEHOLDER": "Sähköposti, esim: someone{'@'}example.fi",
       "ERROR": "Ole hyvä ja syötä validi sähköposti"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/fi/signup.json
+++ b/app/javascript/dashboard/i18n/locale/fi/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Työsähköposti",
-      "PLACEHOLDER": "Anna työsähköpostiosoiteeesi, esim: ismo@hassisenkone.fi",
+      "PLACEHOLDER": "Anna työsähköpostiosoiteeesi, esim: ismo{'@'}hassisenkone.fi",
       "ERROR": "Syötä voimassa oleva työsähköpostiosoite."
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/fr/login.json
+++ b/app/javascript/dashboard/i18n/locale/fr/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Se connecter à Chatwoot",
     "EMAIL": {
       "LABEL": "Courriel",
-      "PLACEHOLDER": "exemple@nomentreprise.fr",
+      "PLACEHOLDER": "exemple{'@'}nomentreprise.fr",
       "ERROR": "Veuillez saisir une adresse de courriel valide"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/he/login.json
+++ b/app/javascript/dashboard/i18n/locale/he/login.json
@@ -3,7 +3,7 @@
     "TITLE": "התחבר ל Woot",
     "EMAIL": {
       "LABEL": "אימייל",
-      "PLACEHOLDER": "מייל לדוגמא: someone@example.com",
+      "PLACEHOLDER": "מייל לדוגמא: someone{'@'}example.com",
       "ERROR": "נא הכנס כתובת דוא\"ל תקינה"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/hi/login.json
+++ b/app/javascript/dashboard/i18n/locale/hi/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Login to Chatwoot",
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "Email eg: someone@example.com",
+      "PLACEHOLDER": "Email eg: someone{'@'}example.com",
       "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/hr/login.json
+++ b/app/javascript/dashboard/i18n/locale/hr/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Login to Chatwoot",
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "Email eg: someone@example.com",
+      "PLACEHOLDER": "Email eg: someone{'@'}example.com",
       "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/hu/login.json
+++ b/app/javascript/dashboard/i18n/locale/hu/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Chatwoot belépés",
     "EMAIL": {
       "LABEL": "E-mail",
-      "PLACEHOLDER": "E-mail pl.: valaki@példa.hu",
+      "PLACEHOLDER": "E-mail pl.: valaki{'@'}példa.hu",
       "ERROR": "Kérjük helyes e-mailcímet adj meg"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/hu/signup.json
+++ b/app/javascript/dashboard/i18n/locale/hu/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Munkahelyi e-mail",
-      "PLACEHOLDER": "Add meg munkahelyi e-mailcímed. Pl. kovacs.janos@email.hu",
+      "PLACEHOLDER": "Add meg munkahelyi e-mailcímed. Pl. kovacs.janos{'@'}email.hu",
       "ERROR": "Please enter a valid work email address"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/hy/login.json
+++ b/app/javascript/dashboard/i18n/locale/hy/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Login to Chatwoot",
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "Email eg: someone@example.com",
+      "PLACEHOLDER": "Email eg: someone{'@'}example.com",
       "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/id/login.json
+++ b/app/javascript/dashboard/i18n/locale/id/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Masuk ke Chatwoot",
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "contoh@perusahan-mu.com",
+      "PLACEHOLDER": "contoh{'@'}perusahan-mu.com",
       "ERROR": "Harap masukkan alamat email yang valid"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/is/login.json
+++ b/app/javascript/dashboard/i18n/locale/is/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Login to Chatwoot",
     "EMAIL": {
       "LABEL": "Tölvupóstfang",
-      "PLACEHOLDER": "Tölvupóstfang t.d. someone@example.com",
+      "PLACEHOLDER": "Tölvupóstfang t.d. someone{'@'}example.com",
       "ERROR": "Vinsamlegast skrifaðu gilt netfang"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/it/login.json
+++ b/app/javascript/dashboard/i18n/locale/it/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Accedi a Chatwoot",
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "Email es.: qualcuno@esempio.com",
+      "PLACEHOLDER": "Email es.: qualcuno{'@'}esempio.com",
       "ERROR": "Inserisci un indirizzo email valido"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/ko/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ko/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "회사 이메일",
-      "PLACEHOLDER": "회사 이메일 주소를 입력하세요. 예: taeyeon@girls.generation",
+      "PLACEHOLDER": "회사 이메일 주소를 입력하세요. 예: taeyeon{'@'}girls.generation",
       "ERROR": "Please enter a valid work email address"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/lt/login.json
+++ b/app/javascript/dashboard/i18n/locale/lt/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Login to Chatwoot",
     "EMAIL": {
       "LABEL": "El. paštas",
-      "PLACEHOLDER": "email pavyzdys: someone@example.com",
+      "PLACEHOLDER": "email pavyzdys: someone{'@'}example.com",
       "ERROR": "Prašau įveskite teisingą el. pašto adresą"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/lv/login.json
+++ b/app/javascript/dashboard/i18n/locale/lv/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Login to Chatwoot",
     "EMAIL": {
       "LABEL": "E-pasts",
-      "PLACEHOLDER": "piemers@firmasnosaukums.com",
+      "PLACEHOLDER": "piemers{'@'}firmasnosaukums.com",
       "ERROR": "Lūdzu, ievadiet derīgu e-pasta adresi"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/nl/login.json
+++ b/app/javascript/dashboard/i18n/locale/nl/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Inloggen bij Chatwoot",
     "EMAIL": {
       "LABEL": "E-mailadres",
-      "PLACEHOLDER": "voorbeeld@bedrijfsnaam.nl",
+      "PLACEHOLDER": "voorbeeld{'@'}bedrijfsnaam.nl",
       "ERROR": "Voer een geldig e-mailadres in"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/no/signup.json
+++ b/app/javascript/dashboard/i18n/locale/no/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Bedriftse-postadresse",
-      "PLACEHOLDER": "Skriv inn din profesjonelle e-postadresse. F.eks: ola@olasbedrift.no",
+      "PLACEHOLDER": "Skriv inn din profesjonelle e-postadresse. F.eks: ola{'@'}olasbedrift.no",
       "ERROR": "Please enter a valid work email address"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/pl/login.json
+++ b/app/javascript/dashboard/i18n/locale/pl/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Zaloguj się do Chatwoot",
     "EMAIL": {
       "LABEL": "E-mail",
-      "PLACEHOLDER": "przyklad@nazwafirmy.com",
+      "PLACEHOLDER": "przyklad{'@'}nazwafirmy.com",
       "ERROR": "Wprowadź poprawny adres e-mail"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/pt/login.json
+++ b/app/javascript/dashboard/i18n/locale/pt/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Entrar no Chatwoot",
     "EMAIL": {
       "LABEL": "E-mail",
-      "PLACEHOLDER": "exemplo@nomedaempresa.pt",
+      "PLACEHOLDER": "exemplo{'@'}nomedaempresa.pt",
       "ERROR": "Por favor, insira um endereço de e-mail válido"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/pt/signup.json
+++ b/app/javascript/dashboard/i18n/locale/pt/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "E-mail de trabalho",
-      "PLACEHOLDER": "Digite o seu endereço de e-mail profissional. Por exemplo: geral@informatico.pt",
+      "PLACEHOLDER": "Digite o seu endereço de e-mail profissional. Por exemplo: geral{'@'}informatico.pt",
       "ERROR": "Please enter a valid work email address"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/pt_BR/login.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Entrar no Chatwoot",
     "EMAIL": {
       "LABEL": "e-mail",
-      "PLACEHOLDER": "exemplo@empresa.com",
+      "PLACEHOLDER": "exemplo{'@'}empresa.com",
       "ERROR": "Digite um endereço de e-mail válido"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/pt_BR/signup.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "E-mail comercial",
-      "PLACEHOLDER": "Digite seu e-mail de trabalho. Ex.: bruce@wayne.com.br",
+      "PLACEHOLDER": "Digite seu e-mail de trabalho. Ex.: bruce{'@'}wayne.com.br",
       "ERROR": "Por favor, insira um endereço de e-mail de trabalho válido."
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/ro/login.json
+++ b/app/javascript/dashboard/i18n/locale/ro/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Conectează-te la Chatwoot",
     "EMAIL": {
       "LABEL": "E-mail",
-      "PLACEHOLDER": "exemplu@companyname.com",
+      "PLACEHOLDER": "exemplu{'@'}companyname.com",
       "ERROR": "Vă rugăm să introduceți o adresă de e-mail validă"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/ru/login.json
+++ b/app/javascript/dashboard/i18n/locale/ru/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Войти в Chatwoot",
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "пример @companyname.com",
+      "PLACEHOLDER": "пример {'@'}companyname.com",
       "ERROR": "Пожалуйста, введите действительный адрес электронной почты"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/tr/login.json
+++ b/app/javascript/dashboard/i18n/locale/tr/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Chatwoot'ta oturum açın",
     "EMAIL": {
       "LABEL": "E-Posta",
-      "PLACEHOLDER": "ornek@firmadi.com",
+      "PLACEHOLDER": "ornek{'@'}firmadi.com",
       "ERROR": "Lütfen geçerli bir e-posta adresi girin"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/zh/login.json
+++ b/app/javascript/dashboard/i18n/locale/zh/login.json
@@ -3,7 +3,7 @@
     "TITLE": "登录到Chatwoot",
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "电子邮址 例如：somone@example.com"
+      "PLACEHOLDER": "电子邮址 例如：somone{'@'}example.com"
     },
     "PASSWORD": {
       "LABEL": "密码",


### PR DESCRIPTION
Vue i18n has a new [linked message syntax.](https://vue-i18n.intlify.dev/guide/essentials/syntax.html#linked-messages)
When it encounters `@` it assumes that we're trying to use a linked message. And tries to parse it as such, in any case, it breaks since the syntax is not valid and the params are not present. So it causes an error. This works on dev but on production the error is bubbled up to the top and rendering breaks.

A lot of folks use Chatwoot with default locale set in the env, this surfaced the issue for the languages for which the syntax was not updated

Fixes: https://github.com/chatwoot/chatwoot/issues/10313