### PR TITLE
feat: improve article search ranking

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -76,18 +76,24 @@ class Article < ApplicationRecord
   scope :order_by_views, -> { reorder(views: :desc) }
 
   # TODO: if text search slows down https://www.postgresql.org/docs/current/textsearch-features.html#TEXTSEARCH-UPDATE-TRIGGERS
+  # - the A, B and C are for weightage. See: https://github.com/Casecommons/pg_search#weighting
+  # - the normalization is for ensuring the long articles that mention the search term too many times are not ranked higher.
+  #   it divides rank by log(document_length) to prevent longer articles from ranking higher just due to sizeSee: https://github.com/Casecommons/pg_search#normalization
+  # - the ranking is to ensure that articles with higher weightage are ranked higher
   pg_search_scope(
     :text_search,
-    against: %i[
-      title
-      description
-      content
-    ],
+    against: {
+      title: 'A',
+      description: 'B',
+      content: 'C'
+    },
     using: {
       tsearch: {
-        prefix: true
+        prefix: true,
+        normalization: 2
       }
-    }
+    },
+    ranked_by: ':tsearch'
   )
 
   def self.search(params)

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -96,7 +96,6 @@ class SearchService
   def filter_articles
     @articles = current_account.articles
                                .text_search(search_query)
-                               .reorder('updated_at DESC')
                                .page(params[:page])
                                .per(15)
   end


### PR DESCRIPTION
This PR enhances article search by implementing weighted ranking that prioritizes title and description matches over content matches. Previously, all text fields were treated equally, which could surface less relevant articles with many content keyword matches rather than focused articles with title matches. We do this with the following changes

- Added weighted search ranking: title (A), description (B), content (C)
- Implemented automatic relevance-based ordering with document length normalization

These changes should introduce minimal performance overhead since the ranking happens in-memory using existing indexes.