### PR TITLE
fix: I18n::MissingInterpolationArgument for assignee activity messages

### DIFF
--- a/app/models/concerns/activity_message_handler.rb
+++ b/app/models/concerns/activity_message_handler.rb
@@ -106,7 +106,7 @@ module ActivityMessageHandler
   end
 
   def generate_assignee_change_activity_content(user_name)
-    params = { assignee_name: assignee&.name, user_name: user_name }.compact
+    params = { assignee_name: assignee&.name || '', user_name: user_name }
     key = assignee_id ? 'assigned' : 'removed'
     key = 'self_assigned' if self_assign? assignee_id
     I18n.t("conversations.activity.assignee.#{key}", **params)


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the following error:
`I18n::MissingInterpolationArgument: missing interpolation argument :assignee_name in "Asignado a %{assignee_name} por %{user_name}" ({user_name: "Marketing Telpronet"} given) (I18n::MissingInterpolationArgument)`

**Issue**

In the Spanish locale, an `I18n::MissingInterpolationArgument` error occurred during bulk assignee operations.
This happened because `assignee&.name` was returning `nil`, and the `.compact` method removed the `assignee_name` key entirely from the params.

<img width="1744" height="164" alt="image" src="https://github.com/user-attachments/assets/3c15ed77-48c0-4938-a7fd-356bdb07da39" />


**Solution**

* Always include the `assignee_name` key with an empty string (`''`) when its value is `nil`.
* Removed the `.compact` method call to ensure the interpolation key is always present.


Fixes https://linear.app/chatwoot/issue/CW-5747/i18nmissinginterpolationargument-missing-interpolation-argument

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
