### PR TITLE
chore: Auto-fetch previous page on last item deletion

### DIFF
--- a/app/javascript/dashboard/components-next/captain/pageComponents/DeleteDialog.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/DeleteDialog.vue
@@ -20,6 +20,8 @@ const props = defineProps({
   },
 });
 
+const emit = defineEmits(['deleteSuccess']);
+
 const { t } = useI18n();
 const store = useStore();
 const deleteDialogRef = ref(null);
@@ -30,6 +32,7 @@ const deleteEntity = async payload => {
 
   try {
     await store.dispatch(`captain${props.type}/delete`, payload);
+    emit('deleteSuccess');
     useAlert(t(`CAPTAIN.${i18nKey.value}.DELETE.SUCCESS_MESSAGE`));
   } catch (error) {
     useAlert(t(`CAPTAIN.${i18nKey.value}.DELETE.ERROR_MESSAGE`));

--- a/app/javascript/dashboard/routes/dashboard/captain/documents/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/documents/Index.vue
@@ -85,6 +85,12 @@ const handleAssistantFilterChange = assistant => {
 
 const onPageChange = page => fetchDocuments(page);
 
+const onDeleteSuccess = () => {
+  if (documents.value?.length === 0 && documentsMeta.value?.page > 1) {
+    onPageChange(documentsMeta.value.page - 1);
+  }
+};
+
 onMounted(() => {
   if (!assistants.value.length) {
     store.dispatch('captainAssistants/get');
@@ -146,6 +152,7 @@ onMounted(() => {
       ref="deleteDocumentDialog"
       :entity="selectedDocument"
       type="Documents"
+      @delete-success="onDeleteSuccess"
     />
   </PageLayout>
 </template>

--- a/app/javascript/dashboard/routes/dashboard/captain/responses/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/responses/Index.vue
@@ -129,6 +129,12 @@ const fetchResponses = (page = 1) => {
 
 const onPageChange = page => fetchResponses(page);
 
+const onDeleteSuccess = () => {
+  if (responses.value?.length === 0 && responseMeta.value?.page > 1) {
+    onPageChange(responseMeta.value.page - 1);
+  }
+};
+
 const handleStatusFilterChange = ({ value }) => {
   selectedStatus.value = value;
   isStatusFilterOpen.value = false;
@@ -211,6 +217,7 @@ onMounted(() => {
       ref="deleteDialog"
       :entity="selectedResponse"
       type="Responses"
+      @delete-success="onDeleteSuccess"
     />
 
     <CreateResponseDialog


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where deleting the last item on the last page of responses/documents, would show an empty state instead of loading the previous page.

Fixes
>  If you have pending responses spanning 2 or more pages .. and you delete the last response in the last page.. instead of showing the previous page the system show empty state.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Loom video**
https://www.loom.com/share/b0e89f774ccd45dab0e8dba2c34bd1ac?sid=d9923bcd-5030-42d9-9b7f-170df5297cfd


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
