### PR TITLE
fix: Allow resource access without filter type in custom_filters API

### DIFF
--- a/app/controllers/api/v1/accounts/custom_filters_controller.rb
+++ b/app/controllers/api/v1/accounts/custom_filters_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::Accounts::CustomFiltersController < Api::V1::Accounts::BaseController
   before_action :check_authorization
-  before_action :fetch_custom_filters, except: [:create]
+  before_action :fetch_custom_filters, only: [:index]
   before_action :fetch_custom_filter, only: [:show, :update, :destroy]
   DEFAULT_FILTER_TYPE = 'conversation'.freeze
 
@@ -9,8 +9,8 @@ class Api::V1::Accounts::CustomFiltersController < Api::V1::Accounts::BaseContro
   def show; end
 
   def create
-    @custom_filter = current_user.custom_filters.create!(
-      permitted_payload.merge(account_id: Current.account.id)
+    @custom_filter = Current.account.custom_filters.create!(
+      permitted_payload.merge(user: Current.user)
     )
     render json: { error: @custom_filter.errors.messages }, status: :unprocessable_entity and return unless @custom_filter.valid?
   end
@@ -27,14 +27,16 @@ class Api::V1::Accounts::CustomFiltersController < Api::V1::Accounts::BaseContro
   private
 
   def fetch_custom_filters
-    @custom_filters = current_user.custom_filters.where(
-      account_id: Current.account.id,
+    @custom_filters = Current.account.custom_filters.where(
+      user: Current.user,
       filter_type: permitted_params[:filter_type] || DEFAULT_FILTER_TYPE
     )
   end
 
   def fetch_custom_filter
-    @custom_filter = @custom_filters.find(permitted_params[:id])
+    @custom_filter = Current.account.custom_filters.where(
+      user: Current.user
+    ).find(permitted_params[:id])
   end
 
   def permitted_payload


### PR DESCRIPTION
The custom filters API previously required a filter_type attribute, even when accessing a resource by its ID, which isn’t necessary. This PR removes that condition.

Fixes https://github.com/chatwoot/chatwoot/issues/11384