### PR TITLE
fix: Use contact_id instead of sender_id for Instagram message locks

### DIFF
--- a/app/jobs/webhooks/instagram_events_job.rb
+++ b/app/jobs/webhooks/instagram_events_job.rb
@@ -78,7 +78,11 @@ class Webhooks::InstagramEventsJob < MutexApplicationJob
   end
 
   def contact_instagram_id
-    messaging = @entries&.dig(0, :messaging, 0)
+    entry = @entries&.first
+    return nil unless entry
+
+    # Handle both messaging and standby arrays
+    messaging = (entry[:messaging].presence || entry[:standby] || []).first
     return nil unless messaging
 
     # For echo messages (outgoing from our account), use recipient's ID (the contact)


### PR DESCRIPTION
# Pull Request Template

## Description

Previously, the lock key for Instagram used sender_id, which for echo messages (outgoing) would be the account's own ID. This caused all outgoing messages to compete for the same lock, creating a bottleneck during bulk messaging.

The fix introduces contact_instagram_id method that correctly identifies the contact's ID regardless of message direction:
- For echo messages (outgoing): uses recipient.id (the contact)
- For incoming messages: uses sender.id (the contact)

This ensures each conversation has a unique lock, allowing parallel processing of webhooks while maintaining race condition protection within individual conversations.

Fixes lock acquisition errors in Sidekiq when processing bulk Instagram messages.

Fixes https://linear.app/chatwoot/issue/CW-5931/p0-mutexapplicationjoblockacquisitionerror-failed-to-acquire-lock-for

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
