### PR TITLE
fix: Move conversation action cable events to inbox stream instead of user pubsub stream

### DIFF
--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -4,7 +4,7 @@ class RoomChannel < ApplicationCable::Channel
     # for now going ahead with guard clauses in update_subscription and broadcast_presence
     current_user
     current_account
-    ensure_stream
+    prepare_stream
     update_subscription
     broadcast_presence
   end
@@ -24,9 +24,18 @@ class RoomChannel < ApplicationCable::Channel
     ActionCable.server.broadcast(pubsub_token, { event: 'presence.update', data: data })
   end
 
-  def ensure_stream
+  def prepare_stream
     stream_from pubsub_token
     stream_from "account_#{@current_account.id}" if @current_account.present? && @current_user.is_a?(User)
+    stream_from_inboxes
+  end
+
+  def stream_from_inboxes
+    return if current_user.blank?
+
+    current_user.assigned_inboxes.each do |inbox|
+      stream_from "inbox_#{inbox.id}"
+    end
   end
 
   def update_subscription

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -60,11 +60,11 @@ class ActionCableListener < BaseListener
   end
 
   def conversation_typing_on(event)
-    broadcast_typing_event(CONVERSATION_TYPING_ON, event)
+    broadcast_typing_event(CONVERSATION_TYPING_ON, event.data)
   end
 
   def conversation_typing_off(event)
-    broadcast_typing_event(CONVERSATION_TYPING_OFF, event)
+    broadcast_typing_event(CONVERSATION_TYPING_OFF, event.data)
   end
 
   def assignee_changed(event)
@@ -143,7 +143,7 @@ class ActionCableListener < BaseListener
     conversation = event_data[:conversation]
     account = conversation.account
     user = event_data[:user]
-    tokens = typing_event_listener_tokens(account, conversation, user)
+    tokens = typing_event_listener_tokens(conversation)
 
     broadcast(
       account,
@@ -151,8 +151,12 @@ class ActionCableListener < BaseListener
       event_name,
       conversation: conversation.push_event_data,
       user: user.push_event_data,
-      is_private: event.data[:is_private] || false
+      is_private: event_data[:is_private] || false
     )
+  end
+
+  def typing_event_listener_tokens(conversation)
+    ["inbox_#{conversation.inbox.id}"] + [conversation.contact_inbox.pubsub_token]
   end
 
   def contact_tokens(contact_inbox, message)


### PR DESCRIPTION
The Action Cable events were previously sent over a stream created for each user. This approach does not scale well for large accounts, as each event iterates through all users and publishes to them individually, creating a major bottleneck.

The PR does not change how the client interacts with the server—the Room Channel remains the same. However, it modifies how stream_for is configured in the Room Channel. Instead of streaming directly for pubsub_token, it now streams for account_{id} and inbox_{id}.