### PR TITLE
feat: save timezone from leadsquared API

### DIFF
--- a/app/services/crm/leadsquared/processor_service.rb
+++ b/app/services/crm/leadsquared/processor_service.rb
@@ -37,7 +37,7 @@ class Crm::Leadsquared::ProcessorService < Crm::BaseProcessorService
       activity_type: 'conversation',
       activity_code_key: 'conversation_activity_code',
       metadata_key: 'created_activity_id',
-      activity_note: Crm::Leadsquared::Mappers::ConversationMapper.map_conversation_activity(conversation)
+      activity_note: Crm::Leadsquared::Mappers::ConversationMapper.map_conversation_activity(@hook, conversation)
     )
   end
 
@@ -50,7 +50,7 @@ class Crm::Leadsquared::ProcessorService < Crm::BaseProcessorService
       activity_type: 'transcript',
       activity_code_key: 'transcript_activity_code',
       metadata_key: 'transcript_activity_id',
-      activity_note: Crm::Leadsquared::Mappers::ConversationMapper.map_transcript_activity(conversation)
+      activity_note: Crm::Leadsquared::Mappers::ConversationMapper.map_transcript_activity(@hook, conversation)
     )
   end
 

--- a/app/services/crm/leadsquared/setup_service.rb
+++ b/app/services/crm/leadsquared/setup_service.rb
@@ -25,11 +25,12 @@ class Crm::Leadsquared::SetupService
     response = @client.get('Authentication.svc/UserByAccessKey.Get')
     endpoint_host = response['LSQCommonServiceURLs']['api']
     app_host = response['LSQCommonServiceURLs']['app']
+    timezone = response['TimeZone']
 
     endpoint_url = "https://#{endpoint_host}/v2/"
     app_url = "https://#{app_host}/"
 
-    update_hook_settings({ :endpoint_url => endpoint_url, :app_url => app_url })
+    update_hook_settings({ :endpoint_url => endpoint_url, :app_url => app_url, :timezone => timezone })
 
     # replace the clients
     @client = Crm::Leadsquared::Api::BaseClient.new(@access_key, @secret_key, endpoint_url)

--- a/config/integration/apps.yml
+++ b/config/integration/apps.yml
@@ -205,6 +205,7 @@ leadsquared:
           'secret_key': { 'type': 'string' },
           'endpoint_url': { 'type': 'string' },
           'app_url': { 'type': 'string' },
+          'timezone': { 'type': 'string' },
           'enable_conversation_activity': { 'type': 'boolean' },
           'enable_transcript_activity': { 'type': 'boolean' },
           'conversation_activity_score': { 'type': 'string' },

--- a/spec/services/crm/leadsquared/mappers/conversation_mapper_spec.rb
+++ b/spec/services/crm/leadsquared/mappers/conversation_mapper_spec.rb
@@ -6,15 +6,39 @@ RSpec.describe Crm::Leadsquared::Mappers::ConversationMapper do
   let(:conversation) { create(:conversation, account: account, inbox: inbox) }
   let(:user) { create(:user, name: 'John Doe') }
   let(:contact) { create(:contact, name: 'Jane Smith') }
+  let(:hook) do
+    create(:integrations_hook, :leadsquared, account: account, settings: {
+             'access_key' => 'test_access_key',
+             'secret_key' => 'test_secret_key',
+             'endpoint_url' => 'https://api.leadsquared.com/v2',
+             'timezone' => 'UTC'
+           })
+  end
+  let(:hook_with_pst) do
+    create(:integrations_hook, :leadsquared, account: account, settings: {
+             'access_key' => 'test_access_key',
+             'secret_key' => 'test_secret_key',
+             'endpoint_url' => 'https://api.leadsquared.com/v2',
+             'timezone' => 'America/Los_Angeles'
+           })
+  end
+  let(:hook_without_timezone) do
+    create(:integrations_hook, :leadsquared, account: account, settings: {
+             'access_key' => 'test_access_key',
+             'secret_key' => 'test_secret_key',
+             'endpoint_url' => 'https://api.leadsquared.com/v2'
+           })
+  end
 
   before do
+    account.enable_features('crm_integration')
     allow(GlobalConfig).to receive(:get).with('BRAND_NAME').and_return({ 'BRAND_NAME' => 'TestBrand' })
   end
 
   describe '.map_conversation_activity' do
-    it 'generates conversation activity note' do
-      travel_to(Time.zone.parse('2024-01-01 10:00:00')) do
-        result = described_class.map_conversation_activity(conversation)
+    it 'generates conversation activity note with UTC timezone' do
+      travel_to(Time.zone.parse('2024-01-01 10:00:00 UTC')) do
+        result = described_class.map_conversation_activity(hook, conversation)
 
         expect(result).to include('New conversation started on TestBrand')
         expect(result).to include('Channel: Test Inbox')
