### PR TITLE
fix: Paginate attachments API

### DIFF
--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -6,6 +6,8 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   before_action :conversation, except: [:index, :meta, :search, :create, :filter]
   before_action :inbox, :contact, :contact_inbox, only: [:create]
 
+  ATTACHMENT_RESULTS_PER_PAGE = 100
+
   def index
     result = conversation_finder.perform
     @conversations = result[:conversations]
@@ -24,7 +26,12 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def attachments
+    @attachments_count = @conversation.attachments.count
     @attachments = @conversation.attachments
+                                .includes(:message)
+                                .order(created_at: :desc)
+                                .page(attachment_params[:page])
+                                .per(ATTACHMENT_RESULTS_PER_PAGE)
   end
 
   def show; end
@@ -122,6 +129,10 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   def permitted_update_params
     # TODO: Move the other conversation attributes to this method and remove specific endpoints for each attribute
     params.permit(:priority)
+  end
+
+  def attachment_params
+    params.permit(:page)
   end
 
   def update_last_seen_on_conversation(last_seen_at, update_assignee)

--- a/app/views/api/v1/accounts/conversations/attachments.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/attachments.json.jbuilder
@@ -1,3 +1,7 @@
+json.meta do
+  json.total_count @attachments_count
+end
+
 json.payload @attachments do |attachment|
   json.message_id attachment.push_event_data[:message_id]
   json.thumb_url attachment.push_event_data[:thumb_url]


### PR DESCRIPTION
There are attachments with over 1000 attachments (unusual) in production, and some of them timeout. This PR would limit the number of attachments to 100 (which is sufficient for viewing the files in the gallery, pagination on the UI can be added later).