### PR TITLE
fix: Disable syncing IMAP if the account is suspended

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -561,7 +561,7 @@ GEM
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.11)
+    rack (2.2.12)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-contrib (2.5.0)

--- a/app/jobs/inboxes/fetch_imap_email_inboxes_job.rb
+++ b/app/jobs/inboxes/fetch_imap_email_inboxes_job.rb
@@ -2,8 +2,15 @@ class Inboxes::FetchImapEmailInboxesJob < ApplicationJob
   queue_as :scheduled_jobs
 
   def perform
-    Inbox.where(channel_type: 'Channel::Email').all.find_each(batch_size: 100) do |inbox|
-      ::Inboxes::FetchImapEmailsJob.perform_later(inbox.channel) if inbox.channel.imap_enabled
+    email_inboxes = Inbox.where(channel_type: 'Channel::Email')
+    email_inboxes.find_each(batch_size: 100) do |inbox|
+      ::Inboxes::FetchImapEmailsJob.perform_later(inbox.channel) if should_fetch_emails?(inbox)
     end
+  end
+
+  private
+
+  def should_fetch_emails?(inbox)
+    inbox.channel.imap_enabled && !inbox.account.suspended?
   end
 end

--- a/spec/jobs/inboxes/fetch_imap_email_inboxes_job_spec.rb
+++ b/spec/jobs/inboxes/fetch_imap_email_inboxes_job_spec.rb
@@ -2,11 +2,19 @@ require 'rails_helper'
 
 RSpec.describe Inboxes::FetchImapEmailInboxesJob do
   let(:account) { create(:account) }
+  let(:suspended_account) { create(:account, status: 'suspended') }
+
   let(:imap_email_channel) do
-    create(:channel_email, imap_enabled: true, imap_address: 'imap.gmail.com', imap_port: 993, imap_login: 'imap@gmail.com',
-                           imap_password: 'password', account: account)
+    create(:channel_email, imap_enabled: true, account: account)
   end
-  let(:email_inbox) { create(:inbox, channel: imap_email_channel, account: account) }
+
+  let(:imap_email_channel_suspended) do
+    create(:channel_email, imap_enabled: true, account: suspended_account)
+  end
+
+  let(:disabled_imap_channel) do
+    create(:channel_email, imap_enabled: false, account: account)
+  end
 
   it 'enqueues the job' do
     expect { described_class.perform_later }.to have_enqueued_job(described_class)
@@ -14,8 +22,25 @@ RSpec.describe Inboxes::FetchImapEmailInboxesJob do
   end
 
   context 'when called' do
-    it 'fetch all the email channels' do
+    it 'fetches emails only for active accounts with imap enabled' do
+      # Should call perform_later only once for the active, imap-enabled inbox
       expect(Inboxes::FetchImapEmailsJob).to receive(:perform_later).with(imap_email_channel).once
+
+      # Should not call for suspended account or disabled IMAP channels
+      expect(Inboxes::FetchImapEmailsJob).not_to receive(:perform_later).with(imap_email_channel_suspended)
+      expect(Inboxes::FetchImapEmailsJob).not_to receive(:perform_later).with(disabled_imap_channel)
+
+      described_class.perform_now
+    end
+
+    it 'skips suspended accounts' do
+      expect(Inboxes::FetchImapEmailsJob).not_to receive(:perform_later).with(imap_email_channel_suspended)
+
+      described_class.perform_now
+    end
+
+    it 'skips disabled imap channels' do
+      expect(Inboxes::FetchImapEmailsJob).not_to receive(:perform_later).with(disabled_imap_channel)
 
       described_class.perform_now
     end


### PR DESCRIPTION
This PR disables the IMAP syncing if the account is suspended. 