### PR TITLE
fix: incorrect first response time for reopened conversations

### DIFF
--- a/app/helpers/reporting_event_helper.rb
+++ b/app/helpers/reporting_event_helper.rb
@@ -18,12 +18,25 @@ module ReportingEventHelper
   end
 
   def last_non_human_activity(conversation)
-    # check if a handoff event already exists
-    handoff_event = ReportingEvent.where(conversation_id: conversation.id, name: 'conversation_bot_handoff').last
+    # Try to get either a handoff or reopened event first
+    # These will always take precendence over any other activity
+    # Also, any of these events can happen at any time in the course of a conversation lifecycle.
+    # So we pick the latest event
+    event = ReportingEvent.where(
+      conversation_id: conversation.id,
+      name: %w[conversation_bot_handoff conversation_reopened]
+    ).order(event_end_time: :desc).first
 
-    # if a handoff exists, last non human activity is when the handoff ended,
-    # otherwise it's when the conversation was created
-    handoff_event&.event_end_time || conversation.created_at
+    return event.event_end_time if event&.event_end_time
+
+    # Fallback to bot resolved event
+    # Because this will be closest to the most accurate activity instead of conversation.created_at
+    bot_event = ReportingEvent.where(conversation_id: conversation.id, name: 'conversation_bot_resolved').last
+
+    return bot_event.event_end_time if bot_event&.event_end_time
+
+    # If no events found, return conversation creation time
+    conversation.created_at
   end
 
   private

--- a/spec/listeners/reporting_event_listener_spec.rb
+++ b/spec/listeners/reporting_event_listener_spec.rb
@@ -267,4 +267,137 @@ describe ReportingEventListener do
       end
     end
   end
