### PR TITLE
chore: Fix inbox warnings for old messenger inbox channel

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -213,12 +213,12 @@ export default {
     // Check there is a facebook inbox with the same instagram_id
     hasDuplicateInstagramInbox() {
       const instagramId = this.inbox.instagram_id;
-      const facebookInbox =
-        this.$store.getters['inboxes/getFacebookInboxByInstagramId'](
+      const instagramInbox =
+        this.$store.getters['inboxes/getInstagramInboxByInstagramId'](
           instagramId
         );
 
-      return this.inbox.channel_type === INBOX_TYPES.FB && facebookInbox;
+      return this.inbox.channel_type === INBOX_TYPES.FB && instagramInbox;
     },
 
     replyWindowBannerMessage() {

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/FinishSetup.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/FinishSetup.vue
@@ -21,14 +21,14 @@ export default {
     // Check if a facebook inbox that has the same instagram_id
     hasDuplicateInstagramInbox() {
       const instagramId = this.currentInbox.instagram_id;
-      const facebookInbox =
-        this.$store.getters['inboxes/getFacebookInboxByInstagramId'](
+      const instagramInbox =
+        this.$store.getters['inboxes/getInstagramInboxByInstagramId'](
           instagramId
         );
 
       return (
         this.currentInbox.channel_type === INBOX_TYPES.INSTAGRAM &&
-        facebookInbox
+        instagramInbox
       );
     },
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -213,12 +213,12 @@ export default {
     // Check if a facebook inbox that has the same instagram_id
     hasDuplicateInstagramInbox() {
       const instagramId = this.inbox.instagram_id;
-      const facebookInbox =
-        this.$store.getters['inboxes/getFacebookInboxByInstagramId'](
+      const instagramInbox =
+        this.$store.getters['inboxes/getInstagramInboxByInstagramId'](
           instagramId
         );
 
-      return this.inbox.channel_type === INBOX_TYPES.FB && facebookInbox;
+      return this.inbox.channel_type === INBOX_TYPES.FB && instagramInbox;
     },
     microsoftUnauthorized() {
       return this.isAMicrosoftInbox && this.inbox.reauthorization_required;

--- a/app/javascript/dashboard/store/modules/inboxes.js
+++ b/app/javascript/dashboard/store/modules/inboxes.js
@@ -122,11 +122,11 @@ export const getters = {
       item => item.channel_type !== INBOX_TYPES.EMAIL
     );
   },
-  getFacebookInboxByInstagramId: $state => instagramId => {
+  getInstagramInboxByInstagramId: $state => instagramId => {
     return $state.records.find(
       item =>
         item.instagram_id === instagramId &&
-        item.channel_type === INBOX_TYPES.FB
+        item.channel_type === INBOX_TYPES.INSTAGRAM
     );
   },
 };

--- a/app/javascript/dashboard/store/modules/specs/inboxes/fixtures.js
+++ b/app/javascript/dashboard/store/modules/specs/inboxes/fixtures.js
@@ -63,4 +63,12 @@ export default [
     channel_type: 'Channel::Sms',
     provider: 'default',
   },
+  {
+    id: 7,
+    channel_id: 7,
+    name: 'Test Instagram 1',
+    channel_type: 'Channel::Instagram',
+    instagram_id: 123456789,
+    provider: 'default',
+  },
 ];

--- a/app/javascript/dashboard/store/modules/specs/inboxes/getters.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/inboxes/getters.spec.js
@@ -26,7 +26,7 @@ describe('#getters', () => {
 
   it('dialogFlowEnabledInboxes', () => {
     const state = { records: inboxList };
-    expect(getters.dialogFlowEnabledInboxes(state).length).toEqual(6);
+    expect(getters.dialogFlowEnabledInboxes(state).length).toEqual(7);
   });
 
   it('getInbox', () => {
@@ -66,19 +66,15 @@ describe('#getters', () => {
     });
   });
 
-  it('getFacebookInboxByInstagramId', () => {
+  it('getInstagramInboxByInstagramId', () => {
     const state = { records: inboxList };
-    expect(getters.getFacebookInboxByInstagramId(state)(123456789)).toEqual({
-      id: 1,
-      channel_id: 1,
-      name: 'Test FacebookPage 1',
-      channel_type: 'Channel::FacebookPage',
-      avatar_url: 'random_image.png',
-      page_id: '12345',
-      widget_color: null,
-      website_token: null,
-      enable_auto_assignment: true,
+    expect(getters.getInstagramInboxByInstagramId(state)(123456789)).toEqual({
+      id: 7,
+      channel_id: 7,
+      name: 'Test Instagram 1',
+      channel_type: 'Channel::Instagram',
       instagram_id: 123456789,
+      provider: 'default',
     });
   });
 });


### PR DESCRIPTION
We have added warnings for existing Instagram messenger channels via https://github.com/chatwoot/chatwoot/pull/11303. There is an issue with checking Instagram inbox while checking warnings. This PR will fixes that issue.