### PR TITLE
fix(ci): specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,12 +91,12 @@ jobs:
             bundle install
             # pnpm install
 
-      # - run:
-      #     name: Download cc-test-reporter
-      #     command: |
-      #       mkdir -p ~/tmp
-      #       curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ~/tmp/cc-test-reporter
-      #       chmod +x ~/tmp/cc-test-reporter
+      - run:
+          name: Download cc-test-reporter
+          command: |
+            mkdir -p ~/tmp
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ~/tmp/cc-test-reporter
+            chmod +x ~/tmp/cc-test-reporter
 
       # Swagger verification
       # - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,25 +91,25 @@ jobs:
             bundle install
             # pnpm install
 
-      - run:
-          name: Download cc-test-reporter
-          command: |
-            mkdir -p ~/tmp
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ~/tmp/cc-test-reporter
-            chmod +x ~/tmp/cc-test-reporter
+      # - run:
+      #     name: Download cc-test-reporter
+      #     command: |
+      #       mkdir -p ~/tmp
+      #       curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ~/tmp/cc-test-reporter
+      #       chmod +x ~/tmp/cc-test-reporter
 
       # Swagger verification
-      - run:
-          name: Verify swagger API specification
-          command: |
-            bundle exec rake swagger:build
-            if [[ `git status swagger/swagger.json --porcelain` ]]
-            then
-              echo "ERROR: The swagger.json file is not in sync with the yaml specification. Run 'rake swagger:build' and commit 'swagger/swagger.json'."
-              exit 1
-            fi
-            curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar > ~/tmp/openapi-generator-cli-6.3.0.jar
-            java -jar ~/tmp/openapi-generator-cli-6.3.0.jar validate -i swagger/swagger.json
+      # - run:
+      #     name: Verify swagger API specification
+      #     command: |
+      #       bundle exec rake swagger:build
+      #       if [[ `git status swagger/swagger.json --porcelain` ]]
+      #       then
+      #         echo "ERROR: The swagger.json file is not in sync with the yaml specification. Run 'rake swagger:build' and commit 'swagger/swagger.json'."
+      #         exit 1
+      #       fi
+      #       curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar > ~/tmp/openapi-generator-cli-6.3.0.jar
+      #       java -jar ~/tmp/openapi-generator-cli-6.3.0.jar validate -i swagger/swagger.json
 
       # we remove the FRONTED_URL from the .env before running the tests
       - run:
@@ -139,26 +139,26 @@ jobs:
           command: bundle exec bundle audit update && bundle exec bundle audit check -v
 
       # Rubocop linting
-      - run:
-          name: Rubocop
-          command: bundle exec rubocop
+      # - run:
+      #     name: Rubocop
+      #     command: bundle exec rubocop
 
-      # ESLint linting
-      - run:
-          name: eslint
-          command: pnpm run eslint
+      # # ESLint linting
+      # - run:
+      #     name: eslint
+      #     command: pnpm run eslint
 
-      - run:
-          name: Run frontend tests
-          command: |
-            mkdir -p ~/build/coverage/frontend
-            ~/tmp/cc-test-reporter before-build
-            pnpm run test:coverage
+      # - run:
+      #     name: Run frontend tests
+      #     command: |
+      #       mkdir -p ~/build/coverage/frontend
+      #       ~/tmp/cc-test-reporter before-build
+      #       pnpm run test:coverage
 
-      - run:
-          name: Code Climate Test Coverage (Frontend)
-          command: |
-            ~/tmp/cc-test-reporter format-coverage -t lcov -o "~/build/coverage/frontend/codeclimate.frontend_$CIRCLE_NODE_INDEX.json"
+      # - run:
+      #     name: Code Climate Test Coverage (Frontend)
+      #     command: |
+      #       ~/tmp/cc-test-reporter format-coverage -t lcov -o "~/build/coverage/frontend/codeclimate.frontend_$CIRCLE_NODE_INDEX.json"
 
       # Run backend tests
       - run:
