### PR TITLE
chore: Disable sending outgoing messages if the conversation is active

### DIFF
--- a/app/services/message_templates/hook_execution_service.rb
+++ b/app/services/message_templates/hook_execution_service.rb
@@ -25,6 +25,8 @@ class MessageTemplates::HookExecutionService
     return false if conversation.tweet?
     # should not send for outbound messages
     return false unless message.incoming?
+    # should not send if there are outgoing messages in last 5 minutes
+    return false if conversation.messages.outgoing.exists?(['created_at > ?', 5.minutes.ago])
 
     inbox.out_of_office? && conversation.messages.today.template.empty? && inbox.out_of_office_message.present?
   end

--- a/app/services/message_templates/hook_execution_service.rb
+++ b/app/services/message_templates/hook_execution_service.rb
@@ -25,7 +25,8 @@ class MessageTemplates::HookExecutionService
     return false if conversation.tweet?
     # should not send for outbound messages
     return false unless message.incoming?
-    # should not send if there are outgoing messages in last 5 minutes
+    # prevents sending out-of-office message if an agent has sent a message in last 5 minutes
+    # ensures better UX by not interrupting active conversations at the end of business hours
     return false if conversation.messages.outgoing.exists?(['created_at > ?', 5.minutes.ago])
 
     inbox.out_of_office? && conversation.messages.today.template.empty? && inbox.out_of_office_message.present?


### PR DESCRIPTION
At 5 PM, when business hours officially end, an automatic out-of-office message is sent to customers. However, this creates a poor experience if an agent is actively chatting with the customer. This update ensures that the out-of-office message is only sent if no agent message has been sent in the last 5 minutes. If the customer reaches out again after 5 minutes, the out-of-office message will be triggered.