### PR TITLE
fix bug when send tranascription by mail pt_BR

### DIFF
--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -174,9 +174,9 @@ pt_BR:
     reply:
       email:
         header:
-          from_with_name: '%{assignee_name} de %{inbox_name} <reply+%{from_email}>'
+          from_with_name: '%{assignee_name} de %{inbox_name} <reply%{from_email}>'
           reply_with_name: '%{assignee_name} de %{inbox_name} <reply+%{reply_email}>'
-          friendly_name: '%{sender_name} de %{business_name} <reply+%{from_email}>'
+          friendly_name: '%{sender_name} de %{business_name} <reply%{from_email}>'
           professional_name: '%{business_name} <%{from_email}>'
       channel_email:
         header:


### PR DESCRIPTION

## Description

when we send a trascription by email it has a bug that does not send email comparing en.yml x pt_BR.yml noticed a difference in the end fix a bug by removing sibolo "+" after <reply

Fixes

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ]  I made the corresponding changes to other models within the project 
- [ x ] My changes generate no new warnings
- [ x ] New and existing unit tests pass locally and in server with my changes

