### PR TITLE
fix(migrations): skip AddFeatureCitationToAssistantConfig on OSS

### DIFF
--- a/db/migrate/20250808123008_add_feature_citation_to_assistant_config.rb
+++ b/db/migrate/20250808123008_add_feature_citation_to_assistant_config.rb
@@ -1,5 +1,7 @@
 class AddFeatureCitationToAssistantConfig < ActiveRecord::Migration[7.1]
   def up
+    return unless ChatwootApp.enterprise?
+
     Captain::Assistant.find_each do |assistant|
       assistant.update!(
         config: assistant.config.merge('feature_citation' => true)
@@ -8,6 +10,8 @@ class AddFeatureCitationToAssistantConfig < ActiveRecord::Migration[7.1]
   end
 
   def down
+    return unless ChatwootApp.enterprise?
+
     Captain::Assistant.find_each do |assistant|
       config = assistant.config.dup
       config.delete('feature_citation')


### PR DESCRIPTION
This migration updates Enterprise-only models. Add a simple ChatwootApp.enterprise? guard in both up and down so community (OSS) installs skips the step, instead of raising a NameError. This keeps db:migrate smooth on OSS and only backfills the feature_citation flag when Enterprise is present. No schema changes, just a data backfill behind an EE check.

Fixes: https://github.com/chatwoot/chatwoot/issues/12216

