### PR TITLE
feat: expose custom attributes in conversation to Captain

### DIFF
--- a/app/services/llm_formatter/conversation_llm_formatter.rb
+++ b/app/services/llm_formatter/conversation_llm_formatter.rb
@@ -11,6 +11,13 @@ class LlmFormatter::ConversationLlmFormatter < LlmFormatter::DefaultLlmFormatter
                 end
 
     sections << "Contact Details: #{@record.contact.to_llm_text}" if config[:include_contact_details]
+
+    attributes = build_attributes
+    if attributes.present?
+      sections << 'Conversation Attributes:'
+      sections << attributes
+    end
+
     sections.join("\n")
   end
 
@@ -29,5 +36,12 @@ class LlmFormatter::ConversationLlmFormatter < LlmFormatter::DefaultLlmFormatter
   def format_message(message)
     sender = message.message_type == 'incoming' ? 'User' : 'Support agent'
     "#{sender}: #{message.content}\n"
+  end
+
+  def build_attributes
+    attributes = @record.account.custom_attribute_definitions.with_attribute_model('conversation_attribute').map do |attribute|
+      "#{attribute.attribute_display_name}: #{@record.custom_attributes[attribute.attribute_key]}"
+    end
+    attributes.join("\n")
   end
 end

--- a/spec/services/llm_formatter/conversation_llm_formatter_spec.rb
+++ b/spec/services/llm_formatter/conversation_llm_formatter_spec.rb
@@ -61,5 +61,30 @@ RSpec.describe LlmFormatter::ConversationLlmFormatter do
         expect(formatter.format(include_contact_details: true)).to eq(expected_output)
       end
     end
+
+    context 'when conversation has custom attributes' do
+      it 'includes formatted custom attributes in the output' do
+        create(
+          :custom_attribute_definition,
+          account: account,
+          attribute_display_name: 'Order ID',
+          attribute_key: 'order_id',
+          attribute_model: :conversation_attribute
+        )
+
+        conversation.update(custom_attributes: { 'order_id' => '12345' })
+
+        expected_output = [
+          "Conversation ID: ##{conversation.display_id}",
+          "Channel: #{conversation.inbox.channel.name}",
+          'Message History:',
+          'No messages in this conversation',
+          'Conversation Attributes:',
+          'Order ID: 12345'
+        ].join("\n")
+
+        expect(formatter.format).to eq(expected_output)
+      end
+    end
   end
 end


### PR DESCRIPTION
# Pull Request Template

## Linear Link
https://linear.app/chatwoot/issue/CW-4480/expose-custom-attributes-in-conversation-to-captain-so-that-it-can

## Description

Expose custom attributes in conversation to Captain so that it can provide more information

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

![Screenshot 2025-06-19 at 9 50 45 AM](https://github.com/user-attachments/assets/5216e116-bd89-4d0c-b6a6-416b082638f7)
![Screenshot 2025-06-19 at 9 50 40 AM](https://github.com/user-attachments/assets/a81cb4ad-973b-405c-b188-295d1acce814)



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
