### PR TITLE
fix: Use gap-4 instead of margins to define space between elements

### DIFF
--- a/app/javascript/v3/views/login/Index.vue
+++ b/app/javascript/v3/views/login/Index.vue
@@ -259,9 +259,9 @@ export default {
       }"
     >
       <div v-if="!email">
-        <div class="flex flex-col">
+        <div class="flex flex-col gap-4">
           <GoogleOAuthButton v-if="showGoogleOAuth" />
-          <div v-if="showSamlLogin" class="mt-4 text-center">
+          <div v-if="showSamlLogin" class="text-center">
             <router-link
               to="/app/login/sso"
               class="inline-flex justify-center w-full px-4 py-3 items-center bg-n-background dark:bg-n-solid-3 rounded-md shadow-sm ring-1 ring-inset ring-n-container dark:ring-n-container focus:outline-offset-0 hover:bg-n-alpha-2 dark:hover:bg-n-alpha-2"


### PR DESCRIPTION
We should avoid using margins to define space between elements, instead use the gap utility. 

The problem with this particular instance was that if Google auth was turned off and SSO is available, there is a weird spacing at the top caused by the margin from the SSO element. 

This PR will fix that. It also introduces a gap between the divider and the button, but that should be okay.