### PR TITLE
feat(webhooks): allow localhost URLs on local environment

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
@@ -4,6 +4,7 @@ import { required, url, minLength, or } from '@vuelidate/validators';
 import wootConstants from 'dashboard/constants/globals';
 import { getI18nKey } from 'dashboard/routes/dashboard/settings/helper/settingsHelper';
 import NextButton from 'dashboard/components-next/button/Button.vue';
+import { isLocalhostUrl } from 'shared/helpers/Validators';
 
 const { EXAMPLE_WEBHOOK_URL } = wootConstants;
 
@@ -19,20 +20,6 @@ const SUPPORTED_WEBHOOK_EVENTS = [
   'conversation_typing_on',
   'conversation_typing_off',
 ];
-
-// NOTE: The `url` validator fails for localhost URLs.
-// This custom validator allows localhost URLs when the app is running on localhost.
-const localhostUrl = value => {
-  if (!value) {
-    return true;
-  }
-  const isRunningOnLocalhost = ['127.0.0.1', 'localhost'].includes(
-    window.location.hostname
-  );
-  const localUrlPattern =
-    /^(?:https?:\/\/)?(?:127\.0\.0\.1|localhost)(?::\d+)?(?:\/.*)?$/i;
-  return isRunningOnLocalhost && localUrlPattern.test(value);
-};
 
 export default {
   components: {
@@ -60,7 +47,7 @@ export default {
     url: {
       required,
       minLength: minLength(7),
-      url: or(localhostUrl, url),
+      url: or(isLocalhostUrl, url),
     },
     subscriptions: {
       required,

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
@@ -1,6 +1,6 @@
 <script>
 import { useVuelidate } from '@vuelidate/core';
-import { required, url, minLength } from '@vuelidate/validators';
+import { required, url, minLength, or } from '@vuelidate/validators';
 import wootConstants from 'dashboard/constants/globals';
 import { getI18nKey } from 'dashboard/routes/dashboard/settings/helper/settingsHelper';
 import NextButton from 'dashboard/components-next/button/Button.vue';
@@ -19,6 +19,20 @@ const SUPPORTED_WEBHOOK_EVENTS = [
   'conversation_typing_on',
   'conversation_typing_off',
 ];
+
+// NOTE: The `url` validator fails for localhost URLs.
+// This custom validator allows localhost URLs when the app is running on localhost.
+const localhostUrl = value => {
+  if (!value) {
+    return true;
+  }
+  const isRunningOnLocalhost = ['127.0.0.1', 'localhost'].includes(
+    window.location.hostname
+  );
+  const localUrlPattern =
+    /^(?:https?:\/\/)?(?:127\.0\.0\.1|localhost)(?::\d+)?(?:\/.*)?$/i;
+  return isRunningOnLocalhost && localUrlPattern.test(value);
+};
 
 export default {
   components: {
@@ -46,7 +60,7 @@ export default {
     url: {
       required,
       minLength: minLength(7),
-      url,
+      url: or(localhostUrl, url),
     },
     subscriptions: {
       required,

--- a/app/javascript/shared/helpers/Validators.js
+++ b/app/javascript/shared/helpers/Validators.js
@@ -107,3 +107,20 @@ export const getRegexp = regexPatternValue => {
  * @returns {boolean} True if the slug is valid, false otherwise.
  */
 export const isValidSlug = value => /^[a-zA-Z0-9-]+$/.test(value);
+
+/**
+ * Validates if a URL is a localhost URL when the app is running on localhost.
+ * @param {string} value - The URL to validate.
+ * @returns {boolean} True if the URL is a localhost URL or empty, false otherwise.
+ */
+export const isLocalhostUrl = value => {
+  if (!value) {
+    return true;
+  }
+  const isRunningOnLocalhost = ['127.0.0.1', 'localhost'].includes(
+    window.location.hostname
+  );
+  const localUrlPattern =
+    /^(?:https?:\/\/)?(?:127\.0\.0\.1|localhost)(?::\d+)?(?:\/.*)?$/i;
+  return isRunningOnLocalhost && localUrlPattern.test(value);
+};

--- a/app/javascript/shared/helpers/specs/ValidatorsHelper.spec.js
+++ b/app/javascript/shared/helpers/specs/ValidatorsHelper.spec.js
@@ -10,6 +10,7 @@ import {
   isDomain,
   getRegexp,
   isValidSlug,
+  isLocalhostUrl,
 } from '../Validators';
 
 describe('#shouldBeUrl', () => {
@@ -173,5 +174,39 @@ describe('#isValidSlug', () => {
     expect(isValidSlug('abc--def!')).toEqual(false);
     expect(isValidSlug('abc-def ')).toEqual(false);
     expect(isValidSlug(' abc-def')).toEqual(false);
+  });
+});
+
+describe('#isLocalhostUrl', () => {
+  const originalLocation = window.location;
+
+  beforeAll(() => {
+    delete window.location;
+  });
+
+  afterAll(() => {
+    window.location = originalLocation;
+  });
+
+  it('should return true for empty value', () => {
+    expect(isLocalhostUrl('')).toEqual(true);
+    expect(isLocalhostUrl(null)).toEqual(true);
+    expect(isLocalhostUrl(undefined)).toEqual(true);
+  });
+
+  it('should return true for localhost URL when running on localhost', () => {
+    window.location = { hostname: 'localhost' };
+    expect(isLocalhostUrl('http://localhost:3000/path')).toEqual(true);
+    expect(isLocalhostUrl('https://localhost:3000/path')).toEqual(true);
+    expect(isLocalhostUrl('http://127.0.0.1:3000/path')).toEqual(true);
+    expect(isLocalhostUrl('https://127.0.0.1:3000/path')).toEqual(true);
+  });
+
+  it('should return true for non-localhost URLs when not running on localhost', () => {
+    window.location = { hostname: 'example.com' };
+    expect(isLocalhostUrl('http://localhost:3000/path')).toEqual(false);
+    expect(isLocalhostUrl('https://localhost:3000/path')).toEqual(false);
+    expect(isLocalhostUrl('http://127.0.0.1:3000/path')).toEqual(false);
+    expect(isLocalhostUrl('https://127.0.0.1:3000/path')).toEqual(false);
   });
 });

--- a/app/javascript/shared/helpers/specs/ValidatorsHelper.spec.js
+++ b/app/javascript/shared/helpers/specs/ValidatorsHelper.spec.js
@@ -202,11 +202,16 @@ describe('#isLocalhostUrl', () => {
     expect(isLocalhostUrl('https://127.0.0.1:3000/path')).toEqual(true);
   });
 
-  it('should return true for non-localhost URLs when not running on localhost', () => {
+  it('should return false for localhost URLs when not running on localhost', () => {
     window.location = { hostname: 'example.com' };
     expect(isLocalhostUrl('http://localhost:3000/path')).toEqual(false);
     expect(isLocalhostUrl('https://localhost:3000/path')).toEqual(false);
     expect(isLocalhostUrl('http://127.0.0.1:3000/path')).toEqual(false);
     expect(isLocalhostUrl('https://127.0.0.1:3000/path')).toEqual(false);
+  });
+
+  it('should return false for non-localhost URLs', () => {
+    expect(isLocalhostUrl('http://example.com')).toEqual(false);
+    expect(isLocalhostUrl('https://example.com')).toEqual(false);
   });
 });


### PR DESCRIPTION
## Description

The `url` validator from `@vuelidate/validators` does not accept localhost URLs (`localhost` and `127.0.0.1`) as valid.

This is inconvenient when working with webhooks on a local environment, so allowing them selectively is a big improvement on Developer Experience.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Validator specs were added, and also tested manually with webhook creation form.

| Before | After |
| --- | --- |
| <img width="992" height="403" alt="image" src="https://github.com/user-attachments/assets/f3e2ec80-69b8-4457-ac92-117609633f34" /> | <img width="995" height="396" alt="image" src="https://github.com/user-attachments/assets/17116b0a-870c-4562-adc0-b79ab7795e3a" /> |



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
