### PR TITLE
chore: Increase Category index per-page limit to 1000

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -25,9 +25,7 @@
 #  index_categories_on_slug_and_locale_and_portal_id  (slug,locale,portal_id) UNIQUE
 #
 class Category < ApplicationRecord
-  PER_PAGE = 1000
-  paginates_per PER_PAGE
-
+  paginates_per Limits::CATEGORIES_PER_PAGE
   belongs_to :account
   belongs_to :portal
   has_many :folders, dependent: :destroy_async

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -25,7 +25,8 @@
 #  index_categories_on_slug_and_locale_and_portal_id  (slug,locale,portal_id) UNIQUE
 #
 class Category < ApplicationRecord
-  paginates_per 1000
+  PER_PAGE = 1000
+  paginates_per PER_PAGE
 
   belongs_to :account
   belongs_to :portal

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -25,6 +25,8 @@
 #  index_categories_on_slug_and_locale_and_portal_id  (slug,locale,portal_id) UNIQUE
 #
 class Category < ApplicationRecord
+  paginates_per 1000
+
   belongs_to :account
   belongs_to :portal
   has_many :folders, dependent: :destroy_async

--- a/lib/limits.rb
+++ b/lib/limits.rb
@@ -4,6 +4,7 @@ module Limits
   URL_LENGTH_LIMIT = 2048 # https://stackoverflow.com/questions/417142
   OUT_OF_OFFICE_MESSAGE_MAX_LENGTH = 10_000
   GREETING_MESSAGE_MAX_LENGTH = 10_000
+  CATEGORIES_PER_PAGE = 1000
 
   def self.conversation_message_per_minute_limit
     ENV.fetch('CONVERSATION_MESSAGE_PER_MINUTE_LIMIT', '200').to_i


### PR DESCRIPTION
# Pull Request Template

## Description

This PR increases the per-page limit for the Category index endpoint from 25 to 1000.

Fixes [CW-5486](https://linear.app/chatwoot/issue/CW-5486/you-cannot-work-with-more-than-25-help-center-categories) https://github.com/chatwoot/chatwoot/issues/12274

## Type of change

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/431fb48491a44578851621fc4607c4dd?sid=81198d89-e8c0-4fb9-b93f-8b4dbf524a46


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