@@ -23,12 +47,29 @@ RSpec.describe Crm::Leadsquared::Mappers::ConversationMapper do
         expect(result).to include('View in TestBrand: http://')
       end
     end
+
+    it 'formats time according to hook timezone setting' do
+      travel_to(Time.zone.parse('2024-01-01 18:00:00 UTC')) do
+        result = described_class.map_conversation_activity(hook_with_pst, conversation)
+
+        # PST is UTC-8, so 18:00 UTC becomes 10:00:00 PST
+        expect(result).to include('Created: 2024-01-01 10:00:00')
+      end
+    end
+
+    it 'falls back to system timezone when hook has no timezone setting' do
+      travel_to(Time.zone.parse('2024-01-01 10:00:00')) do
+        result = described_class.map_conversation_activity(hook_without_timezone, conversation)
+
+        expect(result).to include('Created: 2024-01-01 10:00:00')
+      end
+    end
   end
 
   describe '.map_transcript_activity' do
     context 'when conversation has no messages' do
       it 'returns no messages message' do
-        result = described_class.map_transcript_activity(conversation)
+        result = described_class.map_transcript_activity(hook, conversation)
         expect(result).to eq('No messages in conversation')
       end
     end
@@ -68,7 +109,7 @@ RSpec.describe Crm::Leadsquared::Mappers::ConversationMapper do
       end
 
       it 'generates transcript with messages in reverse chronological order' do
-        result = described_class.map_transcript_activity(conversation)
+        result = described_class.map_transcript_activity(hook, conversation)
 
         expect(result).to include('Conversation Transcript from TestBrand')
         expect(result).to include('Channel: Test Inbox')
@@ -81,6 +122,22 @@ RSpec.describe Crm::Leadsquared::Mappers::ConversationMapper do
 
         # Latest message (10:01) should come before older message (10:00)
         expect(message_positions['[2024-01-01 10:01] Jane Smith: Hi there']).to be < message_positions['[2024-01-01 10:00] John Doe: Hello']
+      end
+
+      it 'formats message times according to hook timezone setting' do
+        travel_to(Time.zone.parse('2024-01-01 18:00:00 UTC')) do
+          create(:message,
+                 conversation: conversation,
+                 sender: user,
+                 content: 'Test message',
+                 message_type: :outgoing,
+                 created_at: Time.zone.parse('2024-01-01 18:00:00 UTC'))
+
+          result = described_class.map_transcript_activity(hook_with_pst, conversation)
+
+          # PST is UTC-8, so 18:00 UTC becomes 10:00 PST
+          expect(result).to include('[2024-01-01 10:00] John Doe: Test message')
+        end
       end
 
       context 'when message has attachments' do
@@ -96,7 +153,7 @@ RSpec.describe Crm::Leadsquared::Mappers::ConversationMapper do
         before { message_with_attachment }
 
         it 'includes attachment information' do
-          result = described_class.map_transcript_activity(conversation)
+          result = described_class.map_transcript_activity(hook, conversation)
 
           expect(result).to include('See attachment')
           expect(result).to include('[Attachment: image]')
@@ -116,7 +173,7 @@ RSpec.describe Crm::Leadsquared::Mappers::ConversationMapper do
         before { empty_message }
 
         it 'shows no content placeholder' do
-          result = described_class.map_transcript_activity(conversation)
+          result = described_class.map_transcript_activity(hook, conversation)
           expect(result).to include('[No content]')
         end
       end
@@ -134,22 +191,9 @@ RSpec.describe Crm::Leadsquared::Mappers::ConversationMapper do
         before { unnamed_sender_message }
 
         it 'uses sender type and id' do
-          result = described_class.map_transcript_activity(conversation)
+          result = described_class.map_transcript_activity(hook, conversation)
           expect(result).to include("User #{unnamed_sender_message.sender_id}")
         end
-      end
-    end
-
-    context 'when specific messages are provided' do
-      let(:message1) { create(:message, conversation: conversation, content: 'Message 1', message_type: :outgoing) }
-      let(:message2) { create(:message, conversation: conversation, content: 'Message 2', message_type: :outgoing) }
-      let(:specific_messages) { [message1] }
-
-      it 'only includes provided messages' do
-        result = described_class.map_transcript_activity(conversation, specific_messages)
-
-        expect(result).to include('Message 1')
-        expect(result).not_to include('Message 2')
       end
     end
 
@@ -169,7 +213,7 @@ RSpec.describe Crm::Leadsquared::Mappers::ConversationMapper do
                              created_at: Time.zone.parse("2024-01-01 #{10 + i}:00:00"))
         end
 
