### PR TITLE
feat: add job to remove stale contacts

### DIFF
--- a/app/jobs/internal/remove_stale_contacts_job.rb
+++ b/app/jobs/internal/remove_stale_contacts_job.rb
@@ -1,0 +1,13 @@
+# housekeeping
+# remove contacts that:
+# - have no identification (email, phone_number, and identifier are NULL)
+# - have no conversations
+# - are older than 30 days
+
+class Internal::RemoveStaleContactsJob < ApplicationJob
+  queue_as :scheduled_jobs
+
+  def perform
+    Internal::RemoveStaleContactsService.new.perform
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -128,6 +128,18 @@ class Contact < ApplicationRecord
     )
   }
 
+  # Find contacts that:
+  # 1. Have no identification (email, phone_number, and identifier are NULL or empty string)
+  # 2. Have no conversations
+  # 3. Are older than the specified time period
+  scope :stale_without_conversations, lambda { |time_period|
+    where('contacts.email IS NULL OR contacts.email = ?', '')
+      .where('contacts.phone_number IS NULL OR contacts.phone_number = ?', '')
+      .where('contacts.identifier IS NULL OR contacts.identifier = ?', '')
+      .where('contacts.created_at < ?', time_period)
+      .where.missing(:conversations)
+  }
+
   def get_source_id(inbox_id)
     contact_inboxes.find_by!(inbox_id: inbox_id).source_id
   end

--- a/app/services/internal/remove_stale_contacts_service.rb
+++ b/app/services/internal/remove_stale_contacts_service.rb
@@ -1,0 +1,43 @@
+class Internal::RemoveStaleContactsService
+  def perform
+    return unless remove_stale_contacts_job_enabled?
+
+    time_period = 30.days.ago
+    contacts_to_delete = stale_contacts(time_period)
+
+    log_stale_contacts_deletion(contacts_to_delete, time_period)
+
+    # Since the number of records to delete is very high,
+    # delete_all would be faster than destroy_all since it operates at database level
+    # and avoid loading all the records in memory
+    # Transaction and batching is used to avoid deadlock and memory issues
+    Contact.transaction do
+      contacts_to_delete
+        .find_in_batches(batch_size: 10_000) do |group|
+          Contact.where(id: group.map(&:id)).delete_all
+        end
+    end
+  end
+
+  private
+
+  def remove_stale_contacts_job_enabled?
+    job_status = ENV.fetch('REMOVE_STALE_CONTACTS_JOB_STATUS', false)
+    return false unless ActiveModel::Type::Boolean.new.cast(job_status)
+
+    true
+  end
+
+  def stale_contacts(time_period)
+    Contact.stale_without_conversations(time_period)
+  end
+
+  def log_stale_contacts_deletion(contacts, time_period)
+    count = contacts.count
+    Rails.logger.info "Deleting #{count} stale contacts older than #{time_period}"
+
+    # Log the SQL query without executing it
+    sql_query = contacts.to_sql
+    Rails.logger.info("SQL Query: #{sql_query}")
+  end
+end

--- a/spec/jobs/internal/remove_stale_contacts_job_spec.rb
+++ b/spec/jobs/internal/remove_stale_contacts_job_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Internal::RemoveStaleContactsJob do
+  subject(:job) { described_class.perform_later }
+
+  it 'enqueues the job' do
+    expect { job }.to have_enqueued_job(described_class)
+      .on_queue('scheduled_jobs')
+  end
+
+  it 'calls the RemoveStaleContactsService' do
+    service = instance_double(Internal::RemoveStaleContactsService)
+    expect(Internal::RemoveStaleContactsService).to receive(:new).and_return(service)
+    expect(service).to receive(:perform)
+    described_class.perform_now
+  end
+end

--- a/spec/services/internal/remove_stale_contacts_service_spec.rb
+++ b/spec/services/internal/remove_stale_contacts_service_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe Internal::RemoveStaleContactsService do
+  describe '#perform' do
+    it 'does not delete stale contacts if REMOVE_STALE_CONTACTS_JOB_STATUS is false' do
+      # default value of REMOVE_STALE_CONTACTS_JOB_STATUS is false
+      create(:contact, created_at: 3.days.ago)
+      create(:contact, created_at: 31.days.ago)
+      create(:contact, created_at: 32.days.ago)
+      create(:contact, created_at: 33.days.ago)
+      create(:contact, created_at: 34.days.ago)
+
+      service = described_class.new
+      expect { service.perform }.not_to change(Contact, :count)
+    end
+
+    it 'deletes stale contacts when REMOVE_STALE_CONTACTS_JOB_STATUS is true' do
+      with_modified_env REMOVE_STALE_CONTACTS_JOB_STATUS: 'true' do
+        # Recent contact - should not be deleted
+        create(:contact, created_at: 3.days.ago)
+
+        # Stale contacts with NULL values - should be deleted
+        create(:contact, email: nil, phone_number: nil, identifier: nil, created_at: 31.days.ago)
+
+        # Stale contacts with empty strings - should be deleted
+        create(:contact, email: '', phone_number: '', identifier: '', created_at: 32.days.ago)
+
+        # Mixed NULL and empty strings - should be deleted
+        create(:contact, email: nil, phone_number: '', identifier: nil, created_at: 33.days.ago)
+        create(:contact, email: '', phone_number: nil, identifier: '', created_at: 34.days.ago)
+
+        service = described_class.new
+        expect { service.perform }.to change(Contact, :count).by(-4)
+      end
+    end
+
+    it 'does not delete contacts with conversations' do
+      with_modified_env REMOVE_STALE_CONTACTS_JOB_STATUS: 'true' do
+        # Contact with NULL values and conversation
+        contact1 = create(:contact, email: nil, phone_number: nil, identifier: nil, created_at: 31.days.ago)
+        create(:conversation, contact: contact1)
+
+        # Contact with empty strings and conversation
+        contact2 = create(:contact, email: '', phone_number: '', identifier: '', created_at: 31.days.ago)
+        create(:conversation, contact: contact2)
+
+        service = described_class.new
+        expect { service.perform }.not_to change(Contact, :count)
+      end
+    end
+
+    it 'does not delete contacts with identification' do
+      with_modified_env REMOVE_STALE_CONTACTS_JOB_STATUS: 'true' do
+        # Non-empty values
+        create(:contact, email: 'test@example.com', created_at: 31.days.ago)
+        create(:contact, phone_number: '+1234567890', created_at: 31.days.ago)
+        create(:contact, identifier: 'test123', created_at: 31.days.ago)
+
+        # Mixed empty and non-empty values - should not be deleted
+        create(:contact, email: 'test@example.com', phone_number: '', identifier: nil, created_at: 31.days.ago)
+        create(:contact, email: nil, phone_number: '+1234567890', identifier: '', created_at: 31.days.ago)
+        create(:contact, email: '', phone_number: nil, identifier: 'test123', created_at: 31.days.ago)
+
+        service = described_class.new
+        expect { service.perform }.not_to change(Contact, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add a job to remove stale contacts across all accounts
- Enable the job by setting `REMOVE_STALE_CONTACTS_JOB_STATUS` to `true`


Stale anonymous contact is defined as 
- have no identification (email, phone_number, and identifier are NULL)
- have no conversations
- are older than 30 days

