### PR TITLE
fix: Disable enqueueing Avatar jobs if the URL is invalid

### DIFF
--- a/app/jobs/avatar/avatar_from_gravatar_job.rb
+++ b/app/jobs/avatar/avatar_from_gravatar_job.rb
@@ -1,5 +1,5 @@
 class Avatar::AvatarFromGravatarJob < ApplicationJob
-  queue_as :low
+  queue_as :purgable
 
   def perform(avatarable, email)
     return if GlobalConfigService.load('DISABLE_GRAVATAR', '').present?

--- a/app/jobs/avatar/avatar_from_url_job.rb
+++ b/app/jobs/avatar/avatar_from_url_job.rb
@@ -1,5 +1,5 @@
 class Avatar::AvatarFromUrlJob < ApplicationJob
-  queue_as :low
+  queue_as :purgable
 
   def perform(avatarable, avatar_url)
     return unless avatarable.respond_to?(:avatar)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -24,6 +24,7 @@
   - low
   - scheduled_jobs
   - deferred
+  - purgable
   - housekeeping
   - async_database_migration
   - active_storage_analysis

--- a/spec/actions/contact_identify_action_spec.rb
+++ b/spec/actions/contact_identify_action_spec.rb
@@ -36,9 +36,15 @@ describe ContactIdentifyAction do
       expect(result.additional_attributes['social_profiles']).to eq({ 'linkedin' => 'saras', 'twitter' => 'saras' })
     end
 
-    it 'enques avatar job when avatar url parameter is passed' do
+    it 'enqueues avatar job when valid avatar url parameter is passed' do
       params = { name: 'test', avatar_url: 'https://chatwoot-assets.local/sample.png' }
       expect(Avatar::AvatarFromUrlJob).to receive(:perform_later).with(contact, params[:avatar_url]).once
+      described_class.new(contact: contact, params: params).perform
+    end
+
+    it 'does not enqueue avatar job when invalid avatar url parameter is passed' do
+      params = { name: 'test', avatar_url: 'invalid-url' }
+      expect(Avatar::AvatarFromUrlJob).not_to receive(:perform_later)
       described_class.new(contact: contact, params: params).perform
     end
 

--- a/spec/jobs/avatar/avatar_from_gravatar_job_spec.rb
+++ b/spec/jobs/avatar/avatar_from_gravatar_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Avatar::AvatarFromGravatarJob do
 
   it 'enqueues the job' do
     expect { described_class.perform_later(avatarable, email) }.to have_enqueued_job(described_class)
-      .on_queue('low')
+      .on_queue('purgable')
   end
 
   it 'will call AvatarFromUrlJob with gravatar url' do

--- a/spec/jobs/avatar/avatar_from_url_job_spec.rb
+++ b/spec/jobs/avatar/avatar_from_url_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Avatar::AvatarFromUrlJob do
 
   it 'enqueues the job' do
     expect { described_class.perform_later(avatarable, avatar_url) }.to have_enqueued_job(described_class)
-      .on_queue('low')
+      .on_queue('purgable')
   end
 
   it 'will attach avatar from url' do


### PR DESCRIPTION
- Add a new queue purgable
- Disable enqueuing the job if URL is invalid