### PR TITLE
fix: Remove whatsapp prefix from twilio phone number for QR code

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/FinishSetup.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/FinishSetup.vue
@@ -131,7 +131,13 @@ async function generateQRCodes() {
 
   // WhatsApp (both Cloud and Twilio)
   if (currentInbox.value.phone_number && isAWhatsAppChannel.value) {
-    await generateQRCode('whatsapp', currentInbox.value.phone_number);
+    // For Twilio WhatsApp, phone_number format is "whatsapp:+1234567890"
+    // Extract just the phone number part for QR code generation
+    const phoneNumber = currentInbox.value.phone_number.replace(
+      'whatsapp:',
+      ''
+    );
+    await generateQRCode('whatsapp', phoneNumber);
   }
 
   // Facebook Messenger
@@ -230,47 +236,47 @@ onMounted(() => {
         </div>
         <div
           v-if="isAWhatsAppChannel && qrCodes.whatsapp"
-          class="flex flex-col items-center mt-8 gap-3"
+          class="flex flex-col gap-3 items-center mt-8"
         >
           <p class="mt-2 text-sm text-n-slate-9">
             {{ $t('INBOX_MGMT.FINISH.WHATSAPP_QR_INSTRUCTION') }}
           </p>
-          <div class="outline-1 outline-n-strong outline rounded-lg shadow">
+          <div class="rounded-lg shadow outline-1 outline-n-strong outline">
             <img
               :src="qrCodes.whatsapp"
               alt="WhatsApp QR Code"
-              class="size-48 dark:invert rounded-lg"
+              class="rounded-lg size-48 dark:invert"
             />
           </div>
         </div>
         <div
           v-if="isAFacebookInbox && qrCodes.messenger"
-          class="flex flex-col items-center mt-8 gap-3"
+          class="flex flex-col gap-3 items-center mt-8"
         >
           <p class="mt-2 text-sm text-n-slate-9">
             {{ $t('INBOX_MGMT.FINISH.MESSENGER_QR_INSTRUCTION') }}
           </p>
-          <div class="outline-1 outline-n-strong outline rounded-lg shadow">
+          <div class="rounded-lg shadow outline-1 outline-n-strong outline">
             <img
               :src="qrCodes.messenger"
               alt="Messenger QR Code"
-              class="size-48 dark:invert rounded-lg"
+              class="rounded-lg size-48 dark:invert"
             />
           </div>
         </div>
         <div
           v-if="isATelegramChannel && qrCodes.telegram"
-          class="flex flex-col items-center mt-8 gap-4"
+          class="flex flex-col gap-4 items-center mt-8"
         >
           <p class="mt-2 text-sm text-n-slate-9">
             {{ $t('INBOX_MGMT.FINISH.TELEGRAM_QR_INSTRUCTION') }}
           </p>
 
-          <div class="outline-1 outline-n-strong outline rounded-lg shadow">
+          <div class="rounded-lg shadow outline-1 outline-n-strong outline">
             <img
               :src="qrCodes.telegram"
               alt="Telegram QR Code"
-              class="size-48 dark:invert rounded-lg"
+              class="rounded-lg size-48 dark:invert"
             />
           </div>
         </div>


### PR DESCRIPTION
 Twilio WhatsApp channels store phone numbers in the format `whatsapp:+1234567890`, but the WhatsApp URL for QR codes expects just the phone number without the prefix. This resulted in malformed URLs like `https://wa.me/whatsapp:+1234567890` instead of the correct `https://wa.me/+1234567890`. This PR fixes QR code generation for Twilio WhatsApp inboxes by stripping the "whatsapp:" prefix from phone numbers.