### PR TITLE
feat: discard Twilio events when Body parameter is not present

### DIFF
--- a/app/jobs/webhooks/twilio_events_job.rb
+++ b/app/jobs/webhooks/twilio_events_job.rb
@@ -2,6 +2,9 @@ class Webhooks::TwilioEventsJob < ApplicationJob
   queue_as :low
 
   def perform(params = {})
+    # Skip processing if Body parameter is not present
+    return if params[:Body].blank?
+
     # Process the Twilio webhook event in the background
     ::Twilio::IncomingMessageService.new(params: params).perform
   end

--- a/spec/jobs/webhooks/twilio_events_job_spec.rb
+++ b/spec/jobs/webhooks/twilio_events_job_spec.rb
@@ -25,4 +25,20 @@ RSpec.describe Webhooks::TwilioEventsJob do
     expect(service).to receive(:perform)
     described_class.new.perform(params)
   end
+
+  context 'when Body parameter is not present' do
+    let(:params_without_body) do
+      {
+        'From' => '+1234567890',
+        'To' => '+0987654321',
+        'AccountSid' => 'AC123',
+        'SmsSid' => 'SM123'
+      }
+    end
+
+    it 'does not process the event' do
+      expect(Twilio::IncomingMessageService).not_to receive(:new)
+      described_class.new.perform(params_without_body)
+    end
+  end
 end


### PR DESCRIPTION
- Discard Twilio events when body parameter is not present.