### PR TITLE
feat: Enable lock to single thread settings for telegram & line

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -439,8 +439,8 @@
         "DISABLED": "Disabled"
       },
       "LOCK_TO_SINGLE_CONVERSATION": {
-        "ENABLED": "Enabled",
-        "DISABLED": "Disabled"
+        "ENABLED": "Reopen same conversation",
+        "DISABLED": "Create new conversations"
       },
       "ENABLE_HMAC": {
         "LABEL": "Enable"
@@ -498,8 +498,8 @@
       "SENDER_NAME_SECTION_TEXT": "Enable/Disable showing Agent's name in email, if disabled it will show business name",
       "ENABLE_CONTINUITY_VIA_EMAIL": "Enable conversation continuity via email",
       "ENABLE_CONTINUITY_VIA_EMAIL_SUB_TEXT": "Conversations will continue over email if the contact email address is available.",
-      "LOCK_TO_SINGLE_CONVERSATION": "Lock to single conversation",
-      "LOCK_TO_SINGLE_CONVERSATION_SUB_TEXT": "Enable or disable multiple conversations for the same contact in this inbox",
+      "LOCK_TO_SINGLE_CONVERSATION": "Conversation Workflow",
+      "LOCK_TO_SINGLE_CONVERSATION_SUB_TEXT": "Configure conversation creation for existing contacts",
       "INBOX_UPDATE_TITLE": "Inbox Settings",
       "INBOX_UPDATE_SUB_TEXT": "Update your inbox settings",
       "AUTO_ASSIGNMENT_SUB_TEXT": "Enable or disable the automatic assignment of new conversations to the agents added to this inbox.",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -18,6 +18,7 @@ import WidgetBuilder from './WidgetBuilder.vue';
 import BotConfiguration from './components/BotConfiguration.vue';
 import { FEATURE_FLAGS } from '../../../../featureFlags';
 import SenderNameExamplePreview from './components/SenderNameExamplePreview.vue';
+import LockToSingleConversationPreview from './components/LockToSingleConversationPreview.vue';
 
 export default {
   components: {
@@ -32,6 +33,7 @@ export default {
     WeeklyAvailability,
     WidgetBuilder,
     SenderNameExamplePreview,
+    LockToSingleConversationPreview,
     MicrosoftReauthorize,
     GoogleReauthorize,
   },
@@ -176,7 +178,9 @@ export default {
         this.isASmsInbox ||
         this.isAWhatsAppChannel ||
         this.isAFacebookInbox ||
-        this.isAPIInbox
+        this.isAPIInbox ||
+        this.isATelegramChannel ||
+        this.isALineChannel
       );
     },
     inboxNameLabel() {
@@ -347,6 +351,9 @@ export default {
           this.$refs.businessNameInput.focus();
         });
       }
+    },
+    toggleLockToSingleConversation(value) {
+      this.locktoSingleConversation = value;
     },
   },
   validations: {
@@ -629,24 +636,6 @@ export default {
             {{ $t('INBOX_MGMT.HELP_CENTER.SUB_TEXT') }}
           </p>
         </div>
-        <label v-if="canLocktoSingleConversation" class="w-3/4 pb-4">
-          {{ $t('INBOX_MGMT.SETTINGS_POPUP.LOCK_TO_SINGLE_CONVERSATION') }}
-          <select v-model="locktoSingleConversation">
-            <option :value="true">
-              {{ $t('INBOX_MGMT.EDIT.LOCK_TO_SINGLE_CONVERSATION.ENABLED') }}
-            </option>
-            <option :value="false">
-              {{ $t('INBOX_MGMT.EDIT.LOCK_TO_SINGLE_CONVERSATION.DISABLED') }}
-            </option>
-          </select>
-          <p class="pb-1 text-sm not-italic text-slate-600 dark:text-slate-400">
-            {{
-              $t(
-                'INBOX_MGMT.SETTINGS_POPUP.LOCK_TO_SINGLE_CONVERSATION_SUB_TEXT'
-              )
-            }}
-          </p>
-        </label>
 
         <label v-if="isAWebWidgetInbox">
           {{ $t('INBOX_MGMT.FEATURES.LABEL') }}
@@ -743,6 +732,23 @@ export default {
           </div>
         </div>
       </SettingsSection>
+
+      <SettingsSection
+        v-if="canLocktoSingleConversation"
+        :title="$t('INBOX_MGMT.SETTINGS_POPUP.LOCK_TO_SINGLE_CONVERSATION')"
+        :sub-title="
+          $t('INBOX_MGMT.SETTINGS_POPUP.LOCK_TO_SINGLE_CONVERSATION_SUB_TEXT')
+        "
+        :show-border="false"
+      >
+        <div class="w-3/4 pb-4">
+          <LockToSingleConversationPreview
+            :lock-to-single-conversation="locktoSingleConversation"
+            @update="toggleLockToSingleConversation"
+          />
+        </div>
+      </SettingsSection>
+
       <SettingsSection :show-border="false">
         <woot-submit-button
           v-if="isAPIInbox"

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/LockToSingleConversationPreview.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/LockToSingleConversationPreview.vue
@@ -1,0 +1,62 @@
+<script>
+import PreviewCard from 'dashboard/components/ui/PreviewCard.vue';
+
+export default {
+  components: {
+    PreviewCard,
+  },
+  props: {
+    lockToSingleConversation: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['update'],
+  data() {
+    return {
+      lockOptions: [
+        {
+          key: true,
+          heading: this.$t(
+            'INBOX_MGMT.EDIT.LOCK_TO_SINGLE_CONVERSATION.ENABLED'
+          ),
+          content:
+            'When a contact messages again, the previous conversation will be reopened.',
+        },
+        {
+          key: false,
+          heading: this.$t(
+            'INBOX_MGMT.EDIT.LOCK_TO_SINGLE_CONVERSATION.DISABLED'
+          ),
+          content:
+            'A new conversation will be created each time after the previous one is resolved.',
+        },
+      ],
+    };
+  },
+  methods: {
+    toggleLockToSingleConversation(key) {
+      this.$emit('update', key);
+    },
+  },
+};
+</script>
+
+<template>
+  <div class="flex flex-col lg:flex-row items-start lg:items-center gap-4">
+    <button
+      v-for="option in lockOptions"
+      :key="option.key"
+      class="text-slate-800 dark:text-slate-100 cursor-pointer p-0"
+      @click="toggleLockToSingleConversation(option.key)"
+    >
+      <PreviewCard
+        :heading="option.heading"
+        :content="option.content"
+        :active="option.key === lockToSingleConversation"
+      >
+        <div class="p-3" />
+      </PreviewCard>
+    </button>
+  </div>
+</template>

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -130,6 +130,14 @@ class Inbox < ApplicationRecord
     channel_type == 'Channel::Whatsapp'
   end
 
+  # Override lock_to_single_conversation to return false for email inboxes
+  # @return [Boolean] false if email inbox, otherwise the database value
+  def lock_to_single_conversation
+    return false if email?
+
+    self[:lock_to_single_conversation]
+  end
+
   def assignable_agents
     (account.users.where(id: members.select(:user_id)) + account.administrators).uniq
   end

--- a/app/services/line/incoming_message_service.rb
+++ b/app/services/line/incoming_message_service.rb
@@ -130,7 +130,12 @@ class Line::IncomingMessageService
   end
 
   def set_conversation
-    @conversation = @contact_inbox.conversations.first
+    # if lock to single conversation is disabled, we will create a new conversation if previous conversation is resolved
+    @conversation = if @inbox.lock_to_single_conversation
+                      @contact_inbox.conversations.last
+                    else
+                      @contact_inbox.conversations.where.not(status: :resolved).last
+                    end
     return if @conversation
 
     @conversation = ::Conversation.create!(conversation_params)

--- a/app/services/telegram/incoming_message_service.rb
+++ b/app/services/telegram/incoming_message_service.rb
@@ -64,7 +64,13 @@ class Telegram::IncomingMessageService
   end
 
   def set_conversation
-    @conversation = @contact_inbox.conversations.first
+    # if lock to single conversation is disabled, we will create a new conversation if previous conversation is resolved
+    @conversation = if @inbox.lock_to_single_conversation
+                      @contact_inbox.conversations.last
+                    else
+                      @contact_inbox.conversations
+                                    .where.not(status: :resolved).last
+                    end
     return if @conversation
 
     @conversation = ::Conversation.create!(conversation_params)

--- a/spec/models/inbox_spec.rb
+++ b/spec/models/inbox_spec.rb
@@ -41,6 +41,37 @@ RSpec.describe Inbox do
     it_behaves_like 'avatarable'
   end
 
+  describe '#lock_to_single_conversation' do
+    let(:email_channel) { create(:channel_email) }
+    let(:email_inbox) { create(:inbox, channel: email_channel) }
+    let(:web_widget_inbox) { create(:inbox) }
+
+    context 'when inbox is an email inbox' do
+      it 'returns false regardless of the database value' do
+        email_inbox.update(lock_to_single_conversation: true)
+        expect(email_inbox.reload.lock_to_single_conversation).to be(false)
+      end
+
+      it 'preserves the actual value in the database' do
+        email_inbox.update(lock_to_single_conversation: true)
+        # Access the raw attribute value using self[]
+        expect(email_inbox.reload[:lock_to_single_conversation]).to be(true)
+      end
+    end
+
+    context 'when inbox is not an email inbox' do
+      it 'returns the actual database value when true' do
+        web_widget_inbox.update(lock_to_single_conversation: true)
+        expect(web_widget_inbox.reload.lock_to_single_conversation).to be(true)
+      end
+
+      it 'returns the actual database value when false' do
+        web_widget_inbox.update(lock_to_single_conversation: false)
+        expect(web_widget_inbox.reload.lock_to_single_conversation).to be(false)
+      end
+    end
+  end
+
   describe '#add_members' do
     let(:inbox) { FactoryBot.create(:inbox) }
 

--- a/spec/services/line/incoming_message_service_spec.rb
+++ b/spec/services/line/incoming_message_service_spec.rb
@@ -241,5 +241,111 @@ describe Line::IncomingMessageService do
         expect(line_channel.inbox.messages.first.attachments.first.file.blob.filename.to_s).to eq('media-354718.mp4')
       end
     end
+
+    context 'when lock_to_single_conversation is false' do
+      before do
+        line_channel.inbox.update(lock_to_single_conversation: false)
+      end
+
+      it 'creates a new conversation when all previous conversations are resolved' do
+        line_bot = double
+        line_user_profile = double
+        allow(Line::Bot::Client).to receive(:new).and_return(line_bot)
+        allow(line_bot).to receive(:get_profile).and_return(line_user_profile)
+        allow(line_user_profile).to receive(:body).and_return(
+          {
+            'displayName': 'LINE Test',
+            'userId': 'U4af4980629',
+            'pictureUrl': 'https://test.com'
+          }.to_json
+        )
+
+        # Create a contact and a resolved conversation
+        described_class.new(inbox: line_channel.inbox, params: params).perform
+
+        # Mark the conversation as resolved
+        conversation = line_channel.inbox.conversations.last
+        conversation.update(status: :resolved)
+
+        # Send a new message
+        new_params = params.deep_dup
+        new_params[:events][0][:message][:id] = '325709'
+        new_params[:events][0][:message][:text] = 'Second message'
+
+        described_class.new(inbox: line_channel.inbox, params: new_params).perform
+
+        # Should create a new conversation
+        expect(line_channel.inbox.conversations.count).to eq(2)
+        expect(line_channel.inbox.conversations.last.messages.first.content).to eq('Second message')
+      end
+
+      it 'uses the existing conversation when there is an unresolved conversation' do
+        line_bot = double
+        line_user_profile = double
+        allow(Line::Bot::Client).to receive(:new).and_return(line_bot)
+        allow(line_bot).to receive(:get_profile).and_return(line_user_profile)
+        allow(line_user_profile).to receive(:body).and_return(
+          {
+            'displayName': 'LINE Test',
+            'userId': 'U4af4980629',
+            'pictureUrl': 'https://test.com'
+          }.to_json
+        )
+
+        # Create a contact and an unresolved conversation
+        described_class.new(inbox: line_channel.inbox, params: params).perform
+
+        # Send a new message
+        new_params = params.deep_dup
+        new_params[:events][0][:message][:id] = '325709'
+        new_params[:events][0][:message][:text] = 'Second message'
+
+        described_class.new(inbox: line_channel.inbox, params: new_params).perform
+
+        # Should use the same conversation
+        expect(line_channel.inbox.conversations.count).to eq(1)
+        expect(line_channel.inbox.conversations.last.messages.count).to eq(2)
+        expect(line_channel.inbox.conversations.last.messages.last.content).to eq('Second message')
+      end
+    end
+
+    context 'when lock_to_single_conversation is true' do
+      before do
+        line_channel.inbox.update(lock_to_single_conversation: true)
+      end
+
+      it 'uses the existing conversation even when it is resolved' do
+        line_bot = double
+        line_user_profile = double
+        allow(Line::Bot::Client).to receive(:new).and_return(line_bot)
+        allow(line_bot).to receive(:get_profile).and_return(line_user_profile)
+        allow(line_user_profile).to receive(:body).and_return(
+          {
+            'displayName': 'LINE Test',
+            'userId': 'U4af4980629',
+            'pictureUrl': 'https://test.com'
+          }.to_json
+        )
+
+        # Create a contact and a resolved conversation
+        described_class.new(inbox: line_channel.inbox, params: params).perform
+
+        # Mark the conversation as resolved
+        conversation = line_channel.inbox.conversations.last
+        conversation.update(status: :resolved)
+
+        # Send a new message
+        new_params = params.deep_dup
+        new_params[:events][0][:message][:id] = '325709'
+        new_params[:events][0][:message][:text] = 'Second message'
+
+        described_class.new(inbox: line_channel.inbox, params: new_params).perform
+
+        # Should use the same conversation
+        expect(line_channel.inbox.conversations.count).to eq(1)
+        expect(line_channel.inbox.conversations.last.messages.count).to eq(2)
+        expect(line_channel.inbox.conversations.last.messages.last.content).to eq('Second message')
+      end
+    end
   end
 end

--- a/spec/services/telegram/incoming_message_service_spec.rb
+++ b/spec/services/telegram/incoming_message_service_spec.rb
@@ -326,5 +326,93 @@ describe Telegram::IncomingMessageService do
         expect(telegram_channel.inbox.messages.first.attachments.first.file_type).to eq('contact')
       end
     end
+
+    context 'when lock_to_single_conversation is false' do
+      before do
+        telegram_channel.inbox.update(lock_to_single_conversation: false)
+      end
+
+      it 'creates a new conversation when all previous conversations are resolved' do
+        # Create a contact and a resolved conversation
+        params = {
+          'update_id' => 2_342_342_343_242,
+          'message' => { 'text' => 'first message' }.merge(message_params)
+        }.with_indifferent_access
+
+        described_class.new(inbox: telegram_channel.inbox, params: params).perform
+
+        # Mark the conversation as resolved
+        conversation = telegram_channel.inbox.conversations.last
+        conversation.update(status: :resolved)
+
+        # Send a new message
+        new_params = {
+          'update_id' => 2_342_342_343_243,
+          'message' => { 'text' => 'second message' }.merge(message_params)
+        }.with_indifferent_access
+
+        described_class.new(inbox: telegram_channel.inbox, params: new_params).perform
+
+        # Should create a new conversation
+        expect(telegram_channel.inbox.conversations.count).to eq(2)
+        expect(telegram_channel.inbox.conversations.last.messages.first.content).to eq('second message')
+      end
+
+      it 'uses the existing conversation when there is an unresolved conversation' do
+        # Create a contact and an unresolved conversation
+        params = {
+          'update_id' => 2_342_342_343_242,
+          'message' => { 'text' => 'first message' }.merge(message_params)
+        }.with_indifferent_access
+
+        described_class.new(inbox: telegram_channel.inbox, params: params).perform
+
+        # Send a new message
+        new_params = {
+          'update_id' => 2_342_342_343_243,
+          'message' => { 'text' => 'second message' }.merge(message_params)
+        }.with_indifferent_access
+
+        described_class.new(inbox: telegram_channel.inbox, params: new_params).perform
+
+        # Should use the same conversation
+        expect(telegram_channel.inbox.conversations.count).to eq(1)
+        expect(telegram_channel.inbox.conversations.last.messages.count).to eq(2)
+        expect(telegram_channel.inbox.conversations.last.messages.last.content).to eq('second message')
+      end
+    end
+
+    context 'when lock_to_single_conversation is true' do
+      before do
+        telegram_channel.inbox.update(lock_to_single_conversation: true)
+      end
+
+      it 'uses the existing conversation even when it is resolved' do
+        # Create a contact and a resolved conversation
+        params = {
+          'update_id' => 2_342_342_343_242,
+          'message' => { 'text' => 'first message' }.merge(message_params)
+        }.with_indifferent_access
+
+        described_class.new(inbox: telegram_channel.inbox, params: params).perform
+
+        # Mark the conversation as resolved
+        conversation = telegram_channel.inbox.conversations.last
+        conversation.update(status: :resolved)
+
+        # Send a new message
+        new_params = {
+          'update_id' => 2_342_342_343_243,
+          'message' => { 'text' => 'second message' }.merge(message_params)
+        }.with_indifferent_access
+
+        described_class.new(inbox: telegram_channel.inbox, params: new_params).perform
+
+        # Should use the same conversation
+        expect(telegram_channel.inbox.conversations.count).to eq(1)
+        expect(telegram_channel.inbox.conversations.last.messages.count).to eq(2)
+        expect(telegram_channel.inbox.conversations.last.messages.last.content).to eq('second message')
+      end
+    end
   end
 end


### PR DESCRIPTION
- Enable single thread settings for telegram & line
- Ensure new email conversations won't get appended to the old thread
- Clean up frontend design for the setting