### PR TITLE
feat: add judoscaler gem for heroku autoscaling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -182,8 +182,8 @@ group :production do
   # we dont want request timing out in development while using byebug
   gem 'rack-timeout'
   # for heroku autoscaling
-  gem "judoscale-rails"
-  gem "judoscale-sidekiq"
+  gem "judoscale-rails", require: false
+  gem "judoscale-sidekiq", require: false
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -182,8 +182,8 @@ group :production do
   # we dont want request timing out in development while using byebug
   gem 'rack-timeout'
   # for heroku autoscaling
-  gem "judoscale-rails", require: false
-  gem "judoscale-sidekiq", require: false
+  gem 'judoscale-rails', require: false
+  gem 'judoscale-sidekiq', require: false
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -181,6 +181,9 @@ gem 'reverse_markdown'
 group :production do
   # we dont want request timing out in development while using byebug
   gem 'rack-timeout'
+  # for heroku autoscaling
+  gem "judoscale-rails"
+  gem "judoscale-sidekiq"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,6 +397,13 @@ GEM
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       uri_template (~> 0.7)
+    judoscale-rails (1.8.2)
+      judoscale-ruby (= 1.8.2)
+      railties
+    judoscale-ruby (1.8.2)
+    judoscale-sidekiq (1.8.2)
+      judoscale-ruby (= 1.8.2)
+      sidekiq (>= 5.0)
     jwt (2.8.1)
       base64
     kaminari (1.2.2)
@@ -891,6 +898,8 @@ DEPENDENCIES
   jbuilder
   json_refs
   json_schemer
+  judoscale-rails
+  judoscale-sidekiq
   jwt
   kaminari
   koala

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,12 @@ if ENV.fetch('SENTRY_DSN', false).present?
   require 'sentry-sidekiq'
 end
 
+# heroku autoscaling
+if ENV.fetch('JUDOSCALE_URL', false).present?
+  require "judoscale-rails"
+  require "judoscale-sidekiq"
+end
+
 module Chatwoot
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,8 +29,8 @@ end
 
 # heroku autoscaling
 if ENV.fetch('JUDOSCALE_URL', false).present?
-  require "judoscale-rails"
-  require "judoscale-sidekiq"
+  require 'judoscale-rails'
+  require 'judoscale-sidekiq'
 end
 
 module Chatwoot


### PR DESCRIPTION
# Pull Request Template

## Description

- add judoscaler gem to allow judoscale use in heroku environments
- This will allow auto scaling for both web and worker dynos across both standard-1x/2x and performance dynos
- This will scaling in response to queue time rather than response time(heroku default)
- This also allows you to scale multiple dynos in and out at once, rather than scaling them one at a time, as is the default.

Ref
----
1. https://judoscale.com/
2. https://devcenter.heroku.com/articles/judoscale

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Tested on staging

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
