### PR TITLE
fix: Escape closing bracket in mention regex

### DIFF
--- a/lib/regex_helper.rb
+++ b/lib/regex_helper.rb
@@ -11,7 +11,7 @@ module RegexHelper
   # Uses [^]]+ to match any characters except ] in display name to support emojis
   # NOTE: Still used by Slack integration (lib/integrations/slack/send_on_slack_service.rb)
   # while notifications use CommonMarker for better markdown processing
-  MENTION_REGEX = Regexp.new('\[(@[^]]+)\]\(mention://(?:user|team)/\d+/([^)]+)\)')
+  MENTION_REGEX = Regexp.new('\[(@[^\\]]+)\]\(mention://(?:user|team)/\d+/([^)]+)\)')
 
   TWILIO_CHANNEL_SMS_REGEX = Regexp.new('^\+\d{1,15}\z')
   TWILIO_CHANNEL_WHATSAPP_REGEX = Regexp.new('^whatsapp:\+\d{1,15}\z')


### PR DESCRIPTION
**Summary**
  - Fixed Ruby warning about unescaped closing bracket in character class within `MENTION_REGEX`
  - Properly escaped the `]` character in the regex pattern to follow Ruby regex syntax standards

**Changes**
  - Updated `MENTION_REGEX` in `lib/regex_helper.rb` to escape the closing bracket in character class `[^]]+` → `[^\\]]+`
