### PR TITLE
fix: Remove duplicate `/` character on the proxy route

### DIFF
--- a/app/controllers/api/v1/accounts/integrations/captain_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/captain_controller.rb
@@ -18,11 +18,11 @@ class Api::V1::Accounts::Integrations::CaptainController < Api::V1::Accounts::Ba
   end
 
   def request_path
-    if params[:route] == '/sessions/profile'
-      'api/sessions/profile'
-    else
-      "api/accounts/#{hook.settings['account_id']}/#{params[:route]}"
-    end
+    request_route = with_leading_hash_on_route(params[:route])
+
+    return 'api/sessions/profile' if request_route == '/sessions/profile'
+
+    "api/accounts/#{hook.settings['account_id']}#{request_route}"
   end
 
   def request_url
@@ -39,6 +39,12 @@ class Api::V1::Accounts::Integrations::CaptainController < Api::V1::Accounts::Ba
     raise 'Invalid or missing HTTP method' unless %w[get post put patch delete options head].include?(method)
 
     method
+  end
+
+  def with_leading_hash_on_route(request_route)
+    return '' if request_route.blank?
+
+    request_route.start_with?('/') ? request_route : "/#{request_route}"
   end
 
   def permitted_params


### PR DESCRIPTION
The proxy method adds an extra slash even if the route param has the character. It’s challenging to check the expected format on each route. The simplest solution is to check if the route param begins with a slash, and if not, append one.

NB: The existing tests are sufficient to cover this case. There’s no need for an additional test to specifically test this.