### PR TITLE
fix: Alignment issue with logo in standard type bubble

### DIFF
--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -51,6 +51,7 @@ export const SDK_CSS = `
   user-select: none;
   width: 64px;
   z-index: 2147483000 !important;
+  overflow: hidden;
 }
 
 .woot-widget-bubble.woot-widget-bubble--flat {
@@ -135,6 +136,7 @@ export const SDK_CSS = `
 .woot-widget-bubble svg {
   all: revert;
   height: 24px;
+  margin: 20px;
   width: 24px;
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the SVG logo alignment issue in the standard-type widget bubble. It also addresses the case reported in [[#11345](https://github.com/chatwoot/chatwoot/pull/11345)](https://github.com/chatwoot/chatwoot/pull/11345).

**Issue**  
The issue does not occur on all websites — for example, this [site](https://www.alessandrodesign.ro/) shows the problem.

**Solution**  
- Re-added `margin: 20px` to fix the logo alignment.  
- Applied `overflow: hidden` to the wrapper, which resolves the outline issue as well.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Screenshots**
**Before**
<img width="103" alt="image" src="https://github.com/user-attachments/assets/fa139bbb-533b-4c15-9edf-9f63ab469a1e" />
<img width="103" alt="image" src="https://github.com/user-attachments/assets/272a1390-bd9f-4ef7-bd1e-b9b704fbb15d" />

**After**
<img width="103" alt="image" src="https://github.com/user-attachments/assets/aaffa192-8cc9-4d76-92d1-3a20a79b4698" />
<img width="103" alt="image" src="https://github.com/user-attachments/assets/7692951b-f44f-4a87-aa3d-d92d0bd0ed9f" />





## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
