### PR TITLE
feat: Improve CSAT responses

### DIFF
--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -138,7 +138,8 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   def inbox_attributes
     [:name, :avatar, :greeting_enabled, :greeting_message, :enable_email_collect, :csat_survey_enabled,
      :enable_auto_assignment, :working_hours_enabled, :out_of_office_message, :timezone, :allow_messages_after_resolved,
-     :lock_to_single_conversation, :portal_id, :sender_name_type, :business_name, :csat_config]
+     :lock_to_single_conversation, :portal_id, :sender_name_type, :business_name,
+     { csat_config: [:display_type, :message, { survey_rules: [:operator, { values: [] }] }] }]
   end
 
   def permitted_params(channel_attributes = [])

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -124,7 +124,6 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   end
 
   def format_csat_config(config)
-    config = JSON.parse(config) if config.is_a?(String)
     {
       display_type: config['display_type'] || 'emoji',
       message: config['message'] || '',

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -42,7 +42,12 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   end
 
   def update
-    @inbox.update!(permitted_params.except(:channel))
+    inbox_params = permitted_params.except(:channel)
+
+    # Handle nested JSON structure with defaults that permitted_params can't manage
+    inbox_params[:csat_config] = format_csat_config(params[:csat_config]) if params[:csat_config].present?
+
+    @inbox.update!(inbox_params)
     update_inbox_working_hours
     update_channel if channel_update_required?
   end
@@ -121,10 +126,25 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
     @inbox.channel.save!
   end
 
+  def format_csat_config(config)
+    # Parse JSON if it's a string
+    config = JSON.parse(config) if config.is_a?(String)
+
+    # Ensure proper structure with defaults
+    {
+      'display_type' => config['display_type'] || 'emoji',
+      'message' => config['message'] || '',
+      'survey_rules' => {
+        'operator' => config.dig('survey_rules', 'operator') || 'contains',
+        'values' => config.dig('survey_rules', 'values') || []
+      }
+    }
+  end
+
   def inbox_attributes
     [:name, :avatar, :greeting_enabled, :greeting_message, :enable_email_collect, :csat_survey_enabled,
      :enable_auto_assignment, :working_hours_enabled, :out_of_office_message, :timezone, :allow_messages_after_resolved,
-     :lock_to_single_conversation, :portal_id, :sender_name_type, :business_name]
+     :lock_to_single_conversation, :portal_id, :sender_name_type, :business_name, :csat_config]
   end
 
   def permitted_params(channel_attributes = [])

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -42,11 +42,8 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   end
 
   def update
-    inbox_params = permitted_params.except(:channel)
-
-    # Handle nested JSON structure with defaults that permitted_params can't manage
-    inbox_params[:csat_config] = format_csat_config(params[:csat_config]) if params[:csat_config].present?
-
+    inbox_params = permitted_params.except(:channel, :csat_config)
+    inbox_params[:csat_config] = format_csat_config(permitted_params[:csat_config]) if permitted_params[:csat_config].present?
     @inbox.update!(inbox_params)
     update_inbox_working_hours
     update_channel if channel_update_required?
@@ -127,16 +124,13 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   end
 
   def format_csat_config(config)
-    # Parse JSON if it's a string
     config = JSON.parse(config) if config.is_a?(String)
