### PR TITLE
fix: Avoid throwing 406 for non-json requests

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -15,7 +15,7 @@ class DashboardController < ActionController::Base
   private
 
   def ensure_html_format
-    head :not_acceptable unless request.format.html?
+    head :not_acceptable if request.format.json?
   end
 
   def set_global_config

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -15,7 +15,7 @@ class DashboardController < ActionController::Base
   private
 
   def ensure_html_format
-    head :not_acceptable if request.format.json?
+    render json: { error: 'Please use API routes instead of dashboard routes for JSON requests' }, status: :not_acceptable if request.format.json?
   end
 
   def set_global_config

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -19,9 +19,10 @@ describe '/app/login', type: :request do
   end
 
   context 'with non-HTML format' do
-    it 'returns not acceptable for JSON' do
-      get '/app/login', params: { format: 'json' }
+    it 'returns not acceptable for JSON with error message' do
+      get '/app/login', headers: { 'Accept' => 'application/json' }
       expect(response).to have_http_status(:not_acceptable)
+      expect(response.parsed_body).to eq({ 'error' => 'Please use API routes instead of dashboard routes for JSON requests' })
     end
   end
 


### PR DESCRIPTION
Users get confused between app routes and API routes. Instead of hitting /api, they append /app in the API call, which ends up calling the dashboard controller and throws an error. To fix this, we added a check to throw a 406 Not Acceptable for non-HTML requests. But Meta requires Accept: \*/\* to return 200 for the integration to be accepted.

This change will only throw an error for JSON requests.

Fixes #11697
Fixes https://github.com/chatwoot/chatwoot/issues/11251
Fixes https://github.com/chatwoot/chatwoot/issues/11205