### PR TITLE
fix: `ComboBox` filtering delay in contact merge search

### DIFF
--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactMergeForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactMergeForm.vue
@@ -50,7 +50,7 @@ const { t } = useI18n();
       </div>
       <ComboBox
         id="inbox"
-        use-api-search
+        use-api-results
         :model-value="primaryContactId"
         :options="primaryContactList"
         :empty-state="

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactMergeForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactMergeForm.vue
@@ -50,6 +50,7 @@ const { t } = useI18n();
       </div>
       <ComboBox
         id="inbox"
+        use-api-search
         :model-value="primaryContactId"
         :options="primaryContactList"
         :empty-state="

--- a/app/javascript/dashboard/components-next/combobox/ComboBox.vue
+++ b/app/javascript/dashboard/components-next/combobox/ComboBox.vue
@@ -13,34 +13,14 @@ const props = defineProps({
     validator: value =>
       value.every(option => 'value' in option && 'label' in option),
   },
-  placeholder: {
-    type: String,
-    default: '',
-  },
-  modelValue: {
-    type: [String, Number],
-    default: '',
-  },
-  disabled: {
-    type: Boolean,
-    default: false,
-  },
-  searchPlaceholder: {
-    type: String,
-    default: '',
-  },
-  emptyState: {
-    type: String,
-    default: '',
-  },
-  message: {
-    type: String,
-    default: '',
-  },
-  hasError: {
-    type: Boolean,
-    default: false,
-  },
+  placeholder: { type: String, default: '' },
+  modelValue: { type: [String, Number], default: '' },
+  disabled: { type: Boolean, default: false },
+  searchPlaceholder: { type: String, default: '' },
+  emptyState: { type: String, default: '' },
+  message: { type: String, default: '' },
+  hasError: { type: Boolean, default: false },
+  useApiSearch: { type: Boolean, default: false }, // useApiSearch prop to determine if search is handled by API
 });
 
 const emit = defineEmits(['update:modelValue', 'search']);
@@ -54,6 +34,12 @@ const dropdownRef = ref(null);
 const comboboxRef = ref(null);
 
 const filteredOptions = computed(() => {
+  // For API search, don't filter options locally
+  if (props.useApiSearch && search.value) {
+    return props.options;
+  }
+
+  // For local search, filter options based on search term
   const searchTerm = search.value.toLowerCase();
   return props.options.filter(option =>
     option.label.toLowerCase().includes(searchTerm)

--- a/app/javascript/dashboard/components-next/combobox/ComboBox.vue
+++ b/app/javascript/dashboard/components-next/combobox/ComboBox.vue
@@ -20,7 +20,7 @@ const props = defineProps({
   emptyState: { type: String, default: '' },
   message: { type: String, default: '' },
   hasError: { type: Boolean, default: false },
-  useApiSearch: { type: Boolean, default: false }, // useApiSearch prop to determine if search is handled by API
+  useApiResults: { type: Boolean, default: false }, // useApiResults prop to determine if search is handled by API
 });
 
 const emit = defineEmits(['update:modelValue', 'search']);
@@ -35,7 +35,7 @@ const comboboxRef = ref(null);
 
 const filteredOptions = computed(() => {
   // For API search, don't filter options locally
-  if (props.useApiSearch && search.value) {
+  if (props.useApiResults && search.value) {
     return props.options;
   }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue with the `ComboBox` component, ensuring it correctly handles API search functionality and displays results instantly.

#### **Cause of this issue**
When using the `ComboBox` with API-based search (e.g., contact search), the component applied local filtering on top of the API-filtered results. This caused search results to disappear when they didn't contain the search term in their labels, even though they were correct matches from the API.

#### **Solution**
- Added a new `useApiResults` prop (default: `false`) to indicate when the ComboBox is being used with API-based search
- When `useApiResults` is `true` and a search is active, the component skips local filtering and shows all options received from the parent

Fixes https://linear.app/chatwoot/issue/CW-4083/contact-merge-search-dropdown-doesnt-display-results-instantly

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### **Loom video**

**Before**
https://www.loom.com/share/2d2df4680390493181c7fa956ea2d848?sid=5704649d-ba51-42ea-b3a8-70c9b540fbeb

**After**
https://www.loom.com/share/4b1bbb0492ba4b9cb1167d8788a4a22a?sid=acfc1bf4-6439-4e73-b305-e7e3e2cf7756


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
