### PR TITLE
feat: limit active sessions per user to 3

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -15,7 +15,7 @@ DeviseTokenAuth.setup do |config|
 
   # Sets the max number of concurrent devices per user, which is 10 by default.
   # After this limit is reached, the oldest tokens will be removed.
-  config.max_number_of_devices = 25
+  config.max_number_of_devices = 3
 
   # Sometimes it's necessary to make several requests to the API at the same
   # time. In this case, each request in the batch will need to share the same


### PR DESCRIPTION
- Implement a limit of 3 active sessions per user to prevent abuse and ensure fair usage across all accounts