### PR TITLE
fix: Undefined local variable or method `error` for an instance of Instagram MessageText 

### DIFF
--- a/app/services/instagram/message_text.rb
+++ b/app/services/instagram/message_text.rb
@@ -44,7 +44,7 @@ class Instagram::MessageText < Instagram::BaseMessageText
     Rails.logger.warn("[InstagramUserFetchError]: account_id #{@inbox.account_id} inbox_id #{@inbox.id}")
     Rails.logger.warn("[InstagramUserFetchError]: #{error_message} #{error_code}")
 
-    ChatwootExceptionTracker.new(error, account: @inbox.account).capture_exception
+    ChatwootExceptionTracker.new(parsed_response, account: @inbox.account).capture_exception
   end
 
   def base_uri


### PR DESCRIPTION
Fixes https://chatwoot-p3.sentry.io/issues/6557025930?project=6382945