### PR TITLE
fix: Exclude notifications for blocked contacts, except mentions

### DIFF
--- a/app/builders/notification_builder.rb
+++ b/app/builders/notification_builder.rb
@@ -25,6 +25,8 @@ class NotificationBuilder
   def build_notification
     # Create conversation_creation notification only if user is subscribed to it
     return if notification_type == 'conversation_creation' && !user_subscribed_to_notification?
+    # skip notifications for blocked conversations except for user mentions
+    return if primary_actor.contact.blocked? && notification_type != 'conversation_mention'
 
     user.notifications.create!(
       notification_type: notification_type,

--- a/spec/builders/notification_builder_spec.rb
+++ b/spec/builders/notification_builder_spec.rb
@@ -56,11 +56,37 @@ describe NotificationBuilder do
       ).to be_nil
     end
 
-    it 'will create a conversation_mention notification eventhough user is not subscribed to it' do
+    it 'will create a conversation_mention notification even though user is not subscribed to it' do
       notification_setting = user.notification_settings.find_by(account_id: account.id)
       notification_setting.selected_email_flags = []
       notification_setting.selected_push_flags = []
       notification_setting.save!
+
+      expect do
+        described_class.new(
+          notification_type: 'conversation_mention',
+          user: user,
+          account: account,
+          primary_actor: primary_actor
+        ).perform
+      end.to change { user.notifications.count }.by(1)
+    end
+
+    it 'will not create a notification if conversation contact is blocked and notification type is not conversation_mention' do
+      primary_actor.contact.update(blocked: true)
+
+      expect do
+        described_class.new(
+          notification_type: 'conversation_creation',
+          user: user,
+          account: account,
+          primary_actor: primary_actor
+        ).perform
+      end.not_to change { user.notifications.count }
+    end
+
+    it 'will create a notification if conversation contact is blocked and notification type is conversation_mention' do
+      primary_actor.contact.update(blocked: true)
 
       expect do
         described_class.new(

--- a/spec/builders/notification_builder_spec.rb
+++ b/spec/builders/notification_builder_spec.rb
@@ -82,7 +82,7 @@ describe NotificationBuilder do
           account: account,
           primary_actor: primary_actor
         ).perform
-      end.not_to change { user.notifications.count }
+      end.not_to(change { user.notifications.count })
     end
 
     it 'will create a notification if conversation contact is blocked and notification type is conversation_mention' do


### PR DESCRIPTION
- Prevents notifications from being created for conversations or actions involving blocked contacts.  
- The exception is the conversation_mention notification type, which will still be created when applicable.
