### PR TITLE
fix: Agents list in bulk action is not loading

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -90,7 +90,6 @@ const chatsOnView = ref([]);
 const foldersQuery = ref({});
 const showAddFoldersModal = ref(false);
 const showDeleteFoldersModal = ref(false);
-const selectedInboxes = ref([]);
 const isContextMenuOpen = ref(false);
 const appliedFilter = ref([]);
 const advancedFilterTypes = ref(
@@ -122,6 +121,7 @@ const getTeamFn = useMapGetter('teams/getTeam');
 useChatListKeyboardEvents(conversationListRef);
 const {
   selectedConversations,
+  selectedInboxes,
   selectConversation,
   deSelectConversation,
   selectAllConversations,


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the issue where the bulk action inbox assignable agent list was not showing.

The issue started after merging this [feat: Vite+Vue 3 PR](https://github.com/chatwoot/chatwoot/pull/10047 ).

**Cause of issue**
Previously, `selectedInboxes` was accessed from the `ChatList.vue` component. However, after moving the bulk action logic from mixin to the `useBulkActions.js` composable, we were still referencing `selectedInboxes` from the `ChatList.vue` component, even though it was being set in the composable. This caused the API failed to load the assignable agent list.

Ref:https://github.com/chatwoot/chatwoot/blob/develop/app/javascript/dashboard/composables/chatlist/useBulkActions.js#L18

**Solution**
Removed the usage of `selectedInboxes` from the `ChatList.vue` component ref and using `selectedInboxes` ref directly from the `useBulkActions.js`

Fixes https://linear.app/chatwoot/issue/CW-3696/bulk-action-agent-list-is-not-loading

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Loom video**
https://www.loom.com/share/21e3835b3db04e34b94531ec128b586b?sid=beda60f0-1c8e-457b-b617-379d4af91873


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
