### PR TITLE
fix: add presence validation for account name

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -48,6 +48,7 @@ class Account < ApplicationRecord
     check_for_column: false
   }.freeze
 
+  validates :name, presence: true
   validates :domain, length: { maximum: 100 }
   validates_with JsonSchemaValidator,
                  schema: SETTINGS_PARAMS_SCHEMA,

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe Account do
   describe 'length validations' do
     let(:account) { create(:account) }
 
+    it 'validates name presence' do
+      account.name = ''
+      account.valid?
+      expect(account.errors[:name]).to include("can't be blank")
+    end
+
     it 'validates name length' do
       account.name = 'a' * 256
       account.valid?


### PR DESCRIPTION
## Description

When a user tries creating a new account through the Super Admin dashboard, and they forget to fill in the account name, they're faced with an ugly error (generic "Something went wrong" on production).

This PR simply adds the `validates :name, presence: true` model validation on `Account` model, which is translated as a proper error message on the Super Admin UI.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added model spec to check if presence validation is actually being done, and manual testing on Super Admin dashboard.

| Before | After |
| --- | --- |
| <img width="1736" height="784" alt="image" src="https://github.com/user-attachments/assets/afcf6026-2413-4fd7-9c45-d8d79a5908ef" /> | <img width="1967" height="998" alt="image" src="https://github.com/user-attachments/assets/88668327-beed-4826-b0b5-91a04ae880d1" /> |


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
