### PR TITLE
fix: Message signature is not appending

### DIFF
--- a/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
@@ -84,29 +84,18 @@ const toggleMessageSignature = () => {
   setSignature();
 };
 
+// Added this watch to dynamically set signature on target inbox change.
 // Only targetInbox has value and is Advance Editor(used by isEmailOrWebWidgetInbox)
 // Set the signature only if the inbox based flag is true
-const handleSignatureSetup = () => {
-  nextTick(() => {
-    if (props.hasSelectedInbox && props.isEmailOrWebWidgetInbox) {
-      setSignature();
-    }
-  });
-};
-
-// Added this watch to dynamically set signature on target inbox change.
 watch(
   () => props.hasSelectedInbox,
   newValue => {
-    if (newValue) handleSignatureSetup();
-  }
+    nextTick(() => {
+      if (newValue && props.isEmailOrWebWidgetInbox) setSignature();
+    });
+  },
+  { immediate: true }
 );
-
-// Added mounted to set signature if the signature is enabled for the inbox
-// and the target inbox is selected and is email or web widget.
-onMounted(() => {
-  handleSignatureSetup();
-});
 
 const onClickInsertEmoji = emoji => {
   emit('insertEmoji', emoji);

--- a/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
@@ -1,12 +1,5 @@
 <script setup>
-import {
-  defineAsyncComponent,
-  ref,
-  computed,
-  watch,
-  nextTick,
-  onMounted,
-} from 'vue';
+import { defineAsyncComponent, ref, computed, watch, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useUISettings } from 'dashboard/composables/useUISettings';
 import { useFileUpload } from 'dashboard/composables/useFileUpload';

--- a/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
@@ -1,5 +1,12 @@
 <script setup>
-import { defineAsyncComponent, ref, computed, watch, nextTick } from 'vue';
+import {
+  defineAsyncComponent,
+  ref,
+  computed,
+  watch,
+  nextTick,
+  onMounted,
+} from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useUISettings } from 'dashboard/composables/useUISettings';
 import { useFileUpload } from 'dashboard/composables/useFileUpload';
@@ -77,17 +84,29 @@ const toggleMessageSignature = () => {
   setSignature();
 };
 
-// Added this watch to dynamically set signature.
 // Only targetInbox has value and is Advance Editor(used by isEmailOrWebWidgetInbox)
 // Set the signature only if the inbox based flag is true
+const handleSignatureSetup = () => {
+  nextTick(() => {
+    if (props.hasSelectedInbox && props.isEmailOrWebWidgetInbox) {
+      setSignature();
+    }
+  });
+};
+
+// Added this watch to dynamically set signature on target inbox change.
 watch(
   () => props.hasSelectedInbox,
   newValue => {
-    nextTick(() => {
-      if (newValue && props.isEmailOrWebWidgetInbox) setSignature();
-    });
+    if (newValue) handleSignatureSetup();
   }
 );
+
+// Added mounted to set signature if the signature is enabled for the inbox
+// and the target inbox is selected and is email or web widget.
+onMounted(() => {
+  handleSignatureSetup();
+});
 
 const onClickInsertEmoji = emoji => {
   emit('insertEmoji', emoji);


### PR DESCRIPTION
# Pull Request Template

## Description

**Issue:** The message signature wasn't being appended to new email conversations when a target inbox was selected.

**Solution:** To address this, a reusable `handleSignatureSetup` function was created to manage the signature logic. The same logic was applied in both cases, when the inbox selection changed (using `watch`) and during the initial load (using `mounted`).

Fixes https://linear.app/chatwoot/issue/CW-4005/allow-to-activate-the-message-signature-for-new-email-conversations-by
https://github.com/chatwoot/chatwoot/issues/10836

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Steps to reproduce**: https://github.com/chatwoot/chatwoot/issues/10836#issuecomment-2637354304

### Loom video

**Before**
https://www.loom.com/share/ccf597cfa8d94d0eaff1222102901d2c?sid=abfea42b-425e-446e-8e92-99359b786607

**After**
https://www.loom.com/share/d9deddfcf8de48ab87e31911dfb774d8?sid=c1aac19b-b243-428e-9a9f-2ad9f4efe49c


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
