### PR TITLE
fix: route params not reacting to changes

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/ConversationCell.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/ConversationCell.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { computed } from 'vue';
+
 const { row } = defineProps({
   row: {
     type: Object,
@@ -6,10 +8,10 @@ const { row } = defineProps({
   },
 });
 
-const routerParams = {
+const routerParams = computed(() => ({
   name: 'inbox_conversation',
   params: { conversation_id: row.original.conversationId },
-};
+}));
 </script>
 
 <template>

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatTable.vue
@@ -90,6 +90,7 @@ const columns = [
       const [ratingObject = {}] = CSAT_RATINGS.filter(
         rating => rating.value === giveRating
       );
+
       return h(
         'span',
         {
@@ -109,13 +110,7 @@ const columns = [
   columnHelper.accessor('conversationId', {
     header: '',
     width: 100,
-    cell: cellProps => {
-      const { row } = cellProps;
-      return h(ConversationCell, {
-        key: row.original.conversationId,
-        row,
-      });
-    },
+    cell: cellProps => h(ConversationCell, cellProps),
   }),
 ];
 


### PR DESCRIPTION
Follow-up fix to: https://github.com/chatwoot/chatwoot/pull/11643

The issue is the following. 

- Open CSAT reports.
- Click on the conversation links (it works fine)
- Apply a user filter (and probably a rating filter), just make sure that you have a new data than previous, any filter would do
- Click on the link, it would redirect to a different link. (if you observe, it is redirecting to the previous conversation data)

Note that the conversation link shown on the UI is different than the one which it is redirected to.

## Preview

https://github.com/user-attachments/assets/96ae79f3-fd42-4293-b8d4-f886f48e7868


