### PR TITLE
fix: Status not updating when creating a Linear issue

### DIFF
--- a/app/controllers/api/v1/accounts/integrations/linear_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/linear_controller.rb
@@ -94,7 +94,8 @@ class Api::V1::Accounts::Integrations::LinearController < Api::V1::Accounts::Bas
   end
 
   def permitted_params
-    params.permit(:team_id, :project_id, :conversation_id, :issue_id, :link_id, :title, :description, :assignee_id, :priority, label_ids: [])
+    params.permit(:team_id, :project_id, :conversation_id, :issue_id, :link_id, :title, :description, :assignee_id, :priority, :state_id,
+                  label_ids: [])
   end
 
   def fetch_hook

--- a/lib/linear.rb
+++ b/lib/linear.rb
@@ -57,7 +57,8 @@ class Linear
       assigneeId: params[:assignee_id],
       priority: params[:priority],
       labelIds: params[:label_ids],
-      projectId: params[:project_id]
+      projectId: params[:project_id],
+      stateId: params[:state_id]
     }.compact
     mutation = Linear::Mutations.issue_create(variables)
     response = post({ query: mutation })

--- a/spec/controllers/api/v1/accounts/integrations/linear_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/linear_controller_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe 'Linear Integration API', type: :request do
         description: 'This is a sample issue.',
         assignee_id: 'user1',
         priority: 'high',
+        state_id: 'state1',
         label_ids: ['label1']
       }
     end

--- a/spec/lib/integrations/linear/processor_service_spec.rb
+++ b/spec/lib/integrations/linear/processor_service_spec.rb
@@ -76,6 +76,7 @@ describe Integrations::Linear::ProcessorService do
         description: 'Issue description',
         assignee_id: 'user1',
         priority: 2,
+        state_id: 'state1',
         label_ids: %w[bug]
       }
     end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes status selection not being applied when creating a Linear ticket from the UI.
Fixes [CW-4376](https://linear.app/chatwoot/issue/CW-4376/linear-integration-when-i-create-a-ticket-with-a-status-the-status-is)

**Cause:**
The `state_id` parameter was not included in the list of permitted parameters in the controller, so the selected status was ignored during issue creation.

**Solution:**
* Added `state_id` to the `permitted_params` in `linear_controller.rb`.
* Mapped `state_id` in the `create_issue` method in `linear.rb`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/291077f13a3c4baca78ef53e428d894e?sid=47911490-6156-479d-a96e-336ff9c0e262


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
