### PR TITLE
fix: Prevent reopening a resolved conversation

### DIFF
--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -43,6 +43,7 @@ export default {
     ...mapGetters({
       activeCampaign: 'campaign/getActiveCampaign',
       conversationSize: 'conversation/getConversationSize',
+      conversationAttributes: 'conversationAttributes/getConversationParams',
       hideMessageBubble: 'appConfig/getHideMessageBubble',
       isFetchingList: 'conversation/getIsFetchingList',
       isRightAligned: 'appConfig/isRightAligned',
@@ -62,6 +63,12 @@ export default {
       return this.$root.$i18n.locale
         ? getLanguageDirection(this.$root.$i18n.locale)
         : false;
+    },
+    isConversationResolved() {
+      return this.conversationAttributes?.status === 'resolved';
+    },
+    hasActiveConversation() {
+      return !!this.messageCount && !this.isConversationResolved;
     },
   },
   watch: {
@@ -308,7 +315,7 @@ export default {
           const shouldShowMessageView =
             ['home'].includes(this.$route.name) &&
             message.isOpen &&
-            this.messageCount;
+            this.hasActiveConversation;
           const shouldShowHomeView =
             !message.isOpen &&
             ['unread-messages', 'campaigns'].includes(this.$route.name);

--- a/app/javascript/widget/views/Home.vue
+++ b/app/javascript/widget/views/Home.vue
@@ -15,12 +15,22 @@ export default {
     ...mapGetters({
       availableAgents: 'agent/availableAgents',
       conversationSize: 'conversation/getConversationSize',
+      conversationAttributes: 'conversationAttributes/getConversationParams',
       unreadMessageCount: 'conversation/getUnreadMessageCount',
     }),
+    isConversationResolved() {
+      return this.conversationAttributes?.status === 'resolved';
+    },
+    hasActiveConversation() {
+      return !!this.conversationSize && !this.isConversationResolved;
+    },
+    shouldShowPreChatForm() {
+      return this.preChatFormEnabled && !this.hasActiveConversation;
+    },
   },
   methods: {
     startConversation() {
-      if (this.preChatFormEnabled && !this.conversationSize) {
+      if (this.shouldShowPreChatForm) {
         return this.replaceRoute('prechat-form');
       }
       return this.replaceRoute('messages');
@@ -33,7 +43,7 @@ export default {
   <div class="z-50 flex flex-col justify-end flex-1 w-full p-4 gap-4">
     <TeamAvailability
       :available-agents="availableAgents"
-      :has-conversation="!!conversationSize"
+      :has-conversation="hasActiveConversation"
       :unread-count="unreadMessageCount"
       @start-conversation="startConversation"
     />


### PR DESCRIPTION
# Pull Request Template

## Description

**This PR includes:**  
- Fix to prevent reopening a resolved conversation when starting a new one if pre-chat form is enabled.  
- Ensures that the pre-chat form appears instead of the conversation window after resolution when widget is toggled.  
- Addresses the issue where navigating back and starting a new conversation incorrectly shows the previous messages. 

Fixes https://linear.app/chatwoot/issue/CW-4169/prevent-continue-conversation-in-previously-resolved-conversation

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Steps to Reproduce the Issue:**  
1. Make sure pre-chat form is enabled, else it will redirect to message screen
2. Create a conversation in the widget and resolve it.  
3. Without refreshing, go back to the previous page.  
4. Click on "Start Conversation."  
5. Previously resolved conversation opens instead of the pre-chat form.  

### Loom video
https://www.loom.com/share/a64818e716ae4b589758a3ef406e424f?sid=1e8eb88f-6d24-4609-9ea3-24e6c1d593a3

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
