### PR TITLE
fix: Fetch assignable agents in expanded layout

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ConversationBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationBox.vue
@@ -62,10 +62,13 @@ export default {
     },
   },
   watch: {
-    'currentChat.inbox_id'(inboxId) {
-      if (inboxId) {
-        this.$store.dispatch('inboxAssignableAgents/fetch', [inboxId]);
-      }
+    'currentChat.inbox_id': {
+      immediate: true,
+      handler(inboxId) {
+        if (inboxId) {
+          this.$store.dispatch('inboxAssignableAgents/fetch', [inboxId]);
+        }
+      },
     },
     'currentChat.id'() {
       this.fetchLabels();


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes https://linear.app/chatwoot/issue/CW-3771/list-of-the-agents-are-not-appearing-in-the-full-width-layout

**Cause of issue**
The watcher in `ConversationBox` component did not handle the initial state correctly when mounted in the expanded layout. This was due to:
1. Differences in the mounting and chat selection timing between the expanded and condensed layouts.
2. The `currentChat.inbox_id` watcher wasn't set up to handle the initial state properly.

**Solution**
The watcher was updated to use the object syntax with a handler function and the `immediate: true` option. This ensures that the watcher executes immediately upon component mounting, irrespective of the layout type. Consequently, inbox assignable agents are fetched promptly whenever an `inbox_id` becomes available in both expanded and condensed layouts.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Before**
https://www.loom.com/share/65fec03ce27e41e884b18748ec601c94?sid=b731e706-b921-465a-b983-59735a700816

**After**
https://www.loom.com/share/b9d6d9c008d741a8aacf3df81c6106bb?sid=5d689f78-e93b-45c4-b7d6-1f3a58785cd3


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
