### PR TITLE
fix(signup): add missing space in signup footer link

### DIFF
--- a/app/javascript/v3/views/auth/signup/Index.vue
+++ b/app/javascript/v3/views/auth/signup/Index.vue
@@ -59,7 +59,7 @@ export default {
           </div>
           <SignupForm />
           <div class="px-1 text-sm text-n-slate-12">
-            <span>{{ $t('REGISTER.HAVE_AN_ACCOUNT') }}</span>
+            <span>{{ $t('REGISTER.HAVE_AN_ACCOUNT') }}</span> 
             <router-link class="text-link text-n-brand" to="/app/login">
               {{
                 useInstallationName(

--- a/app/javascript/v3/views/auth/signup/Index.vue
+++ b/app/javascript/v3/views/auth/signup/Index.vue
@@ -59,7 +59,7 @@ export default {
           </div>
           <SignupForm />
           <div class="px-1 text-sm text-n-slate-12">
-            <span>{{ $t('REGISTER.HAVE_AN_ACCOUNT') }}</span> 
+            <span>{{ $t('REGISTER.HAVE_AN_ACCOUNT') }} </span>
             <router-link class="text-link text-n-brand" to="/app/login">
               {{
                 useInstallationName(


### PR DESCRIPTION
## Description

Add a missing space between the `</span>` and `<router-link>` in the signup footer so it renders correctly:

> Already have an account? Login to Chatwoot

Fixes #11898

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified in the browser that the signup page footer now shows a space before “Login to Chatwoot”  
- Confirmed no other UI regressions on signup

## Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [ ] I have commented on my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes  
- [ ] Any dependent changes have been merged and published in downstream modules  