### PR TITLE
feat: realtime issues investigation [WIP]

### DIFF
--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -29,6 +29,7 @@ class ActionCableConnector extends BaseActionCableConnector {
       'notification.updated': this.onNotificationUpdated,
       'conversation.read': this.onConversationRead,
       'conversation.updated': this.onConversationUpdated,
+      'team.changed': this.onTeamChanged,
       'account.cache_invalidated': this.onCacheInvalidate,
     };
   }
@@ -110,6 +111,11 @@ class ActionCableConnector extends BaseActionCableConnector {
   };
 
   onConversationUpdated = data => {
+    this.app.$store.dispatch('updateConversation', data);
+    this.fetchConversationStats();
+  };
+
+  onTeamChanged = data => {
     this.app.$store.dispatch('updateConversation', data);
     this.fetchConversationStats();
   };


### PR DESCRIPTION
A few users report incorrect items in the Chat list on the teams page. For example, the count on the tab would show 5 conversations, but would only have 4 conversations.

Here's a few things that we're observed

- The issue would occur sporadically, without any consistent way to reproduce it
- It happened on the team page in this particular case, however we are unable to confirm this since the issue is so random
- It is much more visible during peak hours
- The users used the API channel for all the conversation
- A reload fixed this always, that means the issue is in either the websocket payload, or the the handling of the said payload
- No complex automations are in place, except for auto-assignment at the inbox level

### Investigation log

#### Is it the backend?

I suspected, this could be related to using the API channel, any race condition in processing the incoming requests can be causing this. Tried to simulate the environment here: https://github.com/scmmishra/chatwoot-api-simulator. Even after bombarding my system locally with requests, there wasn't any inconsistency in the count. So the issue is not really on the backend

#### Exploring the frontend events

On the frontend, the following events trigger a conversation update

- `onAssigneeChanged`
- `onConversationCreated`
- `onStatusChange`
- `onConversationUpdated`

#### `onAssigneeChanged`

Out of this, `onAssigneeChanged` is the event which has a skippable branch if the id was not present. We can explore to see if there's any issue related to active record caching, or if the assignment happens before the conversation is committed. Or any automation triggering within a transaction which causes the assignment.

So the payload from `assignee.changed` event is triggered in the `AssignmentHandler` concern, and it happens after a commit, so it should have the ID for the conversation, there's no chance that we missed this event on the escape path.
This corresponds to our findings when we added the logging to ChatInc. Need to explore another route.

#### Is it the filtering logic?

[applyPageFilters in helper.js](https://github.com/chatwoot/chatwoot/blob/c18452f6b6623829275981ce2d5af2f5da465257/app/javascript/dashboard/store/modules/conversations/helpers.js#L38) is where the filtering happens, any new changes to the conversation list triggers this. If the issue is specifically on the teams page, there is a case to be made that the team data is not present correctly.

#### Event handlers for each events

`message.created` does not update the conversation ever. What if there's assignment change, the `message.created` is triggered from the activity message, which updates the messages only. But the `conversation.updated` event is not 
triggered correctly, or somehow breaks? If we remove the `store.dispatch` in the `conversation.updated` handler, we get something that looks like the issue (but this is very speculative)

Let's see the code, (the user is on pre Vue 3 branch)

https://github.com/chatwoot/chatwoot/blob/d20d18b2ecfaf3c7851cbea5ed8010dbb170d90e/app/javascript/dashboard/store/modules/conversations/index.js#L192-L211

Here we use `Vue.set`, could this be causing any reactivity issues not triggering the UI update corresponding to the change in the conversation meta. 

Working on this angle... Okay, took a look at this. Vue basically uses the [`observeArray`](https://github.com/vuejs/vue/blob/9e88707940088cb1f4cd7dd210c9168a50dc347c/src/core/observer/index.ts#L90-L94) method to loop through all array items and make them reactive. 

Which in-turn, loops over all the `keys` of the object in the array and makes them reactive [[ref](https://github.com/vuejs/vue/blob/9e88707940088cb1f4cd7dd210c9168a50dc347c/src/core/observer/index.ts#L79-L83)]

However there might be a catch here. If you take a look at the `defineReactive` it will only set the current properties to reactive at the time of creation. So if the `meta` property does not exist on the object at the time of creation, it will not be reactive. Let's see if this can be done

Imagine we get `meta` as `null` to being with. So we start at `defineReactive`, see this [line](https://github.com/vuejs/vue/blob/9e88707940088cb1f4cd7dd210c9168a50dc347c/src/core/observer/index.ts#L154C47-L154C54).. Since `shallow` is false, we create a new `observer`, this happens [here](https://github.com/vuejs/vue/blob/9e88707940088cb1f4cd7dd210c9168a50dc347c/src/core/observer/index.ts#L104-L123) in the same file. Here if you see the `isPlainObject` check, this is interesting, because this will yield false for `null` value. That means that `meta` is never tracked if it starts at `null`, every other subsequent condition fails.

So, to replicate this, perhaps a new conversation should arrive from a websocket event, and then updated to change the team, let's try this... Seems like, there's no case where `meta` would be `null`

What if the issue is with the line `_state.allConversations.push(conversation);`  Okay so if we just get the `created` event as it is, the `push` is not reactive at all. This is a Vue 2.X limitation. 

So if in any case a conversation is created and it gets added to the queue, without a subsequent update event, the addition is not reactive. In regular inboxes, this is never an issue since the created always has a updated event coming in, as a new message is always created almost immediately. Okay I feel so stupid now, the cause was staring me right at my face :/ But turns out in Vue 3, this is solved. Upgrading the installation should fix this If this indeed is the case
