### PR TITLE
fix: Apply filter for inbox when the user is an admin

### DIFF
--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -86,9 +86,13 @@ class ConversationFinder
     @team = current_account.teams.find(params[:team_id]) if params[:team_id]
   end
 
-  def find_all_conversations
+  def find_conversation_by_inbox
     @conversations = current_account.conversations
-    @conversations = @conversations.where(inbox_id: @inbox_ids) unless @is_admin
+    @conversations = @conversations.where(inbox_id: @inbox_ids) unless params[:inbox_id].blank? && @is_admin
+  end
+
+  def find_all_conversations
+    find_conversation_by_inbox
     filter_by_conversation_type if params[:conversation_type]
     @conversations
   end

--- a/spec/finders/conversation_finder_spec.rb
+++ b/spec/finders/conversation_finder_spec.rb
@@ -57,6 +57,16 @@ describe ConversationFinder do
 
         expect(result[:conversations].map(&:id)).not_to include(restricted_conversation.id)
       end
+
+      it 'returns only the conversations from the inbox if inbox_id filter is passed' do
+        conversation = create(:conversation, account: account, inbox_id: inbox.id)
+        params = { inbox_id: restricted_inbox.id }
+        result = described_class.new(admin, params).perform
+
+        conversation_ids = result[:conversations].map(&:id)
+        expect(conversation_ids).not_to include(conversation.id)
+        expect(conversation_ids).to include(restricted_conversation.id)
+      end
     end
 
     context 'with assignee_type all' do


### PR DESCRIPTION
Optimization #11183 missed a condition where the inbox_id filter is manually passed. Due to the previous change, the inbox filter was being discarded for admins, although it continued to work correctly for agents.

This PR includes a fix for that specific case and adds a spec to explicitly test it.