### PR TITLE
feat: implement auto smart assignment

### DIFF
--- a/app/jobs/reassign_offline_agent_chats_job.rb
+++ b/app/jobs/reassign_offline_agent_chats_job.rb
@@ -1,0 +1,77 @@
+class ReassignOfflineAgentChatsJob < ApplicationJob
+  queue_as :default
+
+  def perform(agent_id, account_id = nil)
+    agent = User.find_by(id: agent_id)
+    return unless agent
+
+    conversations = Conversation
+                    .where(assignee_id: agent.id)
+                    .where.not(status: :resolved)
+    conversations = conversations.where(account_id: account_id) if account_id.present?
+    return if conversations.none?
+
+    account = Account.find_by(id: account_id)
+    return unless account
+
+    agent_statuses = agent_statuses_for(account)
+
+    online_agent_ids = agent_statuses.select { |_, status| status.to_s == 'online' }.keys
+
+    if online_agent_ids.empty?
+      Rails.logger.warn("All agents offline in account #{account.id} — unassigning #{conversations.size} conversations")
+      # rubocop:disable Rails/SkipsModelValidations
+      conversations.update_all(assignee_id: nil, updated_at: Time.current)
+      # rubocop:enable Rails/SkipsModelValidations
+      return
+    end
+
+    conversations.find_each do |conversation|
+      reassign_conversation(conversation, agent_statuses)
+    end
+  end
+
+  private
+
+  def reassign_conversation(conversation, agent_statuses)
+    allowed_agent_ids = online_agents_for(conversation, agent_statuses)
+
+    if allowed_agent_ids.empty?
+      Rails.logger.warn("No online agents for conversation #{conversation.id} — unassigning")
+      conversation.update!(assignee_id: nil)
+      return
+    end
+
+    AutoAssignment::AgentAssignmentService.new(
+      conversation: conversation,
+      allowed_agent_ids: allowed_agent_ids
+    ).perform
+
+    Rails.logger.info("Conversation #{conversation.id} reassigned")
+  rescue StandardError => e
+    Rails.logger.error("Failed to reassign conversation #{conversation.id}: #{e.message}")
+  end
+
+  def online_agents_for(conversation, agent_statuses)
+    inbox = conversation.inbox
+    return [] unless inbox
+
+    inbox.members
+         .map(&:id)
+         .uniq
+         .reject { |id| id == conversation.assignee_id }
+         .select { |id| agent_statuses[id].to_s == 'online' }
+  end
+
+  def agent_statuses_for(account)
+    account.users.map do |u|
+      status = OnlineStatusTracker.get_status(account.id, u.id)
+
+      if status.nil?
+        status = u.account_users.find_by(account: account)&.auto_offline? ? 'offline' : 'online'
+      end
+
+      [u.id, status]
+    end.to_h
+  end
+end

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -4,20 +4,34 @@ class AutoAssignment::AgentAssignmentService
   # examples: Agents with assignment capacity, Agents who are members of a team etc
   pattr_initialize [:conversation!, :allowed_agent_ids!]
 
-  def find_assignee
-    round_robin_manage_service.available_agent(allowed_agent_ids: allowed_online_agent_ids)
+  def perform
+    assignee = find_assignee
+    return unless assignee
+
+    conversation.update!(assignee: assignee)
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error("AutoAssignment failed for Conversation #{conversation.id}: #{e.message}")
   end
 
-  def perform
-    new_assignee = find_assignee
-    conversation.update(assignee: new_assignee) if new_assignee
+  def find_assignee
+    ids = allowed_online_agent_ids
+    return if ids.blank?
+
+    counts = active_chat_counts_for(ids)
+    min_count = counts.values.min
+    least_busy_agents = counts.select { |_id, count| count == min_count }.keys
+    selected_id = pick_least_recent_assigned(least_busy_agents)
+
+    User.find_by(id: selected_id)
   end
 
   private
 
   def online_agent_ids
-    online_agents = OnlineStatusTracker.get_available_users(conversation.account_id)
-    online_agents.select { |_key, value| value.eql?('online') }.keys if online_agents.present?
+    @online_agent_ids ||= begin
+      agents = OnlineStatusTracker.get_available_users(conversation.account_id)
+      agents.select { |_id, status| status == 'online' }.keys
+    end
   end
 
   def allowed_online_agent_ids
@@ -25,14 +39,43 @@ class AutoAssignment::AgentAssignmentService
     # Hence taking an intersection of online agents and allowed member ids
 
     # the online user ids are string, since its from redis, allowed member ids are integer, since its from active record
