### PR TITLE
fix: Remove backdrop-blur from Modal

### DIFF
--- a/app/javascript/dashboard/components/Modal.vue
+++ b/app/javascript/dashboard/components/Modal.vue
@@ -75,7 +75,7 @@ onMounted(() => {
       @mousedown="handleMouseDown"
     >
       <div
-        class="relative max-h-full overflow-auto bg-n-alpha-3 backdrop-blur-[100px] shadow-md modal-container rtl:text-right skip-context-menu"
+        class="relative max-h-full overflow-auto bg-n-alpha-3 shadow-md modal-container rtl:text-right skip-context-menu"
         :class="{
           'rounded-xl w-[37.5rem]': !fullWidth,
           'items-center rounded-none flex h-full justify-center w-full':


### PR DESCRIPTION
Remove backdrop-blur-[100px] from Modal as it was causing issues with old design pages.