### PR TITLE
Fix conversation access to respect conversation permissions

### DIFF
--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -160,6 +160,7 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
 
   def conversation
     @conversation ||= Current.account.conversations.find_by!(display_id: params[:id])
+    authorize @conversation
     authorize @conversation.inbox, :show?
   end
 

--- a/app/policies/conversation_policy.rb
+++ b/app/policies/conversation_policy.rb
@@ -1,4 +1,14 @@
 class ConversationPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope if user.is_a?(AgentBot)
+      return scope.none if account.blank?
+
+      conversations = scope.where(account_id: account.id)
+      Conversations::PermissionFilterService.new(conversations, user, account).perform
+    end
+  end
+
   def index?
     true
   end


### PR DESCRIPTION
## Summary
- authorize conversations through the conversation policy before serving account conversation endpoints
- scope conversation policy checks through the permission filter service so custom role permissions are enforced on direct access

## Testing
- bundle exec rubocop app/policies/conversation_policy.rb app/controllers/api/v1/accounts/conversations_controller.rb

------
https://chatgpt.com/codex/tasks/task_e_68de1f62b9b883268a54882e608a8bb8