### PR TITLE
fix: Use documentable instead of document

### DIFF
--- a/enterprise/app/helpers/captain/chat_helper.rb
+++ b/enterprise/app/helpers/captain/chat_helper.rb
@@ -71,7 +71,7 @@ module Captain::ChatHelper
     "
     if response.documentable.present? && response.documentable.try(:external_link)
       formatted_response += "
-      Source: #{response.document.external_link}
+      Source: #{response.documentable.external_link}
       "
     end
 


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-3950/nomethoderror-undefined-method-document-for-an-instance-of