-        result = described_class.map_transcript_activity(conversation, messages)
+        result = described_class.map_transcript_activity(hook, conversation)
 
         # Verify latest message is included (message 14)
         expect(result).to include("[2024-01-02 00:00] John Doe: #{long_message_content} 14")
@@ -189,13 +233,13 @@ RSpec.describe Crm::Leadsquared::Mappers::ConversationMapper do
       it 'respects the ACTIVITY_NOTE_MAX_SIZE constant' do
         # Create a single message that would exceed the limit by itself
         giant_content = 'A' * 2000
-        message = create(:message,
-                         conversation: conversation,
-                         sender: user,
-                         content: giant_content,
-                         message_type: :outgoing)
+        create(:message,
+               conversation: conversation,
+               sender: user,
+               content: giant_content,
+               message_type: :outgoing)
 
-        result = described_class.map_transcript_activity(conversation, [message])
+        result = described_class.map_transcript_activity(hook, conversation)
 
         # Extract just the formatted messages part
         id = conversation.display_id

--- a/spec/services/crm/leadsquared/processor_service_spec.rb
+++ b/spec/services/crm/leadsquared/processor_service_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Crm::Leadsquared::ProcessorService do
 
     before do
       allow(Crm::Leadsquared::Mappers::ConversationMapper).to receive(:map_conversation_activity)
-        .with(conversation)
+        .with(hook, conversation)
         .and_return(activity_note)
     end
 
@@ -180,7 +180,7 @@ RSpec.describe Crm::Leadsquared::ProcessorService do
 
     before do
       allow(Crm::Leadsquared::Mappers::ConversationMapper).to receive(:map_transcript_activity)
-        .with(conversation)
+        .with(hook, conversation)
         .and_return(activity_note)
     end
 

--- a/spec/services/crm/leadsquared/setup_service_spec.rb
+++ b/spec/services/crm/leadsquared/setup_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Crm::Leadsquared::SetupService do
   let(:activity_client) { instance_double(Crm::Leadsquared::Api::ActivityClient) }
   let(:endpoint_response) do
     {
+      'TimeZone' => 'Asia/Kolkata',
       'LSQCommonServiceURLs' => {
         'api' => 'api-in.leadsquared.com',
         'app' => 'app.leadsquared.com'
@@ -45,6 +46,7 @@ RSpec.describe Crm::Leadsquared::SetupService do
           updated_settings = hook.reload.settings
           expect(updated_settings['endpoint_url']).to eq('https://api-in.leadsquared.com/v2/')
           expect(updated_settings['app_url']).to eq('https://app.leadsquared.com/')
+          expect(updated_settings['timezone']).to eq('Asia/Kolkata')
           expect(updated_settings['conversation_activity_code']).to eq(1001)
           expect(updated_settings['transcript_activity_code']).to eq(1002)
         end
@@ -71,6 +73,7 @@ RSpec.describe Crm::Leadsquared::SetupService do
           updated_settings = hook.reload.settings
           expect(updated_settings['endpoint_url']).to eq('https://api-in.leadsquared.com/v2/')
           expect(updated_settings['app_url']).to eq('https://app.leadsquared.com/')
+          expect(updated_settings['timezone']).to eq('Asia/Kolkata')
           expect(updated_settings['conversation_activity_code']).to eq(1001)
           expect(updated_settings['transcript_activity_code']).to eq(1002)
         end


### PR DESCRIPTION
This pull request introduces timezone support for Leadsquared CRM integration, ensuring that all timestamps in conversation and transcript activities are formatted according to the timezone specified in the integration settings. The changes also include updates to the setup process to fetch and store the timezone from the Leadsquared API and corresponding test coverage improvements. The conversation mapper now accepts a hook parameter to access timezone settings, with fallback to system timezone when not configured.

#### LeadSquared Transcript Activity

![CleanShot 2025-05-26 at 14 43 37@2x](https://github.com/user-attachments/assets/f42f2322-f581-462b-a721-76344ba2cede)

> Note that the UI time is in IST, since I'm viewing this from India

#### Conversation in IST

![CleanShot 2025-05-26 at 15 03 47@2x](https://github.com/user-attachments/assets/08cf99b9-5ab2-4f3c-9753-a74c12a8f504)


##  Summary

- Add timezone support to LeadSquared CRM integration for accurate time formatting
- Update conversation and transcript activity mappers to use hook-specific timezone settings

 ## Changes

- API Integration: Fetch timezone from LeadSquared API during setup and store in hook settings
- Time Formatting: Update conversation and transcript mappers to format timestamps using the configured timezone instead of system timezone
- Configuration: Add timezone field to LeadSquared integration schema
- Tests: Update specs to test timezone functionality with UTC, PST, and fallback scenarios