### PR TITLE
feat: Cancel redundant ci runs on consecutive pushes on the same PR

### DIFF
--- a/.github/workflows/deploy_check.yml
+++ b/.github/workflows/deploy_check.yml
@@ -6,6 +6,11 @@ name: Deploy Check
 on:
   pull_request:
 
+# If two pushes happen within a short time in the same PR, cancel the run of the oldest push
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   deployment_check:
     name: Check Deployment

--- a/.github/workflows/logging_percentage_check.yml
+++ b/.github/workflows/logging_percentage_check.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - develop
 
+# If two pushes happen within a short time in the same PR, cancel the run of the oldest push
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   log_lines_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - develop
 
+# If two pushes happen within a short time in the same PR, cancel the run of the oldest push
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
# Pull Request Template

## Description

Currently, if a PR is open and a push happens, the Run Size Limit Check workflow will start running. If, shortly after a subsequent push on the same PR happens, the workflow will start running again without cancelling the previous (now obsolete) run. With these changes, the first run would be cancelled, thus saving compute resources (see below for quantity) without sacrificing functionality, since the second run will contain the changes from the first push as well.

Fixes #11839 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

No testing has been performed, the three added lines come directly out of the [official documentation](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow).


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
