### PR TITLE
fix: Prevent compose modal from closing when creating a link

### DIFF
--- a/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
@@ -171,6 +171,10 @@ watch(
   { immediate: true, deep: true }
 );
 
+const handleClickOutside = () => {
+  showComposeNewConversation.value = false;
+};
+
 onMounted(() => resetContacts());
 
 const keyboardEvents = {
@@ -188,7 +192,12 @@ useKeyboardEvents(keyboardEvents);
 
 <template>
   <div
-    v-on-click-outside="() => (showComposeNewConversation = false)"
+    v-on-click-outside="[
+      handleClickOutside,
+      // Fixed and edge case https://github.com/chatwoot/chatwoot/issues/10785
+      // This will prevent closing the compose conversation modal when the editor Create link popup is open.
+      { ignore: ['div.ProseMirror-prompt'] },
+    ]"
     class="relative"
     :class="{
       'z-40': showComposeNewConversation,


### PR DESCRIPTION
# Pull Request Template

## Description

**Issue**
The compose conversation modal was unexpectedly closing when users attempted to add links using the editor. This was happening because the `vOnClickOutside` directive was triggering when users interacted with the link editor popup.

**Solution**
Modified the `vOnClickOutside` directive to ignore clicks within the ProseMirror link editor popup by adding `div.ProseMirror-prompt` to the ignore list. This ensures the modal stays open while users are working with the link editor.

Fixes https://linear.app/chatwoot/issue/CW-3982/clicking-the-create-link-button-when-composing-a-message-on-the
https://github.com/chatwoot/chatwoot/issues/10785

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

**Loom video**
https://www.loom.com/share/ef7f531d54f44ff083700bca69c08a72?sid=20126754-f8e1-4795-bc52-a989563b818d


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
