### PR TITLE
fix: Force re-render route i18n string

### DIFF
--- a/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
+++ b/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
@@ -90,7 +90,7 @@ const sortedInboxes = computed(() =>
   inboxes.value.slice().sort((a, b) => a.name.localeCompare(b.name))
 );
 
-const newReportRoutes = [
+const newReportRoutes = () => [
   {
     name: 'Reports Agent',
     label: t('SIDEBAR.REPORTS_AGENT'),
@@ -116,7 +116,7 @@ const newReportRoutes = [
   },
 ];
 
-const oldReportRoutes = [
+const oldReportRoutes = () => [
   {
     name: 'Reports Agent',
     label: t('SIDEBAR.REPORTS_AGENT'),
@@ -140,7 +140,7 @@ const oldReportRoutes = [
 ];
 
 const reportRoutes = computed(() =>
-  showV4Routes.value ? newReportRoutes : oldReportRoutes
+  showV4Routes.value ? newReportRoutes() : oldReportRoutes()
 );
 
 const menuItems = computed(() => {


### PR DESCRIPTION
The string were not taking the correct locale as there were initialized during the component mount. This change would force the component to re-render the strings.