### PR TITLE
fix: External links in widget not opening in new tab

### DIFF
--- a/app/javascript/portal/portalHelpers.js
+++ b/app/javascript/portal/portalHelpers.js
@@ -38,16 +38,9 @@ export const openExternalLinksInNewTab = () => {
   document.addEventListener('click', event => {
     if (!isOnArticlePage) return;
 
-    // Some of the links come wrapped in strong tag through prosemirror
+    const link = event.target.closest('a');
 
-    const isTagAnchor = event.target.tagName === 'A';
-    const isParentTagAnchor =
-      event.target.tagName === 'STRONG' &&
-      event.target.parentNode.tagName === 'A';
-
-    if (isTagAnchor || isParentTagAnchor) {
-      const link = isTagAnchor ? event.target : event.target.parentNode;
-
+    if (link) {
       const isInternalLink =
         link.hostname === window.location.hostname ||
         link.href.includes(customDomain) ||

--- a/app/javascript/portal/specs/portal.spec.js
+++ b/app/javascript/portal/specs/portal.spec.js
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
-import { InitializationHelpers } from '../portalHelpers';
+import {
+  InitializationHelpers,
+  openExternalLinksInNewTab,
+} from '../portalHelpers';
 
 describe('InitializationHelpers.navigateToLocalePage', () => {
   let dom;
@@ -42,5 +45,98 @@ describe('InitializationHelpers.navigateToLocalePage', () => {
       'change',
       expect.any(Function)
     );
+  });
+});
+
+describe('openExternalLinksInNewTab', () => {
+  let dom;
+  let document;
+  let window;
+
+  beforeEach(() => {
+    dom = new JSDOM(
+      `<!DOCTYPE html>
+      <html>
+        <body>
+          <div id="cw-article-content">
+            <a href="https://external.com" id="external">External</a>
+            <a href="https://app.chatwoot.com/page" id="internal">Internal</a>
+            <a href="https://custom.domain.com/page" id="custom">Custom</a>
+            <a href="https://example.com" id="nested"><code>Code</code><strong>Bold</strong></a>
+            <ul>
+              <li>Visit the preferences centre here &gt; <a href="https://external.com" id="list-link"><strong>https://external.com</strong></a></li>
+            </ul>
+          </div>
+        </body>
+      </html>`,
+      { url: 'https://app.chatwoot.com/hc/article' }
+    );
+
+    document = dom.window.document;
+    window = dom.window;
+
+    window.portalConfig = {
+      customDomain: 'custom.domain.com',
+      hostURL: 'app.chatwoot.com',
+    };
+
+    global.document = document;
+    global.window = window;
+  });
+
+  afterEach(() => {
+    dom = null;
+    document = null;
+    window = null;
+    delete global.document;
+    delete global.window;
+  });
+
+  const simulateClick = selector => {
+    const element = document.querySelector(selector);
+    const event = new window.MouseEvent('click', { bubbles: true });
+    element.dispatchEvent(event);
+    return element.closest('a') || element;
+  };
+
+  it('opens external links in new tab', () => {
+    openExternalLinksInNewTab();
+
+    const link = simulateClick('#external');
+
+    expect(link.target).toBe('_blank');
+    expect(link.rel).toBe('noopener noreferrer');
+  });
+
+  it('preserves internal links', () => {
+    openExternalLinksInNewTab();
+
+    const internal = simulateClick('#internal');
+    const custom = simulateClick('#custom');
+
+    expect(internal.target).not.toBe('_blank');
+    expect(custom.target).not.toBe('_blank');
+  });
+
+  it('handles clicks on nested elements', () => {
+    openExternalLinksInNewTab();
+
+    simulateClick('#nested code');
+    simulateClick('#nested strong');
+
+    const link = document.getElementById('nested');
+    expect(link.target).toBe('_blank');
+    expect(link.rel).toBe('noopener noreferrer');
+  });
+
+  it('handles links inside list items with strong tags', () => {
+    openExternalLinksInNewTab();
+
+    // Click on the strong element inside the link in the list
+    simulateClick('#list-link strong');
+
+    const link = document.getElementById('list-link');
+    expect(link.target).toBe('_blank');
+    expect(link.rel).toBe('noopener noreferrer');
   });
 });


### PR DESCRIPTION
# Pull Request Template

## Description
This PR fixes an issue where external article links in the widget, including those in nested cases, were not opening in a new tab.

Fixes [CW-4409](https://linear.app/chatwoot/issue/CW-4409/links-are-not-working-properly-in-widget)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/518773f2a8ad42439a99a885249c3575?sid=bd68ee07-36a4-42f8-8cc9-632ff6b1a8f5


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
