### PR TITLE
fix: Send CSAT survey only when agent can reply in conversation

### DIFF
--- a/app/models/concerns/activity_message_handler.rb
+++ b/app/models/concerns/activity_message_handler.rb
@@ -5,6 +5,7 @@ module ActivityMessageHandler
   include LabelActivityMessageHandler
   include SlaActivityMessageHandler
   include TeamActivityMessageHandler
+  include CsatActivityMessageHandler
 
   private
 

--- a/app/models/concerns/csat_activity_message_handler.rb
+++ b/app/models/concerns/csat_activity_message_handler.rb
@@ -1,0 +1,8 @@
+module CsatActivityMessageHandler
+  extend ActiveSupport::Concern
+
+  def create_csat_not_sent_activity_message
+    content = I18n.t('conversations.activity.csat.not_sent_due_to_messaging_window')
+    ::Conversations::ActivityMessageJob.perform_later(self, activity_message_params(content)) if content
+  end
+end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -115,6 +115,7 @@ class Conversation < ApplicationRecord
   before_create :ensure_waiting_since
 
   after_update_commit :execute_after_update_commit_callbacks
+  after_update_commit :trigger_csat_survey_if_resolved
   after_create_commit :notify_conversation_creation
   after_create_commit :load_attributes_created_by_db_triggers
 
@@ -196,6 +197,12 @@ class Conversation < ApplicationRecord
   end
 
   private
+
+  def trigger_csat_survey_if_resolved
+    return unless saved_change_to_status? && resolved?
+
+    CsatSurveyService.new(conversation: self).perform
+  end
 
   def execute_after_update_commit_callbacks
     notify_status_change

--- a/app/services/csat_survey_service.rb
+++ b/app/services/csat_survey_service.rb
@@ -1,0 +1,44 @@
+class CsatSurveyService
+  pattr_initialize [:conversation!]
+
+  def perform
+    return unless should_send_csat_survey?
+
+    if within_messaging_window?
+      send_csat_survey
+    else
+      log_csat_not_sent_activity
+    end
+  end
+
+  private
+
+  delegate :inbox, :contact, to: :conversation
+
+  def should_send_csat_survey?
+    return false unless conversation.resolved?
+    # should not send since the link will be public
+    return false if conversation.tweet?
+    return false unless inbox.csat_survey_enabled?
+    # only send CSAT once per conversation
+    return false if csat_already_sent?
+
+    true
+  end
+
+  def csat_already_sent?
+    conversation.messages.where(content_type: :input_csat).present?
+  end
+
+  def within_messaging_window?
+    conversation.can_reply?
+  end
+
+  def send_csat_survey
+    ::MessageTemplates::Template::CsatSurvey.new(conversation: conversation).perform
+  end
+
+  def log_csat_not_sent_activity
+    conversation.create_csat_not_sent_activity_message
+  end
+end

--- a/app/services/message_templates/hook_execution_service.rb
+++ b/app/services/message_templates/hook_execution_service.rb
@@ -17,7 +17,6 @@ class MessageTemplates::HookExecutionService
     ::MessageTemplates::Template::OutOfOffice.new(conversation: conversation).perform if should_send_out_of_office_message?
     ::MessageTemplates::Template::Greeting.new(conversation: conversation).perform if should_send_greeting?
     ::MessageTemplates::Template::EmailCollect.new(conversation: conversation).perform if inbox.enable_email_collect && should_send_email_collect?
-    ::MessageTemplates::Template::CsatSurvey.new(conversation: conversation).perform if should_send_csat_survey?
   end
 
   def should_send_out_of_office_message?
@@ -54,24 +53,6 @@ class MessageTemplates::HookExecutionService
 
   def contact_has_email?
     contact.email
-  end
-
-  def csat_enabled_conversation?
-    return false unless conversation.resolved?
-    # should not sent since the link will be public
-    return false if conversation.tweet?
-    return false unless inbox.csat_survey_enabled?
-
-    true
-  end
-
-  def should_send_csat_survey?
-    return unless csat_enabled_conversation?
-
-    # only send CSAT once in a conversation
-    return if conversation.messages.where(content_type: :input_csat).present?
-
-    true
   end
 end
 MessageTemplates::HookExecutionService.prepend_mod_with('MessageTemplates::HookExecutionService')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -186,6 +186,8 @@ en:
       sla:
         added: '%{user_name} added SLA policy %{sla_name}'
         removed: '%{user_name} removed SLA policy %{sla_name}'
+      csat:
+        not_sent_due_to_messaging_window: 'CSAT survey not sent due to outgoing message restrictions'
       muted: '%{user_name} has muted the conversation'
       unmuted: '%{user_name} has unmuted the conversation'
       auto_resolution_message: 'Resolving the conversation as it has been inactive for a while. Please start a new conversation if you need further assistance.'

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -836,4 +836,50 @@ RSpec.describe Conversation do
       expect(message_window_service).to have_received(:can_reply?)
     end
   end
