### PR TITLE
chore: Reduce meta conversation API calls

### DIFF
--- a/app/javascript/dashboard/store/modules/conversationStats.js
+++ b/app/javascript/dashboard/store/modules/conversationStats.js
@@ -18,7 +18,7 @@ export const actions = {
     const lastUpdatedTime = new Date($state.updatedOn);
 
     // Skip large accounts from making too many requests
-    if (currentTime - lastUpdatedTime < 10000 && $state.allCount > 30) {
+    if (currentTime - lastUpdatedTime < 10000 && $state.allCount > 100) {
       // eslint-disable-next-line no-console
       console.warn('Skipping conversation meta fetch');
       return;

--- a/app/javascript/dashboard/store/modules/conversationStats.js
+++ b/app/javascript/dashboard/store/modules/conversationStats.js
@@ -18,7 +18,7 @@ export const actions = {
     const lastUpdatedTime = new Date($state.updatedOn);
 
     // Skip large accounts from making too many requests
-    if (currentTime - lastUpdatedTime < 10000 && $state.allCount > 1000) {
+    if (currentTime - lastUpdatedTime < 10000 && $state.allCount > 30) {
       // eslint-disable-next-line no-console
       console.warn('Skipping conversation meta fetch');
       return;


### PR DESCRIPTION
This PR would reduce the API calls if there are more than 100 total conversations, we will throttle requests the number of requests.

Earlier this was 1000 total conversations.