@@ -175,17 +175,17 @@ jobs:
                               -- ${TESTFILES}
           no_output_timeout: 30m
 
-      - run:
-          name: Code Climate Test Coverage (Backend)
-          command: |
-            ~/tmp/cc-test-reporter format-coverage -t simplecov -o "~/build/coverage/backend/codeclimate.$CIRCLE_NODE_INDEX.json"
+      # - run:
+      #     name: Code Climate Test Coverage (Backend)
+      #     command: |
+      #       ~/tmp/cc-test-reporter format-coverage -t simplecov -o "~/build/coverage/backend/codeclimate.$CIRCLE_NODE_INDEX.json"
 
-      - run:
-          name: List coverage directory contents
-          command: |
-            ls -R ~/build/coverage
+      # - run:
+      #     name: List coverage directory contents
+      #     command: |
+      #       ls -R ~/build/coverage
 
-      - persist_to_workspace:
-          root: ~/build
-          paths:
-            - coverage
+      # - persist_to_workspace:
+      #     root: ~/build
+      #     paths:
+      #       - coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,17 +99,17 @@ jobs:
             chmod +x ~/tmp/cc-test-reporter
 
       # Swagger verification
-      - run:
-          name: Verify swagger API specification
-          command: |
-            bundle exec rake swagger:build
-            if [[ `git status swagger/swagger.json --porcelain` ]]
-            then
-              echo "ERROR: The swagger.json file is not in sync with the yaml specification. Run 'rake swagger:build' and commit 'swagger/swagger.json'."
-              exit 1
-            fi
-            curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar > ~/tmp/openapi-generator-cli-6.3.0.jar
-            java -jar ~/tmp/openapi-generator-cli-6.3.0.jar validate -i swagger/swagger.json
+      # - run:
+      #     name: Verify swagger API specification
+      #     command: |
+      #       bundle exec rake swagger:build
+      #       if [[ `git status swagger/swagger.json --porcelain` ]]
+      #       then
+      #         echo "ERROR: The swagger.json file is not in sync with the yaml specification. Run 'rake swagger:build' and commit 'swagger/swagger.json'."
+      #         exit 1
+      #       fi
+      #       curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar > ~/tmp/openapi-generator-cli-6.3.0.jar
+      #       java -jar ~/tmp/openapi-generator-cli-6.3.0.jar validate -i swagger/swagger.json
 
       # we remove the FRONTED_URL from the .env before running the tests
       - run:
@@ -139,26 +139,26 @@ jobs:
           command: bundle exec bundle audit update && bundle exec bundle audit check -v
 
       # Rubocop linting
-      - run:
-          name: Rubocop
-          command: bundle exec rubocop
+      # - run:
+      #     name: Rubocop
+      #     command: bundle exec rubocop
 
-      # ESLint linting
-      - run:
-          name: eslint
-          command: pnpm run eslint
+      # # ESLint linting
+      # - run:
+      #     name: eslint
+      #     command: pnpm run eslint
 
-      - run:
-          name: Run frontend tests
-          command: |
-            mkdir -p ~/build/coverage/frontend
-            ~/tmp/cc-test-reporter before-build
-            pnpm run test:coverage
+      # - run:
+      #     name: Run frontend tests
+      #     command: |
+      #       mkdir -p ~/build/coverage/frontend
+      #       ~/tmp/cc-test-reporter before-build
+      #       pnpm run test:coverage
 
-      - run:
-          name: Code Climate Test Coverage (Frontend)
-          command: |
-            ~/tmp/cc-test-reporter format-coverage -t lcov -o "~/build/coverage/frontend/codeclimate.frontend_$CIRCLE_NODE_INDEX.json"
+      # - run:
+      #     name: Code Climate Test Coverage (Frontend)
+      #     command: |
+      #       ~/tmp/cc-test-reporter format-coverage -t lcov -o "~/build/coverage/frontend/codeclimate.frontend_$CIRCLE_NODE_INDEX.json"
 
       # Run backend tests
       - run:
@@ -175,17 +175,17 @@ jobs:
                               -- ${TESTFILES}
           no_output_timeout: 30m
 
-      - run:
-          name: Code Climate Test Coverage (Backend)
-          command: |
-            ~/tmp/cc-test-reporter format-coverage -t simplecov -o "~/build/coverage/backend/codeclimate.$CIRCLE_NODE_INDEX.json"
+      # - run:
+      #     name: Code Climate Test Coverage (Backend)
+      #     command: |
+      #       ~/tmp/cc-test-reporter format-coverage -t simplecov -o "~/build/coverage/backend/codeclimate.$CIRCLE_NODE_INDEX.json"
 
-      - run:
-          name: List coverage directory contents
-          command: |
-            ls -R ~/build/coverage
+      # - run:
+      #     name: List coverage directory contents
+      #     command: |
+      #       ls -R ~/build/coverage
 
-      - persist_to_workspace:
-          root: ~/build
-          paths:
-            - coverage
+      # - persist_to_workspace:
+      #     root: ~/build
+      #     paths:
+      #       - coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,17 +99,17 @@ jobs:
             chmod +x ~/tmp/cc-test-reporter
 
       # Swagger verification
-      # - run:
-      #     name: Verify swagger API specification
-      #     command: |
-      #       bundle exec rake swagger:build
-      #       if [[ `git status swagger/swagger.json --porcelain` ]]
-      #       then
-      #         echo "ERROR: The swagger.json file is not in sync with the yaml specification. Run 'rake swagger:build' and commit 'swagger/swagger.json'."
-      #         exit 1
-      #       fi
-      #       curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar > ~/tmp/openapi-generator-cli-6.3.0.jar
-      #       java -jar ~/tmp/openapi-generator-cli-6.3.0.jar validate -i swagger/swagger.json
+      - run:
+          name: Verify swagger API specification
+          command: |
+            bundle exec rake swagger:build
+            if [[ `git status swagger/swagger.json --porcelain` ]]
+            then
+              echo "ERROR: The swagger.json file is not in sync with the yaml specification. Run 'rake swagger:build' and commit 'swagger/swagger.json'."
+              exit 1
+            fi
+            curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar > ~/tmp/openapi-generator-cli-6.3.0.jar
+            java -jar ~/tmp/openapi-generator-cli-6.3.0.jar validate -i swagger/swagger.json
 
       # we remove the FRONTED_URL from the .env before running the tests
       - run:
@@ -139,26 +139,26 @@ jobs:
           command: bundle exec bundle audit update && bundle exec bundle audit check -v
 
       # Rubocop linting
-      # - run:
-      #     name: Rubocop
-      #     command: bundle exec rubocop
+      - run:
+          name: Rubocop
+          command: bundle exec rubocop
 
-      # # ESLint linting
-      # - run:
-      #     name: eslint
-      #     command: pnpm run eslint
+      # ESLint linting
+      - run:
+          name: eslint
+          command: pnpm run eslint
 
-      # - run:
-      #     name: Run frontend tests
-      #     command: |
-      #       mkdir -p ~/build/coverage/frontend
-      #       ~/tmp/cc-test-reporter before-build
-      #       pnpm run test:coverage
+      - run:
+          name: Run frontend tests
+          command: |
+            mkdir -p ~/build/coverage/frontend
+            ~/tmp/cc-test-reporter before-build
+            pnpm run test:coverage
 
-      # - run:
-      #     name: Code Climate Test Coverage (Frontend)
-      #     command: |
-      #       ~/tmp/cc-test-reporter format-coverage -t lcov -o "~/build/coverage/frontend/codeclimate.frontend_$CIRCLE_NODE_INDEX.json"
+      - run:
+          name: Code Climate Test Coverage (Frontend)
+          command: |
+            ~/tmp/cc-test-reporter format-coverage -t lcov -o "~/build/coverage/frontend/codeclimate.frontend_$CIRCLE_NODE_INDEX.json"
 
       # Run backend tests
       - run:
