### PR TITLE
chore: Disable throwing error for malformed to address

### DIFF
--- a/spec/mailboxes/application_mailbox_spec.rb
+++ b/spec/mailboxes/application_mailbox_spec.rb
@@ -69,18 +69,26 @@ RSpec.describe ApplicationMailbox do
     end
 
     describe 'Invalid Mail To Address' do
-      it 'raises error when mail.to header is malformed' do
-        expect do
-          described_class.route mail_with_invalid_to_address
-        end.to raise_error(StandardError,
-                           'Invalid email to address header <vishnu@chatwoot.com>vishnu@chatwoot.com')
+      let(:logger) { double }
+
+      before do
+        allow(Rails).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:error)
       end
 
-      it 'raises another error when mail.to header is malformed' do
+      it 'will not raise error when mail.to header is malformed format 1' do
+        expect(logger).to receive(:error).with("Email to address header is malformed `#{mail_with_invalid_to_address.mail.to}`")
+        expect do
+          described_class.route mail_with_invalid_to_address
+        end.not_to raise_error
+      end
+
+      it 'will not raise error when mail.to header is malformed format 2' do
+        expect(logger).to receive(:error).with("Email to address header is malformed `#{mail_with_invalid_to_address_2.mail.to}`")
+
         expect do
           described_class.route mail_with_invalid_to_address_2
-        end.to raise_error(StandardError,
-                           'Invalid email to address header vishnu@chatwoot.com www.chatwoot.com')
+        end.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
We don't need to raise error on sentry for malformed to address as it is already logged.

ref: https://linear.app/chatwoot/issue/CW-3151/standarderror-invalid-email-to-address-header-standarderror

