### PR TITLE
fix: Gate Sidekiq dequeue logger behind env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -256,6 +256,8 @@ AZURE_APP_SECRET=
 ## Change these values to fine tune performance
 # control the concurrency setting of sidekiq
 # SIDEKIQ_CONCURRENCY=10
+# Enable verbose logging each time a job is dequeued in Sidekiq
+# ENABLE_SIDEKIQ_DEQUEUE_LOGGER=false
 
 
 # AI powered features

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -18,8 +18,10 @@ end
 Sidekiq.configure_server do |config|
   config.redis = Redis::Config.app
 
-  config.server_middleware do |chain|
-    chain.add ChatwootDequeuedLogger
+  if ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_SIDEKIQ_DEQUEUE_LOGGER', false))
+    config.server_middleware do |chain|
+      chain.add ChatwootDequeuedLogger
+    end
   end
 
   # skip the default start stop logging


### PR DESCRIPTION
## Summary
- wrap the dequeue middleware registration in a boolean env flag
- document the ENABLE_SIDEKIQ_DEQUEUE_LOGGER option in .env.example


