### PR TITLE
fix: Broken outline in account settings page

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -151,7 +151,7 @@ export default {
 <template>
   <div class="flex flex-col max-w-2xl mx-auto w-full">
     <BaseSettingsHeader :title="$t('GENERAL_SETTINGS.TITLE')" />
-    <div class="flex-grow flex-shrink min-w-0 mt-3 overflow-auto">
+    <div class="flex-grow flex-shrink min-w-0 mt-3">
       <SectionLayout
         :title="$t('GENERAL_SETTINGS.FORM.GENERAL_SECTION.TITLE')"
         :description="$t('GENERAL_SETTINGS.FORM.GENERAL_SECTION.NOTE')"


### PR DESCRIPTION
# Pull Request Template

## Description

**Cause:**
The issue was caused by the use of `overflow-auto` on the General Settings section.

**Fix:**
Removed `overflow-auto` from the General Settings section. It was not needed, as it was not applied to the entire page and did not serve a functional purpose in this context.



Fixes https://linear.app/chatwoot/issue/CW-4316/broken-borders-in-dark-mode-new-settings-page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

### Screen recordings

**Before**

https://github.com/user-attachments/assets/1d88aa01-62a4-4e0e-bfd2-33d792c26c0f


**After**

https://github.com/user-attachments/assets/79639828-d830-4662-8d4a-2ce5b99c39b6




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
