### PR TITLE
fix: Remove Report API calls from being called on every event

### DIFF
--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -27,7 +27,6 @@ class ActionCableConnector extends BaseActionCableConnector {
       'notification.created': this.onNotificationCreated,
       'notification.deleted': this.onNotificationDeleted,
       'notification.updated': this.onNotificationUpdated,
-      'first.reply.created': this.onFirstReplyCreated,
       'conversation.read': this.onConversationRead,
       'conversation.updated': this.onConversationUpdated,
       'account.cache_invalidated': this.onCacheInvalidate,
@@ -160,7 +159,6 @@ class ActionCableConnector extends BaseActionCableConnector {
   // eslint-disable-next-line class-methods-use-this
   fetchConversationStats = () => {
     emitter.emit('fetch_conversation_stats');
-    emitter.emit('fetch_overview_reports');
   };
 
   onContactDelete = data => {
@@ -185,11 +183,6 @@ class ActionCableConnector extends BaseActionCableConnector {
 
   onNotificationUpdated = data => {
     this.app.$store.dispatch('notifications/updateNotification', data);
-  };
-
-  // eslint-disable-next-line class-methods-use-this
-  onFirstReplyCreated = () => {
-    emitter.emit('fetch_overview_reports');
   };
 
   onCacheInvalidate = data => {

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/LiveReports.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/LiveReports.vue
@@ -145,8 +145,9 @@ export default {
         <MetricCard
           :header="$t('OVERVIEW_REPORTS.ACCOUNT_CONVERSATIONS.HEADER')"
           :is-loading="uiFlags.isFetchingAccountConversationMetric"
-          :loading-message="$t('OVERVIEW_REPORTS.ACCOUNT_CONVERSATIONS.LOADING_MESSAGE')
-            "
+          :loading-message="
+            $t('OVERVIEW_REPORTS.ACCOUNT_CONVERSATIONS.LOADING_MESSAGE')
+          "
         >
           <div
             v-for="(metric, name, index) in conversationMetrics"


### PR DESCRIPTION
Previously, the Reports API fetched data based on event triggers. For example, when an event occurred on an account, the system would automatically retrieve and display updated information. However, this approach was designed under the assumption that reports would be accessed by a small number of users and on an infrequent basis (e.g., once daily or weekly).

In scenarios where large customers have multiple team members actively monitoring reports, this event-driven approach led to an excessive number of requests, significantly straining the system.

This PR introduces a interval-based fetching of reports instead of the event-driven model.