### PR TITLE
chore: Display divider only when multiple portals are available

### DIFF
--- a/app/views/public/api/v1/portals/_header.html.erb
+++ b/app/views/public/api/v1/portals/_header.html.erb
@@ -1,18 +1,18 @@
 <header class="sticky top-0 z-50 w-full bg-white shadow-sm dark:bg-slate-900">
   <nav class="hidden sm:flex max-w-5xl px-4 mx-auto md:px-8" aria-label="Top">
     <div class="flex items-center w-full py-5 overflow-hidden">
-      <a href="<%= generate_home_link(@portal.slug, @portal.config['default_locale'] || params[:locale], @theme_from_params, @is_plain_layout_enabled) %>" class="flex items-center h-10">
+      <a href="<%= generate_home_link(@portal.slug, @portal.config['default_locale'] || params[:locale], @theme_from_params, @is_plain_layout_enabled) %>" class="flex items-center min-w-0 h-10">
         <% if @portal.logo.present? %>
-          <img src="<%= url_for(@portal.logo) %>" class="w-auto h-10 ltr:mr-2 rtl:ml-2" />
+          <img src="<%= url_for(@portal.logo) %>" class="w-auto h-10 ltr:mr-2 rtl:ml-2" draggable="false" />
         <% end %>
-        <span class="text-lg font-semibold text-slate-900 dark:text-white <%= @portal.logo.present? ? 'hidden' : 'hidden sm:block' %>"><%= @portal.name %></span>
+        <span class="text-lg font-semibold text-slate-900 truncate dark:text-white <%= @portal.logo.present? ? 'hidden lg:block' : 'hidden sm:block' %>"><%= @portal.name %></span>
       </a>
     </div>
 
     <%# Go to homepage link section %>
     <div class="flex items-center justify-between gap-2 sm:gap-5">
       <% if @portal.homepage_link %>
-        <div class="hidden px-1 py-2 ltr:ml-8 rtl:mr-8 cursor-pointer md:block">
+        <div class="px-1 py-2 ltr:ml-8 rtl:mr-8 cursor-pointer block">
           <div class="flex-grow flex-shrink-0">
             <a id="header-action-button" target="_blank" rel="noopener noreferrer nofollow" href="<%= @portal.homepage_link %>" class="flex flex-row items-center gap-1 text-sm font-medium whitespace-nowrap text-slate-800 dark:text-slate-100 stroke-slate-700 dark:stroke-slate-200">
               <%= render partial: 'icons/redirect' %>
@@ -99,11 +99,11 @@
 
   <nav class="flex sm:hidden max-w-5xl px-4 mx-auto" aria-label="Mobile Top">
     <div class="flex items-center justify-between w-full py-5">
-      <a href="<%= generate_home_link(@portal.slug, @portal.config['default_locale'] || params[:locale], @theme_from_params, @is_plain_layout_enabled) %>" class="flex items-center h-10 text-lg font-semibold text-slate-900 dark:text-white">
+      <a href="<%= generate_home_link(@portal.slug, @portal.config['default_locale'] || params[:locale], @theme_from_params, @is_plain_layout_enabled) %>" class="flex items-center min-w-0 h-10 text-lg font-semibold text-slate-900 dark:text-white">
         <% if @portal.logo.present? %>
-          <img src="<%= url_for(@portal.logo) %>" class="w-auto h-10 ltr:mr-2 rtl:ml-2" />
+          <img src="<%= url_for(@portal.logo) %>" class="w-auto h-10 ltr:mr-2 rtl:ml-2" draggable="false" />
         <% end %>
-         <span class="text-lg font-semibold text-slate-900 dark:text-white <%= @portal.logo.present? ? 'hidden' : 'sm:hidden block' %>"><%= @portal.name %></span>
+         <span class="text-lg font-semibold text-slate-900 truncate dark:text-white <%= @portal.logo.present? ? 'hidden' : 'sm:hidden block' %>"><%= @portal.name %></span>
       </a>
 
       <!-- Mobile Menu Component -->

--- a/app/views/public/api/v1/portals/_hero.html.erb
+++ b/app/views/public/api/v1/portals/_hero.html.erb
@@ -2,7 +2,7 @@
 <section id="portal-bg" class="w-full bg-white dark:bg-slate-900 shadow-inner">
   <div id="portal-bg-gradient" class="pt-8 pb-8 md:pt-14 md:pb-6 min-h-[240px] md:min-h-[260px]">
     <div class="mx-auto max-w-5xl px-4 md:px-8 flex flex-col items-start">
-       <span class="text-sm leading-[24px] font-semibold text-slate-600 dark:text-slate-300 mb-1 <%= @portal.logo.present? ? 'block' : 'hidden' %>"><%= @portal.name %></span>
+       <span class="text-sm leading-[24px] font-semibold text-slate-600 dark:text-slate-300 mb-1 <%= @portal.logo.present? ? 'block lg:hidden' : 'hidden' %>"><%= @portal.name %></span>
       <h1 class="text-2xl md:text-4xl text-slate-900 dark:text-white font-semibold leading-normal">
         <%= portal.header_text %>
       </h1>

--- a/app/views/public/api/v1/portals/_mobile_menu.html.erb
+++ b/app/views/public/api/v1/portals/_mobile_menu.html.erb
@@ -46,7 +46,9 @@
           </div>
         </div>
 
-        <span class="h-px bg-slate-100/70 dark:bg-slate-800/70 w-full"></span>
+        <% if @portal.config["allowed_locales"].length > 1 %>
+          <span class="h-px bg-slate-100/70 dark:bg-slate-800/70 w-full"></span>
+        <% end %>
 
         <!-- Locale Switcher -->
         <% if @portal.config["allowed_locales"].length > 1 %>

--- a/app/views/public/api/v1/portals/_mobile_menu.html.erb
+++ b/app/views/public/api/v1/portals/_mobile_menu.html.erb
@@ -1,3 +1,4 @@
+<% has_multiple_locales = @portal.config["allowed_locales"].length > 1 %>
 
 <input type="checkbox" id="mobile-menu-toggle" class="peer/menu hidden" />
 
@@ -46,12 +47,12 @@
           </div>
         </div>
 
-        <% if @portal.config["allowed_locales"].length > 1 %>
+        <% if has_multiple_locales %>
           <span class="h-px bg-slate-100/70 dark:bg-slate-800/70 w-full"></span>
         <% end %>
 
         <!-- Locale Switcher -->
-        <% if @portal.config["allowed_locales"].length > 1 %>
+        <% if has_multiple_locales %>
           <div id="header-action-button" class="flex flex-col gap-2">
             <h3 class="text-base font-medium text-slate-700 dark:text-slate-300 my-2">
               <%= I18n.t('public_portal.header.language', default: 'Language') %>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where the divider line was shown even when the locale section was not visible.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="404" alt="image" src="https://github.com/user-attachments/assets/1378e834-37bd-4a45-8ca4-af8bebd38ae9" />


**After**
<img width="404" alt="image" src="https://github.com/user-attachments/assets/13586ddb-ede0-4828-b412-87d103022480" />
<img width="404" alt="image" src="https://github.com/user-attachments/assets/806108aa-e69b-4b2d-b9be-b5f7483c368d" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
