### PR TITLE
fix: Update throttle for /meta endpoints, will call every 2s for small account, 10s for large accounts

### DIFF
--- a/app/javascript/dashboard/helper/ConversationMetaThrottleManager.js
+++ b/app/javascript/dashboard/helper/ConversationMetaThrottleManager.js
@@ -1,0 +1,29 @@
+class ConversationMetaThrottleManager {
+  constructor() {
+    this.lastUpdatedTime = null;
+  }
+
+  shouldThrottle(threshold = 10000) {
+    if (!this.lastUpdatedTime) {
+      return false;
+    }
+
+    const currentTime = new Date().getTime();
+    const lastUpdatedTime = new Date(this.lastUpdatedTime).getTime();
+
+    if (currentTime - lastUpdatedTime < threshold) {
+      return true;
+    }
+    return false;
+  }
+
+  markUpdate() {
+    this.lastUpdatedTime = new Date();
+  }
+
+  reset() {
+    this.lastUpdatedTime = null;
+  }
+}
+
+export default new ConversationMetaThrottleManager();

--- a/app/javascript/dashboard/helper/specs/ConversationMetaThrottleManager.spec.js
+++ b/app/javascript/dashboard/helper/specs/ConversationMetaThrottleManager.spec.js
@@ -1,0 +1,34 @@
+import ConversationMetaThrottleManager from '../ConversationMetaThrottleManager';
+
+describe('ConversationMetaThrottleManager', () => {
+  beforeEach(() => {
+    // Reset the lastUpdatedTime before each test
+    ConversationMetaThrottleManager.lastUpdatedTime = null;
+  });
+
+  describe('shouldThrottle', () => {
+    it('returns false when lastUpdatedTime is not set', () => {
+      expect(ConversationMetaThrottleManager.shouldThrottle()).toBe(false);
+    });
+
+    it('returns true when time difference is less than threshold', () => {
+      ConversationMetaThrottleManager.markUpdate();
+      expect(ConversationMetaThrottleManager.shouldThrottle()).toBe(true);
+    });
+
+    it('returns false when time difference is more than threshold', () => {
+      ConversationMetaThrottleManager.lastUpdatedTime = new Date(
+        Date.now() - 11000
+      );
+      expect(ConversationMetaThrottleManager.shouldThrottle()).toBe(false);
+    });
+
+    it('respects custom threshold value', () => {
+      ConversationMetaThrottleManager.lastUpdatedTime = new Date(
+        Date.now() - 5000
+      );
+      expect(ConversationMetaThrottleManager.shouldThrottle(3000)).toBe(false);
+      expect(ConversationMetaThrottleManager.shouldThrottle(6000)).toBe(true);
+    });
+  });
+});

--- a/app/javascript/dashboard/store/modules/specs/conversationStats/helper.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversationStats/helper.spec.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ConversationMetaThrottleManager from 'dashboard/helper/ConversationMetaThrottleManager';
+import { shouldThrottle } from '../../conversationStats';
+
+vi.mock('dashboard/helper/ConversationMetaThrottleManager', () => ({
+  default: {
+    shouldThrottle: vi.fn(),
+  },
+}));
+
+describe('shouldThrottle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses normal threshold for accounts with 100 or fewer conversations', () => {
+    shouldThrottle(100);
+    expect(ConversationMetaThrottleManager.shouldThrottle).toHaveBeenCalledWith(
+      2000
+    );
+  });
+
+  it('uses large account threshold for accounts with more than 100 conversations', () => {
+    shouldThrottle(101);
+    expect(ConversationMetaThrottleManager.shouldThrottle).toHaveBeenCalledWith(
+      10000
+    );
+  });
+
+  it('returns the throttle value from ConversationMetaThrottleManager', () => {
+    ConversationMetaThrottleManager.shouldThrottle.mockReturnValue(true);
+    expect(shouldThrottle(50)).toBe(true);
+
+    ConversationMetaThrottleManager.shouldThrottle.mockReturnValue(false);
+    expect(shouldThrottle(150)).toBe(false);
+  });
+});

--- a/app/javascript/widget/assets/scss/woot.scss
+++ b/app/javascript/widget/assets/scss/woot.scss
@@ -10,7 +10,7 @@
 
 html,
 body {
-  @apply antialiased h-full bg-n-background;
+  @apply antialiased h-full;
 }
 
 .is-mobile {


### PR DESCRIPTION
This update improves the throttling mechanism for conversation meta requests to optimize server load and enhance performance. The changes implement differentiated thresholds based on account size - a 2-second throttle for small accounts (≤100 conversations) and a 10-second throttle for large accounts (>100 conversations). 

Fixes #11178

