### PR TITLE
fix: Category icon update not working when editing

### DIFF
--- a/app/javascript/dashboard/components-next/HelpCenter/Pages/CategoryPage/CategoryForm.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/Pages/CategoryPage/CategoryForm.vue
@@ -200,6 +200,7 @@ defineExpose({ state, isSubmitDisabled });
                 :label="state.icon"
                 color="slate"
                 size="sm"
+                type="button"
                 :icon="!state.icon ? 'i-lucide-smile-plus' : ''"
                 class="!h-[2.4rem] !w-[2.375rem] absolute top-[1.94rem] !outline-none !rounded-[0.438rem] border-0 ltr:left-px rtl:right-px ltr:!rounded-r-none rtl:!rounded-l-none"
                 @click="isEmojiPickerOpen = !isEmojiPickerOpen"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where updating the icon for a category didn’t work while editing. This happened because the edit dialog is wrapped in a form, and the icon button (missing `type="button"`) triggered a form submission instead of opening the icon picker.

**Solution:**
Set the icon button’s `type` to `"button"` to prevent unintended form submission.

Fixes https://linear.app/chatwoot/issue/CW-4350/updating-an-icon-for-the-category-is-not-working

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
