### PR TITLE
fix: Remove the same account validation for whatsapp channels

### DIFF
--- a/app/services/whatsapp/channel_creation_service.rb
+++ b/app/services/whatsapp/channel_creation_service.rb
@@ -10,7 +10,7 @@ class Whatsapp::ChannelCreationService
     validate_parameters!
 
     existing_channel = find_existing_channel
-    raise I18n.t('api.whatsapp.phone_number_already_exists', phone_number: existing_channel.phone_number) if existing_channel
+    raise I18n.t('errors.whatsapp.phone_number_already_exists', phone_number: existing_channel.phone_number) if existing_channel
 
     create_channel_with_inbox
   end

--- a/app/services/whatsapp/channel_creation_service.rb
+++ b/app/services/whatsapp/channel_creation_service.rb
@@ -10,9 +10,7 @@ class Whatsapp::ChannelCreationService
     validate_parameters!
 
     existing_channel = find_existing_channel
-    if existing_channel
-      raise "Channel already exists for this phone number: #{existing_channel.phone_number}, please contact support if the error persists"
-    end
+    raise I18n.t('api.whatsapp.phone_number_already_exists', phone_number: existing_channel.phone_number) if existing_channel
 
     create_channel_with_inbox
   end

--- a/app/services/whatsapp/channel_creation_service.rb
+++ b/app/services/whatsapp/channel_creation_service.rb
@@ -10,7 +10,9 @@ class Whatsapp::ChannelCreationService
     validate_parameters!
 
     existing_channel = find_existing_channel
-    raise "Channel already exists: #{existing_channel.phone_number}" if existing_channel
+    if existing_channel
+      raise "Channel already exists for this phone number: #{existing_channel.phone_number}, please contact support if the error persists"
+    end
 
     create_channel_with_inbox
   end
@@ -26,7 +28,6 @@ class Whatsapp::ChannelCreationService
 
   def find_existing_channel
     Channel::Whatsapp.find_by(
-      account: @account,
       phone_number: @phone_info[:phone_number]
     )
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,7 @@ en:
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'
+      phone_number_already_exists: 'Channel already exists for this phone number: %{phone_number}, please contact support if the error persists'
       reauthorization:
         generic: 'Failed to reauthorize WhatsApp. Please try again.'
         not_supported: 'Reauthorization is not supported for this type of WhatsApp channel.'

--- a/spec/services/whatsapp/channel_creation_service_spec.rb
+++ b/spec/services/whatsapp/channel_creation_service_spec.rb
@@ -73,7 +73,7 @@ describe Whatsapp::ChannelCreationService do
       it 'raises an error even if the channel belongs to a different account' do
         expect { service.perform }.to raise_error(
           RuntimeError,
-          I18n.t('api.whatsapp.phone_number_already_exists', phone_number: '+1234567890')
+          I18n.t('errors.whatsapp.phone_number_already_exists', phone_number: '+1234567890')
         )
       end
     end

--- a/spec/services/whatsapp/channel_creation_service_spec.rb
+++ b/spec/services/whatsapp/channel_creation_service_spec.rb
@@ -62,14 +62,19 @@ describe Whatsapp::ChannelCreationService do
       end
     end
 
-    context 'when channel already exists' do
+    context 'when channel already exists for the phone number' do
+      let(:different_account) { create(:account) }
+
       before do
-        create(:channel_whatsapp, account: account, phone_number: '+1234567890',
+        create(:channel_whatsapp, account: different_account, phone_number: '+1234567890',
                                   provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false)
       end
 
-      it 'raises an error' do
-        expect { service.perform }.to raise_error(/Channel already exists/)
+      it 'raises an error even if the channel belongs to a different account' do
+        expect { service.perform }.to raise_error(
+          RuntimeError,
+          'Channel already exists for this phone number: +1234567890, please contact support if the error persists'
+        )
       end
     end
 

--- a/spec/services/whatsapp/channel_creation_service_spec.rb
+++ b/spec/services/whatsapp/channel_creation_service_spec.rb
@@ -73,7 +73,7 @@ describe Whatsapp::ChannelCreationService do
       it 'raises an error even if the channel belongs to a different account' do
         expect { service.perform }.to raise_error(
           RuntimeError,
-          'Channel already exists for this phone number: +1234567890, please contact support if the error persists'
+          I18n.t('api.whatsapp.phone_number_already_exists', phone_number: '+1234567890')
         )
       end
     end


### PR DESCRIPTION
## Description

Modified the phone number validation in Whatsapp::ChannelCreationService to check for duplicate phone numbers across ALL accounts, not just within the current account.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added test coverage for cross-account phone number validation
- Using actual UI flow 
<img width="1493" height="532" alt="image" src="https://github.com/user-attachments/assets/67d2bb99-2eb9-4115-8d56-449e4785e0d8" />


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
