### PR TITLE
fix: Handle video file types in Slack file shares

### DIFF
--- a/lib/integrations/slack/slack_message_helper.rb
+++ b/lib/integrations/slack/slack_message_helper.rb
@@ -70,8 +70,6 @@ module Integrations::Slack::SlackMessageHelper
     case attachment[:filetype]
     when 'png', 'jpeg', 'gif', 'bmp', 'tiff', 'jpg'
       :image
-    when 'pdf'
-      :file
     when 'mp4', 'avi', 'mov', 'wmv', 'flv', 'webm'
       :video
     else

--- a/lib/integrations/slack/slack_message_helper.rb
+++ b/lib/integrations/slack/slack_message_helper.rb
@@ -72,6 +72,10 @@ module Integrations::Slack::SlackMessageHelper
       :image
     when 'pdf'
       :file
+    when 'mp4', 'avi', 'mov', 'wmv', 'flv', 'webm'
+      :video
+    else
+      :file
     end
   end
 

--- a/spec/lib/integrations/slack/incoming_message_builder_spec.rb
+++ b/spec/lib/integrations/slack/incoming_message_builder_spec.rb
@@ -157,6 +157,19 @@ describe Integrations::Slack::IncomingMessageBuilder do
 
         expect(conversation.messages.count).to eql(messages_count)
       end
+
+      it 'handles different file types correctly' do
+        expect(hook).not_to be_nil
+        video_attachment_params = message_with_attachments.deep_dup
+        video_attachment_params[:event][:files][0][:filetype] = 'mp4'
+        video_attachment_params[:event][:files][0][:mimetype] = 'video/mp4'
+
+        builder = described_class.new(video_attachment_params)
+        allow(builder).to receive(:sender).and_return(nil)
+
+        expect { builder.perform }.not_to raise_error
+        expect(conversation.messages.last.attachments).to be_any
+      end
     end
 
     context 'when link shared' do


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-5752/fix-nomethoderror-when-processing-video-files-in-slack-integration
#### Problem
When users shared video files (like MP4) through Slack, the `file_type` method in `SlackMessageHelper` would return `nil` for unsupported file types. This caused a `NoMethodError (undefined method 'to_sym' for nil)` when the attachment was being processed, as the system expected a symbol value for the `file_type` attribute.

#### Solution
  - Added video file type support in the `file_type` method case statement
  - Added `else` clause to default unknown file types to `:file` instead of returning `nil`
  - This ensures `file_type` always returns a symbol, preventing the `to_sym` error
