### PR TITLE
fix: Show default dashboard prompt for contact and articles

### DIFF
--- a/app/javascript/dashboard/components-next/copilot/CopilotEmptyState.vue
+++ b/app/javascript/dashboard/components-next/copilot/CopilotEmptyState.vue
@@ -46,8 +46,8 @@ const getCurrentRoute = () => {
   const path = route.path;
   if (path.includes('/conversations')) return 'conversations';
   if (path.includes('/dashboard')) return 'dashboard';
-  if (path.includes('/contacts')) return 'contacts';
-  if (path.includes('/articles')) return 'articles';
+  // if (path.includes('/contacts')) return 'contacts';
+  // if (path.includes('/articles')) return 'articles';
   return 'dashboard';
 };
 

--- a/app/javascript/dashboard/components-next/copilot/CopilotEmptyState.vue
+++ b/app/javascript/dashboard/components-next/copilot/CopilotEmptyState.vue
@@ -46,8 +46,6 @@ const getCurrentRoute = () => {
   const path = route.path;
   if (path.includes('/conversations')) return 'conversations';
   if (path.includes('/dashboard')) return 'dashboard';
-  // if (path.includes('/contacts')) return 'contacts';
-  // if (path.includes('/articles')) return 'articles';
   return 'dashboard';
 };
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where the copilot displayed irrelevant prompts on the Contacts and Article pages.

Previously, conversation-specific prompts like "Summarize", "Suggest answer", and "Rate the conversation" were shown even outside conversations. With this update, users navigating to the Contacts or Articles routes will now see appropriate dashboard prompts such as "High priority conversation" and "List contacts".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Contacts Page**
<img width="1401" alt="image" src="https://github.com/user-attachments/assets/242f42a1-d9a5-4369-bd00-5c22e977970d" />

**Articles page**
<img width="1401" alt="image" src="https://github.com/user-attachments/assets/12c5575d-9c50-4530-a0c9-2f02fbf4c732" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
