### PR TITLE
chore: Add internal feature flags for Chatwoot Cloud

### DIFF
--- a/app/helpers/super_admin/account_features_helper.rb
+++ b/app/helpers/super_admin/account_features_helper.rb
@@ -6,4 +6,14 @@ module SuperAdmin::AccountFeaturesHelper
   def self.account_premium_features
     account_features.filter { |feature| feature['premium'] }.pluck('name')
   end
+
+  # Accepts account.features as argument
+  def self.filtered_features(features)
+    deployment_env = GlobalConfig.get_value('DEPLOYMENT_ENV')
+    return features if deployment_env == 'cloud'
+
+    # Filter out internal features for non-cloud environments
+    internal_features = account_features.select { |f| f['chatwoot_internal'] }.pluck('name')
+    features.except(*internal_features)
+  end
 end

--- a/app/javascript/dashboard/components-next/sidebar/SidebarProfileMenu.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarProfileMenu.vue
@@ -5,6 +5,7 @@ import { useMapGetter } from 'dashboard/composables/store';
 import { useI18n } from 'vue-i18n';
 import Avatar from 'next/avatar/Avatar.vue';
 import SidebarProfileMenuStatus from './SidebarProfileMenuStatus.vue';
+import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 
 import {
   DropdownContainer,
@@ -21,14 +22,27 @@ defineOptions({
 
 const { t } = useI18n();
 
-const globalConfig = useMapGetter('globalConfig/get');
 const currentUser = useMapGetter('getCurrentUser');
 const currentUserAvailability = useMapGetter('getCurrentUserAvailability');
+const accountId = useMapGetter('getCurrentAccountId');
+const globalConfig = useMapGetter('globalConfig/get');
+const isFeatureEnabledonAccount = useMapGetter(
+  'accounts/isFeatureEnabledonAccount'
+);
+
+const showChatSupport = computed(() => {
+  return (
+    isFeatureEnabledonAccount.value(
+      accountId.value,
+      FEATURE_FLAGS.CONTACT_CHATWOOT_SUPPORT_TEAM
+    ) && globalConfig.value.chatwootInboxToken
+  );
+});
 
 const menuItems = computed(() => {
   return [
     {
-      show: !!globalConfig.value.chatwootInboxToken,
+      show: showChatSupport.value,
       label: t('SIDEBAR_ITEMS.CONTACT_SUPPORT'),
       icon: 'i-lucide-life-buoy',
       click: () => {

--- a/app/javascript/dashboard/components/layout/sidebarComponents/OptionsMenu.vue
+++ b/app/javascript/dashboard/components/layout/sidebarComponents/OptionsMenu.vue
@@ -4,6 +4,7 @@ import Auth from '../../../api/auth';
 import WootDropdownItem from 'shared/components/ui/dropdown/DropdownItem.vue';
 import WootDropdownMenu from 'shared/components/ui/dropdown/DropdownMenu.vue';
 import AvailabilityStatus from 'dashboard/components/layout/AvailabilityStatus.vue';
+import { FEATURE_FLAGS } from '../../../featureFlags';
 
 export default {
   components: {
@@ -28,6 +29,7 @@ export default {
       currentUser: 'getCurrentUser',
       globalConfig: 'globalConfig/get',
       accountId: 'getCurrentAccountId',
+      isFeatureEnabledonAccount: 'accounts/isFeatureEnabledonAccount',
     }),
     showChangeAccountOption() {
       if (this.globalConfig.createNewAccountFromDashboard) {
@@ -36,6 +38,14 @@ export default {
 
       const { accounts = [] } = this.currentUser;
       return accounts.length > 1;
+    },
+    showChatSupport() {
+      return (
+        this.isFeatureEnabledonAccount(
+          this.accountId,
+          FEATURE_FLAGS.CONTACT_CHATWOOT_SUPPORT_TEAM
+        ) && this.globalConfig.chatwootInboxToken
+      );
     },
   },
   methods: {
@@ -82,7 +92,7 @@ export default {
             {{ $t('SIDEBAR_ITEMS.CHANGE_ACCOUNTS') }}
           </woot-button>
         </WootDropdownItem>
-        <WootDropdownItem v-if="globalConfig.chatwootInboxToken">
+        <WootDropdownItem v-if="showChatSupport">
           <woot-button
             variant="clear"
             color-scheme="secondary"

--- a/app/javascript/dashboard/featureFlags.js
+++ b/app/javascript/dashboard/featureFlags.js
@@ -34,4 +34,5 @@ export const FEATURE_FLAGS = {
   CUSTOM_ROLES: 'custom_roles',
   CHATWOOT_V4: 'chatwoot_v4',
   REPORT_V4: 'report_v4',
+  CONTACT_CHATWOOT_SUPPORT_TEAM: 'contact_chatwoot_support_team',
 };

--- a/app/views/fields/account_features_field/_form.html.erb
+++ b/app/views/fields/account_features_field/_form.html.erb
@@ -2,17 +2,17 @@
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field feature-container">
-    <% field.data.each do |key,val| %>
+  <% SuperAdmin::AccountFeaturesHelper.filtered_features(field.data).each do |key, val| %>
     <div class='feature-cell'>
-    <% is_premium = SuperAdmin::AccountFeaturesHelper.account_premium_features.include? key %>
-    <% if is_premium  %>
-    <span class='icon-container'>
-      <svg class="inline" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 512 512"><path d="M480 224l-186.828 7.487L401.688 64l-59.247-32L256 208 169.824 32l-59.496 32 108.5 167.487L32 224v64l185.537-10.066L113.65 448l55.969 32L256 304l86.381 176 55.949-32-103.867-170.066L480 288z" fill="currentColor"/></svg>
-    </span>
-    <% end %>
-    <span><%= key %></span> 
-    <% should_disable = is_premium && ChatwootHub.pricing_plan == 'community' %>
-    <span class='value-container'><%= check_box "enabled_features", "feature_#{key}", { checked: val, disabled: should_disable  }, true, false  %> </span>
+      <% is_premium = SuperAdmin::AccountFeaturesHelper.account_premium_features.include? key %>
+      <% if is_premium %>
+        <span class='icon-container'>
+          <svg class="inline" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 512 512"><path d="M480 224l-186.828 7.487L401.688 64l-59.247-32L256 208 169.824 32l-59.496 32 108.5 167.487L32 224v64l185.537-10.066L113.65 448l55.969 32L256 304l86.381 176 55.949-32-103.867-170.066L480 288z" fill="currentColor"/></svg>
+        </span>
+      <% end %>
+      <span><%= key %></span> 
+      <% should_disable = is_premium && ChatwootHub.pricing_plan == 'community' %>
+      <span class='value-container'><%= check_box "enabled_features", "feature_#{key}", { checked: val, disabled: should_disable }, true, false %></span>
     </div>
   <% end %>
 </div>

--- a/app/views/fields/account_features_field/_show.html.erb
+++ b/app/views/fields/account_features_field/_show.html.erb
@@ -1,5 +1,5 @@
 <div class='feature-container'>
-  <% field.data.each do |key,val| %>
+  <% SuperAdmin::AccountFeaturesHelper.filtered_features(field.data).each do |key, val| %>
     <div class='feature-cell'>
     <% if SuperAdmin::AccountFeaturesHelper.account_premium_features.include? key %>
     <span class='icon-container'>

--- a/config/features.yml
+++ b/config/features.yml
@@ -71,6 +71,7 @@
 - name: response_bot
   enabled: false
   premium: true
+  chatwoot_internal: true
 - name: message_reply_to
   enabled: false
   help_url: https://chwt.app/hc/reply-to
@@ -96,3 +97,6 @@
   enabled: false
 - name: report_v4
   enabled: false
+- name: contact_chatwoot_support_team
+  enabled: true
+  chatwoot_internal: true


### PR DESCRIPTION
This PR introduces internal feature flags for testing purposes. These flags will not be displayed on regular instances to prevent customer confusion.

Additionally, a new feature flag, `contact_chatwoot_support_team`, has been added for Chatwoot Cloud. This flag disables contact support for third-party onboarded accounts, as support will be handled by the original affiliate team.