### PR TITLE
feat: Handle instagram test service

### DIFF
--- a/app/jobs/webhooks/instagram_events_job.rb
+++ b/app/jobs/webhooks/instagram_events_job.rb
@@ -24,6 +24,11 @@ class Webhooks::InstagramEventsJob < MutexApplicationJob
   private
 
   def process_single_entry(entry)
+    if test_event?(entry)
+      process_test_event(entry)
+      return
+    end
+
     process_messages(entry)
   end
 
@@ -44,6 +49,24 @@ class Webhooks::InstagramEventsJob < MutexApplicationJob
 
   def agent_message_via_echo?(messaging)
     messaging[:message].present? && messaging[:message][:is_echo].present?
+  end
+
+  def test_event?(entry)
+    entry[:changes].present?
+  end
+
+  def process_test_event(entry)
+    messaging = extract_messaging_from_test_event(entry)
+
+    Instagram::TestEventService.new(messaging).perform if messaging.present?
+  end
+
+  def extract_messaging_from_test_event(entry)
+    if entry[:changes].present?
+      entry[:changes].first&.dig(:value)
+    else
+      entry[:messaging]&.first
+    end
   end
 
   def instagram_id(messaging)

--- a/app/services/instagram/test_event_service.rb
+++ b/app/services/instagram/test_event_service.rb
@@ -1,0 +1,79 @@
+class Instagram::TestEventService
+  def initialize(messaging)
+    @messaging = messaging
+  end
+
+  def perform
+    Rails.logger.info("Processing Instagram test webhook event, #{@messaging}")
+
+    return false unless test_webhook_event?
+
+    create_test_text
+  end
+
+  private
+
+  def test_webhook_event?
+    @messaging[:sender][:id] == '12334' && @messaging[:recipient][:id] == '23245'
+  end
+
+  def create_test_text
+    channel = Channel::Instagram.last
+
+    # As of now, we are using the last created instagram channel as the test channel,
+    # since we don't have any other channel for testing purpose at the time of meta approval
+    @inbox = ::Inbox.find_by(channel: channel)
+    return unless @inbox
+
+    @contact = create_test_contact
+
+    @conversation ||= create_test_conversation(conversation_params)
+
+    @message = @conversation.messages.create!(test_message_params)
+  end
+
+  def create_test_contact
+    @contact_inbox = @inbox.contact_inboxes.where(source_id: @messaging[:sender][:id]).first
+    unless @contact_inbox
+      @contact_inbox ||= @inbox.channel.create_contact_inbox(
+        'sender_username', 'sender_username'
+      )
+    end
+
+    @contact_inbox.contact
+  end
+
+  def create_test_conversation(conversation_params)
+    Conversation.find_by(conversation_params) || build_conversation(conversation_params)
+  end
+
+  def test_message_params
+    {
+      account_id: @conversation.account_id,
+      inbox_id: @conversation.inbox_id,
+      message_type: 'incoming',
+      source_id: @messaging[:message][:mid],
+      content: @messaging[:message][:text],
+      sender: @contact
+    }
+  end
+
+  def build_conversation(conversation_params)
+    Conversation.create!(
+      conversation_params.merge(
+        contact_inbox_id: @contact_inbox.id
+      )
+    )
+  end
+
+  def conversation_params
+    {
+      account_id: @inbox.account_id,
+      inbox_id: @inbox.id,
+      contact_id: @contact.id,
+      additional_attributes: {
+        type: 'instagram_direct_message'
+      }
+    }
+  end
+end


### PR DESCRIPTION
This PR will handle the Instagram test events. We are using the last created Instagram channel as the test channel since we don't have any other channels for testing purposes at the time of Meta approval.