### PR TITLE
feat(config): add support for custom PostgreSQL schema via POSTGRES_SCHEMA env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,8 @@ REDIS_SENTINEL_MASTER_NAME=
 POSTGRES_HOST=postgres
 POSTGRES_USERNAME=postgres
 POSTGRES_PASSWORD=
+# PostgreSQL schema (default: public)
+POSTGRES_SCHEMA=public
 RAILS_ENV=development
 # Changes the Postgres query timeout limit. The default is 14 seconds. Modify only when required.
 # POSTGRES_STATEMENT_TIMEOUT=14s

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,6 +8,11 @@ default: &default
   # frequency in seconds to periodically run the Reaper, which attempts
   # to find and recover connections from dead threads
   reaping_frequency: <%= ENV.fetch('DB_POOL_REAPING_FREQUENCY', 30) %>
+
+  # Specifies the PostgreSQL schema Rails should use.
+  # Defaults to "public", override with ENV['POSTGRES_SCHEMA'].
+  schema_search_path: <%= ENV.fetch('POSTGRES_SCHEMA', 'public') %>
+
   variables:
     # we are setting this value to be close to the racktimeout value. we will iterate and reduce this value going forward
     statement_timeout: <%= ENV["POSTGRES_STATEMENT_TIMEOUT"] || "14s" %>

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -46,6 +46,8 @@ services:
       - POSTGRES_USER=postgres
       # Please provide your own password.
       - POSTGRES_PASSWORD=
+      # PostgreSQL schema (default: public)
+      - POSTGRES_SCHEMA=public
 
   redis:
     image: redis:alpine

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -49,6 +49,8 @@ services:
       - POSTGRES_DB=chatwoot
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=
+      # PostgreSQL schema (default: public)
+      - POSTGRES_SCHEMA=public
 
   redis:
     image: redis:alpine

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -93,6 +93,8 @@ services:
       - POSTGRES_DB=chatwoot
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=
+      # PostgreSQL schema (default: public)
+      - POSTGRES_SCHEMA=public
 
   redis:
     image: redis:alpine


### PR DESCRIPTION
# add support for custom PostgreSQL schema via POSTGRES_SCHEMA env var

## Description

This change adds support for a custom PostgreSQL schema by introducing the `POSTGRES_SCHEMA` environment variable, which is used to configure the `schema_search_path` in `config/database.yml`. When `POSTGRES_SCHEMA` is set (for example `chatwoot`), all migrations, web processes and Sidekiq jobs will operate on that schema instead of the default `public`. This enhancement ensures compatibility with hosting platforms like Supabase that rely on non-public schemas.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  
- [ ] This change requires a documentation update  

## How Has This Been Tested?

1. Created a new schema `chatwoot` and granted privileges:
   ```bash
   export PGPASSWORD='<your_postgres_password>'
   psql -h pgvector -p 5432 -U postgres -d postgres <<SQL
   CREATE SCHEMA IF NOT EXISTS chatwoot AUTHORIZATION postgres;
   GRANT USAGE, CREATE ON SCHEMA chatwoot TO postgres;    
2. Set `POSTGRES_SCHEMA=chatwoot` in the environment.  
3. Ran `bin/rails db:chatwoot_prepare` and verified that tables, sequences and extensions were created under `chatwoot.*`.  
4. Started the Rails server and Sidekiq; confirmed no errors in the logs and that data reads/writes occur in the `chatwoot` schema.  
5. Performed manual smoke tests: user login, creating conversations, inbound email processing, notifications, etc., to ensure full feature parity.

## Checklist:

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [x] I have commented on my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] Any dependent changes have been merged and published in downstream modules  

---

> **Discussion [#11080](https://github.com/chatwoot/chatwoot/discussions/11080)** “Can I use a Custom Postgres Database Schema (other than public)?” opened by @luizeof on Mar 13, 2025

---

*Note: No existing issue was opened for this feature; please create one if needed.*