### PR TITLE
fix(ux): don't disable input for auto resolve

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -70,7 +70,7 @@
       },
       "AUTO_RESOLVE_DURATION": {
         "LABEL": "Inactivity duration for resolution",
-        "HELP": "Duration after a ticket should auto resolve if there is no activity",
+        "HELP": "Duration after a conversation should auto resolve if there is no activity",
         "PLACEHOLDER": "30",
         "ERROR": "Please enter a valid auto resolve duration (minimum 1 day and maximum 999 days)",
         "API": {

--- a/app/javascript/dashboard/routes/dashboard/settings/account/components/AutoResolve.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/components/AutoResolve.vue
@@ -85,7 +85,6 @@ const toggleAutoResolve = async () => {
           <!-- allow 10 mins to 999 days -->
           <DurationInput
             v-model="duration"
-            :disabled="!isEnabled"
             min="10"
             max="1439856"
             class="w-full"
@@ -101,7 +100,6 @@ const toggleAutoResolve = async () => {
         <TextArea
           v-model="message"
           class="w-full"
-          :disabled="!isEnabled"
           :placeholder="
             t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_DURATION.MESSAGE_PLACEHOLDER')
           "


### PR DESCRIPTION
This PR addresses a few issues with the auto-resolve UX

1. The inputs were disabled unless the user clicked on the toggle. This was not clear to users, this PR enables it by default. Once updated, the toggle automatically switches
2. Update copy for the help text

https://github.com/user-attachments/assets/4916b712-2dd0-4ae5-ba51-5488ba920ba8

