### PR TITLE
chore: Always display the extension of an attached file

### DIFF
--- a/app/javascript/dashboard/components-next/message/chips/File.vue
+++ b/app/javascript/dashboard/components-next/message/chips/File.vue
@@ -16,15 +16,23 @@ const { t } = useI18n();
 
 const fileName = computed(() => {
   const url = attachment.dataUrl;
-  if (url) {
-    const filename = url.substring(url.lastIndexOf('/') + 1);
-    return filename || t('CONVERSATION.UNKNOWN_FILE_TYPE');
+  if (!url) return t('CONVERSATION.UNKNOWN_FILE_TYPE');
+
+  try {
+    const encodedFilename = url.substring(url.lastIndexOf('/') + 1);
+    return decodeURIComponent(encodedFilename);
+  } catch {
+    return t('CONVERSATION.UNKNOWN_FILE_TYPE');
   }
-  return t('CONVERSATION.UNKNOWN_FILE_TYPE');
 });
 
-const fileType = computed(() => {
-  return fileName.value.split('.').pop();
+const fileType = computed(() => fileName.value.split('.').pop()?.toLowerCase());
+
+const fileNameWithoutExt = computed(() => {
+  const parts = fileName.value.split('.');
+  return parts.length > 1
+    ? parts.slice(0, -1).join('.').trim()
+    : fileName.value.trim();
 });
 
 const textColorClass = computed(() => {
@@ -53,11 +61,16 @@ const textColorClass = computed(() => {
 
 <template>
   <div
-    class="h-9 bg-n-alpha-white gap-2 items-center flex px-2 rounded-lg border border-n-container"
+    class="h-9 bg-n-alpha-white gap-2 overflow-hidden items-center flex px-2 rounded-lg border border-n-container"
   >
     <FileIcon class="flex-shrink-0" :file-type="fileType" />
-    <span class="mr-1 max-w-32 truncate" :class="textColorClass">
-      {{ fileName }}
+    <span
+      :title="fileName"
+      :class="textColorClass"
+      class="inline-flex items-center text-sm overflow-hidden flex-1 min-w-0"
+    >
+      <span class="truncate min-w-0 max-w-32">{{ fileNameWithoutExt }}</span>
+      <span class="flex-shrink-0 whitespace-nowrap">.{{ fileType }}</span>
     </span>
     <a
       v-tooltip="t('CONVERSATION.DOWNLOAD')"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR ensures that the extension of an attached file is always displayed. Additionally, it fixes an issue with rendering by properly handling URL encoding of file names.
Fixes https://linear.app/chatwoot/issue/CW-3941/improvement-display-the-extension-of-an-attached-file-at-all-times

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

**Screenshots**
**Before**
<img width="447" alt="image" src="https://github.com/user-attachments/assets/99957000-d059-4967-9174-f9ebaf9dece0" />


**After**
<img width="447" alt="image" src="https://github.com/user-attachments/assets/2ea8fa59-168d-46b8-a140-342d0ba24e76" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