-    @allowed_online_agent_ids ||= online_agent_ids & allowed_agent_ids&.map(&:to_s)
+    online_ids = online_agent_ids.map(&:to_i)
+    allowed_ids = allowed_agent_ids.map(&:to_i)
+    @allowed_online_agent_ids ||= online_ids & allowed_ids
   end
 
-  def round_robin_manage_service
-    @round_robin_manage_service ||= AutoAssignment::InboxRoundRobinService.new(inbox: conversation.inbox)
+  def active_chat_counts_for(agent_ids)
+    Conversation
+      .where(assignee_id: agent_ids)
+      .where.not(status: :resolved)
+      .group(:assignee_id)
+      .count
+      .tap do |hash|
+        agent_ids.each { |id| hash[id] ||= 0 }
+      end
   end
 
-  def round_robin_key
-    format(::Redis::Alfred::ROUND_ROBIN_AGENTS, inbox_id: conversation.inbox_id)
+  def pick_least_recent_assigned(agent_ids)
+    return agent_ids.sample if agent_ids.size == 1
+
+    last_closed_times = last_closed_chat_times_for(agent_ids)
+    agent_ids.min_by { |id| last_closed_times[id] || Time.zone.at(0) }
   end
+
+  def last_closed_chat_times_for(agent_ids)
+    Conversation
+      .where(assignee_id: agent_ids, status: :resolved)
+      .select('assignee_id, MAX(updated_at) AS last_closed_at')
+      .group(:assignee_id)
+      .pluck(:assignee_id, Arel.sql('MAX(updated_at)'))
+      .to_h
+  end
+
+  # def round_robin_manage_service
+  #   @round_robin_manage_service ||= AutoAssignment::InboxRoundRobinService.new(inbox: conversation.inbox)
+  # end
+
+  # def round_robin_key
+  #   format(::Redis::Alfred::ROUND_ROBIN_AGENTS, inbox_id: conversation.inbox_id)
+  # end
 end

--- a/config/initializers/auto_reassign_offline_agent_chats.rb
+++ b/config/initializers/auto_reassign_offline_agent_chats.rb
@@ -1,0 +1,18 @@
+Rails.application.config.to_prepare do
+  OnlineStatusTracker.singleton_class.class_eval do
+    alias_method :set_status_original, :set_status
+
+    def set_status(account_id, user_id, status)
+      result = set_status_original(account_id, user_id, status)
+
+      if status.to_s == 'offline'
+        Rails.logger.info "Agent #{user_id} went offline in account #{account_id} -> reassign chats"
+        ReassignOfflineAgentChatsJob.perform_later(user_id, account_id)
+      end
+
+      result
+    end
+  end
+
+  Rails.logger.info 'OnlineStatusTracker patched successfully'
+end

--- a/spec/services/auto_assignment/agent_assignment_service_spec.rb
+++ b/spec/services/auto_assignment/agent_assignment_service_spec.rb
@@ -29,11 +29,17 @@ RSpec.describe AutoAssignment::AgentAssignmentService do
   end
 
   describe '#find_assignee' do
-    it 'will return an online agent from the allowed agent ids in roud robin' do
-      expect(described_class.new(conversation: conversation,
-                                 allowed_agent_ids: inbox_members.map(&:user_id).map(&:to_s)).find_assignee).to eq(inbox_members[3].user)
-      expect(described_class.new(conversation: conversation,
-                                 allowed_agent_ids: inbox_members.map(&:user_id).map(&:to_s)).find_assignee).to eq(inbox_members[4].user)
+    it 'returns the online agent with the fewest active chats' do
+      create(:conversation, inbox: inbox, assignee: inbox_members[3].user, status: :open)
+      create(:conversation, inbox: inbox, assignee: inbox_members[3].user, status: :open)
+      create(:conversation, inbox: inbox, assignee: inbox_members[4].user, status: :open)
+
+      assignee = described_class.new(
+        conversation: conversation,
+        allowed_agent_ids: inbox_members.map(&:user_id).map(&:to_s)
+      ).find_assignee
+
+      expect(assignee).to eq(inbox_members[4].user)
     end
   end
 end


### PR DESCRIPTION
## Updated chat assignment logic:

- New chats are now assigned to the agent with the fewest active chats instead of round-robin.

- If several agents have the same number of chats, the first available one gets the chat.

- Only online agents are considered.

- When an agent closes a chat, their load is updated immediately.

- New online agents start with 0 chats and receive new ones until loads are balanced.
