### PR TITLE
fix: Add account_id to the query to force using a better index

### DIFF
--- a/enterprise/app/models/enterprise/inbox.rb
+++ b/enterprise/app/models/enterprise/inbox.rb
@@ -22,7 +22,13 @@ module Enterprise::Inbox
   end
 
   def get_agent_ids_over_assignment_limit(limit)
-    conversations.open.select(:assignee_id).group(:assignee_id).having("count(*) >= #{limit.to_i}").filter_map(&:assignee_id)
+    conversations
+      .open
+      .where(account_id: account_id)
+      .select(:assignee_id)
+      .group(:assignee_id)
+      .having("count(*) >= #{limit.to_i}")
+      .filter_map(&:assignee_id)
   end
 
   def ensure_valid_max_assignment_limit

--- a/spec/enterprise/models/inbox_spec.rb
+++ b/spec/enterprise/models/inbox_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Inbox do
       create(:conversation, inbox: inbox, assignee: inbox_member_1.user)
       # to test conversations in other inboxes won't impact
       create_list(:conversation, 3, assignee: inbox_member_1.user)
-      create_list(:conversation, 2, inbox: inbox, assignee: inbox_member_2.user)
-      create_list(:conversation, 3, inbox: inbox, assignee: inbox_member_3.user)
+      create_list(:conversation, 2, inbox: inbox, account: inbox.account, assignee: inbox_member_2.user)
+      create_list(:conversation, 3, inbox: inbox, account: inbox.account, assignee: inbox_member_3.user)
     end
 
     it 'validated max_assignment_limit' do
@@ -29,7 +29,7 @@ RSpec.describe Inbox do
     it 'returns member ids with assignment capacity with inbox max_assignment_limit is configured' do
       # agent 1 has 1 conversations, agent 2 has 2 conversations, agent 3 has 3 conversations and agent 4 with none
       inbox.update(auto_assignment_config: { max_assignment_limit: 2 })
-      expect(inbox.member_ids_with_assignment_capacity).to contain_exactly(inbox_member_1.user_id, inbox_member_4.user_id)
+      expect(inbox.member_ids_with_assignment_capacity).to eq([inbox_member_1.user_id, inbox_member_4.user_id])
     end
 
     it 'returns all member ids when inbox max_assignment_limit is not configured' do


### PR DESCRIPTION
I've added the account_id filter to the `get_agent_ids_over_assignment_limit` method. This optimization will help the query leverage the existing composite index `conv_acid_inbid_stat_asgnid_idx (account_id, inbox_id, status, assignee_id)` for better performance.

**Before:**
```sql
HashAggregate (cost=224238.12..224256.27 rows=484 width=4)
Group Key: assignee_id
Filter: (count(*) >= 10)
-> Index Scan using index_conversations_on_inbox_id on conversations (cost=0.44..223963.67 rows=54891 width=4)
Index Cond: (inbox_id = ???)
Filter: (status = 0)
```

**After:**
```sql
GroupAggregate (cost=0.44..5688.30 rows=476 width=4)
Group Key: assignee_id
Filter: (count(*) >= 10)
-> Index Only Scan using conv_acid_inbid_stat_asgnid_idx on conversations (cost=0.44..5640.81 rows=5928 width=4)
Index Cond: ((account_id = ??) AND (inbox_id = ??) AND (status = 0))
```