### PR TITLE
fix: respect status parameter when creating articles via API

### DIFF
--- a/app/controllers/api/v1/accounts/articles_controller.rb
+++ b/app/controllers/api/v1/accounts/articles_controller.rb
@@ -22,9 +22,10 @@ class Api::V1::Accounts::ArticlesController < Api::V1::Accounts::BaseController
   def edit; end
 
   def create
-    @article = @portal.articles.create!(article_params)
+    params_with_defaults = article_params
+    params_with_defaults[:status] ||= :draft
+    @article = @portal.articles.create!(params_with_defaults)
     @article.associate_root_article(article_params[:associated_article_id])
-    @article.draft!
     render json: { error: @article.errors.messages }, status: :unprocessable_entity and return unless @article.valid?
   end
 

--- a/spec/controllers/api/v1/accounts/articles_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/articles_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Api::V1::Accounts::Articles', type: :request do
         expect(response).to have_http_status(:success)
         json_response = response.parsed_body
         expect(json_response['payload']['title']).to eql('MyTitle')
-        expect(json_response['payload']['status']).to eql('draft')
+        expect(json_response['payload']['status']).to eql('published')
         expect(json_response['payload']['position']).to be(3)
       end
 
@@ -59,8 +59,28 @@ RSpec.describe 'Api::V1::Accounts::Articles', type: :request do
         expect(response).to have_http_status(:success)
         json_response = response.parsed_body
         expect(json_response['payload']['title']).to eql('MyTitle')
-        expect(json_response['payload']['status']).to eql('draft')
+        expect(json_response['payload']['status']).to eql('published')
         expect(json_response['payload']['position']).to be(3)
+      end
+
+      it 'creates article as draft when status is not provided' do
+        article_params = {
+          article: {
+            category_id: category.id,
+            description: 'test description',
+            title: 'DraftTitle',
+            slug: 'draft-title',
+            content: 'This is my draft content.',
+            author_id: agent.id
+          }
+        }
+        post "/api/v1/accounts/#{account.id}/portals/#{portal.slug}/articles",
+             params: article_params,
+             headers: admin.create_new_auth_token
+        expect(response).to have_http_status(:success)
+        json_response = response.parsed_body
+        expect(json_response['payload']['title']).to eql('DraftTitle')
+        expect(json_response['payload']['status']).to eql('draft')
       end
 
       it 'associate to the root article' do


### PR DESCRIPTION
## Description

The Articles API was ignoring the `status` parameter when creating new articles. All articles were forced to be drafts due to a hardcoded `@article.draft!` call in the controller, even when users explicitly sent `status: 1` (published) in their API request.

This PR removes the hardcoded draft enforcement and allows the status parameter to be respected while maintaining backward compatibility.

Fixes #12063

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Before:**
- API POST with `status: 1` → Created as draft (ignored parameter)
- API POST without status → Created as draft

**After:**
- API POST with `status: 1` → Created as published ✅
- API POST without status → Created as draft (backward compatible) ✅
- UI creates articles → Still creates as draft (UI doesn't send status) ✅

**Tests run:**
```bash
bundle exec rspec spec/controllers/api/v1/accounts/articles_controller_spec.rb
# 17 examples, 0 failures
```

Updated tests:
1. Changed 2 existing tests that were verifying the broken behavior (expecting draft when published was sent)
2. Added new test to verify articles default to draft when status is not provided
3. All existing tests pass, confirming backward compatibility

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes