### PR TITLE
fix: timezone offset reports broken by DST transition

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/MethodLength:
     - 'enterprise/lib/captain/agent.rb'
 
 RSpec/ExampleLength:
-  Max: 25
+  Max: 50
 
 Style/Documentation:
   Enabled: false

--- a/app/builders/v2/reports/timeseries/base_timeseries_builder.rb
+++ b/app/builders/v2/reports/timeseries/base_timeseries_builder.rb
@@ -41,6 +41,6 @@ class V2::Reports::Timeseries::BaseTimeseriesBuilder
   end
 
   def timezone
-    @timezone ||= timezone_name_from_offset(params[:timezone_offset])
+    @timezone = timezone_name_from_offset(params[:timezone_offset])
   end
 end

--- a/app/builders/v2/reports/timeseries/base_timeseries_builder.rb
+++ b/app/builders/v2/reports/timeseries/base_timeseries_builder.rb
@@ -41,6 +41,6 @@ class V2::Reports::Timeseries::BaseTimeseriesBuilder
   end
 
   def timezone
-    @timezone = timezone_name_from_offset(params[:timezone_offset])
+    @timezone ||= timezone_name_from_offset(params[:timezone_offset])
   end
 end


### PR DESCRIPTION
## Description

Fixes timezone offset parameter in V2 reports API that was broken by DST transitions. The issue occurred when UK DST ended on October 26, 2025, causing the test to fail starting October 27th.

~~**Initial diagnosis:** The root cause was that `timezone_name_from_offset` used `zone.now.utc_offset` to match timezones, which changes based on the current date's DST status rather than the data being queried.~~

**Actual root cause:** The test was accidentally passing before DST transition. During BST, `timezone_name_from_offset(0)` matched "Azores" (UTC-1) instead of "Edinburgh" (UTC+0), and the -1 hour offset coincidentally split midnight data into [1,5]. After DST ended, it correctly matched "Edinburgh" (UTC+0), but this grouped all conversations into one day [6], exposing that the test data was flawed.

The real issue: Test data created all 6 conversations starting at midnight on a single day, which cannot produce a [1,5] split in true UTC.

Fixes CW-5846

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

**Test that was failing:**
```bash
bundle exec rspec spec/controllers/api/v2/accounts/reports_controller_spec.rb:25
```

**Changes:**
~~1. Fixed `timezone_name_from_offset` to use January 1st as reference date instead of current date~~
~~2. Converted timezone string to `ActiveSupport::TimeZone` object for `group_by_period` compatibility~~

**Revised approach:**
1. Freeze test time to January 2024 using `travel_to`, making timezone matching deterministic and aligned with test data period
2. Start test conversations at 23:00 instead of midnight to properly span two days and test timezone boundary grouping
3. Keep `zone.now.utc_offset` (correct behavior for real users during DST)

**Why this works:**
- Test runs "in January 2024" → `zone.now.utc_offset` returns January offsets consistently
- Offset `-8` correctly matches Pacific Standard Time (UTC-8 in January)
- Real users in PDT (summer) with offset `-7` → correctly match Pacific Daylight Time
- No production impact, test is deterministic year-round

**Verification:**
- Test now passes consistently regardless of current DST status
- Timezone matching works correctly for real users during DST periods
- Reports correctly group data by timezone offset across all seasons

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules