### PR TITLE
fix: Clean empty option in numbered list message

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -654,6 +654,7 @@ export default {
       if (this.isReplyButtonDisabled) {
         return;
       }
+      this.message = this.removeEmptyOptionFromNumberedList(this.message);
       if (!this.showMentions) {
         const isOnWhatsApp =
           this.isATwilioWhatsAppChannel ||
@@ -1065,6 +1066,9 @@ export default {
       this.attachedFiles = this.attachedFiles.filter(
         file => !file?.isRecordedAudio
       );
+    },
+    removeEmptyOptionFromNumberedList(message) {
+      return message.replace(/\d+\.\s*$/, '');
     },
   },
 };


### PR DESCRIPTION
This PR fixes the following issue:
- https://github.com/chatwoot/chatwoot/issues/10610
(creation of empty options in numbered lists when sending messages with "Ctrl + Enter")

### BEFORE
![image](https://github.com/user-attachments/assets/6741b4b5-41b8-40db-ba1f-43172c4e47d6)
----
### AFTER
![image](https://github.com/user-attachments/assets/e981a6bc-1c15-407e-b558-b401a493ae49)
