### PR TITLE
fix(docker): update Dockerfile to resolve CI warnings for ENV and FROM syntax

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # pre-build stage
-FROM node:23-alpine as node
+FROM node:23-alpine AS node
 FROM ruby:3.4.4-alpine3.21 AS pre-builder
 
 ARG NODE_VERSION="23.7.0"


### PR DESCRIPTION
## Description

This PR updates the `docker/Dockerfile` to resolve CI lint warnings by:
- Changing all `FROM ... as ...` to `FROM ... AS ...` for consistent casing.
- Replacing legacy `ENV VAR ${VAR}` syntax with the recommended `ENV VAR=${VAR}` format.

Fixes #11900

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Opened this branch as a PR against `develop` and confirmed that the GitHub Actions `test-build` job no longer emits `LegacyKeyValueFormat` or `FromAsCasing` warnings.
- Verified that all other build steps pass without errors.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules