### PR TITLE
fix: out of office message not sent if a private note was posted

### DIFF
--- a/app/services/message_templates/hook_execution_service.rb
+++ b/app/services/message_templates/hook_execution_service.rb
@@ -27,7 +27,7 @@ class MessageTemplates::HookExecutionService
     return false unless message.incoming?
     # prevents sending out-of-office message if an agent has sent a message in last 5 minutes
     # ensures better UX by not interrupting active conversations at the end of business hours
-    return false if conversation.messages.outgoing.exists?(['created_at > ?', 5.minutes.ago])
+    return false if conversation.messages.outgoing.where(private: false).exists?(['created_at > ?', 5.minutes.ago])
 
     inbox.out_of_office? && conversation.messages.today.template.empty? && inbox.out_of_office_message.present?
   end


### PR DESCRIPTION
A while back, we added a UX enhancement that disabled sending the OOO message when an agent had replied to the conversation in the last 5 minutes. 

https://github.com/chatwoot/chatwoot/pull/11073

This would not send a "we will be back" message even if that reply was a private note. This would break for bots that posted private notes, and even for agents who need to just add a note and not actually reply to the email.