### PR TITLE
feat: allow bots to handle campaigns when sender_id is nil

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -228,12 +228,15 @@ class Conversation < ApplicationRecord
   def determine_conversation_status
     self.status = :resolved and return if contact.blocked?
 
-    # Message template hooks aren't executed for conversations from campaigns
-    # So making these conversations open for agent visibility
-    return if campaign.present?
+    return handle_campaign_status if campaign.present?
 
     # TODO: make this an inbox config instead of assuming bot conversations should start as pending
     self.status = :pending if inbox.active_bot?
+  end
+
+  def handle_campaign_status
+    # If campaign has no sender (bot-initiated) and inbox has active bot, let bot handle it
+    self.status = :pending if campaign.sender_id.nil? && inbox.active_bot?
   end
 
   def notify_conversation_creation

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -576,9 +576,38 @@ RSpec.describe Conversation do
       expect(conversation.status).to eq('pending')
     end
 
-    it 'returns conversation as open if campaign is present' do
-      conversation = create(:conversation, inbox: bot_inbox.inbox, campaign: create(:campaign))
-      expect(conversation.status).to eq('open')
+    context 'with campaigns' do
+      let(:user) { create(:user, account: bot_inbox.inbox.account) }
+
+      it 'returns conversation as open if campaign has a sender' do
+        campaign = create(:campaign, inbox: bot_inbox.inbox, account: bot_inbox.inbox.account, sender: user)
+        conversation = create(:conversation, inbox: bot_inbox.inbox, campaign: campaign)
+        expect(conversation.status).to eq('open')
+      end
+
+      it 'returns conversation as pending if campaign has no sender (bot-initiated) and bot is active' do
+        campaign = create(:campaign, inbox: bot_inbox.inbox, account: bot_inbox.inbox.account, sender: nil)
+        conversation = create(:conversation, inbox: bot_inbox.inbox, campaign: campaign)
+        expect(conversation.status).to eq('pending')
+      end
+    end
+
+    context 'with campaigns in inbox without bot' do
+      let(:account) { create(:account) }
+      let(:inbox) { create(:inbox, account: account) }
+      let(:user) { create(:user, account: account) }
+
+      it 'returns conversation as open if campaign has no sender but no bot is active' do
+        campaign = create(:campaign, inbox: inbox, account: account, sender: nil)
+        conversation = create(:conversation, inbox: inbox, campaign: campaign)
+        expect(conversation.status).to eq('open')
+      end
+
+      it 'returns conversation as open if campaign has a sender' do
+        campaign = create(:campaign, inbox: inbox, account: account, sender: user)
+        conversation = create(:conversation, inbox: inbox, campaign: campaign)
+        expect(conversation.status).to eq('open')
+      end
     end
   end
 


### PR DESCRIPTION
This PR enables bots to handle campaign-initiated conversations by using the campaign's `sender_id` field as a signal. When a campaign has no sender (`sender_id: nil`) and the inbox has an active bot, conversations will start in the `:pending` state, allowing the bot to engage first. Campaigns with a sender will continue to start in the `:open` state for immediate agent visibility, maintaining backward compatibility.

This approach avoids adding a new database field by leveraging the existing `sender_id` attribute. The logic is simple: `nil` sender means the campaign is system/bot-initiated, so let the bot handle it if one is active. Otherwise, conversations default to open state as they do today.


Ref: https://github.com/chatwoot/chatwoot/pull/12805