### PR TITLE
fix: Date formatting and language translation for other regions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,5 +36,8 @@
     "8025": {
       "label": "Mailhog UI"
     }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {}
   }
 }

--- a/app/javascript/dashboard/App.vue
+++ b/app/javascript/dashboard/App.vue
@@ -98,7 +98,7 @@ export default {
       mql.onchange = e => setColorTheme(e.matches);
     },
     setLocale(locale) {
-      this.$root.$i18n.locale = locale;
+      this.$i18n.locale = locale.replace('-', '_');
     },
     async initializeAccount() {
       await this.$store.dispatch('accounts/get');

--- a/app/javascript/dashboard/components-next/Campaigns/CampaignCard/CampaignCard.vue
+++ b/app/javascript/dashboard/components-next/Campaigns/CampaignCard/CampaignCard.vue
@@ -46,8 +46,6 @@ const props = defineProps({
 
 const emit = defineEmits(['edit', 'delete']);
 
-const locale = getCurrentInstance()?.proxy.$i18n.locale;
-
 const { t } = useI18n();
 
 const STATUS_COMPLETED = 'completed';

--- a/app/javascript/dashboard/components-next/Campaigns/CampaignCard/CampaignCard.vue
+++ b/app/javascript/dashboard/components-next/Campaigns/CampaignCard/CampaignCard.vue
@@ -46,6 +46,8 @@ const props = defineProps({
 
 const emit = defineEmits(['edit', 'delete']);
 
+const locale = getCurrentInstance()?.proxy.$i18n.locale;
+
 const { t } = useI18n();
 
 const STATUS_COMPLETED = 'completed';

--- a/app/javascript/dashboard/components-next/Campaigns/CampaignCard/SMSCampaignDetails.vue
+++ b/app/javascript/dashboard/components-next/Campaigns/CampaignCard/SMSCampaignDetails.vue
@@ -1,6 +1,6 @@
 <script setup>
 import Icon from 'dashboard/components-next/icon/Icon.vue';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 
 import { useI18n } from 'vue-i18n';
 defineProps({

--- a/app/javascript/dashboard/components-next/Campaigns/CampaignCard/SMSCampaignDetails.vue
+++ b/app/javascript/dashboard/components-next/Campaigns/CampaignCard/SMSCampaignDetails.vue
@@ -1,6 +1,6 @@
 <script setup>
 import Icon from 'dashboard/components-next/icon/Icon.vue';
-import { messageStamp } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 
 import { useI18n } from 'vue-i18n';
 defineProps({
@@ -19,6 +19,7 @@ defineProps({
 });
 
 const { t } = useI18n();
+const { localeMessageStamp } = useLocaleDateFormatter();
 </script>
 
 <template>
@@ -36,6 +37,6 @@ const { t } = useI18n();
     {{ t('CAMPAIGN.SMS.CARD.CAMPAIGN_DETAILS.ON') }}
   </span>
   <span class="flex-1 text-sm font-medium truncate text-n-slate-12">
-    {{ messageStamp(new Date(scheduledAt), true, $i18n.locale) }}
+    {{ localeMessageStamp(new Date(scheduledAt), true) }}
   </span>
 </template>

--- a/app/javascript/dashboard/components-next/Campaigns/CampaignCard/SMSCampaignDetails.vue
+++ b/app/javascript/dashboard/components-next/Campaigns/CampaignCard/SMSCampaignDetails.vue
@@ -19,7 +19,7 @@ defineProps({
 });
 
 const { t } = useI18n();
-const { localeMessageStamp } = useLocaleDateFormatter();
+const { localeDateFormat } = useLocaleDateFormatter();
 </script>
 
 <template>
@@ -37,6 +37,6 @@ const { localeMessageStamp } = useLocaleDateFormatter();
     {{ t('CAMPAIGN.SMS.CARD.CAMPAIGN_DETAILS.ON') }}
   </span>
   <span class="flex-1 text-sm font-medium truncate text-n-slate-12">
-    {{ localeMessageStamp(new Date(scheduledAt), true) }}
+    {{ localeDateFormat(new Date(scheduledAt), 'dateM_timeS') }}
   </span>
 </template>

--- a/app/javascript/dashboard/components-next/Campaigns/CampaignCard/SMSCampaignDetails.vue
+++ b/app/javascript/dashboard/components-next/Campaigns/CampaignCard/SMSCampaignDetails.vue
@@ -1,6 +1,6 @@
 <script setup>
 import Icon from 'dashboard/components-next/icon/Icon.vue';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 
 import { useI18n } from 'vue-i18n';
 defineProps({

--- a/app/javascript/dashboard/components-next/Campaigns/CampaignCard/SMSCampaignDetails.vue
+++ b/app/javascript/dashboard/components-next/Campaigns/CampaignCard/SMSCampaignDetails.vue
@@ -36,6 +36,6 @@ const { t } = useI18n();
     {{ t('CAMPAIGN.SMS.CARD.CAMPAIGN_DETAILS.ON') }}
   </span>
   <span class="flex-1 text-sm font-medium truncate text-n-slate-12">
-    {{ messageStamp(new Date(scheduledAt), 'LLL d, h:mm a') }}
+    {{ messageStamp(new Date(scheduledAt), true, $i18n.locale) }}
   </span>
 </template>

--- a/app/javascript/dashboard/components-next/HelpCenter/ArticleCard/ArticleCard.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/ArticleCard/ArticleCard.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 import { useToggle } from '@vueuse/core';
 import { useI18n } from 'vue-i18n';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 import {
   ARTICLE_MENU_ITEMS,
   ARTICLE_MENU_OPTIONS,

--- a/app/javascript/dashboard/components-next/HelpCenter/ArticleCard/ArticleCard.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/ArticleCard/ArticleCard.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 import { useToggle } from '@vueuse/core';
 import { useI18n } from 'vue-i18n';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import {
   ARTICLE_MENU_ITEMS,
   ARTICLE_MENU_OPTIONS,

--- a/app/javascript/dashboard/components-next/HelpCenter/ArticleCard/ArticleCard.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/ArticleCard/ArticleCard.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 import { useToggle } from '@vueuse/core';
 import { useI18n } from 'vue-i18n';
-import { dynamicTime } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import {
   ARTICLE_MENU_ITEMS,
   ARTICLE_MENU_OPTIONS,
@@ -48,7 +48,9 @@ const props = defineProps({
 
 const emit = defineEmits(['openArticle', 'articleAction']);
 
-const { t, locale } = useI18n();
+const { t } = useI18n();
+
+const { localeDynamicTime } = useLocaleDateFormatter();
 
 const [showActionsDropdown, toggleDropdown] = useToggle();
 
@@ -109,7 +111,7 @@ const authorThumbnailSrc = computed(() => {
 });
 
 const lastUpdatedAt = computed(() => {
-  return dynamicTime(props.updatedAt, locale.value);
+  return localeDynamicTime(props.updatedAt);
 });
 
 const handleArticleAction = ({ action, value }) => {

--- a/app/javascript/dashboard/components-next/HelpCenter/ArticleCard/ArticleCard.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/ArticleCard/ArticleCard.vue
@@ -48,7 +48,7 @@ const props = defineProps({
 
 const emit = defineEmits(['openArticle', 'articleAction']);
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 
 const [showActionsDropdown, toggleDropdown] = useToggle();
 
@@ -109,7 +109,7 @@ const authorThumbnailSrc = computed(() => {
 });
 
 const lastUpdatedAt = computed(() => {
-  return dynamicTime(props.updatedAt);
+  return dynamicTime(props.updatedAt, locale.value);
 });
 
 const handleArticleAction = ({ action, value }) => {

--- a/app/javascript/dashboard/components/ui/TimeAgo.vue
+++ b/app/javascript/dashboard/components/ui/TimeAgo.vue
@@ -3,10 +3,7 @@ const MINUTE_IN_MILLI_SECONDS = 60000;
 const HOUR_IN_MILLI_SECONDS = MINUTE_IN_MILLI_SECONDS * 60;
 const DAY_IN_MILLI_SECONDS = HOUR_IN_MILLI_SECONDS * 24;
 
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
-
-const { localeDynamicTime, localeDateFormat, localeShortTimestamp } =
-  useLocaleDateFormatter();
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 
 export default {
   name: 'TimeAgo',
@@ -24,19 +21,24 @@ export default {
       default: '',
     },
   },
+  setup() {
+    const { localeDynamicTime, localeDateFormat, localeShortTimestamp } =
+      useLocaleDateFormatter();
+    return { localeDynamicTime, localeDateFormat, localeShortTimestamp };
+  },
   data() {
     return {
-      lastActivityAtTimeAgo: localeDynamicTime(this.lastActivityTimestamp),
-      createdAtTimeAgo: localeDynamicTime(this.createdAtTimestamp),
+      lastActivityAtTimeAgo: this.localeDynamicTime(this.lastActivityTimestamp),
+      createdAtTimeAgo: this.localeDynamicTime(this.createdAtTimestamp),
       timer: null,
     };
   },
   computed: {
     lastActivityTime() {
-      return localeShortTimestamp(this.lastActivityTimestamp, false);
+      return this.localeShortTimestamp(this.lastActivityTimestamp, false);
     },
     createdAtTime() {
-      return localeShortTimestamp(this.createdAtTimestamp, false);
+      return this.localeShortTimestamp(this.createdAtTimestamp, false);
     },
     createdAt() {
       const createdTimeDiff = Date.now() - this.createdAtTimestamp * 1000;
@@ -45,7 +47,7 @@ export default {
         ? `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.CREATED.LATEST')} ${
             this.createdAtTimeAgo
           }`
-        : `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.CREATED.OLDEST')} ${localeDateFormat(
+        : `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.CREATED.OLDEST')} ${this.localeDateFormat(
             this.createdAtTimestamp
           )}`;
     },
@@ -57,7 +59,7 @@ export default {
         ? `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.LAST_ACTIVITY.ACTIVE')} ${this.lastActivityAtTimeAgo}`
         : `${this.$t(
             'CHAT_LIST.CHAT_TIME_STAMP.LAST_ACTIVITY.NOT_ACTIVE'
-          )} ${localeDateFormat(this.lastActivityTimestamp)}`;
+          )} ${this.localeDateFormat(this.lastActivityTimestamp)}`;
     },
     tooltipText() {
       return `${this.createdAt}
@@ -66,12 +68,12 @@ export default {
   },
   watch: {
     lastActivityTimestamp() {
-      this.lastActivityAtTimeAgo = localeDynamicTime(
+      this.lastActivityAtTimeAgo = this.localeDynamicTime(
         this.lastActivityTimestamp
       );
     },
     createdAtTimestamp() {
-      this.createdAtTimeAgo = localeDynamicTime(this.createdAtTimestamp);
+      this.createdAtTimeAgo = this.localeDynamicTime(this.createdAtTimestamp);
     },
   },
   mounted() {
@@ -85,10 +87,10 @@ export default {
   methods: {
     createTimer() {
       this.timer = setTimeout(() => {
-        this.lastActivityAtTimeAgo = localeDynamicTime(
+        this.lastActivityAtTimeAgo = this.localeDynamicTime(
           this.lastActivityTimestamp
         );
-        this.createdAtTimeAgo = localeDynamicTime(this.createdAtTimestamp);
+        this.createdAtTimeAgo = this.localeDynamicTime(this.createdAtTimestamp);
         this.createTimer();
       }, this.refreshTime());
     },

--- a/app/javascript/dashboard/components/ui/TimeAgo.vue
+++ b/app/javascript/dashboard/components/ui/TimeAgo.vue
@@ -63,9 +63,7 @@ export default {
         Date.now() - this.lastActivityTimestamp * 1000;
       const isNotActive = lastActivityTimeDiff > DAY_IN_MILLI_SECONDS * 30;
       return !isNotActive
-        ? `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.LAST_ACTIVITY.ACTIVE')} ${
-            this.lastActivityAtTimeAgo,
-          }`
+        ? `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.LAST_ACTIVITY.ACTIVE')} ${this.lastActivityAtTimeAgo}`
         : `${this.$t(
             'CHAT_LIST.CHAT_TIME_STAMP.LAST_ACTIVITY.NOT_ACTIVE'
           )} ${dateFormat(this.lastActivityTimestamp, this.$i18n.locale)}`;

--- a/app/javascript/dashboard/components/ui/TimeAgo.vue
+++ b/app/javascript/dashboard/components/ui/TimeAgo.vue
@@ -27,17 +27,24 @@ export default {
   },
   data() {
     return {
-      lastActivityAtTimeAgo: dynamicTime(this.lastActivityTimestamp),
-      createdAtTimeAgo: dynamicTime(this.createdAtTimestamp),
+      lastActivityAtTimeAgo: dynamicTime(
+        this.lastActivityTimestamp,
+        this.$i18n.locale
+      ),
+      createdAtTimeAgo: dynamicTime(this.createdAtTimestamp, this.$i18n.locale),
       timer: null,
     };
   },
   computed: {
     lastActivityTime() {
-      return shortTimestamp(this.lastActivityAtTimeAgo);
+      return shortTimestamp(
+        this.lastActivityTimestamp,
+        false,
+        this.$i18n.locale
+      );
     },
     createdAtTime() {
-      return shortTimestamp(this.createdAtTimeAgo);
+      return shortTimestamp(this.createdAtTimestamp, false, this.$i18n.locale);
     },
     createdAt() {
       const createdTimeDiff = Date.now() - this.createdAtTimestamp * 1000;
@@ -47,7 +54,8 @@ export default {
             this.createdAtTimeAgo
           }`
         : `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.CREATED.OLDEST')} ${dateFormat(
-            this.createdAtTimestamp
+            this.createdAtTimestamp,
+            this.$i18n.locale
           )}`;
     },
     lastActivity() {
@@ -57,7 +65,6 @@ export default {
       return !isNotActive
         ? `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.LAST_ACTIVITY.ACTIVE')} ${
             this.lastActivityAtTimeAgo,
-            this.$i18n.locale
           }`
         : `${this.$t(
             'CHAT_LIST.CHAT_TIME_STAMP.LAST_ACTIVITY.NOT_ACTIVE'
@@ -70,10 +77,16 @@ export default {
   },
   watch: {
     lastActivityTimestamp() {
-      this.lastActivityAtTimeAgo = dynamicTime(this.lastActivityTimestamp);
+      this.lastActivityAtTimeAgo = dynamicTime(
+        this.lastActivityTimestamp,
+        this.$i18n.locale
+      );
     },
     createdAtTimestamp() {
-      this.createdAtTimeAgo = dynamicTime(this.createdAtTimestamp);
+      this.createdAtTimeAgo = dynamicTime(
+        this.createdAtTimestamp,
+        this.$i18n.locale
+      );
     },
   },
   mounted() {
@@ -87,8 +100,14 @@ export default {
   methods: {
     createTimer() {
       this.timer = setTimeout(() => {
-        this.lastActivityAtTimeAgo = dynamicTime(this.lastActivityTimestamp);
-        this.createdAtTimeAgo = dynamicTime(this.createdAtTimestamp);
+        this.lastActivityAtTimeAgo = dynamicTime(
+          this.lastActivityTimestamp,
+          this.$i18n.locale
+        );
+        this.createdAtTimeAgo = dynamicTime(
+          this.createdAtTimestamp,
+          this.$i18n.locale
+        );
         this.createTimer();
       }, this.refreshTime());
     },

--- a/app/javascript/dashboard/components/ui/TimeAgo.vue
+++ b/app/javascript/dashboard/components/ui/TimeAgo.vue
@@ -3,7 +3,7 @@ const MINUTE_IN_MILLI_SECONDS = 60000;
 const HOUR_IN_MILLI_SECONDS = MINUTE_IN_MILLI_SECONDS * 60;
 const DAY_IN_MILLI_SECONDS = HOUR_IN_MILLI_SECONDS * 24;
 
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 
 export default {
   name: 'TimeAgo',

--- a/app/javascript/dashboard/components/ui/TimeAgo.vue
+++ b/app/javascript/dashboard/components/ui/TimeAgo.vue
@@ -56,11 +56,12 @@ export default {
       const isNotActive = lastActivityTimeDiff > DAY_IN_MILLI_SECONDS * 30;
       return !isNotActive
         ? `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.LAST_ACTIVITY.ACTIVE')} ${
-            this.lastActivityAtTimeAgo
+            this.lastActivityAtTimeAgo,
+            this.$i18n.locale
           }`
         : `${this.$t(
             'CHAT_LIST.CHAT_TIME_STAMP.LAST_ACTIVITY.NOT_ACTIVE'
-          )} ${dateFormat(this.lastActivityTimestamp)}`;
+          )} ${dateFormat(this.lastActivityTimestamp, this.$i18n.locale)}`;
     },
     tooltipText() {
       return `${this.createdAt}

--- a/app/javascript/dashboard/components/ui/TimeAgo.vue
+++ b/app/javascript/dashboard/components/ui/TimeAgo.vue
@@ -3,11 +3,10 @@ const MINUTE_IN_MILLI_SECONDS = 60000;
 const HOUR_IN_MILLI_SECONDS = MINUTE_IN_MILLI_SECONDS * 60;
 const DAY_IN_MILLI_SECONDS = HOUR_IN_MILLI_SECONDS * 24;
 
-import {
-  dynamicTime,
-  dateFormat,
-  shortTimestamp,
-} from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+
+const { localeDynamicTime, localeDateFormat, localeShortTimestamp } =
+  useLocaleDateFormatter();
 
 export default {
   name: 'TimeAgo',
@@ -27,24 +26,17 @@ export default {
   },
   data() {
     return {
-      lastActivityAtTimeAgo: dynamicTime(
-        this.lastActivityTimestamp,
-        this.$i18n.locale
-      ),
-      createdAtTimeAgo: dynamicTime(this.createdAtTimestamp, this.$i18n.locale),
+      lastActivityAtTimeAgo: localeDynamicTime(this.lastActivityTimestamp),
+      createdAtTimeAgo: localeDynamicTime(this.createdAtTimestamp),
       timer: null,
     };
   },
   computed: {
     lastActivityTime() {
-      return shortTimestamp(
-        this.lastActivityTimestamp,
-        false,
-        this.$i18n.locale
-      );
+      return localeShortTimestamp(this.lastActivityTimestamp, false);
     },
     createdAtTime() {
-      return shortTimestamp(this.createdAtTimestamp, false, this.$i18n.locale);
+      return localeShortTimestamp(this.createdAtTimestamp, false);
     },
     createdAt() {
       const createdTimeDiff = Date.now() - this.createdAtTimestamp * 1000;
@@ -53,9 +45,8 @@ export default {
         ? `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.CREATED.LATEST')} ${
             this.createdAtTimeAgo
           }`
-        : `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.CREATED.OLDEST')} ${dateFormat(
-            this.createdAtTimestamp,
-            this.$i18n.locale
+        : `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.CREATED.OLDEST')} ${localeDateFormat(
+            this.createdAtTimestamp
           )}`;
     },
     lastActivity() {
@@ -66,7 +57,7 @@ export default {
         ? `${this.$t('CHAT_LIST.CHAT_TIME_STAMP.LAST_ACTIVITY.ACTIVE')} ${this.lastActivityAtTimeAgo}`
         : `${this.$t(
             'CHAT_LIST.CHAT_TIME_STAMP.LAST_ACTIVITY.NOT_ACTIVE'
-          )} ${dateFormat(this.lastActivityTimestamp, this.$i18n.locale)}`;
+          )} ${localeDateFormat(this.lastActivityTimestamp)}`;
     },
     tooltipText() {
       return `${this.createdAt}
@@ -75,16 +66,12 @@ export default {
   },
   watch: {
     lastActivityTimestamp() {
-      this.lastActivityAtTimeAgo = dynamicTime(
-        this.lastActivityTimestamp,
-        this.$i18n.locale
+      this.lastActivityAtTimeAgo = localeDynamicTime(
+        this.lastActivityTimestamp
       );
     },
     createdAtTimestamp() {
-      this.createdAtTimeAgo = dynamicTime(
-        this.createdAtTimestamp,
-        this.$i18n.locale
-      );
+      this.createdAtTimeAgo = localeDynamicTime(this.createdAtTimestamp);
     },
   },
   mounted() {
@@ -98,14 +85,10 @@ export default {
   methods: {
     createTimer() {
       this.timer = setTimeout(() => {
-        this.lastActivityAtTimeAgo = dynamicTime(
-          this.lastActivityTimestamp,
-          this.$i18n.locale
+        this.lastActivityAtTimeAgo = localeDynamicTime(
+          this.lastActivityTimestamp
         );
-        this.createdAtTimeAgo = dynamicTime(
-          this.createdAtTimestamp,
-          this.$i18n.locale
-        );
+        this.createdAtTimeAgo = localeDynamicTime(this.createdAtTimestamp);
         this.createTimer();
       }, this.refreshTime());
     },

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -78,7 +78,7 @@ export default {
       return MESSAGE_STATUS.SENT === this.messageStatus;
     },
     readableTime() {
-      return messageTimestamp(this.createdAt, 'LLL d, h:mm a');
+      return messageTimestamp(this.createdAt, this.$i18n.locale);
     },
     screenName() {
       const { additional_attributes: additionalAttributes = {} } =

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -1,7 +1,9 @@
 <script>
 import { MESSAGE_TYPE, MESSAGE_STATUS } from 'shared/constants/messages';
 import inboxMixin from 'shared/mixins/inboxMixin';
-import { messageTimestamp } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+
+const { localeMessageTimestamp } = useLocaleDateFormatter();
 
 export default {
   mixins: [inboxMixin],
@@ -78,7 +80,7 @@ export default {
       return MESSAGE_STATUS.SENT === this.messageStatus;
     },
     readableTime() {
-      return messageTimestamp(this.createdAt, this.$i18n.locale);
+      return localeMessageTimestamp(this.createdAt);
     },
     screenName() {
       const { additional_attributes: additionalAttributes = {} } =

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -1,9 +1,7 @@
 <script>
 import { MESSAGE_TYPE, MESSAGE_STATUS } from 'shared/constants/messages';
 import inboxMixin from 'shared/mixins/inboxMixin';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
-
-const { localeMessageTimestamp } = useLocaleDateFormatter();
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 
 export default {
   mixins: [inboxMixin],
@@ -57,6 +55,10 @@ export default {
       default: 0,
     },
   },
+  setup() {
+    const { localeMessageTimestamp } = useLocaleDateFormatter();
+    return { localeMessageTimestamp };
+  },
   computed: {
     inbox() {
       return this.$store.getters['inboxes/getInbox'](this.inboxId);
@@ -80,7 +82,7 @@ export default {
       return MESSAGE_STATUS.SENT === this.messageStatus;
     },
     readableTime() {
-      return localeMessageTimestamp(this.createdAt);
+      return this.localeMessageTimestamp(this.createdAt);
     },
     screenName() {
       const { additional_attributes: additionalAttributes = {} } =

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -56,8 +56,8 @@ export default {
     },
   },
   setup() {
-    const { localeMessageTimestamp } = useLocaleDateFormatter();
-    return { localeMessageTimestamp };
+    const { localeMessageDateFormat } = useLocaleDateFormatter();
+    return { localeMessageDateFormat };
   },
   computed: {
     inbox() {
@@ -82,7 +82,7 @@ export default {
       return MESSAGE_STATUS.SENT === this.messageStatus;
     },
     readableTime() {
-      return this.localeMessageTimestamp(this.createdAt);
+      return this.localeMessageDateFormat(this.createdAt);
     },
     screenName() {
       const { additional_attributes: additionalAttributes = {} } =

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -1,7 +1,7 @@
 <script>
 import { MESSAGE_TYPE, MESSAGE_STATUS } from 'shared/constants/messages';
 import inboxMixin from 'shared/mixins/inboxMixin';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 
 export default {
   mixins: [inboxMixin],

--- a/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
@@ -18,7 +18,7 @@ const props = defineProps({
 
 const emit = defineEmits(['close']);
 
-const { localeMessageTimestamp } = useLocaleDateFormatter();
+const { localeMessageDateFormat } = useLocaleDateFormatter();
 
 const show = defineModel('show', { type: Boolean, default: false });
 
@@ -53,7 +53,7 @@ const hasMoreThanOneAttachment = computed(
 const readableTime = computed(() => {
   const { created_at: createdAt } = activeAttachment.value;
   if (!createdAt) return '';
-  return localeMessageTimestamp(createdAt) || '';
+  return localeMessageDateFormat(createdAt) || '';
 });
 
 const isImage = computed(

--- a/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted } from 'vue';
 import { useStoreGetters } from 'dashboard/composables/store';
 import { useKeyboardEvents } from 'dashboard/composables/useKeyboardEvents';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
 
 const props = defineProps({

--- a/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted } from 'vue';
 import { useStoreGetters } from 'dashboard/composables/store';
 import { useKeyboardEvents } from 'dashboard/composables/useKeyboardEvents';
 import { messageTimestamp } from 'shared/helpers/timeHelper';
+import { useI18n } from 'vue-i18n';
 
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
 
@@ -48,10 +49,12 @@ const hasMoreThanOneAttachment = computed(
   () => props.allAttachments.length > 1
 );
 
+const { locale } = useI18n();
+
 const readableTime = computed(() => {
   const { created_at: createdAt } = activeAttachment.value;
   if (!createdAt) return '';
-  return messageTimestamp(createdAt, 'LLL d yyyy, h:mm a') || '';
+  return messageTimestamp(createdAt, locale.value) || '';
 });
 
 const isImage = computed(

--- a/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted } from 'vue';
 import { useStoreGetters } from 'dashboard/composables/store';
 import { useKeyboardEvents } from 'dashboard/composables/useKeyboardEvents';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
 
 const props = defineProps({

--- a/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
@@ -2,9 +2,7 @@
 import { ref, computed, onMounted } from 'vue';
 import { useStoreGetters } from 'dashboard/composables/store';
 import { useKeyboardEvents } from 'dashboard/composables/useKeyboardEvents';
-import { messageTimestamp } from 'shared/helpers/timeHelper';
-import { useI18n } from 'vue-i18n';
-
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
 
 const props = defineProps({
@@ -19,6 +17,9 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['close']);
+
+const { localeMessageTimestamp } = useLocaleDateFormatter();
+
 const show = defineModel('show', { type: Boolean, default: false });
 
 const getters = useStoreGetters();
@@ -49,12 +50,10 @@ const hasMoreThanOneAttachment = computed(
   () => props.allAttachments.length > 1
 );
 
-const { locale } = useI18n();
-
 const readableTime = computed(() => {
   const { created_at: createdAt } = activeAttachment.value;
   if (!createdAt) return '';
-  return messageTimestamp(createdAt, locale.value) || '';
+  return localeMessageTimestamp(createdAt) || '';
 });
 
 const isImage = computed(

--- a/app/javascript/dashboard/composables/useLocaleDateFormatter.js
+++ b/app/javascript/dashboard/composables/useLocaleDateFormatter.js
@@ -1,0 +1,28 @@
+import { useI18n } from 'vue-i18n';
+import {
+  messageStamp,
+  messageTimestamp,
+  dynamicTime,
+  dateFormat,
+  shortTimestamp,
+} from 'shared/helpers/timeHelper';
+
+export default function useLocaleDateFormatter() {
+  const { locale } = useI18n();
+
+  const localeDynamicTime = (...args) => dynamicTime(...args, locale.value);
+  const localeDateFormat = (...args) => dateFormat(...args, locale.value);
+  const localeShortTimestamp = (...args) =>
+    shortTimestamp(...args, locale.value);
+  const localeMessageStamp = (...args) => messageStamp(...args, locale.value);
+  const localeMessageTimestamp = (...args) =>
+    messageTimestamp(...args, locale.value);
+
+  return {
+    localeDynamicTime,
+    localeDateFormat,
+    localeShortTimestamp,
+    localeMessageStamp,
+    localeMessageTimestamp,
+  };
+}

--- a/app/javascript/dashboard/composables/useLocaleDateFormatter.js
+++ b/app/javascript/dashboard/composables/useLocaleDateFormatter.js
@@ -1,7 +1,6 @@
 import { useI18n } from 'vue-i18n';
 import {
-  messageStamp,
-  messageTimestamp,
+  messageDateFormat,
   dynamicTime,
   dateFormat,
   shortTimestamp,
@@ -14,15 +13,12 @@ export function useLocaleDateFormatter() {
   const localeDateFormat = (...args) => dateFormat(...args, locale.value);
   const localeShortTimestamp = (...args) =>
     shortTimestamp(...args, locale.value);
-  const localeMessageStamp = (...args) => messageStamp(...args, locale.value);
-  const localeMessageTimestamp = (...args) =>
-    messageTimestamp(...args, locale.value);
+  const localeMessageDateFormat = (...args) => messageDateFormat(...args, locale.value);
 
   return {
     localeDynamicTime,
     localeDateFormat,
     localeShortTimestamp,
-    localeMessageStamp,
-    localeMessageTimestamp,
+    localeMessageDateFormat,
   };
 }

--- a/app/javascript/dashboard/composables/useLocaleDateFormatter.js
+++ b/app/javascript/dashboard/composables/useLocaleDateFormatter.js
@@ -7,7 +7,7 @@ import {
   shortTimestamp,
 } from 'shared/helpers/timeHelper';
 
-export default function useLocaleDateFormatter() {
+export function useLocaleDateFormatter() {
   const { locale } = useI18n();
 
   const localeDynamicTime = (...args) => dynamicTime(...args, locale.value);

--- a/app/javascript/dashboard/composables/useLocaleDateFormatter.js
+++ b/app/javascript/dashboard/composables/useLocaleDateFormatter.js
@@ -6,14 +6,15 @@ import {
   shortTimestamp,
 } from 'shared/helpers/timeHelper';
 
-export function useLocaleDateFormatter() {
+export default function useLocaleDateFormatter() {
   const { locale } = useI18n();
 
   const localeDynamicTime = (...args) => dynamicTime(...args, locale.value);
   const localeDateFormat = (...args) => dateFormat(...args, locale.value);
   const localeShortTimestamp = (...args) =>
     shortTimestamp(...args, locale.value);
-  const localeMessageDateFormat = (...args) => messageDateFormat(...args, locale.value);
+  const localeMessageDateFormat = (...args) =>
+    messageDateFormat(...args, locale.value);
 
   return {
     localeDynamicTime,

--- a/app/javascript/dashboard/modules/notes/components/ContactNote.vue
+++ b/app/javascript/dashboard/modules/notes/components/ContactNote.vue
@@ -39,7 +39,7 @@ export default {
   },
   computed: {
     readableTime() {
-      return dynamicTime(this.createdAt);
+      return dynamicTime(this.createdAt, this.$i18n.locale);
     },
     noteAuthor() {
       return this.user || {};

--- a/app/javascript/dashboard/modules/notes/components/ContactNote.vue
+++ b/app/javascript/dashboard/modules/notes/components/ContactNote.vue
@@ -1,7 +1,7 @@
 <script>
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
 import { useMessageFormatter } from 'shared/composables/useMessageFormatter';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 
 export default {
   components: {

--- a/app/javascript/dashboard/modules/notes/components/ContactNote.vue
+++ b/app/javascript/dashboard/modules/notes/components/ContactNote.vue
@@ -1,7 +1,9 @@
 <script>
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
 import { useMessageFormatter } from 'shared/composables/useMessageFormatter';
-import { dynamicTime } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+
+const { localeDynamicTime } = useLocaleDateFormatter();
 
 export default {
   components: {
@@ -39,7 +41,7 @@ export default {
   },
   computed: {
     readableTime() {
-      return dynamicTime(this.createdAt, this.$i18n.locale);
+      return localeDynamicTime(this.createdAt);
     },
     noteAuthor() {
       return this.user || {};

--- a/app/javascript/dashboard/modules/notes/components/ContactNote.vue
+++ b/app/javascript/dashboard/modules/notes/components/ContactNote.vue
@@ -1,9 +1,7 @@
 <script>
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
 import { useMessageFormatter } from 'shared/composables/useMessageFormatter';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
-
-const { localeDynamicTime } = useLocaleDateFormatter();
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 
 export default {
   components: {
@@ -30,8 +28,10 @@ export default {
   emits: ['delete'],
   setup() {
     const { formatMessage } = useMessageFormatter();
+    const { localeDynamicTime } = useLocaleDateFormatter();
     return {
       formatMessage,
+      localeDynamicTime,
     };
   },
   data() {
@@ -41,7 +41,7 @@ export default {
   },
   computed: {
     readableTime() {
-      return localeDynamicTime(this.createdAt);
+      return this.localeDynamicTime(this.createdAt);
     },
     noteAuthor() {
       return this.user || {};

--- a/app/javascript/dashboard/modules/search/components/SearchResultConversationItem.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchResultConversationItem.vue
@@ -1,6 +1,6 @@
 <script>
 import { frontendURL } from 'dashboard/helper/URLHelper.js';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import InboxName from 'dashboard/components/widgets/InboxName.vue';
 
 export default {

--- a/app/javascript/dashboard/modules/search/components/SearchResultConversationItem.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchResultConversationItem.vue
@@ -1,7 +1,9 @@
 <script>
 import { frontendURL } from 'dashboard/helper/URLHelper.js';
-import { dynamicTime } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import InboxName from 'dashboard/components/widgets/InboxName.vue';
+
+const { localeDynamicTime } = useLocaleDateFormatter();
 
 export default {
   components: {
@@ -49,7 +51,7 @@ export default {
       );
     },
     createdAtTime() {
-      return dynamicTime(this.createdAt, this.$i18n.locale);
+      return localeDynamicTime(this.createdAt);
     },
   },
 };

--- a/app/javascript/dashboard/modules/search/components/SearchResultConversationItem.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchResultConversationItem.vue
@@ -49,7 +49,7 @@ export default {
       );
     },
     createdAtTime() {
-      return dynamicTime(this.createdAt);
+      return dynamicTime(this.createdAt, this.$i18n.locale);
     },
   },
 };

--- a/app/javascript/dashboard/modules/search/components/SearchResultConversationItem.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchResultConversationItem.vue
@@ -1,9 +1,7 @@
 <script>
 import { frontendURL } from 'dashboard/helper/URLHelper.js';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 import InboxName from 'dashboard/components/widgets/InboxName.vue';
-
-const { localeDynamicTime } = useLocaleDateFormatter();
 
 export default {
   components: {
@@ -39,6 +37,10 @@ export default {
       default: 0,
     },
   },
+  setup() {
+    const { localeDynamicTime } = useLocaleDateFormatter();
+    return { localeDynamicTime };
+  },
   computed: {
     navigateTo() {
       const params = {};
@@ -51,7 +53,7 @@ export default {
       );
     },
     createdAtTime() {
-      return localeDynamicTime(this.createdAt);
+      return this.localeDynamicTime(this.createdAt);
     },
   },
 };

--- a/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsTable.vue
@@ -5,7 +5,7 @@ import {
   createColumnHelper,
   getCoreRowModel,
 } from '@tanstack/vue-table';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import { useI18n } from 'vue-i18n';
 
 import Spinner from 'shared/components/Spinner.vue';

--- a/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsTable.vue
@@ -35,7 +35,7 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['onSortChange']);
-const { t } = useI18n();
+const { t, locale } = useI18n();
 
 const tableData = computed(() => {
   if (props.isLoading) {
@@ -51,8 +51,8 @@ const tableData = computed(() => {
     return {
       ...item,
       profiles: additional.social_profiles || {},
-      last_activity_at: lastActivityAt ? dynamicTime(lastActivityAt) : null,
-      created_at: createdAt ? dynamicTime(createdAt) : null,
+      last_activity_at: lastActivityAt ? dynamicTime(lastActivityAt, locale.value) : null,
+      created_at: createdAt ? dynamicTime(createdAt, locale.value) : null,
     };
   });
 });

--- a/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsTable.vue
@@ -51,7 +51,9 @@ const tableData = computed(() => {
     return {
       ...item,
       profiles: additional.social_profiles || {},
-      last_activity_at: lastActivityAt ? dynamicTime(lastActivityAt, locale.value) : null,
+      last_activity_at: lastActivityAt
+        ? dynamicTime(lastActivityAt, locale.value)
+        : null,
       created_at: createdAt ? dynamicTime(createdAt, locale.value) : null,
     };
   });

--- a/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsTable.vue
@@ -5,7 +5,7 @@ import {
   createColumnHelper,
   getCoreRowModel,
 } from '@tanstack/vue-table';
-import { dynamicTime } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import { useI18n } from 'vue-i18n';
 
 import Spinner from 'shared/components/Spinner.vue';
@@ -35,7 +35,8 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['onSortChange']);
-const { t, locale } = useI18n();
+const { t } = useI18n();
+const { localeDynamicTime } = useLocaleDateFormatter();
 
 const tableData = computed(() => {
   if (props.isLoading) {
@@ -52,9 +53,9 @@ const tableData = computed(() => {
       ...item,
       profiles: additional.social_profiles || {},
       last_activity_at: lastActivityAt
-        ? dynamicTime(lastActivityAt, locale.value)
+        ? localeDynamicTime(lastActivityAt)
         : null,
-      created_at: createdAt ? dynamicTime(createdAt, locale.value) : null,
+      created_at: createdAt ? localeDynamicTime(createdAt) : null,
     };
   });
 });

--- a/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/components/ContactsTable.vue
@@ -5,7 +5,7 @@ import {
   createColumnHelper,
   getCoreRowModel,
 } from '@tanstack/vue-table';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 import { useI18n } from 'vue-i18n';
 
 import Spinner from 'shared/components/Spinner.vue';

--- a/app/javascript/dashboard/routes/dashboard/contacts/components/TimelineCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/components/TimelineCard.vue
@@ -1,6 +1,9 @@
 <!-- Unused file deprecated -->
 <script>
-import { dynamicTime } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+
+const { localeDynamicTime } = useLocaleDateFormatter();
+
 export default {
   props: {
     eventType: {
@@ -24,7 +27,7 @@ export default {
 
   computed: {
     readableTime() {
-      return dynamicTime(this.timeStamp, this.$i18n.locale);
+      return localeDynamicTime(this.timeStamp);
     },
   },
 

--- a/app/javascript/dashboard/routes/dashboard/contacts/components/TimelineCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/components/TimelineCard.vue
@@ -24,7 +24,7 @@ export default {
 
   computed: {
     readableTime() {
-      return dynamicTime(this.timeStamp);
+      return dynamicTime(this.timeStamp, this.$i18n.locale);
     },
   },
 

--- a/app/javascript/dashboard/routes/dashboard/contacts/components/TimelineCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/components/TimelineCard.vue
@@ -1,8 +1,6 @@
 <!-- Unused file deprecated -->
 <script>
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
-
-const { localeDynamicTime } = useLocaleDateFormatter();
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 
 export default {
   props: {
@@ -24,10 +22,13 @@ export default {
     },
   },
   emits: ['more'],
-
+  setup() {
+    const { localeDynamicTime } = useLocaleDateFormatter();
+    return { localeDynamicTime };
+  },
   computed: {
     readableTime() {
-      return localeDynamicTime(this.timeStamp);
+      return this.localeDynamicTime(this.timeStamp);
     },
   },
 

--- a/app/javascript/dashboard/routes/dashboard/contacts/components/TimelineCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/components/TimelineCard.vue
@@ -1,6 +1,6 @@
 <!-- Unused file deprecated -->
 <script>
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 
 export default {
   props: {

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -1,7 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import { useAlert } from 'dashboard/composables';
-import { dynamicTime } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import { useAdmin } from 'dashboard/composables/useAdmin';
 import ContactInfoRow from './ContactInfoRow.vue';
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
@@ -17,6 +17,8 @@ import {
   getConversationDashboardRoute,
 } from '../../../../helper/routeHelpers';
 import { emitter } from 'shared/helpers/mitt';
+
+const { localeDynamicTime } = useLocaleDateFormatter();
 
 export default {
   components: {
@@ -99,7 +101,7 @@ export default {
     },
   },
   methods: {
-    dynamicTime,
+    localeDynamicTime,
     toggleEditModal() {
       this.showEditModal = !this.showEditModal;
     },
@@ -200,9 +202,8 @@ export default {
             <fluent-icon
               v-if="contact.created_at"
               v-tooltip.left="
-                `${$t('CONTACT_PANEL.CREATED_AT_LABEL')} ${dynamicTime(
-                  contact.created_at,
-                  $i18n.locale
+                `${$t('CONTACT_PANEL.CREATED_AT_LABEL')} ${localeDynamicTime(
+                  contact.created_at
                 )}`
               "
               icon="info"

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -1,7 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import { useAlert } from 'dashboard/composables';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 import { useAdmin } from 'dashboard/composables/useAdmin';
 import ContactInfoRow from './ContactInfoRow.vue';
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
@@ -17,8 +17,6 @@ import {
   getConversationDashboardRoute,
 } from '../../../../helper/routeHelpers';
 import { emitter } from 'shared/helpers/mitt';
-
-const { localeDynamicTime } = useLocaleDateFormatter();
 
 export default {
   components: {
@@ -50,8 +48,10 @@ export default {
   emits: ['togglePanel', 'panelClose'],
   setup() {
     const { isAdmin } = useAdmin();
+    const { localeDynamicTime } = useLocaleDateFormatter();
     return {
       isAdmin,
+      localeDynamicTime,
     };
   },
   data() {
@@ -101,7 +101,6 @@ export default {
     },
   },
   methods: {
-    localeDynamicTime,
     toggleEditModal() {
       this.showEditModal = !this.showEditModal;
     },

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -1,7 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import { useAlert } from 'dashboard/composables';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import { useAdmin } from 'dashboard/composables/useAdmin';
 import ContactInfoRow from './ContactInfoRow.vue';
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -201,7 +201,8 @@ export default {
               v-if="contact.created_at"
               v-tooltip.left="
                 `${$t('CONTACT_PANEL.CREATED_AT_LABEL')} ${dynamicTime(
-                  contact.created_at
+                  contact.created_at,
+                  $i18n.locale
                 )}`
               "
               icon="info"

--- a/app/javascript/dashboard/routes/dashboard/inbox/components/InboxCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/components/InboxCard.vue
@@ -4,7 +4,7 @@ import StatusIcon from './StatusIcon.vue';
 import InboxNameAndId from './InboxNameAndId.vue';
 import InboxContextMenu from './InboxContextMenu.vue';
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import { snoozedReopenTime } from 'dashboard/helper/snoozeHelpers';
 import { INBOX_EVENTS } from 'dashboard/helper/AnalyticsHelper/events';
 import { useTrack } from 'dashboard/composables';

--- a/app/javascript/dashboard/routes/dashboard/inbox/components/InboxCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/components/InboxCard.vue
@@ -4,7 +4,7 @@ import StatusIcon from './StatusIcon.vue';
 import InboxNameAndId from './InboxNameAndId.vue';
 import InboxContextMenu from './InboxContextMenu.vue';
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
-import { dynamicTime, shortTimestamp } from 'shared/helpers/timeHelper';
+import { shortTimestamp } from 'shared/helpers/timeHelper';
 import { snoozedReopenTime } from 'dashboard/helper/snoozeHelpers';
 import { INBOX_EVENTS } from 'dashboard/helper/AnalyticsHelper/events';
 import { useTrack } from 'dashboard/composables';

--- a/app/javascript/dashboard/routes/dashboard/inbox/components/InboxCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/components/InboxCard.vue
@@ -4,10 +4,12 @@ import StatusIcon from './StatusIcon.vue';
 import InboxNameAndId from './InboxNameAndId.vue';
 import InboxContextMenu from './InboxContextMenu.vue';
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
-import { shortTimestamp } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import { snoozedReopenTime } from 'dashboard/helper/snoozeHelpers';
 import { INBOX_EVENTS } from 'dashboard/helper/AnalyticsHelper/events';
 import { useTrack } from 'dashboard/composables';
+
+const { localeShortTimestamp } = useLocaleDateFormatter();
 
 export default {
   components: {
@@ -64,10 +66,9 @@ export default {
       );
     },
     lastActivityAt() {
-      return shortTimestamp(
+      return localeShortTimestamp(
         this.notificationItem?.last_activity_at,
-        true,
-        this.$i18n.locale
+        true
       );
     },
     menuItems() {

--- a/app/javascript/dashboard/routes/dashboard/inbox/components/InboxCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/components/InboxCard.vue
@@ -64,8 +64,11 @@ export default {
       );
     },
     lastActivityAt() {
-      const time = dynamicTime(this.notificationItem?.last_activity_at);
-      return shortTimestamp(time, true);
+      return shortTimestamp(
+        this.notificationItem?.last_activity_at,
+        true,
+        this.$i18n.locale
+      );
     },
     menuItems() {
       const items = [

--- a/app/javascript/dashboard/routes/dashboard/inbox/components/InboxCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/components/InboxCard.vue
@@ -4,12 +4,10 @@ import StatusIcon from './StatusIcon.vue';
 import InboxNameAndId from './InboxNameAndId.vue';
 import InboxContextMenu from './InboxContextMenu.vue';
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 import { snoozedReopenTime } from 'dashboard/helper/snoozeHelpers';
 import { INBOX_EVENTS } from 'dashboard/helper/AnalyticsHelper/events';
 import { useTrack } from 'dashboard/composables';
-
-const { localeShortTimestamp } = useLocaleDateFormatter();
 
 export default {
   components: {
@@ -36,6 +34,10 @@ export default {
     'markNotificationAsUnRead',
     'deleteNotification',
   ],
+  setup() {
+    const { localeShortTimestamp } = useLocaleDateFormatter();
+    return { localeShortTimestamp };
+  },
   data() {
     return {
       isContextMenuOpen: false,
@@ -66,7 +68,7 @@ export default {
       );
     },
     lastActivityAt() {
-      return localeShortTimestamp(
+      return this.localeShortTimestamp(
         this.notificationItem?.last_activity_at,
         true
       );

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationPanelItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationPanelItem.vue
@@ -1,6 +1,8 @@
 <script>
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
-import { dynamicTime } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+
+const { localeDynamicTime } = useLocaleDateFormatter();
 
 export default {
   components: {
@@ -29,7 +31,7 @@ export default {
     },
   },
   methods: {
-    dynamicTime,
+    localeDynamicTime,
     onClickOpenNotification() {
       this.$emit('openNotification', this.notificationItem);
     },
@@ -96,7 +98,7 @@ export default {
           <span
             class="flex mt-1 font-semibold text-slate-500 dark:text-slate-400 text-xxs"
           >
-            {{ dynamicTime(notificationItem.last_activity_at, $i18n.locale) }}
+            {{ localeDynamicTime(notificationItem.last_activity_at) }}
           </span>
         </div>
       </div>

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationPanelItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationPanelItem.vue
@@ -1,8 +1,6 @@
 <script>
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
-
-const { localeDynamicTime } = useLocaleDateFormatter();
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 
 export default {
   components: {
@@ -15,6 +13,10 @@ export default {
     },
   },
   emits: ['openNotification'],
+  setup() {
+    const { localeDynamicTime } = useLocaleDateFormatter();
+    return { localeDynamicTime };
+  },
   computed: {
     notificationAssignee() {
       const { primary_actor: primaryActor } = this.notificationItem;
@@ -31,7 +33,6 @@ export default {
     },
   },
   methods: {
-    localeDynamicTime,
     onClickOpenNotification() {
       this.$emit('openNotification', this.notificationItem);
     },

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationPanelItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationPanelItem.vue
@@ -1,6 +1,6 @@
 <script>
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 
 export default {
   components: {

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationPanelItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationPanelItem.vue
@@ -96,7 +96,7 @@ export default {
           <span
             class="flex mt-1 font-semibold text-slate-500 dark:text-slate-400 text-xxs"
           >
-            {{ dynamicTime(notificationItem.last_activity_at) }}
+            {{ dynamicTime(notificationItem.last_activity_at, $i18n.locale) }}
           </span>
         </div>
       </div>

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
@@ -109,7 +109,9 @@ export default {
           <td>
             <div class="text-right timestamp--column">
               <span class="notification--created-at">
-                {{ dynamicTime(notificationItem.last_activity_at, $i18n.locale) }}
+                {{
+                  dynamicTime(notificationItem.last_activity_at, $i18n.locale)
+                }}
               </span>
             </div>
           </td>

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
@@ -2,7 +2,7 @@
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
 import Spinner from 'shared/components/Spinner.vue';
 import EmptyState from 'dashboard/components/widgets/EmptyState.vue';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import { mapGetters } from 'vuex';
 
 export default {

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
@@ -109,7 +109,7 @@ export default {
           <td>
             <div class="text-right timestamp--column">
               <span class="notification--created-at">
-                {{ dynamicTime(notificationItem.last_activity_at) }}
+                {{ dynamicTime(notificationItem.last_activity_at, $i18n.locale) }}
               </span>
             </div>
           </td>

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
@@ -2,8 +2,10 @@
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
 import Spinner from 'shared/components/Spinner.vue';
 import EmptyState from 'dashboard/components/widgets/EmptyState.vue';
-import { dynamicTime } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import { mapGetters } from 'vuex';
+
+const { localeDynamicTime } = useLocaleDateFormatter();
 
 export default {
   components: {
@@ -42,7 +44,7 @@ export default {
     },
   },
   methods: {
-    dynamicTime,
+    localeDynamicTime,
   },
 };
 </script>
@@ -109,9 +111,7 @@ export default {
           <td>
             <div class="text-right timestamp--column">
               <span class="notification--created-at">
-                {{
-                  dynamicTime(notificationItem.last_activity_at, $i18n.locale)
-                }}
+                {{ localeDynamicTime(notificationItem.last_activity_at) }}
               </span>
             </div>
           </td>

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
@@ -2,10 +2,8 @@
 import Thumbnail from 'dashboard/components/widgets/Thumbnail.vue';
 import Spinner from 'shared/components/Spinner.vue';
 import EmptyState from 'dashboard/components/widgets/EmptyState.vue';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 import { mapGetters } from 'vuex';
-
-const { localeDynamicTime } = useLocaleDateFormatter();
 
 export default {
   components: {
@@ -35,6 +33,10 @@ export default {
       default: () => {},
     },
   },
+  setup() {
+    const { localeDynamicTime } = useLocaleDateFormatter();
+    return { localeDynamicTime };
+  },
   computed: {
     ...mapGetters({
       notificationMetadata: 'notifications/getMeta',
@@ -42,9 +44,6 @@ export default {
     showEmptyResult() {
       return !this.isLoading && this.notifications.length === 0;
     },
-  },
-  methods: {
-    localeDynamicTime,
   },
 };
 </script>

--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -113,7 +113,7 @@ export default {
           latest_chatwoot_version: latestChatwootVersion,
         } = this.getAccount(this.accountId);
 
-        this.$i18n.locale = locale;
+        this.$i18n.locale = locale.replace('-', '_');
         this.name = name;
         this.locale = locale;
         this.id = id;
@@ -141,7 +141,7 @@ export default {
           support_email: this.supportEmail,
           auto_resolve_duration: this.autoResolveDuration,
         });
-        this.$i18n.locale = this.locale;
+        this.$i18n.locale = this.locale.replace('-', '_');
         this.getAccount(this.id).locale = this.locale;
         this.updateDirectionView(this.locale);
         useAlert(this.$t('GENERAL_SETTINGS.UPDATE.SUCCESS'));

--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -113,7 +113,7 @@ export default {
           latest_chatwoot_version: latestChatwootVersion,
         } = this.getAccount(this.accountId);
 
-        this.$root.$i18n.locale = locale;
+        this.$i18n.locale = locale;
         this.name = name;
         this.locale = locale;
         this.id = id;
@@ -141,7 +141,7 @@ export default {
           support_email: this.supportEmail,
           auto_resolve_duration: this.autoResolveDuration,
         });
-        this.$root.$i18n.locale = this.locale;
+        this.$i18n.locale = this.locale;
         this.getAccount(this.id).locale = this.locale;
         this.updateDirectionView(this.locale);
         useAlert(this.$t('GENERAL_SETTINGS.UPDATE.SUCCESS'));

--- a/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useAlert } from 'dashboard/composables';
-import { messageTimestamp } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import { useStoreGetters, useStore } from 'dashboard/composables/store';
 import TableFooter from 'dashboard/components/widgets/TableFooter.vue';
 import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';
@@ -19,7 +19,7 @@ const records = computed(() => getters['auditlogs/getAuditLogs'].value);
 const uiFlags = computed(() => getters['auditlogs/getUIFlags'].value);
 const meta = computed(() => getters['auditlogs/getMeta'].value);
 const agentList = computed(() => getters['agents/getAgents'].value);
-
+const { localeMessageTimestamp } = useLocaleDateFormatter();
 const { t } = useI18n();
 const route = useRoute();
 
@@ -113,7 +113,7 @@ const tableHeaders = computed(() => {
                 {{ generateLogText(auditLogItem) }}
               </td>
               <td class="py-4 pr-4 break-all whitespace-nowrap">
-                {{ messageTimestamp(auditLogItem.created_at, $i18n.locale) }}
+                {{ localeMessageTimestamp(auditLogItem.created_at) }}
               </td>
               <td class="py-4 w-[8.75rem]">
                 {{ auditLogItem.remote_address }}

--- a/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useAlert } from 'dashboard/composables';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 import { useStoreGetters, useStore } from 'dashboard/composables/store';
 import TableFooter from 'dashboard/components/widgets/TableFooter.vue';
 import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';

--- a/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
@@ -113,12 +113,7 @@ const tableHeaders = computed(() => {
                 {{ generateLogText(auditLogItem) }}
               </td>
               <td class="py-4 pr-4 break-all whitespace-nowrap">
-                {{
-                  messageTimestamp(
-                    auditLogItem.created_at,
-                    $i18n.locale
-                  )
-                }}
+                {{ messageTimestamp(auditLogItem.created_at, $i18n.locale) }}
               </td>
               <td class="py-4 w-[8.75rem]">
                 {{ auditLogItem.remote_address }}

--- a/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useAlert } from 'dashboard/composables';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import { useStoreGetters, useStore } from 'dashboard/composables/store';
 import TableFooter from 'dashboard/components/widgets/TableFooter.vue';
 import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';

--- a/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
@@ -116,7 +116,7 @@ const tableHeaders = computed(() => {
                 {{
                   messageTimestamp(
                     auditLogItem.created_at,
-                    'MMM dd, yyyy hh:mm a'
+                    $i18n.locale
                   )
                 }}
               </td>

--- a/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/auditlogs/Index.vue
@@ -19,7 +19,7 @@ const records = computed(() => getters['auditlogs/getAuditLogs'].value);
 const uiFlags = computed(() => getters['auditlogs/getUIFlags'].value);
 const meta = computed(() => getters['auditlogs/getMeta'].value);
 const agentList = computed(() => getters['agents/getAgents'].value);
-const { localeMessageTimestamp } = useLocaleDateFormatter();
+const { localeDateFormat } = useLocaleDateFormatter();
 const { t } = useI18n();
 const route = useRoute();
 
@@ -113,7 +113,7 @@ const tableHeaders = computed(() => {
                 {{ generateLogText(auditLogItem) }}
               </td>
               <td class="py-4 pr-4 break-all whitespace-nowrap">
-                {{ localeMessageTimestamp(auditLogItem.created_at) }}
+                {{ localeDateFormat(auditLogItem.created_at, 'dateM_timeM') }}
               </td>
               <td class="py-4 w-[8.75rem]">
                 {{ auditLogItem.remote_address }}

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleRow.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleRow.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { messageStamp } from 'shared/helpers/timeHelper';
+import { useI18n } from 'vue-i18n';
 
 const props = defineProps({
   automation: {
@@ -14,9 +15,11 @@ const props = defineProps({
 
 const emit = defineEmits(['toggle', 'edit', 'delete', 'clone']);
 
-const readableDate = date => messageStamp(new Date(date), false, locale);
+const { locale } = useI18n();
+
+const readableDate = date => messageStamp(new Date(date), false, locale.value);
 const readableDateWithTime = date =>
-  messageStamp(new Date(date), true, locale);
+  messageStamp(new Date(date), true, locale.value);
 
 const toggle = () => {
   const { id, name, active } = props.automation;

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleRow.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleRow.vue
@@ -14,10 +14,11 @@ const props = defineProps({
 
 const emit = defineEmits(['toggle', 'edit', 'delete', 'clone']);
 
-const { localeMessageStamp } = useLocaleDateFormatter();
+const { localeDateFormat } = useLocaleDateFormatter();
 
-const readableDate = date => localeMessageStamp(new Date(date), false);
-const readableDateWithTime = date => localeMessageStamp(new Date(date), true);
+const readableDate = date => localeDateFormat(new Date(date), 'dateM');
+const readableDateWithTime = date =>
+  localeDateFormat(new Date(date), 'dateM_timeM');
 
 const toggle = () => {
   const { id, name, active } = props.automation;

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleRow.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleRow.vue
@@ -1,6 +1,5 @@
 <script setup>
-import { messageStamp } from 'shared/helpers/timeHelper';
-import { useI18n } from 'vue-i18n';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 
 const props = defineProps({
   automation: {
@@ -15,11 +14,10 @@ const props = defineProps({
 
 const emit = defineEmits(['toggle', 'edit', 'delete', 'clone']);
 
-const { locale } = useI18n();
+const { localeMessageStamp } = useLocaleDateFormatter();
 
-const readableDate = date => messageStamp(new Date(date), false, locale.value);
-const readableDateWithTime = date =>
-  messageStamp(new Date(date), true, locale.value);
+const readableDate = date => localeMessageStamp(new Date(date), false);
+const readableDateWithTime = date => localeMessageStamp(new Date(date), true);
 
 const toggle = () => {
   const { id, name, active } = props.automation;

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleRow.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleRow.vue
@@ -14,9 +14,9 @@ const props = defineProps({
 
 const emit = defineEmits(['toggle', 'edit', 'delete', 'clone']);
 
-const readableDate = date => messageStamp(new Date(date), 'LLL d, yyyy');
+const readableDate = date => messageStamp(new Date(date), false, locale);
 const readableDateWithTime = date =>
-  messageStamp(new Date(date), 'LLL d, yyyy hh:mm a');
+  messageStamp(new Date(date), true, locale);
 
 const toggle = () => {
   const { id, name, active } = props.automation;

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleRow.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleRow.vue
@@ -1,5 +1,5 @@
 <script setup>
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 
 const props = defineProps({
   automation: {

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleRow.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleRow.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 
 const props = defineProps({
   automation: {

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/Index.vue
@@ -11,6 +11,7 @@ import AutomationRuleRow from './AutomationRuleRow.vue';
 const getters = useStoreGetters();
 const store = useStore();
 const { t } = useI18n();
+const locale = getCurrentInstance()?.proxy.$i18n.locale;
 const confirmDialog = ref(null);
 
 const loading = ref({});

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/Index.vue
@@ -11,7 +11,7 @@ import AutomationRuleRow from './AutomationRuleRow.vue';
 const getters = useStoreGetters();
 const store = useStore();
 const { t } = useI18n();
-const locale = getCurrentInstance()?.proxy.$i18n.locale;
+
 const confirmDialog = ref(null);
 
 const loading = ref({});

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
@@ -2,7 +2,7 @@
 import { defineEmits, computed, h } from 'vue';
 import { useMapGetter } from 'dashboard/composables/store';
 import { useI18n } from 'vue-i18n';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 
 // [TODO] Instead of converting the values to their reprentation when building the tableData
 // We should do the change in the cell

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
@@ -30,8 +30,8 @@ const { pageIndex } = defineProps({
 });
 
 const emit = defineEmits(['pageChange']);
-const { t } = useI18n();
-const locale = getCurrentInstance()?.proxy.$i18n.locale;
+const { t, locale } = useI18n();
+
 // const isRTL = useMapGetter('accounts/isRTL');
 const csatResponses = useMapGetter('csat/getCSATResponses');
 const metrics = useMapGetter('csat/getMetrics');
@@ -43,8 +43,8 @@ const tableData = computed(() => {
     rating: response.rating,
     feedbackText: response.feedback_message || '---',
     conversationId: response.conversation_id,
-    createdAgo: dynamicTime(response.created_at),
-    createdAt: messageStamp(response.created_at, true, locale),
+    createdAgo: dynamicTime(response.created_at, locale.value),
+    createdAt: messageStamp(response.created_at, true, locale.value),
   }));
 });
 

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
@@ -31,7 +31,7 @@ const { pageIndex } = defineProps({
 
 const emit = defineEmits(['pageChange']);
 const { t } = useI18n();
-const { localeMessageStamp, localeDynamicTime } = useLocaleDateFormatter();
+const { localeDateFormat, localeDynamicTime } = useLocaleDateFormatter();
 // const isRTL = useMapGetter('accounts/isRTL');
 const csatResponses = useMapGetter('csat/getCSATResponses');
 const metrics = useMapGetter('csat/getMetrics');

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
@@ -31,6 +31,7 @@ const { pageIndex } = defineProps({
 
 const emit = defineEmits(['pageChange']);
 const { t } = useI18n();
+const locale = getCurrentInstance()?.proxy.$i18n.locale;
 // const isRTL = useMapGetter('accounts/isRTL');
 const csatResponses = useMapGetter('csat/getCSATResponses');
 const metrics = useMapGetter('csat/getMetrics');
@@ -43,7 +44,7 @@ const tableData = computed(() => {
     feedbackText: response.feedback_message || '---',
     conversationId: response.conversation_id,
     createdAgo: dynamicTime(response.created_at),
-    createdAt: messageStamp(response.created_at, 'LLL d yyyy, h:mm a'),
+    createdAt: messageStamp(response.created_at, true, locale),
   }));
 });
 

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
@@ -2,7 +2,7 @@
 import { defineEmits, computed, h } from 'vue';
 import { useMapGetter } from 'dashboard/composables/store';
 import { useI18n } from 'vue-i18n';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 
 // [TODO] Instead of converting the values to their reprentation when building the tableData
 // We should do the change in the cell

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
@@ -44,7 +44,7 @@ const tableData = computed(() => {
     feedbackText: response.feedback_message || '---',
     conversationId: response.conversation_id,
     createdAgo: localeDynamicTime(response.created_at),
-    createdAt: localeMessageStamp(response.created_at, true),
+    createdAt: localeDateFormat(response.created_at, 'dateM_timeM'),
   }));
 });
 

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
@@ -2,10 +2,10 @@
 import { defineEmits, computed, h } from 'vue';
 import { useMapGetter } from 'dashboard/composables/store';
 import { useI18n } from 'vue-i18n';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 
 // [TODO] Instead of converting the values to their reprentation when building the tableData
 // We should do the change in the cell
-import { messageStamp, dynamicTime } from 'shared/helpers/timeHelper';
 
 // components
 import Table from 'dashboard/components/table/Table.vue';
@@ -30,8 +30,8 @@ const { pageIndex } = defineProps({
 });
 
 const emit = defineEmits(['pageChange']);
-const { t, locale } = useI18n();
-
+const { t } = useI18n();
+const { localeMessageStamp, localeDynamicTime } = useLocaleDateFormatter();
 // const isRTL = useMapGetter('accounts/isRTL');
 const csatResponses = useMapGetter('csat/getCSATResponses');
 const metrics = useMapGetter('csat/getMetrics');
@@ -43,8 +43,8 @@ const tableData = computed(() => {
     rating: response.rating,
     feedbackText: response.feedback_message || '---',
     conversationId: response.conversation_id,
-    createdAgo: dynamicTime(response.created_at, locale.value),
-    createdAt: messageStamp(response.created_at, true, locale.value),
+    createdAgo: localeDynamicTime(response.created_at),
+    createdAt: localeMessageStamp(response.created_at, true),
   }));
 });
 

--- a/app/javascript/shared/helpers/specs/timeHelper.spec.js
+++ b/app/javascript/shared/helpers/specs/timeHelper.spec.js
@@ -1,6 +1,5 @@
 import {
-  messageStamp,
-  messageTimestamp,
+  messageDateFormat,
   dynamicTime,
   dateFormat,
   shortTimestamp,
@@ -9,7 +8,7 @@ import {
 beforeEach(() => {
   process.env.TZ = 'UTC';
   vi.useFakeTimers('modern');
-  const mockDate = new Date(Date.UTC(2023, 4, 5));
+  const mockDate = new Date(Date.UTC(2024, 10, 5, 11, 30));
   vi.setSystemTime(mockDate);
 });
 
@@ -17,76 +16,68 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('#messageStamp', () => {
-  it('returns correct value', () => {
-    expect(messageStamp(1612971343)).toEqual('3:35 PM');
-    expect(messageStamp(1612971343, 'LLL d, h:mm a')).toEqual(
-      'Feb 10, 3:35 PM'
-    );
-  });
-});
-
-describe('#messageTimestamp', () => {
-  it('should return the message date in the specified format if the message was sent in the current year', () => {
-    expect(messageTimestamp(1680777464)).toEqual('Apr 6, 2023');
-  });
-  it('should return the message date and time in a different format if the message was sent in a different year', () => {
-    expect(messageTimestamp(1612971343)).toEqual('Feb 10 2021, 3:35 PM');
-  });
-});
-
 describe('#dynamicTime', () => {
   it('returns correct value', () => {
-    Date.now = vi.fn(() => new Date(Date.UTC(2023, 1, 14)).valueOf());
-    expect(dynamicTime(1612971343)).toEqual('about 2 years ago');
+    expect(dynamicTime(1667646000, 'en')).toEqual('about 2 years ago');
+  });
+});
+
+describe('#messageDateFormat', () => {
+  it('should return the message date in the specified format if the message was sent in the current year', () => {
+    expect(messageDateFormat(1730806200, 'en')).toEqual('11:30 AM');
+  });
+  it('should return the message date and time in a different format if the message was sent in a different year', () => {
+    expect(messageDateFormat(1730633400, 'en')).toEqual(
+      'Nov 3, 2024, 11:30 AM'
+    );
+  });
+  it('should return the message date and time in a different format if the message was sent in a different year', () => {
+    expect(messageDateFormat(1612971343, 'en')).toEqual('Feb 10, 2021');
   });
 });
 
 describe('#dateFormat', () => {
   it('returns correct value', () => {
+    expect(dateFormat(1612971343, 'dateS')).toEqual('2/10/21');
+    expect(dateFormat(1612971343, 'dateM')).toEqual('Feb 10, 2021');
+    expect(dateFormat(1612971343, 'dateM_timeS')).toEqual(
+      'Feb 10, 2021, 3:35 PM'
+    );
+    expect(dateFormat(1612971343, 'dateM_timeM')).toEqual(
+      'Feb 10, 2021, 3:35:43 PM'
+    );
     expect(dateFormat(1612971343)).toEqual('Feb 10, 2021');
-    expect(dateFormat(1612971343, 'LLL d, yyyy')).toEqual('Feb 10, 2021');
   });
 });
 
 describe('#shortTimestamp', () => {
   // Test cases when withAgo is false or not provided
   it('returns correct value without ago', () => {
-    expect(shortTimestamp('less than a minute ago')).toEqual('now');
-    expect(shortTimestamp('1 minute ago')).toEqual('1m');
-    expect(shortTimestamp('12 minutes ago')).toEqual('12m');
-    expect(shortTimestamp('a minute ago')).toEqual('1m');
-    expect(shortTimestamp('an hour ago')).toEqual('1h');
-    expect(shortTimestamp('1 hour ago')).toEqual('1h');
-    expect(shortTimestamp('2 hours ago')).toEqual('2h');
-    expect(shortTimestamp('1 day ago')).toEqual('1d');
-    expect(shortTimestamp('a day ago')).toEqual('1d');
-    expect(shortTimestamp('3 days ago')).toEqual('3d');
-    expect(shortTimestamp('a month ago')).toEqual('1mo');
-    expect(shortTimestamp('1 month ago')).toEqual('1mo');
-    expect(shortTimestamp('2 months ago')).toEqual('2mo');
-    expect(shortTimestamp('a year ago')).toEqual('1y');
-    expect(shortTimestamp('1 year ago')).toEqual('1y');
-    expect(shortTimestamp('4 years ago')).toEqual('4y');
+    expect(shortTimestamp(1730806200)).toEqual('less than a minute');
+    expect(shortTimestamp(1730806140)).toEqual('1 minute');
+    expect(shortTimestamp(1730805480)).toEqual('12 minutes');
+    expect(shortTimestamp(1730802600)).toEqual('1 hour');
+    expect(shortTimestamp(1730799000)).toEqual('2 hours');
+    expect(shortTimestamp(1730719800)).toEqual('1 day');
+    expect(shortTimestamp(1730547000)).toEqual('3 days');
+    expect(shortTimestamp(1728127800)).toEqual('1 month');
+    expect(shortTimestamp(1725535800)).toEqual('2 months');
+    expect(shortTimestamp(1699183800)).toEqual('1 year');
+    expect(shortTimestamp(1604575800)).toEqual('4 years');
   });
 
   // Test cases when withAgo is true
   it('returns correct value with ago', () => {
-    expect(shortTimestamp('less than a minute ago', true)).toEqual('now');
-    expect(shortTimestamp('1 minute ago', true)).toEqual('1m ago');
-    expect(shortTimestamp('12 minutes ago', true)).toEqual('12m ago');
-    expect(shortTimestamp('a minute ago', true)).toEqual('1m ago');
-    expect(shortTimestamp('an hour ago', true)).toEqual('1h ago');
-    expect(shortTimestamp('1 hour ago', true)).toEqual('1h ago');
-    expect(shortTimestamp('2 hours ago', true)).toEqual('2h ago');
-    expect(shortTimestamp('1 day ago', true)).toEqual('1d ago');
-    expect(shortTimestamp('a day ago', true)).toEqual('1d ago');
-    expect(shortTimestamp('3 days ago', true)).toEqual('3d ago');
-    expect(shortTimestamp('a month ago', true)).toEqual('1mo ago');
-    expect(shortTimestamp('1 month ago', true)).toEqual('1mo ago');
-    expect(shortTimestamp('2 months ago', true)).toEqual('2mo ago');
-    expect(shortTimestamp('a year ago', true)).toEqual('1y ago');
-    expect(shortTimestamp('1 year ago', true)).toEqual('1y ago');
-    expect(shortTimestamp('4 years ago', true)).toEqual('4y ago');
+    expect(shortTimestamp(1730806200, true)).toEqual('less than a minute ago');
+    expect(shortTimestamp(1730806140, true)).toEqual('1 minute ago');
+    expect(shortTimestamp(1730805480, true)).toEqual('12 minutes ago');
+    expect(shortTimestamp(1730802600, true)).toEqual('1 hour ago');
+    expect(shortTimestamp(1730799000, true)).toEqual('2 hours ago');
+    expect(shortTimestamp(1730719800, true)).toEqual('1 day ago');
+    expect(shortTimestamp(1730547000, true)).toEqual('3 days ago');
+    expect(shortTimestamp(1728127800, true)).toEqual('1 month ago');
+    expect(shortTimestamp(1725535800, true)).toEqual('2 months ago');
+    expect(shortTimestamp(1699183800, true)).toEqual('1 year ago');
+    expect(shortTimestamp(1604575800, true)).toEqual('4 years ago');
   });
 });

--- a/app/javascript/shared/helpers/timeHelper.js
+++ b/app/javascript/shared/helpers/timeHelper.js
@@ -1,93 +1,106 @@
 import {
-  format,
   isSameYear,
   fromUnixTime,
   formatDistanceToNow,
+  isSameDay,
 } from 'date-fns';
+import * as locales from 'date-fns/locale';
+
+const selectedLocaleToDateFns = (locale = 'en') => {
+  return locales[locale.replace('_', '')];
+};
 
 /**
  * Formats a Unix timestamp into a human-readable time format.
  * @param {number} time - Unix timestamp.
- * @param {string} [dateFormat='h:mm a'] - Desired format of the time.
+ * @param {boolean} [fullDateTime=true] - Desired format of the time.
+ * @param {string} [locale='en'] - Desired locale and region.
  * @returns {string} Formatted time string.
  */
-export const messageStamp = (time, dateFormat = 'h:mm a') => {
+export const messageStamp = (time, fullDateTime = false, locale = 'en') => {
   const unixTime = fromUnixTime(time);
-  return format(unixTime, dateFormat);
+  let options;
+  options = {
+    timeStyle: 'medium',
+  };
+  if (fullDateTime) {
+    options = {
+      dateStyle: 'medium',
+      timeStyle: 'medium',
+    };
+  }
+  return new Intl.DateTimeFormat(locale, options).format(unixTime);
 };
 
 /**
  * Provides a formatted timestamp, adjusting the format based on the current year.
  * @param {number} time - Unix timestamp.
- * @param {string} [dateFormat='MMM d, yyyy'] - Desired date format.
+ * @param {string} [locale='en'] - Desired locale and region.
  * @returns {string} Formatted date string.
  */
-export const messageTimestamp = (time, dateFormat = 'MMM d, yyyy') => {
+export const messageTimestamp = (time, locale = 'en') => {
   const messageTime = fromUnixTime(time);
   const now = new Date();
-  const messageDate = format(messageTime, dateFormat);
-  if (!isSameYear(messageTime, now)) {
-    return format(messageTime, 'LLL d y, h:mm a');
+  let options;
+  if (isSameYear(messageTime, now)) {
+    options = {
+      dateStyle: 'medium',
+      timeStyle: 'medium',
+    };
+    if (isSameDay(messageTime, now)) {
+      options = {
+        timeStyle: 'medium',
+      };
+    }
+  } else {
+    options = {
+      dateStyle: 'medium',
+    };
   }
-  return messageDate;
+
+  return new Intl.DateTimeFormat(locale.replace('_', '-'), options).format(
+    messageTime
+  );
 };
 
 /**
  * Converts a Unix timestamp to a relative time string (e.g., 3 hours ago).
  * @param {number} time - Unix timestamp.
+ * @param {string} [locale='en'] - Desired locale and region.
  * @returns {string} Relative time string.
  */
-export const dynamicTime = time => {
+export const dynamicTime = (time, locale) => {
   const unixTime = fromUnixTime(time);
-  return formatDistanceToNow(unixTime, { addSuffix: true });
+  return formatDistanceToNow(unixTime, {
+    addSuffix: true,
+    locale: selectedLocaleToDateFns(locale),
+  });
 };
 
 /**
  * Formats a Unix timestamp into a specified date format.
  * @param {number} time - Unix timestamp.
- * @param {string} [dateFormat='MMM d, yyyy'] - Desired date format.
+ * @param {string} [locale='en'] - Desired locale and region.
  * @returns {string} Formatted date string.
  */
-export const dateFormat = (time, df = 'MMM d, yyyy') => {
+export const dateFormat = (time, locale = 'en') => {
   const unixTime = fromUnixTime(time);
-  return format(unixTime, df);
+  return new Intl.DateTimeFormat(locale.replace('_', '-'), {
+    dateStyle: 'medium',
+  }).format(unixTime);
 };
 
 /**
  * Converts a detailed time description into a shorter format, optionally appending 'ago'.
  * @param {string} time - Detailed time description (e.g., 'a minute ago').
  * @param {boolean} [withAgo=false] - Whether to append 'ago' to the result.
+ * @param {string} [locale='en'] - Desired locale and region.
  * @returns {string} Shortened time description.
  */
-export const shortTimestamp = (time, withAgo = false) => {
-  // This function takes a time string and converts it to a short time string
-  // with the following format: 1m, 1h, 1d, 1mo, 1y
-  // The function also takes an optional boolean parameter withAgo
-  // which will add the word "ago" to the end of the time string
-  const suffix = withAgo ? ' ago' : '';
-  const timeMappings = {
-    'less than a minute ago': 'now',
-    'a minute ago': `1m${suffix}`,
-    'an hour ago': `1h${suffix}`,
-    'a day ago': `1d${suffix}`,
-    'a month ago': `1mo${suffix}`,
-    'a year ago': `1y${suffix}`,
-  };
-  // Check if the time string is one of the specific cases
-  if (timeMappings[time]) {
-    return timeMappings[time];
-  }
-  const convertToShortTime = time
-    .replace(/about|over|almost|/g, '')
-    .replace(' minute ago', `m${suffix}`)
-    .replace(' minutes ago', `m${suffix}`)
-    .replace(' hour ago', `h${suffix}`)
-    .replace(' hours ago', `h${suffix}`)
-    .replace(' day ago', `d${suffix}`)
-    .replace(' days ago', `d${suffix}`)
-    .replace(' month ago', `mo${suffix}`)
-    .replace(' months ago', `mo${suffix}`)
-    .replace(' year ago', `y${suffix}`)
-    .replace(' years ago', `y${suffix}`);
-  return convertToShortTime;
+export const shortTimestamp = (time, withAgo = false, locale = 'en') => {
+  const unixTime = fromUnixTime(time);
+  return formatDistanceToNow(unixTime, {
+    addSuffix: withAgo,
+    locale: selectedLocaleToDateFns(locale),
+  });
 };

--- a/app/javascript/shared/helpers/timeHelper.js
+++ b/app/javascript/shared/helpers/timeHelper.js
@@ -21,7 +21,8 @@ export const messageStamp = (time, fullDateTime = false, locale = 'en') => {
   const unixTime = fromUnixTime(time);
   let options;
   options = {
-    timeStyle: 'medium',
+    dateStyle: 'short',
+    timeStyle: 'short',
   };
   if (fullDateTime) {
     options = {
@@ -29,7 +30,7 @@ export const messageStamp = (time, fullDateTime = false, locale = 'en') => {
       timeStyle: 'medium',
     };
   }
-  return new Intl.DateTimeFormat(locale, options).format(unixTime);
+  return new Intl.DateTimeFormat(locale.replace('_', '-'), options).format(unixTime);
 };
 
 /**

--- a/app/javascript/shared/helpers/timeHelper.js
+++ b/app/javascript/shared/helpers/timeHelper.js
@@ -30,7 +30,9 @@ export const messageStamp = (time, fullDateTime = false, locale = 'en') => {
       timeStyle: 'medium',
     };
   }
-  return new Intl.DateTimeFormat(locale.replace('_', '-'), options).format(unixTime);
+  return new Intl.DateTimeFormat(locale.replace('_', '-'), options).format(
+    unixTime
+  );
 };
 
 /**

--- a/app/javascript/shared/helpers/timeHelper.js
+++ b/app/javascript/shared/helpers/timeHelper.js
@@ -2,38 +2,10 @@ import {
   isSameYear,
   fromUnixTime,
   formatDistanceToNow,
+  formatDistanceToNowStrict,
   isSameDay,
 } from 'date-fns';
 import * as locales from 'date-fns/locale';
-
-const selectedLocaleToDateFns = (locale = 'en') => {
-  return locales[locale.replace('_', '')];
-};
-
-/**
- * Formats a Unix timestamp into a human-readable time format.
- * @param {number} time - Unix timestamp.
- * @param {boolean} [fullDateTime=true] - Desired format of the time.
- * @param {string} [locale='en'] - Desired locale and region.
- * @returns {string} Formatted time string.
- */
-export const messageStamp = (time, fullDateTime = false, locale = 'en') => {
-  const unixTime = fromUnixTime(time);
-  let options;
-  options = {
-    dateStyle: 'short',
-    timeStyle: 'short',
-  };
-  if (fullDateTime) {
-    options = {
-      dateStyle: 'medium',
-      timeStyle: 'medium',
-    };
-  }
-  return new Intl.DateTimeFormat(locale.replace('_', '-'), options).format(
-    unixTime
-  );
-};
 
 /**
  * Provides a formatted timestamp, adjusting the format based on the current year.
@@ -41,18 +13,18 @@ export const messageStamp = (time, fullDateTime = false, locale = 'en') => {
  * @param {string} [locale='en'] - Desired locale and region.
  * @returns {string} Formatted date string.
  */
-export const messageTimestamp = (time, locale = 'en') => {
+export const messageDateFormat = (time, locale = 'en') => {
   const messageTime = fromUnixTime(time);
   const now = new Date();
   let options;
   if (isSameYear(messageTime, now)) {
     options = {
       dateStyle: 'medium',
-      timeStyle: 'medium',
+      timeStyle: 'short',
     };
     if (isSameDay(messageTime, now)) {
       options = {
-        timeStyle: 'medium',
+        timeStyle: 'short',
       };
     }
   } else {
@@ -60,9 +32,40 @@ export const messageTimestamp = (time, locale = 'en') => {
       dateStyle: 'medium',
     };
   }
-
   return new Intl.DateTimeFormat(locale.replace('_', '-'), options).format(
     messageTime
+  );
+};
+
+/**
+ * Formats a Unix timestamp into a specified date format.
+ * @param {number} time - Unix timestamp.
+ * @param {string} [locale='en'] - Desired locale and region.
+ * @returns {string} Formatted date string.
+ */
+export const dateFormat = (time, formatStyle = 'dateM', locale = 'en') => {
+  const unixTime = fromUnixTime(time);
+  const options = {};
+  switch (formatStyle) {
+    case 'dateS':
+      options.dateStyle = 'short';
+      break;
+    case 'dateM':
+      options.dateStyle = 'medium';
+      break;
+    case 'dateM_timeS':
+      options.dateStyle = 'medium';
+      options.timeStyle = 'short';
+      break;
+    case 'dateM_timeM':
+      options.dateStyle = 'medium';
+      options.timeStyle = 'medium';
+      break;
+    default:
+      options.dateStyle = 'medium';
+  }
+  return new Intl.DateTimeFormat(locale.replace('_', '-'), options).format(
+    unixTime
   );
 };
 
@@ -72,25 +75,12 @@ export const messageTimestamp = (time, locale = 'en') => {
  * @param {string} [locale='en'] - Desired locale and region.
  * @returns {string} Relative time string.
  */
-export const dynamicTime = (time, locale) => {
+export const dynamicTime = (time, locale = 'en') => {
   const unixTime = fromUnixTime(time);
   return formatDistanceToNow(unixTime, {
     addSuffix: true,
-    locale: selectedLocaleToDateFns(locale),
+    locale: locales[locale.replace('_', '')],
   });
-};
-
-/**
- * Formats a Unix timestamp into a specified date format.
- * @param {number} time - Unix timestamp.
- * @param {string} [locale='en'] - Desired locale and region.
- * @returns {string} Formatted date string.
- */
-export const dateFormat = (time, locale = 'en') => {
-  const unixTime = fromUnixTime(time);
-  return new Intl.DateTimeFormat(locale.replace('_', '-'), {
-    dateStyle: 'medium',
-  }).format(unixTime);
 };
 
 /**
@@ -102,8 +92,14 @@ export const dateFormat = (time, locale = 'en') => {
  */
 export const shortTimestamp = (time, withAgo = false, locale = 'en') => {
   const unixTime = fromUnixTime(time);
-  return formatDistanceToNow(unixTime, {
+  if (Date.now() / 1000 - time < 60) {
+    return formatDistanceToNow(unixTime, {
+      addSuffix: withAgo,
+      locale: locales[locale.replace('_', '')],
+    });
+  }
+  return formatDistanceToNowStrict(unixTime, {
     addSuffix: withAgo,
-    locale: selectedLocaleToDateFns(locale),
+    locale: locales[locale.replace('_', '')],
   });
 };

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -120,7 +120,7 @@ export default {
       }
     },
     setLocale(locale) {
-      this.$i18n.locale = locale || 'en';
+      this.$i18n.locale = locale.replace('-', '_') || 'en';
     },
   },
 };

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -120,7 +120,7 @@ export default {
       }
     },
     setLocale(locale) {
-      this.$root.$i18n.locale = locale || 'en';
+      this.$i18n.locale = locale || 'en';
     },
   },
 };

--- a/app/javascript/v3/App.vue
+++ b/app/javascript/v3/App.vue
@@ -31,7 +31,7 @@ export default {
       };
     },
     setLocale(locale) {
-      this.$i18n.locale = locale;
+      this.$i18n.locale = locale.replace('-', '_');
     },
   },
 };

--- a/app/javascript/v3/App.vue
+++ b/app/javascript/v3/App.vue
@@ -31,7 +31,7 @@ export default {
       };
     },
     setLocale(locale) {
-      this.$root.$i18n.locale = locale;
+      this.$i18n.locale = locale;
     },
   },
 };

--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -131,9 +131,9 @@ export default {
       );
 
       if (hasLocaleWithVariation) {
-        this.$i18n.locale = localeWithVariation;
+        this.$i18n.locale = localeWithVariation.replace('-', '_');
       } else if (hasLocaleWithoutVariation) {
-        this.$i18n.locale = localeWithoutVariation;
+        this.$i18n.locale = localeWithoutVariation.replace('-', '_');
       }
     },
     registerUnreadEvents() {

--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -131,9 +131,9 @@ export default {
       );
 
       if (hasLocaleWithVariation) {
-        this.$root.$i18n.locale = localeWithVariation;
+        this.$i18n.locale = localeWithVariation;
       } else if (hasLocaleWithoutVariation) {
-        this.$root.$i18n.locale = localeWithoutVariation;
+        this.$i18n.locale = localeWithoutVariation;
       }
     },
     registerUnreadEvents() {

--- a/app/javascript/widget/api/specs/endPoints.spec.js
+++ b/app/javascript/widget/api/specs/endPoints.spec.js
@@ -11,10 +11,8 @@ describe('#sendMessage', () => {
     });
 
     window.WOOT_WIDGET = {
-      $root: {
-        $i18n: {
-          locale: 'ar',
-        },
+      $i18n: {
+        locale: 'ar',
       },
     };
 

--- a/app/javascript/widget/components/AgentMessage.vue
+++ b/app/javascript/widget/components/AgentMessage.vue
@@ -2,7 +2,7 @@
 import UserMessage from 'widget/components/UserMessage.vue';
 import AgentMessageBubble from 'widget/components/AgentMessageBubble.vue';
 import MessageReplyButton from 'widget/components/MessageReplyButton.vue';
-import { messageStamp } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import ImageBubble from 'widget/components/ImageBubble.vue';
 import VideoBubble from 'widget/components/VideoBubble.vue';
 import FileBubble from 'widget/components/FileBubble.vue';
@@ -15,6 +15,8 @@ import { useDarkMode } from 'widget/composables/useDarkMode';
 import ReplyToChip from 'widget/components/ReplyToChip.vue';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import { emitter } from 'shared/helpers/mitt';
+
+const { localeMessageStamp } = useLocaleDateFormatter();
 
 export default {
   name: 'AgentMessage',
@@ -64,7 +66,7 @@ export default {
     },
     readableTime() {
       const { created_at: createdAt = '' } = this.message;
-      return messageStamp(createdAt, true, this.$i18n.locale);
+      return localeMessageStamp(createdAt, true);
     },
     messageType() {
       const { message_type: type = 1 } = this.message;

--- a/app/javascript/widget/components/AgentMessage.vue
+++ b/app/javascript/widget/components/AgentMessage.vue
@@ -64,7 +64,7 @@ export default {
     },
     readableTime() {
       const { created_at: createdAt = '' } = this.message;
-      return messageStamp(createdAt, 'LLL d yyyy, h:mm a');
+      return messageStamp(createdAt, true, this.$i18n.locale);
     },
     messageType() {
       const { message_type: type = 1 } = this.message;

--- a/app/javascript/widget/components/AgentMessage.vue
+++ b/app/javascript/widget/components/AgentMessage.vue
@@ -2,7 +2,7 @@
 import UserMessage from 'widget/components/UserMessage.vue';
 import AgentMessageBubble from 'widget/components/AgentMessageBubble.vue';
 import MessageReplyButton from 'widget/components/MessageReplyButton.vue';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 import ImageBubble from 'widget/components/ImageBubble.vue';
 import VideoBubble from 'widget/components/VideoBubble.vue';
 import FileBubble from 'widget/components/FileBubble.vue';
@@ -15,8 +15,6 @@ import { useDarkMode } from 'widget/composables/useDarkMode';
 import ReplyToChip from 'widget/components/ReplyToChip.vue';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import { emitter } from 'shared/helpers/mitt';
-
-const { localeMessageStamp } = useLocaleDateFormatter();
 
 export default {
   name: 'AgentMessage',
@@ -43,8 +41,10 @@ export default {
   },
   setup() {
     const { getThemeClass } = useDarkMode();
+    const { localeMessageStamp } = useLocaleDateFormatter();
     return {
       getThemeClass,
+      localeMessageStamp,
     };
   },
   data() {
@@ -66,7 +66,7 @@ export default {
     },
     readableTime() {
       const { created_at: createdAt = '' } = this.message;
-      return localeMessageStamp(createdAt, true);
+      return this.localeMessageStamp(createdAt, true);
     },
     messageType() {
       const { message_type: type = 1 } = this.message;

--- a/app/javascript/widget/components/AgentMessage.vue
+++ b/app/javascript/widget/components/AgentMessage.vue
@@ -41,10 +41,10 @@ export default {
   },
   setup() {
     const { getThemeClass } = useDarkMode();
-    const { localeMessageStamp } = useLocaleDateFormatter();
+    const { localeDateFormat } = useLocaleDateFormatter();
     return {
       getThemeClass,
-      localeMessageStamp,
+      localeDateFormat,
     };
   },
   data() {
@@ -66,7 +66,7 @@ export default {
     },
     readableTime() {
       const { created_at: createdAt = '' } = this.message;
-      return this.localeMessageStamp(createdAt, true);
+      return this.localeDateFormat(createdAt, 'dateM_timeM');
     },
     messageType() {
       const { message_type: type = 1 } = this.message;

--- a/app/javascript/widget/components/AgentMessage.vue
+++ b/app/javascript/widget/components/AgentMessage.vue
@@ -2,7 +2,7 @@
 import UserMessage from 'widget/components/UserMessage.vue';
 import AgentMessageBubble from 'widget/components/AgentMessageBubble.vue';
 import MessageReplyButton from 'widget/components/MessageReplyButton.vue';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import ImageBubble from 'widget/components/ImageBubble.vue';
 import VideoBubble from 'widget/components/VideoBubble.vue';
 import FileBubble from 'widget/components/FileBubble.vue';

--- a/app/javascript/widget/components/HeaderActions.vue
+++ b/app/javascript/widget/components/HeaderActions.vue
@@ -63,7 +63,7 @@ export default {
       popoutChatWindow(
         origin,
         websiteToken,
-        this.$root.$i18n.locale,
+        this.$i18n.locale,
         authToken
       );
     },

--- a/app/javascript/widget/components/HeaderActions.vue
+++ b/app/javascript/widget/components/HeaderActions.vue
@@ -60,12 +60,7 @@ export default {
         chatwootWebChannel: { websiteToken },
         authToken,
       } = window;
-      popoutChatWindow(
-        origin,
-        websiteToken,
-        this.$i18n.locale,
-        authToken
-      );
+      popoutChatWindow(origin, websiteToken, this.$i18n.locale, authToken);
     },
     closeWindow() {
       if (IFrameHelper.isIFrame()) {

--- a/app/javascript/widget/components/PreChat/Form.vue
+++ b/app/javascript/widget/components/PreChat/Form.vue
@@ -37,7 +37,7 @@ export default {
   },
   data() {
     return {
-      locale: this.$root.$i18n.locale,
+      locale: this.$i18n.locale,
       hasErrorInPhoneInput: false,
       message: '',
       formValues: {},

--- a/app/javascript/widget/components/UserMessage.vue
+++ b/app/javascript/widget/components/UserMessage.vue
@@ -5,13 +5,15 @@ import ImageBubble from 'widget/components/ImageBubble.vue';
 import VideoBubble from 'widget/components/VideoBubble.vue';
 import FluentIcon from 'shared/components/FluentIcon/Index.vue';
 import FileBubble from 'widget/components/FileBubble.vue';
-import { messageStamp } from 'shared/helpers/timeHelper';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import messageMixin from '../mixins/messageMixin';
 import ReplyToChip from 'widget/components/ReplyToChip.vue';
 import DragWrapper from 'widget/components/DragWrapper.vue';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import { emitter } from 'shared/helpers/mitt';
 import { mapGetters } from 'vuex';
+
+const { localeMessageStamp } = useLocaleDateFormatter();
 
 export default {
   name: 'UserMessage',
@@ -57,7 +59,7 @@ export default {
     },
     readableTime() {
       const { created_at: createdAt = '' } = this.message;
-      return messageStamp(createdAt, false, this.$i18n.locale);
+      return localeMessageStamp(createdAt, false);
     },
     isFailed() {
       const { status = '' } = this.message;

--- a/app/javascript/widget/components/UserMessage.vue
+++ b/app/javascript/widget/components/UserMessage.vue
@@ -5,15 +5,13 @@ import ImageBubble from 'widget/components/ImageBubble.vue';
 import VideoBubble from 'widget/components/VideoBubble.vue';
 import FluentIcon from 'shared/components/FluentIcon/Index.vue';
 import FileBubble from 'widget/components/FileBubble.vue';
-import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
+import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
 import messageMixin from '../mixins/messageMixin';
 import ReplyToChip from 'widget/components/ReplyToChip.vue';
 import DragWrapper from 'widget/components/DragWrapper.vue';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import { emitter } from 'shared/helpers/mitt';
 import { mapGetters } from 'vuex';
-
-const { localeMessageStamp } = useLocaleDateFormatter();
 
 export default {
   name: 'UserMessage',
@@ -38,6 +36,10 @@ export default {
       default: () => {},
     },
   },
+  setup() {
+    const { localeMessageStamp } = useLocaleDateFormatter();
+    return { localeMessageStamp };
+  },
   data() {
     return {
       hasImageError: false,
@@ -59,7 +61,7 @@ export default {
     },
     readableTime() {
       const { created_at: createdAt = '' } = this.message;
-      return localeMessageStamp(createdAt, false);
+      return this.localeMessageStamp(createdAt, false);
     },
     isFailed() {
       const { status = '' } = this.message;

--- a/app/javascript/widget/components/UserMessage.vue
+++ b/app/javascript/widget/components/UserMessage.vue
@@ -37,8 +37,8 @@ export default {
     },
   },
   setup() {
-    const { localeMessageStamp } = useLocaleDateFormatter();
-    return { localeMessageStamp };
+    const { localeDateFormat } = useLocaleDateFormatter();
+    return { localeDateFormat };
   },
   data() {
     return {
@@ -61,7 +61,7 @@ export default {
     },
     readableTime() {
       const { created_at: createdAt = '' } = this.message;
-      return this.localeMessageStamp(createdAt, false);
+      return this.localeDateFormat(createdAt, 'dateM_timeM');
     },
     isFailed() {
       const { status = '' } = this.message;

--- a/app/javascript/widget/components/UserMessage.vue
+++ b/app/javascript/widget/components/UserMessage.vue
@@ -5,7 +5,7 @@ import ImageBubble from 'widget/components/ImageBubble.vue';
 import VideoBubble from 'widget/components/VideoBubble.vue';
 import FluentIcon from 'shared/components/FluentIcon/Index.vue';
 import FileBubble from 'widget/components/FileBubble.vue';
-import { useLocaleDateFormatter } from 'dashboard/composables/useLocaleDateFormatter';
+import useLocaleDateFormatter from 'dashboard/composables/useLocaleDateFormatter';
 import messageMixin from '../mixins/messageMixin';
 import ReplyToChip from 'widget/components/ReplyToChip.vue';
 import DragWrapper from 'widget/components/DragWrapper.vue';

--- a/app/javascript/widget/components/UserMessage.vue
+++ b/app/javascript/widget/components/UserMessage.vue
@@ -57,7 +57,7 @@ export default {
     },
     readableTime() {
       const { created_at: createdAt = '' } = this.message;
-      return messageStamp(createdAt);
+      return messageStamp(createdAt, false, this.$i18n.locale);
     },
     isFailed() {
       const { status = '' } = this.message;

--- a/app/javascript/widget/helpers/specs/urlParamsHelper.spec.js
+++ b/app/javascript/widget/helpers/specs/urlParamsHelper.spec.js
@@ -9,10 +9,8 @@ describe('#buildSearchParamsWithLocale', () => {
     let windowSpy = vi.spyOn(window, 'window', 'get');
     windowSpy.mockImplementation(() => ({
       WOOT_WIDGET: {
-        $root: {
-          $i18n: {
-            locale: 'el',
-          },
+        $i18n: {
+          locale: 'el',
         },
       },
     }));

--- a/app/javascript/widget/helpers/urlParamsHelper.js
+++ b/app/javascript/widget/helpers/urlParamsHelper.js
@@ -1,6 +1,6 @@
 export const buildSearchParamsWithLocale = search => {
   // [TODO] for now this works, but we will need to find a way to get the locale from the root component
-  const locale = window.WOOT_WIDGET.$root.$i18n.locale;
+  const locale = window.WOOT_WIDGET.$i18n.locale;
   const params = new URLSearchParams(search);
   params.append('locale', locale);
 

--- a/app/javascript/widget/store/modules/specs/conversation/actions.spec.js
+++ b/app/javascript/widget/store/modules/specs/conversation/actions.spec.js
@@ -20,10 +20,8 @@ describe('#actions', () => {
       let windowSpy = vi.spyOn(window, 'window', 'get');
       windowSpy.mockImplementation(() => ({
         WOOT_WIDGET: {
-          $root: {
-            $i18n: {
-              locale: 'el',
-            },
+          $i18n: {
+            locale: 'el',
           },
         },
         location: {
@@ -100,10 +98,8 @@ describe('#actions', () => {
       const windowSpy = vi.spyOn(window, 'window', 'get');
       windowSpy.mockImplementation(() => ({
         WOOT_WIDGET: {
-          $root: {
-            $i18n: {
-              locale: 'ar',
-            },
+          $i18n: {
+            locale: 'ar',
           },
         },
         location: {


### PR DESCRIPTION

# Pull Request Template

## Description

I decided to close PR https://github.com/chatwoot/chatwoot/pull/10360 and split it into 2 separate PRs.

1. When applying a new language setting from the account settings, date and time formatting is applied to the language of choice. Previously, only the 'en' localization was applied. This caused confusion and doubt for the end user.
2. Other changes have also been applied to translate texts that were not handled by the i18n library ​​that contain region code.

Resolves https://github.com/chatwoot/chatwoot/issues/7862, https://github.com/chatwoot/chatwoot/issues/9285, https://github.com/chatwoot/chatwoot/issues/10327

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

1. Go to app.chatwoot.com/app/accounts/1/settings/general and change the account language.
2. All pages showing dates will be in the correct format for your locale.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
