### PR TITLE
chore: Update Guyana's country dial code from +595 to +592

### DIFF
--- a/app/javascript/shared/constants/countries.js
+++ b/app/javascript/shared/constants/countries.js
@@ -541,7 +541,7 @@ const countries = [
   },
   {
     name: 'Guyana',
-    dial_code: '+595',
+    dial_code: '+592',
     emoji: '🇬🇾',
     id: 'GY',
   },


### PR DESCRIPTION
# Pull Request Template

## Description

This PR updates Guyana's country dial code from +595 to +592

Fixes https://github.com/chatwoot/chatwoot/issues/12501 , [CW-5669](https://linear.app/chatwoot/issue/CW-5669/incorrect-country-code)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
