### PR TITLE
fix: Fix duplicate contact inbox race condition

### DIFF
--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -65,6 +65,11 @@ class ContactInboxBuilder
       source_id: @source_id
     )
   rescue ActiveRecord::RecordNotUnique
+    update_old_contact_inbox
+    retry
+  end
+
+  def update_old_contact_inbox
     # The race condition occurs when there’s a contact inbox with the
     # same source ID but linked to a different contact. This can happen
     # if the agent updates the contact’s email or phone number, or
@@ -77,12 +82,6 @@ class ContactInboxBuilder
     # needed for non-live chat channels.
     raise ActiveRecord::RecordNotUnique unless allowed_channels?
 
-    update_old_contact_inbox
-
-    retry
-  end
-
-  def update_old_contact_inbox
     contact_inbox = ::ContactInbox.find_by(inbox_id: @inbox.id, source_id: @source_id)
     return if contact_inbox.blank?
 

--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -64,5 +64,31 @@ class ContactInboxBuilder
       inbox_id: @inbox.id,
       source_id: @source_id
     )
+  rescue ActiveRecord::RecordNotUnique
+    # The race condition occurs when there’s a contact inbox with the
+    # same source ID but linked to a different contact. This can happen
+    # if the agent updates the contact’s email or phone number, or
+    # if the contact is merged with another.
+    #
+    # We update the old contact inbox source_id to a random value to
+    # avoid disrupting the current flow. However, the root cause of
+    # this issue is a flaw in the contact inbox model design.
+    # Contact inbox is essentially tracking a session and is not
+    # needed for non-live chat channels.
+    update_old_contact_inbox
+    retry
+  end
+
+  def update_old_contact_inbox
+    contact_inbox = ::ContactInbox.find_by(inbox_id: @inbox.id, source_id: @source_id)
+    return if contact_inbox.blank?
+
+    new_source_id = if @inbox.whatsapp? || @inbox.sms? || @inbox.twilio?
+                      "whatsapp:#{@source_id}#{rand(100)}"
+                    else
+                      "#{rand(10)}#{@source_id}"
+                    end
+
+    contact_inbox.update!(source_id: new_source_id)
   end
 end

--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -65,6 +65,7 @@ class ContactInboxBuilder
       source_id: @source_id
     )
   rescue ActiveRecord::RecordNotUnique
+    Rails.logger.info("[ContactInboxBuilder] RecordNotUnique #{@source_id} #{@contact.id} #{@inbox.id}")
     update_old_contact_inbox
     retry
   end

--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -75,6 +75,8 @@ class ContactInboxBuilder
     # this issue is a flaw in the contact inbox model design.
     # Contact inbox is essentially tracking a session and is not
     # needed for non-live chat channels.
+    raise ActiveRecord::RecordNotUnique unless @inbox.email? || @inbox.sms? || @inbox.twilio? || @inbox.whatsapp?
+
     update_old_contact_inbox
     retry
   end

--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -75,9 +75,10 @@ class ContactInboxBuilder
     # this issue is a flaw in the contact inbox model design.
     # Contact inbox is essentially tracking a session and is not
     # needed for non-live chat channels.
-    raise ActiveRecord::RecordNotUnique unless @inbox.email? || @inbox.sms? || @inbox.twilio? || @inbox.whatsapp?
+    raise ActiveRecord::RecordNotUnique unless allowed_channels?
 
     update_old_contact_inbox
+
     retry
   end
 
@@ -92,5 +93,9 @@ class ContactInboxBuilder
                     end
 
     contact_inbox.update!(source_id: new_source_id)
+  end
+
+  def allowed_channels?
+    @inbox.email? || @inbox.sms? || @inbox.twilio? || @inbox.whatsapp?
   end
 end

--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -86,13 +86,15 @@ class ContactInboxBuilder
     contact_inbox = ::ContactInbox.find_by(inbox_id: @inbox.id, source_id: @source_id)
     return if contact_inbox.blank?
 
-    new_source_id = if @inbox.whatsapp? || @inbox.sms? || @inbox.twilio?
-                      "whatsapp:#{@source_id}#{rand(100)}"
-                    else
-                      "#{rand(10)}#{@source_id}"
-                    end
-
     contact_inbox.update!(source_id: new_source_id)
+  end
+
+  def new_source_id
+    if @inbox.whatsapp? || @inbox.sms? || @inbox.twilio?
+      "whatsapp:#{@source_id}#{rand(100)}"
+    else
+      "#{rand(10)}#{@source_id}"
+    end
   end
 
   def allowed_channels?

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -98,6 +98,10 @@ class Inbox < ApplicationRecord
     update_account_cache
   end
 
+  def sms?
+    channel_type == 'Channel::Sms'
+  end
+
   def facebook?
     channel_type == 'Channel::FacebookPage'
   end

--- a/spec/builders/contact_inbox_builder_spec.rb
+++ b/spec/builders/contact_inbox_builder_spec.rb
@@ -335,26 +335,36 @@ describe ContactInboxBuilder do
       let(:account) { create(:account) }
       let(:contact) { create(:contact, account: account) }
       let(:contact2) { create(:contact, account: account) }
-      let(:inbox) { create(:inbox, account: account) }
+      let(:channel) { create(:channel_email, account: account) }
+      let(:channel_api) { create(:channel_api, account: account) }
       let(:source_id) { 'source_123' }
-      let(:builder) do
-        described_class.new(
-          contact: contact,
-          inbox: inbox,
-          source_id: source_id
-        )
-      end
 
       it 'handles RecordNotUnique error by updating source_id and retrying' do
-        existing_contact_inbox = create(:contact_inbox, contact: contact2, inbox: inbox, source_id: source_id)
+        existing_contact_inbox = create(:contact_inbox, contact: contact2, inbox: channel.inbox, source_id: source_id)
 
-        builder.perform
+        described_class.new(
+          contact: contact,
+          inbox: channel.inbox,
+          source_id: source_id
+        ).perform
 
         expect(ContactInbox.last.source_id).to eq(source_id)
         expect(ContactInbox.last.contact_id).to eq(contact.id)
-        expect(ContactInbox.last.inbox_id).to eq(inbox.id)
+        expect(ContactInbox.last.inbox_id).to eq(channel.inbox.id)
         expect(existing_contact_inbox.reload.source_id).to include(source_id)
         expect(existing_contact_inbox.reload.source_id).not_to eq(source_id)
+      end
+
+      it 'does not update source_id for channels other than email or phone number' do
+        create(:contact_inbox, contact: contact2, inbox: channel_api.inbox, source_id: source_id)
+
+        expect do
+          described_class.new(
+            contact: contact,
+            inbox: channel_api.inbox,
+            source_id: source_id
+          ).perform
+        end.to raise_error(ActiveRecord::RecordNotUnique)
       end
     end
   end


### PR DESCRIPTION
This PR addresses a race condition in the contact inbox model caused by duplicate `source_id` values linked to different contacts. 

The issue typically occurs when an agent updates a contact’s email or phone number or when two contacts are merged. In these scenarios, the `source_id`, which is intended to uniquely identify the contact in a session, may still be associated with the old contact inbox.

To solve this, we check if there’s already a ContactInbox with the same source_id but linked to another contact. If we find one, we update that old record by changing its source_id to a random value. This breaks the wrong connection and prevents issues, while still keeping the old data safe.

However, this is only a temporary fix. The main issue is with the way the contact inbox model is designed. Right now, it’s being used to track sessions, but that may not be necessary for non-live chat channels. In the long run, we should consider redesigning this part of the system to avoid such problems.