### PR TITLE
fix: Assignment V2 controller fix

### DIFF
--- a/enterprise/app/controllers/api/v1/accounts/agent_capacity_policies/users_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/agent_capacity_policies/users_controller.rb
@@ -4,8 +4,8 @@ class Api::V1::Accounts::AgentCapacityPolicies::UsersController < Api::V1::Accou
   before_action :fetch_user, only: [:destroy]
 
   def index
-    @users = Current.account.users.joins(:account_users)
-                    .where(account_users: { agent_capacity_policy_id: @agent_capacity_policy.id })
+    @users = User.joins(:account_users)
+                 .where(account_users: { account_id: Current.account.id, agent_capacity_policy_id: @agent_capacity_policy.id })
   end
 
   def create

--- a/enterprise/app/controllers/api/v1/accounts/agent_capacity_policies_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/agent_capacity_policies_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::Accounts::AgentCapacityPoliciesController < Api::V1::Accounts::En
     params.require(:agent_capacity_policy).permit(
       :name,
       :description,
-      exclusion_rules: [:overall_capacity, { hours: [], days: [] }]
+      exclusion_rules: [:exclude_older_than_hours, { excluded_labels: [] }]
     )
   end
 


### PR DESCRIPTION
## Description

Fixes # (issue)
This PR addresses two issues in the Assignment V2 controller:
1. Agent Listing in Assignment Policy – The query for retrieving agents had incorrect joins, causing inaccurate agent listings for assignment policies. This has been corrected by fixing the query.
2. Exclusion Rules in Permitted Params – The controller previously allowed an incorrect format of exclusion rules. The permitted params have now been updated to enforce the correct format.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Unit test cases
- Using API curls

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
