### PR TITLE
fix: Handle JSON requests in DashboardController

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -7,12 +7,16 @@ class DashboardController < ActionController::Base
   around_action :switch_locale
   before_action :ensure_installation_onboarding, only: [:index]
   before_action :render_hc_if_custom_domain, only: [:index]
-
+  before_action :ensure_html_format
   layout 'vueapp'
 
   def index; end
 
   private
+
+  def ensure_html_format
+    head :not_acceptable unless request.format.html?
+  end
 
   def set_global_config
     @global_config = GlobalConfig.get(

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -18,6 +18,13 @@ describe '/app/login', type: :request do
     end
   end
 
+  context 'with non-HTML format' do
+    it 'returns not acceptable for JSON' do
+      get '/app/login', params: { format: 'json' }
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+
   # Routes are loaded once on app start
   # hence Rails.application.reload_routes! is used in this spec
   # ref : https://stackoverflow.com/a/63584877/939299


### PR DESCRIPTION
This is the error that is triggering a P0 incident in Chatwoot. 

```
DashboardController#index is missing a template for this request format and variant. request.formats: ["application/json"] request.variant: []
```

The user is calling `/app/accounts/api/v1/accounts/<account-id>/inboxes`. The URL is wrong, the requests are routed to dashboard controller as it starts with `/app/accounts`. The dashboard controller is not handling JSON requests and it creates errors. There are 312k errors over the last 2 years. Close to 50k during last 3 days.

This fix would return not_acceptable response to the attempts.
