### PR TITLE
fix: Display proper conversation ID with click-to-open in SLA reports

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/SLA/SLAReportItem.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/SLA/SLAReportItem.vue
@@ -27,6 +27,11 @@ const conversationLabels = computed(() => {
     ? props.conversation.labels.split(',').map(item => item.trim())
     : [];
 });
+
+const routerParams = computed(() => ({
+  name: 'inbox_conversation',
+  params: { conversation_id: props.conversationId },
+}));
 </script>
 
 <template>
@@ -36,9 +41,9 @@ const conversationLabels = computed(() => {
     <div
       class="flex items-center gap-2 col-span-6 px-0 py-2 text-sm tracking-[0.5] text-n-slate-12 rtl:text-right"
     >
-      <span class="text-n-slate-12">
-        {{ `#${conversationId} ` }}
-      </span>
+      <router-link :to="routerParams" class="text-n-slate-12 hover:underline">
+        {{ `#${conversationId}` }}
+      </router-link>
       <span class="text-n-slate-11">
         {{ $t('SLA_REPORTS.WITH') }}
       </span>

--- a/enterprise/app/views/api/v1/accounts/applied_slas/index.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/applied_slas/index.json.jbuilder
@@ -3,7 +3,7 @@ json.payload do
     json.applied_sla applied_sla.push_event_data
     json.conversation do
       conversation = applied_sla.conversation
-      json.id conversation.id
+      json.id conversation.display_id
       json.contact do
         json.name conversation.contact.name if conversation.contact
       end

--- a/spec/enterprise/controllers/api/v1/accounts/applied_slas_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/applied_slas_controller_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe 'Applied SLAs API', type: :request do
         body = JSON.parse(response.body)
         expect(body['payload'].size).to eq(1)
         expect(body['payload'].first).to include('applied_sla')
-        expect(body['payload'].first['conversation']['id']).to eq(conversation2.id)
+        expect(body['payload'].first['conversation']['id']).to eq(conversation2.display_id)
         expect(body['meta']).to include('count' => 1)
       end
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR includes, 
* Fixed SLA reports to display the correct conversation ID instead of a random number.
* Made the conversation ID clickable so it opens the corresponding conversation.

Fixes [CW-5722](https://linear.app/chatwoot/issue/CW-5722/sla-reports-should-show-conversation-id-instead-it-shows-random-number
) 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screencast

https://github.com/user-attachments/assets/6e64ba1a-b5ca-4db4-94a7-2981fd6779d2




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
