### PR TITLE
chore: log events for inactive channels

### DIFF
--- a/app/jobs/webhooks/telegram_events_job.rb
+++ b/app/jobs/webhooks/telegram_events_job.rb
@@ -5,12 +5,32 @@ class Webhooks::TelegramEventsJob < ApplicationJob
     return unless params[:bot_token]
 
     channel = Channel::Telegram.find_by(bot_token: params[:bot_token])
-    return unless channel
+
+    if channel_is_inactive?(channel)
+      log_inactive_channel(channel, params)
+      return
+    end
 
     process_event_params(channel, params)
   end
 
   private
+
+  def channel_is_inactive?(channel)
+    return true if channel.blank?
+    return true unless channel.account.active?
+
+    false
+  end
+
+  def log_inactive_channel(channel, params)
+    message = if channel&.id
+                "Account #{channel.account.id} is not active for channel #{channel.id}"
+              else
+                "Channel not found for bot_token: #{params[:bot_token]}"
+              end
+    Rails.logger.warn("Telegram event discarded: #{message}")
+  end
 
   def process_event_params(channel, params)
     return unless params[:telegram]

--- a/spec/jobs/webhooks/telegram_events_job_spec.rb
+++ b/spec/jobs/webhooks/telegram_events_job_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe Webhooks::TelegramEventsJob do
       expect(described_class.perform_now({})).to be_nil
     end
 
-    it 'returns nil when invalid bot_token' do
-      expect(described_class.perform_now({ bot_token: 'invalid' })).to be_nil
+    it 'logs a warning when channel is not found' do
+      expect(Rails.logger).to receive(:warn).with('Telegram event discarded: Channel not found for bot_token: invalid')
+      described_class.perform_now({ bot_token: 'invalid' })
     end
   end
 
@@ -30,6 +31,19 @@ RSpec.describe Webhooks::TelegramEventsJob do
       expect(Telegram::IncomingMessageService).to receive(:new).with(inbox: telegram_channel.inbox,
                                                                      params: params['telegram'].with_indifferent_access)
       expect(process_service).to receive(:perform)
+      described_class.perform_now(params.with_indifferent_access)
+    end
+
+    it 'logs a warning and does not process events if account is suspended' do
+      account = telegram_channel.account
+      account.update!(status: :suspended)
+
+      process_service = double
+      allow(Telegram::IncomingMessageService).to receive(:new).and_return(process_service)
+      allow(process_service).to receive(:perform)
+
+      expect(Rails.logger).to receive(:warn).with("Telegram event discarded: Account #{account.id} is not active for channel #{telegram_channel.id}")
+      expect(Telegram::IncomingMessageService).not_to receive(:new)
       described_class.perform_now(params.with_indifferent_access)
     end
   end


### PR DESCRIPTION
- add a warning logs when Chatwoot receives events for inactive channels 