### PR TITLE
fix(ce): Check the edition before running the data migration

### DIFF
--- a/db/migrate/20250116061033_convert_document_to_polymorphic_association.rb
+++ b/db/migrate/20250116061033_convert_document_to_polymorphic_association.rb
@@ -3,10 +3,12 @@ class ConvertDocumentToPolymorphicAssociation < ActiveRecord::Migration[7.0]
     add_column :captain_assistant_responses, :documentable_type, :string
 
     # rubocop:disable Rails/SkipsModelValidations
-    Captain::AssistantResponse
-      .where
-      .not(document_id: nil)
-      .update_all(documentable_type: 'Captain::Document')
+    if ChatwootApp.enterprise?
+      Captain::AssistantResponse
+        .where
+        .not(document_id: nil)
+        .update_all(documentable_type: 'Captain::Document')
+    end
     # rubocop:enable Rails/SkipsModelValidations
     remove_index :captain_assistant_responses, :document_id if index_exists?(
       :captain_assistant_responses, :document_id


### PR DESCRIPTION
Fixes #10721

This PR addresses an issue where the data migration in the CE edition was failing due to missing models. The change ensures that the migration process runs only when the deployment is using the EE image.