### PR TITLE
fix: Use translations for name when sending emails

### DIFF
--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -101,7 +101,7 @@ class ConversationReplyMailer < ApplicationMailer
   end
 
   def custom_sender_name
-    current_message&.sender&.available_name || @agent&.available_name || 'Notifications'
+    current_message&.sender&.available_name || @agent&.available_name || I18n.t('conversations.reply.email.header.notifications')
   end
 
   def business_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,6 +228,7 @@ en:
     reply:
       email:
         header:
+          notifications: 'Notifications'
           from_with_name: '%{assignee_name} from %{inbox_name} <%{from_email}>'
           reply_with_name: '%{assignee_name} from %{inbox_name} <reply+%{reply_email}>'
           friendly_name: '%{sender_name} from %{business_name} <%{from_email}>'


### PR DESCRIPTION
Fix missing translation.