### PR TITLE
fix: Hide Configuration page for Microsoft & Gmail channels

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -121,8 +121,6 @@ export default {
         this.isALineChannel ||
         this.isAPIInbox ||
         (this.isAnEmailChannel && !this.inbox.provider) ||
-        this.isAMicrosoftInbox ||
-        this.isAGoogleInbox ||
         this.isAWhatsAppChannel ||
         this.isAWebWidgetInbox
       ) {


### PR DESCRIPTION
The Microsoft and Gmail channels don’t function with custom SMTP or IMAP configurations or forwarding option. Displaying the configuration tab creates confusion among users. 

This PR would eliminate the option for these channels.