### PR TITLE
fix: footer in ssl_instructions email

### DIFF
--- a/app/mailers/portal_instructions_mailer.rb
+++ b/app/mailers/portal_instructions_mailer.rb
@@ -15,7 +15,7 @@ class PortalInstructionsMailer < ApplicationMailer
   private
 
   def liquid_locals
-    { cname_record: @cname_record }
+    super.merge({ cname_record: @cname_record })
   end
 
   def generate_cname_record


### PR DESCRIPTION
- fix footer in helpcenter SSL instructions email

### before
----

<img width="676" height="398" alt="image" src="https://github.com/user-attachments/assets/f51376c8-0859-4005-b7f5-ca78926e54c8" />


### after
----

<img width="778" height="418" alt="image" src="https://github.com/user-attachments/assets/92347ccc-80bc-4a7e-bc8c-0c1a8f69341b" />
