### PR TITLE
chore: move stalecontacts job to different sidekiq queue

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -38,4 +38,4 @@ remove_stale_redis_keys_job.rb:
 process_stale_contacts_job:
   cron: '30 04 * * *'
   class: 'Internal::ProcessStaleContactsJob'
-  queue: scheduled_jobs
+  queue: housekeeping

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -23,6 +23,7 @@
   - action_mailbox_routing
   - low
   - scheduled_jobs
+  - housekeeping
   - async_database_migration
   - active_storage_analysis
   - active_storage_purge


### PR DESCRIPTION
- move stale contacts job to `housekeeping` queue below `low`