### PR TITLE
fix: Out of order conversation events causing stale data to reflect in the UI

### DIFF
--- a/app/javascript/shared/helpers/BaseActionCableConnector.js
+++ b/app/javascript/shared/helpers/BaseActionCableConnector.js
@@ -79,10 +79,10 @@ class BaseActionCableConnector {
     this.consumer.disconnect();
   }
 
-  onReceived = ({ event, data } = {}) => {
+  onReceived = ({ event, data, event_timestamp } = {}) => {
     if (this.isAValidEvent(data)) {
       if (this.events[event] && typeof this.events[event] === 'function') {
-        this.events[event](data);
+        this.events[event](data, event_timestamp);
       }
     }
   };

--- a/spec/jobs/action_cable_broadcast_job_spec.rb
+++ b/spec/jobs/action_cable_broadcast_job_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.describe ActionCableBroadcastJob do
+  include Events::Types
+
+  let(:account) { create(:account) }
+  let(:conversation) { create(:conversation, account: account) }
+  let(:members) { %w[test_member_1 test_member_2] }
+  let(:event_name) { 'test.event' }
+  let(:data) { { account_id: account.id, id: conversation.display_id } }
+  let(:timestamp) { Time.zone.now.to_f }
+
+  describe '#perform' do
+    context 'when members are blank' do
+      it 'returns without broadcasting' do
+        expect(ActionCable.server).not_to receive(:broadcast)
+        described_class.perform_now([], event_name, data, timestamp)
+      end
+    end
+
+    context 'when event is not a conversation update event' do
+      it 'broadcasts original data to all members' do
+        members.each do |member|
+          expect(ActionCable.server).to receive(:broadcast).with(
+            member,
+            {
+              event: event_name,
+              data: data,
+              event_timestamp: timestamp
+            }
+          )
+        end
+
+        described_class.perform_now(members, event_name, data, timestamp)
+      end
+    end
+
+    context 'when event is a conversation update event' do
+      let(:conversation_data) { conversation.push_event_data.merge(account_id: account.id) }
+      let(:conversation_update_events) do
+        [
+          Events::Types::CONVERSATION_READ,
+          Events::Types::CONVERSATION_UPDATED,
+          Events::Types::TEAM_CHANGED,
+          Events::Types::ASSIGNEE_CHANGED,
+          Events::Types::CONVERSATION_STATUS_CHANGED
+        ]
+      end
+
+      it 'refreshes and broadcasts latest conversation data for each update event' do
+        conversation_update_events.each do |update_event|
+          members.each do |member|
+            expect(ActionCable.server).to receive(:broadcast).with(
+              member,
+              {
+                event: update_event,
+                data: conversation_data,
+                event_timestamp: timestamp
+              }
+            )
+          end
+
+          described_class.perform_now(members, update_event, data, timestamp)
+        end
+      end
+
+      context 'when conversation is not found' do
+        let(:data) { { account_id: account.id, id: 0 } }
+
+        it 'raises ActiveRecord::RecordNotFound' do
+          expect do
+            described_class.perform_now(
+              members,
+              Events::Types::CONVERSATION_UPDATED,
+              data,
+              timestamp
+            )
+          end.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+  end
+
+  describe 'queue' do
+    it 'uses critical queue' do
+      expect(described_class.queue_name).to eq('critical')
+    end
+  end
+
+  describe 'timestamp handling' do
+    it 'includes event_timestamp in broadcast data' do
+      expect(ActionCable.server).to receive(:broadcast).with(
+        members.first,
+        hash_including(event_timestamp: timestamp)
+      ).once
+
+      expect(ActionCable.server).to receive(:broadcast).with(
+        members.last,
+        hash_including(event_timestamp: timestamp)
+      ).once
+
+      described_class.perform_now(members, event_name, data, timestamp)
+    end
+  end
+end

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -30,7 +30,8 @@ describe ActionCableListener do
           agent.pubsub_token, admin.pubsub_token, conversation.contact_inbox.pubsub_token
         ),
         'message.created',
-        message.push_event_data.merge(account_id: account.id)
+        message.push_event_data.merge(account_id: account.id),
+        nil
       )
       listener.message_created(event)
     end
