### PR TITLE
feat: use addEventListener instead of onmessage

### DIFF
--- a/app/javascript/dashboard/components/widgets/DashboardApp/Frame.vue
+++ b/app/javascript/dashboard/components/widgets/DashboardApp/Frame.vue
@@ -1,5 +1,6 @@
 <script>
 import LoadingState from 'dashboard/components/widgets/LoadingState.vue';
+
 export default {
   components: {
     LoadingState,
@@ -51,19 +52,18 @@ export default {
       }
     },
   },
-
   mounted() {
-    window.onmessage = e => {
-      if (
-        typeof e.data !== 'string' ||
-        e.data !== 'chatwoot-dashboard-app:fetch-info'
-      ) {
-        return;
-      }
-      this.onIframeLoad(0);
-    };
+    window.addEventListener('message', this.triggerEvent);
+  },
+  unmounted() {
+    window.removeEventListener('message', this.triggerEvent);
   },
   methods: {
+    triggerEvent(event) {
+      if (event.data === 'chatwoot-dashboard-app:fetch-info') {
+        this.onIframeLoad(0);
+      }
+    },
     getFrameId(index) {
       return `dashboard-app--frame-${this.position}-${index}`;
     },

--- a/app/javascript/dashboard/components/widgets/DashboardApp/Frame.vue
+++ b/app/javascript/dashboard/components/widgets/DashboardApp/Frame.vue
@@ -60,6 +60,7 @@ export default {
   },
   methods: {
     triggerEvent(event) {
+      if (!this.isVisible) return;
       if (event.data === 'chatwoot-dashboard-app:fetch-info') {
         this.onIframeLoad(0);
       }


### PR DESCRIPTION

This one is a fix for an interesting issue pointed here: https://github.com/chatwoot/chatwoot/issues/10339

### What was happening 

The user had two dashboard apps configured, each of which could request data from the parent Chatwoot window by posting a message with `window.parent.postMessage('chatwoot-dashboard-app:fetch-info', '*')`

The "Dashboard Frame" component had a listener set on window using `window.onmessage`, this was added during the `mounted` event

https://github.com/chatwoot/chatwoot/blob/601a0f8a766e8a02a48a743346a4f3b44b7019c6/app/javascript/dashboard/components/widgets/DashboardApp/Frame.vue#L55-L65

The problem with this approach is the first iframe on mount attaches this event correctly, but every subsequent frame opened `onmessage` would be overridden. Now since the dashboard app frames are caches (see: https://github.com/chatwoot/chatwoot/commit/e6505fc7a42ca9f3de1735939b488a18a979adcb) if you wen't back to a particular tab that was already loaded the `mounted` would not get triggered again, that means the older `onmessage` would still be active and will receive the messages exclusively

### What is the fix

The simplest fix is to use `addEventListener`, that way every `Frame` handles it's own events. **However there is a caveat here;** If one app requests data using `fetch-info`, every frame will get the data back. I have a feeling this is not intended, to ensure this does not happen we can add a check to `triggerEvent` method

```diff
    triggerEvent(event) {
+     if (!this.isVisible) return;
      if (event.data === 'chatwoot-dashboard-app:fetch-info') {
        this.onIframeLoad(0);
      }
    },
```

