### PR TITLE
fix: Initialize SDK along with emitter registration

### DIFF
--- a/app/javascript/dashboard/helper/scriptHelpers.js
+++ b/app/javascript/dashboard/helper/scriptHelpers.js
@@ -8,6 +8,7 @@ import DashboardAudioNotificationHelper from './AudioAlerts/DashboardAudioNotifi
 import { emitter } from 'shared/helpers/mitt';
 
 export const initializeAnalyticsEvents = () => {
+  AnalyticsHelper.init();
   emitter.on(ANALYTICS_IDENTITY, ({ user }) => {
     AnalyticsHelper.identify(user);
   });


### PR DESCRIPTION
Initialize the SDK along with the emitter registration to ensure accurate data reporting for analytics events.