### PR TITLE
fix: use supported access method for schema_format in Rails 7

### DIFF
--- a/lib/tasks/db_enhancements.rake
+++ b/lib/tasks/db_enhancements.rake
@@ -18,7 +18,7 @@ db_namespace = namespace :db do
     ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
       ActiveRecord::Base.establish_connection(db_config.configuration_hash)
       unless ActiveRecord::Base.connection.table_exists? 'ar_internal_metadata'
-        db_namespace['load_config'].invoke if Rails.application.config.active_record.schema_format == :ruby
+        db_namespace['load_config'].invoke if ActiveRecord.schema_format == :ruby
         ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:ruby, ENV.fetch('SCHEMA', nil))
         db_namespace['seed'].invoke
       end


### PR DESCRIPTION
Description
In Rails 7.1+, accessing `schema_format` via `ActiveRecord::Base` is no longer supported, causing a method error.
The correct approach is to use `Rails.application.config.active_record.schema_format`, which aligns with the public API.
This issue occurs locally because the environment uses newer versions of Ruby and Rails than others.

Fixes: https://github.com/chatwoot/chatwoot/issues/11594

Type of change
 Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?
Ran make db to verify database tasks execute without raising conversion errors

Verified the code executes correctly in the local development environment

Checklist:

- [ ]  My code follows the style guidelines of this project
- [ ]  I have performed a self-review of my code
- [ ]  I have commented on my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [ ]  My changes generate no new warnings
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [ ]  New and existing unit tests pass locally with my changes
- [ ]  Any dependent changes have been merged and published in downstream modules