### PR TITLE
fix: throttle stalecontacts job

### DIFF
--- a/app/jobs/internal/process_stale_contacts_job.rb
+++ b/app/jobs/internal/process_stale_contacts_job.rb
@@ -7,14 +7,18 @@
 class Internal::ProcessStaleContactsJob < ApplicationJob
   queue_as :scheduled_jobs
 
+  ACCOUNTS_PER_DAY = 5000
+
   def perform
     return unless ChatwootApp.chatwoot_cloud?
 
-    Account.find_in_batches(batch_size: 100) do |accounts|
-      accounts.each do |account|
-        Rails.logger.info "Enqueuing RemoveStaleContactsJob for account #{account.id}"
-        Internal::RemoveStaleContactsJob.perform_later(account)
-      end
+    # Use day of week (0-6) to determine which accounts to process today
+    day_offset = Time.current.wday * ACCOUNTS_PER_DAY
+
+    Account.order(:id).offset(day_offset).limit(ACCOUNTS_PER_DAY).find_each do |account|
+      Rails.logger.info "Enqueuing RemoveStaleContactsJob for account #{account.id}"
+      # Add a small delay between jobs to prevent queue overload
+      Internal::RemoveStaleContactsJob.set(wait: 5.seconds).perform_later(account)
     end
   end
 end

--- a/app/jobs/internal/process_stale_contacts_job.rb
+++ b/app/jobs/internal/process_stale_contacts_job.rb
@@ -18,7 +18,7 @@ class Internal::ProcessStaleContactsJob < ApplicationJob
 
     # Use the day of the month to determine which accounts to process
     day_of_month = Date.current.day
-    remainder = day_of_month % DISTRIBUTION_GROUPS # 0, 1, 2, 3, or 4
+    remainder = day_of_month % DISTRIBUTION_GROUPS
 
     # Count total accounts for logging
     total_accounts = Account.count
@@ -26,13 +26,12 @@ class Internal::ProcessStaleContactsJob < ApplicationJob
     log_message += "#{remainder} (out of #{total_accounts} total accounts)"
     Rails.logger.info log_message
 
-    # Process only accounts where ID % DISTRIBUTION_GROUPS = remainder for today
-    # This ensures each account is processed approximately once every DISTRIBUTION_GROUPS days
+    # Process only accounts where ID % 5 = remainder for today
+    # This ensures each account is processed approximately once every 5 days
     Account.where("id % #{DISTRIBUTION_GROUPS} = ?", remainder).find_each(batch_size: MAX_ACCOUNTS_PER_BATCH) do |account|
       Rails.logger.info "Enqueuing RemoveStaleContactsJob for account #{account.id}"
 
       # Add a small delay between jobs to further reduce queue pressure
-      # The delay increases slightly for each account to spread out the load
       delay = rand(1..10).minutes
       Internal::RemoveStaleContactsJob.set(wait: delay).perform_later(account)
     end

--- a/spec/jobs/internal/process_stale_contacts_job_spec.rb
+++ b/spec/jobs/internal/process_stale_contacts_job_spec.rb
@@ -6,41 +6,65 @@ RSpec.describe Internal::ProcessStaleContactsJob do
   it 'enqueues the job' do
     allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
     expect { job }.to have_enqueued_job(described_class)
-      .on_queue('scheduled_jobs')
+      .on_queue('housekeeping')
   end
 
-  it 'enqueues RemoveStaleContactsJob for each account' do
-    allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
-    account1 = create(:account)
-    account2 = create(:account)
-    account3 = create(:account)
+  context 'when in cloud environment' do
+    before do
+      allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
+    end
 
-    expect { described_class.perform_now }.to have_enqueued_job(Internal::RemoveStaleContactsJob)
-      .with(account1)
-      .on_queue('low')
-    expect { described_class.perform_now }.to have_enqueued_job(Internal::RemoveStaleContactsJob)
-      .with(account2)
-      .on_queue('low')
-    expect { described_class.perform_now }.to have_enqueued_job(Internal::RemoveStaleContactsJob)
-      .with(account3)
-      .on_queue('low')
+    it 'processes accounts based on the day of month' do
+      # Set a fixed day for testing
+      day_of_month = 16
+      remainder = day_of_month % described_class::DISTRIBUTION_GROUPS
+      allow(Date).to receive(:current).and_return(Date.new(2025, 5, day_of_month))
+
+      # Create an account and set its ID to match today's pattern
+      account = create(:account)
+      allow(account).to receive(:id).and_return(remainder)
+
+      # Mock the Account.where to return our filtered accounts
+      account_relation = double
+      allow(Account).to receive(:where).with("id % #{described_class::DISTRIBUTION_GROUPS} = ?", remainder).and_return(account_relation)
+      allow(account_relation).to receive(:find_each).and_yield(account)
+
+      # Mock the delay setting
+      allow(Internal::RemoveStaleContactsJob).to receive(:set).and_return(Internal::RemoveStaleContactsJob)
+      expect(Internal::RemoveStaleContactsJob).to receive(:perform_later).with(account)
+
+      described_class.perform_now
+    end
+
+    it 'adds a delay between jobs' do
+      day_of_month = 15
+      remainder = day_of_month % described_class::DISTRIBUTION_GROUPS
+      allow(Date).to receive(:current).and_return(Date.new(2025, 5, day_of_month))
+
+      account = create(:account)
+
+      account_relation = double
+      allow(Account).to receive(:where).with("id % #{described_class::DISTRIBUTION_GROUPS} = ?", remainder).and_return(account_relation)
+      allow(account_relation).to receive(:find_each).and_yield(account)
+
+      expect(Internal::RemoveStaleContactsJob).to receive(:set) do |args|
+        expect(args[:wait]).to be_between(1.minute, 10.minutes)
+        Internal::RemoveStaleContactsJob
+      end
+      expect(Internal::RemoveStaleContactsJob).to receive(:perform_later).with(account)
+
+      described_class.perform_now
+    end
   end
 
-  it 'processes accounts in batches' do
-    allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
-    account = create(:account)
-    allow(Account).to receive(:find_in_batches).with(batch_size: 100).and_yield([account])
+  context 'when not in cloud environment' do
+    it 'does not process any accounts' do
+      allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(false)
 
-    expect(Internal::RemoveStaleContactsJob).to receive(:perform_later).with(account)
-    described_class.perform_now
-  end
+      expect(Account).not_to receive(:where)
+      expect(Internal::RemoveStaleContactsJob).not_to receive(:perform_later)
 
-  it 'does not process accounts when not in cloud environment' do
-    allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(false)
-    create(:account)
-
-    expect(Account).not_to receive(:find_in_batches)
-    expect(Internal::RemoveStaleContactsJob).not_to receive(:perform_later)
-    described_class.perform_now
+      described_class.perform_now
+    end
   end
 end


### PR DESCRIPTION
- throttle stale contacts job
- process 20% accounts every day
- reduce batch size from 100 to 20
- add delay between jobs