### PR TITLE
fix: Emoji rendering issue with `<textarea/>` in chrome

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -1136,7 +1136,7 @@ export default {
         v-else-if="!showRichContentEditor"
         ref="messageInput"
         v-model="message"
-        class="input"
+        class="input rounded-none"
         :placeholder="messagePlaceHolder"
         :min-height="4"
         :signature="signatureToApply"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR resolves a Chrome-specific rendering bug where emojis in the `<textarea>` of the reply box display a shadow or different color tone when placed at the start of the input without a leading space.

**Solution:** Removed the border-radius from the textarea in the Reply box component, which resolves the rendering issue in Chrome

**Cause:** This appears to be a Chrome rendering bug related to how border-radius is handled on form elements, especially with emojis. The exact cause is unclear, but there is some known issue
[Chromium Issue 40333458](https://issues.chromium.org/issues/40333458)
[Related Chromium Duplicates](https://issues.chromium.org/issues/40333458/dupes)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screen recording

**Before**

https://github.com/user-attachments/assets/618de129-5631-4c7c-ab0b-7188b83c6bf1

**After**

https://github.com/user-attachments/assets/bb3adcbe-e603-4792-a8fd-51501d284c78





## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
