### PR TITLE
perf: optimise the label query by using cached_label_list instead of joins

### DIFF
--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -156,7 +156,8 @@ class ConversationFinder
   def filter_by_labels
     return unless params[:labels]
 
-    @conversations = @conversations.tagged_with(params[:labels], any: true)
+    pattern = params[:labels].map { |label| Regexp.escape(label) }.join('|')
+    @conversations = @conversations.where('cached_label_list ~ ?', "\\y(#{pattern})\\y")
   end
 
   def filter_by_source_id


### PR DESCRIPTION
## Linear Ticket
- https://linear.app/chatwoot/issue/CW-5738/query-optimisation-use-cached-label-list

## Description
The join with tag table is expensive and using a lot of CPU, in order to optimise that we are directly querying on cached_label_list

## Type of change

- [ ]  Query/Performance Optimisation

## How Has This Been Tested?

- Manual query on meta base using the query created by code
- Rspec to test the functionality

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