@@ -48,7 +49,8 @@ describe ActionCableListener do
           agent.pubsub_token, admin.pubsub_token, conversation.contact_inbox.pubsub_token, verified_contact_inbox.pubsub_token
         ),
         'message.created',
-        message.push_event_data.merge(account_id: account.id)
+        message.push_event_data.merge(account_id: account.id),
+        nil
       )
       listener.message_created(event)
     end
@@ -68,7 +70,8 @@ describe ActionCableListener do
         'conversation.typing_on', { conversation: conversation.push_event_data,
                                     user: agent.push_event_data,
                                     account_id: account.id,
-                                    is_private: false }
+                                    is_private: false },
+        nil
       )
       listener.conversation_typing_on(event)
     end
@@ -88,7 +91,8 @@ describe ActionCableListener do
         'conversation.typing_on', { conversation: conversation.push_event_data,
                                     user: conversation.contact.push_event_data,
                                     account_id: account.id,
-                                    is_private: false }
+                                    is_private: false },
+        nil
       )
       listener.conversation_typing_on(event)
     end
@@ -108,7 +112,8 @@ describe ActionCableListener do
         'conversation.typing_off', { conversation: conversation.push_event_data,
                                      user: agent.push_event_data,
                                      account_id: account.id,
-                                     is_private: false }
+                                     is_private: false },
+        nil
       )
       listener.conversation_typing_off(event)
     end
@@ -125,7 +130,8 @@ describe ActionCableListener do
           agent.pubsub_token, admin.pubsub_token
         ),
         'contact.deleted',
-        contact.push_event_data.merge(account_id: account.id)
+        contact.push_event_data.merge(account_id: account.id),
+        nil
       )
       listener.contact_deleted(event)
     end
@@ -147,7 +153,8 @@ describe ActionCableListener do
           },
           unread_count: 1,
           count: 1
-        }
+        },
+        nil
       )
 
       listener.notification_deleted(event)
@@ -168,7 +175,8 @@ describe ActionCableListener do
           notification: notification.push_event_data,
           unread_count: 1,
           count: 1
-        }
+        },
+        nil
       )
 
       listener.notification_updated(event)
@@ -177,7 +185,8 @@ describe ActionCableListener do
 
   describe '#conversation_updated' do
     let(:event_name) { :'conversation.updated' }
-    let!(:event) { Events::Base.new(event_name, Time.zone.now, conversation: conversation, user: agent, is_private: false) }
+    let(:timestamp) { Time.zone.now }
+    let!(:event) { Events::Base.new(event_name, timestamp, conversation: conversation, user: agent, is_private: false) }
 
     before do
       conversation.add_labels(['support'])
@@ -189,7 +198,8 @@ describe ActionCableListener do
       expect(ActionCableBroadcastJob).to receive(:perform_later).with(
         [agent.pubsub_token, admin.pubsub_token, conversation.contact_inbox.pubsub_token],
         'conversation.updated',
-        conversation.push_event_data.merge(account_id: account.id)
+        conversation.push_event_data.merge(account_id: account.id),
+        timestamp.to_f
       )
       listener.conversation_updated(event)
     end
@@ -200,9 +210,96 @@ describe ActionCableListener do
       expect(ActionCableBroadcastJob).to receive(:perform_later).with(
         [agent.pubsub_token, admin.pubsub_token, conversation.contact_inbox.pubsub_token],
         'conversation.updated',
-        conversation.push_event_data.merge(account_id: account.id)
+        conversation.push_event_data.merge(account_id: account.id),
+        timestamp.to_f
       )
       listener.conversation_updated(event)
