### PR TITLE
fix: Use case sensitive filter for phone_numbers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -727,7 +727,7 @@ GEM
     retriable (3.1.2)
     reverse_markdown (2.1.1)
       nokogiri
-    rexml (3.4.1)
+    rexml (3.4.4)
     rotp (6.3.0)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)

--- a/lib/filters/filter_keys.yml
+++ b/lib/filters/filter_keys.yml
@@ -3,8 +3,7 @@
 # 2. Contact Filters (app/services/filter_service.rb)
 # 3. Automation Filters  (app/services/automation_rules/conditions_filter_service.rb), (app/services/automation_rules/condition_validation_service.rb)
 
-
-# Format 
+# Format
 # - Parent Key (conversation, contact, messages)
 #   - Key (attribute_name)
 #     - attribute_type: "standard" : supported ["standard", "additional_attributes (only for conversations and messages)"]
@@ -15,218 +14,216 @@
 
 conversations:
   status:
-    attribute_type: "standard"
-    data_type: "text"
+    attribute_type: 'standard'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   assignee_id:
-    attribute_type: "standard"
-    data_type: "text"
+    attribute_type: 'standard'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "is_present"
-      - "is_not_present"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   inbox_id:
-    attribute_type: "standard"
-    data_type: "text"
+    attribute_type: 'standard'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "is_present"
-      - "is_not_present"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   team_id:
-    attribute_type: "standard"
-    data_type: "number"
+    attribute_type: 'standard'
+    data_type: 'number'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "is_present"
-      - "is_not_present"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   priority:
-    attribute_type: "standard"
-    data_type: "text"
+    attribute_type: 'standard'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   display_id:
-    attribute_type: "standard"
-    data_type: "Number"
+    attribute_type: 'standard'
+    data_type: 'Number'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
   campaign_id:
-    attribute_type: "standard"
-    data_type: "Number"
+    attribute_type: 'standard'
+    data_type: 'Number'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "is_present"
-      - "is_not_present"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   labels:
-    attribute_type: "standard"
-    data_type: "labels"
+    attribute_type: 'standard'
+    data_type: 'labels'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "is_present"
-      - "is_not_present"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   browser_language:
-    attribute_type: "additional_attributes"
-    data_type: "text"
+    attribute_type: 'additional_attributes'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   conversation_language:
-    attribute_type: "additional_attributes"
-    data_type: "text"
+    attribute_type: 'additional_attributes'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   country_code:
-    attribute_type: "additional_attributes"
-    data_type: "text"
+    attribute_type: 'additional_attributes'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   referer:
-    attribute_type: "additional_attributes"
-    data_type: "link"
+    attribute_type: 'additional_attributes'
+    data_type: 'link'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
   created_at:
-    attribute_type: "standard"
-    data_type: "date"
+    attribute_type: 'standard'
+    data_type: 'date'
     filter_operators:
-      - "is_greater_than"
-      - "is_less_than"
-      - "days_before"
+      - 'is_greater_than'
+      - 'is_less_than'
+      - 'days_before'
   last_activity_at:
-    attribute_type: "standard"
-    data_type: "date"
+    attribute_type: 'standard'
+    data_type: 'date'
     filter_operators:
-      - "is_greater_than"
-      - "is_less_than"
-      - "days_before"
+      - 'is_greater_than'
+      - 'is_less_than'
+      - 'days_before'
   mail_subject:
-    attribute_type: "additional_attributes"
-    data_type: "text"
+    attribute_type: 'additional_attributes'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
 
 ### ----- End of Conversation Filters ----- ###
-
 
 ### ----- Contact Filters ----- ###
 contacts:
   name:
-    attribute_type: "standard"
-    data_type: "text_case_insensitive"
+    attribute_type: 'standard'
+    data_type: 'text_case_insensitive'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
   phone_number:
-    attribute_type: "standard"
-    data_type: "text_case_insensitive"
+    attribute_type: 'standard'
+    data_type: 'text' # Text is not explicity defined in filters, default filter will be used
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
-      - "starts_with"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
+      - 'starts_with'
   email:
