### PR TITLE
fix: memory leak in vue-letter from fallback text content

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/Email/Index.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Email/Index.vue
@@ -41,9 +41,7 @@ const originalEmailText = computed(() => {
 });
 
 const originalEmailHtml = computed(
-  () =>
-    contentAttributes?.value?.email?.htmlContent?.full ??
-    originalEmailText.value
+  () => contentAttributes?.value?.email?.htmlContent?.full || ''
 );
 
 const messageContent = computed(() => {


### PR DESCRIPTION
The EmailBubble component was experiencing a memory leak when rendering certain email messages, particularly those without HTML content. This caused the application to freeze or crash when displaying these emails.

The issue occurred because `originalEmailHtml` was falling back to `originalEmailText` when `htmlContent.full` was null:

```javascript
// Before (problematic code)
const originalEmailHtml = computed(
  () =>
    contentAttributes?.value?.email?.htmlContent?.full ??
    originalEmailText.value
);
```

The `originalEmailText` value contains plain text that has been processed to replace newlines with `<br>` tags. However, this text often contains special characters (like `>` for email quotes, `<` in URLs, etc.) that are not properly escaped for HTML. When this invalid HTML was passed to the Letter component for parsing, it caused memory issues.

## Solution
The fix removes the fallback to text content and ensures `originalEmailHtml` returns an empty string when no HTML content is available:

```javascript
// After (fixed code)
const originalEmailHtml = computed(
  () => contentAttributes?.value?.email?.htmlContent?.full || ''
);
```

This ensures:
1. The Letter component receives valid HTML (or an empty string) for its `:html` prop
2. When no HTML content exists, the Letter component properly falls back to using the `:text` prop
3. No invalid HTML parsing occurs, preventing the memory leak
