### PR TITLE
fix: Disable branding on help center if the feature is turned on

### DIFF
--- a/app/views/layouts/portal.html.erb
+++ b/app/views/layouts/portal.html.erb
@@ -64,7 +64,7 @@ By default, it renders:
           <%= render "public/api/v1/portals/header", portal: @portal %>
         <% end %>
         <%= yield %>
-        <% if !@is_plain_layout_enabled %>
+        <% if !(@is_plain_layout_enabled || @portal.account.feature_enabled?('disable_branding')) %>
           <%= render "public/api/v1/portals/footer" %>
         <% end %>
       </main>


### PR DESCRIPTION
Disable branding on help center as well if the feature is turned on the account.