### PR TITLE
chore: Disable drag on macro item when preview is open

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/Macros/List.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/Macros/List.vue
@@ -104,7 +104,6 @@ onMounted(() => {
           :key="element.id"
           :macro="element"
           :conversation-id="conversationId"
-          class="drag-handle cursor-grab"
         />
       </template>
     </Draggable>

--- a/app/javascript/dashboard/routes/dashboard/conversation/Macros/MacroItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/Macros/MacroItem.vue
@@ -54,6 +54,7 @@ const closeMacroPreview = () => {
 <template>
   <div
     class="relative flex items-center justify-between leading-4 rounded-md h-10 pl-3 pr-2"
+    :class="showPreview ? 'cursor-default' : 'drag-handle cursor-grab'"
   >
     <span
       class="overflow-hidden whitespace-nowrap text-ellipsis font-medium text-n-slate-12"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR updates the macro list behavior to prevent dragging only on the item whose preview is open, allowing users to easily copy content from the macro preview and paste it into the editor or elsewhere.

Since the `showPreview` flag exists within each `MacroItem`, the drag disabling logic is handled locally inside the component, ensuring the rest of the list remains draggable.


Fixes [CW-4548](https://linear.app/chatwoot/issue/CW-4548/conversation-macro-can-no-longer-be-copied), https://github.com/chatwoot/chatwoot/issues/11814

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/53f6d995a8514413b0c99e702aba5b73?sid=f6233dd8-18cb-4f2a-84a6-f72edc36b798


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
