### PR TITLE
fix: Show campaigns only if the feature is enabled

### DIFF
--- a/app/controllers/api/v1/widget/campaigns_controller.rb
+++ b/app/controllers/api/v1/widget/campaigns_controller.rb
@@ -2,10 +2,15 @@ class Api::V1::Widget::CampaignsController < Api::V1::Widget::BaseController
   skip_before_action :set_contact
 
   def index
-    @campaigns = @web_widget
-                 .inbox
-                 .campaigns
-                 .where(enabled: true, account_id: @web_widget.inbox.account_id)
-                 .includes(:sender)
+    account = @web_widget.inbox.account
+    @campaigns = if account.feature_enabled?('campaigns')
+                   @web_widget
+                     .inbox
+                     .campaigns
+                     .where(enabled: true, account_id: account.id)
+                     .includes(:sender)
+                 else
+                   []
+                 end
   end
 end

--- a/spec/controllers/api/v1/widget/campaigns_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/campaigns_controller_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe '/api/v1/widget/campaigns', type: :request do
   describe 'GET /api/v1/widget/campaigns' do
     let(:params) { { website_token: web_widget.website_token } }
 
-    context 'with correct website token' do
+    context 'when campaigns feature is enabled' do
+      before do
+        account.enable_features!('campaigns')
+      end
+
       it 'returns the list of enabled campaigns' do
         get '/api/v1/widget/campaigns', params: params
 
@@ -21,8 +25,22 @@ RSpec.describe '/api/v1/widget/campaigns', type: :request do
       end
     end
 
+    context 'when campaigns feature is disabled' do
+      before do
+        account.disable_features!('campaigns')
+      end
+
+      it 'returns empty array' do
+        get '/api/v1/widget/campaigns', params: params
+
+        expect(response).to have_http_status(:success)
+        json_response = response.parsed_body
+        expect(json_response).to eq []
+      end
+    end
+
     context 'with invalid website token' do
-      it 'returns the list of agents' do
+      it 'returns not found status' do
         get '/api/v1/widget/campaigns', params: { website_token: '' }
         expect(response).to have_http_status(:not_found)
       end


### PR DESCRIPTION
If the feature is disabled (manually or due to plan changes), the customer cannot disable the existing campaigns. This PR would fix that. 

Fixes https://linear.app/chatwoot/issue/CW-3691/fix-disable-campaigns-on-plan-downgrade