### PR TITLE
fix: Use `current_available` instead `available` to compute the document limit

### DIFF
--- a/enterprise/app/jobs/captain/documents/crawl_job.rb
+++ b/enterprise/app/jobs/captain/documents/crawl_job.rb
@@ -32,7 +32,7 @@ class Captain::Documents::CrawlJob < ApplicationJob
   def perform_firecrawl_crawl(document)
     captain_usage_limits = document.account.usage_limits[:captain] || {}
     document_limit = captain_usage_limits[:documents] || {}
-    crawl_limit = [document_limit[:available] || 10, 500].min
+    crawl_limit = [document_limit[:current_available] || 10, 500].min
 
     Captain::Tools::FirecrawlService
       .new

--- a/spec/enterprise/jobs/captain/documents/crawl_job_spec.rb
+++ b/spec/enterprise/jobs/captain/documents/crawl_job_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Captain::Documents::CrawlJob, type: :job do
 
       context 'with account usage limits' do
         before do
-          allow(account).to receive(:usage_limits).and_return({ captain: { documents: { available: 20 } } })
+          allow(account).to receive(:usage_limits).and_return({ captain: { documents: { current_available: 20 } } })
         end
 
         it 'uses FirecrawlService with the correct crawl limit' do
@@ -35,7 +35,7 @@ RSpec.describe Captain::Documents::CrawlJob, type: :job do
 
       context 'when crawl limit exceeds maximum' do
         before do
-          allow(account).to receive(:usage_limits).and_return({ captain: { documents: { available: 1000 } } })
+          allow(account).to receive(:usage_limits).and_return({ captain: { documents: { current_available: 1000 } } })
         end
 
         it 'caps the crawl limit at 500' do


### PR DESCRIPTION
The available limit for documents is now stored in captain.documents.current_available. This PR fixes the limit sent on crawler job.