### PR TITLE
fix: Accidental contact creation on country dropdown toggle

### DIFF
--- a/app/javascript/dashboard/components-next/dropdown-menu/DropdownMenu.vue
+++ b/app/javascript/dashboard/components-next/dropdown-menu/DropdownMenu.vue
@@ -81,6 +81,7 @@ onMounted(() => {
     <button
       v-for="(item, index) in filteredMenuItems"
       :key="index"
+      type="button"
       class="inline-flex items-center justify-start w-full h-8 min-w-0 gap-2 px-2 py-1.5 transition-all duration-200 ease-in-out border-0 rounded-lg z-60 hover:bg-n-alpha-1 dark:hover:bg-n-alpha-2 disabled:cursor-not-allowed disabled:pointer-events-none disabled:opacity-50"
       :class="{
         'bg-n-alpha-1 dark:bg-n-solid-active': item.isSelected,

--- a/app/javascript/dashboard/components-next/phonenumberinput/PhoneNumberInput.vue
+++ b/app/javascript/dashboard/components-next/phonenumberinput/PhoneNumberInput.vue
@@ -185,6 +185,7 @@ watch(
               "
               trailing-icon
               :disabled="disabled"
+              type="button"
               class="!h-[1.875rem] top-1 ltr:ml-px rtl:mr-px !px-2 outline-0 !outline-none !rounded-lg border-0 ltr:!rounded-r-none rtl:!rounded-l-none"
               @click="toggleCountryDropdown"
             >


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where toggling the country dropdown unintentionally triggered form submission, resulting in a false contact creation success message.

**Cause:**
The toggle button was missing type="button", so it defaulted to type="submit" inside a form.

**Solution:**
Explicitly set the dropdown toggle button’s type to "button" to prevent accidental form submission.

Fixes https://github.com/orgs/chatwoot/discussions/11326#discussioncomment-12950015

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video

**Before**
https://www.loom.com/share/e554fdd7fa144beda18003ac2ee9dfbb?sid=8e753e2c-10cf-41c6-bac6-a5b65b885db6

**After**
https://www.loom.com/share/16560d22238240fea526cb9c4b14b8b4?sid=fa601780-9b06-4fbb-b1e4-907b7d584328

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
