### PR TITLE
chore: handle WebPush rate limiting in push notification service

### DIFF
--- a/app/services/notification/push_notification_service.rb
+++ b/app/services/notification/push_notification_service.rb
@@ -71,6 +71,8 @@ class Notification::PushNotificationService
   rescue WebPush::ExpiredSubscription, WebPush::InvalidSubscription, WebPush::Unauthorized => e
     Rails.logger.info "WebPush subscription expired: #{e.message}"
     subscription.destroy!
+  rescue WebPush::TooManyRequests => e
+    Rails.logger.warn "WebPush rate limited for #{user.email} on account #{notification.account.id}: #{e.message}"
   rescue Errno::ECONNRESET, Net::OpenTimeout, Net::ReadTimeout => e
     Rails.logger.error "WebPush operation error: #{e.message}"
   rescue StandardError => e


### PR DESCRIPTION
Implemented a rescue block for WebPush::TooManyRequests that logs warnings during rate limiting events. This captures user email and account ID for better traceability. We will implement a proper throttling mechanism after identifying patterns across accounts.