### PR TITLE
fix: Add inbound_emails feature to the list of enabled features in paid account

### DIFF
--- a/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
+++ b/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
@@ -66,7 +66,7 @@ class Enterprise::Billing::HandleStripeEventService
   end
 
   def features_to_update
-    %w[help_center campaigns team_management channel_twitter channel_facebook channel_email captain_integration]
+    %w[inbound_emails help_center campaigns team_management channel_twitter channel_facebook channel_email captain_integration]
   end
 
   def subscription


### PR DESCRIPTION
Enable inbound_emails in paid accounts automatically