### PR TITLE
chore: Update captain pending FAQ interface

### DIFF
--- a/app/javascript/dashboard/components-next/captain/assistant/ResponseCard.vue
+++ b/app/javascript/dashboard/components-next/captain/assistant/ResponseCard.vue
@@ -164,109 +164,105 @@ const handleDocumentableClick = () => {
       {{ answer }}
     </span>
     <div v-if="!compact" class="items-center justify-between hidden lg:flex">
-      <div class="inline-flex items-center">
-        <span
-          class="text-sm shrink-0 truncate text-n-slate-11 inline-flex items-center gap-1"
-        >
-          <i class="i-woot-captain" />
-          {{ assistant?.name || '' }}
-        </span>
-        <div
-          v-if="documentable"
-          class="shrink-0 text-sm text-n-slate-11 inline-flex line-clamp-1 gap-1 ml-3"
-        >
-          <span
-            v-if="documentable.type === 'Captain::Document'"
-            class="inline-flex items-center gap-1 truncate over"
-          >
-            <i class="i-ph-files-light text-base" />
-            <span class="max-w-96 truncate" :title="documentable.name">
-              {{ documentable.name }}
-            </span>
-          </span>
-          <span
-            v-if="documentable.type === 'User'"
-            class="inline-flex items-center gap-1"
-          >
-            <i class="i-ph-user-circle-plus text-base" />
-            <span
-              class="max-w-96 truncate"
-              :title="documentable.available_name"
-            >
-              {{ documentable.available_name }}
-            </span>
-          </span>
-          <span
-            v-else-if="documentable.type === 'Conversation'"
-            class="inline-flex items-center gap-1 group cursor-pointer"
-            role="button"
-            @click="handleDocumentableClick"
-          >
-            <i class="i-ph-chat-circle-dots text-base" />
-            <span class="group-hover:underline">
-              {{
-                t(`CAPTAIN.RESPONSES.DOCUMENTABLE.CONVERSATION`, {
-                  id: documentable.display_id,
-                })
-              }}
-            </span>
-          </span>
-          <span v-else />
-        </div>
-        <div
-          v-if="status !== 'approved'"
-          class="shrink-0 text-sm text-n-slate-11 line-clamp-1 inline-flex items-center gap-1 ml-3"
-        >
-          <i
-            class="i-ph-stack text-base"
-            :title="t('CAPTAIN.RESPONSES.STATUS.TITLE')"
+      <Policy v-if="showActions" :permissions="['administrator']">
+        <div class="flex gap-5 flex-1">
+          <Button
+            v-if="status === 'pending'"
+            :label="$t('CAPTAIN.RESPONSES.OPTIONS.APPROVE')"
+            icon="i-lucide-circle-check-big"
+            sm
+            link
+            class="hover:!no-underline"
+            @click="
+              handleAssistantAction({ action: 'approve', value: 'approve' })
+            "
           />
-          {{ t(`CAPTAIN.RESPONSES.STATUS.${status.toUpperCase()}`) }}
+          <Button
+            :label="$t('CAPTAIN.RESPONSES.OPTIONS.EDIT_RESPONSE')"
+            icon="i-lucide-pencil-line"
+            sm
+            slate
+            link
+            class="hover:!no-underline"
+            @click="
+              handleAssistantAction({
+                action: 'edit',
+                value: 'edit',
+              })
+            "
+          />
+          <Button
+            :label="$t('CAPTAIN.RESPONSES.OPTIONS.DELETE_RESPONSE')"
+            icon="i-lucide-trash"
+            sm
+            ruby
+            link
+            class="hover:!no-underline"
+            @click="
+              handleAssistantAction({ action: 'delete', value: 'delete' })
+            "
+          />
         </div>
-      </div>
-      <div
-        class="shrink-0 text-sm text-n-slate-11 line-clamp-1 inline-flex items-center gap-1 ml-3"
-      >
-        <i class="i-ph-calendar-dot" />
-        {{ timestamp }}
+      </Policy>
+      <div class="flex items-center gap-3">
+        <div class="inline-flex items-center gap-3">
+          <span
+            v-if="status === 'approved'"
+            class="text-sm shrink-0 truncate text-n-slate-11 inline-flex items-center gap-1"
+          >
+            <i class="i-woot-captain" />
+            {{ assistant?.name || '' }}
+          </span>
+          <div
+            v-if="documentable"
+            class="shrink-0 text-sm text-n-slate-11 inline-flex line-clamp-1 gap-1"
+          >
+            <span
+              v-if="documentable.type === 'Captain::Document'"
+              class="inline-flex items-center gap-1 truncate over"
+            >
+              <i class="i-ph-files-light text-base" />
+              <span class="max-w-96 truncate" :title="documentable.name">
+                {{ documentable.name }}
+              </span>
+            </span>
+            <span
+              v-if="documentable.type === 'User'"
+              class="inline-flex items-center gap-1"
+            >
+              <i class="i-ph-user-circle-plus text-base" />
+              <span
+                class="max-w-96 truncate"
+                :title="documentable.available_name"
+              >
+                {{ documentable.available_name }}
+              </span>
+            </span>
+            <span
+              v-else-if="documentable.type === 'Conversation'"
+              class="inline-flex items-center gap-1 group cursor-pointer"
+              role="button"
+              @click="handleDocumentableClick"
+            >
+              <i class="i-ph-chat-circle-dots text-base" />
+              <span class="group-hover:underline">
+                {{
+                  t(`CAPTAIN.RESPONSES.DOCUMENTABLE.CONVERSATION`, {
+                    id: documentable.display_id,
+                  })
+                }}
+              </span>
+            </span>
+            <span v-else />
+          </div>
+        </div>
+        <div
+          class="shrink-0 text-sm text-n-slate-11 line-clamp-1 inline-flex items-center gap-1"
+        >
+          <i class="i-ph-calendar-dot" />
+          {{ timestamp }}
+        </div>
       </div>
     </div>
-    <Policy v-if="showActions" :permissions="['administrator']">
-      <div class="flex gap-2 mt-2">
-        <Button
-          v-if="status === 'pending'"
-          :label="$t('CAPTAIN.RESPONSES.OPTIONS.APPROVE')"
-          icon="i-lucide-circle-check-big"
-          sm
-          link
-          class="hover:!no-underline"
-          @click="
-            handleAssistantAction({ action: 'approve', value: 'approve' })
-          "
-        />
-        <Button
-          :label="$t('CAPTAIN.RESPONSES.OPTIONS.EDIT_RESPONSE')"
-          icon="i-lucide-pencil-line"
-          sm
-          link
-          class="hover:!no-underline"
-          @click="
-            handleAssistantAction({
-              action: 'edit',
-              value: 'edit',
-            })
-          "
-        />
-        <Button
-          :label="$t('CAPTAIN.RESPONSES.OPTIONS.DELETE_RESPONSE')"
-          icon="i-lucide-trash"
-          sm
-          ruby
-          link
-          class="hover:!no-underline"
-          @click="handleAssistantAction({ action: 'delete', value: 'delete' })"
-        />
-      </div>
-    </Policy>
   </CardLayout>
 </template>

--- a/app/javascript/dashboard/components-next/captain/assistant/ResponseCard.vue
+++ b/app/javascript/dashboard/components-next/captain/assistant/ResponseCard.vue
@@ -9,6 +9,7 @@ import DropdownMenu from 'dashboard/components-next/dropdown-menu/DropdownMenu.v
 import Button from 'dashboard/components-next/button/Button.vue';
 import Checkbox from 'dashboard/components-next/checkbox/Checkbox.vue';
 import Policy from 'dashboard/components/policy.vue';
+import Icon from 'dashboard/components-next/icon/Icon.vue';
 
 const props = defineProps({
   id: {
@@ -163,9 +164,12 @@ const handleDocumentableClick = () => {
     <span class="text-n-slate-11 text-sm line-clamp-5">
       {{ answer }}
     </span>
-    <div v-if="!compact" class="items-center justify-between hidden lg:flex">
+    <div
+      v-if="!compact"
+      class="flex items-start justify-between flex-col-reverse md:flex-row gap-3"
+    >
       <Policy v-if="showActions" :permissions="['administrator']">
-        <div class="flex gap-5 flex-1">
+        <div class="flex items-center gap-2 sm:gap-5 w-full">
           <Button
             v-if="status === 'pending'"
             :label="$t('CAPTAIN.RESPONSES.OPTIONS.APPROVE')"
@@ -204,62 +208,69 @@ const handleDocumentableClick = () => {
           />
         </div>
       </Policy>
-      <div class="flex items-center gap-3">
-        <div class="inline-flex items-center gap-3">
+      <div
+        class="flex items-center gap-3"
+        :class="{ 'justify-between w-full': !showActions }"
+      >
+        <div class="inline-flex items-center gap-3 min-w-0">
           <span
             v-if="status === 'approved'"
             class="text-sm shrink-0 truncate text-n-slate-11 inline-flex items-center gap-1"
           >
-            <i class="i-woot-captain" />
+            <Icon icon="i-woot-captain" class="size-3.5" />
             {{ assistant?.name || '' }}
           </span>
           <div
             v-if="documentable"
-            class="shrink-0 text-sm text-n-slate-11 inline-flex line-clamp-1 gap-1"
+            class="text-sm text-n-slate-11 grid grid-cols-[auto_1fr] items-center gap-1 min-w-0"
           >
+            <Icon
+              v-if="documentable.type === 'Captain::Document'"
+              icon="i-ph-files-light"
+              class="size-3.5"
+            />
+            <Icon
+              v-else-if="documentable.type === 'User'"
+              icon="i-ph-user-circle-plus"
+              class="size-3.5"
+            />
+            <Icon
+              v-else-if="documentable.type === 'Conversation'"
+              icon="i-ph-chat-circle-dots"
+              class="size-3.5"
+            />
             <span
               v-if="documentable.type === 'Captain::Document'"
-              class="inline-flex items-center gap-1 truncate over"
+              class="truncate"
+              :title="documentable.name"
             >
-              <i class="i-ph-files-light text-base" />
-              <span class="max-w-96 truncate" :title="documentable.name">
-                {{ documentable.name }}
-              </span>
+              {{ documentable.name }}
             </span>
             <span
-              v-if="documentable.type === 'User'"
-              class="inline-flex items-center gap-1"
+              v-else-if="documentable.type === 'User'"
+              class="truncate"
+              :title="documentable.available_name"
             >
-              <i class="i-ph-user-circle-plus text-base" />
-              <span
-                class="max-w-96 truncate"
-                :title="documentable.available_name"
-              >
-                {{ documentable.available_name }}
-              </span>
+              {{ documentable.available_name }}
             </span>
             <span
               v-else-if="documentable.type === 'Conversation'"
-              class="inline-flex items-center gap-1 group cursor-pointer"
+              class="hover:underline truncate cursor-pointer"
               role="button"
               @click="handleDocumentableClick"
             >
-              <i class="i-ph-chat-circle-dots text-base" />
-              <span class="group-hover:underline">
-                {{
-                  t(`CAPTAIN.RESPONSES.DOCUMENTABLE.CONVERSATION`, {
-                    id: documentable.display_id,
-                  })
-                }}
-              </span>
+              {{
+                t(`CAPTAIN.RESPONSES.DOCUMENTABLE.CONVERSATION`, {
+                  id: documentable.display_id,
+                })
+              }}
             </span>
-            <span v-else />
           </div>
         </div>
         <div
           class="shrink-0 text-sm text-n-slate-11 line-clamp-1 inline-flex items-center gap-1"
         >
-          <i class="i-ph-calendar-dot" />
+          <Icon icon="i-ph-calendar-dot" class="size-3.5" />
           {{ timestamp }}
         </div>
       </div>

--- a/app/javascript/dashboard/components-next/captain/assistant/ResponseCard.vue
+++ b/app/javascript/dashboard/components-next/captain/assistant/ResponseCard.vue
@@ -231,33 +231,42 @@ const handleDocumentableClick = () => {
         {{ timestamp }}
       </div>
     </div>
-    <div v-if="showActions" class="flex gap-2 mt-2">
-      <Button
-        v-if="status === 'pending'"
-        :label="$t('CAPTAIN.RESPONSES.OPTIONS.APPROVE')"
-        icon="i-lucide-circle-check-big"
-        sm
-        link
-        class="hover:!no-underline"
-        @click="handleAssistantAction({ action: 'approve', value: 'approve' })"
-      />
-      <Button
-        :label="$t('CAPTAIN.RESPONSES.OPTIONS.EDIT_RESPONSE')"
-        icon="i-lucide-pencil-line"
-        sm
-        link
-        class="hover:!no-underline"
-        @click="handleAssistantAction({ action: 'edit', value: 'edit' })"
-      />
-      <Button
-        :label="$t('CAPTAIN.RESPONSES.OPTIONS.DELETE_RESPONSE')"
-        icon="i-lucide-trash"
-        sm
-        ruby
-        link
-        class="hover:!no-underline"
-        @click="handleAssistantAction({ action: 'delete', value: 'delete' })"
-      />
-    </div>
+    <Policy v-if="showActions" :permissions="['administrator']">
+      <div class="flex gap-2 mt-2">
+        <Button
+          v-if="status === 'pending'"
+          :label="$t('CAPTAIN.RESPONSES.OPTIONS.APPROVE')"
+          icon="i-lucide-circle-check-big"
+          sm
+          link
+          class="hover:!no-underline"
+          @click="
+            handleAssistantAction({ action: 'approve', value: 'approve' })
+          "
+        />
+        <Button
+          :label="$t('CAPTAIN.RESPONSES.OPTIONS.EDIT_RESPONSE')"
+          icon="i-lucide-pencil-line"
+          sm
+          link
+          class="hover:!no-underline"
+          @click="
+            handleAssistantAction({
+              action: 'edit',
+              value: 'edit',
+            })
+          "
+        />
+        <Button
+          :label="$t('CAPTAIN.RESPONSES.OPTIONS.DELETE_RESPONSE')"
+          icon="i-lucide-trash"
+          sm
+          ruby
+          link
+          class="hover:!no-underline"
+          @click="handleAssistantAction({ action: 'delete', value: 'delete' })"
+        />
+      </div>
+    </Policy>
   </CardLayout>
 </template>

--- a/app/javascript/dashboard/components-next/captain/assistant/ResponseCard.vue
+++ b/app/javascript/dashboard/components-next/captain/assistant/ResponseCard.vue
@@ -59,6 +59,10 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  showActions: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits(['action', 'navigate', 'select', 'hover']);
@@ -226,6 +230,34 @@ const handleDocumentableClick = () => {
         <i class="i-ph-calendar-dot" />
         {{ timestamp }}
       </div>
+    </div>
+    <div v-if="showActions" class="flex gap-2 mt-2">
+      <Button
+        v-if="status === 'pending'"
+        :label="$t('CAPTAIN.RESPONSES.OPTIONS.APPROVE')"
+        icon="i-lucide-circle-check-big"
+        sm
+        link
+        class="hover:!no-underline"
+        @click="handleAssistantAction({ action: 'approve', value: 'approve' })"
+      />
+      <Button
+        :label="$t('CAPTAIN.RESPONSES.OPTIONS.EDIT_RESPONSE')"
+        icon="i-lucide-pencil-line"
+        sm
+        link
+        class="hover:!no-underline"
+        @click="handleAssistantAction({ action: 'edit', value: 'edit' })"
+      />
+      <Button
+        :label="$t('CAPTAIN.RESPONSES.OPTIONS.DELETE_RESPONSE')"
+        icon="i-lucide-trash"
+        sm
+        ruby
+        link
+        class="hover:!no-underline"
+        @click="handleAssistantAction({ action: 'delete', value: 'delete' })"
+      />
     </div>
   </CardLayout>
 </template>

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -861,6 +861,7 @@
     },
     "RESPONSES": {
       "HEADER": "FAQs",
+      "PENDING_FAQS": "Pending FAQs",
       "ADD_NEW": "Create new FAQ",
       "DOCUMENTABLE": {
         "CONVERSATION": "Conversation #{id}"
@@ -899,6 +900,10 @@
         "PENDING": "Pending",
         "APPROVED": "Approved",
         "ALL": "All"
+      },
+      "PENDING_BANNER": {
+        "TITLE": "Captain has identified new FAQs.",
+        "ACTION": "Click here to review"
       },
       "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
       "CREATE": {

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -902,7 +902,7 @@
         "ALL": "All"
       },
       "PENDING_BANNER": {
-        "TITLE": "Captain has identified new FAQs.",
+        "TITLE": "Captain has found some FAQs your customers were looking for.",
         "ACTION": "Click here to review"
       },
       "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
@@ -936,9 +936,9 @@
         "APPROVE_SUCCESS_MESSAGE": "The FAQ was marked as approved"
       },
       "OPTIONS": {
-        "APPROVE": "Mark as approved",
-        "EDIT_RESPONSE": "Edit FAQ",
-        "DELETE_RESPONSE": "Delete FAQ"
+        "APPROVE": "Approve",
+        "EDIT_RESPONSE": "Edit",
+        "DELETE_RESPONSE": "Delete"
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",

--- a/app/javascript/dashboard/routes/dashboard/captain/captain.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/captain/captain.routes.js
@@ -10,6 +10,7 @@ import AssistantGuidelinesIndex from './assistants/guidelines/Index.vue';
 import AssistantScenariosIndex from './assistants/scenarios/Index.vue';
 import DocumentsIndex from './documents/Index.vue';
 import ResponsesIndex from './responses/Index.vue';
+import ResponsesPendingIndex from './responses/Pending.vue';
 import CustomToolsIndex from './tools/Index.vue';
 
 export const routes = [
@@ -127,7 +128,7 @@ export const routes = [
   },
   {
     path: frontendURL('accounts/:accountId/captain/responses/pending'),
-    component: ResponsesIndex,
+    component: ResponsesPendingIndex,
     name: 'captain_responses_pending',
     meta: {
       permissions: ['administrator', 'agent'],

--- a/app/javascript/dashboard/routes/dashboard/captain/captain.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/captain/captain.routes.js
@@ -126,6 +126,19 @@ export const routes = [
     },
   },
   {
+    path: frontendURL('accounts/:accountId/captain/responses/pending'),
+    component: ResponsesIndex,
+    name: 'captain_responses_pending',
+    meta: {
+      permissions: ['administrator', 'agent'],
+      featureFlag: FEATURE_FLAGS.CAPTAIN,
+      installationTypes: [
+        INSTALLATION_TYPES.CLOUD,
+        INSTALLATION_TYPES.ENTERPRISE,
+      ],
+    },
+  },
+  {
     path: frontendURL('accounts/:accountId/captain/tools'),
     component: CustomToolsIndex,
     name: 'captain_tools_index',

--- a/app/javascript/dashboard/routes/dashboard/captain/responses/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/responses/Index.vue
@@ -7,6 +7,7 @@ import { useRouter, useRoute } from 'vue-router';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import { debounce } from '@chatwoot/utils';
 import { useAccount } from 'dashboard/composables/useAccount';
+import { frontendURL } from 'dashboard/helper/URLHelper';
 
 import Banner from 'dashboard/components-next/banner/Banner.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
@@ -55,6 +56,11 @@ const isPendingRoute = computed(
 );
 
 const pendingCount = useMapGetter('captainResponses/getPendingCount');
+
+const backUrl = computed(() => {
+  if (!isPendingRoute.value) return undefined;
+  return frontendURL(`accounts/${route.params.accountId}/captain/responses`);
+});
 
 // Filter out approved responses in pending view
 const filteredResponses = computed(() => {
@@ -288,7 +294,7 @@ onMounted(() => {
     :is-empty="!filteredResponses.length"
     :show-pagination-footer="!isFetching && !!filteredResponses.length"
     :feature-flag="FEATURE_FLAGS.CAPTAIN"
-    :back-url="isPendingRoute ? '/captain/responses' : undefined"
+    :back-url="backUrl"
     @update:current-page="onPageChange"
     @click="handleCreate"
   >

--- a/app/javascript/dashboard/store/captain/response.js
+++ b/app/javascript/dashboard/store/captain/response.js
@@ -1,9 +1,22 @@
 import CaptainResponseAPI from 'dashboard/api/captain/response';
 import { createStore } from './storeFactory';
 
+const SET_PENDING_COUNT = 'SET_PENDING_COUNT';
+
 export default createStore({
   name: 'CaptainResponse',
   API: CaptainResponseAPI,
+  getters: {
+    getPendingCount: state => state.meta.pendingCount || 0,
+  },
+  mutations: {
+    [SET_PENDING_COUNT](state, count) {
+      state.meta = {
+        ...state.meta,
+        pendingCount: Number(count),
+      };
+    },
+  },
   actions: mutations => ({
     removeBulkResponses: ({ commit, state }, ids) => {
       const updatedRecords = state.records.filter(
@@ -27,6 +40,19 @@ export default createStore({
       });
 
       commit(mutations.SET, updatedRecords);
+    },
+    fetchPendingCount: async ({ commit }, assistantId) => {
+      try {
+        const response = await CaptainResponseAPI.get({
+          status: 'pending',
+          page: 1,
+          assistantId,
+        });
+        const count = response.data?.meta?.total_count || 0;
+        commit(SET_PENDING_COUNT, count);
+      } catch (error) {
+        commit(SET_PENDING_COUNT, 0);
+      }
     },
   }),
 });

--- a/app/javascript/dashboard/store/captain/storeFactory.js
+++ b/app/javascript/dashboard/store/captain/storeFactory.js
@@ -49,6 +49,7 @@ export const createMutations = mutationTypes => ({
   },
   [mutationTypes.SET_META](state, meta) {
     state.meta = {
+      ...state.meta,
       totalCount: Number(meta.total_count),
       page: Number(meta.page),
     };
@@ -69,7 +70,7 @@ export const createCrudActions = (API, mutationTypes) => ({
 });
 
 export const createStore = options => {
-  const { name, API, actions, getters } = options;
+  const { name, API, actions, getters, mutations } = options;
   const mutationTypes = generateMutationTypes(name);
 
   const customActions = actions ? actions(mutationTypes) : {};
@@ -81,7 +82,10 @@ export const createStore = options => {
       ...createGetters(),
       ...(getters || {}),
     },
-    mutations: createMutations(mutationTypes),
+    mutations: {
+      ...createMutations(mutationTypes),
+      ...(mutations || {}),
+    },
     actions: {
       ...createCrudActions(API, mutationTypes),
       ...customActions,


### PR DESCRIPTION
# Pull Request Template

## Description

**This PR includes,**
- Added new pending FAQs view with approve/edit/delete actions for each response.
- Implemented banner notification showing pending FAQ count on main approved responses page.
- Created dedicated route for pending FAQs review at /captain/responses/pending.
- Added automatic pending count updates when switching assistants or routes.
- Modified ResponseCard component to show action buttons instead of dropdown in pending view.

Fixes https://linear.app/chatwoot/issue/CW-5833/pending-faqs-in-a-different-ux

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/5fe8f79b04cd4681b9360c48710b9373


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
