### PR TITLE
chore: Reload conversation data in ActionCableBroadcastJob before sending

### DIFF
--- a/app/jobs/action_cable_broadcast_job.rb
+++ b/app/jobs/action_cable_broadcast_job.rb
@@ -2,8 +2,31 @@ class ActionCableBroadcastJob < ApplicationJob
   queue_as :critical
 
   def perform(members, event_name, data)
+    return if members.blank?
+
+    broadcast_data = prepare_broadcast_data(event_name, data)
+    broadcast_to_members(members, event_name, broadcast_data)
+  end
+
+  private
+
+  def prepare_broadcast_data(event_name, data)
+    return data unless event_name == 'conversation.updated'
+
+    account = Account.find(data[:account_id])
+    conversation = account.conversations.find_by!(display_id: data[:id])
+    conversation.push_event_data.merge(account_id: data[:account_id])
+  end
+
+  def broadcast_to_members(members, event_name, broadcast_data)
     members.each do |member|
-      ActionCable.server.broadcast(member, { event: event_name, data: data })
+      ActionCable.server.broadcast(
+        member,
+        {
+          event: event_name,
+          data: broadcast_data
+        }
+      )
     end
   end
 end


### PR DESCRIPTION
During high-traffic periods, events may appear out of order, causing the conversation job to queue outdated data, which can lead to issues in the UI. This update ensures that only the latest available data is sent to the UI. 

The conversation object refreshed before sending it to the UI.