### PR TITLE
feat: Flag icon component

### DIFF
--- a/app/javascript/dashboard/assets/scss/_woot.scss
+++ b/app/javascript/dashboard/assets/scss/_woot.scss
@@ -34,8 +34,6 @@
 @import 'plugins/multiselect';
 @import 'plugins/dropdown';
 
-@import 'flag-icons/css/flag-icons.min.css';
-
 .tooltip {
   @apply bg-slate-900 text-white py-1 px-2 z-40 text-xs rounded-md dark:bg-slate-200 dark:text-slate-900 max-w-96;
 }

--- a/app/javascript/dashboard/assets/scss/_woot.scss
+++ b/app/javascript/dashboard/assets/scss/_woot.scss
@@ -34,6 +34,8 @@
 @import 'plugins/multiselect';
 @import 'plugins/dropdown';
 
+@import 'flag-icons/css/flag-icons.min.css';
+
 .tooltip {
   @apply bg-slate-900 text-white py-1 px-2 z-40 text-xs rounded-md dark:bg-slate-200 dark:text-slate-900 max-w-96;
 }

--- a/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
@@ -6,6 +6,7 @@ import CardLayout from 'dashboard/components-next/CardLayout.vue';
 import ContactsForm from 'dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
+import Flag from 'dashboard/components-next/flag/Flag.vue';
 import countries from 'shared/constants/countries';
 
 const props = defineProps({
@@ -56,13 +57,19 @@ const countryDetails = computed(() => {
 
   if (!activeCountry) return null;
 
-  const parts = [
-    activeCountry.emoji,
-    city ? `${city},` : null,
-    activeCountry.name,
-  ].filter(Boolean);
+  return {
+    countryCode: activeCountry.id,
+    city: city ? `${city},` : null,
+    name: activeCountry.name,
+  };
+});
 
-  return parts.length ? parts.join(' ') : null;
+const formattedLocation = computed(() => {
+  if (!countryDetails.value) return '';
+
+  return [countryDetails.value.city, countryDetails.value.name]
+    .filter(Boolean)
+    .join(' ');
 });
 
 const handleFormUpdate = updatedData => {
@@ -114,8 +121,12 @@ const onClickViewDetails = () => emit('showContact', props.id);
             {{ phoneNumber }}
           </span>
           <div v-if="phoneNumber" class="w-px h-3 truncate bg-n-slate-6" />
-          <span v-if="countryDetails" class="text-sm truncate text-n-slate-11">
-            {{ countryDetails }}
+          <span
+            v-if="countryDetails"
+            class="inline-flex items-center gap-2 text-sm truncate text-n-slate-11"
+          >
+            <Flag :country="countryDetails.countryCode" class="size-3.5" />
+            {{ formattedLocation }}
           </span>
           <div v-if="countryDetails" class="w-px h-3 truncate bg-n-slate-6" />
           <Button

--- a/app/javascript/dashboard/components-next/flag/Flag.vue
+++ b/app/javascript/dashboard/components-next/flag/Flag.vue
@@ -18,3 +18,7 @@ const renderFlag = () => {
 <template>
   <component :is="renderFlag" />
 </template>
+
+<style>
+@import 'flag-icons/css/flag-icons.min.css';
+</style>

--- a/app/javascript/dashboard/components-next/flag/Flag.vue
+++ b/app/javascript/dashboard/components-next/flag/Flag.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { h, defineProps } from 'vue';
+
+const props = defineProps({
+  country: { type: String, required: true },
+  squared: { type: Boolean, default: false },
+});
+
+const renderFlag = () => {
+  const classes = ['fi', `fi-${props.country.toLowerCase()}`, 'flex-shrink-0'];
+  if (props.squared) {
+    classes.push('fis');
+  }
+  return h('span', { class: classes });
+};
+</script>
+
+<template>
+  <component :is="renderFlag" />
+</template>

--- a/app/javascript/dashboard/components-next/flag/story/Flag.story.vue
+++ b/app/javascript/dashboard/components-next/flag/story/Flag.story.vue
@@ -24,12 +24,22 @@ const BasicTemplate = {
 
 const SizeVariants = {
   components: { Flag },
+  setup() {
+    const isSquared = ref(false);
+    return { isSquared };
+  },
   template: `
-    <div class="flex items-center gap-4 p-4 border rounded border-n-weak">
-      <Flag country="in" class="size-4" />
-      <Flag country="in" class="size-6" />
-      <Flag country="in" class="size-8" />
-      <Flag country="in" class="size-10" />
+    <div class="flex flex-col gap-4">
+      <label class="flex items-center gap-2">
+        <input type="checkbox" v-model="isSquared">
+        Squared flags
+      </label>
+      <div class="flex items-center gap-4 p-4 border rounded border-n-weak">
+        <Flag country="in" class="!size-4" :squared="isSquared" />
+        <Flag country="in" class="!size-6" :squared="isSquared" />
+        <Flag country="in" class="!size-8" :squared="isSquared" />
+        <Flag country="in" class="!size-10" :squared="isSquared" />
+      </div>
     </div>
   `,
 };
@@ -69,7 +79,7 @@ const AllFlags = {
 <template>
   <Story title="Components/Flag">
     <Variant title="Basic Usage">
-      <BasicTemplate country="us" squared />
+      <BasicTemplate country="us" :squared="false" />
     </Variant>
 
     <Variant title="Size Variants">

--- a/app/javascript/dashboard/components-next/flag/story/Flag.story.vue
+++ b/app/javascript/dashboard/components-next/flag/story/Flag.story.vue
@@ -3,17 +3,22 @@ import { ref } from 'vue';
 import Flag from '../Flag.vue';
 import countries from 'shared/constants/countries';
 
-const story = {
-  title: 'Components/Flag',
-  component: Flag,
-};
-
 const BasicTemplate = {
   components: { Flag },
+  props: {
+    country: {
+      type: String,
+      default: 'us',
+    },
+    squared: {
+      type: Boolean,
+      default: false,
+    },
+  },
   template: `
     <div class="flex items-center gap-4 p-4 border rounded border-n-weak">
-      <Flag country="us" />
-      <Flag country="us" squared />
+      <Flag :country="country" />
+      <Flag :country="country" :squared="squared" />
     </div>
   `,
 };
@@ -63,9 +68,9 @@ const AllFlags = {
 </script>
 
 <template>
-  <Story :title="story.title">
+  <Story title="Components/Flag">
     <Variant title="Basic Usage">
-      <BasicTemplate />
+      <BasicTemplate country="us" squared />
     </Variant>
 
     <Variant title="Size Variants">

--- a/app/javascript/dashboard/components-next/flag/story/Flag.story.vue
+++ b/app/javascript/dashboard/components-next/flag/story/Flag.story.vue
@@ -17,7 +17,6 @@ const BasicTemplate = {
   },
   template: `
     <div class="flex items-center gap-4 p-4 border rounded border-n-weak">
-      <Flag :country="country" />
       <Flag :country="country" :squared="squared" />
     </div>
   `,

--- a/app/javascript/dashboard/components-next/flag/story/Flag.story.vue
+++ b/app/javascript/dashboard/components-next/flag/story/Flag.story.vue
@@ -1,0 +1,79 @@
+<script setup>
+import { ref } from 'vue';
+import Flag from '../Flag.vue';
+import countries from 'shared/constants/countries';
+
+const story = {
+  title: 'Components/Flag',
+  component: Flag,
+};
+
+const BasicTemplate = {
+  components: { Flag },
+  template: `
+    <div class="flex items-center gap-4 p-4 border rounded border-n-weak">
+      <Flag country="us" />
+      <Flag country="us" squared />
+    </div>
+  `,
+};
+
+const SizeVariants = {
+  components: { Flag },
+  template: `
+    <div class="flex items-center gap-4 p-4 border rounded border-n-weak">
+      <Flag country="in" class="size-4" />
+      <Flag country="in" class="size-6" />
+      <Flag country="in" class="size-8" />
+      <Flag country="in" class="size-10" />
+    </div>
+  `,
+};
+
+const AllFlags = {
+  components: { Flag },
+  setup() {
+    const isSquared = ref(false);
+    return { countries, isSquared };
+  },
+  template: `
+    <div class="flex flex-col gap-4">
+      <label class="flex items-center gap-2">
+        <input type="checkbox" v-model="isSquared">
+        Squared flags
+      </label>
+
+      <div class="grid grid-cols-2 gap-4 p-4 border rounded border-n-strong md:grid-cols-3 lg:grid-cols-4">
+        <div 
+          v-for="country in countries" 
+          :key="country.id"
+          class="flex items-center gap-2 px-4 py-2 border rounded border-n-strong"
+        >
+          <Flag 
+            :country="country.id" 
+            :squared="isSquared"
+            class="size-6" 
+          />
+          <span class="text-sm">{{ country.name }}</span>
+        </div>
+      </div>
+    </div>
+  `,
+};
+</script>
+
+<template>
+  <Story :title="story.title">
+    <Variant title="Basic Usage">
+      <BasicTemplate />
+    </Variant>
+
+    <Variant title="Size Variants">
+      <SizeVariants />
+    </Variant>
+
+    <Variant title="All Flags">
+      <AllFlags />
+    </Variant>
+  </Story>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -9,7 +9,6 @@ import SocialIcons from './SocialIcons.vue';
 import EditContact from './EditContact.vue';
 import NewConversation from './NewConversation.vue';
 import ContactMergeModal from 'dashboard/modules/contact/ContactMergeModal.vue';
-import { getCountryFlag } from 'dashboard/helper/flag';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import {
   isAConversationRoute,
@@ -127,8 +126,12 @@ export default {
     },
     findCountryFlag(countryCode, cityAndCountry) {
       try {
-        const countryFlag = countryCode ? getCountryFlag(countryCode) : '🌎';
-        return `${cityAndCountry} ${countryFlag}`;
+        if (!countryCode) {
+          return `${cityAndCountry} 🌎`;
+        }
+
+        const code = countryCode?.toLowerCase();
+        return `${cityAndCountry} <span class="fi fi-${code} size-3.5"></span>`;
       } catch (error) {
         return '';
       }

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfoRow.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfoRow.vue
@@ -87,10 +87,9 @@ export default {
       />
       <span
         v-if="value"
+        v-dompurify-html="value"
         class="overflow-hidden text-sm whitespace-nowrap text-ellipsis"
-      >
-        {{ value }}
-      </span>
+      />
       <span v-else class="text-sm text-slate-300 dark:text-slate-600">{{
         $t('CONTACT_PANEL.NOT_AVAILABLE')
       }}</span>

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "date-fns": "2.21.1",
     "date-fns-tz": "^1.3.3",
     "dompurify": "3.1.6",
+    "flag-icons": "^7.2.3",
     "floating-vue": "^5.2.2",
     "highlight.js": "^11.10.0",
     "idb": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       dompurify:
         specifier: 3.1.6
         version: 3.1.6
+      flag-icons:
+        specifier: ^7.2.3
+        version: 7.2.3
       floating-vue:
         specifier: ^5.2.2
         version: 5.2.2(vue@3.5.12(typescript@5.6.2))
@@ -2853,6 +2856,9 @@ packages:
   find-up@6.3.0:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  flag-icons@7.2.3:
+    resolution: {integrity: sha512-X2gUdteNuqdNqob2KKTJTS+ZCvyWeLCtDz9Ty8uJP17Y4o82Y+U/Vd4JNrdwTAjagYsRznOn9DZ+E/Q52qbmqg==}
 
   flat-cache@3.1.0:
     resolution: {integrity: sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==}
@@ -8163,6 +8169,8 @@ snapshots:
     dependencies:
       locate-path: 7.2.0
       path-exists: 5.0.0
+
+  flag-icons@7.2.3: {}
 
   flat-cache@3.1.0:
     dependencies:


### PR DESCRIPTION
# Pull Request Template

## Description

This PR introduces a new `Flag` component that provides a way to display country flags using the [flag-icons](https://github.com/lipis/flag-icons?tab=readme-ov-file#flag-icons) library.

### Props

| Prop | Type | Required | Default | Description |
|------|------|----------|---------|-------------|
| `country` | String | Yes | - | ISO 3166-1-alpha-2 country code (e.g., 'US', 'GB', 'FR') |
| `squared` | Boolean | No | `false` | Display flag in square format |

### Features
- Supports all country flags from ISO 3166-1-alpha-2 standard
- Customizable size using Tailwind's size utilities
- Supports both rectangular and squared formats
- Inherits custom classes for additional styling
- Prevents shrinking with `flex-shrink-0`


### Story
<img width="213" alt="image" src="https://github.com/user-attachments/assets/57f879b6-5099-4d0c-8c3e-6986a50d0601">
<img width="246" alt="image" src="https://github.com/user-attachments/assets/5652ec1c-8c20-49cb-8204-954ab45b2ff9">
<img width="246" alt="image" src="https://github.com/user-attachments/assets/e3283611-85f2-41c3-aa14-fe0eafb1395d">


**All flags**
<img width="2069" alt="image" src="https://github.com/user-attachments/assets/187b2642-b217-4998-bd86-d731cb421e84">


### Preview

**Contact card**
<img width="980" alt="image" src="https://github.com/user-attachments/assets/39e4e4d8-1418-4254-a7be-a69b199d76ac">


**Conversation sidebar**
<img width="393" alt="image" src="https://github.com/user-attachments/assets/8a9f3683-a797-4474-b54b-a75aecc89a0c">
