### PR TITLE
feat: add custom roles seeding to account seeder

### DIFF
--- a/lib/seeders/seed_data.yml
+++ b/lib/seeders/seed_data.yml
@@ -61,41 +61,49 @@ users:
     email: 'karn@paperlayer.test'
     team:
       - 'Sales'
+    custom_role: 'Sales Representative'
   - name: 'Danny Cordray'
     gender: female
     email: 'danny@paperlayer.test'
     team:
       - 'Sales'
+    custom_role: 'Customer Support Lead'
   - name: 'Ben Nugent'
     gender: male
     email: 'ben@paperlayer.test'
     team:
       - 'Sales'
+    custom_role: 'Junior Agent'
   - name: 'Todd Packer'
     gender: male
     email: 'todd@paperlayer.test'
     team:
       - 'Sales'
+    custom_role: 'Sales Representative'
   - name: 'Cathy Simms'
     gender: female
     email: 'cathy@paperlayer.test'
     team:
       - 'Administration'
+    custom_role: 'Knowledge Manager'
   - name: 'Hunter Jo'
     gender: male
     email: 'hunter@paperlayer.test'
     team:
       - 'Administration'
+    custom_role: 'Analytics Specialist'
   - name: 'Rolando Silva'
     gender: male
     email: 'rolando@paperlayer.test'
     team:
       - 'Administration'
+    custom_role: 'Junior Agent'
   - name: 'Stephanie Wilson'
     gender: female
     email: 'stephanie@paperlayer.test'
     team:
       - 'Administration'
+    custom_role: 'Escalation Handler'
   - name: 'Jordan Garfield'
     gender: male
     email: 'jorodan@paperlayer.test'
@@ -111,6 +119,7 @@ users:
     email: 'lonny@paperlayer.test'
     team:
       - 'Warehouse'
+    custom_role: 'Customer Support Lead'
   - name: 'Madge Madsen'
     gender: female
     email: 'madge@paperlayer.test'
@@ -162,6 +171,7 @@ users:
   - name: 'Devon White'
     gender: male
     email: 'devon@paperlayer.test'
+    custom_role: 'Escalation Handler'
   - name: 'Kendall'
     gender: male
     email: 'kendall@paperlayer.test'
@@ -173,6 +183,39 @@ teams:
   - '💼 Management'
   - '👩‍💼 Administration'
   - '🚛 Warehouse'
+custom_roles:
+  - name: 'Customer Support Lead'
+    description: 'Lead support agent with full conversation and contact management'
+    permissions:
+      - 'conversation_manage'
+      - 'contact_manage'
+      - 'report_manage'
+  - name: 'Sales Representative'
+    description: 'Sales team member with conversation and contact access'
+    permissions:
+      - 'conversation_unassigned_manage'
+      - 'conversation_participating_manage'
+      - 'contact_manage'
+  - name: 'Knowledge Manager'
+    description: 'Manages knowledge base and participates in conversations'
+    permissions:
+      - 'knowledge_base_manage'
+      - 'conversation_participating_manage'
+  - name: 'Junior Agent'
+    description: 'Entry-level agent with basic conversation access'
+    permissions:
+      - 'conversation_participating_manage'
+  - name: 'Analytics Specialist'
+    description: 'Focused on reports and data analysis'
+    permissions:
+      - 'report_manage'
+      - 'conversation_participating_manage'
+  - name: 'Escalation Handler'
+    description: 'Handles unassigned conversations and escalations'
+    permissions:
+      - 'conversation_unassigned_manage'
+      - 'conversation_participating_manage'
+      - 'contact_manage'
 labels:
     - title: 'billing'
       color: '#28AD21'


### PR DESCRIPTION
Introduce custom roles in account seed data to support testing of realistic role-based access scenarios. Includes six distinct roles with varied permission sets and assigns them to multiple users for comprehensive test coverage.