-    attribute_type: "standard"
-    data_type: "text_case_insensitive"
+    attribute_type: 'standard'
+    data_type: 'text_case_insensitive'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
   identifier:
-    attribute_type: "standard"
-    data_type: "text_case_insensitive"
+    attribute_type: 'standard'
+    data_type: 'text_case_insensitive'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   country_code:
-    attribute_type: "additional_attributes"
-    data_type: "text_case_insensitive"
+    attribute_type: 'additional_attributes'
+    data_type: 'text_case_insensitive'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   city:
-    attribute_type: "additional_attributes"
-    data_type: "text_case_insensitive"
+    attribute_type: 'additional_attributes'
+    data_type: 'text_case_insensitive'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
   company:
-    attribute_type: "additional_attributes"
-    data_type: "text_case_insensitive"
+    attribute_type: 'additional_attributes'
+    data_type: 'text_case_insensitive'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
   labels:
-    attribute_type: "standard"
-    data_type: "labels"
+    attribute_type: 'standard'
+    data_type: 'labels'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "is_present"
-      - "is_not_present"
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'is_present'
+      - 'is_not_present'
   created_at:
-    attribute_type: "standard"
-    data_type: "date"
+    attribute_type: 'standard'
+    data_type: 'date'
     filter_operators:
-      - "is_greater_than"
-      - "is_less_than"
-      - "days_before"
+      - 'is_greater_than'
+      - 'is_less_than'
+      - 'days_before'
   last_activity_at:
-    attribute_type: "standard"
-    data_type: "date"
+    attribute_type: 'standard'
+    data_type: 'date'
     filter_operators:
-      - "is_greater_than"
-      - "is_less_than"
-      - "days_before"
+      - 'is_greater_than'
+      - 'is_less_than'
+      - 'days_before'
   blocked:
-    attribute_type: "standard"
-    data_type: "boolean"
+    attribute_type: 'standard'
+    data_type: 'boolean'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
 
 ### ----- End of Contact Filters ----- ###
 
 ### ----- Message Filters ----- ###
 messages:
   message_type:
-    attribute_type: "standard"
-    data_type: "numeric"
+    attribute_type: 'standard'
+    data_type: 'numeric'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
+      - 'equal_to'
+      - 'not_equal_to'
   content:
-    attribute_type: "standard"
-    data_type: "text"
+    attribute_type: 'standard'
+    data_type: 'text'
     filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
-
+      - 'equal_to'
+      - 'not_equal_to'
+      - 'contains'
+      - 'does_not_contain'
 ### ----- End of Message Filters ----- ###

--- a/lib/filters/filter_keys.yml
+++ b/lib/filters/filter_keys.yml
@@ -3,6 +3,7 @@
 # 2. Contact Filters (app/services/filter_service.rb)
 # 3. Automation Filters  (app/services/automation_rules/conditions_filter_service.rb), (app/services/automation_rules/condition_validation_service.rb)
 
+
 # Format
 # - Parent Key (conversation, contact, messages)
 #   - Key (attribute_name)
@@ -14,216 +15,218 @@
 
 conversations:
   status:
-    attribute_type: 'standard'
-    data_type: 'text'
+    attribute_type: "standard"
+    data_type: "text"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
+      - "equal_to"
+      - "not_equal_to"
   assignee_id:
-    attribute_type: 'standard'
-    data_type: 'text'
+    attribute_type: "standard"
+    data_type: "text"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'is_present'
-      - 'is_not_present'
+      - "equal_to"
+      - "not_equal_to"
+      - "is_present"
+      - "is_not_present"
   inbox_id:
-    attribute_type: 'standard'
-    data_type: 'text'
+    attribute_type: "standard"
+    data_type: "text"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'is_present'
-      - 'is_not_present'
+      - "equal_to"
+      - "not_equal_to"
+      - "is_present"
+      - "is_not_present"
   team_id:
-    attribute_type: 'standard'
-    data_type: 'number'
+    attribute_type: "standard"
+    data_type: "number"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'is_present'
-      - 'is_not_present'
+      - "equal_to"
+      - "not_equal_to"
+      - "is_present"
+      - "is_not_present"
   priority:
