### PR TITLE
chore: use housekeeping queue for remove_stale_contacts job

### DIFF
--- a/app/jobs/internal/remove_stale_contact_inboxes_job.rb
+++ b/app/jobs/internal/remove_stale_contact_inboxes_job.rb
@@ -3,7 +3,7 @@
 # and are older than 3 months
 
 class Internal::RemoveStaleContactInboxesJob < ApplicationJob
-  queue_as :scheduled_jobs
+  queue_as :housekeeping
 
   def perform
     Internal::RemoveStaleContactInboxesService.new.perform

--- a/app/jobs/internal/remove_stale_contact_inboxes_job.rb
+++ b/app/jobs/internal/remove_stale_contact_inboxes_job.rb
@@ -3,7 +3,7 @@
 # and are older than 3 months
 
 class Internal::RemoveStaleContactInboxesJob < ApplicationJob
-  queue_as :housekeeping
+  queue_as :low
 
   def perform
     Internal::RemoveStaleContactInboxesService.new.perform

--- a/app/jobs/internal/remove_stale_contact_inboxes_job.rb
+++ b/app/jobs/internal/remove_stale_contact_inboxes_job.rb
@@ -3,7 +3,7 @@
 # and are older than 3 months
 
 class Internal::RemoveStaleContactInboxesJob < ApplicationJob
-  queue_as :low
+  queue_as :scheduled_jobs
 
   def perform
     Internal::RemoveStaleContactInboxesService.new.perform

--- a/app/jobs/internal/remove_stale_contacts_job.rb
+++ b/app/jobs/internal/remove_stale_contacts_job.rb
@@ -5,7 +5,7 @@
 # - are older than 30 days
 
 class Internal::RemoveStaleContactsJob < ApplicationJob
-  queue_as :low
+  queue_as :housekeeping
 
   def perform(account, batch_size = 1000)
     Internal::RemoveStaleContactsService.new(account: account).perform(batch_size)

--- a/spec/jobs/internal/process_stale_contacts_job_spec.rb
+++ b/spec/jobs/internal/process_stale_contacts_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Internal::ProcessStaleContactsJob do
   it 'enqueues the job' do
     allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
     expect { job }.to have_enqueued_job(described_class)
-      .on_queue('scheduled_jobs')
+      .on_queue('housekeeping')
   end
 
   it 'enqueues RemoveStaleContactsJob for each account' do
@@ -17,13 +17,13 @@ RSpec.describe Internal::ProcessStaleContactsJob do
 
     expect { described_class.perform_now }.to have_enqueued_job(Internal::RemoveStaleContactsJob)
       .with(account1)
-      .on_queue('low')
+      .on_queue('housekeeping')
     expect { described_class.perform_now }.to have_enqueued_job(Internal::RemoveStaleContactsJob)
       .with(account2)
-      .on_queue('low')
+      .on_queue('housekeeping')
     expect { described_class.perform_now }.to have_enqueued_job(Internal::RemoveStaleContactsJob)
       .with(account3)
-      .on_queue('low')
+      .on_queue('housekeeping')
   end
 
   it 'processes accounts in batches' do

--- a/spec/jobs/internal/remove_stale_contacts_job_spec.rb
+++ b/spec/jobs/internal/remove_stale_contacts_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Internal::RemoveStaleContactsJob do
   it 'enqueues the job' do
     expect { job }.to have_enqueued_job(described_class)
       .with(account)
-      .on_queue('low')
+      .on_queue('housekeeping')
   end
 
   it 'calls the RemoveStaleContactsService' do


### PR DESCRIPTION
- Use the housekeeping queue for the `remove_stale_contacts` job
- fix specs