### PR TITLE
Ajusta ordenação das conversas por prioridade e tempo de espera

### DIFF
--- a/app/controllers/public/api/v1/inboxes/conversations_controller.rb
+++ b/app/controllers/public/api/v1/inboxes/conversations_controller.rb
@@ -3,7 +3,7 @@ class Public::Api::V1::Inboxes::ConversationsController < Public::Api::V1::Inbox
   before_action :set_conversation, only: [:toggle_typing, :update_last_seen, :show, :toggle_status]
 
   def index
-    @conversations = @contact_inbox.hmac_verified? ? @contact_inbox.contact.conversations : @contact_inbox.conversations
+    @conversations = (@contact_inbox.hmac_verified? ? @contact_inbox.contact.conversations : @contact_inbox.conversations).ordered_for_inbox
   end
 
   def show; end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -94,6 +94,10 @@ class Conversation < ApplicationRecord
     ).sort_on_last_user_message_at
   }
 
+  scope :ordered_for_inbox, lambda {
+    order(Arel.sql('COALESCE(priority, 0) DESC, COALESCE(last_activity_at) ASC'))
+  }
+
   belongs_to :account
   belongs_to :inbox
   belongs_to :assignee, class_name: 'User', optional: true, inverse_of: :assigned_conversations


### PR DESCRIPTION
## Description

Little modification on sorting, now by priority and last_activity_at. Bsed on my experience with customer service i bilieve it will perform better tha nthe stardard ones.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Not tested yet

