### PR TITLE
chore: Disable warnings old instagram inbox for messenger conversations

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -213,12 +213,17 @@ export default {
     // Check there is a instagram inbox exists with the same instagram_id
     hasDuplicateInstagramInbox() {
       const instagramId = this.inbox.instagram_id;
+      const { additional_attributes: additionalAttributes = {} } = this.inbox;
       const instagramInbox =
         this.$store.getters['inboxes/getInstagramInboxByInstagramId'](
           instagramId
         );
 
-      return this.inbox.channel_type === INBOX_TYPES.FB && instagramInbox;
+      return (
+        this.inbox.channel_type === INBOX_TYPES.FB &&
+        additionalAttributes.type === 'instagram_direct_message' &&
+        instagramInbox
+      );
     },
 
     replyWindowBannerMessage() {


### PR DESCRIPTION
We have added warnings for existing Instagram messenger inboxes via https://github.com/chatwoot/chatwoot/pull/11303. However, an issue arose where warnings were incorrectly displaying for messenger conversations. This PR resolves that issue.