### PR TITLE
feat: switch to postgres docker images with pgvector support (v4.0)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     network_mode: service:db
 
   db:
-    image: postgres:latest
+    image: pgvector/pgvector:pg16
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -35,7 +35,7 @@ services:
     restart: always
 
   postgres:
-    image: postgres:12
+    image: pgvector/pgvector:pg16
     restart: always
     ports:
       - '127.0.0.1:5432:5432'

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -39,7 +39,7 @@ services:
     command: ['bundle', 'exec', 'sidekiq', '-C', 'config/sidekiq.yml']
 
   postgres:
-    image: postgres:12
+    image: pgvector/pgvector:pg16
     restart: always
     ports:
       - '5432:5432'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -83,7 +83,7 @@ services:
     command: bin/vite dev
 
   postgres:
-    image: postgres:12
+    image: pgvector/pgvector:pg16
     restart: always
     ports:
       - '5432:5432'


### PR DESCRIPTION
# Pull Request Template

## Description

Starting v4.0, pgvector support is mandatory. This PR adds pgvector support for new docker installations.

- Switch to postgres images with pgvector support
- Change the default postgres version from `12` to `16`
 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

- Tested on a new docker installation running on ec2
- Upgrade existing installation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
