### PR TITLE
chore: Ignore notification when assignee is nil

### DIFF
--- a/app/listeners/notification_listener.rb
+++ b/app/listeners/notification_listener.rb
@@ -30,6 +30,11 @@ class NotificationListener < BaseListener
   def assignee_changed(event)
     conversation, account = extract_conversation_and_account(event)
     assignee = conversation.assignee
+
+    # NOTE: This occurs when the conversation is created and assignee is added
+    # but a subsequent change to the assignee is triggered which makes it nil
+    # We need to debug this properly, but for now no need to pollute the jobs
+    return if assignee.blank?
     return if event.data[:notifiable_assignee_change].blank?
     return if conversation.pending?
 

--- a/app/listeners/notification_listener.rb
+++ b/app/listeners/notification_listener.rb
@@ -31,8 +31,8 @@ class NotificationListener < BaseListener
     conversation, account = extract_conversation_and_account(event)
     assignee = conversation.assignee
 
-    # NOTE:  The issue was that when a team change results in an assignee being set to nil, 
-    # the system was still trying to create a notification about the assignment change, 
+    # NOTE:  The issue was that when a team change results in an assignee being set to nil,
+    # the system was still trying to create a notification about the assignment change,
     # but there was no assignee to notify, causing potential issues in the notification system.
     # We need to debug this properly, but for now no need to pollute the jobs
     return if assignee.blank?

--- a/app/listeners/notification_listener.rb
+++ b/app/listeners/notification_listener.rb
@@ -31,8 +31,9 @@ class NotificationListener < BaseListener
     conversation, account = extract_conversation_and_account(event)
     assignee = conversation.assignee
 
-    # NOTE: This occurs when the conversation is created and assignee is added
-    # but a subsequent change to the assignee is triggered which makes it nil
+    # NOTE:  The issue was that when a team change results in an assignee being set to nil, 
+    # the system was still trying to create a notification about the assignment change, 
+    # but there was no assignee to notify, causing potential issues in the notification system.
     # We need to debug this properly, but for now no need to pollute the jobs
     return if assignee.blank?
     return if event.data[:notifiable_assignee_change].blank?

--- a/spec/listeners/notification_listener_spec.rb
+++ b/spec/listeners/notification_listener_spec.rb
@@ -200,4 +200,28 @@ describe NotificationListener do
       end
     end
   end
+
+  describe 'assignee_changed' do
+    let(:event_name) { :'conversation.assignee_changed' }
+
+    context 'when notifiable_assignee_change is true but assignee is nil' do
+      it 'does not create a notification' do
+        conversation_with_nil_assignee = create(:conversation, account: account, inbox: inbox, assignee: nil)
+
+        notification_builder_mock = instance_double(NotificationBuilder)
+        allow(NotificationBuilder).to receive(:new).and_return(notification_builder_mock)
+
+        event = Events::Base.new(
+          event_name,
+          Time.zone.now,
+          conversation: conversation_with_nil_assignee,
+          data: { notifiable_assignee_change: true }
+        )
+
+        expect(notification_builder_mock).not_to receive(:perform)
+
+        listener.assignee_changed(event)
+      end
+    end
+  end
 end


### PR DESCRIPTION
 The issue was that when a team change results in an assignee being set to nil, the system was still trying to create a notification about the assignment change, but there was no assignee to notify, causing potential issues in the notification system.