### PR TITLE
fix: Disable IMAP inboxes that requires authorization

### DIFF
--- a/spec/enterprise/jobs/inboxes/fetch_imap_email_inboxes_job_spec.rb
+++ b/spec/enterprise/jobs/inboxes/fetch_imap_email_inboxes_job_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Inboxes::FetchImapEmailInboxesJob do
+  context 'when chatwoot_cloud is enabled' do
+    let(:account) { create(:account) }
+    let(:premium_account) { create(:account, custom_attributes: { plan_name: 'Startups' }) }
+    let(:imap_email_channel) { create(:channel_email, imap_enabled: true, account: account) }
+    let(:premium_imap_channel) { create(:channel_email, imap_enabled: true, account: premium_account) }
+
+    before do
+      premium_account.custom_attributes['plan_name'] = 'Startups'
+      InstallationConfig.where(name: 'DEPLOYMENT_ENV').first_or_create!(value: 'cloud')
+      InstallationConfig.where(name: 'CHATWOOT_CLOUD_PLANS').first_or_create!(value: [{ 'name' => 'Hacker' }])
+    end
+
+    it 'skips inboxes with default plan' do
+      expect(Inboxes::FetchImapEmailsJob).not_to receive(:perform_later).with(imap_email_channel)
+      described_class.perform_now
+    end
+
+    it 'processes inboxes with premium plan' do
+      expect(Inboxes::FetchImapEmailsJob).to receive(:perform_later).with(premium_imap_channel)
+      described_class.perform_now
+    end
+  end
+end

--- a/spec/jobs/inboxes/fetch_imap_email_inboxes_job_spec.rb
+++ b/spec/jobs/inboxes/fetch_imap_email_inboxes_job_spec.rb
@@ -72,10 +72,7 @@ RSpec.describe Inboxes::FetchImapEmailInboxesJob do
       end
 
       it 'skips inboxes with default plan' do
-        create(:inbox, channel: imap_email_channel, account: account)
-
         expect(Inboxes::FetchImapEmailsJob).not_to receive(:perform_later).with(imap_email_channel)
-
         described_class.perform_now
       end
 

--- a/spec/jobs/inboxes/fetch_imap_email_inboxes_job_spec.rb
+++ b/spec/jobs/inboxes/fetch_imap_email_inboxes_job_spec.rb
@@ -64,22 +64,5 @@ RSpec.describe Inboxes::FetchImapEmailInboxesJob do
 
       described_class.perform_now
     end
-
-    context 'when chatwoot_cloud is enabled' do
-      before do
-        InstallationConfig.where(name: 'DEPLOYMENT_ENV').first_or_create!(value: 'cloud')
-        InstallationConfig.where(name: 'CHATWOOT_CLOUD_PLANS').first_or_create!(value: [{ 'name' => 'Hacker' }])
-      end
-
-      it 'skips inboxes with default plan' do
-        expect(Inboxes::FetchImapEmailsJob).not_to receive(:perform_later).with(imap_email_channel)
-        described_class.perform_now
-      end
-
-      it 'processes inboxes with premium plan' do
-        expect(Inboxes::FetchImapEmailsJob).to receive(:perform_later).with(premium_imap_channel)
-        described_class.perform_now
-      end
-    end
   end
 end

--- a/spec/jobs/inboxes/fetch_imap_email_inboxes_job_spec.rb
+++ b/spec/jobs/inboxes/fetch_imap_email_inboxes_job_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Inboxes::FetchImapEmailInboxesJob do
   let(:account) { create(:account) }
   let(:suspended_account) { create(:account, status: 'suspended') }
+  let(:premium_account) { create(:account, custom_attributes: { plan_name: 'Startups' }) }
 
   let(:imap_email_channel) do
     create(:channel_email, imap_enabled: true, account: account)
@@ -14,6 +15,19 @@ RSpec.describe Inboxes::FetchImapEmailInboxesJob do
 
   let(:disabled_imap_channel) do
     create(:channel_email, imap_enabled: false, account: account)
+  end
+
+  let(:reauth_required_channel) do
+    create(:channel_email, imap_enabled: true, account: account)
+  end
+
+  let(:premium_imap_channel) do
+    create(:channel_email, imap_enabled: true, account: premium_account)
+  end
+
+  before do
+    reauth_required_channel.prompt_reauthorization!
+    premium_account.custom_attributes['plan_name'] = 'Startups'
   end
 
   it 'enqueues the job' do
@@ -43,6 +57,32 @@ RSpec.describe Inboxes::FetchImapEmailInboxesJob do
       expect(Inboxes::FetchImapEmailsJob).not_to receive(:perform_later).with(disabled_imap_channel)
 
       described_class.perform_now
+    end
+
+    it 'skips channels requiring reauthorization' do
+      expect(Inboxes::FetchImapEmailsJob).not_to receive(:perform_later).with(reauth_required_channel)
+
+      described_class.perform_now
+    end
+
+    context 'when chatwoot_cloud is enabled' do
+      before do
+        InstallationConfig.where(name: 'DEPLOYMENT_ENV').first_or_create!(value: 'cloud')
+        InstallationConfig.where(name: 'CHATWOOT_CLOUD_PLANS').first_or_create!(value: [{ 'name' => 'Hacker' }])
+      end
+
+      it 'skips inboxes with default plan' do
+        create(:inbox, channel: imap_email_channel, account: account)
+
+        expect(Inboxes::FetchImapEmailsJob).not_to receive(:perform_later).with(imap_email_channel)
+
+        described_class.perform_now
+      end
+
+      it 'processes inboxes with premium plan' do
+        expect(Inboxes::FetchImapEmailsJob).to receive(:perform_later).with(premium_imap_channel)
+        described_class.perform_now
+      end
     end
   end
 end


### PR DESCRIPTION
This PR disables queueing IMAP sync jobs for emails channels that 
- are in free plan if on Chatwoot cloud.
- requires authorization
