### PR TITLE
fix: Handle nil `processed_params` for WhatsApp templates without params

### DIFF
--- a/app/services/whatsapp/template_parameter_converter_service.rb
+++ b/app/services/whatsapp/template_parameter_converter_service.rb
@@ -86,6 +86,9 @@ class Whatsapp::TemplateParameterConverterService
       # Hash format: {"1": "John", "name": "Jane"} → {body: {"1": "John", "name": "Jane"}}
       body_params = convert_hash_to_body_params(legacy_params)
       enhanced['body'] = body_params unless body_params.empty?
+    when NilClass
+      # Templates without parameters (nil processed_params)
+      # Return empty enhanced structure
     else
       raise ArgumentError, "Unknown legacy format: #{legacy_params.class}"
     end

--- a/spec/factories/channel/channel_whatsapp.rb
+++ b/spec/factories/channel/channel_whatsapp.rb
@@ -63,6 +63,25 @@ FactoryBot.define do
          ],
          'sub_category' => 'CUSTOM',
          'parameter_format' => 'NAMED'
+       },
+       {
+         'name' => 'test_no_params_template',
+         'status' => 'APPROVED',
+         'category' => 'UTILITY',
+         'language' => 'en',
+         'namespace' => 'ed41a221_133a_4558_a1d6_192960e3aee9',
+         'id' => '9876543210987654',
+         'length' => 1,
+         'parameter_format' => 'POSITIONAL',
+         'previous_category' => 'MARKETING',
+         'sub_category' => 'CUSTOM',
+         'components' => [
+           {
+             'text' => 'Thank you for contacting us! Your request has been processed successfully. Have a great day! 🙂',
+             'type' => 'BODY'
+           }
+         ],
+         'rejected_reason' => 'NONE'
        }]
     end
     message_templates_last_updated { Time.now.utc }


### PR DESCRIPTION
WhatsApp templates without parameters (body-only templates like notifications, confirmations) were failing to send with the error: ArgumentError (Unknown legacy format: NilClass). This affected all parameter-less templates across marketing messages, notifications, and utility templates.