### PR TITLE
fix: Add composite index on messages for csat_metrics API performance

### DIFF
--- a/db/migrate/20250627195529_add_index_to_messages.rb
+++ b/db/migrate/20250627195529_add_index_to_messages.rb
@@ -1,0 +1,20 @@
+class AddIndexToMessages < ActiveRecord::Migration[7.0]
+  def change
+    # This index is added as a temporary fix for performance issues in the CSAT
+    # responses controller where we query messages with account_id, content_type
+    # and created_at. The current implementation (account.message.input_csat.count)
+    # times out with millions of messages.
+    #
+    # TODO: Create a dedicated csat_survey table and add entries when surveys are
+    # sent, then query this table instead of the entire messages table for better
+    # performance.
+    return if index_exists?(
+      :messages,
+      [:account_id, :content_type, :created_at],
+      name: 'idx_messages_account_content_created'
+    )
+
+    add_index :messages, [:account_id, :content_type, :created_at],
+              name: 'idx_messages_account_content_created', algorithm: :concurrently
+  end
+end


### PR DESCRIPTION
This PR adds a composite index (:account_id, :content_type, :created_at) on the table messages.

This index is added as a temporary fix for performance issues in the CSAT responses controller where we query messages with account_id, content_type and created_at. The current implementation (account.message.input_csat.count) times out with millions of messages.

TODO: Create a dedicated csat_survey table and add entries when surveys are sent, then query this table instead of the entire messages table for better performance.