### PR TITLE
feat: cache conversation meta

### DIFF
--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -201,7 +201,7 @@ class ConversationFinder
   end
 
   def additional_filters?
-    params[:q].present? || params[:conversation_type].present? || params[:team_id].present? || params[:labels].present? || params[:source_id].present?
+    [:q, :conversation_type, :team_id, :labels, :source_id, :inbox_id].any? { |key| params[key].present? }
   end
 
   def current_page

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -184,7 +184,7 @@ class ConversationFinder
   end
 
   def should_cache?
-    true
+    current_account.feature_enabled?('cache_meta_counts')
   end
 
   def cache_key
@@ -192,6 +192,7 @@ class ConversationFinder
   end
 
   def cache_expiry(unassigned_count)
+    # these numbers are intentionally chosen to balance between cache hit rate and freshness
     return 5.seconds if unassigned_count < 100
     return 10.seconds if unassigned_count < 200
     return 15.seconds if unassigned_count < 500

--- a/config/features.yml
+++ b/config/features.yml
@@ -161,3 +161,6 @@
 - name: search_with_gin
   display_name: Search messages with GIN
   enabled: false
+- name: cache_meta_counts
+  display_name: Cache Meta Counts
+  enabled: false

--- a/lib/redis/redis_keys.rb
+++ b/lib/redis/redis_keys.rb
@@ -41,4 +41,7 @@ module Redis::RedisKeys
   IG_MESSAGE_MUTEX = 'IG_MESSAGE_CREATE_LOCK::%<sender_id>s::%<ig_account_id>s'.freeze
   SLACK_MESSAGE_MUTEX = 'SLACK_MESSAGE_LOCK::%<conversation_id>s::%<reference_id>s'.freeze
   EMAIL_MESSAGE_MUTEX = 'EMAIL_CHANNEL_LOCK::%<inbox_id>s'.freeze
+
+  # Cache for storing conversation meta counts
+  CONVERSATION_COUNTS = 'CONVERSATION::COUNTS::%<inbox_ids>s::%<status>s'.freeze
 end


### PR DESCRIPTION
The meta call is extremely expensive for large systems, every actionCable event related to conversation triggers a request, this can easily saturate the incoming requests queue on the backend. 

This PR addresses the backend side of things by caching the total count and unassigned count

### Cache Meta Numbers

1. We cache the unassigned and the all count, (Mine count is always computed fresh)
2. This caching only works if the user has no filters except for status. 
3. The key uses the sorted `inbox_ids` and `status`, so agents who have the same level of access can share this key
4. This behavior is not the default, and can be enabled with the `cache_meta_counts` feature flag
5. The cache expiry can be anywhere between 5 seconds and 20 seconds, depending on the unassigned count. Unassigned seemed like a better metric of the activity on the system compared to all count which can vary across accounts. 

Frontend PR: https://github.com/chatwoot/chatwoot/pull/11187