### PR TITLE
fix: Use textContent as fallback for htmlContent instead of content.value

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/Email/Index.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Email/Index.vue
@@ -29,8 +29,15 @@ const isOutgoing = computed(() => {
 });
 const isIncoming = computed(() => !isOutgoing.value);
 
+const textToShow = computed(() => {
+  const text =
+    contentAttributes?.value?.email?.textContent?.full ?? content.value;
+  return text?.replace(/\n/g, '<br>');
+});
+
+// Use TextContent as the default to fullHTML
 const fullHTML = computed(() => {
-  return contentAttributes?.value?.email?.htmlContent?.full ?? content.value;
+  return contentAttributes?.value?.email?.htmlContent?.full ?? textToShow.value;
 });
 
 const unquotedHTML = computed(() => {
@@ -39,12 +46,6 @@ const unquotedHTML = computed(() => {
 
 const hasQuotedMessage = computed(() => {
   return EmailQuoteExtractor.hasQuotes(fullHTML.value);
-});
-
-const textToShow = computed(() => {
-  const text =
-    contentAttributes?.value?.email?.textContent?.full ?? content.value;
-  return text?.replace(/\n/g, '<br>');
 });
 </script>
 


### PR DESCRIPTION
Some emails contain HTML content within the text part, but our content parser currently strips HTML automatically, which needs a proper fix. In the new UI, the fallback for HTML content was set to the parsed content, which may omit HTML tags, leading to issues like missing inline attachments.

This PR updates the fallback mechanism to use the text content instead of the parsed content, ensuring HTML elements are preserved.