### PR TITLE
fix: Incorrect conversation count shown for filters/folders after idle period

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -756,6 +756,7 @@ function toggleSelectAll(check) {
 }
 
 useEmitter('fetch_conversation_stats', () => {
+  if (hasAppliedFiltersOrActiveFolders.value) return;
   store.dispatch('conversationStats/get', conversationFilters.value);
 });
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where the `/meta` endpoint is triggered via an Action Cable event, which updates the store with unfiltered chat type data. This results in incorrect conversation counts being shown for active filters or folders, especially after the app has been idle for some time.


**Solution**
A check is now added to skip fetching stats if `hasAppliedFilters` or `hasActiveFolders` is true.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
