### PR TITLE
fix: Contact Attributes resetting when form is updated

### DIFF
--- a/app/javascript/dashboard/components-next/Contacts/Pages/ContactDetails.vue
+++ b/app/javascript/dashboard/components-next/Contacts/Pages/ContactDetails.vue
@@ -68,7 +68,8 @@ const handleFormUpdate = updatedData => {
 
 const updateContact = async () => {
   try {
-    await store.dispatch('contacts/update', contactData.value);
+    const { customAttributes, ...basicContactData } = contactData.value;
+    await store.dispatch('contacts/update', basicContactData);
     useAlert(t('CONTACTS_LAYOUT.CARD.EDIT_DETAILS_FORM.SUCCESS_MESSAGE'));
   } catch (error) {
     useAlert(t('CONTACTS_LAYOUT.CARD.EDIT_DETAILS_FORM.ERROR_MESSAGE'));


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes https://linear.app/chatwoot/issue/CW-3773/contact-attributes-getting-reset-when-the-form-is-updated

**Cause of issue**
The issue occurs because the `contactData` state is updated with the selected contact's data. Upon updating the contact form, the `contactData` object is reassigned with the updated values.

Initially, on component mount, the `contactData` reference is set with the full selected contact's values. When the update button is clicked, the `contactData` reference is passed as a parameter. This includes non-updated or outdated custom attribute values if custom attributes are edited but not properly managed during the update. As a result, the custom attributes are reset when the form is updated.

**Solution**
During the update contact trigger, only the base contact data is passed, excluding the custom attributes. This ensures that the custom attributes remain unaffected.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Before**
https://www.loom.com/share/242a1936906048e9a7d1b53d72ec45c0?t=1

**After**
https://www.loom.com/share/f8c4ee3f99af4130b2dc125ee5855ccf?sid=448a8758-8683-4615-9b8b-1fbcac272e55


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
