### PR TITLE
fix: Duplicate attachments when navigating back to a conversation

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -78,10 +78,7 @@ export const mutations = {
     }
   },
   [types.SET_ALL_ATTACHMENTS](_state, { id, data }) {
-    const attachments = _state.attachments[id] || [];
-
-    attachments.push(...data);
-    _state.attachments[id] = [...attachments];
+    _state.attachments[id] = [...data];
   },
   [types.SET_MISSING_MESSAGES](_state, { id, data }) {
     const [chat] = _state.allConversations.filter(c => c.id === id);


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes [CW-4330](https://linear.app/chatwoot/issue/CW-4330/bug-attachments-in-gallery-view-gets-duplicated-when-you-navigate-back)

**Cause**
When navigating back to a previously viewed conversation, attachments were being duplicated in the Gallery View. This occurred because the `SET_ALL_ATTACHMENTS` mutation was appending new attachments to existing ones `(attachments.push(...data))` instead of replacing them. Each time a user returned to a conversation, the attachment list would grow, showing duplicate images.

**Solution**
Updated the `SET_ALL_ATTACHMENTS` mutation to replace the entire attachments array instead of appending to it. This change ensures attachments are cleared before adding new ones when returning to a previously viewed conversation, preventing duplicates.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/b2472c07e95843f6879724b19ef89311?sid=eed42238-b4bc-4dbe-8ede-a25a13b4610d

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
