### PR TITLE
fix: styles in ProseMirror URL prompt modal

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -785,11 +785,11 @@ useEmitter(BUS_EVENTS.INSERT_INTO_RICH_EDITOR, insertContentIntoEditor);
       @apply h-8 px-3;
 
       &[type='submit'] {
-        @apply bg-n-brand text-white;
+        @apply bg-n-brand text-white hover:bg-n-brand/90;
       }
 
       &[type='button'] {
-        @apply bg-n-slate-9/10 text-n-slate-12;
+        @apply bg-n-slate-9/10 text-n-slate-12 hover:bg-n-slate-9/20;
       }
     }
   }

--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -774,10 +774,24 @@ useEmitter(BUS_EVENTS.INSERT_INTO_RICH_EDITOR, insertContentIntoEditor);
 }
 
 .ProseMirror-prompt {
-  @apply z-[9999] bg-slate-25 dark:bg-slate-700 rounded-md border border-solid border-slate-75 dark:border-slate-800 shadow-lg;
+  @apply z-[9999] bg-n-alpha-3 backdrop-blur-[100px] border border-n-strong p-6 shadow-xl rounded-xl;
 
   h5 {
-    @apply dark:text-slate-25 text-slate-800;
+    @apply text-n-slate-12 mb-1.5;
+  }
+
+  .ProseMirror-prompt-buttons {
+    button {
+      @apply h-8 px-3;
+
+      &[type='submit'] {
+        @apply bg-n-brand text-white;
+      }
+
+      &[type='button'] {
+        @apply bg-n-slate-9/10 text-n-slate-12;
+      }
+    }
   }
 }
 

--- a/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
@@ -339,11 +339,11 @@ export default {
       @apply h-8 px-3;
 
       &[type='submit'] {
-        @apply bg-n-brand text-white;
+        @apply bg-n-brand text-white hover:bg-n-brand/90;
       }
 
       &[type='button'] {
-        @apply bg-n-slate-9/10 text-n-slate-12;
+        @apply bg-n-slate-9/10 text-n-slate-12 hover:bg-n-slate-9/20;
       }
     }
   }

--- a/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
@@ -328,11 +328,24 @@ export default {
 }
 
 .ProseMirror-prompt {
-  z-index: var(--z-index-highest);
-  background: var(--white);
-  box-shadow: var(--shadow-large);
-  border-radius: var(--border-radius-normal);
-  border: 1px solid var(--color-border);
-  min-width: 25rem;
+  @apply z-[9999] bg-n-alpha-3 min-w-80 backdrop-blur-[100px] border border-n-strong p-6 shadow-xl rounded-xl;
+
+  h5 {
+    @apply text-n-slate-12 mb-1.5;
+  }
+
+  .ProseMirror-prompt-buttons {
+    button {
+      @apply h-8 px-3;
+
+      &[type='submit'] {
+        @apply bg-n-brand text-white;
+      }
+
+      &[type='button'] {
+        @apply bg-n-slate-9/10 text-n-slate-12;
+      }
+    }
+  }
 }
 </style>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the button styling issue in the Prose Mirror URL prompt modal and updates the overall modal styles to align with the new design.
This issue occurs after merging this [PR](https://github.com/chatwoot/chatwoot/pull/11159): 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screencast

**Before**
<img width="285" alt="image" src="https://github.com/user-attachments/assets/b6338d68-1f34-4064-b384-6b9d8edc18b0" />
<img width="285" alt="image" src="https://github.com/user-attachments/assets/5c7f5a85-1ace-445c-9211-0ccb9c36e6c6" />


**After**
https://www.loom.com/share/f5d59f2df4d94623b7c14336bd2090a9?sid=fb3c24f7-ec0d-4abf-8f4e-1c8baa08130b


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
