### PR TITLE
feat: Add custom domain to article URL if custom domain exists for the portal

### DIFF
--- a/app/javascript/dashboard/helper/portalHelper.js
+++ b/app/javascript/dashboard/helper/portalHelper.js
@@ -12,12 +12,14 @@ export const buildPortalURL = (portalSlug, customDomain) => {
 
   const { hostURL, helpCenterURL } = window.chatwootConfig || {};
   const normalizedPortalSlug = portalSlug.trim().toLowerCase();
-
   let baseURL = '';
+
   if (customDomain) {
-    baseURL = `https://${customDomain.trim().replace(/^https?:\/\//, '')}`;
+    baseURL = customDomain.startsWith('https')
+      ? customDomain
+      : `https://${customDomain}`;
   } else {
-    baseURL = (helpCenterURL || hostURL || '').replace(/\/$/, '');
+    baseURL = helpCenterURL || hostURL || '';
   }
 
   if (!baseURL) {

--- a/app/javascript/dashboard/helper/portalHelper.js
+++ b/app/javascript/dashboard/helper/portalHelper.js
@@ -1,11 +1,30 @@
+/**
+ * Builds a portal URL using the provided portal slug and optional custom domain
+ * @param {string} portalSlug - The slug identifier for the portal
+ * @param {string} [customDomain] - Optional custom domain for the portal
+ * @returns {string} The complete portal URL
+ * @throws {Error} If portalSlug is not provided or invalid
+ */
 export const buildPortalURL = (portalSlug, customDomain) => {
-  const { hostURL, helpCenterURL } = window.chatwootConfig;
-  const baseURL =
-    (customDomain && `https://${customDomain}`) ||
-    helpCenterURL ||
-    hostURL ||
-    '';
-  return `${baseURL}/hc/${portalSlug}`;
+  if (!portalSlug || typeof portalSlug !== 'string') {
+    throw new Error('Portal slug is required and must be a string');
+  }
+
+  const { hostURL, helpCenterURL } = window.chatwootConfig || {};
+  const normalizedPortalSlug = portalSlug.trim().toLowerCase();
+
+  let baseURL = '';
+  if (customDomain) {
+    baseURL = `https://${customDomain.trim().replace(/^https?:\/\//, '')}`;
+  } else {
+    baseURL = (helpCenterURL || hostURL || '').replace(/\/$/, '');
+  }
+
+  if (!baseURL) {
+    throw new Error('No valid base URL found in configuration');
+  }
+
+  return `${baseURL}/hc/${normalizedPortalSlug}`;
 };
 
 export const buildPortalArticleURL = (

--- a/app/javascript/dashboard/helper/portalHelper.js
+++ b/app/javascript/dashboard/helper/portalHelper.js
@@ -6,10 +6,6 @@
  * @throws {Error} If portalSlug is not provided or invalid
  */
 export const buildPortalURL = (portalSlug, customDomain) => {
-  if (!portalSlug || typeof portalSlug !== 'string') {
-    throw new Error('Portal slug is required and must be a string');
-  }
-
   const { hostURL, helpCenterURL } = window.chatwootConfig || {};
   const normalizedPortalSlug = portalSlug.trim().toLowerCase();
   let baseURL = '';

--- a/app/javascript/dashboard/helper/portalHelper.js
+++ b/app/javascript/dashboard/helper/portalHelper.js
@@ -1,6 +1,6 @@
-export const buildPortalURL = portalSlug => {
+export const buildPortalURL = (portalSlug, customDomain) => {
   const { hostURL, helpCenterURL } = window.chatwootConfig;
-  const baseURL = helpCenterURL || hostURL || '';
+  const baseURL = customDomain || helpCenterURL || hostURL || '';
   return `${baseURL}/hc/${portalSlug}`;
 };
 
@@ -8,9 +8,10 @@ export const buildPortalArticleURL = (
   portalSlug,
   categorySlug,
   locale,
-  articleSlug
+  articleSlug,
+  customDomain
 ) => {
-  const portalURL = buildPortalURL(portalSlug);
+  const portalURL = buildPortalURL(portalSlug, customDomain);
   return `${portalURL}/articles/${articleSlug}`;
 };
 

--- a/app/javascript/dashboard/helper/portalHelper.js
+++ b/app/javascript/dashboard/helper/portalHelper.js
@@ -1,6 +1,10 @@
 export const buildPortalURL = (portalSlug, customDomain) => {
   const { hostURL, helpCenterURL } = window.chatwootConfig;
-  const baseURL = customDomain || helpCenterURL || hostURL || '';
+  const baseURL =
+    (customDomain && `https://${customDomain}`) ||
+    helpCenterURL ||
+    hostURL ||
+    '';
   return `${baseURL}/hc/${portalSlug}`;
 };
 

--- a/app/javascript/dashboard/helper/specs/portalHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/portalHelper.spec.js
@@ -25,5 +25,21 @@ describe('PortalHelper', () => {
       ).toEqual('https://help.chatwoot.com/hc/handbook/articles/article-slug');
       window.chatwootConfig = {};
     });
+
+    it('returns the correct url with custom domain', () => {
+      window.chatwootConfig = {
+        hostURL: 'https://app.chatwoot.com',
+        helpCenterURL: 'https://help.chatwoot.com',
+      };
+      expect(
+        buildPortalArticleURL(
+          'handbook',
+          'culture',
+          'fr',
+          'article-slug',
+          'custom-domain.dev'
+        )
+      ).toEqual('https://custom-domain.dev/hc/handbook/articles/article-slug');
+    });
   });
 });

--- a/app/javascript/dashboard/helper/specs/portalHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/portalHelper.spec.js
@@ -41,5 +41,49 @@ describe('PortalHelper', () => {
         )
       ).toEqual('https://custom-domain.dev/hc/handbook/articles/article-slug');
     });
