### PR TITLE
fix: Force re-render the CSAT component when data changes

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
@@ -90,7 +90,6 @@ const columns = [
       const [ratingObject = {}] = CSAT_RATINGS.filter(
         rating => rating.value === giveRating
       );
-
       return h(
         'span',
         {
@@ -110,7 +109,13 @@ const columns = [
   columnHelper.accessor('conversationId', {
     header: '',
     width: 100,
-    cell: cellProps => h(ConversationCell, cellProps),
+    cell: cellProps => {
+      const { row } = cellProps;
+      return h(ConversationCell, {
+        key: row.original.conversationId,
+        row,
+      });
+    },
   }),
 ];
 


### PR DESCRIPTION
The CSAT table was retaining links from the previous conversation even after the underlying data changed. This seems to be related to how TanStack Table renders the components. As a temporary fix, I’ve added a key prop to force a re-render.