### PR TITLE
feat: use numbers when fetching from the API

### DIFF
--- a/app/services/crm/leadsquared/setup_service.rb
+++ b/app/services/crm/leadsquared/setup_service.rb
@@ -57,7 +57,7 @@ class Crm::Leadsquared::SetupService
       activity_id = find_or_create_activity_type(activity_type, existing_types)
 
       if activity_id.present?
-        activity_codes[activity_type[:setting_key]] = activity_id
+        activity_codes[activity_type[:setting_key]] = activity_id.to_i
       else
         Rails.logger.error "Failed to find or create activity type: #{activity_type[:name]}"
       end


### PR DESCRIPTION
The response from the LeadSquared API for the activity ID when searching is a number, however, when creating it, it's a string. This was causing the the validations to break