-
-    # Ensure proper structure with defaults
     {
-      'display_type' => config['display_type'] || 'emoji',
-      'message' => config['message'] || '',
-      'survey_rules' => {
-        'operator' => config.dig('survey_rules', 'operator') || 'contains',
-        'values' => config.dig('survey_rules', 'values') || []
+      display_type: config['display_type'] || 'emoji',
+      message: config['message'] || '',
+      survey_rules: {
+        operator: config.dig('survey_rules', 'operator') || 'contains',
+        values: config.dig('survey_rules', 'values') || []
       }
     }
   end

--- a/app/javascript/dashboard/components-next/filter/inputs/FilterSelect.vue
+++ b/app/javascript/dashboard/components-next/filter/inputs/FilterSelect.vue
@@ -25,6 +25,10 @@ const props = defineProps({
     type: String,
     default: 'faded',
   },
+  label: {
+    type: String,
+    default: null,
+  },
 });
 
 const selected = defineModel({
@@ -56,7 +60,7 @@ const updateSelected = newValue => {
           :variant
           :icon="iconToRender"
           :trailing-icon="selectedOption.icon ? false : true"
-          :label="hideLabel ? null : selectedOption.label"
+          :label="label || (hideLabel ? null : selectedOption.label)"
           @click="toggle"
         />
       </slot>

--- a/app/javascript/dashboard/components-next/message/bubbles/CSAT.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/CSAT.vue
@@ -2,10 +2,10 @@
 import { computed } from 'vue';
 import BaseBubble from './Base.vue';
 import { useI18n } from 'vue-i18n';
-import { CSAT_RATINGS } from 'shared/constants/messages';
+import { CSAT_RATINGS, CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
 import { useMessageContext } from '../provider.js';
 
-const { contentAttributes } = useMessageContext();
+const { contentAttributes, content } = useMessageContext();
 const { t } = useI18n();
 
 const response = computed(() => {
@@ -14,6 +14,14 @@ const response = computed(() => {
 
 const isRatingSubmitted = computed(() => {
   return !!response.value.rating;
+});
+
+const displayType = computed(() => {
+  return contentAttributes.value?.displayType || CSAT_DISPLAY_TYPES.EMOJI;
+});
+
+const isStarRating = computed(() => {
+  return displayType.value === CSAT_DISPLAY_TYPES.STAR;
 });
 
 const rating = computed(() => {
@@ -25,16 +33,33 @@ const rating = computed(() => {
 
   return null;
 });
+
+const starRatingValue = computed(() => {
+  return response.value.rating || 0;
+});
 </script>
 
 <template>
   <BaseBubble class="px-4 py-3" data-bubble-name="csat">
-    <h4>{{ t('CONVERSATION.CSAT_REPLY_MESSAGE') }}</h4>
+    <h4>{{ content || t('CONVERSATION.CSAT_REPLY_MESSAGE') }}</h4>
     <dl v-if="isRatingSubmitted" class="mt-4">
       <dt class="text-n-slate-11 italic">
         {{ t('CONVERSATION.RATING_TITLE') }}
       </dt>
-      <dd>{{ t(rating.translationKey) }}</dd>
+      <dd v-if="!isStarRating">
+        {{ t(rating.translationKey) }}
+      </dd>
+      <dd v-else class="flex mt-1">
+        <span v-for="n in 5" :key="n" class="text-2xl mr-1">
+          <i
+            :class="[
+              n <= starRatingValue
+                ? 'i-ri-star-fill text-n-amber-9'
+                : 'i-ri-star-line text-n-slate-10',
+            ]"
+          />
+        </span>
+      </dd>
 
       <dt v-if="response.feedbackMessage" class="text-n-slate-11 italic mt-2">
         {{ t('CONVERSATION.FEEDBACK_TITLE') }}

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -481,7 +481,8 @@
       "PRE_CHAT_FORM": "Pre Chat Form",
       "BUSINESS_HOURS": "Business Hours",
       "WIDGET_BUILDER": "Widget Builder",
-      "BOT_CONFIGURATION": "Bot Configuration"
+      "BOT_CONFIGURATION": "Bot Configuration",
+      "CSAT": "CSAT"
     },
     "SETTINGS": "Settings",
     "FEATURES": {
@@ -576,6 +577,37 @@
       },
       "REQUIRE_EMAIL": {
         "LABEL": "Visitors should provide their name and email address before starting the chat"
+      }
+    },
+    "CSAT": {
+      "TITLE": "Customer Satisfaction (CSAT)",
+      "SUBTITLE": "Customer Satisfaction (CSAT) survey after resolving a conversation",
+      "DISPLAY_TYPE": {
+        "LABEL": "Display type",
+        "DESCRIPTION": "Select the type of display for the CSAT survey.",
+        "OPTIONS": {
+          "EMOJI": "Emoji",
+          "STAR": "Star"
+        }
+      },
+      "MESSAGE": {
+        "LABEL": "Message",
+        "DESCRIPTION": "This message would be visible to the users along with the form",
+        "PLACEHOLDER": "Please enter the message"
+      },
+      "SURVEY_RULE": {
+        "LABEL": "Survey rule",
+        "DESCRIPTION": "Set the rule for sending the survey.",
+        "DESCRIPTION_PREFIX": "Send the survey if the conversation",
+        "DESCRIPTION_SUFFIX": "any of the labels",
+        "OPERATOR": {
+          "CONTAINS": "contains",
+          "DOES_NOT_CONTAINS": "does not contain"
+        }
+      },
+      "API": {
+        "SUCCESS_MESSAGE": "CSAT settings updated successfully",
+        "ERROR_MESSAGE": "We couldn't update CSAT settings. Please try again later."
       }
     },
     "BUSINESS_HOURS": {

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -599,6 +599,7 @@
         },
         "SELECT_PLACEHOLDER": "select labels"
       },
+      "NOTE": "Note: CSAT surveys are sent only once per conversation",
       "API": {
         "SUCCESS_MESSAGE": "CSAT settings updated successfully",
         "ERROR_MESSAGE": "We couldn't update CSAT settings. Please try again later."

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -583,27 +583,21 @@
       "TITLE": "Customer Satisfaction (CSAT)",
       "SUBTITLE": "Customer Satisfaction (CSAT) survey after resolving a conversation",
       "DISPLAY_TYPE": {
-        "LABEL": "Display type",
-        "DESCRIPTION": "Select the type of display for the CSAT survey.",
-        "OPTIONS": {
-          "EMOJI": "Emoji",
-          "STAR": "Star"
-        }
+        "LABEL": "Display type"
       },
       "MESSAGE": {
         "LABEL": "Message",
-        "DESCRIPTION": "This message would be visible to the users along with the form",
-        "PLACEHOLDER": "Please enter the message"
+        "PLACEHOLDER": "Please enter a message to show users with the form"
       },
       "SURVEY_RULE": {
         "LABEL": "Survey rule",
-        "DESCRIPTION": "Set the rule for sending the survey.",
         "DESCRIPTION_PREFIX": "Send the survey if the conversation",
         "DESCRIPTION_SUFFIX": "any of the labels",
         "OPERATOR": {
           "CONTAINS": "contains",
           "DOES_NOT_CONTAINS": "does not contain"
-        }
+        },
+        "SELECT_PLACEHOLDER": "select labels"
       },
       "API": {
         "SUCCESS_MESSAGE": "CSAT settings updated successfully",

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -503,9 +503,7 @@
       "ENABLE_EMAIL_COLLECT_BOX": "Enable email collect box",
       "ENABLE_EMAIL_COLLECT_BOX_SUB_TEXT": "Enable or disable email collect box on new conversation",
       "AUTO_ASSIGNMENT": "Enable auto assignment",
-      "ENABLE_CSAT": "Enable CSAT",
       "SENDER_NAME_SECTION": "Enable Agent Name in Email",
-      "ENABLE_CSAT_SUB_TEXT": "Enable/Disable CSAT(Customer satisfaction) survey after resolving a conversation",
       "SENDER_NAME_SECTION_TEXT": "Enable/Disable showing Agent's name in email, if disabled it will show business name",
       "ENABLE_CONTINUITY_VIA_EMAIL": "Enable conversation continuity via email",
       "ENABLE_CONTINUITY_VIA_EMAIL_SUB_TEXT": "Conversations will continue over email if the contact email address is available.",
@@ -580,8 +578,8 @@
       }
     },
     "CSAT": {
-      "TITLE": "Customer Satisfaction (CSAT)",
-      "SUBTITLE": "Customer Satisfaction (CSAT) survey after resolving a conversation",
+      "TITLE": "Enable CSAT",
+      "SUBTITLE": "Automatically trigger CSAT surveys at the end of conversations to understand how customers feel about their support experience. Track satisfaction trends and identify areas for improvement over time.",
       "DISPLAY_TYPE": {
         "LABEL": "Display type"
       },

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -15,6 +15,7 @@ import PreChatFormSettings from './PreChatForm/Settings.vue';
 import WeeklyAvailability from './components/WeeklyAvailability.vue';
 import GreetingsEditor from 'shared/components/GreetingsEditor.vue';
 import ConfigurationPage from './settingsPage/ConfigurationPage.vue';
+import CustomerSatisfactionPage from './settingsPage/CustomerSatisfactionPage.vue';
 import CollaboratorsPage from './settingsPage/CollaboratorsPage.vue';
 import WidgetBuilder from './WidgetBuilder.vue';
 import BotConfiguration from './components/BotConfiguration.vue';
@@ -28,6 +29,7 @@ export default {
     BotConfiguration,
     CollaboratorsPage,
     ConfigurationPage,
+    CustomerSatisfactionPage,
     FacebookReauthorize,
     GreetingsEditor,
     PreChatFormSettings,
@@ -106,6 +108,10 @@ export default {
         {
           key: 'businesshours',
           name: this.$t('INBOX_MGMT.TABS.BUSINESS_HOURS'),
+        },
+        {
+          key: 'csat',
+          name: this.$t('INBOX_MGMT.TABS.CSAT'),
         },
       ];
 
@@ -801,6 +807,9 @@ export default {
       </div>
       <div v-if="selectedTabKey === 'configuration'">
         <ConfigurationPage :inbox="inbox" />
+      </div>
+      <div v-if="selectedTabKey === 'csat'">
+        <CustomerSatisfactionPage :inbox="inbox" />
       </div>
       <div v-if="selectedTabKey === 'preChatForm'">
         <PreChatFormSettings :inbox="inbox" />

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -55,7 +55,6 @@ export default {
       greetingEnabled: true,
       greetingMessage: '',
       emailCollectEnabled: false,
-      csatSurveyEnabled: false,
       senderNameType: 'friendly',
       businessName: '',
       locktoSingleConversation: false,
@@ -283,7 +282,6 @@ export default {
         this.greetingEnabled = this.inbox.greeting_enabled || false;
         this.greetingMessage = this.inbox.greeting_message || '';
         this.emailCollectEnabled = this.inbox.enable_email_collect;
-        this.csatSurveyEnabled = this.inbox.csat_survey_enabled;
         this.senderNameType = this.inbox.sender_name_type;
         this.businessName = this.inbox.business_name;
         this.allowMessagesAfterResolved =
@@ -306,7 +304,6 @@ export default {
           id: this.currentInboxId,
           name: this.selectedInboxName,
           enable_email_collect: this.emailCollectEnabled,
-          csat_survey_enabled: this.csatSurveyEnabled,
           allow_messages_after_resolved: this.allowMessagesAfterResolved,
           greeting_enabled: this.greetingEnabled,
           greeting_message: this.greetingMessage || '',
@@ -592,21 +589,6 @@ export default {
                   'INBOX_MGMT.SETTINGS_POPUP.ENABLE_EMAIL_COLLECT_BOX_SUB_TEXT'
                 )
               }}
-            </p>
-          </label>
-
-          <label class="pb-4">
-            {{ $t('INBOX_MGMT.SETTINGS_POPUP.ENABLE_CSAT') }}
-            <select v-model="csatSurveyEnabled">
-              <option :value="true">
-                {{ $t('INBOX_MGMT.EDIT.ENABLE_CSAT.ENABLED') }}
-              </option>
-              <option :value="false">
-                {{ $t('INBOX_MGMT.EDIT.ENABLE_CSAT.DISABLED') }}
-              </option>
-            </select>
-            <p class="pb-1 text-sm not-italic text-n-slate-11">
-              {{ $t('INBOX_MGMT.SETTINGS_POPUP.ENABLE_CSAT_SUB_TEXT') }}
             </p>
           </label>
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
@@ -170,6 +170,7 @@ const saveSettings = async () => {
             v-model="state.message"
             :placeholder="$t('INBOX_MGMT.CSAT.MESSAGE.PLACEHOLDER')"
             :max-length="200"
+            class="w-full"
           />
         </WithLabel>
 
@@ -215,6 +216,9 @@ const saveSettings = async () => {
             </span>
           </div>
         </WithLabel>
+        <p class="text-sm italic text-n-slate-11">
+          {{ $t('INBOX_MGMT.CSAT.NOTE') }}
+        </p>
         <div>
           <NextButton
             type="submit"

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
@@ -145,8 +145,8 @@ const saveSettings = async () => {
 <template>
   <div class="mx-8 lg:max-w-[60%]">
     <SectionLayout
-      :title="$t('INBOX_MGMT.SETTINGS_POPUP.ENABLE_CSAT')"
-      :description="$t('INBOX_MGMT.SETTINGS_POPUP.ENABLE_CSAT_SUB_TEXT')"
+      :title="$t('INBOX_MGMT.CSAT.TITLE')"
+      :description="$t('INBOX_MGMT.CSAT.SUBTITLE')"
     >
       <template #headerActions>
         <div class="flex justify-end">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
@@ -103,7 +103,7 @@ const removeLabel = label => {
   }
 };
 
-const updateInboxAPI = async attributes => {
+const updateInbox = async attributes => {
   const payload = {
     id: props.inbox.id,
     formData: false,
@@ -126,7 +126,7 @@ const saveSettings = async () => {
       },
     };
 
-    await updateInboxAPI({
+    await updateInbox({
       csat_survey_enabled: state.csatSurveyEnabled,
       csat_config: csatConfig,
     });

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
@@ -143,7 +143,7 @@ const saveSettings = async () => {
 </script>
 
 <template>
-  <div class="mx-8 lg:max-w-[60%]">
+  <div class="mx-8">
     <SectionLayout
       :title="$t('INBOX_MGMT.CSAT.TITLE')"
       :description="$t('INBOX_MGMT.CSAT.SUBTITLE')"

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
@@ -174,7 +174,7 @@ const saveSettings = async () => {
         <Editor
           v-model="state.message"
           :placeholder="$t('INBOX_MGMT.CSAT.MESSAGE.PLACEHOLDER')"
-          :max-length="2000"
+          :max-length="200"
         />
       </SettingsSection>
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
@@ -1,0 +1,233 @@
+<script setup>
+import { reactive, onMounted, ref, defineProps, watch, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useAlert } from 'dashboard/composables';
+import { useStore, useMapGetter } from 'dashboard/composables/store';
+import { CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
+
+import SettingsSection from 'dashboard/components/SettingsSection.vue';
+import CSATDisplayTypeSelector from './components/CSATDisplayTypeSelector.vue';
+import Editor from 'dashboard/components-next/Editor/Editor.vue';
+import FilterSelect from 'dashboard/components-next/filter/inputs/FilterSelect.vue';
+import NextButton from 'dashboard/components-next/button/Button.vue';
+
+const props = defineProps({
+  inbox: { type: Object, required: true },
+});
+
+const { t } = useI18n();
+const store = useStore();
+const labels = useMapGetter('labels/getLabels');
+
+const isUpdating = ref(false);
+const selectedLabelValues = ref([]);
+const currentLabel = ref('');
+
+const state = reactive({
+  csatSurveyEnabled: false,
+  displayType: 'emoji',
+  message: '',
+  surveyRuleOperator: 'contains',
+});
+
+const filterTypes = [
+  {
+    label: t('INBOX_MGMT.CSAT.SURVEY_RULE.OPERATOR.CONTAINS'),
+    value: 'contains',
+  },
+  {
+    label: t('INBOX_MGMT.CSAT.SURVEY_RULE.OPERATOR.DOES_NOT_CONTAINS'),
+    value: 'does_not_contain',
+  },
+];
+
+const labelOptions = computed(() =>
+  labels.value?.length
+    ? labels.value
+        .map(label => ({ label: label.title, value: label.title }))
+        .filter(label => !selectedLabelValues.value.includes(label.value))
+    : []
+);
+
+const initializeState = () => {
+  if (!props.inbox) return;
+
+  const { csat_survey_enabled, csat_config } = props.inbox;
+
+  state.csatSurveyEnabled = csat_survey_enabled || false;
+
+  if (!csat_config) return;
+
+  const {
+    display_type: displayType = CSAT_DISPLAY_TYPES.EMOJI,
+    message = '',
+    survey_rules: surveyRules = {},
+  } = csat_config;
+
+  state.displayType = displayType;
+  state.message = message;
+  state.surveyRuleOperator = surveyRules.operator || 'contains';
+
+  selectedLabelValues.value = Array.isArray(surveyRules.values)
+    ? [...surveyRules.values]
+    : [];
+};
+
+onMounted(() => {
+  initializeState();
+  if (!labels.value?.length) store.dispatch('labels/get');
+});
+
+watch(() => props.inbox, initializeState, { immediate: true });
+
+const handleLabelSelect = value => {
+  if (!value || selectedLabelValues.value.includes(value)) {
+    return;
+  }
+
+  selectedLabelValues.value.push(value);
+};
+
+const updateDisplayType = type => {
+  state.displayType = type;
+};
+
+const updateSurveyRuleOperator = operator => {
+  state.surveyRuleOperator = operator;
+};
+
+const removeLabel = label => {
+  const index = selectedLabelValues.value.indexOf(label);
+  if (index !== -1) {
+    selectedLabelValues.value.splice(index, 1);
+  }
+};
+
+const updateInboxAPI = async attributes => {
+  const payload = {
+    id: props.inbox.id,
+    formData: false,
+    ...attributes,
+  };
+
+  return store.dispatch('inboxes/updateInbox', payload);
+};
+
+const saveSettings = async () => {
+  try {
+    isUpdating.value = true;
+
+    const csatConfig = {
+      display_type: state.displayType,
+      message: state.message,
+      survey_rules: {
+        operator: state.surveyRuleOperator,
+        values: selectedLabelValues.value,
+      },
+    };
+
+    await updateInboxAPI({
+      csat_survey_enabled: state.csatSurveyEnabled,
+      csat_config: csatConfig,
+    });
+
+    useAlert(t('INBOX_MGMT.CSAT.API.SUCCESS_MESSAGE'));
+  } catch (error) {
+    useAlert(t('INBOX_MGMT.CSAT.API.ERROR_MESSAGE'));
+  } finally {
+    isUpdating.value = false;
+  }
+};
+</script>
+
+<template>
+  <div class="mx-8">
+    <SettingsSection
+      :title="$t('INBOX_MGMT.SETTINGS_POPUP.ENABLE_CSAT')"
+      :sub-title="$t('INBOX_MGMT.SETTINGS_POPUP.ENABLE_CSAT_SUB_TEXT')"
+    >
+      <select v-model="state.csatSurveyEnabled" class="max-w-56">
+        <option :value="true">
+          {{ $t('INBOX_MGMT.EDIT.ENABLE_CSAT.ENABLED') }}
+        </option>
+        <option :value="false">
+          {{ $t('INBOX_MGMT.EDIT.ENABLE_CSAT.DISABLED') }}
+        </option>
+      </select>
+    </SettingsSection>
+
+    <div v-if="state.csatSurveyEnabled">
+      <SettingsSection
+        :title="$t('INBOX_MGMT.CSAT.DISPLAY_TYPE.LABEL')"
+        :sub-title="$t('INBOX_MGMT.CSAT.DISPLAY_TYPE.DESCRIPTION')"
+      >
+        <CSATDisplayTypeSelector
+          :selected-type="state.displayType"
+          @update="updateDisplayType"
+        />
+      </SettingsSection>
+
+      <SettingsSection
+        :title="$t('INBOX_MGMT.CSAT.MESSAGE.LABEL')"
+        :sub-title="$t('INBOX_MGMT.CSAT.MESSAGE.DESCRIPTION')"
+      >
+        <Editor
+          v-model="state.message"
+          :placeholder="$t('INBOX_MGMT.CSAT.MESSAGE.PLACEHOLDER')"
+          :max-length="2000"
+        />
+      </SettingsSection>
+
+      <SettingsSection
+        :title="$t('INBOX_MGMT.CSAT.SURVEY_RULE.LABEL')"
+        :sub-title="$t('INBOX_MGMT.CSAT.SURVEY_RULE.DESCRIPTION')"
+      >
+        <div class="mb-4">
+          <span
+            class="inline-flex flex-wrap items-center gap-1.5 text-base text-n-slate-12"
+          >
+            {{ $t('INBOX_MGMT.CSAT.SURVEY_RULE.DESCRIPTION_PREFIX') }}
+            <FilterSelect
+              v-model="state.surveyRuleOperator"
+              variant="faded"
+              :options="filterTypes"
+              class="inline-flex shrink-0"
+              @update:model-value="updateSurveyRuleOperator"
+            />
+            {{ $t('INBOX_MGMT.CSAT.SURVEY_RULE.DESCRIPTION_SUFFIX') }}
+
+            <NextButton
+              v-for="label in selectedLabelValues"
+              :key="label"
+              sm
+              faded
+              slate
+              trailing-icon
+              :label="label"
+              icon="i-lucide-x"
+              class="inline-flex shrink-0"
+              @click="removeLabel(label)"
+            />
+            <FilterSelect
+              v-model="currentLabel"
+              :options="labelOptions"
+              hide-label
+              variant="faded"
+              class="inline-flex shrink-0"
+              @update:model-value="handleLabelSelect"
+            />
+          </span>
+        </div>
+      </SettingsSection>
+    </div>
+
+    <SettingsSection :show-border="false">
+      <NextButton
+        type="submit"
+        :label="$t('INBOX_MGMT.SETTINGS_POPUP.UPDATE')"
+        :is-loading="isUpdating"
+        @click="saveSettings"
+      />
+    </SettingsSection>
+  </div>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/CustomerSatisfactionPage.vue
@@ -5,11 +5,13 @@ import { useAlert } from 'dashboard/composables';
 import { useStore, useMapGetter } from 'dashboard/composables/store';
 import { CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
 
-import SettingsSection from 'dashboard/components/SettingsSection.vue';
+import WithLabel from 'v3/components/Form/WithLabel.vue';
+import SectionLayout from 'dashboard/routes/dashboard/settings/account/components/SectionLayout.vue';
 import CSATDisplayTypeSelector from './components/CSATDisplayTypeSelector.vue';
 import Editor from 'dashboard/components-next/Editor/Editor.vue';
 import FilterSelect from 'dashboard/components-next/filter/inputs/FilterSelect.vue';
 import NextButton from 'dashboard/components-next/button/Button.vue';
+import Switch from 'next/switch/Switch.vue';
 
 const props = defineProps({
   inbox: { type: Object, required: true },
@@ -141,93 +143,87 @@ const saveSettings = async () => {
 </script>
 
 <template>
-  <div class="mx-8">
-    <SettingsSection
+  <div class="mx-8 lg:max-w-[60%]">
+    <SectionLayout
       :title="$t('INBOX_MGMT.SETTINGS_POPUP.ENABLE_CSAT')"
-      :sub-title="$t('INBOX_MGMT.SETTINGS_POPUP.ENABLE_CSAT_SUB_TEXT')"
+      :description="$t('INBOX_MGMT.SETTINGS_POPUP.ENABLE_CSAT_SUB_TEXT')"
     >
-      <select v-model="state.csatSurveyEnabled" class="max-w-56">
-        <option :value="true">
-          {{ $t('INBOX_MGMT.EDIT.ENABLE_CSAT.ENABLED') }}
-        </option>
-        <option :value="false">
-          {{ $t('INBOX_MGMT.EDIT.ENABLE_CSAT.DISABLED') }}
-        </option>
-      </select>
-    </SettingsSection>
-
-    <div v-if="state.csatSurveyEnabled">
-      <SettingsSection
-        :title="$t('INBOX_MGMT.CSAT.DISPLAY_TYPE.LABEL')"
-        :sub-title="$t('INBOX_MGMT.CSAT.DISPLAY_TYPE.DESCRIPTION')"
-      >
-        <CSATDisplayTypeSelector
-          :selected-type="state.displayType"
-          @update="updateDisplayType"
-        />
-      </SettingsSection>
-
-      <SettingsSection
-        :title="$t('INBOX_MGMT.CSAT.MESSAGE.LABEL')"
-        :sub-title="$t('INBOX_MGMT.CSAT.MESSAGE.DESCRIPTION')"
-      >
-        <Editor
-          v-model="state.message"
-          :placeholder="$t('INBOX_MGMT.CSAT.MESSAGE.PLACEHOLDER')"
-          :max-length="200"
-        />
-      </SettingsSection>
-
-      <SettingsSection
-        :title="$t('INBOX_MGMT.CSAT.SURVEY_RULE.LABEL')"
-        :sub-title="$t('INBOX_MGMT.CSAT.SURVEY_RULE.DESCRIPTION')"
-      >
-        <div class="mb-4">
-          <span
-            class="inline-flex flex-wrap items-center gap-1.5 text-base text-n-slate-12"
-          >
-            {{ $t('INBOX_MGMT.CSAT.SURVEY_RULE.DESCRIPTION_PREFIX') }}
-            <FilterSelect
-              v-model="state.surveyRuleOperator"
-              variant="faded"
-              :options="filterTypes"
-              class="inline-flex shrink-0"
-              @update:model-value="updateSurveyRuleOperator"
-            />
-            {{ $t('INBOX_MGMT.CSAT.SURVEY_RULE.DESCRIPTION_SUFFIX') }}
-
-            <NextButton
-              v-for="label in selectedLabelValues"
-              :key="label"
-              sm
-              faded
-              slate
-              trailing-icon
-              :label="label"
-              icon="i-lucide-x"
-              class="inline-flex shrink-0"
-              @click="removeLabel(label)"
-            />
-            <FilterSelect
-              v-model="currentLabel"
-              :options="labelOptions"
-              hide-label
-              variant="faded"
-              class="inline-flex shrink-0"
-              @update:model-value="handleLabelSelect"
-            />
-          </span>
+      <template #headerActions>
+        <div class="flex justify-end">
+          <Switch v-model="state.csatSurveyEnabled" />
         </div>
-      </SettingsSection>
-    </div>
+      </template>
 
-    <SettingsSection :show-border="false">
-      <NextButton
-        type="submit"
-        :label="$t('INBOX_MGMT.SETTINGS_POPUP.UPDATE')"
-        :is-loading="isUpdating"
-        @click="saveSettings"
-      />
-    </SettingsSection>
+      <div class="grid gap-5">
+        <WithLabel
+          :label="$t('INBOX_MGMT.CSAT.DISPLAY_TYPE.LABEL')"
+          name="display_type"
+        >
+          <CSATDisplayTypeSelector
+            :selected-type="state.displayType"
+            @update="updateDisplayType"
+          />
+        </WithLabel>
+
+        <WithLabel :label="$t('INBOX_MGMT.CSAT.MESSAGE.LABEL')" name="message">
+          <Editor
+            v-model="state.message"
+            :placeholder="$t('INBOX_MGMT.CSAT.MESSAGE.PLACEHOLDER')"
+            :max-length="200"
+          />
+        </WithLabel>
+
+        <WithLabel
+          :label="$t('INBOX_MGMT.CSAT.SURVEY_RULE.LABEL')"
+          name="survey_rule"
+        >
+          <div class="mb-4">
+            <span
+              class="inline-flex flex-wrap items-center gap-1.5 text-sm text-n-slate-12"
+            >
+              {{ $t('INBOX_MGMT.CSAT.SURVEY_RULE.DESCRIPTION_PREFIX') }}
+              <FilterSelect
+                v-model="state.surveyRuleOperator"
+                variant="faded"
+                :options="filterTypes"
+                class="inline-flex shrink-0"
+                @update:model-value="updateSurveyRuleOperator"
+              />
+              {{ $t('INBOX_MGMT.CSAT.SURVEY_RULE.DESCRIPTION_SUFFIX') }}
+
+              <NextButton
+                v-for="label in selectedLabelValues"
+                :key="label"
+                sm
+                faded
+                slate
+                trailing-icon
+                :label="label"
+                icon="i-lucide-x"
+                class="inline-flex shrink-0"
+                @click="removeLabel(label)"
+              />
+              <FilterSelect
+                v-model="currentLabel"
+                :options="labelOptions"
+                :label="$t('INBOX_MGMT.CSAT.SURVEY_RULE.SELECT_PLACEHOLDER')"
+                hide-label
+                variant="faded"
+                class="inline-flex shrink-0"
+                @update:model-value="handleLabelSelect"
+              />
+            </span>
+          </div>
+        </WithLabel>
+        <div>
+          <NextButton
+            type="submit"
+            :label="$t('INBOX_MGMT.SETTINGS_POPUP.UPDATE')"
+            :is-loading="isUpdating"
+            @click="saveSettings"
+          />
+        </div>
+      </div>
+    </SectionLayout>
   </div>
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/components/CSATDisplayTypeSelector.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/components/CSATDisplayTypeSelector.vue
@@ -1,0 +1,72 @@
+<script setup>
+import { ref } from 'vue';
+import { CSAT_RATINGS, CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
+
+const props = defineProps({
+  selectedType: {
+    type: String,
+    default: CSAT_DISPLAY_TYPES.EMOJI,
+  },
+});
+const emit = defineEmits(['update']);
+
+const emojis = CSAT_RATINGS;
+const selectedEmoji = ref(4);
+const selectedStar = ref(4);
+</script>
+
+<template>
+  <div class="flex flex-wrap gap-6 mt-2">
+    <div
+      class="flex items-center rounded-lg transition-all duration-500 cursor-pointer border px-4 py-2 gap-2 min-w-56"
+      :class="
+        props.selectedType === CSAT_DISPLAY_TYPES.EMOJI
+          ? 'border-n-brand bg-n-brand/5'
+          : 'border-n-weak bg-n-alpha-black2'
+      "
+      @click="emit('update', CSAT_DISPLAY_TYPES.EMOJI)"
+    >
+      <button
+        v-for="(emoji, id) in emojis"
+        :key="emoji.key"
+        type="button"
+        class="rounded-full p-1 transition-transform duration-150 focus:outline-none flex items-center flex-shrink-0"
+        :aria-label="emoji.translationKey"
+        @click="selectedEmoji = id"
+      >
+        <span
+          class="text-2xl"
+          :class="selectedEmoji !== id && 'grayscale opacity-60'"
+        >
+          {{ emoji.emoji }}
+        </span>
+      </button>
+    </div>
+    <div
+      class="flex items-center rounded-lg transition-all duration-500 cursor-pointer border px-4 py-2 gap-2 min-w-56"
+      :class="
+        props.selectedType === CSAT_DISPLAY_TYPES.STAR
+          ? 'border-n-brand bg-n-brand/5'
+          : 'border-n-weak bg-n-alpha-black2'
+      "
+      @click="emit('update', CSAT_DISPLAY_TYPES.STAR)"
+    >
+      <button
+        v-for="n in 5"
+        :key="'star-' + n"
+        type="button"
+        class="rounded-full p-1 transition-transform duration-150 focus:outline-none flex items-center flex-shrink-0"
+        :aria-label="`Star ${n}`"
+        @click="selectedStar = n"
+      >
+        <i
+          :class="
+            selectedStar >= n
+              ? 'i-ri-star-fill text-n-amber-9 text-2xl'
+              : 'i-ri-star-line text-n-slate-10 text-2xl'
+          "
+        />
+      </button>
+    </div>
+  </div>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/components/CSATDisplayTypeSelector.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/components/CSATDisplayTypeSelector.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { ref } from 'vue';
-import { CSAT_RATINGS, CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
+import { CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
+import CSATEmojiInput from './CSATEmojiInput.vue';
+import CSATStarInput from './CSATStarInput.vue';
 
 const props = defineProps({
   selectedType: {
@@ -9,64 +10,17 @@ const props = defineProps({
   },
 });
 const emit = defineEmits(['update']);
-
-const emojis = CSAT_RATINGS;
-const selectedEmoji = ref(4);
-const selectedStar = ref(4);
 </script>
 
 <template>
   <div class="flex flex-wrap gap-6 mt-2">
-    <div
-      class="flex items-center rounded-lg transition-all duration-500 cursor-pointer border px-4 py-2 gap-2 min-w-56"
-      :class="
-        props.selectedType === CSAT_DISPLAY_TYPES.EMOJI
-          ? 'border-n-brand bg-n-brand/5'
-          : 'border-n-weak bg-n-alpha-black2'
-      "
-      @click="emit('update', CSAT_DISPLAY_TYPES.EMOJI)"
-    >
-      <button
-        v-for="(emoji, id) in emojis"
-        :key="emoji.key"
-        type="button"
-        class="rounded-full p-1 transition-transform duration-150 focus:outline-none flex items-center flex-shrink-0"
-        :aria-label="emoji.translationKey"
-        @click="selectedEmoji = id"
-      >
-        <span
-          class="text-2xl"
-          :class="selectedEmoji !== id && 'grayscale opacity-60'"
-        >
-          {{ emoji.emoji }}
-        </span>
-      </button>
-    </div>
-    <div
-      class="flex items-center rounded-lg transition-all duration-500 cursor-pointer border px-4 py-2 gap-2 min-w-56"
-      :class="
-        props.selectedType === CSAT_DISPLAY_TYPES.STAR
-          ? 'border-n-brand bg-n-brand/5'
-          : 'border-n-weak bg-n-alpha-black2'
-      "
-      @click="emit('update', CSAT_DISPLAY_TYPES.STAR)"
-    >
-      <button
-        v-for="n in 5"
-        :key="'star-' + n"
-        type="button"
-        class="rounded-full p-1 transition-transform duration-150 focus:outline-none flex items-center flex-shrink-0"
-        :aria-label="`Star ${n}`"
-        @click="selectedStar = n"
-      >
-        <i
-          :class="
-            selectedStar >= n
-              ? 'i-ri-star-fill text-n-amber-9 text-2xl'
-              : 'i-ri-star-line text-n-slate-10 text-2xl'
-          "
-        />
-      </button>
-    </div>
+    <CSATEmojiInput
+      :selected="props.selectedType === CSAT_DISPLAY_TYPES.EMOJI"
+      @update="emit('update', $event)"
+    />
+    <CSATStarInput
+      :selected="props.selectedType === CSAT_DISPLAY_TYPES.STAR"
+      @update="emit('update', $event)"
+    />
   </div>
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/components/CSATEmojiInput.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/components/CSATEmojiInput.vue
@@ -1,0 +1,43 @@
+<script setup>
+import { ref, computed } from 'vue';
+import { CSAT_RATINGS, CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
+
+const props = defineProps({
+  selected: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update']);
+
+const selectionClass = computed(() => {
+  return props.selected
+    ? 'outline-n-brand bg-n-brand/5'
+    : 'outline-n-weak bg-n-alpha-black2';
+});
+
+const emojis = CSAT_RATINGS;
+const selectedEmoji = ref(5);
+</script>
+
+<template>
+  <button
+    class="flex items-center rounded-lg transition-all duration-500 cursor-pointer outline outline-1 px-4 py-2 gap-2 min-w-56"
+    :class="selectionClass"
+    @click="emit('update', CSAT_DISPLAY_TYPES.EMOJI)"
+  >
+    <div
+      v-for="emoji in emojis"
+      :key="emoji.key"
+      class="rounded-full p-1 transition-transform duration-150 focus:outline-none flex items-center flex-shrink-0"
+    >
+      <span
+        class="text-2xl"
+        :class="selectedEmoji === emoji.value ? '' : 'grayscale opacity-60'"
+      >
+        {{ emoji.emoji }}
+      </span>
+    </div>
+  </button>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/components/CSATStarInput.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/components/CSATStarInput.vue
@@ -1,0 +1,36 @@
+<script setup>
+import { CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
+import { computed } from 'vue';
+
+const props = defineProps({
+  selected: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update']);
+
+const selectionClass = computed(() => {
+  return props.selected
+    ? 'bg-n-brand/5 outline-n-brand'
+    : 'bg-n-alpha-black2 outline-n-weak';
+});
+</script>
+
+<template>
+  <button
+    class="flex items-center rounded-lg transition-all duration-300 cursor-pointer outline outline-1 px-4 py-2 gap-2 min-w-56"
+    :class="selectionClass"
+    @click="emit('update', CSAT_DISPLAY_TYPES.STAR)"
+  >
+    <div
+      v-for="n in 5"
+      :key="'star-' + n"
+      class="rounded-full p-1 transition-transform duration-150 focus:outline-none flex items-center flex-shrink-0"
+      :aria-label="`Star ${n}`"
+    >
+      <i class="i-ri-star-fill text-n-amber-9 text-2xl" />
+    </div>
+  </button>
+</template>

--- a/app/javascript/shared/components/CustomerSatisfaction.vue
+++ b/app/javascript/shared/components/CustomerSatisfaction.vue
@@ -3,12 +3,14 @@ import { mapGetters } from 'vuex';
 import Spinner from 'shared/components/Spinner.vue';
 import { CSAT_RATINGS, CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
 import FluentIcon from 'shared/components/FluentIcon/Index.vue';
+import StarRating from 'shared/components/StarRating.vue';
 import { getContrastingTextColor } from '@chatwoot/utils';
 
 export default {
   components: {
     Spinner,
     FluentIcon,
+    StarRating,
   },
   props: {
     messageContentAttributes: {
@@ -35,8 +37,6 @@ export default {
       selectedRating: null,
       isUpdating: false,
       feedback: '',
-      starRatings: [1, 2, 3, 4, 5],
-      hoveredRating: 0,
     };
   },
   computed: {
@@ -64,21 +64,6 @@ export default {
     },
     isStarType() {
       return this.displayType === CSAT_DISPLAY_TYPES.STAR;
-    },
-    getStarClass() {
-      return value => {
-        const isStarActive =
-          (this.hoveredRating > 0 &&
-            !this.isRatingSubmitted &&
-            this.hoveredRating >= value) ||
-          this.selectedRating >= value;
-
-        const starTypeClass = isStarActive
-          ? 'i-ri-star-fill text-n-amber-9'
-          : 'i-ri-star-line text-n-slate-10';
-
-        return starTypeClass;
-      };
     },
   },
 
@@ -119,10 +104,7 @@ export default {
         this.isUpdating = false;
       }
     },
-    onHoverRating(value) {
-      if (this.isRatingSubmitted) return;
-      this.hoveredRating = value;
-    },
+
     selectRating(rating) {
       this.selectedRating = rating.value;
       this.onSubmit();
@@ -153,28 +135,12 @@ export default {
         {{ rating.emoji }}
       </button>
     </div>
-    <div
+    <StarRating
       v-else-if="isStarType"
-      class="ratings flex justify-center py-5 px-4 gap-3"
-    >
-      <button
-        v-for="value in starRatings"
-        :key="value"
-        type="button"
-        class="rounded-full p-1 transition-all duration-200 hover:enabled:scale-[1.2] focus:outline-none flex items-center flex-shrink-0"
-        :class="{ 'cursor-not-allowed opacity-50': isRatingSubmitted }"
-        :disabled="isRatingSubmitted"
-        :aria-label="'Star ' + value"
-        @click="selectStarRating(value)"
-        @mouseenter="onHoverRating(value)"
-        @mouseleave="onHoverRating(0)"
-      >
-        <span
-          :class="getStarClass(value)"
-          class="transition-all duration-500 text-2xl"
-        />
-      </button>
-    </div>
+      :selected-rating="selectedRating"
+      :is-disabled="isRatingSubmitted"
+      @select-rating="selectStarRating"
+    />
     <form
       v-if="!isFeedbackSubmitted"
       class="feedback-form flex"

--- a/app/javascript/shared/components/StarRating.vue
+++ b/app/javascript/shared/components/StarRating.vue
@@ -1,0 +1,65 @@
+<script setup>
+import { ref, defineProps, defineEmits } from 'vue';
+
+const props = defineProps({
+  selectedRating: {
+    type: Number,
+    default: null,
+  },
+  isDisabled: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['selectRating']);
+
+const starRatings = [1, 2, 3, 4, 5];
+const hoveredRating = ref(0);
+
+const onHoverRating = value => {
+  if (props.isDisabled) return;
+  hoveredRating.value = value;
+};
+
+const selectRating = value => {
+  if (props.isDisabled) return;
+  emit('selectRating', value);
+};
+
+const getStarClass = value => {
+  const isStarActive =
+    (hoveredRating.value > 0 &&
+      !props.isDisabled &&
+      hoveredRating.value >= value) ||
+    props.selectedRating >= value;
+
+  const starTypeClass = isStarActive
+    ? 'i-ri-star-fill text-n-amber-9'
+    : 'i-ri-star-line text-n-slate-10';
+
+  return starTypeClass;
+};
+</script>
+
+<template>
+  <div class="flex justify-center py-5 px-4 gap-3">
+    <button
+      v-for="value in starRatings"
+      :key="value"
+      type="button"
+      class="rounded-full p-1 transition-all duration-200 focus:enabled:scale-[1.2] focus-within:enabled:scale-[1.2] hover:enabled:scale-[1.2] focus:outline-none flex items-center flex-shrink-0"
+      :class="{ 'cursor-not-allowed opacity-50': isDisabled }"
+      :disabled="isDisabled"
+      :aria-label="'Star ' + value"
+      @click="selectRating(value)"
+      @mouseenter="onHoverRating(value)"
+      @mouseleave="onHoverRating(0)"
+    >
+      <span
+        :class="getStarClass(value)"
+        class="transition-all duration-500 text-2xl"
+      />
+    </button>
+  </div>
+</template>

--- a/app/javascript/shared/constants/messages.js
+++ b/app/javascript/shared/constants/messages.js
@@ -100,6 +100,11 @@ export const CSAT_RATINGS = [
   },
 ];
 
+export const CSAT_DISPLAY_TYPES = {
+  EMOJI: 'emoji',
+  STAR: 'star',
+};
+
 export const AUDIO_FORMATS = {
   WEBM: 'audio/webm',
   OGG: 'audio/ogg',

--- a/app/javascript/survey/App.vue
+++ b/app/javascript/survey/App.vue
@@ -10,7 +10,7 @@ export default {
 </script>
 
 <template>
-  <div id="app" class="woot-survey-wrap min-h-screen">
+  <div id="app" dir="ltr" class="woot-survey-wrap min-h-screen">
     <Response />
   </div>
 </template>

--- a/app/javascript/survey/assets/scss/woot.scss
+++ b/app/javascript/survey/assets/scss/woot.scss
@@ -3,6 +3,7 @@
 @import 'tailwindcss/utilities';
 @import 'widget/assets/scss/reset';
 @import 'shared/assets/fonts/widget_fonts';
+@import 'dashboard/assets/scss/next-colors';
 
 html,
 body {

--- a/app/javascript/survey/components/Banner.vue
+++ b/app/javascript/survey/components/Banner.vue
@@ -24,7 +24,7 @@ export default {
       class="ion-checkmark-circled text-3xl text-green-500 mr-1"
     />
     <i v-if="showError" class="ion-android-alert text-3xl text-red-600 mr-1" />
-    <label class="text-base font-medium text-black-800 mt-4 mb-4">
+    <label class="text-base font-medium text-n-slate-12 mt-4 mb-4">
       {{ message }}
     </label>
   </div>

--- a/app/javascript/survey/components/Feedback.vue
+++ b/app/javascript/survey/components/Feedback.vue
@@ -32,7 +32,7 @@ export default {
 
 <template>
   <div class="mt-6">
-    <label class="text-base font-medium text-black-800">
+    <label class="text-base font-medium text-n-slate-12">
       {{ $t('SURVEY.FEEDBACK.LABEL') }}
     </label>
     <TextArea

--- a/app/javascript/widget/components/AgentMessageBubble.vue
+++ b/app/javascript/widget/components/AgentMessageBubble.vue
@@ -144,6 +144,8 @@ export default {
     <CustomerSatisfaction
       v-if="isCSAT"
       :message-content-attributes="messageContentAttributes.submitted_values"
+      :display-type="messageContentAttributes.display_type"
+      :message="message"
       :message-id="messageId"
     />
   </div>

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -9,6 +9,7 @@
 #  auto_assignment_config        :jsonb
 #  business_name                 :string
 #  channel_type                  :string
+#  csat_config                   :jsonb            not null
 #  csat_survey_enabled           :boolean          default(FALSE)
 #  email_address                 :string
 #  enable_auto_assignment        :boolean          default(TRUE)

--- a/app/services/message_templates/template/csat_survey.rb
+++ b/app/services/message_templates/template/csat_survey.rb
@@ -11,60 +11,46 @@ class MessageTemplates::Template::CsatSurvey
 
   private
 
-  delegate :contact, :account, to: :conversation
+  delegate :contact, :account, :inbox, to: :conversation
+  delegate :csat_config, to: :inbox
 
   def should_send_csat_survey?
-    # Return true if no survey rules are configured
     return true unless survey_rules_configured?
 
-    # Get the conversation labels
-    labels = conversation_labels
+    labels = conversation.label_list
 
-    # Apply the rule based on the operator
+    return true if rule_values.empty?
+
     case rule_operator
     when 'contains'
-      # Check if any configured label exists in the conversation's labels
       rule_values.any? { |label| labels.include?(label) }
     when 'does_not_contain'
-      # Check that none of the configured labels exist in the conversation's labels
       rule_values.none? { |label| labels.include?(label) }
     else
       true
     end
   end
 
-  def conversation_labels
-    # Use cached_label_list if available, otherwise fall back to other methods
-    return conversation.cached_label_list.split(', ') if conversation.cached_label_list.present?
-
-    []
-  end
-
   def survey_rules_configured?
-    return false if inbox.csat_config.blank?
-    return false if inbox.csat_config['survey_rules'].blank?
-    return false unless inbox.csat_config['survey_rules']['values'].is_a?(Array)
-    return false if inbox.csat_config['survey_rules']['values'].empty?
+    return false if csat_config.blank?
+    return false if csat_config['survey_rules'].blank?
+    return false if rule_values.empty?
 
     true
   end
 
   def rule_operator
-    inbox.csat_config.dig('survey_rules', 'operator') || 'contains'
+    csat_config.dig('survey_rules', 'operator') || 'contains'
   end
 
   def rule_values
-    inbox.csat_config.dig('survey_rules', 'values') || []
+    csat_config.dig('survey_rules', 'values') || []
   end
 
-  def inbox
-    @inbox ||= conversation.inbox
-  end
+  def message_content
+    return I18n.t('conversations.templates.csat_input_message_body') if csat_config.blank? || csat_config['message'].blank?
 
-  def custom_message
-    return I18n.t('conversations.templates.csat_input_message_body') if inbox.csat_config.blank? || inbox.csat_config['message'].blank?
-
-    inbox.csat_config['message']
+    csat_config['message']
   end
 
   def csat_survey_message_params
@@ -73,17 +59,18 @@ class MessageTemplates::Template::CsatSurvey
       inbox_id: @conversation.inbox_id,
       message_type: :template,
       content_type: :input_csat,
-      content: custom_message,
-      content_attributes: build_content_attributes
+      content: message_content,
+      content_attributes: content_attributes
     }
   end
 
-  def build_content_attributes
-    attributes = {}
+  def csat_config
+    inbox.csat_config || {}
+  end
 
-    # Add display_type if present in the configuration
-    attributes[:display_type] = inbox.csat_config['display_type'] if inbox.csat_config.present? && inbox.csat_config['display_type'].present?
-
-    attributes
+  def content_attributes
+    {
+      display_type: csat_config['display_type'] || 'emoji'
+    }
   end
 end

--- a/app/services/message_templates/template/csat_survey.rb
+++ b/app/services/message_templates/template/csat_survey.rb
@@ -2,6 +2,8 @@ class MessageTemplates::Template::CsatSurvey
   pattr_initialize [:conversation!]
 
   def perform
+    return unless should_send_csat_survey?
+
     ActiveRecord::Base.transaction do
       conversation.messages.create!(csat_survey_message_params)
     end
@@ -10,7 +12,64 @@ class MessageTemplates::Template::CsatSurvey
   private
 
   delegate :contact, :account, to: :conversation
-  delegate :inbox, to: :message
+
+  def should_send_csat_survey?
+    # Return true if no survey rules are configured
+    return true unless survey_rules_configured?
+
+    # Get the conversation labels
+    labels = conversation_labels
+
+    # Apply the rule based on the operator
+    case rule_operator
+    when 'contains'
+      # Check if any configured label exists in the conversation's labels
+      rule_values.any? { |label| labels.include?(label) }
+    when 'does_not_contain'
+      # Check that none of the configured labels exist in the conversation's labels
+      rule_values.none? { |label| labels.include?(label) }
+    else
+      true
+    end
+  end
+
+  def conversation_labels
+    # Use cached_label_list if available, otherwise fall back to other methods
+    return conversation.cached_label_list.split(', ') if conversation.cached_label_list.present?
+
+    # Fallback methods if needed
+    return conversation.label_list if conversation.respond_to?(:label_list) && conversation.label_list.present?
+
+    # If all else fails, return an empty array
+    []
+  end
+
+  def survey_rules_configured?
+    return false if inbox.csat_config.blank?
+    return false if inbox.csat_config['survey_rules'].blank?
+    return false unless inbox.csat_config['survey_rules']['values'].is_a?(Array)
+    return false if inbox.csat_config['survey_rules']['values'].empty?
+
+    true
+  end
+
+  def rule_operator
+    inbox.csat_config.dig('survey_rules', 'operator') || 'contains'
+  end
+
+  def rule_values
+    inbox.csat_config.dig('survey_rules', 'values') || []
+  end
+
+  def inbox
+    @inbox ||= conversation.inbox
+  end
+
+  def custom_message
+    return I18n.t('conversations.templates.csat_input_message_body') if inbox.csat_config.blank? || inbox.csat_config['message'].blank?
+
+    inbox.csat_config['message']
+  end
 
   def csat_survey_message_params
     {
@@ -18,7 +77,17 @@ class MessageTemplates::Template::CsatSurvey
       inbox_id: @conversation.inbox_id,
       message_type: :template,
       content_type: :input_csat,
-      content: I18n.t('conversations.templates.csat_input_message_body')
+      content: custom_message,
+      content_attributes: build_content_attributes
     }
+  end
+
+  def build_content_attributes
+    attributes = {}
+
+    # Add display_type if present in the configuration
+    attributes[:display_type] = inbox.csat_config['display_type'] if inbox.csat_config.present? && inbox.csat_config['display_type'].present?
+
+    attributes
   end
 end

--- a/app/services/message_templates/template/csat_survey.rb
+++ b/app/services/message_templates/template/csat_survey.rb
@@ -37,10 +37,6 @@ class MessageTemplates::Template::CsatSurvey
     # Use cached_label_list if available, otherwise fall back to other methods
     return conversation.cached_label_list.split(', ') if conversation.cached_label_list.present?
 
-    # Fallback methods if needed
-    return conversation.label_list if conversation.respond_to?(:label_list) && conversation.label_list.present?
-
-    # If all else fails, return an empty array
     []
   end
 

--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -8,6 +8,7 @@ json.greeting_message resource.greeting_message
 json.working_hours_enabled resource.working_hours_enabled
 json.enable_email_collect resource.enable_email_collect
 json.csat_survey_enabled resource.csat_survey_enabled
+json.csat_config resource.csat_config
 json.enable_auto_assignment resource.enable_auto_assignment
 json.auto_assignment_config resource.auto_assignment_config
 json.out_of_office_message resource.out_of_office_message

--- a/app/views/public/api/v1/models/_csat_survey.json.jbuilder
+++ b/app/views/public/api/v1/models/_csat_survey.json.jbuilder
@@ -1,5 +1,7 @@
 json.id resource.id
 json.csat_survey_response resource.csat_survey_response
+json.display_type resource.inbox.csat_config.try(:[], 'display_type') || 'emoji'
+json.content resource.inbox.csat_config.try(:[], 'message')
 json.inbox_avatar_url resource.inbox.avatar_url
 json.inbox_name resource.inbox.name
 json.locale resource.account.locale

--- a/db/migrate/20250514045638_add_csat_config_to_inboxes.rb
+++ b/db/migrate/20250514045638_add_csat_config_to_inboxes.rb
@@ -1,9 +1,5 @@
 class AddCsatConfigToInboxes < ActiveRecord::Migration[7.0]
   def change
-    add_column :inboxes, :csat_config, :jsonb, default: {
-      display_type: 'emoji',
-      message: '',
-      survey_rules: {}
-    }, null: false
+    add_column :inboxes, :csat_config, :jsonb, default: {}, null: false
   end
 end

--- a/db/migrate/20250514045638_add_csat_config_to_inboxes.rb
+++ b/db/migrate/20250514045638_add_csat_config_to_inboxes.rb
@@ -1,0 +1,9 @@
+class AddCsatConfigToInboxes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :inboxes, :csat_config, :jsonb, default: {
+      display_type: 'emoji',
+      message: '',
+      survey_rules: {}
+    }, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema[7.0].define(version: 2025_05_14_045638) do
   # These extensions should be enabled to support this database
-enable_extension "pg_stat_statements"
+  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -573,6 +573,31 @@ enable_extension "pg_stat_statements"
     t.index ["team_id"], name: "index_conversations_on_team_id"
     t.index ["uuid"], name: "index_conversations_on_uuid", unique: true
     t.index ["waiting_since"], name: "index_conversations_on_waiting_since"
+  end
+
+  create_table "copilot_messages", force: :cascade do |t|
+    t.bigint "copilot_thread_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "account_id", null: false
+    t.string "message_type", null: false
+    t.jsonb "message", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_copilot_messages_on_account_id"
+    t.index ["copilot_thread_id"], name: "index_copilot_messages_on_copilot_thread_id"
+    t.index ["user_id"], name: "index_copilot_messages_on_user_id"
+  end
+
+  create_table "copilot_threads", force: :cascade do |t|
+    t.string "title", null: false
+    t.bigint "user_id", null: false
+    t.bigint "account_id", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_copilot_threads_on_account_id"
+    t.index ["user_id"], name: "index_copilot_threads_on_user_id"
+    t.index ["uuid"], name: "index_copilot_threads_on_uuid", unique: true
   end
 
   create_table "csat_survey_responses", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_21_085134) do
+ActiveRecord::Schema[7.0].define(version: 2025_05_14_045638) do
   # These extensions should be enabled to support this database
-  enable_extension "pg_stat_statements"
+enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -704,6 +704,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_04_21_085134) do
     t.bigint "portal_id"
     t.integer "sender_name_type", default: 0, null: false
     t.string "business_name"
+    t.jsonb "csat_config", default: {"message"=>"", "display_type"=>"emoji", "survey_rules"=>{}}, null: false
     t.index ["account_id"], name: "index_inboxes_on_account_id"
     t.index ["channel_id", "channel_type"], name: "index_inboxes_on_channel_id_and_channel_type"
     t.index ["portal_id"], name: "index_inboxes_on_portal_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -704,7 +704,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_14_045638) do
     t.bigint "portal_id"
     t.integer "sender_name_type", default: 0, null: false
     t.string "business_name"
-    t.jsonb "csat_config", default: {"message"=>"", "display_type"=>"emoji", "survey_rules"=>{}}, null: false
+    t.jsonb "csat_config", default: {}, null: false
     t.index ["account_id"], name: "index_inboxes_on_account_id"
     t.index ["channel_id", "channel_type"], name: "index_inboxes_on_channel_id_and_channel_type"
     t.index ["portal_id"], name: "index_inboxes_on_portal_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -575,31 +575,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_14_045638) do
     t.index ["waiting_since"], name: "index_conversations_on_waiting_since"
   end
 
-  create_table "copilot_messages", force: :cascade do |t|
-    t.bigint "copilot_thread_id", null: false
-    t.bigint "user_id", null: false
-    t.bigint "account_id", null: false
-    t.string "message_type", null: false
-    t.jsonb "message", default: {}, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["account_id"], name: "index_copilot_messages_on_account_id"
-    t.index ["copilot_thread_id"], name: "index_copilot_messages_on_copilot_thread_id"
-    t.index ["user_id"], name: "index_copilot_messages_on_user_id"
-  end
-
-  create_table "copilot_threads", force: :cascade do |t|
-    t.string "title", null: false
-    t.bigint "user_id", null: false
-    t.bigint "account_id", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["account_id"], name: "index_copilot_threads_on_account_id"
-    t.index ["user_id"], name: "index_copilot_threads_on_user_id"
-    t.index ["uuid"], name: "index_copilot_threads_on_uuid", unique: true
-  end
-
   create_table "csat_survey_responses", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.bigint "conversation_id", null: false

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -723,11 +723,11 @@ RSpec.describe 'Inboxes API', type: :request do
       let(:inbox) { create(:inbox, account: account) }
       let(:csat_config) do
         {
-          display_type: 'emoji',
-          message: 'How would you rate your experience?',
-          survey_rules: {
-            operator: 'contains',
-            values: %w[support help]
+          'display_type' => 'emoji',
+          'message' => 'How would you rate your experience?',
+          'survey_rules' => {
+            'operator' => 'contains',
+            'values' => %w[support help]
           }
         }
       end
@@ -736,7 +736,7 @@ RSpec.describe 'Inboxes API', type: :request do
         patch "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}",
               params: {
                 csat_survey_enabled: true,
-                csat_config: csat_config.to_json
+                csat_config: csat_config
               },
               headers: admin.create_new_auth_token,
               as: :json
@@ -749,7 +749,7 @@ RSpec.describe 'Inboxes API', type: :request do
           patch "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}",
                 params: {
                   csat_survey_enabled: true,
-                  csat_config: csat_config.to_json
+                  csat_config: csat_config
                 },
                 headers: admin.create_new_auth_token,
                 as: :json

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -717,6 +717,94 @@ RSpec.describe 'Inboxes API', type: :request do
         expect(email_channel.reload.smtp_authentication).to eq('plain')
       end
     end
+
+    context 'when handling CSAT configuration' do
+      let(:admin) { create(:user, account: account, role: :administrator) }
+      let(:inbox) { create(:inbox, account: account) }
+      let(:csat_config) do
+        {
+          display_type: 'emoji',
+          message: 'How would you rate your experience?',
+          survey_rules: {
+            operator: 'contains',
+            values: %w[support help]
+          }
+        }
+      end
+
+      it 'successfully updates the inbox with CSAT configuration' do
+        patch "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}",
+              params: {
+                csat_survey_enabled: true,
+                csat_config: csat_config.to_json
+              },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+      end
+
+      context 'when CSAT is configured' do
+        before do
+          patch "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}",
+                params: {
+                  csat_survey_enabled: true,
+                  csat_config: csat_config.to_json
+                },
+                headers: admin.create_new_auth_token,
+                as: :json
+        end
+
+        it 'returns configured CSAT settings in inbox details' do
+          get "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}",
+              headers: admin.create_new_auth_token,
+              as: :json
+
+          expect(response).to have_http_status(:success)
+          json_response = response.parsed_body
+          expect(json_response['csat_survey_enabled']).to be true
+
+          saved_config = json_response['csat_config']
+          expect(saved_config).to be_present
+          expect(saved_config['display_type']).to eq('emoji')
+        end
+
+        it 'returns configured CSAT message' do
+          get "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}",
+              headers: admin.create_new_auth_token,
+              as: :json
+
+          json_response = response.parsed_body
+          saved_config = json_response['csat_config']
+          expect(saved_config['message']).to eq('How would you rate your experience?')
+        end
+
+        it 'returns configured CSAT survey rules' do
+          get "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}",
+              headers: admin.create_new_auth_token,
+              as: :json
+
+          json_response = response.parsed_body
+          saved_config = json_response['csat_config']
+          expect(saved_config['survey_rules']['operator']).to eq('contains')
+          expect(saved_config['survey_rules']['values']).to match_array(%w[support help])
+        end
+
+        it 'includes CSAT configuration in inbox list' do
+          get "/api/v1/accounts/#{account.id}/inboxes",
+              headers: admin.create_new_auth_token,
+              as: :json
+
+          expect(response).to have_http_status(:success)
+          inbox_list = response.parsed_body
+          found_inbox = inbox_list['payload'].find { |i| i['id'] == inbox.id }
+
+          expect(found_inbox['csat_survey_enabled']).to be true
+          expect(found_inbox['csat_config']).to be_present
+          expect(found_inbox['csat_config']['display_type']).to eq('emoji')
+        end
+      end
+    end
   end
 
   describe 'GET /api/v1/accounts/{account.id}/inboxes/{inbox.id}/agent_bot' do

--- a/spec/services/message_templates/template/csat_survey_spec.rb
+++ b/spec/services/message_templates/template/csat_survey_spec.rb
@@ -1,13 +1,247 @@
 require 'rails_helper'
 
 describe MessageTemplates::Template::CsatSurvey do
-  context 'when this hook is called' do
-    let(:conversation) { create(:conversation) }
+  let(:account) { create(:account) }
+  let(:inbox) { create(:inbox, account: account) }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox) }
+  let(:service) { described_class.new(conversation: conversation) }
 
-    it 'creates the out of office messages' do
-      described_class.new(conversation: conversation).perform
-      expect(conversation.messages.template.count).to eq(1)
-      expect(conversation.messages.template.first.content_type).to eq('input_csat')
+  describe '#perform' do
+    context 'when no survey rules are configured' do
+      it 'creates a CSAT survey message' do
+        service.perform
+
+        expect(conversation.messages.template.count).to eq(1)
+        expect(conversation.messages.template.first.content_type).to eq('input_csat')
+      end
+    end
+  end
+
+  describe '#perform with contains operator' do
+    let(:csat_config) do
+      {
+        'display_type' => 'emoji',
+        'message' => 'Please rate your experience',
+        'survey_rules' => {
+          'operator' => 'contains',
+          'values' => %w[support help]
+        }
+      }
+    end
+
+    before do
+      inbox.update(csat_config: csat_config)
+    end
+
+    context 'when conversation has matching labels' do
+      before do
+        allow(conversation).to receive(:cached_label_list).and_return('support, urgent')
+      end
+
+      it 'creates a CSAT survey message' do
+        service.perform
+
+        expect(conversation.messages.template.count).to eq(1)
+        message = conversation.messages.template.first
+        expect(message.content_type).to eq('input_csat')
+        expect(message.content).to eq('Please rate your experience')
+        expect(message.content_attributes['display_type']).to eq('emoji')
+      end
+    end
+
+    context 'when conversation has no matching labels' do
+      before do
+        allow(conversation).to receive(:cached_label_list).and_return('billing, payment')
+      end
+
+      it 'does not create a CSAT survey message' do
+        service.perform
+
+        expect(conversation.messages.template.count).to eq(0)
+      end
+    end
+  end
+
+  describe '#perform with does_not_contain operator' do
+    let(:csat_config) do
+      {
+        'display_type' => 'emoji',
+        'message' => 'Please rate your experience',
+        'survey_rules' => {
+          'operator' => 'does_not_contain',
+          'values' => %w[support help]
+        }
+      }
+    end
+
+    before do
+      inbox.update(csat_config: csat_config)
+    end
+
+    context 'when conversation does not have matching labels' do
+      before do
+        allow(conversation).to receive(:cached_label_list).and_return('billing, payment')
+      end
+
+      it 'creates a CSAT survey message' do
+        service.perform
+
+        expect(conversation.messages.template.count).to eq(1)
+        expect(conversation.messages.template.first.content_type).to eq('input_csat')
+      end
+    end
+
+    context 'when conversation has matching labels' do
+      before do
+        allow(conversation).to receive(:cached_label_list).and_return('support, urgent')
+      end
+
+      it 'does not create a CSAT survey message' do
+        service.perform
+
+        expect(conversation.messages.template.count).to eq(0)
+      end
+    end
+  end
+
+  describe '#conversation_labels' do
+    context 'when cached_label_list is present' do
+      before do
+        allow(conversation).to receive(:cached_label_list).and_return('support, help, urgent')
+      end
+
+      it 'returns the cached label list as an array' do
+        expect(service.send(:conversation_labels)).to eq(%w[support help urgent])
+      end
+    end
+
+    context 'when cached_label_list is not present' do
+      before do
+        allow(conversation).to receive(:cached_label_list).and_return(nil)
+      end
+
+      it 'returns an empty array' do
+        expect(service.send(:conversation_labels)).to eq([])
+      end
+    end
+
+    context 'when cached_label_list is empty' do
+      before do
+        allow(conversation).to receive(:cached_label_list).and_return('')
+      end
+
+      it 'returns an empty array' do
+        expect(service.send(:conversation_labels)).to eq([])
+      end
+    end
+  end
+
+  describe '#survey_rules_configured?' do
+    context 'when inbox has no csat_config' do
+      before do
+        allow(inbox).to receive(:csat_config).and_return(nil)
+      end
+
+      it 'returns false' do
+        expect(service.send(:survey_rules_configured?)).to be_falsey
+      end
+    end
+
+    context 'when inbox has no survey_rules' do
+      before do
+        allow(inbox).to receive(:csat_config).and_return({ 'display_type' => 'emoji' })
+      end
+
+      it 'returns false' do
+        expect(service.send(:survey_rules_configured?)).to be_falsey
+      end
+    end
+
+    context 'when survey_rules values is not an array' do
+      before do
+        allow(inbox).to receive(:csat_config).and_return({
+                                                           'survey_rules' => { 'operator' => 'contains', 'values' => 'support' }
+                                                         })
+      end
+
+      it 'returns false' do
+        expect(service.send(:survey_rules_configured?)).to be_falsey
+      end
+    end
+
+    context 'when survey_rules values is an empty array' do
+      before do
+        allow(inbox).to receive(:csat_config).and_return({
+                                                           'survey_rules' => { 'operator' => 'contains', 'values' => [] }
+                                                         })
+      end
+
+      it 'returns false' do
+        expect(service.send(:survey_rules_configured?)).to be_falsey
+      end
+    end
+
+    context 'when survey_rules are properly configured' do
+      before do
+        allow(inbox).to receive(:csat_config).and_return({
+                                                           'survey_rules' => { 'operator' => 'contains', 'values' => %w[support help] }
+                                                         })
+      end
+
+      it 'returns true' do
+        expect(service.send(:survey_rules_configured?)).to be_truthy
+      end
+    end
+  end
+
+  describe '#build_content_attributes' do
+    context 'when display_type is configured' do
+      before do
+        allow(inbox).to receive(:csat_config).and_return({
+                                                           'display_type' => 'star'
+                                                         })
+      end
+
+      it 'includes display_type in content attributes' do
+        attributes = service.send(:build_content_attributes)
+        expect(attributes[:display_type]).to eq('star')
+      end
+    end
+
+    context 'when display_type is not configured' do
+      before do
+        allow(inbox).to receive(:csat_config).and_return({})
+      end
+
+      it 'returns an empty hash' do
+        attributes = service.send(:build_content_attributes)
+        expect(attributes).to eq({})
+      end
+    end
+  end
+
+  describe '#custom_message' do
+    context 'when inbox has a custom message configured' do
+      before do
+        allow(inbox).to receive(:csat_config).and_return({
+                                                           'message' => 'How would you rate your support experience?'
+                                                         })
+      end
+
+      it 'returns the custom message' do
+        expect(service.send(:custom_message)).to eq('How would you rate your support experience?')
+      end
+    end
+
+    context 'when inbox has no custom message' do
+      before do
+        allow(inbox).to receive(:csat_config).and_return({})
+        allow(I18n).to receive(:t).with('conversations.templates.csat_input_message_body').and_return('Default message')
+      end
+
+      it 'returns the default message from I18n' do
+        expect(service.send(:custom_message)).to eq('Default message')
+      end
     end
   end
 end

--- a/spec/services/message_templates/template/csat_survey_spec.rb
+++ b/spec/services/message_templates/template/csat_survey_spec.rb
@@ -9,6 +9,8 @@ describe MessageTemplates::Template::CsatSurvey do
   describe '#perform' do
     context 'when no survey rules are configured' do
       it 'creates a CSAT survey message' do
+        inbox.update(csat_config: {})
+
         service.perform
 
         expect(conversation.messages.template.count).to eq(1)
@@ -34,11 +36,9 @@ describe MessageTemplates::Template::CsatSurvey do
     end
 
     context 'when conversation has matching labels' do
-      before do
-        allow(conversation).to receive(:cached_label_list).and_return('support, urgent')
-      end
-
       it 'creates a CSAT survey message' do
+        conversation.update(label_list: %w[support urgent])
+
         service.perform
 
         expect(conversation.messages.template.count).to eq(1)
@@ -50,11 +50,9 @@ describe MessageTemplates::Template::CsatSurvey do
     end
 
     context 'when conversation has no matching labels' do
-      before do
-        allow(conversation).to receive(:cached_label_list).and_return('billing, payment')
-      end
-
       it 'does not create a CSAT survey message' do
+        conversation.update(label_list: %w[billing-support payment])
+
         service.perform
 
         expect(conversation.messages.template.count).to eq(0)
@@ -79,11 +77,9 @@ describe MessageTemplates::Template::CsatSurvey do
     end
 
     context 'when conversation does not have matching labels' do
-      before do
-        allow(conversation).to receive(:cached_label_list).and_return('billing, payment')
-      end
-
       it 'creates a CSAT survey message' do
+        conversation.update(label_list: %w[billing payment])
+
         service.perform
 
         expect(conversation.messages.template.count).to eq(1)
@@ -92,155 +88,12 @@ describe MessageTemplates::Template::CsatSurvey do
     end
 
     context 'when conversation has matching labels' do
-      before do
-        allow(conversation).to receive(:cached_label_list).and_return('support, urgent')
-      end
-
       it 'does not create a CSAT survey message' do
+        conversation.update(label_list: %w[support urgent])
+
         service.perform
 
         expect(conversation.messages.template.count).to eq(0)
-      end
-    end
-  end
-
-  describe '#conversation_labels' do
-    context 'when cached_label_list is present' do
-      before do
-        allow(conversation).to receive(:cached_label_list).and_return('support, help, urgent')
-      end
-
-      it 'returns the cached label list as an array' do
-        expect(service.send(:conversation_labels)).to eq(%w[support help urgent])
-      end
-    end
-
-    context 'when cached_label_list is not present' do
-      before do
-        allow(conversation).to receive(:cached_label_list).and_return(nil)
-      end
-
-      it 'returns an empty array' do
-        expect(service.send(:conversation_labels)).to eq([])
-      end
-    end
-
-    context 'when cached_label_list is empty' do
-      before do
-        allow(conversation).to receive(:cached_label_list).and_return('')
-      end
-
-      it 'returns an empty array' do
-        expect(service.send(:conversation_labels)).to eq([])
-      end
-    end
-  end
-
-  describe '#survey_rules_configured?' do
-    context 'when inbox has no csat_config' do
-      before do
-        allow(inbox).to receive(:csat_config).and_return(nil)
-      end
-
-      it 'returns false' do
-        expect(service.send(:survey_rules_configured?)).to be_falsey
-      end
-    end
-
-    context 'when inbox has no survey_rules' do
-      before do
-        allow(inbox).to receive(:csat_config).and_return({ 'display_type' => 'emoji' })
-      end
-
-      it 'returns false' do
-        expect(service.send(:survey_rules_configured?)).to be_falsey
-      end
-    end
-
-    context 'when survey_rules values is not an array' do
-      before do
-        allow(inbox).to receive(:csat_config).and_return({
-                                                           'survey_rules' => { 'operator' => 'contains', 'values' => 'support' }
-                                                         })
-      end
-
-      it 'returns false' do
-        expect(service.send(:survey_rules_configured?)).to be_falsey
-      end
-    end
-
-    context 'when survey_rules values is an empty array' do
-      before do
-        allow(inbox).to receive(:csat_config).and_return({
-                                                           'survey_rules' => { 'operator' => 'contains', 'values' => [] }
-                                                         })
-      end
-
-      it 'returns false' do
-        expect(service.send(:survey_rules_configured?)).to be_falsey
-      end
-    end
-
-    context 'when survey_rules are properly configured' do
-      before do
-        allow(inbox).to receive(:csat_config).and_return({
-                                                           'survey_rules' => { 'operator' => 'contains', 'values' => %w[support help] }
-                                                         })
-      end
-
-      it 'returns true' do
-        expect(service.send(:survey_rules_configured?)).to be_truthy
-      end
-    end
-  end
-
-  describe '#build_content_attributes' do
-    context 'when display_type is configured' do
-      before do
-        allow(inbox).to receive(:csat_config).and_return({
-                                                           'display_type' => 'star'
-                                                         })
-      end
-
-      it 'includes display_type in content attributes' do
-        attributes = service.send(:build_content_attributes)
-        expect(attributes[:display_type]).to eq('star')
-      end
-    end
-
-    context 'when display_type is not configured' do
-      before do
-        allow(inbox).to receive(:csat_config).and_return({})
-      end
-
-      it 'returns an empty hash' do
-        attributes = service.send(:build_content_attributes)
-        expect(attributes).to eq({})
-      end
-    end
-  end
-
-  describe '#custom_message' do
-    context 'when inbox has a custom message configured' do
-      before do
-        allow(inbox).to receive(:csat_config).and_return({
-                                                           'message' => 'How would you rate your support experience?'
-                                                         })
-      end
-
-      it 'returns the custom message' do
-        expect(service.send(:custom_message)).to eq('How would you rate your support experience?')
-      end
-    end
-
-    context 'when inbox has no custom message' do
-      before do
-        allow(inbox).to receive(:csat_config).and_return({})
-        allow(I18n).to receive(:t).with('conversations.templates.csat_input_message_body').and_return('Default message')
-      end
-
-      it 'returns the default message from I18n' do
-        expect(service.send(:custom_message)).to eq('Default message')
       end
     end
   end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR introduces basic customization options for the CSAT survey:

* **Display Type**: Option to use star ratings instead of emojis.
* **Message Text**: Customize the survey message (up to 200 characters).
* **Survey Rules**: Send surveys based on labels — trigger when a conversation has or doesn't have a specific label.

Fixes https://linear.app/chatwoot/document/improve-csat-responses-a61cf30e054e

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Loom videos

**Website Channel (Widget)**
https://www.loom.com/share/7f47836cde7940ae9d17b7997d060a18?sid=aad2ad0a-140a-4a09-8829-e01fa2e102c5

**Email Channel (Survey link)**
https://www.loom.com/share/e92f4c4c0f73417ba300a25885e093ce?sid=4bb006f0-1c2a-4352-a232-8bf684e3d757

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
