### PR TITLE
chore: Disable audio alert for `pending` status conversation

### DIFF
--- a/app/javascript/dashboard/helper/AudioAlerts/AudioNotificationStore.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/AudioNotificationStore.js
@@ -3,6 +3,7 @@ import {
   CONVERSATION_PERMISSIONS,
 } from 'dashboard/constants/permissions';
 import { getUserPermissions } from 'dashboard/helper/permissionsHelper';
+import wootConstants from 'dashboard/constants/globals';
 
 class AudioNotificationStore {
   constructor(store) {
@@ -16,6 +17,15 @@ class AudioNotificationStore {
     });
 
     return mineConversation.some(conv => conv.unread_count > 0);
+  };
+
+  isMessageFromPendingConversation = ({
+    conversation_id: conversationId,
+  } = {}) => {
+    if (!conversationId) return false;
+    const activeConversation =
+      this.store.getters.getConversationById(conversationId);
+    return activeConversation?.status === wootConstants.STATUS_TYPE.PENDING;
   };
 
   isMessageFromCurrentConversation = message => {

--- a/app/javascript/dashboard/helper/AudioAlerts/AudioNotificationStore.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/AudioNotificationStore.js
@@ -19,10 +19,10 @@ class AudioNotificationStore {
     return mineConversation.some(conv => conv.unread_count > 0);
   };
 
-  isMessageFromPendingConversation = ({
-    conversation_id: conversationId,
-  } = {}) => {
+  isMessageFromPendingConversation = (message = {}) => {
+    const { conversation_id: conversationId } = message || {};
     if (!conversationId) return false;
+
     const activeConversation =
       this.store.getters.getConversationById(conversationId);
     return activeConversation?.status === wootConstants.STATUS_TYPE.PENDING;

--- a/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js
@@ -172,6 +172,12 @@ export class DashboardAudioNotificationHelper {
       return;
     }
 
+    // If the conversation status is pending, then dismiss the alert
+    // This case is common for all audio event types
+    if (this.store.isMessageFromPendingConversation(message)) {
+      return;
+    }
+
     // If the message is sent by the current user then dismiss the alert
     if (isMessageFromCurrentUser(message, this.currentUser.id)) {
       return;

--- a/app/javascript/dashboard/helper/AudioAlerts/specs/AudioNotificationStore.spec.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/specs/AudioNotificationStore.spec.js
@@ -4,6 +4,8 @@ import {
   CONVERSATION_PERMISSIONS,
 } from 'dashboard/constants/permissions';
 import { getUserPermissions } from 'dashboard/helper/permissionsHelper';
+import wootConstants from 'dashboard/constants/globals';
+
 vi.mock('dashboard/helper/permissionsHelper', () => ({
   getUserPermissions: vi.fn(),
 }));
@@ -18,6 +20,7 @@ describe('AudioNotificationStore', () => {
         getMineChats: vi.fn(),
         getSelectedChat: null,
         getCurrentAccountId: 1,
+        getConversationById: vi.fn(),
       },
     };
     audioNotificationStore = new AudioNotificationStore(store);
@@ -56,6 +59,63 @@ describe('AudioNotificationStore', () => {
         assigneeType: 'me',
         status: 'open',
       });
+    });
+  });
+
+  describe('isMessageFromPendingConversation', () => {
+    it('should return true when conversation status is pending', () => {
+      store.getters.getConversationById.mockReturnValue({
+        id: 123,
+        status: wootConstants.STATUS_TYPE.PENDING,
+      });
+      const message = { conversation_id: 123 };
+
+      expect(
+        audioNotificationStore.isMessageFromPendingConversation(message)
+      ).toBe(true);
+      expect(store.getters.getConversationById).toHaveBeenCalledWith(123);
+    });
+
+    it('should return false when conversation status is not pending', () => {
+      store.getters.getConversationById.mockReturnValue({
+        id: 123,
+        status: wootConstants.STATUS_TYPE.OPEN,
+      });
+      const message = { conversation_id: 123 };
+
+      expect(
+        audioNotificationStore.isMessageFromPendingConversation(message)
+      ).toBe(false);
+      expect(store.getters.getConversationById).toHaveBeenCalledWith(123);
+    });
+
+    it('should return false when conversation is not found', () => {
+      store.getters.getConversationById.mockReturnValue(null);
+      const message = { conversation_id: 123 };
+
+      expect(
+        audioNotificationStore.isMessageFromPendingConversation(message)
+      ).toBe(false);
+      expect(store.getters.getConversationById).toHaveBeenCalledWith(123);
+    });
+
+    it('should return false when message has no conversation_id', () => {
+      const message = {};
+
+      expect(
+        audioNotificationStore.isMessageFromPendingConversation(message)
+      ).toBe(false);
+      expect(store.getters.getConversationById).not.toHaveBeenCalled();
+    });
+
+    it('should return false when message is null or undefined', () => {
+      expect(
+        audioNotificationStore.isMessageFromPendingConversation(null)
+      ).toBe(false);
+      expect(
+        audioNotificationStore.isMessageFromPendingConversation(undefined)
+      ).toBe(false);
+      expect(store.getters.getConversationById).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR disables audio alerts for conversations with a status of "pending." It applies to all notification event types, ensuring that audio will not play for conversations marked as "pending."

Fixes https://linear.app/chatwoot/issue/CW-3951/audio-alerts-shouldnt-be-triggered-in-conversation-is-in-pending-state

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

Steps:
1. Create a conversation.
2. Then mark the conversation as pending.
3. Send message.
4. Make sure audio notification are enabled.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
