### PR TITLE
fix: use stricter validation to restrict gmail signups

### DIFF
--- a/app/controllers/devise_overrides/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_overrides/omniauth_callbacks_controller.rb
@@ -55,7 +55,7 @@ class DeviseOverrides::OmniauthCallbacksController < DeviseTokenAuth::OmniauthCa
 
   def validate_business_account?
     # return true if the user is a business account, false if it is a gmail account
-    auth_hash['info']['email'].exclude?('@gmail.com')
+    auth_hash['info']['email'].downcase.exclude?('@gmail.com')
   end
 
   def create_account_for_user


### PR DESCRIPTION
- use stricter validation to restrict gmail signups