### PR TITLE
fix: Add delay to messenger echo events to prevent duplicate messages

### DIFF
--- a/app/controllers/webhooks/instagram_controller.rb
+++ b/app/controllers/webhooks/instagram_controller.rb
@@ -4,7 +4,16 @@ class Webhooks::InstagramController < ActionController::API
   def events
     Rails.logger.info('Instagram webhook received events')
     if params['object'].casecmp('instagram').zero?
-      ::Webhooks::InstagramEventsJob.perform_later(params.to_unsafe_hash[:entry])
+      entry_params = params.to_unsafe_hash[:entry]
+
+      if contains_echo_event?(entry_params)
+        # Add delay to prevent race condition where echo arrives before send message API completes
+        # This avoids duplicate messages when echo comes early during API processing
+        ::Webhooks::InstagramEventsJob.set(wait: 2.seconds).perform_later(entry_params)
+      else
+        ::Webhooks::InstagramEventsJob.perform_later(entry_params)
+      end
+
       render json: :ok
     else
       Rails.logger.warn("Message is not received from the instagram webhook event: #{params['object']}")
@@ -13,6 +22,16 @@ class Webhooks::InstagramController < ActionController::API
   end
 
   private
+
+  def contains_echo_event?(entry_params)
+    return false unless entry_params.is_a?(Array)
+
+    entry_params.any? do |entry|
+      # Check messaging array for echo events
+      messaging_events = entry[:messaging] || []
+      messaging_events.any? { |messaging| messaging.dig(:message, :is_echo).present? }
+    end
+  end
 
   def valid_token?(token)
     # Validates against both IG_VERIFY_TOKEN (Instagram channel via Facebook page) and

--- a/config/initializers/facebook_messenger.rb
+++ b/config/initializers/facebook_messenger.rb
@@ -39,6 +39,8 @@ Rails.application.reloader.to_prepare do
   end
 
   Facebook::Messenger::Bot.on :message_echo do |message|
-    Webhooks::FacebookEventsJob.perform_later(message.to_json)
+    # Add delay to prevent race condition where echo arrives before send message API completes
+    # This avoids duplicate messages when echo comes early during API processing
+    Webhooks::FacebookEventsJob.set(wait: 2.seconds).perform_later(message.to_json)
   end
 end


### PR DESCRIPTION
- Add 2-second delay to Facebook Messenger echo event processing to prevent race condition
- Add 2-second delay to Instagram echo event processing for consistency
- Prevent duplicate messages when echo events arrive before send message API completes processing