### PR TITLE
fix: migrate from deprecated annotate gem to annotaterb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -207,7 +207,7 @@ group :production do
 end
 
 group :development do
-  gem 'annotate'
+  gem 'annotaterb'
   gem 'bullet'
   gem 'letter_opener'
   gem 'scss_lint', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,9 +128,9 @@ GEM
       selectize-rails (~> 0.6)
     ai-agents (0.4.3)
       ruby_llm (~> 1.3)
-    annotate (3.2.0)
-      activerecord (>= 3.2, < 8.0)
-      rake (>= 10.4, < 14.0)
+    annotaterb (4.20.0)
+      activerecord (>= 6.0.0)
+      activesupport (>= 6.0.0)
     ast (2.4.3)
     attr_extras (7.1.0)
     audited (5.4.1)
@@ -992,7 +992,7 @@ DEPENDENCIES
   administrate-field-active_storage (>= 1.0.3)
   administrate-field-belongs_to_search (>= 0.9.0)
   ai-agents (>= 0.4.3)
-  annotate
+  annotaterb
   attr_extras
   audited (~> 5.4, >= 5.4.1)
   aws-sdk-s3

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -2,11 +2,14 @@
 # NOTE: are sensitive to local FS writes, and besides -- it's just not proper
 # NOTE: to have a dev-mode tool do its thing in production.
 if Rails.env.development?
-  require 'annotate'
+  require 'annotate_rb'
+
+  AnnotateRb::Core.load_rake_tasks
+
   task :set_annotation_options do
     # You can override any of these by setting an environment variable of the
     # same name.
-    Annotate.set_defaults(
+    AnnotateRb::Options.set_defaults(
       'additional_file_patterns' => [],
       'routes' => 'false',
       'models' => 'true',
@@ -55,6 +58,4 @@ if Rails.env.development?
       'with_comment' => 'true'
     )
   end
-
-  Annotate.load_tasks
 end


### PR DESCRIPTION
## Description

The `annotate` gem has been deprecated and users are experiencing annotation errors with the new Rails 7 `serialize` syntax. This PR migrates to `annotaterb`, the actively maintained fork.

Users reported errors when running `make db`:
```
Unable to annotate app/models/installation_config.rb: no implicit conversion of Hash into String  
Unable to annotate app/models/installation_config.rb: no implicit conversion of nil into Array
```

This PR updates the Gemfile and rake configuration to use `annotaterb` instead.

Fixes #11673

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested locally with the following steps:
1. Run `bundle install` - successfully installed annotaterb 4.20.0
2. Run `RAILS_ENV=development bundle exec rails db:chatwoot_prepare` - completed without annotation errors
3. Run `RAILS_ENV=development bundle exec rails annotate_rb:models` - successfully annotated all models including InstallationConfig
4. Verified InstallationConfig model annotations are present and correct

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes