### PR TITLE
fix: Remove unnecessary scroll bars from filter dropdown

### DIFF
--- a/app/javascript/dashboard/components-next/copilot/ToggleCopilotAssistant.vue
+++ b/app/javascript/dashboard/components-next/copilot/ToggleCopilotAssistant.vue
@@ -45,7 +45,7 @@ const activeAssistantLabel = computed(() => {
         />
       </template>
       <DropdownBody class="bottom-9 min-w-64 z-50" strong>
-        <DropdownSection class="max-h-80 overflow-scroll">
+        <DropdownSection class="[&>ul]:max-h-80">
           <DropdownItem
             v-for="assistant in assistants"
             :key="assistant.id"

--- a/app/javascript/dashboard/components-next/filter/inputs/FilterSelect.vue
+++ b/app/javascript/dashboard/components-next/filter/inputs/FilterSelect.vue
@@ -91,7 +91,7 @@ const updateSelected = newValue => {
       :class="dropdownPosition"
       strong
     >
-      <DropdownSection class="max-h-80 overflow-scroll">
+      <DropdownSection class="[&>ul]:max-h-80">
         <DropdownItem
           v-for="option in options"
           :key="option.value"

--- a/app/javascript/dashboard/components-next/filter/inputs/MultiSelect.vue
+++ b/app/javascript/dashboard/components-next/filter/inputs/MultiSelect.vue
@@ -123,7 +123,7 @@ const toggleOption = option => {
       </Button>
     </template>
     <DropdownBody class="top-0 min-w-48 z-50" strong>
-      <DropdownSection class="max-h-80 overflow-scroll">
+      <DropdownSection class="[&>ul]:max-h-80">
         <DropdownItem
           v-for="option in options"
           :key="option.id"

--- a/app/javascript/dashboard/components-next/filter/inputs/SingleSelect.vue
+++ b/app/javascript/dashboard/components-next/filter/inputs/SingleSelect.vue
@@ -124,7 +124,7 @@ const toggleSelected = option => {
           :placeholder="searchPlaceholder || t('COMBOBOX.SEARCH_PLACEHOLDER')"
         />
       </div>
-      <DropdownSection class="max-h-80 overflow-scroll">
+      <DropdownSection class="[&>ul]:max-h-80">
         <template v-if="searchResults.length">
           <DropdownItem
             v-for="option in searchResults"

--- a/app/javascript/dashboard/components-next/sidebar/SidebarProfileMenuStatus.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarProfileMenuStatus.vue
@@ -76,7 +76,7 @@ function changeAvailabilityStatus(availability) {
 </script>
 
 <template>
-  <DropdownSection>
+  <DropdownSection class="[&>ul]:overflow-visible">
     <div class="grid gap-0">
       <DropdownItem preserve-open>
         <div class="flex-grow flex items-center gap-1">


### PR DESCRIPTION
# Pull Request Template

## Description

**This PR fixes unnecessary vertical and horizontal scroll bars in the filter dropdown.**

**Cause:**
The child element had both `max-height` and `overflow-y-auto`, while the wrapper also applied `max-height` and `overflow-scroll`, which created duplicate scroll bars.

**Solution:**
Removed the redundant `overflow-scroll` from the wrapper and applied `max-height` only where needed.

Fixes https://linear.app/chatwoot/issue/CW-5677/filter-dropdown-shows-multiple-scrollbars-even-when-not-required

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="239" height="408" alt="image" src="https://github.com/user-attachments/assets/6ee3a3d7-d999-4ba4-bdad-197378ae3e58" />
<img width="239" height="352" alt="image" src="https://github.com/user-attachments/assets/1dd5b39b-1e00-40ee-b1ec-6456cab9d94c" />
<img width="222" height="233" alt="image" src="https://github.com/user-attachments/assets/2210f6f7-a8df-4a0a-b9c0-ed33dc2c7753" />


**After**
<img width="239" height="408" alt="image" src="https://github.com/user-attachments/assets/72dd5258-b556-43a3-8d66-5ab560995df0" />
<img width="239" height="352" alt="image" src="https://github.com/user-attachments/assets/f1757d9b-100c-4eeb-be69-6c49811bc857" />
<img width="222" height="263" alt="image" src="https://github.com/user-attachments/assets/31bb18b3-4170-4e88-96a3-2d8000acf9c7" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
