### PR TITLE
fix: Update the photo/video caption when an update event is received

### DIFF
--- a/app/services/telegram/update_message_service.rb
+++ b/app/services/telegram/update_message_service.rb
@@ -28,6 +28,12 @@ class Telegram::UpdateMessageService
   end
 
   def update_message
-    @message.update!(content: params[:edited_message][:text])
+    edited_message = params[:edited_message]
+
+    if edited_message[:text].present?
+      @message.update!(content: edited_message[:text])
+    elsif edited_message[:caption].present?
+      @message.update!(content: edited_message[:caption])
+    end
   end
 end


### PR DESCRIPTION
The update ensures proper handling of text updates in photo/video messages by accounting for the caption attribute in addition to the text attribute. This change enables consistent processing across both messages.

Fixes https://github.com/chatwoot/chatwoot/issues/10760

Note: TIL, you can update the video/photo you’ve sent on Telegram, not just the text. Currently, we’re not handling this. To support it, we need to parse the payload and update the attachments accordingly. This could be taken as a followup.