### PR TITLE
fix: TypeError: Cannot read properties of null (reading 'config')

### DIFF
--- a/app/javascript/widget/components/pageComponents/Home/Article/ArticleContainer.vue
+++ b/app/javascript/widget/components/pageComponents/Home/Article/ArticleContainer.vue
@@ -21,6 +21,9 @@ const articleUiFlags = useMapGetter('article/uiFlags');
 
 const locale = computed(() => {
   const { locale: selectedLocale } = i18n;
+
+  if (!portal.value || !portal.value.config) return null;
+
   const { allowed_locales: allowedLocales } = portal.value.config;
   return getMatchingLocale(selectedLocale.value, allowedLocales);
 });


### PR DESCRIPTION
# Pull Request Template

## Description

The `ArticleContainer` component was throwing a `TypeError: Cannot read properties of null (reading 'config')` when trying to access `portal.value.config` in the locale computed property.

**Cause**
When no portal is configured for the account, `portal.value` is null, which leads to this error or the `window.chatwootWebChannel.portal` object is not immediately available when the component mounts. 


**Solution**
Added null safety checks in the locale computed property:


Fixes https://linear.app/chatwoot/issue/CW-5563/typeerror-cannot-read-properties-of-null-reading-config

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

### Screenshots


**Before**
<img width="1129" height="729" alt="image" src="https://github.com/user-attachments/assets/836e093c-4022-4c74-9f84-d30385a9db93" />


**After**
<img width="1129" height="729" alt="image" src="https://github.com/user-attachments/assets/9685e944-bae1-4b61-bd5b-a90e089549b8" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
