### PR TITLE
fix: next sidebar issues

### DIFF
--- a/app/javascript/dashboard/components-next/sidebar/SidebarAccountSwitcher.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarAccountSwitcher.vue
@@ -99,9 +99,11 @@ const emitNewAccount = () => {
             />
           </button>
         </div>
-        <div class="px-2 mt-2 pb-2">
+        <div
+          v-if="globalConfig.createNewAccountFromDashboard"
+          class="px-2 mt-2 pb-2"
+        >
           <ButtonNext
-            v-if="globalConfig.createNewAccountFromDashboard"
             variant="secondary"
             class="w-full"
             size="sm"

--- a/app/javascript/dashboard/components-next/sidebar/SidebarAccountSwitcher.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarAccountSwitcher.vue
@@ -73,7 +73,7 @@ const emitNewAccount = () => {
           >
             <div
               :for="account.name"
-              class="text-left rtl:text-right flex gap-2"
+              class="text-left rtl:text-right flex gap-2 items-center"
             >
               <span
                 class="text-n-slate-12 max-w-36 truncate min-w-0"
@@ -81,6 +81,7 @@ const emitNewAccount = () => {
               >
                 {{ account.name }}
               </span>
+              <div class="flex-shrink-0 w-px h-3 bg-n-strong" />
               <span
                 class="text-n-slate-11 max-w-24 truncate capitalize"
                 :title="account.name"

--- a/app/javascript/dashboard/components-next/sidebar/SidebarAccountSwitcher.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarAccountSwitcher.vue
@@ -56,7 +56,7 @@ const emitNewAccount = () => {
     </button>
     <div v-if="showDropdown" v-on-clickaway="close" class="absolute top-8 z-50">
       <div
-        class="w-72 text-sm block bg-n-solid-1 border border-n-weak rounded-xl shadow-sm"
+        class="min-w-72 max-w-96 text-sm block bg-n-solid-1 border border-n-weak rounded-xl shadow-sm"
       >
         <div
           class="px-4 pt-3 pb-2 leading-4 font-medium tracking-[0.2px] text-n-slate-10 text-xs"
@@ -75,10 +75,16 @@ const emitNewAccount = () => {
               :for="account.name"
               class="text-left rtl:text-right flex gap-2"
             >
-              <span class="text-n-slate-12">
+              <span
+                class="text-n-slate-12 max-w-36 truncate min-w-0"
+                :title="account.name"
+              >
                 {{ account.name }}
               </span>
-              <span class="text-n-slate-11 capitalize">
+              <span
+                class="text-n-slate-11 max-w-24 truncate capitalize"
+                :title="account.name"
+              >
                 {{
                   account.custom_role_id
                     ? account.custom_role.name

--- a/app/javascript/dashboard/components-next/sidebar/SidebarAccountSwitcher.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarAccountSwitcher.vue
@@ -56,10 +56,10 @@ const emitNewAccount = () => {
     </button>
     <div v-if="showDropdown" v-on-clickaway="close" class="absolute top-8 z-50">
       <div
-        class="min-w-72 max-w-96 text-sm block bg-n-solid-1 border border-n-weak rounded-xl shadow-sm"
+        class="min-w-72 max-w-96 text-sm bg-n-solid-1 border border-n-weak rounded-xl shadow-sm py-4 px-2 flex flex-col gap-2"
       >
         <div
-          class="px-4 pt-3 pb-2 leading-4 font-medium tracking-[0.2px] text-n-slate-10 text-xs"
+          class="px-4 leading-4 font-medium tracking-[0.2px] text-n-slate-10 text-xs"
         >
           {{ t('SIDEBAR_ITEMS.CHANGE_ACCOUNTS') }}
         </div>
@@ -100,10 +100,7 @@ const emitNewAccount = () => {
             />
           </button>
         </div>
-        <div
-          v-if="globalConfig.createNewAccountFromDashboard"
-          class="px-2 mt-2 pb-2"
-        >
+        <div v-if="globalConfig.createNewAccountFromDashboard" class="px-2">
           <ButtonNext
             variant="secondary"
             class="w-full"

--- a/app/javascript/dashboard/components-next/sidebar/SidebarGroup.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarGroup.vue
@@ -28,11 +28,12 @@ const {
 
 const parentEl = ref(null);
 
-const locateLastChild = () => {
-  parentEl.value?.querySelectorAll('.child-item').forEach((child, index) => {
-    if (index === parentEl.value.querySelectorAll('.child-item').length - 1) {
-      child.classList.add('last-child-item');
-    }
+const locateLastChild = async () => {
+  const children = parentEl.value?.querySelectorAll('.child-item');
+  if (!children) return;
+
+  children.forEach((child, index) => {
+    child.classList.toggle('last-child-item', index === children.length - 1);
   });
 };
 
@@ -93,7 +94,7 @@ const hasActiveChild = computed(() => {
   return activeChild.value !== undefined;
 });
 
-watch(expandedItem, locateLastChild, {
+watch([expandedItem, accessibleItems], locateLastChild, {
   immediate: true,
 });
 </script>

--- a/app/javascript/dashboard/components-next/sidebar/SidebarGroup.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarGroup.vue
@@ -91,6 +91,19 @@ const hasActiveChild = computed(() => {
   return activeChild.value !== undefined;
 });
 
+const toggleTrigger = () => {
+  if (
+    hasAccessibleChildren.value &&
+    !isExpanded.value &&
+    !hasActiveChild.value
+  ) {
+    // if not already expanded, navigate to the first child
+    const firstItem = accessibleItems.value[0];
+    router.push(firstItem.to);
+  }
+  setExpandedItem(props.name);
+};
+
 watch([expandedItem, accessibleItems], locateLastChild, {
   immediate: true,
 });


### PR DESCRIPTION
This PR fixes two issues with the sidebar

1. Text does not truncate correctly on account switcher
2. `locateLastChild` would not work correctly on reloading
3. Spacing for create new account button in account switcher
4. Add separator in account switcher 

![CleanShot 2024-10-24 at 21 15 13@2x](https://github.com/user-attachments/assets/da6bd5ba-a995-4979-9e82-ea7dd54e3900)