@@ -175,17 +175,17 @@ jobs:
                               -- ${TESTFILES}
           no_output_timeout: 30m
 
-      # - run:
-      #     name: Code Climate Test Coverage (Backend)
-      #     command: |
-      #       ~/tmp/cc-test-reporter format-coverage -t simplecov -o "~/build/coverage/backend/codeclimate.$CIRCLE_NODE_INDEX.json"
+      - run:
+          name: Code Climate Test Coverage (Backend)
+          command: |
+            ~/tmp/cc-test-reporter format-coverage -t simplecov -o "~/build/coverage/backend/codeclimate.$CIRCLE_NODE_INDEX.json"
 
-      # - run:
-      #     name: List coverage directory contents
-      #     command: |
-      #       ls -R ~/build/coverage
+      - run:
+          name: List coverage directory contents
+          command: |
+            ls -R ~/build/coverage
 
-      # - persist_to_workspace:
-      #     root: ~/build
-      #     paths:
-      #       - coverage
+      - persist_to_workspace:
+          root: ~/build
+          paths:
+            - coverage

--- a/enterprise/app/controllers/api/v1/accounts/captain/copilot_threads_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/copilot_threads_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::Accounts::Captain::CopilotThreadsController < Api::V1::Accounts::
   def create
     ActiveRecord::Base.transaction do
       @copilot_thread = Current.account.copilot_threads.create!(
-        title: copilot_thread_params[:message],
+        title: copilot_thread_params[:message][:content],
         user: Current.user,
         assistant: assistant
       )
@@ -25,7 +25,7 @@ class Api::V1::Accounts::Captain::CopilotThreadsController < Api::V1::Accounts::
   private
 
   def ensure_message
-    return render_could_not_create_error('Message is required') if copilot_thread_params[:message].blank?
+    return render_could_not_create_error('Message is required') if copilot_thread_params[:message][:content].blank?
   end
 
   def assistant
@@ -33,7 +33,7 @@ class Api::V1::Accounts::Captain::CopilotThreadsController < Api::V1::Accounts::
   end
 
   def copilot_thread_params
-    params.permit(:message, :assistant_id)
+    params.permit(:assistant_id, message: [:content])
   end
 
   def permitted_params

--- a/spec/enterprise/controllers/api/v1/accounts/captain/copilot_threads_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/copilot_threads_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Api::V1::Accounts::Captain::CopilotThreads', type: :request do
 
   describe 'POST /api/v1/accounts/{account.id}/captain/copilot_threads' do
     let(:assistant) { create(:captain_assistant, account: account) }
-    let(:valid_params) { { message: 'Hello, how can you help me?', assistant_id: assistant.id } }
+    let(:valid_params) { { message: { content: 'Hello, how can you help me?' }, assistant_id: assistant.id } }
 
     context 'when it is an un-authenticated user' do
       it 'returns unauthorized' do
@@ -66,7 +66,7 @@ RSpec.describe 'Api::V1::Accounts::Captain::CopilotThreads', type: :request do
       context 'with invalid params' do
         it 'returns error when message is blank' do
           post "/api/v1/accounts/#{account.id}/captain/copilot_threads",
-               params: { message: '', assistant_id: assistant.id },
+               params: { message: { content: '' }, assistant_id: assistant.id },
                headers: agent.create_new_auth_token,
                as: :json
 
@@ -76,7 +76,7 @@ RSpec.describe 'Api::V1::Accounts::Captain::CopilotThreads', type: :request do
 
         it 'returns error when assistant_id is invalid' do
           post "/api/v1/accounts/#{account.id}/captain/copilot_threads",
-               params: { message: 'Hello', assistant_id: 0 },
+               params: { message: { content: 'Hello' }, assistant_id: 0 },
                headers: agent.create_new_auth_token,
                as: :json
 
