### PR TITLE
chore: Add dependant destroy_async for sla events

### DIFF
--- a/enterprise/app/models/applied_sla.rb
+++ b/enterprise/app/models/applied_sla.rb
@@ -22,7 +22,7 @@ class AppliedSla < ApplicationRecord
   belongs_to :sla_policy
   belongs_to :conversation
 
-  has_many :sla_events, dependent: :destroy
+  has_many :sla_events, dependent: :destroy_async
 
   validates :account_id, uniqueness: { scope: %i[sla_policy_id conversation_id] }
   before_validation :ensure_account_id


### PR DESCRIPTION
Added the destroy_async to  prevent timeout during SLA policy deletion by processing SLA events asynchronously.