### PR TITLE
fix: Add missing 'hc' path segment after custom domain in article URLs

### DIFF
--- a/app/javascript/dashboard/helper/portalHelper.js
+++ b/app/javascript/dashboard/helper/portalHelper.js
@@ -19,7 +19,7 @@ const getDefaultBaseURL = () => {
     throw new Error('No valid base URL found in configuration');
   }
 
-  return `${baseURL}/hc`;
+  return baseURL;
 };
 
 /**
@@ -39,7 +39,7 @@ const getPortalBaseURL = customDomain =>
  */
 export const buildPortalURL = (portalSlug, customDomain) => {
   const baseURL = getPortalBaseURL(customDomain);
-  return `${baseURL}/${portalSlug}`;
+  return `${baseURL}/hc/${portalSlug}`;
 };
 
 export const buildPortalArticleURL = (

--- a/app/javascript/dashboard/helper/specs/portalHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/portalHelper.spec.js
@@ -39,7 +39,7 @@ describe('PortalHelper', () => {
           'article-slug',
           'custom-domain.dev'
         )
-      ).toEqual('https://custom-domain.dev/handbook/articles/article-slug');
+      ).toEqual('https://custom-domain.dev/hc/handbook/articles/article-slug');
     });
 
     it('handles https in custom domain correctly', () => {
@@ -55,7 +55,7 @@ describe('PortalHelper', () => {
           'article-slug',
           'https://custom-domain.dev'
         )
-      ).toEqual('https://custom-domain.dev/handbook/articles/article-slug');
+      ).toEqual('https://custom-domain.dev/hc/handbook/articles/article-slug');
     });
 
     it('uses hostURL when helpCenterURL is not available', () => {


### PR DESCRIPTION
We have added custom domain support to article URLs when a custom domain exists for the portal via https://github.com/chatwoot/chatwoot/pull/11349. However, we missed adding `hc` after the domain. This PR will fix that issue.