### PR TITLE
fix: messages overlap when switching tabs too quickly

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -25,6 +25,9 @@ export const hasMessageFailedWithExternalError = pendingMessage => {
   return status === MESSAGE_STATUS.FAILED && externalError !== '';
 };
 
+// variables
+let currentRequestId = 0;
+
 // actions
 const actions = {
   getConversation: async ({ commit }, conversationId) => {
@@ -38,18 +41,21 @@ const actions = {
   },
 
   fetchAllConversations: async ({ commit, state, dispatch }) => {
+    const requestId = ++currentRequestId;
     commit(types.SET_LIST_LOADING_STATUS);
     try {
       const params = state.conversationFilters;
       const {
         data: { data },
       } = await ConversationApi.get(params);
-      buildConversationList(
-        { commit, dispatch },
-        params,
-        data,
-        params.assigneeType
-      );
+      if (requestId === currentRequestId) {
+        buildConversationList(
+          { commit, dispatch },
+          params,
+          data,
+          params.assigneeType
+        );
+      }
     } catch (error) {
       // Handle error
     }


### PR DESCRIPTION
# Pull Request Template

## Description

When switching between message categories ('All Conversations', 'Mentions', 'Unattended'), the messages displayed should correspond to the selected category. If I switch categories quickly, messages from the previously selected category sometimes appear in the new one. It seems that messages from one category are being loaded into another due to some delay or overlapping request handling.

An incremental identifier ensures that only the data from the most recent request is processed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

Simulated rapid switching between message categories ('All Conversations', 'Mentions', and 'Unattended') to replicate the conditions where messages from one category were loaded into another. After the code update, performed the same rapid switching to confirm that messages now load correctly and correspond to the selected category without overlap.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
