### PR TITLE
fix: Reports chart by removing y-axis numeric labels

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/reports/ReportContainer.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/ReportContainer.vue
@@ -112,33 +112,28 @@ export default {
       };
     },
     getChartOptions(metric) {
-      const baseOptions = METRIC_CHART[metric.KEY].scales;
+      const options = {
+        scales: METRIC_CHART[metric.KEY].scales,
+      };
 
-      // If not an average metric type, return base options early
-      if (!this.isAverageMetricType(metric.KEY)) {
-        return baseOptions;
-      }
-
-      // Only create tooltip config for time-based metrics
-      return {
-        ...baseOptions,
-        plugins: {
+      // Only add tooltip configuration for time-based metrics
+      if (this.isAverageMetricType(metric.KEY)) {
+        options.plugins = {
           tooltip: {
             callbacks: {
               label: ({ raw, dataIndex }) => {
-                const value = raw || 0;
-                const count =
-                  this.accountReport.data[metric.KEY][dataIndex]?.count || 0;
-
                 return this.$t(metric.TOOLTIP_TEXT, {
-                  metricValue: formatTime(value),
-                  conversationCount: count,
+                  metricValue: formatTime(raw || 0),
+                  conversationCount:
+                    this.accountReport.data[metric.KEY][dataIndex]?.count || 0,
                 });
               },
             },
           },
-        },
-      };
+        };
+      }
+
+      return options;
     },
   },
 };


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes showing y-axis numeric labels in reports charts. It occurs after merging this PR. https://github.com/chatwoot/chatwoot/pull/10938

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

#### **Screenshots**

#### **Before**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/40299ba8-6f6b-43d5-b71a-5af22c238e2d" />


#### **After**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/72ee5729-9789-43c4-a85f-8037f647c7df" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