+
+  describe '#conversation_opened' do
+    context 'when conversation is opened for the first time' do
+      let(:new_conversation) { create(:conversation, account: account, inbox: inbox, assignee: user) }
+
+      it 'does not create conversation_reopened event' do
+        expect(account.reporting_events.where(name: 'conversation_reopened').count).to be 0
+        event = Events::Base.new('conversation.opened', Time.zone.now, conversation: new_conversation)
+        listener.conversation_opened(event)
+        expect(account.reporting_events.where(name: 'conversation_reopened').count).to be 0
+      end
+    end
+
+    context 'when conversation is reopened after being resolved' do
+      let(:resolved_time) { 2.hours.ago }
+      let(:reopened_time) { 1.hour.ago }
+      let(:reopened_conversation) do
+        create(:conversation, account: account, inbox: inbox, assignee: user, updated_at: reopened_time)
+      end
+
+      before do
+        # Create a resolved event first
+        create(:reporting_event,
+               name: 'conversation_resolved',
+               account_id: account.id,
+               inbox_id: inbox.id,
+               conversation_id: reopened_conversation.id,
+               user_id: user.id,
+               value: 3600,
+               event_start_time: reopened_conversation.created_at,
+               event_end_time: resolved_time)
+      end
+
+      it 'creates conversation_reopened event' do
+        expect(account.reporting_events.where(name: 'conversation_reopened').count).to be 0
+        event = Events::Base.new('conversation.opened', reopened_time, conversation: reopened_conversation)
+        listener.conversation_opened(event)
+        expect(account.reporting_events.where(name: 'conversation_reopened').count).to be 1
+      end
+
+      it 'calculates correct time since resolution' do
+        event = Events::Base.new('conversation.opened', reopened_time, conversation: reopened_conversation)
+        listener.conversation_opened(event)
+
+        reopened_event = account.reporting_events.where(name: 'conversation_reopened').first
+        expect(reopened_event.value).to be_within(1).of(3600) # 1 hour = 3600 seconds
+        expect(reopened_event.event_start_time).to be_within(1.second).of(resolved_time)
+        expect(reopened_event.event_end_time).to be_within(1.second).of(reopened_time)
+      end
+
+      it 'sets correct attributes for conversation_reopened event' do
+        event = Events::Base.new('conversation.opened', reopened_time, conversation: reopened_conversation)
+        listener.conversation_opened(event)
+
+        reopened_event = account.reporting_events.where(name: 'conversation_reopened').first
+        expect(reopened_event.account_id).to eq(account.id)
+        expect(reopened_event.inbox_id).to eq(inbox.id)
+        expect(reopened_event.conversation_id).to eq(reopened_conversation.id)
+        expect(reopened_event.user_id).to eq(user.id)
+      end
+
+      context 'when business hours enabled for inbox' do
+        let(:resolved_time) { Time.zone.parse('March 20, 2022 12:00') }
+        let(:reopened_time) { Time.zone.parse('March 21, 2022 14:00') }
+        let!(:business_hours_inbox) { create(:inbox, working_hours_enabled: true, account: account) }
+        let!(:business_hours_conversation) do
+          create(:conversation, account: account, inbox: business_hours_inbox, assignee: user, updated_at: reopened_time)
+        end
+
+        before do
+          create(:reporting_event,
+                 name: 'conversation_resolved',
+                 account_id: account.id,
+                 inbox_id: business_hours_inbox.id,
+                 conversation_id: business_hours_conversation.id,
+                 user_id: user.id,
+                 value: 3600,
+                 event_start_time: business_hours_conversation.created_at,
+                 event_end_time: resolved_time)
+        end
+
+        it 'creates conversation_reopened event with business hour value' do
+          event = Events::Base.new('conversation.opened', reopened_time, conversation: business_hours_conversation)
+          listener.conversation_opened(event)
+
+          reopened_event = account.reporting_events.where(name: 'conversation_reopened').first
+          expect(reopened_event.value_in_business_hours).to be 18_000.0 # 5 business hours (26 hours total - 21 non-business hours)
+        end
+      end
+    end
+
+    context 'when conversation has multiple resolutions' do
+      let(:first_resolved_time) { 3.hours.ago }
+      let(:second_resolved_time) { 1.hour.ago }
+      let(:reopened_time) { 30.minutes.ago }
+      let(:multiple_resolution_conversation) do
+        create(:conversation, account: account, inbox: inbox, assignee: user, updated_at: reopened_time)
+      end
+
+      before do
+        # Create first resolved event
+        create(:reporting_event,
+               name: 'conversation_resolved',
+               account_id: account.id,
+               inbox_id: inbox.id,
+               conversation_id: multiple_resolution_conversation.id,
+               user_id: user.id,
+               value: 3600,
+               event_start_time: multiple_resolution_conversation.created_at,
+               event_end_time: first_resolved_time)
+
+        # Create second resolved event (more recent)
+        create(:reporting_event,
+               name: 'conversation_resolved',
+               account_id: account.id,
+               inbox_id: inbox.id,
+               conversation_id: multiple_resolution_conversation.id,
+               user_id: user.id,
+               value: 1800,
+               event_start_time: first_resolved_time,
+               event_end_time: second_resolved_time)
+      end
+
+      it 'uses the most recent resolved event for calculation' do
+        event = Events::Base.new('conversation.opened', reopened_time, conversation: multiple_resolution_conversation)
+        listener.conversation_opened(event)
+
+        reopened_event = account.reporting_events.where(name: 'conversation_reopened').first
+        expect(reopened_event.value).to be_within(1).of(1800) # 30 minutes from second resolution
+        expect(reopened_event.event_start_time).to be_within(1.second).of(second_resolved_time)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When Captain resolves a conversation without human intervention and it's later reopened, the first response time metric is incorrectly calculated from the original conversation creation time instead of from when it was reopened. This inflates response times.

#### Example

```
Monday 9:00am    → Conversation created
Monday 9:05am    → Captain bot resolves (no human intervention)
       ⋮         → 5 days pass...
Friday 2:00pm    → Conversation reopened
Friday 2:10pm    → Agent replies

❌ Reported: 5 days 1 hour 10 minutes response time
✅ Should be: 10 minutes response time
```
## Solution

Added `conversation_reopened` reporting event that tracks when resolved conversations are reopened. The existing `last_non_human_activity` method already queries for these events, so first response times are now calculated correctly.

### Before
```
Conversation created → Bot resolves → Conversation reopened → Agent replies
↑                                                            ↑
└────────────── First response time calculated from here (incorrect!)
```

### After
```
Bot resolves → Conversation reopened → Agent replies
              ↑                      ↑
              └──── First response time calculated from here (correct!)
```