### PR TITLE
feat: Add webhook event support for macros

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/macros.json
+++ b/app/javascript/dashboard/i18n/locale/en/macros.json
@@ -97,7 +97,8 @@
       "SEND_ATTACHMENT": "Send Attachment",
       "SEND_MESSAGE": "Send a Message",
       "CHANGE_PRIORITY": "Change Priority",
-      "ADD_PRIVATE_NOTE": "Add a Private Note"
+      "ADD_PRIVATE_NOTE": "Add a Private Note",
+      "SEND_WEBHOOK_EVENT": "Send Webhook Event"
     }
   }
 }

--- a/app/javascript/dashboard/routes/dashboard/conversation/Macros/MacroPreview.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/Macros/MacroPreview.vue
@@ -65,7 +65,7 @@ const resolvedMacro = computed(() => {
         class="absolute -left-[0.21875rem] top-[0.2734375rem] w-2 h-2 rounded-full bg-n-solid-1 border-2 border-solid border-n-weak dark:border-slate-600"
       />
       <p class="mb-1 text-xs text-n-slate-11">
-        {{ action.actionName }}
+        {{ $t(`MACROS.ACTIONS.${action.actionName}`) }}
       </p>
       <p class="text-n-slate-12 text-sm">{{ action.actionValue }}</p>
     </div>

--- a/app/javascript/dashboard/routes/dashboard/settings/macros/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/macros/constants.js
@@ -64,4 +64,9 @@ export const MACRO_ACTION_TYPES = [
     label: 'CHANGE_PRIORITY',
     inputType: 'search_select',
   },
+  {
+    key: 'send_webhook_event',
+    label: 'SEND_WEBHOOK_EVENT',
+    inputType: 'url',
+  },
 ];

--- a/app/models/macro.rb
+++ b/app/models/macro.rb
@@ -31,7 +31,8 @@ class Macro < ApplicationRecord
   validate :json_actions_format
 
   ACTIONS_ATTRS = %w[send_message add_label assign_team assign_agent mute_conversation change_status remove_label remove_assigned_team
-                     resolve_conversation snooze_conversation change_priority send_email_transcript send_attachment add_private_note].freeze
+                     resolve_conversation snooze_conversation change_priority send_email_transcript send_attachment
+                     add_private_note send_webhook_event].freeze
 
   def set_visibility(user, params)
     self.visibility = params[:visibility]

--- a/app/services/macros/execution_service.rb
+++ b/app/services/macros/execution_service.rb
@@ -62,4 +62,9 @@ class Macros::ExecutionService < ActionService
     mb = Messages::MessageBuilder.new(@user, @conversation.reload, params)
     mb.perform
   end
+
+  def send_webhook_event(webhook_url)
+    payload = @conversation.webhook_data.merge(event: 'macro.executed')
+    WebhookJob.perform_later(webhook_url.first, payload)
+  end
 end

--- a/spec/services/macros/execution_service_spec.rb
+++ b/spec/services/macros/execution_service_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Macros::ExecutionService, type: :service do
                                                        { action_name: 'assign_agent', action_params: ['self'] },
                                                        { action_name: 'add_private_note', action_params: ['Test note'] },
                                                        { action_name: 'send_message', action_params: ['Test message'] },
-                                                       { action_name: 'send_attachment', action_params: [1, 2] }
+                                                       { action_name: 'send_attachment', action_params: [1, 2] },
+                                                       { action_name: 'send_webhook_event', action_params: ['https://example.com/webhook'] }
                                                      ])
       end
 
@@ -145,6 +146,13 @@ RSpec.describe Macros::ExecutionService, type: :service do
           service.send(:send_attachment, [macro.files.first.blob_id])
         end.not_to change(Message, :count)
       end
+    end
+  end
+
+  describe '#send_webhook_event' do
+    it 'sends a webhook event' do
+      expect(WebhookJob).to receive(:perform_later)
+      service.send(:send_webhook_event, ['https://example.com/webhook'])
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/chatwoot/chatwoot/issues/5968

We will not support custom payload in V1.