### PR TITLE
fix: UX issues on Help Center editor

### DIFF
--- a/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
@@ -27,7 +27,6 @@ const props = defineProps({
 
 const emit = defineEmits([
   'saveArticle',
-  'saveArticleAsync',
   'goBack',
   'setAuthor',
   'setCategory',
@@ -36,50 +35,23 @@ const emit = defineEmits([
 
 const { t } = useI18n();
 
-const isNewArticle = computed(() => !props.article?.id);
-
 const saveAndSync = value => {
   emit('saveArticle', value);
 };
 
-// this will only send the data to the backend
-// but will not update the local state preventing unnecessary re-renders
-// since the data is already saved and we keep the editor text as the source of truth
-const quickSave = debounce(
-  value => emit('saveArticleAsync', value),
-  400,
-  false
-);
-
-// 2.5 seconds is enough to know that the user has stopped typing and is taking a pause
-// so we can save the data to the backend and retrieve the updated data
-// this will update the local state with response data
-// Only use to save for existing articles
-const saveAndSyncDebounced = debounce(saveAndSync, 2500, false);
-
-// Debounced save for new articles
-const quickSaveNewArticle = debounce(saveAndSync, 400, false);
-
-const handleSave = value => {
-  if (isNewArticle.value) {
-    quickSaveNewArticle(value);
-  } else {
-    quickSave(value);
-    saveAndSyncDebounced(value);
-  }
-};
+const quickSave = debounce(saveAndSync, 200, false);
 
 const articleTitle = computed({
   get: () => props.article.title,
   set: value => {
-    handleSave({ title: value });
+    quickSave({ title: value });
   },
 });
 
 const articleContent = computed({
   get: () => props.article.content,
   set: content => {
-    handleSave({ content });
+    quickSave({ content });
   },
 });
 

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesEditPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesEditPage.vue
@@ -34,11 +34,10 @@ const portalLink = computed(() => {
   );
 });
 
-const saveArticle = async ({ ...values }, isAsync = false) => {
-  const actionToDispatch = isAsync ? 'articles/updateAsync' : 'articles/update';
+const saveArticle = async ({ ...values }) => {
   isUpdating.value = true;
   try {
-    await store.dispatch(actionToDispatch, {
+    await store.dispatch('articles/update', {
       portalSlug,
       articleId: articleSlug,
       ...values,
@@ -54,10 +53,6 @@ const saveArticle = async ({ ...values }, isAsync = false) => {
       isSaved.value = true;
     }, 1500);
   }
-};
-
-const saveArticleAsync = async ({ ...values }) => {
-  saveArticle({ ...values }, true);
 };
 
 const isCategoryArticles = computed(() => {
@@ -106,7 +101,6 @@ onMounted(fetchArticleDetails);
     :is-updating="isUpdating"
     :is-saved="isSaved"
     @save-article="saveArticle"
-    @save-article-async="saveArticleAsync"
     @preview-article="previewArticle"
     @go-back="goBackToArticles"
   />

--- a/app/javascript/dashboard/store/modules/helpCenterArticles/actions.js
+++ b/app/javascript/dashboard/store/modules/helpCenterArticles/actions.js
@@ -69,25 +69,6 @@ export const actions = {
     }
   },
 
-  updateAsync: async ({ commit }, { portalSlug, articleId, ...articleObj }) => {
-    commit(types.UPDATE_ARTICLE_FLAG, {
-      uiFlags: { isUpdating: true },
-      articleId,
-    });
-
-    try {
-      await articlesAPI.updateArticle({ portalSlug, articleId, articleObj });
-      return articleId;
-    } catch (error) {
-      return throwErrorMessage(error);
-    } finally {
-      commit(types.UPDATE_ARTICLE_FLAG, {
-        uiFlags: { isUpdating: false },
-        articleId,
-      });
-    }
-  },
-
   update: async ({ commit }, { portalSlug, articleId, ...articleObj }) => {
     commit(types.UPDATE_ARTICLE_FLAG, {
       uiFlags: {


### PR DESCRIPTION
This PR targets the following issues

### Cursor shifting sporadically on save.

Earlier the `FullEditor` component had a watch on `modelValue`, this was because the article body was not immediately available when the component was initialised, so without the watch, the editor would not get updated and we would see an empty page. 

There was a check to ensure this was only triggered when there's a difference in the content which makes sense. Earlier the `modelValue` is empty, and later it's populated. However when editing the article, there's a case where you hold typing for a while and the debounced saved triggers, with the old content. You continue typing however, so when the response arrives, `modelValue` gets updated, a diff is found, and the editor state reloads. 

This PR fixes it by add a `once` to the watch, effectively terminating the two-way binding with the editor. 

> Note: We need to ensure that the article state is fully saved when the user stops typing or navigates away from the page.

### Title editor not working correctly

_PENDING_

### Initialising a new article is complicated

_PENDING_