+    end
+  end
+
+  context 'with event timestamps' do
+    let(:timestamp) { Time.zone.now }
+
+    describe '#conversation_created' do
+      let(:event_name) { :'conversation.created' }
+      let!(:event) { Events::Base.new(event_name, timestamp, conversation: conversation) }
+
+      it 'sends event with timestamp' do
+        expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+          [agent.pubsub_token, admin.pubsub_token, conversation.contact_inbox.pubsub_token],
+          'conversation.created',
+          conversation.push_event_data.merge(account_id: account.id),
+          timestamp.to_f
+        )
+        listener.conversation_created(event)
+      end
+    end
+
+    describe '#conversation_status_changed' do
+      let(:event_name) { :'conversation.status_changed' }
+      let!(:event) { Events::Base.new(event_name, timestamp, conversation: conversation) }
+
+      it 'sends event with timestamp' do
+        expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+          [agent.pubsub_token, admin.pubsub_token, conversation.contact_inbox.pubsub_token],
+          'conversation.status_changed',
+          conversation.push_event_data.merge(account_id: account.id),
+          timestamp.to_f
+        )
+        listener.conversation_status_changed(event)
+      end
+    end
+
+    describe '#assignee_changed' do
+      let(:event_name) { :'conversation.assignee_changed' }
+      let!(:event) { Events::Base.new(event_name, timestamp, conversation: conversation) }
+
+      it 'sends event with timestamp' do
+        expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+          [agent.pubsub_token, admin.pubsub_token],
+          'assignee.changed',
+          conversation.push_event_data.merge(account_id: account.id),
+          timestamp.to_f
+        )
+        listener.assignee_changed(event)
+      end
+    end
+
+    describe '#team_changed' do
+      let(:event_name) { :'conversation.team_changed' }
+      let!(:event) { Events::Base.new(event_name, timestamp, conversation: conversation) }
+
+      it 'sends event with timestamp' do
+        expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+          [agent.pubsub_token, admin.pubsub_token],
+          'team.changed',
+          conversation.push_event_data.merge(account_id: account.id),
+          timestamp.to_f
+        )
+        listener.team_changed(event)
+      end
+    end
+
+    # Update the existing conversation_updated test to include timestamp verification
+    describe '#conversation_updated' do
+      let(:event_name) { :'conversation.updated' }
+      let!(:event) { Events::Base.new(event_name, timestamp, conversation: conversation, user: agent, is_private: false) }
+
+      before do
+        conversation.add_labels(['support'])
+      end
+
+      it 'sends update to inbox members with timestamp' do
+        expect(conversation.inbox.reload.inbox_members.count).to eq(1)
+
+        expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+          [agent.pubsub_token, admin.pubsub_token, conversation.contact_inbox.pubsub_token],
+          'conversation.updated',
+          conversation.push_event_data.merge(account_id: account.id),
+          timestamp.to_f
+        )
+        listener.conversation_updated(event)
+      end
     end
   end
 end


### PR DESCRIPTION
### Problem

As identified in our investigation, conversation events were sometimes delivered out of sequence through ActionCable, causing UI issues where conversations would briefly appear and then disappear, this would cause the stats to show the correct number on the list header, but the chat list would show incorrect items. This was happening because of the following reasons:

- `ActionCable` doesn't guarantee delivery order when broadcasts occur from separate Sidekiq jobs
- Multiple related events (`conversation.updated`, `assignee.changed`, etc.) were being processed in an unpredictable order
- Each event would overwrite the entire conversation state without checking if it represented the latest state

### Solution

This PR implements a timestamp-based event sequencing mechanism to ensure we only process the most recent updates for each conversation:

- Added `event_timestamp` to all `ActionCable` broadcasts, using the original event timestamp from the application. This timestamp is generated on the main thread, at the model before the action is ever dispatched and can be considered a reliable key to find the order of events.
- Created a client-side tracking mechanism in `ActionCableConnector` to maintain the latest known timestamp for each conversation
- Added validation logic to ignore any events with timestamps older than what we've already processed

### Implementation Details

- Added `conversationEventTimestamps` Map to track the latest timestamp per conversation
- Added `eventOutOfSequence()` helper method to detect and filter out-of-sequence events
- Modified event handlers for `assigneeChanged`, `conversationRead`, `statusChange`, and `conversationUpdated` to respect event ordering
- Updated backend broadcasters to include event timestamps with all websocket messages

### Future work

- We can get rid of `CONVERSATION_UPDATE_EVENTS` in `ActionCableBroadcastJob`, and avoid re-fetching of the objects.
- We can implement granular updates for events like team or assignee change