### PR TITLE
chore: Rescue slack link unfurling errors.

### DIFF
--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -18,6 +18,11 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
     slack_client.chat_unfurl(
       event
     )
+  rescue Slack::Web::Api::Errors::AccountInactive, Slack::Web::Api::Errors::MissingScope, Slack::Web::Api::Errors::InvalidAuth,
+         Slack::Web::Api::Errors::ChannelNotFound, Slack::Web::Api::Errors::NotInChannel => e
+    Rails.logger.error e
+    hook.prompt_reauthorization!
+    hook.disable
   end
 
   private

--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -18,11 +18,8 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
     slack_client.chat_unfurl(
       event
     )
-  rescue Slack::Web::Api::Errors::AccountInactive, Slack::Web::Api::Errors::MissingScope, Slack::Web::Api::Errors::InvalidAuth,
-         Slack::Web::Api::Errors::ChannelNotFound, Slack::Web::Api::Errors::NotInChannel => e
+  rescue Slack::Web::Api::Errors::MissingScope => e
     Rails.logger.error e
-    hook.prompt_reauthorization!
-    hook.disable
   end
 
   private

--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -18,6 +18,8 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
     slack_client.chat_unfurl(
       event
     )
+    # You may wonder why we're not requesting reauthorization and disabling hooks when scope errors occur.
+    # Since link unfurling is just a nice-to-have feature that doesn't affect core functionality, we will silently ignore these errors.
   rescue Slack::Web::Api::Errors::MissingScope => e
     Rails.logger.error e
   end

--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -21,7 +21,7 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
     # You may wonder why we're not requesting reauthorization and disabling hooks when scope errors occur.
     # Since link unfurling is just a nice-to-have feature that doesn't affect core functionality, we will silently ignore these errors.
   rescue Slack::Web::Api::Errors::MissingScope => e
-    Rails.logger.error e
+    Rails.logger.warn "Slack: Missing scope error: #{e.message}"
   end
 
   private

--- a/spec/lib/integrations/slack/send_on_slack_service_spec.rb
+++ b/spec/lib/integrations/slack/send_on_slack_service_spec.rb
@@ -278,7 +278,7 @@ describe Integrations::Slack::SendOnSlackService do
           .with(unflur_payload)
           .and_raise(error)
 
-        expect(Rails.logger).to receive(:error).with(error)
+        expect(Rails.logger).to receive(:warn).with('Slack: Missing scope error: Missing required scope')
 
         link_builder.link_unfurl(unflur_payload)
       end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-4122/slackwebapierrorsmissingscope-missing-scope

This PR adds the ability to handle errors when scopes are missing during link unfurling. Since link unfurling is just a nice-to-have feature that doesn't affect core functionality, we will silently ignore these errors.