### PR TITLE
feat(api): add AgentBot “streaming” endpoints and fix AgentBot sender serialization

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/message_streams_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/message_streams_controller.rb
@@ -1,0 +1,87 @@
+class Api::V1::Accounts::Conversations::MessageStreamsController < Api::V1::Accounts::Conversations::BaseController
+  include Events::Types
+
+  before_action :ensure_agent_bot!
+  before_action :set_message, only: [:append, :finish]
+
+  # POST /api/v1/accounts/:account_id/conversations/:conversation_id/message_streams/start
+  # Params: { content: "", private: false, content_type: 'text', echo_id: 'optional', sender_id: bot_id }
+  def start
+    # indicate typing on
+    toggle_typing('on')
+
+    builder_params = {
+      message_type: 'outgoing',
+      # set a lightweight placeholder so UI renders a bubble; will be replaced on first append
+      content: params[:content].presence || '…',
+      private: ActiveModel::Type::Boolean.new.cast(params[:private]),
+      content_type: params[:content_type] || 'text',
+      sender_type: 'AgentBot',
+      sender_id: Current.user.id,
+      echo_id: params[:echo_id]
+    };
+    @message = Messages::MessageBuilder.new(Current.user, @conversation, builder_params).perform
+
+    render 'api/v1/accounts/conversations/messages/create', status: :created
+  rescue StandardError => e
+    render_could_not_create_error(e.message)
+  end
+
+  # POST /api/v1/accounts/:account_id/conversations/:conversation_id/message_streams/append
+  # Params: { id: message_id, delta: "partial text" }
+  def append
+    delta = params[:delta].to_s
+    return head :bad_request if delta.blank?
+
+    current = @message.content.to_s
+    new_content = if current == '…' || current.blank?
+                    delta
+                  else
+                    current + delta
+                  end
+
+    @message.update!(content: new_content)
+    # will emit MESSAGE_UPDATED via after_update_commit
+
+    render 'api/v1/accounts/conversations/messages/update', status: :ok
+  end
+
+  # POST /api/v1/accounts/:account_id/conversations/:conversation_id/message_streams/finish
+  # Params: { id: message_id, content: "final", status: 'sent'|'failed', external_error: '...' }
+  def finish
+    attrs = {}
+    attrs[:content] = params[:content] if params.key?(:content)
+
+    # optional status update similar to messages#update constraints
+    if @conversation.inbox.api? && params[:status].present?
+      Messages::StatusUpdateService.new(@message, params[:status], params[:external_error]).perform
+      @message.reload
+    end
+
+    @message.update!(attrs) if attrs.present?
+
+    # indicate typing off
+    toggle_typing('off')
+
+    render 'api/v1/accounts/conversations/messages/update', status: :ok
+  end
+
+  private
+
+  def ensure_agent_bot!
+    render_unauthorized('Only AgentBot can access streaming') unless Current.user.is_a?(AgentBot)
+  end
+
+  def set_message
+    @message = @conversation.messages.find(params[:id])
+    render json: { error: 'Message must be outgoing and from this bot' }, status: :forbidden and return unless @message.outgoing?
+    return if @message.sender == Current.user
+
+    render json: { error: 'Not the sender of this message' }, status: :forbidden
+  end
+
+  def toggle_typing(status)
+    typing_status_manager = ::Conversations::TypingStatusManager.new(@conversation, Current.user, { typing_status: status, is_private: false })
+    typing_status_manager.toggle_typing_status
+  end
+end

--- a/app/controllers/concerns/access_token_auth_helper.rb
+++ b/app/controllers/concerns/access_token_auth_helper.rb
@@ -2,7 +2,8 @@ module AccessTokenAuthHelper
   BOT_ACCESSIBLE_ENDPOINTS = {
     'api/v1/accounts/conversations' => %w[toggle_status toggle_priority create update custom_attributes],
     'api/v1/accounts/conversations/messages' => ['create'],
-    'api/v1/accounts/conversations/assignments' => ['create']
+    'api/v1/accounts/conversations/assignments' => ['create'],
+    'api/v1/accounts/conversations/message_streams' => %w[start append finish]
   }.freeze
 
   def ensure_access_token

--- a/app/models/agent_bot.rb
+++ b/app/models/agent_bot.rb
@@ -50,6 +50,12 @@ class AgentBot < ApplicationRecord
     }
   end
 
+  # Some serializers/listeners expect `pubsub_token` on `sender`.
+  # AgentBot does not receive WS messages, so return empty string for safe subtraction in listeners.
+  def pubsub_token
+    ''
+  end
+
   def system_bot?
     account.nil?
   end


### PR DESCRIPTION
# Pull Request Template

## Description

Might be more a prove of concept. But i implemented a working "fake-streaming" with minimal changes.

Introduce minimal server-side “streaming” for webhook-based AgentBots by allowing progressive message updates via ActionCable, and fix a serialization error when the sender is an AgentBot.

- Adds start/append/finish endpoints to progressively build outgoing bot messages and broadcast updates as message.updated events. start/finish also toggle typing_on/off.
- Fixes NoMethodError on sender.pubsub_token for AgentBot by adding a safe pubsub_token method.

Motivation: Enable ChatGPT-like streaming UX for bot replies without HTTP chunked responses, and prevent 422/NoMethodError when AgentBot is the sender.

Dependencies: None

Fixes #10315

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manual verification in a local dev environment:

1) Create/obtain an AgentBot with an access token.
2) Start a conversation and note its display_id.
3) Call:
   - POST /api/v1/accounts/:account_id/conversations/:conversation_id/message_streams/start
   - POST /api/v1/accounts/:account_id/conversations/:conversation_id/message_streams/append
   - POST /api/v1/accounts/:account_id/conversations/:conversation_id/message_streams/finish
   Headers: api_access_token: <AgentBot token>, Content-Type: application/json
4) Observe in dashboard:
   - start creates an outgoing placeholder and emits typing_on + message.created
   - append updates content progressively via message.updated
   - finish finalizes content and emits typing_off (+ optional status update for API inboxes)
5) Confirm no 422/NoMethodError when AgentBot is the sender (serializer uses AgentBot#pubsub_token).

Notes:
- conversation_id is the display_id.
- The new endpoints are whitelisted for AgentBot access tokens and enforce bot ownership on append/finish.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
