### PR TITLE
fix: Prevent duplicate notifications for mentions

### DIFF
--- a/spec/listeners/notification_listener_spec.rb
+++ b/spec/listeners/notification_listener_spec.rb
@@ -121,7 +121,7 @@ describe NotificationListener do
   end
 
   # integration tests to ensure that the order mention service and new message notification service are called in the correct order
-  describe 'message_created' do
+  describe 'message_created - mentions, participation & assignment integration' do
     let(:event_name) { :'message.created' }
 
     it 'will not create duplicate new message notification for the same user for mentions participation & assignment' do

--- a/spec/listeners/notification_listener_spec.rb
+++ b/spec/listeners/notification_listener_spec.rb
@@ -120,6 +120,51 @@ describe NotificationListener do
     end
   end
 
+  # integration tests to ensure that the order mention service and new message notification service are called in the correct order
+  describe 'message_created' do
+    let(:event_name) { :'message.created' }
+
+    it 'will not create duplicate new message notification for the same user for mentions participation & assignment' do
+      create(:inbox_member, user: first_agent, inbox: inbox)
+      conversation.update(assignee: first_agent)
+
+      message = build(
+        :message,
+        conversation: conversation,
+        account: account,
+        content: "hi [#{first_agent.name}](mention://user/#{first_agent.id}/#{first_agent.name})",
+        private: true
+      )
+      event = Events::Base.new(event_name, Time.zone.now, message: message)
+      listener.message_created(event)
+
+      expect(first_agent.notifications.count).to eq(1)
+      expect(first_agent.notifications.first.notification_type).to eq('conversation_mention')
+    end
+
+    it 'will not create duplicate new message notifications for assignment & participation' do
+      create(:inbox_member, user: first_agent, inbox: inbox)
+      conversation.update(assignee: first_agent)
+      # participants is created by async job. so creating it directly for testcase
+      conversation.conversation_participants.first_or_create(user: first_agent)
+
+      message = build(
+        :message,
+        conversation: conversation,
+        account: account,
+        content: 'hi',
+        private: true
+      )
+
+      event = Events::Base.new(event_name, Time.zone.now, message: message)
+      listener.message_created(event)
+
+      expect(conversation.conversation_participants.map(&:user)).to include(first_agent)
+      expect(first_agent.notifications.count).to eq(1)
+      expect(first_agent.notifications.first.notification_type).to eq('assigned_conversation_new_message')
+    end
+  end
+
   describe 'conversation_bot_handoff' do
     let(:event_name) { :'conversation.bot_handoff' }
 


### PR DESCRIPTION
This PR addresses an issue where mention_notification was being overwritten by assigned_conversation_new_message notifications. Similarly, participating_conversation_new_message was taking priority over assigned_conversation_new_message.

The fix ensures that additional notifications are not created in these scenarios by establishing a priority order for notifications as follows:

1. mention_notification
2. assigned_conversation_new_message
3. participating_conversation_new_message

This change maintains consistency and prevents redundant notifications.

----

Note: In the older implementation of notifications in Chatwoot, notification objects were created only if the user had subscribed to a specific notification type. With the new inbox_view model, we are changing this approach to create notification objects in all cases. This PR updates the services to remove reliance on notification preferences, simplifying the logic.


----

Caveat: Since we don’t create extra notifications for new messages if a mention_notification already exists, a user subscribed to new_message_notification push/email notifications but not to mention_notification will not receive notifications in these cases.