-    attribute_type: 'standard'
-    data_type: 'text'
+    attribute_type: "standard"
+    data_type: "text"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
+      - "equal_to"
+      - "not_equal_to"
   display_id:
-    attribute_type: 'standard'
-    data_type: 'Number'
+    attribute_type: "standard"
+    data_type: "Number"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'contains'
-      - 'does_not_contain'
+      - "equal_to"
+      - "not_equal_to"
+      - "contains"
+      - "does_not_contain"
   campaign_id:
-    attribute_type: 'standard'
-    data_type: 'Number'
+    attribute_type: "standard"
+    data_type: "Number"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'is_present'
-      - 'is_not_present'
+      - "equal_to"
+      - "not_equal_to"
+      - "is_present"
+      - "is_not_present"
   labels:
-    attribute_type: 'standard'
-    data_type: 'labels'
+    attribute_type: "standard"
+    data_type: "labels"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'is_present'
-      - 'is_not_present'
+      - "equal_to"
+      - "not_equal_to"
+      - "is_present"
+      - "is_not_present"
   browser_language:
-    attribute_type: 'additional_attributes'
-    data_type: 'text'
+    attribute_type: "additional_attributes"
+    data_type: "text"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
+      - "equal_to"
+      - "not_equal_to"
   conversation_language:
-    attribute_type: 'additional_attributes'
-    data_type: 'text'
+    attribute_type: "additional_attributes"
+    data_type: "text"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
+      - "equal_to"
+      - "not_equal_to"
   country_code:
-    attribute_type: 'additional_attributes'
-    data_type: 'text'
+    attribute_type: "additional_attributes"
+    data_type: "text"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
+      - "equal_to"
+      - "not_equal_to"
   referer:
-    attribute_type: 'additional_attributes'
-    data_type: 'link'
+    attribute_type: "additional_attributes"
+    data_type: "link"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'contains'
-      - 'does_not_contain'
+      - "equal_to"
+      - "not_equal_to"
+      - "contains"
+      - "does_not_contain"
   created_at:
-    attribute_type: 'standard'
-    data_type: 'date'
+    attribute_type: "standard"
+    data_type: "date"
     filter_operators:
-      - 'is_greater_than'
-      - 'is_less_than'
-      - 'days_before'
+      - "is_greater_than"
+      - "is_less_than"
+      - "days_before"
   last_activity_at:
-    attribute_type: 'standard'
-    data_type: 'date'
+    attribute_type: "standard"
+    data_type: "date"
     filter_operators:
-      - 'is_greater_than'
-      - 'is_less_than'
-      - 'days_before'
+      - "is_greater_than"
+      - "is_less_than"
+      - "days_before"
   mail_subject:
-    attribute_type: 'additional_attributes'
-    data_type: 'text'
+    attribute_type: "additional_attributes"
+    data_type: "text"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'contains'
-      - 'does_not_contain'
+      - "equal_to"
+      - "not_equal_to"
+      - "contains"
+      - "does_not_contain"
 
 ### ----- End of Conversation Filters ----- ###
+
 
 ### ----- Contact Filters ----- ###
 contacts:
   name:
-    attribute_type: 'standard'
-    data_type: 'text_case_insensitive'
+    attribute_type: "standard"
+    data_type: "text_case_insensitive"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'contains'
-      - 'does_not_contain'
+      - "equal_to"
+      - "not_equal_to"
+      - "contains"
+      - "does_not_contain"
   phone_number:
-    attribute_type: 'standard'
-    data_type: 'text' # Text is not explicity defined in filters, default filter will be used
+    attribute_type: "standard"
+    data_type: "text" # Text is not explicity defined in filters, default filter will be used
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'contains'
-      - 'does_not_contain'
-      - 'starts_with'
+      - "equal_to"
+      - "not_equal_to"
+      - "contains"
+      - "does_not_contain"
+      - "starts_with"
   email:
-    attribute_type: 'standard'
-    data_type: 'text_case_insensitive'
+    attribute_type: "standard"
+    data_type: "text_case_insensitive"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'contains'
-      - 'does_not_contain'
+      - "equal_to"
+      - "not_equal_to"
+      - "contains"
+      - "does_not_contain"
   identifier:
