### PR TITLE
chore: disable newrelic monitoring on staging env

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -58,6 +58,7 @@ test:
 staging:
   <<: *default_settings
   app_name: <%= ENV.fetch('NEW_RELIC_APP_NAME', 'Chatwoot')  %> (Staging)
+  monitor_mode: <%= ENV.fetch('NEW_RELIC_STAGING_MONITORING_ENABLED', false) %>
 
 production:
   <<: *default_settings


### PR DESCRIPTION
# Pull Request Template

## Description
- Disable newrelic monitoring in staging environments by default
- Use `NEW_RELIC_STAGING_MONITORING_ENABLED` env variable to toggle this behavior if needed

Fixes https://linear.app/chatwoot/issue/CW-3724/newrelic-disable-monitoring-in-staging-env

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Tested in staging

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
