### PR TITLE
fix: Snackbar notifications hidden behind modal dialogs

### DIFF
--- a/app/javascript/dashboard/components/Snackbar.vue
+++ b/app/javascript/dashboard/components/Snackbar.vue
@@ -20,7 +20,7 @@ export default {
 <template>
   <div>
     <div
-      class="shadow-sm bg-slate-800 dark:bg-slate-700 rounded-[4px] items-center gap-3 inline-flex mb-2 max-w-[25rem] min-h-[1.875rem] min-w-[15rem] px-6 py-3 text-left"
+      class="shadow-sm bg-n-slate-12 dark:bg-n-slate-7 rounded-lg items-center gap-3 inline-flex mb-2 max-w-[25rem] min-h-[1.875rem] min-w-[15rem] px-6 py-3 text-left"
     >
       <div class="text-sm font-medium text-white dark:text-white">
         {{ message }}
@@ -29,7 +29,7 @@ export default {
         <router-link
           v-if="action.type == 'link'"
           :to="action.to"
-          class="font-medium cursor-pointer select-none text-woot-500 dark:text-woot-500 hover:text-woot-600 dark:hover:text-woot-600"
+          class="font-medium cursor-pointer select-none text-n-blue-10 hover:text-n-brand"
         >
           {{ action.message }}
         </router-link>


### PR DESCRIPTION
# Pull Request Template

## Description

### Cause
Snackbar notifications were not visible when a modal dialog was open. This happened because native `<dialog>` elements rendered with `showModal()` are placed in the browser’s **top layer**, above all normal z-index values, even `z-index: 9999`. As a result, snackbars appeared behind the dialog’s backdrop.

### Solution
Used the **[Popover API](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover#manual)** to render snackbars in the top layer, ensuring they appear above modal dialogs.

### Changes
* Added `popover="manual"` to the snackbar container.
* Used `showPopover()` to move the element to the top layer.
* Hides and re-shows the popover on new messages.
* Update the component to Composition API


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/9e51d1aa0f4a4739a0585b7a0983077a?sid=eaafb0fa-88c7-45e7-b149-e3fda5bc2c6e


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
