### PR TITLE
fix: Update old data to fix login issues

### DIFF
--- a/db/migrate/20241217041352_fix_old_audio_alert_data.rb
+++ b/db/migrate/20241217041352_fix_old_audio_alert_data.rb
@@ -1,0 +1,18 @@
+class FixOldAudioAlertData < ActiveRecord::Migration[7.0]
+  def change
+    # rubocop:disable Rails/SkipsModelValidations
+
+    # Update users with audio alerts enabled to 'mine'
+    User.where(
+      "users.ui_settings #>> '{enable_audio_alerts}' = ?", 'true'
+    ).update_all(
+      "ui_settings = jsonb_set(ui_settings, '{enable_audio_alerts}', '\"mine\"')"
+    )
+
+    # Update users with audio alerts enabled to 'none'
+    User
+      .where("users.ui_settings #>> '{enable_audio_alerts}' = ?", 'true')
+      .update_all("ui_settings = jsonb_set(ui_settings, '{enable_audio_alerts}', '\"mine\"')")
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_23_215335) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_17_041352) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"


### PR DESCRIPTION
The following lines caused issues for some users, specifically those who signed up in 2021 when audio alerts were implemented as a flag. The data type update for the flag was not handled correctly. This PR fixes the issue by updating it to a compatible value.

https://github.com/chatwoot/chatwoot/blob/9410b3bcbbb7aba4b790f33bea52a430bf69466c/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js#L76-L81