### PR TITLE
feat: use separate redis for sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,11 +3,11 @@ require Rails.root.join('lib/redis/config')
 schedule_file = 'config/schedule.yml'
 
 Sidekiq.configure_client do |config|
-  config.redis = Redis::Config.app
+  config.redis = Redis::Config.sidekiq
 end
 
 Sidekiq.configure_server do |config|
-  config.redis = Redis::Config.app
+  config.redis = Redis::Config.sidekiq
 
   # skip the default start stop logging
   if Rails.env.production?

--- a/lib/redis/config.rb
+++ b/lib/redis/config.rb
@@ -5,14 +5,32 @@ module Redis::Config
       config
     end
 
+    def sidekiq
+      sidekiq_config
+    end
+
     def config
       @config ||= sentinel? ? sentinel_config : base_config
+    end
+
+    def sidekiq_config
+      @sidekiq_config ||= sentinel? ? sentinel_config : base_sidekiq_config
     end
 
     def base_config
       {
         url: ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379'),
         password: ENV.fetch('REDIS_PASSWORD', nil).presence,
+        ssl_params: { verify_mode: Chatwoot.redis_ssl_verify_mode },
+        reconnect_attempts: 2,
+        timeout: 1
+      }
+    end
+
+    def base_sidekiq_config
+      {
+        url: ENV.fetch('SIDEKIQ_REDIS_URL', ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379')),
+        password: ENV.fetch('SIDEKIQ_REDIS_PASSWORD', ENV.fetch('REDIS_PASSWORD', nil)).presence,
         ssl_params: { verify_mode: Chatwoot.redis_ssl_verify_mode },
         reconnect_attempts: 2,
         timeout: 1


### PR DESCRIPTION
This change separates the Redis connections for Rails and Sidekiq, improving scalability and resource management.

 - Configures Sidekiq to use a dedicated Redis instance.
-  Falls back to the original Redis instance if the separate Redis configuration is not set.
-  Helps avoid hitting connection limits by maintaining independent Redis instances for Rails and Sidekiq.
-  Enables better resource management and allows for independent scaling of Redis instances.