@@ -97,13 +97,13 @@ RSpec.describe 'Api::V1::Accounts::Captain::CopilotThreads', type: :request do
           expect(response).to have_http_status(:success)
 
           thread = CopilotThread.last
-          expect(thread.title).to eq(valid_params[:message])
+          expect(thread.title).to eq(valid_params[:message][:content])
           expect(thread.user_id).to eq(agent.id)
           expect(thread.assistant_id).to eq(assistant.id)
 
           message = thread.copilot_messages.last
           expect(message.message_type).to eq('user')
-          expect(message.message).to eq(valid_params[:message])
+          expect(message.message).to eq(valid_params[:message].stringify_keys)
         end
       end
     end

--- a/spec/enterprise/services/captain/tools/copilot/search_linear_issues_service_spec.rb
+++ b/spec/enterprise/services/captain/tools/copilot/search_linear_issues_service_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Captain::Tools::Copilot::SearchLinearIssuesService do
   let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
   let(:assistant) { create(:captain_assistant, account: account) }
-  let(:service) { described_class.new(assistant) }
+  let(:service) { described_class.new(assistant, user: user) }
 
   describe '#name' do
     it 'returns the correct service name' do

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -205,16 +205,17 @@ describe Webhooks::InstagramEventsJob do
           )
       end
 
-      it 'creates incoming message with correct contact info in the instagram direct inbox' do
-        instagram_webhook.perform_now(message_events[:dm][:entry])
-        instagram_inbox.reload
+      # skip failing test
+      # it 'creates incoming message with correct contact info in the instagram direct inbox' do
+      #   instagram_webhook.perform_now(message_events[:dm][:entry])
+      #   instagram_inbox.reload
 
-        expect(instagram_inbox.contacts.count).to eq 1
-        expect(instagram_inbox.contacts.last.additional_attributes['social_instagram_user_name']).to eq 'some_user_name'
-        expect(instagram_inbox.conversations.count).to eq 1
-        expect(instagram_inbox.messages.count).to eq 1
-        expect(instagram_inbox.messages.last.content_attributes['is_unsupported']).to be_nil
-      end
+      #   expect(instagram_inbox.contacts.count).to eq 1
+      #   expect(instagram_inbox.contacts.last.additional_attributes['social_instagram_user_name']).to eq 'some_user_name'
+      #   expect(instagram_inbox.conversations.count).to eq 1
+      #   expect(instagram_inbox.messages.count).to eq 1
+      #   expect(instagram_inbox.messages.last.content_attributes['is_unsupported']).to be_nil
+      # end
 
       it 'sets correct instagram attributes on contact' do
         instagram_webhook.perform_now(message_events[:dm][:entry])

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -7,6 +7,10 @@ describe Webhooks::InstagramEventsJob, :serial do
     stub_request(:post, /graph\.facebook\.com/)
     stub_request(:get, 'https://www.example.com/test.jpeg')
       .to_return(status: 200, body: '', headers: {})
+
+    # Clear Redis mutex key to prevent lock conflicts in parallel tests
+    mutex_key = format(Redis::Alfred::IG_MESSAGE_MUTEX, sender_id: 'Sender-id-1', ig_account_id: 'chatwoot-app-user-id-1')
+    Redis::Alfred.delete(mutex_key)
   end
 
   let!(:account) { create(:account) }

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -206,16 +206,16 @@ describe Webhooks::InstagramEventsJob, :serial do
       end
 
       # skip failing test
-      # it 'creates incoming message with correct contact info in the instagram direct inbox' do
-      #   instagram_webhook.perform_now(message_events[:dm][:entry])
-      #   instagram_inbox.reload
+      it 'creates incoming message with correct contact info in the instagram direct inbox' do
+        instagram_webhook.perform_now(message_events[:dm][:entry])
+        instagram_inbox.reload
 
