### PR TITLE
feat(whatsapp): add agent name to outgoing messages via Cloud API

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -299,10 +299,10 @@ class Message < ApplicationRecord
 
   def prepend_agent_name_to_whatsapp_message
     return unless should_prepend_agent_name?
-  
-    self.content = "*#{sender.name}*\n#{self.content}"
+
+    self.content = "*#{sender.name}*\n#{content}"
   end
-  
+
   def should_prepend_agent_name?
     outgoing? &&
       conversation&.inbox&.channel&.provider == 'whatsapp_cloud' &&


### PR DESCRIPTION
## Description

This PR introduces a feature that automatically prepends the agent's name to outgoing WhatsApp messages when using the WhatsApp Cloud API integration. This enhancement improves the end-user experience by making it clear which agent is responding, especially in multi-agent environments.

Fallback: If there is no agent name, then the message will not be affected, as suggested by @muhsin-k.

Fixes: No specific issue linked.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The feature was tested manually in a self-hosted Chatwoot environment with WhatsApp Cloud API integration. After implementing the callback in the `Message` model, messages sent by agents were verified to include the agent's name in the message body. The system was restarted and tested across multiple conversations to ensure stability and expected behavior.

## Checklist:

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [x] I have commented on my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes  
- [ ] Any dependent changes have been merged and published in downstream modules  


## Test Screenshots:


<img width="400" alt="image" src="https://github.com/user-attachments/assets/cfbc7c73-fff3-4c8c-9232-129602f58ce6" />
<br>
<img width="700" alt="image" src="https://github.com/user-attachments/assets/7cc1f2f5-d823-4686-a3f7-d2ba013ecafc" />

P.S. Hope this helps 😊