### PR TITLE
feat: Differentiate bot and user in the summary

### DIFF
--- a/app/services/llm_formatter/conversation_llm_formatter.rb
+++ b/app/services/llm_formatter/conversation_llm_formatter.rb
@@ -39,7 +39,14 @@ class LlmFormatter::ConversationLlmFormatter < LlmFormatter::DefaultLlmFormatter
   end
 
   def format_message(message)
-    sender = message.message_type == 'incoming' ? 'User' : 'Support agent'
+    sender = case message.sender_type
+             when 'User'
+               'Support Agent'
+             when 'Contact'
+               'User'
+             else
+               'Bot'
+             end
     sender = "[Private Note] #{sender}" if message.private?
     "#{sender}: #{message.content}\n"
   end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -27,6 +27,13 @@ FactoryBot.define do
       end
     end
 
+    trait :bot_message do
+      message_type { 'outgoing' }
+      after(:build) do |message|
+        message.sender = nil
+      end
+    end
+
     after(:build) do |message|
       message.sender ||= message.outgoing? ? create(:user, account: message.account) : create(:contact, account: message.account)
       message.inbox ||= message.conversation&.inbox || create(:inbox, account: message.account)

--- a/spec/services/llm_formatter/conversation_llm_formatter_spec.rb
+++ b/spec/services/llm_formatter/conversation_llm_formatter_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe LlmFormatter::ConversationLlmFormatter do
 
         create(
           :message,
+          :bot_message,
+          conversation: conversation,
+          message_type: 'outgoing',
+          content: 'Thanks for reaching out, an agent will reach out to you soon'
+        )
+
+        create(
+          :message,
           conversation: conversation,
           message_type: 'outgoing',
           content: 'How can I assist you today?'
@@ -40,7 +48,8 @@ RSpec.describe LlmFormatter::ConversationLlmFormatter do
           "Channel: #{conversation.inbox.channel.name}",
           'Message History:',
           'User: Hello, I need help',
-          'Support agent: How can I assist you today?',
+          'Bot: Thanks for reaching out, an agent will reach out to you soon',
+          'Support Agent: How can I assist you today?',
           ''
         ].join("\n")
 


### PR DESCRIPTION
While generating the summary, use the appropriate sender type for the message.