### PR TITLE
fix: Update ActiveStorage::FileNotFoundError error and fix the captain condition in audio transcription

### DIFF
--- a/enterprise/app/jobs/captain/conversation/response_builder_job.rb
+++ b/enterprise/app/jobs/captain/conversation/response_builder_job.rb
@@ -13,7 +13,7 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
       generate_and_process_response
     end
   rescue StandardError => e
-    raise e if e.is_a?(ActiveJob::FileNotFoundError)
+    raise e if e.is_a?(ActiveStorage::FileNotFoundError)
 
     handle_error(e)
   ensure

--- a/enterprise/app/services/messages/audio_transcription_service.rb
+++ b/enterprise/app/services/messages/audio_transcription_service.rb
@@ -20,7 +20,7 @@ class Messages::AudioTranscriptionService < Llm::BaseOpenAiService
   private
 
   def can_transcribe?
-    return false if account.feature_enabled?('captain_integration')
+    return false unless account.feature_enabled?('captain_integration')
     return false if account.audio_transcriptions.blank?
 
     account.usage_limits[:captain][:responses][:current_available].positive?

--- a/spec/enterprise/services/messages/audio_transcription_service_spec.rb
+++ b/spec/enterprise/services/messages/audio_transcription_service_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe Messages::AudioTranscriptionService, type: :service do
   describe '#perform' do
     let(:service) { described_class.new(attachment) }
 
+    context 'when captain_integration feature is not enabled' do
+      before do
+        account.disable_features!('captain_integration')
+      end
+
+      it 'returns transcription limit exceeded' do
+        expect(service.perform).to eq({ error: 'Transcription limit exceeded' })
+      end
+    end
+
     context 'when transcription is successful' do
       before do
         # Mock can_transcribe? to return true and transcribe_audio method


### PR DESCRIPTION
Update the error to `ActiveStorage::FileNotFoundError`. Fix the condition to enable audio transcription and added a spec for it.