### PR TITLE
fix: Exclude authentication templates from WhatsApp template selection

### DIFF
--- a/app/javascript/dashboard/store/modules/inboxes.js
+++ b/app/javascript/dashboard/store/modules/inboxes.js
@@ -78,6 +78,11 @@ export const getters = {
         return false;
       }
 
+      // Filter out authentication templates
+      if (template.category === 'AUTHENTICATION') {
+        return false;
+      }
+
       // Filter out interactive templates (LIST, PRODUCT, CATALOG), location templates, and call permission templates
       const hasUnsupportedComponents = template.components.some(
         component =>

--- a/app/javascript/dashboard/store/modules/specs/inboxes/getters.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/inboxes/getters.spec.js
@@ -265,6 +265,39 @@ describe('#getters', () => {
       expect(result[0].name).toBe('regular_template');
     });
 
+    it('filters out authentication templates', () => {
+      const authenticationTemplates = [
+        {
+          name: 'auth_template',
+          status: 'approved',
+          category: 'AUTHENTICATION',
+          components: [
+            { type: 'BODY', text: 'Your verification code is {{1}}' },
+          ],
+        },
+        {
+          name: 'regular_template',
+          status: 'approved',
+          category: 'MARKETING',
+          components: [{ type: 'BODY', text: 'Regular message' }],
+        },
+      ];
+
+      const state = {
+        records: [
+          {
+            id: 1,
+            channel_type: 'Channel::Whatsapp',
+            message_templates: authenticationTemplates,
+          },
+        ],
+      };
+
+      const result = getters.getFilteredWhatsAppTemplates(state)(1);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('regular_template');
+    });
+
     it('returns valid templates from fixture data', () => {
       const state = {
         records: [


### PR DESCRIPTION
This PR add the changes for excluding the authentication templates from the WhatsApp template selection in the frontend, as these templates are not supported at the moment. Reference: https://www.chatwoot.com/hc/user-guide/articles/1754940076-whatsapp-templates#what-is-not-supported

Fixes https://linear.app/chatwoot/issue/CW-5850/authentication-templates-are-showing-up