### PR TITLE
fix: Add actor parameter to Linear OAuth for proper app attribution

### DIFF
--- a/app/models/integrations/app.rb
+++ b/app/models/integrations/app.rb
@@ -71,7 +71,8 @@ class Integrations::App
       "redirect_uri=#{self.class.linear_integration_url}",
       "state=#{encode_state}",
       'scope=read,write',
-      'prompt=consent'
+      'prompt=consent',
+      'actor=app'
     ].join('&')
   end
 


### PR DESCRIPTION
 - Add `actor=app` parameter to Linear OAuth authorization URL
  - Ensures all Linear issues are consistently attributed to the app rather than individual users