### PR TITLE
feat: Use portal logo as favicon in helpcenter pages

### DIFF
--- a/app/views/layouts/portal.html.erb
+++ b/app/views/layouts/portal.html.erb
@@ -39,6 +39,10 @@ By default, it renders:
     <% else %>
       <title><%= @portal.page_title%></title>
     <% end %>
+    
+    <% if @portal.logo.present? %>
+      <link rel="icon" type="image/png" href="<%= url_for(@portal.logo) %>">
+    <% end %>
 
     <% unless @theme_from_params.blank? %>
     <%# this adds the theme from params, ensuring that there a localstorage value set %>

--- a/app/views/layouts/portal.html.erb
+++ b/app/views/layouts/portal.html.erb
@@ -41,7 +41,7 @@ By default, it renders:
     <% end %>
     
     <% if @portal.logo.present? %>
-      <link rel="icon" type="image/png" href="<%= url_for(@portal.logo) %>">
+      <link rel="icon" href="<%= url_for(@portal.logo) %>">
     <% end %>
 
     <% unless @theme_from_params.blank? %>

--- a/spec/controllers/public/api/v1/portals_controller_spec.rb
+++ b/spec/controllers/public/api/v1/portals_controller_spec.rb
@@ -30,6 +30,32 @@ RSpec.describe Public::Api::V1::PortalsController, type: :request do
       expect(json_response['error']).to eql "Domain: www.example.com is not registered with us. \
       Please send us an email at support@chatwoot.com with the custom domain name and account API key"
     end
+
+    context 'when portal has a logo' do
+      it 'includes the logo as favicon' do
+        # Attach a test image to the portal
+        file = Rails.root.join('spec/assets/sample.png').open
+        portal.logo.attach(io: file, filename: 'sample.png', content_type: 'image/png')
+        file.close
+
+        get "/hc/#{portal.slug}/en"
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include('<link rel="icon" type="image/png" href=')
+      end
+    end
+
+    context 'when portal has no logo' do
+      it 'does not include a favicon link' do
+        # Ensure logo is not attached
+        portal.logo.purge if portal.logo.attached?
+
+        get "/hc/#{portal.slug}/en"
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).not_to include('<link rel="icon" type="image/png" href=')
+      end
+    end
   end
 
   describe 'GET /public/api/v1/portals/{portal_slug}/sitemap' do

--- a/spec/controllers/public/api/v1/portals_controller_spec.rb
+++ b/spec/controllers/public/api/v1/portals_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Public::Api::V1::PortalsController, type: :request do
         get "/hc/#{portal.slug}/en"
 
         expect(response).to have_http_status(:success)
-        expect(response.body).to include('<link rel="icon" type="image/png" href=')
+        expect(response.body).to include('<link rel="icon" href=')
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe Public::Api::V1::PortalsController, type: :request do
         get "/hc/#{portal.slug}/en"
 
         expect(response).to have_http_status(:success)
-        expect(response.body).not_to include('<link rel="icon" type="image/png" href=')
+        expect(response.body).not_to include('<link rel="icon" href=')
       end
     end
   end


### PR DESCRIPTION
- Added favicon link to portal layout when logo is present
- Added tests to verify favicon behavior with and without logo