### PR TITLE
feat: Allow agent bots to update custom attributes in accessible conversations

### DIFF
--- a/app/controllers/concerns/access_token_auth_helper.rb
+++ b/app/controllers/concerns/access_token_auth_helper.rb
@@ -1,6 +1,6 @@
 module AccessTokenAuthHelper
   BOT_ACCESSIBLE_ENDPOINTS = {
-    'api/v1/accounts/conversations' => %w[toggle_status toggle_priority create update],
+    'api/v1/accounts/conversations' => %w[toggle_status toggle_priority create update custom_attributes],
     'api/v1/accounts/conversations/messages' => ['create'],
     'api/v1/accounts/conversations/assignments' => ['create']
   }.freeze

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -843,9 +843,30 @@ RSpec.describe 'Conversations API', type: :request do
         create(:inbox_member, user: agent, inbox: conversation.inbox)
       end
 
-      it 'updates last seen' do
+      it 'updates custom attributes' do
         post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/custom_attributes",
              headers: agent.create_new_auth_token,
+             params: valid_params,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.custom_attributes).not_to be_nil
+        expect(conversation.reload.custom_attributes.count).to eq 3
+      end
+    end
+
+    context 'when it is a bot' do
+      let(:agent_bot) { create(:agent_bot, account: account) }
+      let(:custom_attributes) { { bot_id: 1001, flow_name: 'support_flow', step: 'greeting' } }
+      let(:valid_params) { { custom_attributes: custom_attributes } }
+
+      before do
+        create(:agent_bot_inbox, agent_bot: agent_bot, inbox: conversation.inbox)
+      end
+
+      it 'updates custom attributes' do
+        post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/custom_attributes",
+             headers: { api_access_token: agent_bot.access_token.token },
              params: valid_params,
              as: :json
 


### PR DESCRIPTION
Previously, agent bots weren’t allowed to edit custom attributes in conversations. But with AI, it’s now more feasible to return accurate and useful attributes. Since there’s no strong reason to block this, this PR enables bots to update custom attributes.

Fixes https://github.com/chatwoot/chatwoot/issues/11378