### PR TITLE
fix: toggle for reply editor

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/EditorModeToggle.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/EditorModeToggle.vue
@@ -52,7 +52,7 @@ const translateValue = computed(() => {
 
 <template>
   <button
-    class="flex items-center w-auto h-8 p-1 transition-all border rounded-full duration-600 bg-n-alpha-2 group relative duration-300 ease-in-out"
+    class="flex items-center w-auto h-8 p-1 transition-all border rounded-full bg-n-alpha-2 group relative duration-300 ease-in-out"
     @click="$emit('toggleMode')"
   >
     <div ref="wootEditorReplyMode" class="flex items-center gap-1 px-2 z-20">

--- a/app/javascript/dashboard/components/widgets/WootWriter/EditorModeToggle.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/EditorModeToggle.vue
@@ -3,8 +3,6 @@ import { computed, useTemplateRef } from 'vue';
 import { useElementSize } from '@vueuse/core';
 import { REPLY_EDITOR_MODES } from './constants';
 
-import Icon from 'dashboard/components-next/icon/Icon.vue';
-
 const props = defineProps({
   mode: {
     type: String,
@@ -58,11 +56,9 @@ const translateValue = computed(() => {
     @click="$emit('toggleMode')"
   >
     <div ref="wootEditorReplyMode" class="flex items-center gap-1 px-2 z-20">
-      <Icon v-show="!isPrivate" icon="i-material-symbols-lock-open-rounded" />
       {{ $t('CONVERSATION.REPLYBOX.REPLY') }}
     </div>
     <div ref="wootEditorPrivateMode" class="flex items-center gap-1 px-2 z-20">
-      <Icon v-show="isPrivate" icon="i-material-symbols-lock" />
       {{ $t('CONVERSATION.REPLYBOX.PRIVATE_NOTE') }}
     </div>
     <div

--- a/app/javascript/dashboard/components/widgets/WootWriter/EditorModeToggle.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/EditorModeToggle.vue
@@ -66,12 +66,16 @@ const translateValue = computed(() => {
       {{ $t('CONVERSATION.REPLYBOX.PRIVATE_NOTE') }}
     </div>
     <div
-      class="absolute shadow-sm rounded-full h-6 w-[var(--chip-width)] transition-all duration-300 ease-in-out translate-x-[var(--translate-value)]"
+      class="absolute shadow-sm rounded-full h-6 w-[var(--chip-width)] transition-all duration-300 ease-in-out translate-x-[var(--translate-x)] rtl:translate-x-[var(--rtl-translate-x)]"
       :class="{
         'bg-n-solid-1': !isPrivate,
         'bg-n-amber-2': isPrivate,
       }"
-      :style="{ '--chip-width': width, '--translate-value': translateValue }"
+      :style="{
+        '--chip-width': width,
+        '--translate-x': translateValue,
+        '--rtl-translate-x': `calc(-1 * var(--translate-x))`,
+      }"
     />
   </button>
 </template>

--- a/app/javascript/dashboard/components/widgets/WootWriter/EditorModeToggle.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/EditorModeToggle.vue
@@ -18,7 +18,7 @@ const isPrivate = computed(() => props.mode === REPLY_EDITOR_MODES.NOTE);
 
 <template>
   <button
-    class="flex items-center h-8 p-1 transition-all border rounded-full duration-600 bg-n-alpha-2 dark:bg-n-alpha-2 hover:bg-n-alpha-1 dark:hover:brightness-105 group relative transition-all duration-300 ease-in-out"
+    class="flex items-center h-8 p-1 transition-all border rounded-full duration-600 bg-n-alpha-2 dark:bg-n-alpha-2 hover:bg-n-alpha-1 dark:hover:brightness-105 group relative duration-300 ease-in-out"
     :class="[
       isPrivate
         ? 'border-n-amber-12/10 dark:border-n-amber-3/30 w-[128px]'
@@ -27,7 +27,7 @@ const isPrivate = computed(() => props.mode === REPLY_EDITOR_MODES.NOTE);
     @click="$emit('toggleMode')"
   >
     <div
-      class="flex absolute items-center justify-center w-6 transition-all duration-200 rounded-full bg-n-alpha-black1 size-6 transition-all duration-300 ease-in-out"
+      class="flex absolute items-center justify-center w-6 rounded-full bg-n-alpha-black1 size-6 transition-all duration-300 ease-in-out"
       :class="[
         isPrivate
           ? 'ltr:translate-x-[94px] rtl:-translate-x-[94px]'


### PR DESCRIPTION
The reply editor toggle was a bit confusing for a few users, where it's not clear that it's clickable. This PR updates it to make it more clear

### Pending Work

- [x] RTL view

### Preview

##### Dark Mode

https://github.com/user-attachments/assets/9e377eda-34d5-4f64-a06a-23ae822da50e

##### Light Mode

https://github.com/user-attachments/assets/84c6b23c-cd17-4805-8e63-9d7d1cc0d799

