### PR TITLE
feat: handle rails turbo morphing

### DIFF
--- a/app/javascript/entrypoints/sdk.js
+++ b/app/javascript/entrypoints/sdk.js
@@ -30,6 +30,7 @@ const runSDK = ({ baseUrl, websiteToken }) => {
     // We have already added data-turbo-permananent to true. This
     // will ensure that the widget it preserved
     // Read more about morphing here: https://turbo.hotwired.dev/handbook/page_refreshes#morphing
+    // and peristing elements here: https://turbo.hotwired.dev/handbook/building#persisting-elements-across-page-loads
     if (event.detail.renderMethod === 'morph') return;
 
     restoreWidgetInDOM(event.detail.newBody);

--- a/app/javascript/entrypoints/sdk.js
+++ b/app/javascript/entrypoints/sdk.js
@@ -25,9 +25,16 @@ const runSDK = ({ baseUrl, websiteToken }) => {
 
   if (window.Turbo) {
     // if this is a Rails Turbo app
-    document.addEventListener('turbo:before-render', event =>
-      restoreWidgetInDOM(event.detail.newBody)
-    );
+    document.addEventListener('turbo:before-render', event => {
+      // when morphing the page, this typically happens on reload like events
+      // say you update a "Customer" on a form and it reloads the page
+      // We have already added data-turbo-permananent to true. This
+      // will ensure that the widget it preserved
+      // Read more about morphing here: https://turbo.hotwired.dev/handbook/page_refreshes#morphing
+      if (event.detail.renderMethod === 'morph') return;
+
+      restoreWidgetInDOM(event.detail.newBody);
+    });
   }
 
   if (window.Turbolinks) {

--- a/app/javascript/entrypoints/sdk.js
+++ b/app/javascript/entrypoints/sdk.js
@@ -23,19 +23,17 @@ const runSDK = ({ baseUrl, websiteToken }) => {
     return;
   }
 
-  if (window.Turbo) {
-    // if this is a Rails Turbo app
-    document.addEventListener('turbo:before-render', event => {
-      // when morphing the page, this typically happens on reload like events
-      // say you update a "Customer" on a form and it reloads the page
-      // We have already added data-turbo-permananent to true. This
-      // will ensure that the widget it preserved
-      // Read more about morphing here: https://turbo.hotwired.dev/handbook/page_refreshes#morphing
-      if (event.detail.renderMethod === 'morph') return;
+  // if this is a Rails Turbo app
+  document.addEventListener('turbo:before-render', event => {
+    // when morphing the page, this typically happens on reload like events
+    // say you update a "Customer" on a form and it reloads the page
+    // We have already added data-turbo-permananent to true. This
+    // will ensure that the widget it preserved
+    // Read more about morphing here: https://turbo.hotwired.dev/handbook/page_refreshes#morphing
+    if (event.detail.renderMethod === 'morph') return;
 
-      restoreWidgetInDOM(event.detail.newBody);
-    });
-  }
+    restoreWidgetInDOM(event.detail.newBody);
+  });
 
   if (window.Turbolinks) {
     document.addEventListener('turbolinks:before-render', event => {

--- a/app/javascript/sdk/DOMHelpers.js
+++ b/app/javascript/sdk/DOMHelpers.js
@@ -5,6 +5,7 @@ export const loadCSS = () => {
   const css = document.createElement('style');
   css.innerHTML = `${SDK_CSS}`;
   css.id = 'cw-widget-styles';
+  css.dataset.turboPermanent = true;
   document.body.appendChild(css);
 };
 

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -82,6 +82,7 @@ export const IFrameHelper = {
 
     addClasses(widgetHolder, holderClassName);
     widgetHolder.id = 'cw-widget-holder';
+    widgetHolder.dataset.turboPermanent = true;
     widgetHolder.appendChild(iframe);
     body.appendChild(widgetHolder);
     IFrameHelper.initPostMessageCommunication();

--- a/app/javascript/sdk/bubbleHelpers.js
+++ b/app/javascript/sdk/bubbleHelpers.js
@@ -67,6 +67,7 @@ export const createBubbleHolder = hideMessageBubble => {
   }
   addClasses(bubbleHolder, 'woot--bubble-holder');
   bubbleHolder.id = 'cw-bubble-holder';
+  bubbleHolder.dataset.turboPermanent = true;
   body.appendChild(bubbleHolder);
 };
 


### PR DESCRIPTION
Rails Turbo has two ways of rendering a page, `replace` and `morph`. Navigations typically happen with replace, however refreshes (say after submitting a form) happens with morphs, where Turbo will use a HTML diffing/morphing lib to morph the elements (basically surgically replace what is required, to provide a good UX) 

Since Chatwoot widget is rendered in JS, the morphing function has no context of it's existence. We solve this with two things

1. Add `data-turbo-permanent` to the elements that the widget renders. This will ensure that the element is preserved
2. Break out of the `restoreWidgetInDOM` logic when the rendering method is morphing
3. Remove the `window.Turbo` check, it may or may not always be present correctly.

Fixes: https://github.com/chatwoot/chatwoot/issues/11219