### PR TITLE
fix: hide pdf citations in captain faq responses

### DIFF
--- a/enterprise/lib/captain/tools/faq_lookup_tool.rb
+++ b/enterprise/lib/captain/tools/faq_lookup_tool.rb
@@ -28,12 +28,21 @@ class Captain::Tools::FaqLookupTool < Captain::Tools::BasePublicTool
         Question: #{response.question}
         Answer: #{response.answer}
         "
-    if response.documentable.present? && response.documentable.try(:external_link)
+    if should_show_source?(response)
       formatted_response += "
           Source: #{response.documentable.external_link}
           "
     end
 
     formatted_response
+  end
+
+  def should_show_source?(response)
+    return false if response.documentable.blank?
+    return false unless response.documentable.try(:external_link)
+
+    # Don't show source if it's a PDF placeholder
+    external_link = response.documentable.external_link
+    !external_link.start_with?('PDF:')
   end
 end


### PR DESCRIPTION
## Description

When Captain responds using FAQs generated from uploaded PDFs, it includes citations with internal PDF filenames like [[1](PDF: Twilio content templates (1)_20250902141455)]. These citations are:
- Not clickable URLs
- Expose internal document naming
- Not useful for customers

Modified Captain::Tools::FaqLookupTool to conditionally show citations:
-  Show citations for web-based documents (real URLs)
-  Hide citations for uploaded PDFs (internal "PDF:" placeholders)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
