### PR TITLE
fix: Remove the warnings generated from the Sidebar component

### DIFF
--- a/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
+++ b/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
@@ -140,7 +140,12 @@ const menuItems = computed(() => {
             name: `${inbox.name}-${inbox.id}`,
             label: inbox.name,
             to: accountScopedRoute('inbox_dashboard', { inbox_id: inbox.id }),
-            component: leafProps => h(ChannelLeaf, { ...leafProps, inbox }),
+            component: leafProps =>
+              h(ChannelLeaf, {
+                label: leafProps.label,
+                active: leafProps.active,
+                inbox,
+              }),
           })),
         },
         {


### PR DESCRIPTION
The following warning occurred since the `ChannelLeaf` component was passed extra props. This PR fixes it by passing only the required props

![image](https://github.com/user-attachments/assets/68587e94-6c66-4167-9766-39c68eba61d9)
