### PR TITLE
feat: allow auto resolve waiting option

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -92,7 +92,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def settings_params
-    params.permit(:auto_resolve_after, :auto_resolve_message, :auto_resolve_waiting)
+    params.permit(:auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting)
   end
 
   def check_signup_enabled

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -92,7 +92,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def settings_params
-    params.permit(:auto_resolve_after, :auto_resolve_message)
+    params.permit(:auto_resolve_after, :auto_resolve_message, :auto_resolve_waiting)
   end
 
   def check_signup_enabled

--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -70,7 +70,7 @@
       },
       "AUTO_RESOLVE_IGNORE_WAITING": {
         "LABEL": "Exclude unattended conversations",
-        "HELP": "If toggled, the system will automatically not resolve conversations that have been waiting for an agent reply."
+        "HELP": "If toggled, the system will not resolve conversations that have been waiting for an agent reply."
       },
       "AUTO_RESOLVE_DURATION": {
         "LABEL": "Inactivity duration for resolution",

--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -68,11 +68,15 @@
         "PLACEHOLDER": "Your company's support email",
         "ERROR": ""
       },
+      "AUTO_RESOLVE_WAITING": {
+        "LABEL": "Auto-resolve pending conversations",
+        "HELP": "If enabled, the system will automatically resolve all conversations, including those that have been waiting for an agent reply."
+      },
       "AUTO_RESOLVE_DURATION": {
         "LABEL": "Inactivity duration for resolution",
         "HELP": "Duration after a conversation should auto resolve if there is no activity",
         "PLACEHOLDER": "30",
-        "ERROR": "Please enter a valid auto resolve duration (minimum 1 day and maximum 999 days)",
+        "ERROR": "Auto resolve duration should be between 10 minutes and 999 days",
         "API": {
           "SUCCESS": "Auto resolve settings updated successfully",
           "ERROR": "Failed to update auto resolve settings"

--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -68,9 +68,9 @@
         "PLACEHOLDER": "Your company's support email",
         "ERROR": ""
       },
-      "AUTO_RESOLVE_WAITING": {
-        "LABEL": "Include unattended conversations",
-        "HELP": "If enabled, the system will automatically resolve all conversations, including those that have been waiting for an agent reply."
+      "AUTO_RESOLVE_IGNORE_WAITING": {
+        "LABEL": "Exclude unattended conversations",
+        "HELP": "If toggled, the system will automatically not resolve conversations that have been waiting for an agent reply."
       },
       "AUTO_RESOLVE_DURATION": {
         "LABEL": "Inactivity duration for resolution",

--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -46,7 +46,7 @@
       },
       "AUTO_RESOLVE": {
         "TITLE": "Auto-resolve conversations",
-        "NOTE": "This configuration would allow you to automatically end the conversation after a certain period. Set the duration and customize the message to the user below."
+        "NOTE": "This configuration would allow you to automatically resolve the conversation after a certain period. Set the duration and customize the message to the user below."
       },
       "NAME": {
         "LABEL": "Account name",

--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -69,7 +69,7 @@
         "ERROR": ""
       },
       "AUTO_RESOLVE_WAITING": {
-        "LABEL": "Auto-resolve pending conversations",
+        "LABEL": "Include unattended conversations",
         "HELP": "If enabled, the system will automatically resolve all conversations, including those that have been waiting for an agent reply."
       },
       "AUTO_RESOLVE_DURATION": {
@@ -81,7 +81,7 @@
           "SUCCESS": "Auto resolve settings updated successfully",
           "ERROR": "Failed to update auto resolve settings"
         },
-        "UPDATE_BUTTON": "Update Auto-resolve",
+        "UPDATE_BUTTON": "Update",
         "MESSAGE_LABEL": "Custom resolution message",
         "MESSAGE_PLACEHOLDER": "Conversation was marked resolved by system due to 15 days of inactivity",
         "MESSAGE_HELP": "This message is sent to the customer when a conversation is automatically resolved by the system due to inactivity."

--- a/app/javascript/dashboard/routes/dashboard/settings/account/components/AutoResolve.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/components/AutoResolve.vue
@@ -13,7 +13,7 @@ import NextButton from 'dashboard/components-next/button/Button.vue';
 const { t } = useI18n();
 const duration = ref(0);
 const message = ref('');
-const autoResolveAll = ref(false);
+const ignoreWaiting = ref(false);
 const isEnabled = ref(false);
 
 const { currentAccount, updateAccount } = useAccount();
@@ -21,11 +21,15 @@ const { currentAccount, updateAccount } = useAccount();
 watch(
   currentAccount,
   () => {
-    const { auto_resolve_after, auto_resolve_message } =
-      currentAccount.value?.settings || {};
+    const {
+      auto_resolve_after,
+      auto_resolve_message,
+      auto_resolve_ignore_waiting,
+    } = currentAccount.value?.settings || {};
 
     duration.value = auto_resolve_after;
     message.value = auto_resolve_message;
+    ignoreWaiting.value = auto_resolve_ignore_waiting;
 
     if (duration.value) {
       isEnabled.value = true;
@@ -52,7 +56,7 @@ const handleSubmit = async () => {
   return updateAccountSettings({
     auto_resolve_after: duration.value,
     auto_resolve_message: message.value,
-    auto_resolve_waiting: autoResolveAll.value,
+    auto_resolve_ignore_waiting: ignoreWaiting.value,
   });
 };
 
@@ -63,7 +67,7 @@ const handleDisable = async () => {
   return updateAccountSettings({
     auto_resolve_after: null,
     auto_resolve_message: '',
-    auto_resolve_waiting: false,
+    auto_resolve_ignore_waiting: false,
   });
 };
 
@@ -113,12 +117,14 @@ const toggleAutoResolve = async () => {
           "
         />
       </WithLabel>
-      <WithLabel :label="t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_WAITING.LABEL')">
+      <WithLabel
+        :label="t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_IGNORE_WAITING.LABEL')"
+      >
         <template #rightOfLabel>
-          <Switch v-model="autoResolveAll" />
+          <Switch v-model="ignoreWaiting" />
         </template>
         <p class="text-sm ml-px text-n-slate-10 max-w-lg">
-          {{ t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_WAITING.HELP') }}
+          {{ t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_IGNORE_WAITING.HELP') }}
         </p>
       </WithLabel>
       <div class="flex gap-2">

--- a/app/javascript/dashboard/routes/dashboard/settings/account/components/AutoResolve.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/components/AutoResolve.vue
@@ -13,6 +13,7 @@ import NextButton from 'dashboard/components-next/button/Button.vue';
 const { t } = useI18n();
 const duration = ref(0);
 const message = ref('');
+const autoResolveAll = ref(false);
 const isEnabled = ref(false);
 
 const { currentAccount, updateAccount } = useAccount();
@@ -43,9 +44,15 @@ const updateAccountSettings = async settings => {
 };
 
 const handleSubmit = async () => {
+  if (duration.value < 10) {
+    useAlert(t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_DURATION.ERROR'));
+    return Promise.resolve();
+  }
+
   return updateAccountSettings({
     auto_resolve_after: duration.value,
     auto_resolve_message: message.value,
+    auto_resolve_waiting: autoResolveAll.value,
   });
 };
 
@@ -56,6 +63,7 @@ const handleDisable = async () => {
   return updateAccountSettings({
     auto_resolve_after: null,
     auto_resolve_message: '',
+    auto_resolve_waiting: false,
   });
 };
 
@@ -85,7 +93,7 @@ const toggleAutoResolve = async () => {
           <!-- allow 10 mins to 999 days -->
           <DurationInput
             v-model="duration"
-            min="10"
+            min="0"
             max="1439856"
             class="w-full"
           />
@@ -104,6 +112,14 @@ const toggleAutoResolve = async () => {
             t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_DURATION.MESSAGE_PLACEHOLDER')
           "
         />
+      </WithLabel>
+      <WithLabel :label="t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_WAITING.LABEL')">
+        <template #rightOfLabel>
+          <Switch v-model="autoResolveAll" />
+        </template>
+        <p class="text-xs ml-px text-n-slate-10 max-w-lg">
+          {{ t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_WAITING.HELP') }}
+        </p>
       </WithLabel>
       <div class="flex gap-2">
         <NextButton

--- a/app/javascript/dashboard/routes/dashboard/settings/account/components/AutoResolve.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/components/AutoResolve.vue
@@ -84,7 +84,7 @@ const toggleAutoResolve = async () => {
       </div>
     </template>
 
-    <form class="grid gap-4" @submit.prevent="handleSubmit">
+    <form class="grid gap-5" @submit.prevent="handleSubmit">
       <WithLabel
         :label="t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_DURATION.LABEL')"
         :help-message="t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_DURATION.HELP')"

--- a/app/javascript/dashboard/routes/dashboard/settings/account/components/AutoResolve.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/components/AutoResolve.vue
@@ -117,7 +117,7 @@ const toggleAutoResolve = async () => {
         <template #rightOfLabel>
           <Switch v-model="autoResolveAll" />
         </template>
-        <p class="text-xs ml-px text-n-slate-10 max-w-lg">
+        <p class="text-sm ml-px text-n-slate-10 max-w-lg">
           {{ t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_WAITING.HELP') }}
         </p>
       </WithLabel>

--- a/app/javascript/dashboard/routes/dashboard/settings/account/components/SectionLayout.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/components/SectionLayout.vue
@@ -17,7 +17,7 @@ defineProps({
 
 <template>
   <section
-    class="grid grid-cols-1 py-8 gap-10"
+    class="grid grid-cols-1 py-8 gap-8"
     :class="{ 'border-t border-n-weak': withBorder }"
   >
     <header class="grid grid-cols-4">
@@ -25,7 +25,7 @@ defineProps({
         <h4 class="text-lg font-medium text-n-slate-12">
           <slot name="title">{{ title }}</slot>
         </h4>
-        <p class="text-n-slate-11 text-sm">
+        <p class="text-n-slate-11 text-sm mt-2">
           <slot name="description">{{ description }}</slot>
         </p>
       </div>

--- a/app/javascript/dashboard/routes/dashboard/settings/account/components/SectionLayout.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/components/SectionLayout.vue
@@ -25,7 +25,7 @@ defineProps({
         <h4 class="text-lg font-medium text-n-slate-12">
           <slot name="title">{{ title }}</slot>
         </h4>
-        <p class="text-n-slate-11">
+        <p class="text-n-slate-11 text-sm">
           <slot name="description">{{ description }}</slot>
         </p>
       </div>

--- a/app/javascript/v3/components/Form/WithLabel.vue
+++ b/app/javascript/v3/components/Form/WithLabel.vue
@@ -34,13 +34,13 @@ defineProps({
       </div>
       <div
         v-if="errorMessage && hasError"
-        class="text-xs mt-2 ml-px text-n-ruby-9 leading-tight"
+        class="text-sm mt-2 ml-px text-n-ruby-9 leading-tight"
       >
         {{ errorMessage }}
       </div>
       <div
         v-else-if="helpMessage || $slots.help"
-        class="text-xs mt-2 ml-px text-n-slate-10 leading-tight"
+        class="text-sm mt-2 ml-px text-n-slate-10 leading-tight"
       >
         <slot name="help">
           {{ helpMessage }}

--- a/app/javascript/v3/components/Form/WithLabel.vue
+++ b/app/javascript/v3/components/Form/WithLabel.vue
@@ -34,13 +34,13 @@ defineProps({
       </div>
       <div
         v-if="errorMessage && hasError"
-        class="text-sm mt-2 ml-px text-n-ruby-9 leading-tight"
+        class="text-sm mt-1.5 ml-px text-n-ruby-9 leading-tight"
       >
         {{ errorMessage }}
       </div>
       <div
         v-else-if="helpMessage || $slots.help"
-        class="text-sm mt-2 ml-px text-n-slate-10 leading-tight"
+        class="text-sm mt-1.5 ml-px text-n-slate-10 leading-tight"
       >
         <slot name="help">
           {{ helpMessage }}

--- a/app/jobs/conversations/resolution_job.rb
+++ b/app/jobs/conversations/resolution_job.rb
@@ -15,10 +15,10 @@ class Conversations::ResolutionJob < ApplicationJob
   private
 
   def conversation_scope(account)
-    if account.auto_resolve_waiting
-      account.conversations.resolvable_all(account.auto_resolve_after)
-    else
+    if account.auto_resolve_ignore_waiting
       account.conversations.resolvable_not_waiting(account.auto_resolve_after)
+    else
+      account.conversations.resolvable_all(account.auto_resolve_after)
     end
   end
 end

--- a/app/jobs/conversations/resolution_job.rb
+++ b/app/jobs/conversations/resolution_job.rb
@@ -3,12 +3,22 @@ class Conversations::ResolutionJob < ApplicationJob
 
   def perform(account:)
     # limiting the number of conversations to be resolved to avoid any performance issues
-    resolvable_conversations = account.conversations.resolvable(account.auto_resolve_after).limit(Limits::BULK_ACTIONS_LIMIT)
+    resolvable_conversations = conversation_scope(account).limit(Limits::BULK_ACTIONS_LIMIT)
     resolvable_conversations.each do |conversation|
       # send message from bot that conversation has been resolved
       # do this is account.auto_resolve_message is set
       ::MessageTemplates::Template::AutoResolve.new(conversation: conversation).perform if account.auto_resolve_message.present?
       conversation.toggle_status
+    end
+  end
+
+  private
+
+  def conversation_scope(account)
+    if account.auto_resolve_waiting
+      account.conversations.resolvable_all(account.auto_resolve_after)
+    else
+      account.conversations.resolvable_not_waiting(account.auto_resolve_after)
     end
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -35,7 +35,7 @@ class Account < ApplicationRecord
       {
         'auto_resolve_after': { 'type': %w[integer null], 'minimum': 10, 'maximum': 1_439_856 },
         'auto_resolve_message': { 'type': %w[string null] },
-        'auto_resolve_waiting': { 'type': %w[boolean null] }
+        'auto_resolve_ignore_waiting': { 'type': %w[boolean null] }
       },
     'required': [],
     'additionalProperties': false
@@ -51,7 +51,7 @@ class Account < ApplicationRecord
                  schema: SETTINGS_PARAMS_SCHEMA,
                  attribute_resolver: ->(record) { record.settings }
 
-  store_accessor :settings, :auto_resolve_after, :auto_resolve_message, :auto_resolve_waiting
+  store_accessor :settings, :auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting
 
   has_many :account_users, dependent: :destroy_async
   has_many :agent_bot_inboxes, dependent: :destroy_async

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -34,7 +34,8 @@ class Account < ApplicationRecord
     'properties':
       {
         'auto_resolve_after': { 'type': %w[integer null], 'minimum': 10, 'maximum': 1_439_856 },
-        'auto_resolve_message': { 'type': %w[string null] }
+        'auto_resolve_message': { 'type': %w[string null] },
+        'auto_resolve_waiting': { 'type': %w[boolean null] }
       },
     'required': [],
     'additionalProperties': false
@@ -50,7 +51,7 @@ class Account < ApplicationRecord
                  schema: SETTINGS_PARAMS_SCHEMA,
                  attribute_resolver: ->(record) { record.settings }
 
-  store_accessor :settings, :auto_resolve_after, :auto_resolve_message
+  store_accessor :settings, :auto_resolve_after, :auto_resolve_message, :auto_resolve_waiting
 
   has_many :account_users, dependent: :destroy_async
   has_many :agent_bot_inboxes, dependent: :destroy_async

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -38,7 +38,7 @@ class Account < ApplicationRecord
         'auto_resolve_ignore_waiting': { 'type': %w[boolean null] }
       },
     'required': [],
-    'additionalProperties': false
+    'additionalProperties': true
   }.to_json.freeze
 
   DEFAULT_QUERY_SETTING = {

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -76,10 +76,15 @@ class Conversation < ApplicationRecord
   scope :assigned, -> { where.not(assignee_id: nil) }
   scope :assigned_to, ->(agent) { where(assignee_id: agent.id) }
   scope :unattended, -> { where(first_reply_created_at: nil).or(where.not(waiting_since: nil)) }
-  scope :resolvable, lambda { |auto_resolve_after|
+  scope :resolvable_not_waiting, lambda { |auto_resolve_after|
     return none if auto_resolve_after.to_i.zero?
 
     open.where('last_activity_at < ? AND waiting_since IS NULL', Time.now.utc - auto_resolve_after.minutes)
+  }
+  scope :resolvable_all, lambda { |auto_resolve_after|
+    return none if auto_resolve_after.to_i.zero?
+
+    open.where('last_activity_at < ?', Time.now.utc - auto_resolve_after.minutes)
   }
 
   scope :last_user_message_at, lambda {

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe 'Accounts API', type: :request do
         support_email: 'care@example.com',
         auto_resolve_after: 40,
         auto_resolve_message: 'Auto resolved',
+        auto_resolve_waiting: false,
         timezone: 'Asia/Kolkata',
         industry: 'Technology',
         company_size: '1-10'
@@ -207,7 +208,7 @@ RSpec.describe 'Accounts API', type: :request do
         expect(account.reload.domain).to eq(params[:domain])
         expect(account.reload.support_email).to eq(params[:support_email])
 
-        %w[auto_resolve_after auto_resolve_message].each do |attribute|
+        %w[auto_resolve_after auto_resolve_message auto_resolve_waiting].each do |attribute|
           expect(account.reload.settings[attribute]).to eq(params[attribute.to_sym])
         end
 

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe 'Accounts API', type: :request do
         support_email: 'care@example.com',
         auto_resolve_after: 40,
         auto_resolve_message: 'Auto resolved',
-        auto_resolve_waiting: false,
+        auto_resolve_ignore_waiting: false,
         timezone: 'Asia/Kolkata',
         industry: 'Technology',
         company_size: '1-10'
@@ -208,7 +208,7 @@ RSpec.describe 'Accounts API', type: :request do
         expect(account.reload.domain).to eq(params[:domain])
         expect(account.reload.support_email).to eq(params[:support_email])
 
-        %w[auto_resolve_after auto_resolve_message auto_resolve_waiting].each do |attribute|
+        %w[auto_resolve_after auto_resolve_message auto_resolve_ignore_waiting].each do |attribute|
           expect(account.reload.settings[attribute]).to eq(params[attribute.to_sym])
         end
 

--- a/spec/jobs/conversations/resolution_job_spec.rb
+++ b/spec/jobs/conversations/resolution_job_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Conversations::ResolutionJob do
   it 'resolves only a limited number of conversations in a single execution' do
     stub_const('Limits::BULK_ACTIONS_LIMIT', 2)
     account.update(auto_resolve_after: 14_400, auto_resolve_waiting: true) # 10 days in minutes
-    conversations = create_list(:conversation, 3, account: account, last_activity_at: 13.days.ago)
+    create_list(:conversation, 3, account: account, last_activity_at: 13.days.ago)
     described_class.perform_now(account: account)
     expect(account.conversations.resolved.count).to eq(Limits::BULK_ACTIONS_LIMIT)
   end

--- a/spec/jobs/conversations/resolution_job_spec.rb
+++ b/spec/jobs/conversations/resolution_job_spec.rb
@@ -17,18 +17,40 @@ RSpec.describe Conversations::ResolutionJob do
     expect(conversation.reload.status).to eq('open')
   end
 
-  it 'resolves the issue if time of inactivity is more than the auto resolve duration' do
-    account.update(auto_resolve_after: 14_400) # 10 days in minutes
-    conversation.update(last_activity_at: 13.days.ago, waiting_since: nil)
-    described_class.perform_now(account: account)
-    expect(conversation.reload.status).to eq('resolved')
+  context 'when auto_resolve_waiting is false' do
+    it 'resolves non-waiting conversations if time of inactivity is more than auto resolve duration' do
+      account.update(auto_resolve_after: 14_400, auto_resolve_waiting: false) # 10 days in minutes
+      conversation.update(last_activity_at: 13.days.ago, waiting_since: nil)
+      described_class.perform_now(account: account)
+      expect(conversation.reload.status).to eq('resolved')
+    end
+
+    it 'does not resolve waiting conversations even if time of inactivity is more than auto resolve duration' do
+      account.update(auto_resolve_after: 14_400, auto_resolve_waiting: false) # 10 days in minutes
+      conversation.update(last_activity_at: 13.days.ago, waiting_since: 13.days.ago)
+      described_class.perform_now(account: account)
+      expect(conversation.reload.status).to eq('open')
+    end
   end
 
-  it 'resolved only a limited number of conversations in a single execution' do
+  context 'when auto_resolve_waiting is true' do
+    it 'resolves all conversations if time of inactivity is more than auto resolve duration' do
+      account.update(auto_resolve_after: 14_400, auto_resolve_waiting: true) # 10 days in minutes
+      # Create one waiting conversation and one non-waiting conversation
+      waiting_conversation = create(:conversation, account: account, last_activity_at: 13.days.ago, waiting_since: 13.days.ago)
+      non_waiting_conversation = create(:conversation, account: account, last_activity_at: 13.days.ago, waiting_since: nil)
+
+      described_class.perform_now(account: account)
+
+      expect(waiting_conversation.reload.status).to eq('resolved')
+      expect(non_waiting_conversation.reload.status).to eq('resolved')
+    end
+  end
+
+  it 'resolves only a limited number of conversations in a single execution' do
     stub_const('Limits::BULK_ACTIONS_LIMIT', 2)
-    account.update(auto_resolve_after: 14_400) # 10 days in minutes
+    account.update(auto_resolve_after: 14_400, auto_resolve_waiting: true) # 10 days in minutes
     conversations = create_list(:conversation, 3, account: account, last_activity_at: 13.days.ago)
-    conversations.each { |conversation| conversation.update(waiting_since: nil) }
     described_class.perform_now(account: account)
     expect(account.conversations.resolved.count).to eq(Limits::BULK_ACTIONS_LIMIT)
   end

--- a/spec/jobs/conversations/resolution_job_spec.rb
+++ b/spec/jobs/conversations/resolution_job_spec.rb
@@ -17,25 +17,25 @@ RSpec.describe Conversations::ResolutionJob do
     expect(conversation.reload.status).to eq('open')
   end
 
-  context 'when auto_resolve_waiting is false' do
+  context 'when auto_resolve_ignore_waiting is true' do
     it 'resolves non-waiting conversations if time of inactivity is more than auto resolve duration' do
-      account.update(auto_resolve_after: 14_400, auto_resolve_waiting: false) # 10 days in minutes
+      account.update(auto_resolve_after: 14_400, auto_resolve_ignore_waiting: true) # 10 days in minutes
       conversation.update(last_activity_at: 13.days.ago, waiting_since: nil)
       described_class.perform_now(account: account)
       expect(conversation.reload.status).to eq('resolved')
     end
 
     it 'does not resolve waiting conversations even if time of inactivity is more than auto resolve duration' do
-      account.update(auto_resolve_after: 14_400, auto_resolve_waiting: false) # 10 days in minutes
+      account.update(auto_resolve_after: 14_400, auto_resolve_ignore_waiting: true) # 10 days in minutes
       conversation.update(last_activity_at: 13.days.ago, waiting_since: 13.days.ago)
       described_class.perform_now(account: account)
       expect(conversation.reload.status).to eq('open')
     end
   end
 
-  context 'when auto_resolve_waiting is true' do
+  context 'when auto_resolve_ignore_waiting is false' do
     it 'resolves all conversations if time of inactivity is more than auto resolve duration' do
-      account.update(auto_resolve_after: 14_400, auto_resolve_waiting: true) # 10 days in minutes
+      account.update(auto_resolve_after: 14_400, auto_resolve_ignore_waiting: false) # 10 days in minutes
       # Create one waiting conversation and one non-waiting conversation
       waiting_conversation = create(:conversation, account: account, last_activity_at: 13.days.ago, waiting_since: 13.days.ago)
       non_waiting_conversation = create(:conversation, account: account, last_activity_at: 13.days.ago, waiting_since: nil)
@@ -49,7 +49,7 @@ RSpec.describe Conversations::ResolutionJob do
 
   it 'resolves only a limited number of conversations in a single execution' do
     stub_const('Limits::BULK_ACTIONS_LIMIT', 2)
-    account.update(auto_resolve_after: 14_400, auto_resolve_waiting: true) # 10 days in minutes
+    account.update(auto_resolve_after: 14_400, auto_resolve_ignore_waiting: false) # 10 days in minutes
     create_list(:conversation, 3, account: account, last_activity_at: 13.days.ago)
     described_class.perform_now(account: account)
     expect(account.conversations.resolved.count).to eq(Limits::BULK_ACTIONS_LIMIT)


### PR DESCRIPTION
This PR has the following changes

1. Revert to the previous behaviour of auto-resolving all conversations
2. Add an option that allows users to ignore conversations that are waiting for a response. 
3. Fix issue where auto resolve duration input would just enter `10` since that was the lowest value, replaced it with a validation instead
4. Fix copy for the alerts and help texts

![CleanShot 2025-05-08 at 12 02 34@2x](https://github.com/user-attachments/assets/142f6f38-06c3-4997-a8fe-85af07fc40d4)