### PR TITLE
fix: TypeError - Cannot read properties of null (reading 'name')

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/BaseAttachment.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/BaseAttachment.vue
@@ -24,7 +24,7 @@ const { sender } = useMessageContext();
 const { t } = useI18n();
 
 const senderName = computed(() => {
-  return sender?.value.name;
+  return sender?.value?.name || '';
 });
 </script>
 

--- a/app/javascript/dashboard/components-next/message/bubbles/Dyte.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Dyte.vue
@@ -9,7 +9,7 @@ import { useI18n } from 'vue-i18n';
 import { useMessageContext } from '../provider.js';
 import BaseAttachmentBubble from './BaseAttachment.vue';
 
-const { contentAttributes } = useMessageContext();
+const { content, sender, contentAttributes } = useMessageContext();
 
 const { t } = useI18n();
 
@@ -53,6 +53,11 @@ const action = computed(() => ({
     sender-translation-key="CONVERSATION.SHARED_ATTACHMENT.MEETING"
     :action="action"
   >
+    <div v-if="!sender" class="text-n-slate-12 text-sm truncate">
+      <!-- Added as a fallback, where the sender is not available (Deleted) -->
+      <!-- Will show the content, if senderName in BaseAttachment.vue is empty -->
+      {{ content }}
+    </div>
     <div v-if="dyteAuthToken" class="video-call--container">
       <iframe
         :src="meetingLink"


### PR DESCRIPTION
# Pull Request Template

## Description

### **Issue**  
The component throws `TypeError: Cannot read properties of null (reading 'name')` when accessing the sender's name in base message attachments.  

### **Root Cause**  
1. The `sender` prop in the `Message` component defaults to `null` and is unavailable when the sender is deleted.  
2. When converted to refs using `toRefs(props)` and passed via `provideMessageContext`, the `sender` ref may be `null` or not available.  
3. The code `sender?.value.name` lacks null checks, causing a `TypeError` when `sender` or `sender.value` is `null`.  

### **Solution**  
Add `null` checks for the `sender` ref and provide a fallback value for `Dyte` integration.


Fixes https://linear.app/chatwoot/issue/CW-4031/typeerror-cannot-read-properties-of-null-reading-name

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Loom Video**

**Before**
https://www.loom.com/share/9701f60850aa41cd99d04587b5f9d3a3?sid=10c6d030-f985-49e3-82f2-695b32b369f1

**After**
https://www.loom.com/share/7f36313e6fb74ce68732bdc3c4d75e75?sid=dcedbb60-3957-4dd6-9be7-10e8d9e85e30


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
