### PR TITLE
chore: Enable chatwoot_v4 feature flag by default for accounts

### DIFF
--- a/db/migrate/20250416182131_flip_chatwoot_v4_default_feature_flag_installation_config.rb
+++ b/db/migrate/20250416182131_flip_chatwoot_v4_default_feature_flag_installation_config.rb
@@ -1,0 +1,24 @@
+class FlipChatwootV4DefaultFeatureFlagInstallationConfig < ActiveRecord::Migration[7.0]
+  def up
+    # Update the default feature flag config to enable chatwoot_v4
+    config = InstallationConfig.find_by(name: 'ACCOUNT_LEVEL_FEATURE_DEFAULTS')
+    if config && config.value.present?
+      features = config.value.map do |f|
+        if f['name'] == 'chatwoot_v4'
+          f.merge('enabled' => true)
+        else
+          f
+        end
+      end
+      config.value = features
+      config.save!
+    end
+
+    # Enable chatwoot_v4 for all accounts in batches of 100
+    Account.find_in_batches(batch_size: 100) do |accounts|
+      accounts.each { |account| account.enable_features!('chatwoot_v4') }
+    end
+
+    GlobalConfig.clear_cache
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_10_061725) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_16_182131) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"


### PR DESCRIPTION
- Updates ACCOUNT_LEVEL_FEATURE_DEFAULTS installation config to enable chatwoot_v4
- Enables chatwoot_v4 for all existing accounts in batches of 100
- Clears GlobalConfig cache after update

