### PR TITLE
fix: Migration error on fresh dev setup

### DIFF
--- a/db/migrate/20231211010807_add_cached_labels_list.rb
+++ b/db/migrate/20231211010807_add_cached_labels_list.rb
@@ -2,6 +2,6 @@ class AddCachedLabelsList < ActiveRecord::Migration[7.0]
   def change
     add_column :conversations, :cached_label_list, :string
     Conversation.reset_column_information
-    ActsAsTaggableOn::Taggable::Cache.included(Conversation)
+    ActsAsTaggableOn::Taggable::Caching.included(Conversation)
   end
 end


### PR DESCRIPTION
## Description

This PR fixes the problem in the following issue: #11853 

For new setups, when running migrations an error occurs. This is due to a syntax error: `ActsAsTaggableOn::Taggable::Cache` (does not exist, the correct one according to the gem is `ActsAsTaggableOn::Taggable::Caching`)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Clone the project from the `develop` branch and follow the setup according to the current official documentation.

