### PR TITLE
chore: Add more conversation events for reload

### DIFF
--- a/app/jobs/action_cable_broadcast_job.rb
+++ b/app/jobs/action_cable_broadcast_job.rb
@@ -1,5 +1,14 @@
 class ActionCableBroadcastJob < ApplicationJob
   queue_as :critical
+  include Events::Types
+
+  CONVERSATION_UPDATE_EVENTS = [
+    CONVERSATION_READ,
+    CONVERSATION_UPDATED,
+    TEAM_CHANGED,
+    ASSIGNEE_CHANGED,
+    CONVERSATION_STATUS_CHANGED
+  ].freeze
 
   def perform(members, event_name, data)
     return if members.blank?
@@ -14,7 +23,7 @@ class ActionCableBroadcastJob < ApplicationJob
   # caused by out-of-order events during high-traffic periods. This prevents
   # the conversation job from processing outdated data.
   def prepare_broadcast_data(event_name, data)
-    return data unless event_name == 'conversation.updated'
+    return data unless CONVERSATION_UPDATE_EVENTS.include?(event_name)
 
     account = Account.find(data[:account_id])
     conversation = account.conversations.find_by!(display_id: data[:id])


### PR DESCRIPTION
Followup PR for https://github.com/chatwoot/chatwoot/pull/10876. This PR just adds all the events related to conversation update to be reloaded before sending it to the UI.