### PR TITLE
Fix(Webhooks): Trigger webhooks for integration messages

### DIFF
--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -26,7 +26,7 @@ class WebhookListener < BaseListener
     message = extract_message_and_account(event)[0]
     inbox = message.inbox
 
-    return unless message.webhook_sendable?
+    return unless message.content_type == 'integrations' || message.webhook_sendable?
 
     payload = message.webhook_data.merge(event: __method__.to_s)
     deliver_webhook_payloads(payload, inbox)
@@ -36,7 +36,7 @@ class WebhookListener < BaseListener
     message = extract_message_and_account(event)[0]
     inbox = message.inbox
 
-    return unless message.webhook_sendable?
+    return unless message.content_type == 'integrations' || message.webhook_sendable?
 
     payload = message.webhook_data.merge(event: __method__.to_s)
     deliver_webhook_payloads(payload, inbox)


### PR DESCRIPTION
This change fixes an issue where webhooks were not being triggered for messages with the `integrations` content type. These messages are created when a user selects a "tool" from the Captain AI assistant.

The `WebhookListener` was checking the `webhook_sendable?` method, which was returning `false` for these types of messages. This change modifies the `WebhookListener` to bypass this check for messages with `content_type: 'integrations'`, ensuring that webhooks are triggered as expected.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
