### PR TITLE
chore: Update the behavior of Captain resolutions

### DIFF
--- a/enterprise/app/jobs/enterprise/account/conversations_resolution_scheduler_job.rb
+++ b/enterprise/app/jobs/enterprise/account/conversations_resolution_scheduler_job.rb
@@ -9,7 +9,13 @@ module Enterprise::Account::ConversationsResolutionSchedulerJob
 
   def resolve_captain_conversations
     CaptainInbox.all.find_each(batch_size: 100) do |captain_inbox|
-      Captain::InboxPendingConversationsResolutionJob.perform_later(captain_inbox.inbox)
+      inbox = captain_inbox.inbox
+
+      next if inbox.email?
+
+      Captain::InboxPendingConversationsResolutionJob.perform_later(
+        inbox
+      )
     end
   end
 end

--- a/enterprise/app/services/captain/llm/conversation_faq_service.rb
+++ b/enterprise/app/services/captain/llm/conversation_faq_service.rb
@@ -8,7 +8,11 @@ class Captain::Llm::ConversationFaqService < Captain::Llm::BaseOpenAiService
     @content = conversation.to_llm_text
   end
 
+  # Generates and deduplicates FAQs from conversation content
+  # Skips processing if there was no human interaction
   def generate_and_deduplicate
+    return [] if no_human_interaction?
+
     new_faqs = generate
     return [] if new_faqs.empty?
 
@@ -20,6 +24,10 @@ class Captain::Llm::ConversationFaqService < Captain::Llm::BaseOpenAiService
   private
 
   attr_reader :content, :conversation, :assistant
+
+  def no_human_interaction?
+    conversation.first_reply_created_at.nil?
+  end
 
   def find_and_separate_duplicates(faqs)
     duplicate_faqs = []

--- a/spec/enterprise/services/captain/llm/conversation_faq_service_spec.rb
+++ b/spec/enterprise/services/captain/llm/conversation_faq_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Captain::Llm::ConversationFaqService do
   let(:captain_assistant) { create(:captain_assistant) }
-  let(:conversation) { create(:conversation) }
+  let(:conversation) { create(:conversation, first_reply_created_at: Time.zone.now) }
   let(:service) { described_class.new(captain_assistant, conversation) }
   let(:client) { instance_double(OpenAI::Client) }
   let(:embedding_service) { instance_double(Captain::Llm::EmbeddingService) }
@@ -54,6 +54,14 @@ RSpec.describe Captain::Llm::ConversationFaqService do
           ['What is the purpose?', 'To help users.', 'pending', conversation.id],
           ['How does it work?', 'Through AI.', 'pending', conversation.id]
         )
+      end
+    end
+
+    context 'without human interaction' do
+      let(:conversation) { create(:conversation) }
+
+      it 'returns an empty array without generating FAQs' do
+        expect(service.generate_and_deduplicate).to eq([])
       end
     end
 

--- a/spec/factories/inboxes.rb
+++ b/spec/factories/inboxes.rb
@@ -9,5 +9,10 @@ FactoryBot.define do
     after(:create) do |inbox|
       inbox.channel.save!
     end
+
+    trait :with_email do
+      channel { FactoryBot.build(:channel_email, account: account) }
+      name { 'Email Inbox' }
+    end
   end
 end


### PR DESCRIPTION
This PR ensures that only conversations from quick conversation channels are resolved, avoiding resolutions on the email channel (we still need to improve the UX here). It also updates the FAQ generation logic, limiting it to conversations that had at least one human interaction.