### PR TITLE
fix: Not using saved `order_by` when fetching conversation list

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -353,10 +353,11 @@ function setFiltersFromUISettings() {
   const { conversations_filter_by: filterBy = {} } = uiSettings.value;
   const { status, order_by: orderBy } = filterBy;
   activeStatus.value = status || wootConstants.STATUS_TYPE.OPEN;
-  activeSortBy.value =
-    Object.keys(wootConstants.SORT_BY_TYPE).find(
-      sortField => sortField === orderBy
-    ) || wootConstants.SORT_BY_TYPE.LAST_ACTIVITY_AT_DESC;
+  activeSortBy.value = Object.values(wootConstants.SORT_BY_TYPE).includes(
+    orderBy
+  )
+    ? orderBy
+    : wootConstants.SORT_BY_TYPE.LAST_ACTIVITY_AT_DESC;
 }
 
 function emitConversationLoaded() {


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the issue where the saved `order_by` value for the conversation list is not being applied. The feature was originally added in PR https://github.com/chatwoot/chatwoot/pull/8237 but broke after merging the Vue 3 migration PR https://github.com/chatwoot/chatwoot/pull/10047

Fixes https://linear.app/chatwoot/issue/CW-4110/not-using-the-saved-sort-order-by-option-from-ui-settings

**Cause of the Issue:**  
The previous implementation checked `orderBy` against the keys of the sorting constants instead of their values. Since `orderBy` stores a sorting value, this caused the condition to fail, leading to fallback to the default sorting option.  

**Solution:**  
The fix ensures that `orderBy` is validated against the values of the sorting constants rather than the keys. This correctly applies the saved sorting preference, while still falling back to the default if needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Loom video**
https://www.loom.com/share/ebe8a4d3f1c041c6862334dc3b6d43a3?sid=5167feb7-eb4a-4f2c-8211-662830ba946c




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