+
+  describe '#trigger_csat_survey_if_resolved' do
+    let(:conversation) { create(:conversation, status: :open) }
+    let(:csat_service) { instance_double(CsatSurveyService) }
+
+    before do
+      allow(CsatSurveyService).to receive(:new).with(conversation: conversation).and_return(csat_service)
+      allow(csat_service).to receive(:perform)
+    end
+
+    it 'triggers CSAT survey when conversation status changes to resolved' do
+      conversation.update!(status: :resolved)
+
+      expect(CsatSurveyService).to have_received(:new).with(conversation: conversation)
+      expect(csat_service).to have_received(:perform)
+    end
+
+    it 'does not trigger CSAT survey when status changes to other states' do
+      conversation.update!(status: :pending)
+
+      expect(CsatSurveyService).not_to have_received(:new)
+      expect(csat_service).not_to have_received(:perform)
+    end
+
+    it 'does not trigger CSAT survey when other attributes change' do
+      conversation.update!(priority: :high)
+
+      expect(CsatSurveyService).not_to have_received(:new)
+      expect(csat_service).not_to have_received(:perform)
+    end
+
+    it 'does not trigger CSAT survey if already resolved' do
+      # Start with a resolved conversation
+      resolved_conversation = create(:conversation, status: :resolved)
+      resolved_service = instance_double(CsatSurveyService)
+
+      allow(CsatSurveyService).to receive(:new).with(conversation: resolved_conversation).and_return(resolved_service)
+      allow(resolved_service).to receive(:perform)
+
+      # Update priority, not status - should not trigger CSAT
+      resolved_conversation.update!(priority: :high)
+
+      expect(CsatSurveyService).not_to have_received(:new)
+      expect(resolved_service).not_to have_received(:perform)
+    end
+  end
 end

--- a/spec/services/csat_survey_service_spec.rb
+++ b/spec/services/csat_survey_service_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+describe CsatSurveyService do
+  let(:account) { create(:account) }
+  let(:inbox) { create(:inbox, account: account, csat_survey_enabled: true) }
+  let(:conversation) { create(:conversation, inbox: inbox, account: account, status: :resolved) }
+  let(:service) { described_class.new(conversation: conversation) }
+
+  describe '#perform' do
+    let(:csat_template) { instance_double(MessageTemplates::Template::CsatSurvey) }
+
+    before do
+      allow(MessageTemplates::Template::CsatSurvey).to receive(:new).and_return(csat_template)
+      allow(csat_template).to receive(:perform)
+      allow(conversation).to receive(:create_csat_not_sent_activity_message)
+    end
+
+    context 'when CSAT survey should be sent' do
+      before do
+        allow(conversation).to receive(:can_reply?).and_return(true)
+      end
+
+      it 'sends CSAT survey when within messaging window' do
+        service.perform
+
+        expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: conversation)
+      end
+    end
+
+    context 'when outside messaging window' do
+      before do
+        allow(conversation).to receive(:can_reply?).and_return(false)
+      end
+
+      it 'creates activity message instead of sending survey' do
+        service.perform
+
+        expect(conversation).to have_received(:create_csat_not_sent_activity_message)
+        expect(MessageTemplates::Template::CsatSurvey).not_to have_received(:new)
+      end
+    end
+
+    context 'when CSAT survey should not be sent' do
+      it 'does nothing when conversation is not resolved' do
+        conversation.update(status: :open)
+
+        service.perform
+
+        expect(MessageTemplates::Template::CsatSurvey).not_to have_received(:new)
+        expect(conversation).not_to have_received(:create_csat_not_sent_activity_message)
+      end
+
+      it 'does nothing when CSAT survey is not enabled' do
+        inbox.update(csat_survey_enabled: false)
+
+        service.perform
+
+        expect(MessageTemplates::Template::CsatSurvey).not_to have_received(:new)
+        expect(conversation).not_to have_received(:create_csat_not_sent_activity_message)
+      end
+
+      it 'does nothing when CSAT already sent' do
+        create(:message, conversation: conversation, content_type: :input_csat)
+
+        service.perform
+
+        expect(MessageTemplates::Template::CsatSurvey).not_to have_received(:new)
+        expect(conversation).not_to have_received(:create_csat_not_sent_activity_message)
+      end
+
+      it 'does nothing for Twitter conversations' do
+        twitter_channel = create(:channel_twitter_profile)
+        twitter_inbox = create(:inbox, channel: twitter_channel, csat_survey_enabled: true)
+        twitter_conversation = create(:conversation,
+                                      inbox: twitter_inbox,
+                                      status: :resolved,
+                                      additional_attributes: { type: 'tweet' })
+        twitter_service = described_class.new(conversation: twitter_conversation)
+
+        twitter_service.perform
+
+        expect(MessageTemplates::Template::CsatSurvey).not_to have_received(:new)
+        expect(conversation).not_to have_received(:create_csat_not_sent_activity_message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-4415/postmortem-csat-survey-infinite-loop-issue