### PR TITLE
chore(dev): Update histoire config for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,7 @@ yarn-debug.log*
 .claude/settings.local.json
 .cursor
 CLAUDE.local.md
+
+# Histoire deployment
+.netlify
+.histoire

--- a/histoire.config.ts
+++ b/histoire.config.ts
@@ -4,6 +4,7 @@ import { HstVue } from '@histoire/plugin-vue';
 export default defineConfig({
   setupFile: './histoire.setup.ts',
   plugins: [HstVue()],
+  collectMaxThreads: 4,
   vite: {
     server: {
       port: 6179,


### PR DESCRIPTION

- Adds `.netlify` and `.histoire` directories to `.gitignore` to prevent deployment artifacts from being committed.
- Adds `collectMaxThreads: 4` to `histoire.config.ts` to optimize resource usage during Netlify deployment.

Fixes #CW-5579

