### PR TITLE
fix: Incorrect account ID in conversation header back button URL

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
@@ -39,15 +39,21 @@ const chatMetadata = computed(() => props.chat.meta);
 
 const backButtonUrl = computed(() => {
   const {
-    params: { inbox_id: inboxId, label, teamId },
+    params: { inbox_id: inboxId, label, teamId, id: customViewId },
     name,
   } = route;
+
+  const conversationTypeMap = {
+    conversation_through_mentions: 'mention',
+    conversation_through_unattended: 'unattended',
+  };
   return conversationListPageURL({
     accountId: accountId.value,
     inboxId,
     label,
     teamId,
-    conversationType: name === 'conversation_mentions' ? 'mention' : '',
+    conversationType: conversationTypeMap[name],
+    customViewId,
   });
 });
 

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
@@ -43,7 +43,7 @@ const backButtonUrl = computed(() => {
     name,
   } = route;
   return conversationListPageURL({
-    accountId,
+    accountId: accountId.value,
     inboxId,
     label,
     teamId,


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where the back button in the conversation header generated an invalid URL due to an incorrect account ID. It also improves the handling of `conversationType` values and adds support for custom views in the URL.

**Cause:**

* A computed reactive `accountId` was passed directly to `conversationListPageURL`, resulting in `[object Object]` in the generated path.
* `conversationType` was handled with a limited conditional check.
* The `customViewId` path was not handled previously.

**Solution:**

* Pass `accountId.value` to ensure a valid numeric ID is used.
* Use a `conversationTypeMap` for more explicit and scalable mapping of route names.
* Include `customViewId` from the route params to support custom views in the back button URL.


Fixes https://github.com/chatwoot/chatwoot/issues/11859, [CW-4573](https://linear.app/chatwoot/issue/CW-4573/the-previous-button-is-not-working-properly-v420-chatwoot)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/03523144349a42eaa4ece1f88d3b64c3?sid=369f5aac-8294-44b1-86f7-1208d241aec1


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
