### PR TITLE
chore: Configure iOS universal linking

### DIFF
--- a/app/views/apple_app/site_association.html.erb
+++ b/app/views/apple_app/site_association.html.erb
@@ -4,7 +4,7 @@
         "details": [
             {
                 "appID": "<%= ENV['IOS_APP_ID'] %>",
-                "paths": [ "NOT /super_admin/*", "*" ]
+                "paths": [ "NOT /super_admin/*", "/app/accounts/*/conversations/*" ]
             }
         ]
     }

--- a/app/views/apple_app/site_association.html.erb
+++ b/app/views/apple_app/site_association.html.erb
@@ -4,7 +4,7 @@
         "details": [
             {
                 "appID": "<%= ENV['IOS_APP_ID'] %>",
-                "paths": [ "NOT /super_admin/*", "/app/accounts/*/conversations/*" ]
+                "paths": [ "/app/accounts/*/conversations/*"]
             }
         ]
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -461,8 +461,8 @@ Rails.application.routes.draw do
 
   # ----------------------------------------------------------------------
   # Routes for external service verifications
-  get 'apple-app-site-association' => 'apple_app#site_association'
   get '.well-known/assetlinks.json' => 'android_app#assetlinks'
+  get '.well-known/apple-app-site-association' => 'apple_app#site_association'
   get '.well-known/microsoft-identity-association.json' => 'microsoft#identity_association'
 
   # ----------------------------------------------------------------------

--- a/spec/controllers/apple_app_spec.rb
+++ b/spec/controllers/apple_app_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-describe '/apple-app-site-association', type: :request do
-  describe 'GET /apple-app-site-association' do
+describe '.well-known/apple-app-site-association', type: :request do
+  describe 'GET /.well-known/apple-app-site-association' do
     it 'renders the apple-app-site-association file' do
-      get '/apple-app-site-association'
+      get '/.well-known/apple-app-site-association'
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
- Moved `apple-app-site-association` to `.well-known/apple-app-site-association`
- Updated the paths pattern to accept conversation links only.