### PR TITLE
fix: Retrieve Incoming Messages Based on Agent-Assigned Conversations #10423

### DIFF
--- a/app/builders/v2/reports/timeseries/count_report_builder.rb
+++ b/app/builders/v2/reports/timeseries/count_report_builder.rb
@@ -30,7 +30,11 @@ class V2::Reports::Timeseries::CountReportBuilder < V2::Reports::Timeseries::Bas
   end
 
   def scope_for_incoming_messages_count
-    scope.messages.where(account_id: account.id, created_at: range).incoming.unscope(:order)
+    scope.conversations
+      .where(account_id: account.id)
+      .joins(:messages)
+      .where(messages: { created_at: range, message_type: 0 })
+      .unscope(:order)
   end
 
   def scope_for_outgoing_messages_count


### PR DESCRIPTION
## Description

This pull request updates the query logic used to fetch incoming messages for the "Agents - Messages Received" report.

Previously, the query did not correctly associate incoming messages with the agent since incoming messages do not have a direct relationship with the agent. The new implementation retrieves incoming messages from conversations assigned to the agent, ensuring the metric is accurate.

Fixes #10423

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Created conversations assigned to agents and sent incoming messages through a Website Inbox.
- Verified that the "Messages Received" count in Reports → Agents updates accurately.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
