### PR TITLE
fix: Email rendering issue with Google Drive link

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/Email/Index.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Email/Index.vue
@@ -93,7 +93,7 @@ const hasQuotedMessage = computed(() => {
         <template v-else>
           <Letter
             v-if="showQuotedMessage"
-            class-name="prose prose-bubble !max-w-none"
+            class-name="prose prose-bubble !max-w-none letter-render"
             :allowed-css-properties="[
               ...allowedCssProperties,
               'transform',
@@ -104,7 +104,7 @@ const hasQuotedMessage = computed(() => {
           />
           <Letter
             v-else
-            class-name="prose prose-bubble !max-w-none"
+            class-name="prose prose-bubble !max-w-none letter-render"
             :html="unquotedHTML"
             :allowed-css-properties="[
               ...allowedCssProperties,
@@ -143,3 +143,16 @@ const hasQuotedMessage = computed(() => {
     </section>
   </BaseBubble>
 </template>
+
+<style lang="scss">
+// Fix for an issue with display gmail google drive link.
+// Ref: https://app.chatwoot.com/app/accounts/1/conversations/46387?messageId=122475128
+
+.letter-render [class*='gmail_drive_chip'] {
+  box-sizing: initial;
+
+  a img {
+    display: inline-block;
+  }
+}
+</style>

--- a/app/javascript/dashboard/components-next/message/bubbles/Email/Index.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Email/Index.vue
@@ -145,14 +145,19 @@ const hasQuotedMessage = computed(() => {
 </template>
 
 <style lang="scss">
-// Fix for an issue with display gmail google drive link.
-// Ref: https://app.chatwoot.com/app/accounts/1/conversations/46387?messageId=122475128
+// Tailwind resets break the rendering of google drive link in Gmail messages
+// This fixes it using https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors
 
 .letter-render [class*='gmail_drive_chip'] {
   box-sizing: initial;
+  @apply bg-n-slate-4 border-n-slate-6 rounded-md !important;
 
-  a img {
-    display: inline-block;
+  a {
+    @apply text-n-slate-12 !important;
+
+    img {
+      display: inline-block;
+    }
   }
 }
 </style>


### PR DESCRIPTION
# Pull Request Template

## Description

The PR includes a fix for rendering Google Drive link attachments in email bubbles and update the colors.

**Cause**: The Google Drive attachment displays incorrectly in emails due to inherited `box-sizing: border-box` from parent styles, creating layout issues.

**Solution**: Added targeted CSS for '**gmail_drive_chip**' elements to reset to `box-sizing: initial` and ensure proper image display.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots
**Before**
<img width="444" alt="image" src="https://github.com/user-attachments/assets/c6a673cd-edb1-45ea-91ac-8cb2e60fb73f" />
<img width="437" alt="image" src="https://github.com/user-attachments/assets/72d12dea-aa0f-4af7-9adf-efcc9a5572c9" />



**After**
<img width="437" alt="image" src="https://github.com/user-attachments/assets/356f1958-d264-46d6-bc3a-03c3bc02af8d" />
<img width="437" alt="image" src="https://github.com/user-attachments/assets/40d5a34c-3612-4b43-935d-5ba1830738d2" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
