### PR TITLE
feat: exclude account settings page from upgrade paywall

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/Dashboard.vue
+++ b/app/javascript/dashboard/routes/dashboard/Dashboard.vue
@@ -56,6 +56,7 @@ export default {
       return [
         'billing_settings_index',
         'settings_inbox_list',
+        'general_settings_index',
         'agent_list',
       ].includes(this.$route.name);
     },


### PR DESCRIPTION
This pull request includes a small change to the `Dashboard.vue` file. The change adds `'general_settings_index'` to the list of route names checked for inclusion.

Fixes: https://linear.app/chatwoot/issue/CW-4672/account-delete-option-is-disabled-if-the-user-account-has-crossed-plan