### PR TITLE
chore: disable worker MemoryHigh throttling in systemd unit

### DIFF
--- a/deployment/chatwoot-worker.1.service
+++ b/deployment/chatwoot-worker.1.service
@@ -17,7 +17,7 @@ StandardInput=null
 SyslogIdentifier=%p
 
 MemoryMax=1.5G
-MemoryHigh=1.4G
+MemoryHigh=infinity
 MemorySwapMax=0
 OOMPolicy=stop
 


### PR DESCRIPTION
  - set MemoryHigh to infinity in deployment/chatwoot-worker.1.service so the worker is throttled only by the existing
    MemoryMax hard limit
  - prevents cgroup reclaim from slowing Sidekiq under transient spikes while still keeping the hard stop at 1.5 GB