### PR TITLE
chore: Resolve flaky spec for Contact country sorting

### DIFF
--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -98,7 +98,6 @@ RSpec.describe 'Contacts API', type: :request do
 
         expect(response).to have_http_status(:success)
         response_body = response.parsed_body
-        Rails.logger.info(response_body)
         expect(response_body['payload'].first['email']).to eq(contact_from_albania.email)
         expect(response_body['payload'].first['id']).to eq(contact_from_albania.id)
         expect(response_body['payload'].last['email']).to eq(contact_4.email)

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -91,16 +91,16 @@ RSpec.describe 'Contacts API', type: :request do
       end
 
       it 'returns all contacts with country name desc order with null values at last' do
+        contact_from_albania = create(:contact, :with_email, account: account, additional_attributes: { country_code: 'AL', country: 'Albania' })
         get "/api/v1/accounts/#{account.id}/contacts?include_contact_inboxes=false&sort=country",
             headers: admin.create_new_auth_token,
             as: :json
 
         expect(response).to have_http_status(:success)
         response_body = response.parsed_body
-        # TODO: this spec has been flaky for a while, so adding a debug statement to see the response
         Rails.logger.info(response_body)
-        expect(response_body['payload'].first['email']).to eq(contact.email)
-        expect(response_body['payload'].first['id']).to eq(contact.id)
+        expect(response_body['payload'].first['email']).to eq(contact_from_albania.email)
+        expect(response_body['payload'].first['id']).to eq(contact_from_albania.id)
         expect(response_body['payload'].last['email']).to eq(contact_4.email)
       end
 


### PR DESCRIPTION
We have been encountering errors in the community pipeline for the contacts sort by country spec. Upon investigation, it was discovered that the spec assumes the country code is used for sorting. However, the sorting actually relies on the country attribute.

The payload from a previous spec run indicates that none of the contact objects include the country attribute. This fix addresses the issue by aligning the spec with the actual implementation logic.

Here’s an example payload from the previous spec run for reference:
<img width="1063" alt="Screenshot 2025-01-31 at 6 17 44 PM" src="https://github.com/user-attachments/assets/df9b26e8-c5d0-432a-9d2a-16f76cb66967" />
