### PR TITLE
fix: Dropdown for custom attributes in conversation sidebar hides under the list

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/customAttributes/CustomAttributes.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/customAttributes/CustomAttributes.vue
@@ -271,7 +271,7 @@ const evenClass = [
       ghost-class="ghost"
       handle=".drag-handle"
       item-key="key"
-      class="last:rounded-b-lg overflow-hidden"
+      class="last:rounded-b-lg"
       :class="evenClass"
       @start="dragging = true"
       @end="onDragEnd"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the issue where the custom attributes type list dropdown in the conversation sidebar gets hidden under the section.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots
**Before**
<img width="310" alt="image" src="https://github.com/user-attachments/assets/1aec7f08-8ca8-4868-914a-d545eab34dce" />


**After**
<img width="310" alt="image" src="https://github.com/user-attachments/assets/eb9006f3-0bc1-4008-ac0d-1feeeadc139d" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
