### PR TITLE
fix: CSAT select label dropdown overflow issue

### DIFF
--- a/app/javascript/dashboard/components-next/filter/inputs/FilterSelect.vue
+++ b/app/javascript/dashboard/components-next/filter/inputs/FilterSelect.vue
@@ -38,8 +38,11 @@ const selected = defineModel({
 });
 
 const triggerRef = ref(null);
+const dropdownRef = ref(null);
+
 const { top } = useElementBounding(triggerRef);
 const { height } = useWindowSize();
+const { height: dropdownHeight } = useElementBounding(dropdownRef);
 
 const selectedOption = computed(() => {
   return props.options.find(o => o.value === selected.value) || {};
@@ -50,15 +53,19 @@ const iconToRender = computed(() => {
   return selectedOption.value.icon || 'i-lucide-chevron-down';
 });
 
+const dropdownPosition = computed(() => {
+  const DROPDOWN_MAX_HEIGHT = 340;
+  // Get actual height if available or use default
+  const menuHeight = dropdownHeight.value
+    ? dropdownHeight.value + 20
+    : DROPDOWN_MAX_HEIGHT;
+  const spaceBelow = height.value - top.value;
+  return spaceBelow < menuHeight ? 'bottom-0' : 'top-0';
+});
+
 const updateSelected = newValue => {
   selected.value = newValue;
 };
-
-const dropdownPosition = computed(() => {
-  const DROPDOWN_HEIGHT = 340;
-  const spaceBelow = height.value - top.value;
-  return spaceBelow < DROPDOWN_HEIGHT ? 'bottom-0' : 'top-0';
-});
 </script>
 
 <template>
@@ -77,7 +84,12 @@ const dropdownPosition = computed(() => {
         />
       </slot>
     </template>
-    <DropdownBody class="min-w-48 z-50" :class="dropdownPosition" strong>
+    <DropdownBody
+      ref="dropdownRef"
+      class="min-w-48 z-50"
+      :class="dropdownPosition"
+      strong
+    >
       <DropdownSection class="max-h-80 overflow-scroll">
         <DropdownItem
           v-for="option in options"

--- a/app/javascript/dashboard/components-next/filter/inputs/FilterSelect.vue
+++ b/app/javascript/dashboard/components-next/filter/inputs/FilterSelect.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+import { useElementBounding, useWindowSize } from '@vueuse/core';
 import DropdownContainer from 'next/dropdown-menu/base/DropdownContainer.vue';
 import DropdownSection from 'next/dropdown-menu/base/DropdownSection.vue';
 import DropdownBody from 'next/dropdown-menu/base/DropdownBody.vue';
@@ -36,6 +37,10 @@ const selected = defineModel({
   required: true,
 });
 
+const triggerRef = ref(null);
+const { top } = useElementBounding(triggerRef);
+const { height } = useWindowSize();
+
 const selectedOption = computed(() => {
   return props.options.find(o => o.value === selected.value) || {};
 });
@@ -48,6 +53,12 @@ const iconToRender = computed(() => {
 const updateSelected = newValue => {
   selected.value = newValue;
 };
+
+const dropdownPosition = computed(() => {
+  const DROPDOWN_HEIGHT = 340;
+  const spaceBelow = height.value - top.value;
+  return spaceBelow < DROPDOWN_HEIGHT ? 'bottom-0' : 'top-0';
+});
 </script>
 
 <template>
@@ -55,6 +66,7 @@ const updateSelected = newValue => {
     <template #trigger="{ toggle }">
       <slot name="trigger" :toggle="toggle">
         <Button
+          ref="triggerRef"
           sm
           slate
           :variant
@@ -65,7 +77,7 @@ const updateSelected = newValue => {
         />
       </slot>
     </template>
-    <DropdownBody class="top-0 min-w-48 z-50" strong>
+    <DropdownBody class="min-w-48 z-50" :class="dropdownPosition" strong>
       <DropdownSection class="max-h-80 overflow-scroll">
         <DropdownItem
           v-for="option in options"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes a UI bug where the "Select Label" dropdown in the CSAT survey rule overflowed off the screen. The dropdown now stays within the visible bounds.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/6a26ba5524de4fcdb2f209a6ec215ba6?sid=7cf1c84c-b167-4237-9571-00af56f7da18


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
