### PR TITLE
chore: Default file limits for private notes and reset attachment on mode switch

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
@@ -7,6 +7,7 @@ import * as ActiveStorage from 'activestorage';
 import inboxMixin from 'shared/mixins/inboxMixin';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import { getAllowedFileTypesByChannel } from '@chatwoot/utils';
+import { ALLOWED_FILE_TYPES } from 'shared/constants/messages';
 import VideoCallButton from '../VideoCallButton.vue';
 import AIAssistanceButton from '../AIAssistanceButton.vue';
 import { REPLY_EDITOR_MODES } from './constants';
@@ -151,6 +152,11 @@ export default {
       uploadRef,
     };
   },
+  data() {
+    return {
+      ALLOWED_FILE_TYPES,
+    };
+  },
   computed: {
     ...mapGetters({
       accountId: 'getCurrentAccountId',
@@ -192,6 +198,11 @@ export default {
       return this.conversationType === 'instagram_direct_message';
     },
     allowedFileTypes() {
+      // Use default file types for private notes
+      if (this.isOnPrivateNote) {
+        return this.ALLOWED_FILE_TYPES;
+      }
+
       let channelType = this.channelType || this.inbox?.channel_type;
 
       if (this.isAnInstagramChannel || this.isInstagramDM) {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -793,6 +793,10 @@ export default {
       }, 100);
     },
     setReplyMode(mode = REPLY_EDITOR_MODES.REPLY) {
+      // Clear attachments when switching between private note and reply modes
+      // This is to prevent from breaking the upload rules
+      if (this.attachedFiles.length > 0) this.attachedFiles = [];
+
       const { can_reply: canReply } = this.currentChat;
       this.$store.dispatch('draftMessages/setReplyEditorMode', {
         mode,

--- a/app/javascript/dashboard/composables/useFileUpload.js
+++ b/app/javascript/dashboard/composables/useFileUpload.js
@@ -4,14 +4,16 @@ import { useI18n } from 'vue-i18n';
 import { DirectUpload } from 'activestorage';
 import { checkFileSizeLimit } from 'shared/helpers/FileHelper';
 import { getMaxUploadSizeByChannel } from '@chatwoot/utils';
+import { MAXIMUM_FILE_UPLOAD_SIZE } from 'shared/constants/messages';
 
 /**
  * Composable for handling file uploads in conversations
  * @param {Object} options
  * @param {Object} options.inbox - Current inbox object (has channel_type, medium, etc.)
  * @param {Function} options.attachFile - Callback to handle file attachment
+ * @param {boolean} options.isPrivateNote - Whether the upload is for a private note
  */
-export const useFileUpload = ({ inbox, attachFile }) => {
+export const useFileUpload = ({ inbox, attachFile, isPrivateNote = false }) => {
   const { t } = useI18n();
 
   const accountId = useMapGetter('getCurrentAccountId');
@@ -20,12 +22,18 @@ export const useFileUpload = ({ inbox, attachFile }) => {
   const globalConfig = useMapGetter('globalConfig/get');
 
   // helper: compute max upload size for a given file's mime
-  const maxSizeFor = mime =>
-    getMaxUploadSizeByChannel({
+  const maxSizeFor = mime => {
+    // Use default file size limit for private notes
+    if (isPrivateNote) {
+      return MAXIMUM_FILE_UPLOAD_SIZE;
+    }
+
+    return getMaxUploadSizeByChannel({
       channelType: inbox?.channel_type,
       medium: inbox?.medium, // e.g. 'sms' | 'whatsapp' | etc.
       mime, // e.g. 'image/png'
     });
+  };
 
   const alertOverLimit = maxSizeMB =>
     useAlert(

--- a/app/javascript/dashboard/mixins/fileUploadMixin.js
+++ b/app/javascript/dashboard/mixins/fileUploadMixin.js
@@ -3,6 +3,7 @@ import { useAlert } from 'dashboard/composables';
 import { checkFileSizeLimit } from 'shared/helpers/FileHelper';
 import { getMaxUploadSizeByChannel } from '@chatwoot/utils';
 import { DirectUpload } from 'activestorage';
+import { MAXIMUM_FILE_UPLOAD_SIZE } from 'shared/constants/messages';
 
 export default {
   computed: {
@@ -13,6 +14,11 @@ export default {
 
   methods: {
     maxSizeFor(mime) {
+      // Use default file size limit for private notes
+      if (this.isOnPrivateNote) {
+        return MAXIMUM_FILE_UPLOAD_SIZE;
+      }
+
       return getMaxUploadSizeByChannel({
         channelType: this.inbox?.channel_type,
         medium: this.inbox?.medium, // e.g. 'sms' | 'whatsapp'


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the handling of attachments and file limits in reply modes:

* Applies **default file size and type limits** for private notes
* **Resets attachments** automatically when switching reply modes


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/abad3e6a0383405ea5f31314c1494f2f?sid=38715fd0-e305-4a9b-8f4d-fc6a6e5c0833


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
