### PR TITLE
chore: Remove the background SVG from the help center

### DIFF
--- a/app/helpers/portal_helper.rb
+++ b/app/helpers/portal_helper.rb
@@ -5,8 +5,7 @@ module PortalHelper
   end
 
   def generate_portal_bg(portal_color, theme)
-    bg_image = theme == 'dark' ? 'hexagon-dark.svg' : 'hexagon-light.svg'
-    "url(/assets/images/hc/#{bg_image}) #{generate_portal_bg_color(portal_color, theme)}"
+    generate_portal_bg_color(portal_color, theme)
   end
 
   def generate_gradient_to_bottom(theme)

--- a/spec/helpers/portal_helper_spec.rb
+++ b/spec/helpers/portal_helper_spec.rb
@@ -33,26 +33,26 @@ describe PortalHelper do
   describe '#generate_portal_bg' do
     context 'when theme is dark' do
       it 'returns the correct background with dark grid image and color mix with black' do
-        expected_bg = 'url(/assets/images/hc/hexagon-dark.svg) color-mix(in srgb, #ff0000 20%, black)'
+        expected_bg = 'color-mix(in srgb, #ff0000 20%, black)'
         expect(helper.generate_portal_bg('#ff0000', 'dark')).to eq(expected_bg)
       end
     end
 
     context 'when theme is not dark' do
       it 'returns the correct background with light grid image and color mix with white' do
-        expected_bg = 'url(/assets/images/hc/hexagon-light.svg) color-mix(in srgb, #ff0000 20%, white)'
+        expected_bg = 'color-mix(in srgb, #ff0000 20%, white)'
         expect(helper.generate_portal_bg('#ff0000', 'light')).to eq(expected_bg)
       end
     end
 
     context 'when provided with various colors' do
       it 'adjusts the background appropriately for dark theme' do
-        expected_bg = 'url(/assets/images/hc/hexagon-dark.svg) color-mix(in srgb, #00ff00 20%, black)'
+        expected_bg = 'color-mix(in srgb, #00ff00 20%, black)'
         expect(helper.generate_portal_bg('#00ff00', 'dark')).to eq(expected_bg)
       end
 
       it 'adjusts the background appropriately for light theme' do
-        expected_bg = 'url(/assets/images/hc/hexagon-light.svg) color-mix(in srgb, #0000ff 20%, white)'
+        expected_bg = 'color-mix(in srgb, #0000ff 20%, white)'
         expect(helper.generate_portal_bg('#0000ff', 'light')).to eq(expected_bg)
       end
     end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will remove the hexagon background image from public portal.

Fixes https://linear.app/chatwoot/issue/CW-4013/remove-the-background-from-the-help-center

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Screenshots**
**Before**
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/3539631d-013b-4770-8bfc-643daf695e0d" />

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/8f511a12-7f77-4301-a0db-bb8ef6f0e37f" />



**After**
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/4eb1a072-991c-4632-8c10-c7551def3a24" />

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/555e9f69-317a-4bc9-97aa-0990908729fa" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
