### PR TITLE
fix: label tags for contactable inboxes

### DIFF
--- a/swagger/paths/application/contact_inboxes/create.yml
+++ b/swagger/paths/application/contact_inboxes/create.yml
@@ -1,6 +1,6 @@
 post:
   tags:
-    - Contact
+    - Contacts
   operationId: contactInboxCreation
   description: Create a contact inbox record for an inbox
   summary: Create contact inbox

--- a/swagger/paths/application/contactable_inboxes/get.yml
+++ b/swagger/paths/application/contactable_inboxes/get.yml
@@ -1,6 +1,6 @@
 get:
   tags:
-    - Contact
+    - Contacts
   operationId: contactableInboxesGet
   description: Get List of contactable Inboxes
   summary: Get Contactable Inboxes

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -3281,7 +3281,7 @@
     "/api/v1/accounts/{account_id}/contacts/{id}/contact_inboxes": {
       "post": {
         "tags": [
-          "Contact"
+          "Contacts"
         ],
         "operationId": "contactInboxCreation",
         "description": "Create a contact inbox record for an inbox",
@@ -3366,7 +3366,7 @@
     "/api/v1/accounts/{account_id}/contacts/{id}/contactable_inboxes": {
       "get": {
         "tags": [
-          "Contact"
+          "Contacts"
         ],
         "operationId": "contactableInboxesGet",
         "description": "Get List of contactable Inboxes",

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -1821,6 +1821,152 @@
         }
       }
     },
+    "/api/v1/accounts/{account_id}/contacts/{id}/contact_inboxes": {
+      "post": {
+        "tags": [
+          "Contacts"
+        ],
+        "operationId": "contactInboxCreation",
+        "description": "Create a contact inbox record for an inbox",
+        "summary": "Create contact inbox",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/account_id"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "number"
+            },
+            "description": "ID of the contact",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "inbox_id"
+                ],
+                "properties": {
+                  "inbox_id": {
+                    "type": "number",
+                    "description": "The ID of the inbox",
+                    "example": 1
+                  },
+                  "source_id": {
+                    "type": "string",
+                    "description": "Contact Inbox Source Id"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/contact_inboxes"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Incorrect payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/{account_id}/contacts/{id}/contactable_inboxes": {
+      "get": {
+        "tags": [
+          "Contacts"
+        ],
+        "operationId": "contactableInboxesGet",
+        "description": "Get List of contactable Inboxes",
+        "summary": "Get Contactable Inboxes",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/account_id"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "number"
+            },
+            "description": "ID of the contact",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/contactable_inboxes_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Incorrect payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/accounts/{account_id}/automation_rules": {
       "parameters": [
         {


### PR DESCRIPTION
## Description
Two contact-related endpoints were not appearing in the Application tag group swagger documentation due to a tag mismatch:
POST /api/v1/accounts/{account_id}/contacts/{id}/contact_inboxes
GET /api/v1/accounts/{account_id}/contacts/{id}/contactable_inboxes

The endpoints were tagged with "Contact" (singular) but the Application tag group expected "Contacts" (plural), causing them to be filtered out during swagger generation.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Locally hosting the docs repo and confirming the precedes of the endpoints
<img width="1687" height="1198" alt="image" src="https://github.com/user-attachments/assets/f1b91b55-da69-4bbd-b5c2-9acceaed970c" />


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
