### PR TITLE
fix: transcription email locales for pt_BR

### DIFF
--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -174,9 +174,9 @@ pt_BR:
     reply:
       email:
         header:
-          from_with_name: '%{assignee_name} de %{inbox_name} <reply+%{from_email}>'
+          from_with_name: '%{assignee_name} de %{inbox_name} <reply%{from_email}>'
           reply_with_name: '%{assignee_name} de %{inbox_name} <reply+%{reply_email}>'
-          friendly_name: '%{sender_name} de %{business_name} <reply+%{from_email}>'
+          friendly_name: '%{sender_name} de %{business_name} <reply%{from_email}>'
           professional_name: '%{business_name} <%{from_email}>'
       channel_email:
         header:

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -174,9 +174,9 @@ pt_BR:
     reply:
       email:
         header:
-          from_with_name: '%{assignee_name} de %{inbox_name} <reply%{from_email}>'
+          from_with_name: '%{assignee_name} de %{inbox_name} <%{from_email}>'
           reply_with_name: '%{assignee_name} de %{inbox_name} <reply+%{reply_email}>'
-          friendly_name: '%{sender_name} de %{business_name} <reply%{from_email}>'
+          friendly_name: '%{sender_name} de %{business_name} <%{from_email}>'
           professional_name: '%{business_name} <%{from_email}>'
       channel_email:
         header:


### PR DESCRIPTION
## Description

[fix bug when send tranascription by mail pt_BR](https://github.com/chatwoot/chatwoot/commit/d6c2e5eaadf37c1d6e2d2c705e678e014a23021d) 

when we send a trascription by email has a bug that don't send e-mail
comparing  en.yml x pt_BR.yml I see a diference in  end fix a bug removing + after <reply

Fixes

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
