### PR TITLE
fix: Avoid introducing new attributes in search

### DIFF
--- a/app/presenters/messages/search_data_presenter.rb
+++ b/app/presenters/messages/search_data_presenter.rb
@@ -3,7 +3,7 @@ class Messages::SearchDataPresenter < SimpleDelegator
     {
       **searchable_content,
       **message_attributes,
-      **search_additional_data,
+      additional_attributes: additional_attributes_data,
       conversation: conversation_data
     }
   end
@@ -49,7 +49,7 @@ class Messages::SearchDataPresenter < SimpleDelegator
     { id: conversation.display_id }
   end
 
-  def search_additional_data
+  def additional_attributes_data
     {
       campaign_id: additional_attributes&.dig('campaign_id'),
       automation_rule_id: content_attributes&.dig('automation_rule_id')

--- a/spec/presenters/messages/search_data_presenter_spec.rb
+++ b/spec/presenters/messages/search_data_presenter_spec.rb
@@ -67,11 +67,11 @@ RSpec.describe Messages::SearchDataPresenter do
       end
 
       it 'includes campaign_id' do
-        expect(presenter.search_data[:campaign_id]).to eq('123')
+        expect(presenter.search_data[:additional_attributes][:campaign_id]).to eq('123')
       end
 
       it 'includes automation_rule_id' do
-        expect(presenter.search_data[:automation_rule_id]).to eq('456')
+        expect(presenter.search_data[:additional_attributes][:automation_rule_id]).to eq('456')
       end
     end
   end

--- a/spec/services/widget/token_service_expiry_spec.rb
+++ b/spec/services/widget/token_service_expiry_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Widget::TokenService, type: :service do
         travel_to '2025-01-01' do
           token = service.generate_token
           decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: 'HS256').first
-          expect(decoded['iat']).to eq(Time.now.to_i)
-          expect(decoded['exp']).to eq(30.days.from_now.to_i)
+          expect(decoded['iat']).to eq(Time.zone.now.to_i)
+          expect(decoded['exp']).to eq(Time.zone.now.to_i + 30.days.to_i)
         end
       end
     end
@@ -33,8 +33,8 @@ RSpec.describe Widget::TokenService, type: :service do
         travel_to '2025-01-01' do
           token = service.generate_token
           decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: 'HS256').first
-          expect(decoded['iat']).to eq(Time.now.to_i)
-          expect(decoded['exp']).to eq(180.days.from_now.to_i)
+          expect(decoded['iat']).to eq(Time.zone.now.to_i)
+          expect(decoded['exp']).to eq(Time.zone.now.to_i + 180.days.to_i)
         end
       end
     end

--- a/spec/services/widget/token_service_expiry_spec.rb
+++ b/spec/services/widget/token_service_expiry_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Widget::TokenService, type: :service do
       end
 
       it 'uses the configured value for token expiry' do
-        freeze_time do
+        travel_to '2025-01-01' do
           token = service.generate_token
           decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: 'HS256').first
           expect(decoded['iat']).to eq(Time.now.to_i)
@@ -30,7 +30,7 @@ RSpec.describe Widget::TokenService, type: :service do
       end
 
       it 'uses the default expiry' do
-        freeze_time do
+        travel_to '2025-01-01' do
           token = service.generate_token
           decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: 'HS256').first
           expect(decoded['iat']).to eq(Time.now.to_i)


### PR DESCRIPTION
Fix `Limit of total fields [1000] has been exceeded`

https://linear.app/chatwoot/issue/CW-5861/searchkickimporterror-type-=-illegal-argument-exception-reason-=-limit#comment-6b6e41bd