### PR TITLE
chore: Move Captain activity messages to EE

### DIFF
--- a/app/models/concerns/activity_message_handler.rb
+++ b/app/models/concerns/activity_message_handler.rb
@@ -80,7 +80,6 @@ module ActivityMessageHandler
   def automation_status_change_activity_content
     if Current.executed_by.instance_of?(AutomationRule)
       I18n.t("conversations.activity.status.#{status}", user_name: I18n.t('automation.system_name'))
-
     elsif Current.executed_by.instance_of?(Contact)
       Current.executed_by = nil
       I18n.t('conversations.activity.status.system_auto_open')

--- a/app/models/concerns/activity_message_handler.rb
+++ b/app/models/concerns/activity_message_handler.rb
@@ -80,8 +80,7 @@ module ActivityMessageHandler
   def automation_status_change_activity_content
     if Current.executed_by.instance_of?(AutomationRule)
       I18n.t("conversations.activity.status.#{status}", user_name: I18n.t('automation.system_name'))
-    elsif Current.executed_by.instance_of?(Captain::Assistant) && resolved?
-      I18n.t('conversations.activity.captain.resolved', user_name: Current.executed_by.name)
+
     elsif Current.executed_by.instance_of?(Contact)
       Current.executed_by = nil
       I18n.t('conversations.activity.status.system_auto_open')
@@ -128,3 +127,5 @@ module ActivityMessageHandler
     user_name
   end
 end
+
+ActivityMessageHandler.prepend_mod_with('ActivityMessageHandler')

--- a/enterprise/app/models/enterprise/activity_message_handler.rb
+++ b/enterprise/app/models/enterprise/activity_message_handler.rb
@@ -1,0 +1,9 @@
+module Enterprise::ActivityMessageHandler
+  def automation_status_change_activity_content
+    if Current.executed_by.instance_of?(Captain::Assistant) && resolved?
+      I18n.t('conversations.activity.captain.resolved', user_name: Current.executed_by.name)
+    else
+      super
+    end
+  end
+end


### PR DESCRIPTION
- Fix the CE build errors due to captain activity message generation in CE code. hence moving this to EE