### PR TITLE
feat: implement smart chat assignment

### DIFF
--- a/app/jobs/reassign_offline_agent_chats_job.rb
+++ b/app/jobs/reassign_offline_agent_chats_job.rb
@@ -1,0 +1,47 @@
+class ReassignOfflineAgentChatsJob < ApplicationJob
+  queue_as :default
+
+  def perform(agent_id)
+    agent = User.find_by(id: agent_id)
+    return unless agent
+
+    conversations = Conversation.where(assignee_id: agent.id).where.not(status: :resolved)
+    return if conversations.none?
+
+    conversations.find_each do |conversation|
+      reassign_conversation(conversation)
+    end
+  end
+
+  private
+
+  def reassign_conversation(conversation)
+    allowed_agent_ids = online_agents_for(conversation)
+    if allowed_agent_ids.empty?
+      Rails.logger.warn("No online agents available for conversation #{conversation.id}")
+      return
+    end
+
+    AutoAssignment::AgentAssignmentService.new(
+      conversation: conversation,
+      allowed_agent_ids: allowed_agent_ids
+    ).perform
+
+    Rails.logger.info("Conversation #{conversation.id} reassigned")
+  rescue StandardError => e
+    Rails.logger.error("Failed to reassign conversation #{conversation.id}: #{e.message}")
+  end
+
+  def online_agents_for(conversation)
+    inbox = conversation.inbox
+    return [] unless inbox
+
+    account_id = conversation.account_id
+
+    inbox.members
+         .map(&:id)
+         .uniq
+         .reject { |id| id == conversation.assignee_id }
+         .select { |id| OnlineStatusTracker.get_status(account_id, id) == 'online' }
+  end
+end

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -4,20 +4,32 @@ class AutoAssignment::AgentAssignmentService
   # examples: Agents with assignment capacity, Agents who are members of a team etc
   pattr_initialize [:conversation!, :allowed_agent_ids!]
 
-  def find_assignee
-    round_robin_manage_service.available_agent(allowed_agent_ids: allowed_online_agent_ids)
-  end
-
   def perform
-    new_assignee = find_assignee
-    conversation.update(assignee: new_assignee) if new_assignee
+    assignee_id = find_assignee
+    return unless assignee_id
+
+    conversation.update(assignee_id: assignee_id)
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error("AutoAssignment failed for Conversation #{conversation.id}: #{e.message}")
   end
 
   private
 
+  def find_assignee
+    ids = allowed_online_agent_ids
+    return if ids.blank?
+
+    counts = active_chat_counts_for(ids)
+    min_count = counts.values.min
+    least_busy_agents = counts.select { |_id, count| count == min_count }.keys
+    pick_least_recent_assigned(least_busy_agents)
+  end
+
   def online_agent_ids
-    online_agents = OnlineStatusTracker.get_available_users(conversation.account_id)
-    online_agents.select { |_key, value| value.eql?('online') }.keys if online_agents.present?
+    @online_agent_ids ||= begin
+      agents = OnlineStatusTracker.get_available_users(conversation.account_id)
+      agents.select { |_id, status| status == 'online' }.keys
+    end
   end
 
   def allowed_online_agent_ids
@@ -25,14 +37,43 @@ class AutoAssignment::AgentAssignmentService
     # Hence taking an intersection of online agents and allowed member ids
 
     # the online user ids are string, since its from redis, allowed member ids are integer, since its from active record
-    @allowed_online_agent_ids ||= online_agent_ids & allowed_agent_ids&.map(&:to_s)
+    online_ids = online_agent_ids.map(&:to_i)
+    allowed_ids = allowed_agent_ids.map(&:to_i)
+    @allowed_online_agent_ids ||= online_ids & allowed_ids
   end
 
-  def round_robin_manage_service
-    @round_robin_manage_service ||= AutoAssignment::InboxRoundRobinService.new(inbox: conversation.inbox)
+  def active_chat_counts_for(agent_ids)
+    Conversation
+      .where(assignee_id: agent_ids)
+      .where.not(status: :resolved)
+      .group(:assignee_id)
+      .count
+      .tap do |hash|
+        agent_ids.each { |id| hash[id] ||= 0 }
+      end
   end
 
-  def round_robin_key
-    format(::Redis::Alfred::ROUND_ROBIN_AGENTS, inbox_id: conversation.inbox_id)
+  def pick_least_recent_assigned(agent_ids)
+    return agent_ids.sample if agent_ids.size == 1
+
+    last_closed_times = last_closed_chat_times_for(agent_ids)
+    agent_ids.min_by { |id| last_closed_times[id] || Time.zone.at(0) }
   end
+
+  def last_closed_chat_times_for(agent_ids)
+    Conversation
+      .where(assignee_id: agent_ids, status: :resolved)
+      .select('assignee_id, MAX(updated_at) AS last_closed_at')
+      .group(:assignee_id)
+      .pluck(:assignee_id, Arel.sql('MAX(updated_at)'))
+      .to_h
+  end
+
+  # def round_robin_manage_service
+  #   @round_robin_manage_service ||= AutoAssignment::InboxRoundRobinService.new(inbox: conversation.inbox)
+  # end
+
+  # def round_robin_key
+  #   format(::Redis::Alfred::ROUND_ROBIN_AGENTS, inbox_id: conversation.inbox_id)
+  # end
 end

--- a/config/initializers/auto_reassign_offline_agent_chats.rb
+++ b/config/initializers/auto_reassign_offline_agent_chats.rb
@@ -1,0 +1,18 @@
+Rails.application.config.to_prepare do
+  OnlineStatusTracker.singleton_class.class_eval do
+    alias_method :set_status_original, :set_status
+
+    def set_status(account_id, user_id, status)
+      result = set_status_original(account_id, user_id, status)
+
+      if status.to_s == 'offline'
+        Rails.logger.info "Agent #{user_id} went offline -> reassign chats"
+        ReassignOfflineAgentChatsJob.perform_later(user_id)
+      end
+
+      result
+    end
+  end
+
+  Rails.logger.info 'OnlineStatusTracker patched successfully'
+end


### PR DESCRIPTION
Updated chat assignment logic:
New chats are now assigned to the agent with the fewest active chats instead of round-robin.

- If several agents have the same number of chats, the first available one gets the chat.

- Only online agents are considered.

- When an agent closes a chat, their load is updated immediately.

- New online agents start with 0 chats and receive new ones until loads are balanced.

commit from https://github.com/rondelinga/chatwoot/pull/1