### PR TITLE
fix: Variable search item not showing after braces/commas

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/VariableList.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/VariableList.vue
@@ -1,6 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import { MESSAGE_VARIABLES } from 'shared/constants/messages';
+import { sanitizeVariableSearchKey } from 'dashboard/helper/commons';
 import MentionBox from '../mentions/MentionBox.vue';
 
 export default {
@@ -17,11 +18,7 @@ export default {
       customAttributes: 'attributes/getAttributes',
     }),
     sanitizedSearchKey() {
-      // Remove braces, commas, and whitespace for accurate matching
-      return this.searchKey
-        .replace(/[{}]/g, '') // remove all curly braces
-        .replace(/,/g, '') // remove commas
-        .trim();
+      return sanitizeVariableSearchKey(this.searchKey);
     },
     items() {
       return [

--- a/app/javascript/dashboard/components/widgets/conversation/VariableList.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/VariableList.vue
@@ -16,6 +16,13 @@ export default {
     ...mapGetters({
       customAttributes: 'attributes/getAttributes',
     }),
+    sanitizedSearchKey() {
+      // Remove braces, commas, and whitespace for accurate matching
+      return this.searchKey
+        .replace(/[{}]/g, '') // remove all curly braces
+        .replace(/,/g, '') // remove commas
+        .trim();
+    },
     items() {
       return [
         ...this.standardAttributeVariables,
@@ -25,8 +32,8 @@ export default {
     standardAttributeVariables() {
       return MESSAGE_VARIABLES.filter(variable => {
         return (
-          variable.label.includes(this.searchKey) ||
-          variable.key.includes(this.searchKey)
+          variable.label.includes(this.sanitizedSearchKey) ||
+          variable.key.includes(this.sanitizedSearchKey)
         );
       }).map(variable => ({
         label: variable.key,

--- a/app/javascript/dashboard/helper/commons.js
+++ b/app/javascript/dashboard/helper/commons.js
@@ -83,3 +83,16 @@ export const convertToPortalSlug = text => {
     .replace(/[^\w ]+/g, '')
     .replace(/ +/g, '-');
 };
+
+/**
+ * Strip curly braces, commas and leading/trailing whitespace from a search key.
+ * Eg. "{{contact.name}}," => "contact.name"
+ * @param {string} searchKey
+ * @returns {string}
+ */
+export const sanitizeVariableSearchKey = (searchKey = '') => {
+  return searchKey
+    .replace(/[{}]/g, '') // remove all curly braces
+    .replace(/,/g, '') // remove commas
+    .trim();
+};

--- a/app/javascript/dashboard/helper/specs/commons.spec.js
+++ b/app/javascript/dashboard/helper/specs/commons.spec.js
@@ -4,6 +4,7 @@ import {
   convertToAttributeSlug,
   convertToCategorySlug,
   convertToPortalSlug,
+  sanitizeVariableSearchKey,
 } from '../commons';
 
 describe('#getTypingUsersText', () => {
@@ -105,5 +106,39 @@ describe('convertToCategorySlug', () => {
 describe('convertToPortalSlug', () => {
   it('should convert to slug', () => {
     expect(convertToPortalSlug('Room rental')).toBe('room-rental');
+  });
+});
+
+describe('sanitizeVariableSearchKey', () => {
+  it('removes braces', () => {
+    expect(sanitizeVariableSearchKey('{{contact.name}}')).toBe('contact.name');
+  });
+
+  it('removes right braces', () => {
+    expect(sanitizeVariableSearchKey('contact.name}}')).toBe('contact.name');
+  });
+
+  it('removes braces, comma and whitespace', () => {
+    expect(sanitizeVariableSearchKey(' {{contact.name }},')).toBe(
+      'contact.name'
+    );
+  });
+
+  it('trims whitespace', () => {
+    expect(sanitizeVariableSearchKey('  contact.name  ')).toBe('contact.name');
+  });
+
+  it('handles multiple commas', () => {
+    expect(sanitizeVariableSearchKey('{{contact.name}},,')).toBe(
+      'contact.name'
+    );
+  });
+
+  it('returns empty string when only braces/commas/whitespace', () => {
+    expect(sanitizeVariableSearchKey(' {  }, , ')).toBe('');
+  });
+
+  it('returns empty string for undefined input', () => {
+    expect(sanitizeVariableSearchKey()).toBe('');
   });
 });


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where typing variables, like `{{contact.name}}`, caused the variable list to miss showing `contact.name`. The search key in this case became `contact.name}},` which didn't match any available options. The logic in `VariableList.vue` only checked the part after the last comma and didn’t fully sanitize the input.

**Solution**
Updated `searchKey` to remove all {} and commas for accurate matching.

Fixes [CW-4574](https://linear.app/chatwoot/issue/CW-4574/i-dont-see-an-option-for-contactname-it-shows-initially-but-it-doesnt)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/fc86e53853ad49e6acf6de57ebbd8fcb?sid=6702f896-d1a3-4c5a-9eb7-b96b5ed91531


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
