### PR TITLE
chore: Move instagram channel feature to GA

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -166,4 +166,3 @@
 - name: channel_instagram
   display_name: Instagram Channel
   enabled: true
-  chatwoot_internal: true


### PR DESCRIPTION
- Move instagram channel from  `internal` to  general availability