### PR TITLE
fix(migrations): skip enabling postgres extensions if already present

### DIFF
--- a/db/migrate/20230426130150_init_schema.rb
+++ b/db/migrate/20230426130150_init_schema.rb
@@ -1,10 +1,11 @@
 class InitSchema < ActiveRecord::Migration[6.1]
   def up
     # These are extensions that must be enabled in order to support this database
-    enable_extension "pg_stat_statements"
-    enable_extension "pg_trgm"
-    enable_extension "pgcrypto"
-    enable_extension "plpgsql"
+    enable_extension "pg_stat_statements" unless extension_enabled?("pg_stat_statements")
+    enable_extension "pg_trgm" unless extension_enabled?("pg_trgm")
+    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
+    enable_extension "plpgsql" unless extension_enabled?("plpgsql")
+
     create_table "access_tokens" do |t|
       t.string "owner_type"
       t.bigint "owner_id"


### PR DESCRIPTION
### Fix: prevent error when enabling pg_stat_statements, pg_trgm, pgcrypto and plpgsql on PostgreSQL environments like Azure

#### Context

When deploying Chatwoot to Azure Database for PostgreSQL, the following errors were triggered during database migrations:

```
ERROR: extension "pg_stat_statements" must not be created explicitly
ERROR: extension "pg_trgm" must not be created explicitly
ERROR: extension "pgcrypto" must not be created explicitly
ERROR: extension "plpgsql" must not be created explicitly
```

This happens because in Azure-managed PostgreSQL instances, some extension are already enabled by default at the system level. PostgreSQL does not allow explicitly enabling this extension again, not even with `IF NOT EXISTS`, which causes migrations to fail.

#### Fix

To resolve this issue, this PR introduces a conditional check before enabling the extension:

```ruby
    enable_extension "pg_stat_statements" unless extension_enabled?("pg_stat_statements")
    enable_extension "pg_trgm" unless extension_enabled?("pg_trgm")
    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
    enable_extension "plpgsql" unless extension_enabled?("plpgsql")
```

This ensures that the migration will only attempt to enable the extension if it is not already present, thus avoiding the error in managed environments like Azure.

#### Result

After applying this change, migrations complete successfully on Azure PostgreSQL without any interruption. The change is backwards-compatible and safe for all environments, including local or standard PostgreSQL setups.

This fix ensures smoother deployment of Chatwoot in cloud infrastructure scenarios.

---