### PR TITLE
fix: Invalid image URL issue in Help Center articles

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@breezystack/lamejs": "^1.2.7",
     "@chatwoot/ninja-keys": "1.2.3",
-    "@chatwoot/prosemirror-schema": "1.2.1",
+    "@chatwoot/prosemirror-schema": "1.2.3",
     "@chatwoot/utils": "^0.0.51",
     "@formkit/core": "^1.6.7",
     "@formkit/vue": "^1.6.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: 1.2.3
         version: 1.2.3
       '@chatwoot/prosemirror-schema':
-        specifier: 1.2.1
-        version: 1.2.1
+        specifier: 1.2.3
+        version: 1.2.3
       '@chatwoot/utils':
         specifier: ^0.0.51
         version: 0.0.51
@@ -406,8 +406,8 @@ packages:
   '@chatwoot/ninja-keys@1.2.3':
     resolution: {integrity: sha512-xM8d9P5ikDMZm2WbaCTk/TW5HFauylrU3cJ75fq5je6ixKwyhl/0kZbVN/vbbZN4+AUX/OaSIn6IJbtCgIF67g==}
 
-  '@chatwoot/prosemirror-schema@1.2.1':
-    resolution: {integrity: sha512-UbiEvG5tgi1d0lMbkaqxgTh7vHfywEYKLQo1sxqp4Q7aLZh4QFtbLzJ2zyBtu4Nhipe+guFfEJdic7i43MP/XQ==}
+  '@chatwoot/prosemirror-schema@1.2.3':
+    resolution: {integrity: sha512-q/EfirVK9jt8FJAx3Gf6y3LoVadmYVLknbYvPrkUe81WO0f2mkZ/kY2UQgpUISVvOGEkCH4bkfYMp5UQ+Buz3g==}
 
   '@chatwoot/utils@0.0.51':
     resolution: {integrity: sha512-WlEmWfOTzR7YZRUWzn5Wpm15/BRudpwqoNckph8TohyDbiim1CP4UZGa+qjajxTbNGLLhtKlm0Xl+X16+5Wceg==}
@@ -4768,7 +4768,7 @@ snapshots:
       hotkeys-js: 3.8.7
       lit: 2.2.6
 
-  '@chatwoot/prosemirror-schema@1.2.1':
+  '@chatwoot/prosemirror-schema@1.2.3':
     dependencies:
       markdown-it-sup: 2.0.0
       prosemirror-commands: 1.6.0


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where pasting content (e.g., from Notion) into the Help Center editor caused errors like **“Invalid URL provided”** or **“Unable to upload image”** due to invalid image sources such as `attachment:` URLs.

The update ensures only **valid HTTP/HTTPS image URLs** are processed, and **invalid images are automatically removed** from the ProseMirror node.

ProseMirror PR: https://github.com/chatwoot/prosemirror-schema/pull/37


Fixes https://linear.app/chatwoot/issue/CW-5896/helpdesk-throws-unable-to-upload-image-error-when-we-try-to-upload

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video

**Before**
https://www.loom.com/share/76ebd47f132f474085ff1ddc1a374f0e

**After**
https://www.loom.com/share/9469309854384ce3a9c80daf0c6c3cf7



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
