### PR TITLE
chore: Simplify reply message lookup with store-based fetching

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -74,9 +74,17 @@ export const mutations = {
   [types.SET_PREVIOUS_CONVERSATIONS](_state, { id, data }) {
     if (data.length) {
       const [chat] = _state.allConversations.filter(c => c.id === id);
-      chat.messages.unshift(...data);
+      if (chat) {
+        // Duplicate check: only add messages that don't already exist
+        const existingIds = new Set(chat.messages.map(m => m.id));
+        const newMessages = data.filter(m => !existingIds.has(m.id));
+        if (newMessages.length) {
+          chat.messages.unshift(...newMessages);
+        }
+      }
     }
   },
+
   [types.SET_ALL_ATTACHMENTS](_state, { id, data }) {
     _state.attachments[id] = [...data];
   },

--- a/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
@@ -615,6 +615,29 @@ describe('#mutations', () => {
       mutations[types.SET_PREVIOUS_CONVERSATIONS](state, payload);
       expect(state.allConversations[0].messages).toEqual([{ id: 'msg2' }]);
     });
+
+    it('should filter out duplicate messages', () => {
+      const state = {
+        allConversations: [{ id: 1, messages: [{ id: 'msg2' }] }],
+      };
+      const payload = { id: 1, data: [{ id: 'msg1' }, { id: 'msg2' }] };
+
+      mutations[types.SET_PREVIOUS_CONVERSATIONS](state, payload);
+      expect(state.allConversations[0].messages).toEqual([
+        { id: 'msg1' },
+        { id: 'msg2' },
+      ]);
+    });
+
+    it('should do nothing if conversation is not found', () => {
+      const state = {
+        allConversations: [{ id: 2, messages: [{ id: 'msg2' }] }],
+      };
+      const payload = { id: 1, data: [{ id: 'msg1' }] };
+
+      mutations[types.SET_PREVIOUS_CONVERSATIONS](state, payload);
+      expect(state.allConversations[0].messages).toEqual([{ id: 'msg2' }]);
+    });
   });
 
   describe('#SET_MISSING_MESSAGES', () => {


### PR DESCRIPTION
# Pull Request Template

## Description

In this [PR](https://github.com/chatwoot/chatwoot/pull/10024), we introduced the ability to load reply-to messages dynamically when they are missing from the message list. The earlier implementation relied on fetching directly from the API, which sometimes caused multiple redundant calls.

The updated approach shifts this to a store-based logic. While fetching conversation messages, any reply-to messages are also cached in the store. This ensures that when the same reply-to message is needed again (for example, during scroll-up), it is served from the store instead of triggering another API call.

## How Has This Been Tested?

### Loom video



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
