### PR TITLE
fix: do not enforce max_limits if inbox_auto_assignment is disabled

### DIFF
--- a/enterprise/app/models/enterprise/inbox.rb
+++ b/enterprise/app/models/enterprise/inbox.rb
@@ -1,5 +1,7 @@
 module Enterprise::Inbox
   def member_ids_with_assignment_capacity
+    return super unless enable_auto_assignment?
+
     max_assignment_limit = auto_assignment_config['max_assignment_limit']
     overloaded_agent_ids = max_assignment_limit.present? ? get_agent_ids_over_assignment_limit(max_assignment_limit) : []
     super - overloaded_agent_ids

--- a/spec/enterprise/models/conversation_spec.rb
+++ b/spec/enterprise/models/conversation_spec.rb
@@ -74,4 +74,33 @@ RSpec.describe Conversation, type: :model do
       end
     end
   end
+
+  describe 'assignment capacity limits' do
+    describe 'team assignment with inbox auto-assignment disabled' do
+      let(:account) { create(:account) }
+      let(:inbox) { create(:inbox, account: account, enable_auto_assignment: false, auto_assignment_config: { max_assignment_limit: 1 }) }
+      let(:team) { create(:team, account: account, allow_auto_assign: true) }
+      let!(:agent1) { create(:user, account: account, role: :agent) }
+      let!(:agent2) { create(:user, account: account, role: :agent) }
+
+      before do
+        create(:inbox_member, inbox: inbox, user: agent1)
+        create(:inbox_member, inbox: inbox, user: agent2)
+        create(:team_member, team: team, user: agent1)
+        create(:team_member, team: team, user: agent2)
+        # Both agents are over the limit (simulate by assigning open conversations)
+        create_list(:conversation, 2, inbox: inbox, assignee: agent1, status: :open)
+        create_list(:conversation, 2, inbox: inbox, assignee: agent2, status: :open)
+      end
+
+      it 'does not enforce max_assignment_limit for team assignment when inbox auto-assignment is disabled' do
+        conversation = create(:conversation, inbox: inbox, account: account, assignee: nil, status: :open)
+        # Assign to team to trigger the assignment logic
+        conversation.update!(team: team)
+        # Should assign to a team member even if they are over the limit
+        expect(conversation.reload.assignee).to be_present
+        expect([agent1, agent2]).to include(conversation.reload.assignee)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Pull Request Template

## Description

The `auto_assignment` max_limits were being enforced even if the inbox level `auto_assign` feature was disabled.  This was because the enterprise method was not verifying the feature status before returning the available agents.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Tested locally
- Added Specs

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
