### PR TITLE
fix: Reset conversation sidebar when copilot is open

### DIFF
--- a/app/javascript/dashboard/components-next/copilot/CopilotLauncher.vue
+++ b/app/javascript/dashboard/components-next/copilot/CopilotLauncher.vue
@@ -42,6 +42,7 @@ const showCopilotLauncher = computed(() => {
 const toggleSidebar = () => {
   updateUISettings({
     is_copilot_panel_open: !uiSettings.value.is_copilot_panel_open,
+    is_contact_sidebar_open: false,
   });
 };
 </script>


### PR DESCRIPTION
Both the Copilot and the conversation sidebar were open at the same time, which shouldn’t be possible.