### PR TITLE
chore: set rack-timeout to log at ERROR level

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,7 @@
+
+require "rack-timeout"
+
+# Reduce noise by filtering state=ready and state=completed which are logged at INFO level
+Rails.application.config.after_initialize do
+  Rack::Timeout::Logger.level = Logger::ERROR
+end

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,5 +1,4 @@
-
-require "rack-timeout"
+require 'rack-timeout'
 
 # Reduce noise by filtering state=ready and state=completed which are logged at INFO level
 Rails.application.config.after_initialize do


### PR DESCRIPTION
# Pull Request Template

## Context
40 % of Chatwoot's current log volume is from state transition logs generated by `rack-timeout`, which are logged at the `INFO` level. 


## Description

- Reduce the noise in logs
- Set RACK::TIMEOUT to log at `error` level
- Bring down log volume by 40% (cost-savings)


Fixes https://linear.app/chatwoot/issue/CW-3714/newrelic-set-rack-timeout-log-level-to-error

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested in staging

Logs before and after deploying the branch
----
<img width="1674" alt="image" src="https://github.com/user-attachments/assets/f3928fdb-582a-46f3-8499-5bd926c909bc">

Note: The graph is flat in the first half due to the paper trail running out of credits. I upgraded the paper trail first to ensure logs were coming in and then made the deployment.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
