### PR TITLE
chore: Refactor UTM params to stay compliant with standards

### DIFF
--- a/app/helpers/portal_helper.rb
+++ b/app/helpers/portal_helper.rb
@@ -74,6 +74,17 @@ module PortalHelper
     end
   end
 
+  def generate_portal_brand_url(brand_url, referer)
+    url = URI(brand_url)
+    query_params = Rack::Utils.parse_query(url.query)
+    query_params['utm_medium'] = 'helpcenter'
+    query_params['utm_campaign'] = 'branding'
+    query_params.delete('utm_referrer')
+    query_params['utm_source'] = URI(referer).host if referer.present?
+    url.query = query_params.to_query
+    url.to_s
+  end
+
   def render_category_content(content)
     ChatwootMarkdownRenderer.new(content).render_markdown_to_plain_text
   end

--- a/app/helpers/portal_helper.rb
+++ b/app/helpers/portal_helper.rb
@@ -75,11 +75,12 @@ module PortalHelper
   end
 
   def generate_portal_brand_url(brand_url, referer)
-    url = URI.parse(brand_url)
+    url = URI.parse(brand_url.to_s)
     query_params = Rack::Utils.parse_query(url.query)
     query_params['utm_medium'] = 'helpcenter'
     query_params['utm_campaign'] = 'branding'
-    query_params['utm_source'] = URI.parse(referer).host if referer.present?
+    query_params['utm_source'] = URI.parse(referer).host if referer.present? && referer.match?(URI::DEFAULT_PARSER.make_regexp)
+
     url.query = query_params.to_query
     url.to_s
   end

--- a/app/helpers/portal_helper.rb
+++ b/app/helpers/portal_helper.rb
@@ -75,12 +75,11 @@ module PortalHelper
   end
 
   def generate_portal_brand_url(brand_url, referer)
-    url = URI(brand_url)
+    url = URI.parse(brand_url)
     query_params = Rack::Utils.parse_query(url.query)
     query_params['utm_medium'] = 'helpcenter'
     query_params['utm_campaign'] = 'branding'
-    query_params.delete('utm_referrer')
-    query_params['utm_source'] = URI(referer).host if referer.present?
+    query_params['utm_source'] = URI.parse(referer).host if referer.present?
     url.query = query_params.to_query
     url.to_s
   end

--- a/app/javascript/shared/components/Branding.vue
+++ b/app/javascript/shared/components/Branding.vue
@@ -33,13 +33,15 @@ export default {
     brandRedirectURL() {
       try {
         const referrerHost = this.$store.getters['appConfig/getReferrerHost'];
-        const baseURL = `${this.globalConfig.widgetBrandURL}?utm_source=${
-          referrerHost ? 'widget_branding' : 'survey_branding'
-        }`;
+        const url = new URL(this.globalConfig.widgetBrandURL);
         if (referrerHost) {
-          return `${baseURL}&utm_referrer=${referrerHost}`;
+          url.searchParams.set('utm_source', referrerHost);
+          url.searchParams.set('utm_medium', 'widget');
+        } else {
+          url.searchParams.set('utm_medium', 'survey');
         }
-        return baseURL;
+        url.searchParams.set('utm_campaign', 'branding');
+        return url.toString();
       } catch (e) {
         // Suppressing the error as getter is not defined in some cases
       }

--- a/app/views/public/api/v1/portals/_footer.html.erb
+++ b/app/views/public/api/v1/portals/_footer.html.erb
@@ -8,12 +8,12 @@
           alt="<%= @global_config['BRAND_NAME'] %>"
           src="<%= @global_config['LOGO_THUMBNAIL'] %>"
         />
-      <p class="text-slate-700 dark:text-slate-300 text-sm font-medium text-center">
-        <%= I18n.t('public_portal.footer.made_with') %>
-       
-          <a class="hover:underline" href="<%= @global_config['BRAND_URL'] %>" target="_blank" rel="noopener noreferrer nofoll/ow"><%= @global_config['BRAND_NAME'] %></a>
-    
-      </p>
+        <p class="text-slate-700 dark:text-slate-300 text-sm font-medium text-center">
+          <%= I18n.t('public_portal.footer.made_with') %>
+
+            <a class="hover:underline" href="<%= generate_portal_brand_url(@global_config['BRAND_URL'], request.referer) %>" target="_blank" rel="noopener noreferrer nofollow"><%= @global_config['BRAND_NAME'] %></a>
+
+        </p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
We were using UTM  params on various branding urls which weren't compliant to standard utm params and hence were ignored by analytics tooling. this PR ensures that the params stays compliant with defined standard 

ref: https://en.wikipedia.org/wiki/UTM_parameters

## Changes 

- updated utm tags on widget and survey urls
- added utm on helpcenter branding 