-      #   expect(instagram_inbox.contacts.count).to eq 1
-      #   expect(instagram_inbox.contacts.last.additional_attributes['social_instagram_user_name']).to eq 'some_user_name'
-      #   expect(instagram_inbox.conversations.count).to eq 1
-      #   expect(instagram_inbox.messages.count).to eq 1
-      #   expect(instagram_inbox.messages.last.content_attributes['is_unsupported']).to be_nil
-      # end
+        expect(instagram_inbox.contacts.count).to eq 1
+        expect(instagram_inbox.contacts.last.additional_attributes['social_instagram_user_name']).to eq 'some_user_name'
+        expect(instagram_inbox.conversations.count).to eq 1
+        expect(instagram_inbox.messages.count).to eq 1
+        expect(instagram_inbox.messages.last.content_attributes['is_unsupported']).to be_nil
+      end
 
       it 'sets correct instagram attributes on contact' do
         instagram_webhook.perform_now(message_events[:dm][:entry])

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -186,7 +186,8 @@ describe Webhooks::InstagramEventsJob do
 
         stub_request(:get, 'https://graph.instagram.com/v22.0/Sender-id-1')
           .with(query: hash_including(
-            'fields' => 'name,username,profile_pic,follower_count,is_user_follow_business,is_business_follow_user,is_verified_user', 'access_token' => 'valid_instagram_token'
+            'fields' => 'name,username,profile_pic,follower_count,is_user_follow_business,is_business_follow_user,is_verified_user',
+            'access_token' => 'valid_instagram_token'
           ))
           .to_return(
             status: 200,

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Webhooks::InstagramEventsJob do
+describe Webhooks::InstagramEventsJob, :serial do
   subject(:instagram_webhook) { described_class }
 
   before do

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -184,7 +184,10 @@ describe Webhooks::InstagramEventsJob do
       before do
         instagram_channel.update(access_token: 'valid_instagram_token')
 
-        stub_request(:get, %r{https://graph\.instagram\.com/v22\.0/Sender-id-1\?.*})
+        stub_request(:get, 'https://graph.instagram.com/v22.0/Sender-id-1')
+          .with(query: hash_including(
+            'fields' => 'name,username,profile_pic,follower_count,is_user_follow_business,is_business_follow_user,is_verified_user', 'access_token' => 'valid_instagram_token'
+          ))
           .to_return(
             status: 200,
             body: {
@@ -268,7 +271,8 @@ describe Webhooks::InstagramEventsJob do
       end
 
       it 'does not create contact or messages when Instagram API call fails' do
-        stub_request(:get, %r{https://graph\.instagram\.com/v22\.0/.*\?.*})
+        stub_request(:get, 'https://graph.instagram.com/v22.0/Sender-id-1')
+          .with(query: hash_including('access_token' => 'valid_instagram_token'))
           .to_return(status: 401, body: { error: { message: 'Invalid OAuth access token' } }.to_json)
 
         instagram_webhook.perform_now(message_events[:story_mention_echo][:entry])


### PR DESCRIPTION
The PR fixes three tests

### Copilot Linear Search Tool

The spec failed simply because the described class was not initialized correctly. Fixing that was very straightforward

### Copilot Threads

The issue was that the test was passing a plain string as the message parameter, but the CopilotMessage model expects the message field to be a JSON object with specific keys like content.

#### Changes made:

1. Updated test parameters: Changed message: `Hello, how can you help me?` to message: `{ content: 'Hello, how can you help me?' }` in all test cases
2. Updated controller:
  - Modified `copilot_thread_params` to properly permit nested message parameters
  - Updated title creation to use `copilot_thread_params[:message][:content]`
  - Updated validation to check `copilot_thread_params[:message][:content].blank?`
3. Updated test expectations: Used `stringify_keys` to compare the hash properly since Rails stores JSON as string keys

The test now correctly creates both a `CopilotThread` and `CopilotMessage` and all assertions pass.
