### PR TITLE
chore: Ensure admin notification mailer specs are order agnostic

### DIFF
--- a/spec/mailers/administrator_notifications/base_mailer_spec.rb
+++ b/spec/mailers/administrator_notifications/base_mailer_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe AdministratorNotifications::BaseMailer do
       # Call the private method
       admin_emails = mailer.send(:admin_emails)
 
-      expect(admin_emails).to include(admin1.email)
-      expect(admin_emails).to include(admin2.email)
+      expect(admin_emails).to contain_exactly(admin1.email, admin2.email)
       expect(admin_emails).not_to include(agent.email)
     end
   end
@@ -49,7 +48,7 @@ RSpec.describe AdministratorNotifications::BaseMailer do
 
       # Mock the send_mail_with_liquid method
       expect(mailer).to receive(:send_mail_with_liquid).with(
-        to: [admin1.email, admin2.email],
+        to: contain_exactly(admin1.email, admin2.email),
         subject: subject
       ).and_return(true)
 

--- a/spec/mailers/administrator_notifications/channel_notifications_mailer_spec.rb
+++ b/spec/mailers/administrator_notifications/channel_notifications_mailer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe AdministratorNotifications::ChannelNotificationsMailer do
   let(:class_instance) { described_class.new }
   let!(:account) { create(:account) }
   let!(:administrator) { create(:user, :administrator, email: 'agent1@example.com', account: account) }
+  let!(:another_administrator) { create(:user, :administrator, email: 'agent2@example.com', account: account) }
 
   describe 'facebook_disconnect' do
     before do
@@ -26,7 +27,7 @@ RSpec.describe AdministratorNotifications::ChannelNotificationsMailer do
       end
 
       it 'renders the receiver email' do
-        expect(mail.to).to eq([administrator.email])
+        expect(mail.to).to contain_exactly(administrator.email, another_administrator.email)
       end
     end
   end
@@ -41,7 +42,7 @@ RSpec.describe AdministratorNotifications::ChannelNotificationsMailer do
     end
 
     it 'renders the receiver email' do
-      expect(mail.to).to eq([administrator.email])
+      expect(mail.to).to contain_exactly(administrator.email, another_administrator.email)
     end
   end
 
@@ -55,7 +56,7 @@ RSpec.describe AdministratorNotifications::ChannelNotificationsMailer do
     end
 
     it 'renders the receiver email' do
-      expect(mail.to).to eq([administrator.email])
+      expect(mail.to).to contain_exactly(administrator.email, another_administrator.email)
     end
   end
 end

--- a/spec/mailers/administrator_notifications/integrations_notification_mailer_spec.rb
+++ b/spec/mailers/administrator_notifications/integrations_notification_mailer_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe AdministratorNotifications::IntegrationsNotificationMailer do
 
   let!(:account) { create(:account) }
   let!(:administrator) { create(:user, :administrator, email: 'admin@example.com', account: account) }
+  let!(:another_administrator) { create(:user, :administrator, email: 'owner@example.com', account: account) }
 
   describe 'slack_disconnect' do
     let(:mail) { described_class.with(account: account).slack_disconnect.deliver_now }
@@ -15,7 +16,7 @@ RSpec.describe AdministratorNotifications::IntegrationsNotificationMailer do
     end
 
     it 'renders the receiver email' do
-      expect(mail.to).to eq([administrator.email])
+      expect(mail.to).to contain_exactly(administrator.email, another_administrator.email)
     end
 
     it 'includes reconnect instructions in the body' do
@@ -35,7 +36,7 @@ RSpec.describe AdministratorNotifications::IntegrationsNotificationMailer do
     end
 
     it 'renders the receiver email' do
-      expect(mail.to).to eq([administrator.email])
+      expect(mail.to).to contain_exactly(administrator.email, another_administrator.email)
     end
   end
 end


### PR DESCRIPTION
## Summary
- update the admin notification base mailer spec to ignore ordering when verifying administrator email addresses
- extend the channel and integrations admin notification mailer specs to cover multiple administrators without relying on recipient order

------
https://chatgpt.com/codex/tasks/task_e_68cc7457cf788326a765f116ceab1732