### PR TITLE
fix: Updating the Ubuntu version to run the tests

### DIFF
--- a/.github/workflows/frontend-fe.yml
+++ b/.github/workflows/frontend-fe.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly_installer.yml
+++ b/.github/workflows/nightly_installer.yml
@@ -2,7 +2,7 @@
 # #
 # # Linux nightly installer action
 # # This action will try to install and setup
-# # chatwoot on an Ubuntu 20.04 machine using
+# # chatwoot on an Ubuntu 22.04 machine using
 # # the linux installer script.
 # #
 # # This is set to run daily at midnight.

--- a/.github/workflows/run_foss_spec.yml
+++ b/.github/workflows/run_foss_spec.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: pgvector/pgvector:pg15

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
In my previous PR I got some errors that when checking it is possible to conclude that the version of ubuntu 20.04 in the Github Actions images to run the tests is no longer supported.
![image](https://github.com/user-attachments/assets/f637e8da-3d15-43a1-8800-6c2785faf70c)

Possible to check at this url: https://github.com/actions/runner-images/issues/11101

## What's changed
Changing the Ubuntu version in the image to run the tests.
Old version: 20.04
New version: 22.04

## BEFORE:
![image](https://github.com/user-attachments/assets/bd2dfdcd-3913-425e-a57c-504c7604d70a)

## NOW:
![image](https://github.com/user-attachments/assets/437ef89b-89d0-4e58-8e3c-ee3073dad417)
