### PR TITLE
fix:  Old Instagram inbox warnings

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -210,7 +210,7 @@ export default {
       return contactLastSeenAt;
     },
 
-    // Check there is a instagram inbox with the same instagram_id
+    // Check there is a instagram inbox exists with the same instagram_id
     hasDuplicateInstagramInbox() {
       const instagramId = this.inbox.instagram_id;
       const instagramInbox =

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -210,15 +210,15 @@ export default {
       return contactLastSeenAt;
     },
 
-    // Check there is a facebook inbox with the same instagram_id
+    // Check there is a instagram inbox with the same instagram_id
     hasDuplicateInstagramInbox() {
       const instagramId = this.inbox.instagram_id;
-      const facebookInbox =
-        this.$store.getters['inboxes/getFacebookInboxByInstagramId'](
+      const instagramInbox =
+        this.$store.getters['inboxes/getInstagramInboxByInstagramId'](
           instagramId
         );
 
-      return this.inbox.channel_type === INBOX_TYPES.FB && facebookInbox;
+      return this.inbox.channel_type === INBOX_TYPES.FB && instagramInbox;
     },
 
     replyWindowBannerMessage() {

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/FinishSetup.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/FinishSetup.vue
@@ -18,7 +18,7 @@ export default {
     isATwilioInbox() {
       return this.currentInbox.channel_type === 'Channel::TwilioSms';
     },
-    // Check if a facebook inbox that has the same instagram_id
+    // Check if a facebook inbox exists with the same instagram_id
     hasDuplicateInstagramInbox() {
       const instagramId = this.currentInbox.instagram_id;
       const facebookInbox =

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -210,7 +210,7 @@ export default {
     instagramUnauthorized() {
       return this.isAInstagramChannel && this.inbox.reauthorization_required;
     },
-    // Check if a facebook inbox that has the same instagram_id
+    // Check if a instagram inbox exists with the same instagram_id
     hasDuplicateInstagramInbox() {
       const instagramId = this.inbox.instagram_id;
       const instagramInbox =

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -213,12 +213,12 @@ export default {
     // Check if a facebook inbox that has the same instagram_id
     hasDuplicateInstagramInbox() {
       const instagramId = this.inbox.instagram_id;
-      const facebookInbox =
-        this.$store.getters['inboxes/getFacebookInboxByInstagramId'](
+      const instagramInbox =
+        this.$store.getters['inboxes/getInstagramInboxByInstagramId'](
           instagramId
         );
 
-      return this.inbox.channel_type === INBOX_TYPES.FB && facebookInbox;
+      return this.inbox.channel_type === INBOX_TYPES.FB && instagramInbox;
     },
     microsoftUnauthorized() {
       return this.isAMicrosoftInbox && this.inbox.reauthorization_required;

--- a/app/javascript/dashboard/store/modules/inboxes.js
+++ b/app/javascript/dashboard/store/modules/inboxes.js
@@ -129,6 +129,13 @@ export const getters = {
         item.channel_type === INBOX_TYPES.FB
     );
   },
+  getInstagramInboxByInstagramId: $state => instagramId => {
+    return $state.records.find(
+      item =>
+        item.instagram_id === instagramId &&
+        item.channel_type === INBOX_TYPES.INSTAGRAM
+    );
+  },
 };
 
 const sendAnalyticsEvent = channelType => {

--- a/app/javascript/dashboard/store/modules/specs/inboxes/fixtures.js
+++ b/app/javascript/dashboard/store/modules/specs/inboxes/fixtures.js
@@ -63,4 +63,12 @@ export default [
     channel_type: 'Channel::Sms',
     provider: 'default',
   },
+  {
+    id: 7,
+    channel_id: 7,
+    name: 'Test Instagram 1',
+    channel_type: 'Channel::Instagram',
+    instagram_id: 123456789,
+    provider: 'default',
+  },
 ];

--- a/app/javascript/dashboard/store/modules/specs/inboxes/getters.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/inboxes/getters.spec.js
@@ -26,7 +26,7 @@ describe('#getters', () => {
 
   it('dialogFlowEnabledInboxes', () => {
     const state = { records: inboxList };
-    expect(getters.dialogFlowEnabledInboxes(state).length).toEqual(6);
+    expect(getters.dialogFlowEnabledInboxes(state).length).toEqual(7);
   });
 
   it('getInbox', () => {
@@ -79,6 +79,18 @@ describe('#getters', () => {
       website_token: null,
       enable_auto_assignment: true,
       instagram_id: 123456789,
+    });
+  });
+
+  it('getInstagramInboxByInstagramId', () => {
+    const state = { records: inboxList };
+    expect(getters.getInstagramInboxByInstagramId(state)(123456789)).toEqual({
+      id: 7,
+      channel_id: 7,
+      name: 'Test Instagram 1',
+      channel_type: 'Channel::Instagram',
+      instagram_id: 123456789,
+      provider: 'default',
     });
   });
 });


### PR DESCRIPTION
We have added warnings for existing Instagram messenger inboxes via https://github.com/chatwoot/chatwoot/pull/11303. There is an issue with finding the correct Instagram/messenger inbox. This PR will fixes that issue.