### PR TITLE
fix: disable_ddl_transaction! on add_index action

### DIFF
--- a/db/migrate/20250627195529_add_index_to_messages.rb
+++ b/db/migrate/20250627195529_add_index_to_messages.rb
@@ -1,4 +1,6 @@
 class AddIndexToMessages < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
   def change
     # This index is added as a temporary fix for performance issues in the CSAT
     # responses controller where we query messages with account_id, content_type


### PR DESCRIPTION
All migrations will automatically be wrapped in a transaction. There are queries that you can’t execute inside a transaction. Adding index concurrently is one of them, we have to disable the transaction. I missed this in the earlier PR. #11831 