### PR TITLE
chore: Avoid contact inboxes getting deleted

### DIFF
--- a/app/actions/contact_merge_action.rb
+++ b/app/actions/contact_merge_action.rb
@@ -54,7 +54,7 @@ class ContactMergeAction
     # attributes in base contact are given preference
     merged_attributes = mergee_contact_attributes.deep_merge(base_contact_attributes)
 
-    @mergee_contact.destroy!
+    @mergee_contact.reload.destroy!
     Rails.configuration.dispatcher.dispatch(CONTACT_MERGED, Time.zone.now, contact: @base_contact,
                                                                            tokens: [@base_contact.contact_inboxes.filter_map(&:pubsub_token)])
     @base_contact.update!(merged_attributes)


### PR DESCRIPTION
We observed some rare instances on prod where a contact inbox was getting deleted during the contact merge action. the potential suspect is contact inbox objects already loaded into the memory getting cleared through the destroy association job. Reloading the object to avoid this case !!!