### PR TITLE
fix: add named volumes for storage, postgres, and redis

### DIFF
--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -5,7 +5,7 @@ services:
     image: chatwoot/chatwoot:latest
     env_file: .env ## Change this file for customized env variables
     volumes:
-      - /data/storage:/app/storage
+      - storage_data:/app/storage
 
   rails:
     <<: *base
@@ -13,7 +13,7 @@ services:
       - postgres
       - redis
     ports:
-      - '127.0.0.1:3000:3000'
+      - '3000:3000'
     environment:
       - NODE_ENV=production
       - RAILS_ENV=production
@@ -38,9 +38,9 @@ services:
     image: pgvector/pgvector:pg16
     restart: always
     ports:
-      - '127.0.0.1:5432:5432'
+      - '5432:5432'
     volumes:
-      - /data/postgres:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
     environment:
       - POSTGRES_DB=chatwoot
       - POSTGRES_USER=postgres
@@ -53,6 +53,11 @@ services:
     command: ["sh", "-c", "redis-server --requirepass \"$REDIS_PASSWORD\""]
     env_file: .env
     volumes:
-      - /data/redis:/data
+      - redis_data:/data
     ports:
-      - '127.0.0.1:6379:6379'
+      - '6379:6379'
+
+volumes:
+  storage_data:
+  postgres_data:
+  redis_data:

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -13,7 +13,7 @@ services:
       - postgres
       - redis
     ports:
-      - '3000:3000'
+      - '127.0.0.1:3000:3000'
     environment:
       - NODE_ENV=production
       - RAILS_ENV=production
@@ -38,7 +38,7 @@ services:
     image: pgvector/pgvector:pg16
     restart: always
     ports:
-      - '5432:5432'
+      - '127.0.0.1:5432:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:
@@ -55,7 +55,7 @@ services:
     volumes:
       - redis_data:/data
     ports:
-      - '6379:6379'
+      - '127.0.0.1:6379:6379'
 
 volumes:
   storage_data:


### PR DESCRIPTION
## Github Issue Link 
https://github.com/chatwoot/chatwoot/issues/11341

## Description
This PR updates docker-compose.production.yaml to simplify volume management and eliminate host-path mounts that were causing permission and startup errors. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Removed any preexisting Chatwoot containers and volumes
2. Brought up the development stack
3. Ran database preparation successfully without manual directory creation


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
