### PR TITLE
feat: debounce meta request

### DIFF
--- a/app/javascript/dashboard/store/modules/conversationStats.js
+++ b/app/javascript/dashboard/store/modules/conversationStats.js
@@ -1,37 +1,39 @@
 import types from '../mutation-types';
+import { debounce } from '@chatwoot/utils';
 import ConversationApi from '../../api/inbox/conversation';
 
 const state = {
   mineCount: 0,
   unAssignedCount: 0,
   allCount: 0,
-  updatedOn: null,
 };
 
 export const getters = {
   getStats: $state => $state,
 };
 
+// Create a debounced version of the actual API call function
+const fetchMetaData = async (commit, params) => {
+  try {
+    const response = await ConversationApi.meta(params);
+    const {
+      data: { meta },
+    } = response;
+    commit(types.SET_CONV_TAB_META, meta);
+  } catch (error) {
+    // ignore
+  }
+};
+
+const debouncedFetchMetaData = debounce(fetchMetaData, 500);
+const longDebouncedFetchMetaData = debounce(fetchMetaData, 5000);
+
 export const actions = {
-  get: async ({ commit, state: $state }, params) => {
-    const currentTime = new Date();
-    const lastUpdatedTime = new Date($state.updatedOn);
-
-    // Skip large accounts from making too many requests
-    if (currentTime - lastUpdatedTime < 10000 && $state.allCount > 100) {
-      // eslint-disable-next-line no-console
-      console.warn('Skipping conversation meta fetch');
-      return;
-    }
-
-    try {
-      const response = await ConversationApi.meta(params);
-      const {
-        data: { meta },
-      } = response;
-      commit(types.SET_CONV_TAB_META, meta);
-    } catch (error) {
-      // Ignore error
+  get: ({ commit, state: $state }, params) => {
+    if ($state.allCount > 100) {
+      longDebouncedFetchMetaData(commit, params);
+    } else {
+      debouncedFetchMetaData(commit, params);
     }
   },
   set({ commit }, meta) {

--- a/app/javascript/dashboard/store/modules/conversationStats.js
+++ b/app/javascript/dashboard/store/modules/conversationStats.js
@@ -53,7 +53,6 @@ export const mutations = {
     $state.mineCount = mineCount;
     $state.allCount = allCount;
     $state.unAssignedCount = unAssignedCount;
-    $state.updatedOn = new Date();
   },
 };
 

--- a/app/javascript/dashboard/store/modules/specs/conversationStats/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversationStats/actions.spec.js
@@ -6,22 +6,41 @@ const commit = vi.fn();
 global.axios = axios;
 vi.mock('axios');
 
+vi.mock('@chatwoot/utils', () => ({
+  debounce: vi.fn(fn => {
+    return fn;
+  }),
+}));
+
 describe('#actions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers(); // Set up fake timers
+    commit.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers(); // Reset to real timers after each test
+  });
+
   describe('#get', () => {
     it('sends correct mutations if API is success', async () => {
       axios.get.mockResolvedValue({ data: { meta: { mine_count: 1 } } });
-      await actions.get(
-        { commit, state: { updatedOn: null } },
+      actions.get(
+        { commit, state: { allCount: 0 } },
         { inboxId: 1, assigneeTpe: 'me', status: 'open' }
       );
+
+      await vi.runAllTimersAsync();
+      await vi.waitFor(() => expect(commit).toHaveBeenCalled());
+
       expect(commit.mock.calls).toEqual([
         [types.default.SET_CONV_TAB_META, { mine_count: 1 }],
       ]);
     });
     it('sends correct actions if API is error', async () => {
       axios.get.mockRejectedValue({ message: 'Incorrect header' });
-      await actions.get(
-        { commit, state: { updatedOn: null } },
+      actions.get(
+        { commit, state: { allCount: 0 } },
         { inboxId: 1, assigneeTpe: 'me', status: 'open' }
       );
       expect(commit.mock.calls).toEqual([]);

--- a/app/javascript/dashboard/store/modules/specs/conversationStats/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversationStats/mutations.spec.js
@@ -14,7 +14,6 @@ describe('#mutations', () => {
         mineCount: 1,
         unAssignedCount: 1,
         allCount: 2,
-        updatedOn: expect.any(Date),
       });
     });
   });


### PR DESCRIPTION
The meta call is extremely expensive for large systems, every actionCable event related to conversation triggers a request, this can easily saturate the incoming requests queue on the backend. 

Earlier we added a stop gap solution to do an early return if the last updated time was within 10 seconds of the request, if there were more than 100 conversations. While this worked well initially, our logs show the number of these requests are still way larger than the theoretical limit this implementation allows, assuming it works.

There's a possibility the processing delay between committing the `updatedOn` data to the store (basically one Vue lifecycle tick) many requests slip through. This is not noticable generally, but during peak hours, we can get multiple events with a millisecond, near instantaneously. This subverts the check we have, making it apparent that the core problem here is the the check is strongly coupled with the Vue lifecycle.
Another criticism of this was that the numbers would often mismatch, this is because for the last event if the counts changed, no fresh data was fetched. We need some form of eventual consistency

### Change Summary

1. We split out the get function and get a separate `fetchMetaData` function
2. This is debounced at two intervals at 0.5 seconds and 5 seconds. These functions are declared at the top completely separate from the vue lifecycle. 
3. Default behaviour is to debounce by 0.5 seconds always, and make it 5 seconds if there are more than 5 seconds.
4. This addresses the issue that the numbers were not eventually consistent, a request always goes through at the end of the timer

Backend PR: https://github.com/chatwoot/chatwoot/pull/11184