+
+    it('handles https in custom domain correctly', () => {
+      window.chatwootConfig = {
+        hostURL: 'https://app.chatwoot.com',
+        helpCenterURL: 'https://help.chatwoot.com',
+      };
+      expect(
+        buildPortalArticleURL(
+          'handbook',
+          'culture',
+          'fr',
+          'article-slug',
+          'https://custom-domain.dev'
+        )
+      ).toEqual('https://custom-domain.dev/hc/handbook/articles/article-slug');
+    });
+
+    it('uses hostURL when helpCenterURL is not available', () => {
+      window.chatwootConfig = {
+        hostURL: 'https://app.chatwoot.com',
+        helpCenterURL: '',
+      };
+      expect(
+        buildPortalArticleURL('handbook', 'culture', 'fr', 'article-slug')
+      ).toEqual('https://app.chatwoot.com/hc/handbook/articles/article-slug');
+    });
+
+    it('normalizes portal slug casing', () => {
+      window.chatwootConfig = {
+        helpCenterURL: 'https://help.chatwoot.com',
+      };
+      expect(
+        buildPortalArticleURL('HANDBOOK', 'culture', 'fr', 'article-slug')
+      ).toEqual('https://help.chatwoot.com/hc/handbook/articles/article-slug');
+    });
+
+    it('handles portal slug with whitespace', () => {
+      window.chatwootConfig = {
+        helpCenterURL: 'https://help.chatwoot.com',
+      };
+      expect(
+        buildPortalArticleURL(' handbook ', 'culture', 'fr', 'article-slug')
+      ).toEqual('https://help.chatwoot.com/hc/handbook/articles/article-slug');
+    });
   });
 });

--- a/app/javascript/dashboard/routes/dashboard/conversation/ConversationView.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ConversationView.vue
@@ -120,6 +120,7 @@ export default {
 
   mounted() {
     this.$store.dispatch('agents/get');
+    this.$store.dispatch('portals/index');
     this.initialize();
     this.$watch('$store.state.route', () => this.initialize());
     this.$watch('chatList.length', () => {

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleSearch/SearchPopover.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleSearch/SearchPopover.vue
@@ -77,7 +77,7 @@ export default {
         '',
         '',
         article.slug,
-        'chatwoot.help'
+        this.portalCustomDomain
       );
     },
     localeName(code) {

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleSearch/SearchPopover.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/components/ArticleSearch/SearchPopover.vue
@@ -1,6 +1,7 @@
 <script>
 import { debounce } from '@chatwoot/utils';
 import { useAlert } from 'dashboard/composables';
+import { mapGetters } from 'vuex';
 import allLocales from 'shared/constants/locales.js';
 
 import SearchHeader from './Header.vue';
@@ -33,6 +34,15 @@ export default {
     };
   },
   computed: {
+    ...mapGetters({
+      portalBySlug: 'portals/portalBySlug',
+    }),
+    portal() {
+      return this.portalBySlug(this.selectedPortalSlug);
+    },
+    portalCustomDomain() {
+      return this.portal?.custom_domain;
+    },
     articleViewerUrl() {
       const article = this.activeArticle(this.activeId);
       if (!article) return '';
@@ -47,6 +57,7 @@ export default {
 
       return `${url}`;
     },
+
     searchResultsWithUrl() {
       return this.searchResults.map(article => ({
         ...article,
@@ -65,7 +76,8 @@ export default {
         this.selectedPortalSlug,
         '',
         '',
-        article.slug
+        article.slug,
+        'chatwoot.help'
       );
     },
     localeName(code) {
@@ -111,7 +123,6 @@ export default {
     },
     onInsert(id) {
       const article = this.activeArticle(id || this.activeId);
-
       this.$emit('insert', article);
       useAlert(this.$t('HELP_CENTER.ARTICLE_SEARCH.SUCCESS_ARTICLE_INSERTED'));
       this.onClose();

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesEditPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesEditPage.vue
@@ -20,17 +20,23 @@ const articleById = useMapGetter('articles/articleById');
 
 const article = computed(() => articleById.value(articleSlug));
 
+const portalBySlug = useMapGetter('portals/portalBySlug');
+
+const portal = computed(() => portalBySlug.value(portalSlug));
+
 const isUpdating = ref(false);
 const isSaved = ref(false);
 
 const portalLink = computed(() => {
   const { slug: categorySlug, locale: categoryLocale } = article.value.category;
   const { slug: articleSlugValue } = article.value;
+  const portalCustomDomain = portal.value?.custom_domain;
   return buildPortalArticleURL(
     portalSlug,
     categorySlug,
     categoryLocale,
-    articleSlugValue
+    articleSlugValue,
+    portalCustomDomain
   );
 });
 

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesEditPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesEditPage.vue
@@ -27,7 +27,7 @@ const portal = computed(() => portalBySlug.value(portalSlug));
 const isUpdating = ref(false);
 const isSaved = ref(false);
 
-const portalLink = computed(() => {
+const articleLink = computed(() => {
   const { slug: categorySlug, locale: categoryLocale } = article.value.category;
   const { slug: articleSlugValue } = article.value;
   const portalCustomDomain = portal.value?.custom_domain;
@@ -97,7 +97,7 @@ const fetchArticleDetails = () => {
 };
 
 const previewArticle = () => {
-  window.open(portalLink.value, '_blank');
+  window.open(articleLink.value, '_blank');
   useTrack(PORTALS_EVENTS.PREVIEW_ARTICLE, {
     status: article.value?.status,
   });


### PR DESCRIPTION
Portals can have custom domains. When inserting or previewing articles, we consider the frontend URL. This PR fixes article URL generation to properly include the portal's custom domain.