### PR TITLE
fix: Handle Instagram echo events

### DIFF
--- a/app/builders/messages/instagram/base_message_builder.rb
+++ b/app/builders/messages/instagram/base_message_builder.rb
@@ -94,10 +94,9 @@ class Messages::Instagram::BaseMessageBuilder < Messages::Messenger::MessageBuil
   def build_message
     # Duplicate webhook events may be sent for the same message
     # when a user is connected to the Instagram account through both Messenger and Instagram login.
+    # There is chance for echo events to be sent for the same message.
     # Therefore, we need to check if the message already exists before creating it.
     return if message_already_exists?
-
-    return if @outgoing_echo
 
     return if message_content.blank? && all_unsupported_files?
 


### PR DESCRIPTION
This PR fixes the issue with message creation when someone sends messages from the Instagram app instead of the Chatwoot dashboard.