### PR TITLE
feat: remove colon and semicolons when sanitizing inbox name

### DIFF
--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -191,7 +191,7 @@ class Inbox < ApplicationRecord
   end
 
   def apply_sanitization_rules(name)
-    name.gsub(/[\\<>@"!#$%&*+=?^`{|}~]/, '')            # Remove forbidden chars
+    name.gsub(/[\\<>@"!#$%&*+=?^`{|}~:;]/, '')         # Remove forbidden chars
         .gsub(/[\x00-\x1F\x7F]/, ' ')                   # Replace control chars with spaces
         .gsub(/\A[[:punct:]]+|[[:punct:]]+\z/, '')      # Remove leading/trailing punctuation
         .gsub(/\s+/, ' ')                               # Normalize spaces

--- a/spec/models/inbox_spec.rb
+++ b/spec/models/inbox_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe Inbox do
   describe '#sanitized_name' do
     context 'when inbox name contains forbidden characters' do
       it 'removes forbidden and spam-trigger characters' do
-        inbox = FactoryBot.build(:inbox, name: 'Test/Name\\With<Bad>@Characters"And\'Quotes!#$%')
+        inbox = FactoryBot.build(:inbox, name: 'Test/Name\\With<Bad>@Characters"And\';:Quotes!#$%')
         expect(inbox.sanitized_name).to eq('Test/NameWithBadCharactersAnd\'Quotes')
       end
     end


### PR DESCRIPTION
Ref: https://app.chatwoot.com/app/accounts/1/conversations/53511