### PR TITLE
Added variable envs in docker-comopose, and pnpm-store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ coverage
 # ignore packages
 node_modules
 package-lock.json
-
+.pnpm-store/
 *.dump
 
 

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -45,7 +45,7 @@ services:
       - POSTGRES_DB=chatwoot
       - POSTGRES_USER=postgres
       # Please provide your own password.
-      - POSTGRES_PASSWORD=
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD} #in production also? idk
 
   redis:
     image: redis:alpine

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -48,7 +48,7 @@ services:
     environment:
       - POSTGRES_DB=chatwoot
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 
   redis:
     image: redis:alpine

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -92,7 +92,7 @@ services:
     environment:
       - POSTGRES_DB=chatwoot
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 
   redis:
     image: redis:alpine


### PR DESCRIPTION
- feat: use env variable password for postgres in docker-compose, and add pnpm-store in .gitignore

## Description

Everything’s working the same as before, but now Docker Compose pulls the PostgreSQL password from an environment variable defined in the .env file. to get the password in the environment and use in up containers, also added pnpm-store to .gitignore, since Git was tracking all its files.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

i just ran all commands to bring up development env, and it all work! :D

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Linked issues

Closes #12712
