### PR TITLE
feat: Save recorded audio as draft when switching chats

### DIFF
--- a/app/javascript/dashboard/components/widgets/AttachmentsPreview.vue
+++ b/app/javascript/dashboard/components/widgets/AttachmentsPreview.vue
@@ -98,12 +98,7 @@ const fileName = file => {
         <span
           class="h-4 overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap"
         >
-          {{
-            item.isRecordedAudio
-              ? fileName(item.attachment.resource) ||
-                $t('CONVERSATION.REPLYBOX.AUDIO_RECORDING')
-              : fileName(item.attachment.resource)
-          }}
+          {{ fileName(item.attachment.resource) }}
         </span>
       </div>
       <div class="w-[30%] justify-center">

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -454,6 +454,10 @@ export default {
       // Autosave the current message draft.
       this.doAutoSaveDraft();
     },
+    replyType(updatedReplyType, oldReplyType) {
+      this.setToDraft(this.conversationIdByRoute, oldReplyType);
+      this.getFromDraft();
+    },
   },
 
   mounted() {
@@ -572,6 +576,14 @@ export default {
       if (this.hasRecordedAudio && this.attachedFiles.length) {
         const audioFile = this.attachedFiles.find(file => file.isRecordedAudio);
         if (audioFile) {
+          // Check if the audio file size exceeds the 5MB limit for localStorage
+          // If it does, show an error message and do not save
+          if (audioFile.resource.file.size > 5 * 1024 * 1024) {
+            useAlert(
+              this.$t('CONVERSATION.REPLYBOX.DRAFT_AUDIO_SIZE_LIMIT_ERROR')
+            );
+            return;
+          }
           saveAudioToDraft(oldConversationId, this.replyType, audioFile);
         }
       }
@@ -600,7 +612,6 @@ export default {
         // ensure that the message has signature set based on the ui setting
         this.message = this.toggleSignatureForDraft(messageFromStore);
         // get audio recording from draft
-
         this.getAudioRecordingFromDraft(this.conversationIdByRoute);
       }
     },

--- a/app/javascript/dashboard/helpers/audioDraftHelper.js
+++ b/app/javascript/dashboard/helpers/audioDraftHelper.js
@@ -63,6 +63,11 @@ export const saveAudioToDraft = async (
     if (!audioFile?.resource?.file) {
       return;
     }
+    // Check if the audio file size exceeds the 5MB limit for localStorage
+    // If it does, show an error message and do not save
+    if (audioFile.resource.file.size > 5 * 1024 * 1024) {
+      return;
+    }
 
     const key = getAudioStorageKey(conversationId, replyType);
 

--- a/app/javascript/dashboard/helpers/audioDraftHelper.js
+++ b/app/javascript/dashboard/helpers/audioDraftHelper.js
@@ -1,0 +1,144 @@
+import { LocalStorage } from 'shared/helpers/localStorage';
+
+const AUDIO_STORAGE_KEY = 'draftRecordedAudio';
+
+/**
+ * Converts a Blob to a Base64 string
+ * @param {Blob} blob - The blob to convert
+ * @returns {Promise<string>} - A promise that resolves with the Base64 string
+ */
+export const blobToBase64 = blob => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+};
+
+/**
+ * Converts a Base64 string back to a Blob
+ * @param {string} base64String - The Base64 string to convert
+ * @returns {Blob} - The resulting Blob
+ */
+export const base64ToBlob = base64String => {
+  const [header, base64] = base64String.split(',');
+  const matches = header.match(/^data:([A-Za-z-+/]+);base64$/);
+
+  if (!matches || matches.length !== 2) {
+    throw new Error('Invalid base64 string format');
+  }
+
+  const contentType = matches[1];
+  const binaryString = atob(base64);
+  const bytes = new Uint8Array(
+    [...binaryString].map(char => char.charCodeAt(0))
+  );
+
+  return new Blob([bytes], { type: contentType });
+};
+
+/**
+ * Generates a storage key for a conversation's audio draft
+ * @param {string} conversationId - The conversation ID
+ * @param {string} replyType - The reply type (REPLY or NOTE)
+ * @returns {string} - The storage key
+ */
+export const getAudioStorageKey = (conversationId, replyType) =>
+  `audio-${conversationId}-${replyType}`;
+
+/**
+ * Saves the recorded audio to the draft storage
+ * @param {string} conversationId - The conversation ID
+ * @param {string} replyType - The reply type (REPLY or NOTE)
+ * @param {Object} audioFile - The audio file object to save
+ * @returns {Promise<void>}
+ */
+export const saveAudioToDraft = async (
+  conversationId,
+  replyType,
+  audioFile
+) => {
+  try {
+    if (!audioFile?.resource?.file) {
+      return;
+    }
+
+    const key = getAudioStorageKey(conversationId, replyType);
+
+    // Convert audio blob to Base64
+    const base64Audio = await blobToBase64(audioFile.resource.file);
+
+    // Save audio metadata
+    const audioData = {
+      base64: base64Audio,
+      thumb: audioFile.thumb,
+      name: audioFile.resource.name,
+      type: audioFile.resource.type,
+      size: audioFile.resource.size,
+      isPrivate: audioFile.isPrivate,
+      timestamp: Date.now(),
+    };
+
+    LocalStorage.updateJsonStore(AUDIO_STORAGE_KEY, key, audioData);
+  } catch (error) {
+    // Error saving audio draft
+  }
+};
+
+/**
+ * Retrieves audio from draft storage
+ * @param {string} conversationId - The conversation ID
+ * @param {string} replyType - The reply type (REPLY or NOTE)
+ * @returns {Promise<Object|null>} - The audio file object or null if not found
+ */
+export const getAudioFromDraft = (conversationId, replyType) => {
+  try {
+    const key = getAudioStorageKey(conversationId, replyType);
+    const audioData = LocalStorage.getFromJsonStore(AUDIO_STORAGE_KEY, key);
+
+    if (!audioData) {
+      return null;
+    }
+
+    // Convert Base64 back to Blob
+    const blob = base64ToBlob(audioData.base64);
+
+    // Create a file from the blob
+    const file = new File([blob], audioData.name, {
+      type: audioData.type,
+      lastModified: audioData.timestamp,
+    });
+
+    // Return the complete audio file object
+    return {
+      resource: {
+        file,
+        name: audioData.name,
+        type: audioData.type,
+        size: audioData.size,
+      },
+      isPrivate: audioData.isPrivate,
+      thumb: audioData.thumb,
+      isRecordedAudio: true,
+    };
+  } catch (error) {
+    // Error retrieving audio draft
+
+    return null;
+  }
+};
+
+/**
+ * Removes audio draft from storage
+ * @param {string} conversationId - The conversation ID
+ * @param {string} replyType - The reply type (REPLY or NOTE)
+ */
+export const removeAudioDraft = (conversationId, replyType) => {
+  try {
+    const key = getAudioStorageKey(conversationId, replyType);
+    LocalStorage.deleteFromJsonStore(AUDIO_STORAGE_KEY, key);
+  } catch (error) {
+    // Error removing audio draft
+  }
+};

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -195,7 +195,8 @@
           "YES": "Send",
           "CANCEL": "Cancel"
         }
-      }
+      },
+      "AUDIO_RECORDING": "Recorded Audio"
     },
     "VISIBLE_TO_AGENTS": "Private Note: Only visible to you and your team",
     "CHANGE_STATUS": "Conversation status changed",

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -196,7 +196,7 @@
           "CANCEL": "Cancel"
         }
       },
-      "AUDIO_RECORDING": "Recorded Audio"
+      "DRAFT_AUDIO_SIZE_LIMIT_ERROR": "Audio recording exceeds the 5MB size limit and cannot be saved as a draft"
     },
     "VISIBLE_TO_AGENTS": "Private Note: Only visible to you and your team",
     "CHANGE_STATUS": "Conversation status changed",


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will save recorded audio as a draft in local storage when switching chats. This ensures that users can retrieve and send the recorded audio when they return to the chat.

**Note**: If the audio size exceeds 5MB, it will not be saved as a draft, and an alert message will be shown because local storage has a limited capacity (typically around 5MB)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/d77350c24bb54efa9bcaa78152b316ad?sid=5cc27918-1b16-49d9-9954-5f2638db73ae


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
