### PR TITLE
feat(conversations): Improve conversation list pagination and updates

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/helpers/actionHelpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers/actionHelpers.js
@@ -45,7 +45,11 @@ export const buildConversationList = (
   filterType
 ) => {
   const { payload: conversationList, meta: metaData } = responseData;
-  context.commit(types.SET_ALL_CONVERSATION, conversationList);
+  const pageNumber = Number(requestPayload?.page) || 1;
+  context.commit(types.SET_ALL_CONVERSATION, {
+    records: conversationList,
+    page: pageNumber,
+  });
   context.dispatch('conversationStats/set', metaData);
   context.dispatch(
     'conversationLabels/setBulkConversationLabels',

--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -27,11 +27,10 @@ const state = {
 // mutations
 export const mutations = {
   [types.SET_ALL_CONVERSATION](_state, payload) {
-    const { records: conversationList = [], page: incomingPage = 1 } = Array.isArray(
-      payload
-    )
-      ? { records: payload, page: 1 }
-      : { records: payload?.records || [], page: payload?.page ?? 1 };
+    const { records: conversationList = [], page: incomingPage = 1 } =
+      Array.isArray(payload)
+        ? { records: payload, page: 1 }
+        : { records: payload?.records || [], page: payload?.page ?? 1 };
 
     const pageNumber = Number(incomingPage) || 1;
     const previousConversations = _state.allConversations;

--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -26,33 +26,48 @@ const state = {
 
 // mutations
 export const mutations = {
-  [types.SET_ALL_CONVERSATION](_state, conversationList) {
-    const newAllConversations = [..._state.allConversations];
-    conversationList.forEach(conversation => {
-      const indexInCurrentList = newAllConversations.findIndex(
-        c => c.id === conversation.id
-      );
-      if (indexInCurrentList < 0) {
-        newAllConversations.push(conversation);
-      } else if (conversation.id !== _state.selectedChatId) {
-        // If the conversation is already in the list, replace it
-        // Added this to fix the issue of the conversation not being updated
-        // When reconnecting to the websocket. If the selectedChatId is not the same as
-        // the conversation.id in the store, replace the existing conversation with the new one
-        newAllConversations[indexInCurrentList] = conversation;
-      } else {
-        // If the conversation is already in the list and selectedChatId is the same,
-        // replace all data except the messages array, attachments, dataFetched, allMessagesLoaded
-        const existingConversation = newAllConversations[indexInCurrentList];
-        newAllConversations[indexInCurrentList] = {
-          ...conversation,
-          allMessagesLoaded: existingConversation.allMessagesLoaded,
-          messages: existingConversation.messages,
-          dataFetched: existingConversation.dataFetched,
-        };
+  [types.SET_ALL_CONVERSATION](_state, payload) {
+    const { records: conversationList = [], page: incomingPage = 1 } = Array.isArray(
+      payload
+    )
+      ? { records: payload, page: 1 }
+      : { records: payload?.records || [], page: payload?.page ?? 1 };
+
+    const pageNumber = Number(incomingPage) || 1;
+    const previousConversations = _state.allConversations;
+    const existingConversationMap = new Map(
+      previousConversations.map(conversation => [conversation.id, conversation])
+    );
+    const idsInCurrentPage = new Set(
+      conversationList.map(conversation => conversation.id)
+    );
+
+    const retainedConversations = previousConversations.filter(
+      conversation => !idsInCurrentPage.has(conversation.id)
+    );
+
+    const mergedPageConversations = conversationList.map(conversation => {
+      const existingConversation = existingConversationMap.get(conversation.id);
+      if (!existingConversation) {
+        return conversation;
       }
+
+      if (conversation.id !== _state.selectedChatId) {
+        return conversation;
+      }
+
+      return {
+        ...conversation,
+        allMessagesLoaded: existingConversation.allMessagesLoaded,
+        messages: existingConversation.messages,
+        dataFetched: existingConversation.dataFetched,
+      };
     });
-    _state.allConversations = newAllConversations;
+
+    _state.allConversations =
+      pageNumber === 1
+        ? [...mergedPageConversations, ...retainedConversations]
+        : [...retainedConversations, ...mergedPageConversations];
   },
   [types.EMPTY_ALL_CONVERSATION](_state) {
     _state.allConversations = [];

--- a/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
@@ -435,7 +435,10 @@ describe('#actions', () => {
       expect(commit).toHaveBeenCalledTimes(2);
       expect(commit.mock.calls).toEqual([
         ['SET_LIST_LOADING_STATUS'],
-        ['SET_ALL_CONVERSATION', dataReceived.payload],
+        [
+          'SET_ALL_CONVERSATION',
+          { records: dataReceived.payload, page: 1 },
+        ],
       ]);
     });
   });

--- a/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
@@ -435,10 +435,7 @@ describe('#actions', () => {
       expect(commit).toHaveBeenCalledTimes(2);
       expect(commit.mock.calls).toEqual([
         ['SET_LIST_LOADING_STATUS'],
-        [
-          'SET_ALL_CONVERSATION',
-          { records: dataReceived.payload, page: 1 },
-        ],
+        ['SET_ALL_CONVERSATION', { records: dataReceived.payload, page: 1 }],
       ]);
     });
   });

--- a/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
@@ -363,6 +363,63 @@ describe('#mutations', () => {
       mutations[types.SET_ALL_CONVERSATION](state, data);
       expect(state.allConversations).toEqual(data);
     });
+
+    it('preserves server order when merging first page results', () => {
+      const state = {
+        allConversations: [
+          { id: 1, name: 'mine-1' },
+          { id: 3, name: 'mine-3' },
+          { id: 5, name: 'mine-5' },
+        ],
+        selectedChatId: null,
+      };
+      const payload = {
+        records: [
+          { id: 1, name: 'all-1' },
+          { id: 2, name: 'all-2' },
+          { id: 3, name: 'all-3' },
+          { id: 4, name: 'all-4' },
+          { id: 5, name: 'all-5' },
+        ],
+        page: 1,
+      };
+
+      mutations[types.SET_ALL_CONVERSATION](state, payload);
+
+      expect(state.allConversations.map(conversation => conversation.id)).toEqual([
+        1,
+        2,
+        3,
+        4,
+        5,
+      ]);
+    });
+
+    it('appends subsequent pages after existing records', () => {
+      const state = {
+        allConversations: [
+          { id: 1, name: 'first-page-1' },
+          { id: 2, name: 'first-page-2' },
+        ],
+        selectedChatId: null,
+      };
+      const payload = {
+        records: [
+          { id: 3, name: 'second-page-3' },
+          { id: 4, name: 'second-page-4' },
+        ],
+        page: 2,
+      };
+
+      mutations[types.SET_ALL_CONVERSATION](state, payload);
+
+      expect(state.allConversations.map(conversation => conversation.id)).toEqual([
+        1,
+        2,
+        3,
+        4,
+      ]);
+    });
   });
 
   describe('#SET_ALL_ATTACHMENTS', () => {

--- a/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
@@ -386,13 +386,9 @@ describe('#mutations', () => {
 
       mutations[types.SET_ALL_CONVERSATION](state, payload);
 
-      expect(state.allConversations.map(conversation => conversation.id)).toEqual([
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]);
+      expect(
+        state.allConversations.map(conversation => conversation.id)
+      ).toEqual([1, 2, 3, 4, 5]);
     });
 
     it('appends subsequent pages after existing records', () => {
@@ -413,12 +409,9 @@ describe('#mutations', () => {
 
       mutations[types.SET_ALL_CONVERSATION](state, payload);
 
-      expect(state.allConversations.map(conversation => conversation.id)).toEqual([
-        1,
-        2,
-        3,
-        4,
-      ]);
+      expect(
+        state.allConversations.map(conversation => conversation.id)
+      ).toEqual([1, 2, 3, 4]);
     });
   });
 


### PR DESCRIPTION
Refactor the `SET_ALL_CONVERSATION` mutation to handle paginated conversation lists more effectively.

Previously, the mutation would append or replace conversations without considering the page number, leading to potential issues with duplicate or missing conversations when navigating between pages.

This change introduces the following improvements:
- The `SET_ALL_CONVERSATION` mutation now accepts a payload containing `records` (the conversation list) and `page` number.
- When `page` is 1, the new conversations are merged with existing ones, prioritizing the new data while retaining specific properties (messages, attachments) for the currently selected chat.
- For subsequent pages, the new conversations are appended, ensuring that the list grows correctly as the user scrolls or navigates.
- Existing conversations not present in the current page's payload are retained, preventing data loss when switching pages.

This ensures a more robust and consistent conversation list display, especially in paginated views.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes #12197

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
