### PR TITLE
chore(deps): Bump slack-ruby-client from 2.5.1 to 2.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ gem 'twitty', '~> 0.1.5'
 # facebook client
 gem 'koala'
 # slack client
-gem 'slack-ruby-client', '~> 2.5.1'
+gem 'slack-ruby-client', '~> 2.5.2'
 # for dialogflow integrations
 gem 'google-cloud-dialogflow-v2', '>= 0.24.0'
 gem 'grpc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -747,7 +747,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    slack-ruby-client (2.5.1)
+    slack-ruby-client (2.5.2)
       faraday (>= 2.0)
       faraday-mashify
       faraday-multipart
@@ -954,7 +954,7 @@ DEPENDENCIES
   sidekiq (>= 7.3.1)
   sidekiq-cron (>= 1.12.0)
   simplecov (= 0.17.1)
-  slack-ruby-client (~> 2.5.1)
+  slack-ruby-client (~> 2.5.2)
   spring
   spring-watcher-listen
   squasher


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-4082/slackwebapierrorsinvalidarguments-invalid-arguments

Recent Slack file uploads are generating "invalid_arguments" [errors](https://chatwoot-p3.sentry.io/issues/6327909812/?referrer=Linear) in some channels. The issue occurs when using a single files_upload_v2 method with a #channel parameter. Version v2.5.2 fixes these issues The gem has been updated with a new version containing [fixes](https://github.com/slack-ruby/slack-ruby-client/blob/master/CHANGELOG.md#252-20250219).