### PR TITLE
fix: handle empty FIRECRAWL_KEY in captain crawl job

### DIFF
--- a/enterprise/app/jobs/captain/documents/crawl_job.rb
+++ b/enterprise/app/jobs/captain/documents/crawl_job.rb
@@ -2,7 +2,7 @@ class Captain::Documents::CrawlJob < ApplicationJob
   queue_as :low
 
   def perform(document)
-    if InstallationConfig.find_by(name: 'CAPTAIN_FIRECRAWL_API_KEY').present?
+    if InstallationConfig.find_by(name: 'CAPTAIN_FIRECRAWL_API_KEY')&.value.present?
       perform_firecrawl_crawl(document)
     else
       perform_simple_crawl(document)


### PR DESCRIPTION

- handle empty FIRECRAWL_KEY in captain crawl job
