### PR TITLE
fix: Dynamic seconds delay by attachments size on message send reply

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -320,10 +320,14 @@ class Message < ApplicationRecord
                                                                             previous_changes: previous_changes)
   end
 
-  def send_reply
+  def send_reply  def send_reply
+    return ::SendReplyJob.perform_later(id) if attachments.blank?
+
     # FIXME: Giving it few seconds for the attachment to be uploaded to the service
     # active storage attaches the file only after commit
-    attachments.blank? ? ::SendReplyJob.perform_later(id) : ::SendReplyJob.set(wait: 2.seconds).perform_later(id)
+    seconds = (attachments.map(&:file).map(&:byte_size).sum() / 1024 / 1000).to_i.seconds # a second per 1MB
+    ::SendReplyJob.set(wait: seconds).perform_later(id)
+  end
   end
 
   def reopen_conversation


### PR DESCRIPTION
# Pull Request Template

## Dynamic seconds delay by attachments size on message send reply

Sometimes where size of files is more large, the presign url return 403


