### PR TITLE
chore: Remove duplicate webhook section in twilio sms finish page

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/FinishSetup.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/FinishSetup.vue
@@ -34,6 +34,7 @@ const {
   isAWhatsAppChannel,
   isAFacebookInbox,
   isATelegramChannel,
+  isATwilioWhatsAppChannel,
 } = useInbox(route.params.inbox_id);
 
 const hasDuplicateInstagramInbox = computed(() => {
@@ -168,7 +169,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="w-full h-full col-span-6 p-6 overflow-auto">
+  <div class="overflow-auto col-span-6 p-6 w-full h-full">
     <DuplicateInboxBanner
       v-if="hasDuplicateInstagramInbox"
       :content="$t('INBOX_MGMT.ADD.INSTAGRAM.NEW_INBOX_SUGGESTION')"
@@ -187,7 +188,7 @@ onMounted(() => {
         </div>
         <div class="w-[50%] max-w-[50%] ml-[25%]">
           <woot-code
-            v-if="isATwilioChannel"
+            v-if="isATwilioWhatsAppChannel"
             lang="html"
             :script="currentInbox.callback_webhook_url"
           />


### PR DESCRIPTION
**Before**
<img width="899" height="826" alt="CleanShot 2025-09-09 at 15 34 24" src="https://github.com/user-attachments/assets/5ee82eb0-5ae9-4b5e-8659-1ac728692743" />
**After**
<img width="902" height="723" alt="CleanShot 2025-09-09 at 15 34 00" src="https://github.com/user-attachments/assets/b460a2c4-ce28-4f25-9c93-1b2939e29ef1" />