-    attribute_type: 'standard'
-    data_type: 'text_case_insensitive'
+    attribute_type: "standard"
+    data_type: "text_case_insensitive"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
+      - "equal_to"
+      - "not_equal_to"
   country_code:
-    attribute_type: 'additional_attributes'
-    data_type: 'text_case_insensitive'
+    attribute_type: "additional_attributes"
+    data_type: "text_case_insensitive"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
+      - "equal_to"
+      - "not_equal_to"
   city:
-    attribute_type: 'additional_attributes'
-    data_type: 'text_case_insensitive'
+    attribute_type: "additional_attributes"
+    data_type: "text_case_insensitive"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'contains'
-      - 'does_not_contain'
+      - "equal_to"
+      - "not_equal_to"
+      - "contains"
+      - "does_not_contain"
   company:
-    attribute_type: 'additional_attributes'
-    data_type: 'text_case_insensitive'
+    attribute_type: "additional_attributes"
+    data_type: "text_case_insensitive"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'contains'
-      - 'does_not_contain'
+      - "equal_to"
+      - "not_equal_to"
+      - "contains"
+      - "does_not_contain"
   labels:
-    attribute_type: 'standard'
-    data_type: 'labels'
+    attribute_type: "standard"
+    data_type: "labels"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'is_present'
-      - 'is_not_present'
+      - "equal_to"
+      - "not_equal_to"
+      - "is_present"
+      - "is_not_present"
   created_at:
-    attribute_type: 'standard'
-    data_type: 'date'
+    attribute_type: "standard"
+    data_type: "date"
     filter_operators:
-      - 'is_greater_than'
-      - 'is_less_than'
-      - 'days_before'
+      - "is_greater_than"
+      - "is_less_than"
+      - "days_before"
   last_activity_at:
-    attribute_type: 'standard'
-    data_type: 'date'
+    attribute_type: "standard"
+    data_type: "date"
     filter_operators:
-      - 'is_greater_than'
-      - 'is_less_than'
-      - 'days_before'
+      - "is_greater_than"
+      - "is_less_than"
+      - "days_before"
   blocked:
-    attribute_type: 'standard'
-    data_type: 'boolean'
+    attribute_type: "standard"
+    data_type: "boolean"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
+      - "equal_to"
+      - "not_equal_to"
 
 ### ----- End of Contact Filters ----- ###
 
 ### ----- Message Filters ----- ###
 messages:
   message_type:
-    attribute_type: 'standard'
-    data_type: 'numeric'
+    attribute_type: "standard"
+    data_type: "numeric"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
+      - "equal_to"
+      - "not_equal_to"
   content:
-    attribute_type: 'standard'
-    data_type: 'text'
+    attribute_type: "standard"
+    data_type: "text"
     filter_operators:
-      - 'equal_to'
-      - 'not_equal_to'
-      - 'contains'
-      - 'does_not_contain'
+      - "equal_to"
+      - "not_equal_to"
+      - "contains"
+      - "does_not_contain"
+
 ### ----- End of Message Filters ----- ###


### PR DESCRIPTION
The contact filter APIs were timing out due to the case‑insensitive filter. There is no index for lower case phone numbers, so it would perform a table scan, potentially examining 8 million records or more at a time. 

This change should fix the issue. 
I am changing the filter to use direct comparison without lower‑case.

**Previous:**
```sql
SELECT contacts.*
FROM contacts
WHERE contacts.account_id = $1
  AND (
    LOWER(contacts.phone_number) = '<number>'
    OR LOWER(contacts.phone_number) = '<other-number>'
  )
ORDER BY contacts.created_at DESC NULLS LAST
LIMIT $2
OFFSET $3
```

**Updated:**
```sql
SELECT contacts.*
FROM contacts
WHERE contacts.account_id = $1
  AND (
    contacts.phone_number = '<number>'
    OR contacts.phone_number = '<other-number>'
  )
ORDER BY contacts.created_at DESC NULLS LAST
LIMIT $2
OFFSET $3
```

Fixes https://linear.app/chatwoot/issue/CW-5582/contact-filter-timing-out