### PR TITLE
fix: Add support for named parameter templates in WhatsApp

### DIFF
--- a/app/services/contacts/contactable_inboxes_service.rb
+++ b/app/services/contacts/contactable_inboxes_service.rb
@@ -42,20 +42,20 @@ class Contacts::ContactableInboxesService
   end
 
   def email_contactable_inbox(inbox)
-    return unless @contact.email
+    return if @contact.email.blank?
 
     { source_id: @contact.email, inbox: inbox }
   end
 
   def whatsapp_contactable_inbox(inbox)
-    return unless @contact.phone_number
+    return if @contact.phone_number.blank?
 
     # Remove the plus since thats the format 360 dialog uses
     { source_id: @contact.phone_number.delete('+'), inbox: inbox }
   end
 
   def sms_contactable_inbox(inbox)
-    return unless @contact.phone_number
+    return if @contact.phone_number.blank?
 
     { source_id: @contact.phone_number, inbox: inbox }
   end

--- a/spec/factories/channel/channel_whatsapp.rb
+++ b/spec/factories/channel/channel_whatsapp.rb
@@ -30,7 +30,39 @@ FactoryBot.define do
          'components' =>
          [{ 'text' => 'Your package has been shipped. It will be delivered in {{1}} business days.', 'type' => 'BODY' },
           { 'text' => 'This message is from an unverified business.', 'type' => 'FOOTER' }],
-         'rejected_reason' => 'NONE' }]
+         'rejected_reason' => 'NONE' },
+       {
+         'name' => 'ticket_status_updated',
+         'status' => 'APPROVED',
+         'category' => 'UTILITY',
+         'language' => 'en',
+         'components' => [
+           { 'text' => "Hello {{name}},  Your support ticket with ID: \#{{ticket_id}} has been updated by the support agent.",
+             'type' => 'BODY',
+             'example' => { 'body_text_named_params' => [
+               { 'example' => 'John', 'param_name' => 'name' },
+               { 'example' => '2332', 'param_name' => 'ticket_id' }
+             ] } }
+         ],
+         'sub_category' => 'CUSTOM',
+         'parameter_format' => 'NAMED'
+       },
+       {
+         'name' => 'ticket_status_updated',
+         'status' => 'APPROVED',
+         'category' => 'UTILITY',
+         'language' => 'en_US',
+         'components' => [
+           { 'text' => "Hello {{last_name}},  Your support ticket with ID: \#{{ticket_id}} has been updated by the support agent.",
+             'type' => 'BODY',
+             'example' => { 'body_text_named_params' => [
+               { 'example' => 'Dale', 'param_name' => 'last_name' },
+               { 'example' => '2332', 'param_name' => 'ticket_id' }
+             ] } }
+         ],
+         'sub_category' => 'CUSTOM',
+         'parameter_format' => 'NAMED'
+       }]
     end
     message_templates_last_updated { Time.now.utc }
 


### PR DESCRIPTION
The expected payload on WhatsApp Cloud API is the following. 
```json
{ 
  "template": {
    "name": "TEMPLATE_NAME",
    "language": {
      "code": "LANGUAGE_AND_LOCALE_CODE"
    },
    "components": [
         "<NAMED_PARAMETER_INPUT>",
         "<POSITIONAL_PARAMETER_INPUT>"
     ]
  }
}
```
Named templates expect a `parameter_name`

```json
{
   "type": "body",
    "parameters": [
      {
        "type": "text",
        "parameter_name": "customer_name",
        "text": "John"
      },
      {
        "type": "text",
        "parameter_name": "order_id",
        "text": "9128312831"
      }        
    ]
}
```

In this PR, we would check if the template is a name template, then we would send the `parameter_name` as well.

Reference: https://github.com/chatwoot/chatwoot/issues/10886