### PR TITLE
chore: Use `getFileInfo` helper from utils

### DIFF
--- a/app/javascript/dashboard/components-next/message/chips/File.vue
+++ b/app/javascript/dashboard/components-next/message/chips/File.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { getFileInfo } from '@chatwoot/utils';
 
 import FileIcon from 'next/icon/FileIcon.vue';
 import Icon from 'next/icon/Icon.vue';
@@ -14,43 +15,20 @@ const { attachment } = defineProps({
 
 const { t } = useI18n();
 
-const fileName = computed(() => {
-  const url = attachment.dataUrl;
-  if (!url) return t('CONVERSATION.UNKNOWN_FILE_TYPE');
-
-  try {
-    const encodedFilename = url.substring(url.lastIndexOf('/') + 1);
-    return decodeURIComponent(encodedFilename);
-  } catch {
-    return t('CONVERSATION.UNKNOWN_FILE_TYPE');
-  }
-});
-
-const fileType = computed(() => fileName.value.split('.').pop()?.toLowerCase());
-
-const fileNameWithoutExt = computed(() => {
-  const parts = fileName.value.split('.');
-
-  // If there's no extension (no dots in filename)
-  if (parts.length === 1) {
-    return fileName.value.trim();
-  }
-
-  // Take all parts except the last one (extension)
-  const nameWithoutExt = parts.slice(0, -1).join('.');
-  return nameWithoutExt.trim();
+const fileDetails = computed(() => {
+  return getFileInfo(attachment?.dataUrl || '');
 });
 
 const displayFileName = computed(() => {
-  const name = fileNameWithoutExt.value;
+  const { base, type } = fileDetails.value;
   const truncatedName = (str, maxLength, hasExt) =>
     str.length > maxLength
       ? `${str.substring(0, maxLength).trimEnd()}${hasExt ? '..' : '...'}`
       : str;
 
-  return fileType.value
-    ? `${truncatedName(name, 14, true)}.${fileType.value}`
-    : truncatedName(name, 16, false);
+  return type
+    ? `${truncatedName(base, 12, true)}.${type}`
+    : truncatedName(base, 14, false);
 });
 
 const textColorClass = computed(() => {
@@ -73,7 +51,7 @@ const textColorClass = computed(() => {
     zip: 'dark:text-[#EDEEF0] text-[#2F265F]',
   };
 
-  return colorMap[fileType.value] || 'text-n-slate-12';
+  return colorMap[fileDetails.value.type] || 'text-n-slate-12';
 });
 </script>
 
@@ -81,10 +59,10 @@ const textColorClass = computed(() => {
   <div
     class="h-9 bg-n-alpha-white gap-2 overflow-hidden items-center flex px-2 rounded-lg border border-n-container"
   >
-    <FileIcon class="flex-shrink-0" :file-type="fileType" />
+    <FileIcon class="flex-shrink-0" :file-type="fileDetails.type" />
     <span
       class="flex-1 min-w-0 text-sm max-w-36"
-      :title="fileName"
+      :title="fileDetails.name"
       :class="textColorClass"
     >
       {{ displayFileName }}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@breezystack/lamejs": "^1.2.7",
     "@chatwoot/ninja-keys": "1.2.3",
     "@chatwoot/prosemirror-schema": "1.1.1-next",
-    "@chatwoot/utils": "^0.0.33",
+    "@chatwoot/utils": "^0.0.34",
     "@formkit/core": "^1.6.7",
     "@formkit/vue": "^1.6.7",
     "@hcaptcha/vue3-hcaptcha": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@breezystack/lamejs": "^1.2.7",
     "@chatwoot/ninja-keys": "1.2.3",
     "@chatwoot/prosemirror-schema": "1.1.1-next",
-    "@chatwoot/utils": "^0.0.34",
+    "@chatwoot/utils": "^0.0.35",
     "@formkit/core": "^1.6.7",
     "@formkit/vue": "^1.6.7",
     "@hcaptcha/vue3-hcaptcha": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: 1.1.1-next
         version: 1.1.1-next
       '@chatwoot/utils':
-        specifier: ^0.0.33
-        version: 0.0.33
+        specifier: ^0.0.34
+        version: 0.0.34
       '@formkit/core':
         specifier: ^1.6.7
         version: 1.6.7
@@ -404,8 +404,8 @@ packages:
   '@chatwoot/prosemirror-schema@1.1.1-next':
     resolution: {integrity: sha512-/M2qZ+ZF7GlQNt1riwVP499fvp3hxSqd5iy8hxyF9pkj9qQ+OKYn5JK+v3qwwqQY3IxhmNOn1Lp6tm7vstrd9Q==}
 
-  '@chatwoot/utils@0.0.33':
-    resolution: {integrity: sha512-o5+2h+k+2XWRTfhI7mogRCYnbjh+/BKE/px7PYKUMsIS9uecxfNeLzrnaUzNw60dl/0MFe6G0OmcINW+AEh5KA==}
+  '@chatwoot/utils@0.0.34':
+    resolution: {integrity: sha512-Wa2B9EgH1wTchSVwdBpTIsmxhxXjrlq+8jMG24nsKJ4Df2iB9Td3Ej+EbqkVuVqvAAz495jND3zgAC7XyBo1sQ==}
     engines: {node: '>=10'}
 
   '@codemirror/commands@6.7.0':
@@ -5154,7 +5154,7 @@ snapshots:
       prosemirror-utils: 1.2.2(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)
       prosemirror-view: 1.34.1
 
-  '@chatwoot/utils@0.0.33':
+  '@chatwoot/utils@0.0.34':
     dependencies:
       date-fns: 2.29.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: 1.1.1-next
         version: 1.1.1-next
       '@chatwoot/utils':
-        specifier: ^0.0.34
-        version: 0.0.34
+        specifier: ^0.0.35
+        version: 0.0.35
       '@formkit/core':
         specifier: ^1.6.7
         version: 1.6.7
@@ -404,8 +404,8 @@ packages:
   '@chatwoot/prosemirror-schema@1.1.1-next':
     resolution: {integrity: sha512-/M2qZ+ZF7GlQNt1riwVP499fvp3hxSqd5iy8hxyF9pkj9qQ+OKYn5JK+v3qwwqQY3IxhmNOn1Lp6tm7vstrd9Q==}
 
-  '@chatwoot/utils@0.0.34':
-    resolution: {integrity: sha512-Wa2B9EgH1wTchSVwdBpTIsmxhxXjrlq+8jMG24nsKJ4Df2iB9Td3Ej+EbqkVuVqvAAz495jND3zgAC7XyBo1sQ==}
+  '@chatwoot/utils@0.0.35':
+    resolution: {integrity: sha512-uSRbd3pFp+IcEhsRtK1XGcFGFJc+X/YIwQnQrVDXsvsX3Mm7HEANj+Yz6J2clfHotajniwJwH2u5/y48+JrTyA==}
     engines: {node: '>=10'}
 
   '@codemirror/commands@6.7.0':
@@ -5154,7 +5154,7 @@ snapshots:
       prosemirror-utils: 1.2.2(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)
       prosemirror-view: 1.34.1
 
-  '@chatwoot/utils@0.0.34':
+  '@chatwoot/utils@0.0.35':
     dependencies:
       date-fns: 2.29.3
 


### PR DESCRIPTION
# Pull Request Template

## Description
The PR includes the usage of `getFileInfo` helper from utils https://github.com/chatwoot/utils/pull/40.

Fixes https://github.com/chatwoot/chatwoot/pull/10806#discussion_r1937797905

## How Has This Been Tested?

**Screenshot**
<img width="490" alt="image" src="https://github.com/user-attachments/assets/f0788e89-b670-47da-b0ca-3765eb424be0" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
