### PR TITLE
fix: Display message content for CSAT messages in non-widget inboxes

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -185,7 +185,11 @@ class Message < ApplicationRecord
     # move this to a presenter
     return self[:content] if !input_csat? || inbox.web_widget?
 
-    I18n.t('conversations.survey.response', link: "#{ENV.fetch('FRONTEND_URL', nil)}/survey/responses/#{conversation.uuid}")
+    survey_link = "#{ENV.fetch('FRONTEND_URL', nil)}/survey/responses/#{conversation.uuid}"
+
+    return inbox.csat_config['message'] + " #{survey_link}" if inbox.csat_config.present? && inbox.csat_config['message'].present?
+
+    I18n.t('conversations.survey.response', link: survey_link)
   end
 
   def email_notifiable_message?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -187,9 +187,11 @@ class Message < ApplicationRecord
 
     survey_link = "#{ENV.fetch('FRONTEND_URL', nil)}/survey/responses/#{conversation.uuid}"
 
-    return inbox.csat_config['message'] + " #{survey_link}" if inbox.csat_config.present? && inbox.csat_config['message'].present?
-
-    I18n.t('conversations.survey.response', link: survey_link)
+    if inbox.csat_config&.dig('message').present?
+      "#{inbox.csat_config['message']} #{survey_link}"
+    else
+      I18n.t('conversations.survey.response', link: survey_link)
+    end
   end
 
   def email_notifiable_message?


### PR DESCRIPTION
We made so many improvements for CSAT via https://github.com/chatwoot/chatwoot/pull/11485. However, we missed showing message content in the dashboard for CSAT URLs created in non-widget inboxes. This PR fixes the issue by ensuring that CSAT-configured messages are passed along with CSAT responses, otherwise defaulting to the translation.