### PR TITLE
feat(webhooks): allow selecting inbox

### DIFF
--- a/app/controllers/api/v1/accounts/webhooks_controller.rb
+++ b/app/controllers/api/v1/accounts/webhooks_controller.rb
@@ -7,12 +7,12 @@ class Api::V1::Accounts::WebhooksController < Api::V1::Accounts::BaseController
   end
 
   def create
-    @webhook = Current.account.webhooks.new(webhook_params)
+    @webhook = Current.account.webhooks.new(webhook_create_params)
     @webhook.save!
   end
 
   def update
-    @webhook.update!(webhook_params)
+    @webhook.update!(webhook_update_params)
   end
 
   def destroy
@@ -22,8 +22,13 @@ class Api::V1::Accounts::WebhooksController < Api::V1::Accounts::BaseController
 
   private
 
-  def webhook_params
+  def webhook_create_params
     params.require(:webhook).permit(:inbox_id, :name, :url, subscriptions: [])
+  end
+
+  def webhook_update_params
+    # NOTE: Do not allow updating linked inbox to avoid events being sent for unexpected inboxes.
+    params.require(:webhook).permit(:name, :url, subscriptions: [])
   end
 
   def fetch_webhook

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -50,6 +50,13 @@
           "LABEL": "Webhook Name",
           "PLACEHOLDER": "Enter the name of the webhook"
         },
+        "INBOX": {
+          "LABEL": "Inbox",
+          "TITLE": "Select the inbox",
+          "PLACEHOLDER": "All Inboxes",
+          "NO_RESULTS": "No inboxes found",
+          "INPUT_PLACEHOLDER": "Search inbox"
+        },
         "END_POINT": {
           "LABEL": "Webhook URL",
           "PLACEHOLDER": "Example: {webhookExampleURL}",

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/EditWebHook.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/EditWebHook.vue
@@ -53,6 +53,7 @@ export default {
       :value="value"
       :is-submitting="uiFlags.updatingItem"
       :submit-label="$t('INTEGRATION_SETTINGS.WEBHOOK.FORM.EDIT_SUBMIT')"
+      is-editing
       @submit="onSubmit"
       @cancel="onClose"
     />

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
@@ -74,6 +74,7 @@ export default {
   computed: {
     inboxesList() {
       if (this.assignedInbox?.id) {
+        // NOTE: Only show "All Inboxes" option when an inbox is already assigned
         return [
           {
             id: 0,

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
@@ -4,6 +4,8 @@ import { required, url, minLength } from '@vuelidate/validators';
 import wootConstants from 'dashboard/constants/globals';
 import { getI18nKey } from 'dashboard/routes/dashboard/settings/helper/settingsHelper';
 import NextButton from 'dashboard/components-next/button/Button.vue';
+import MultiselectDropdown from 'shared/components/ui/MultiselectDropdown.vue';
+import { useMapGetter } from 'dashboard/composables/store';
 
 const { EXAMPLE_WEBHOOK_URL } = wootConstants;
 
@@ -23,6 +25,7 @@ const SUPPORTED_WEBHOOK_EVENTS = [
 export default {
   components: {
     NextButton,
+    MultiselectDropdown,
   },
   props: {
     value: {
@@ -37,10 +40,17 @@ export default {
       type: String,
       required: true,
     },
+    isEditing: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ['submit', 'cancel'],
   setup() {
-    return { v$: useVuelidate() };
+    return {
+      v$: useVuelidate(),
+      inboxes: useMapGetter('inboxes/getInboxes'),
+    };
   },
   validations: {
     url: {
@@ -55,12 +65,27 @@ export default {
   data() {
     return {
       url: this.value.url || '',
+      assignedInbox: this.value.inbox || null,
       name: this.value.name || '',
       subscriptions: this.value.subscriptions || [],
       supportedWebhookEvents: SUPPORTED_WEBHOOK_EVENTS,
     };
   },
   computed: {
+    inboxesList() {
+      if (this.assignedInbox?.id) {
+        return [
+          {
+            id: 0,
+            name: this.$t(
+              'INTEGRATION_SETTINGS.WEBHOOK.FORM.INBOX.PLACEHOLDER'
+            ),
+          },
+          ...this.inboxes,
+        ];
+      }
+      return this.inboxes;
+    },
     webhookURLInputPlaceholder() {
       return this.$t(
         'INTEGRATION_SETTINGS.WEBHOOK.FORM.END_POINT.PLACEHOLDER',
@@ -77,9 +102,13 @@ export default {
     onSubmit() {
       this.$emit('submit', {
         url: this.url,
+        inbox_id: this.assignedInbox?.id || null,
         name: this.name,
         subscriptions: this.subscriptions,
       });
+    },
+    onClickAssignInbox(inbox) {
+      this.assignedInbox = inbox;
     },
     getI18nKey,
   },
@@ -109,6 +138,29 @@ export default {
           type="text"
           name="name"
           :placeholder="webhookNameInputPlaceholder"
+        />
+      </label>
+      <label>
+        {{ $t('INTEGRATION_SETTINGS.WEBHOOK.FORM.INBOX.LABEL') }}
+        <!-- NOTE: 16px bottom margin to match default input margin for even spacing -->
+        <MultiselectDropdown
+          class="mb-4"
+          :options="inboxesList"
+          :selected-item="assignedInbox"
+          :multiselector-title="
+            $t('INTEGRATION_SETTINGS.WEBHOOK.FORM.INBOX.TITLE')
+          "
+          :multiselector-placeholder="
+            $t('INTEGRATION_SETTINGS.WEBHOOK.FORM.INBOX.PLACEHOLDER')
+          "
+          :no-search-result="
+            $t('INTEGRATION_SETTINGS.WEBHOOK.FORM.INBOX.NO_RESULTS')
+          "
+          :input-placeholder="
+            $t('INTEGRATION_SETTINGS.WEBHOOK.FORM.INBOX.INPUT_PLACEHOLDER')
+          "
+          :disabled="isEditing"
+          @select="onClickAssignInbox"
         />
       </label>
       <label :class="{ error: v$.url.$error }" class="mb-2">

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookRow.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookRow.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 import { getI18nKey } from 'dashboard/routes/dashboard/settings/helper/settingsHelper';
 import ShowMore from 'dashboard/components/widgets/ShowMore.vue';
 import { useI18n } from 'vue-i18n';
+import InboxName from 'components/widgets/InboxName.vue';
 
 import Button from 'dashboard/components-next/button/Button.vue';
 
@@ -37,6 +38,7 @@ const subscribedEvents = computed(() => {
 <template>
   <tr>
     <td class="py-4 ltr:pr-4 rtl:pl-4">
+      <InboxName v-if="webhook.inbox" class="!mx-0" :inbox="webhook.inbox" />
       <div class="flex gap-2 font-medium break-words text-n-slate-12">
         <template v-if="webhook.name">
           {{ webhook.name }}

--- a/app/javascript/shared/components/ui/MultiselectDropdown.vue
+++ b/app/javascript/shared/components/ui/MultiselectDropdown.vue
@@ -36,6 +36,10 @@ const props = defineProps({
     type: String,
     default: 'Search',
   },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits(['select']);
@@ -66,6 +70,8 @@ const hasValue = computed(() => {
           showSearchDropdown ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'
         "
         class="w-full !px-2"
+        type="button"
+        :disabled="disabled"
         @click="
           () => toggleDropdown() // ensure that the event is not passed to the button
         "
@@ -98,6 +104,10 @@ const hasValue = computed(() => {
           'hidden invisible': !showSearchDropdown,
         }"
         class="box-border top-[2.625rem] w-full border rounded-lg bg-n-alpha-3 backdrop-blur-[100px] absolute shadow-lg border-n-strong dark:border-n-strong p-2 z-[9999]"
+        @click="
+          // NOTE: Avoid closing the dropdown when interacting with it when inside a label tag.
+          event => event.preventDefault()
+        "
       >
         <div class="flex items-center justify-between mb-1">
           <h4

--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -110,6 +110,7 @@ class WebhookListener < BaseListener
   def deliver_account_webhooks(payload, account)
     account.webhooks.account_type.each do |webhook|
       next unless webhook.subscriptions.include?(payload[:event])
+      next if payload[:inbox].present? && webhook.inbox_id.present? && webhook.inbox_id != payload[:inbox][:id]
 
       WebhookJob.perform_later(webhook.url, payload)
     end

--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -101,6 +101,7 @@ class WebhookListener < BaseListener
     payload = {
       event: event_name,
       user: user.webhook_data,
+      inbox_id: inbox.id,
       conversation: conversation.webhook_data,
       is_private: event.data[:is_private] || false
     }
@@ -110,7 +111,9 @@ class WebhookListener < BaseListener
   def deliver_account_webhooks(payload, account)
     account.webhooks.account_type.each do |webhook|
       next unless webhook.subscriptions.include?(payload[:event])
-      next if payload[:inbox].present? && webhook.inbox_id.present? && webhook.inbox_id != payload[:inbox][:id]
+
+      inbox_id = payload[:inbox_id] || payload.dig(:inbox, :id)
+      next if inbox_id.present? && webhook.inbox_id.present? && webhook.inbox_id != inbox_id
 
       WebhookJob.perform_later(webhook.url, payload)
     end

--- a/app/views/api/v1/accounts/webhooks/_webhook.json.jbuilder
+++ b/app/views/api/v1/accounts/webhooks/_webhook.json.jbuilder
@@ -7,5 +7,6 @@ if webhook.inbox
   json.inbox do
     json.id webhook.inbox.id
     json.name webhook.inbox.name
+    json.channel_type webhook.inbox.channel_type
   end
 end

--- a/spec/controllers/api/v1/accounts/webhook_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/webhook_controller_spec.rb
@@ -120,6 +120,17 @@ RSpec.describe 'Webhooks API', type: :request do
         expect(response.parsed_body['payload']['webhook']['url']).to eql 'https://hello.com'
         expect(response.parsed_body['payload']['webhook']['name']).to eql 'Another Webhook'
       end
+
+      it 'ignores trying to update inbox_id' do
+        new_inbox = create(:inbox, account: account)
+
+        put "/api/v1/accounts/#{account.id}/webhooks/#{webhook.id}",
+            params: { inbox_id: new_inbox.id },
+            headers: administrator.create_new_auth_token,
+            as: :json
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['payload']['webhook']['inbox']['id']).to eql inbox.id
+      end
     end
   end
 

--- a/spec/listeners/webhook_listener_spec.rb
+++ b/spec/listeners/webhook_listener_spec.rb
@@ -11,86 +11,37 @@ describe WebhookListener do
     create(:message, message_type: 'outgoing',
                      account: account, inbox: inbox, conversation: conversation)
   end
-  let(:message_created_event) { Events::Base.new(event_name, Time.zone.now, message: message) }
-  let(:conversation_created_event) { Events::Base.new(event_name, Time.zone.now, conversation: conversation) }
-  let(:contact_event) { Events::Base.new(event_name, Time.zone.now, contact: contact) }
+  let!(:message_created_event) { Events::Base.new(event_name, Time.zone.now, message: message) }
+  let!(:conversation_created_event) { Events::Base.new(event_name, Time.zone.now, conversation: conversation) }
+  let!(:contact_event) { Events::Base.new(event_name, Time.zone.now, contact: contact) }
 
   describe 'filter events by inbox' do
-    context 'when webhook is filtered by inbox' do
-      context 'with events containing inbox hash' do
-        let(:event_name) { :'message.created' }
+    context 'with events containing inbox hash' do
+      let(:event_name) { :'message.created' }
 
-        it 'triggers webhook when inbox matches' do
-          webhook = create(:webhook, account: account, inbox: inbox)
-          expect(WebhookJob).to receive(:perform_later)
-            .with(webhook.url, message.webhook_data.merge(event: 'message_created')).once
-
-          listener.message_created(message_created_event)
-        end
-
-        it 'does not trigger webhook when inbox does not match' do
-          another_inbox = create(:inbox, account: account)
-          create(:webhook, account: account, inbox: another_inbox, url: 'https://different.webhook.com')
-          expect(WebhookJob).to receive(:perform_later).exactly(0).times
-
-          listener.message_created(message_created_event)
-        end
-      end
-
-      context 'with events containing inbox_id' do
-        let(:event_name) { :'conversation.typing_on' }
-        let(:typing_event) { Events::Base.new(event_name, Time.zone.now, conversation: conversation, user: user) }
-
-        it 'triggers webhook when inbox_id matches' do
-          webhook = create(:webhook, account: account, inbox: inbox, subscriptions: ['conversation_typing_on'])
-          payload = {
-            event: 'conversation_typing_on',
-            user: user.webhook_data,
-            inbox_id: inbox.id,
-            conversation: conversation.webhook_data,
-            is_private: false
-          }
-
-          expect(WebhookJob).to receive(:perform_later).with(webhook.url, payload).once
-          listener.conversation_typing_on(typing_event)
-        end
-
-        it 'does not trigger webhook when inbox_id does not match' do
-          another_inbox = create(:inbox, account: account)
-          create(:webhook, account: account, inbox: another_inbox, subscriptions: ['conversation_typing_on'], url: 'https://different.webhook.com')
-
-          expect(WebhookJob).not_to receive(:perform_later)
-          listener.conversation_typing_on(typing_event)
-        end
-      end
-
-      context 'with events without inbox' do
-        let(:event_name) { :'contact.created' }
-
-        it 'triggers webhook for events without inbox info' do
-          webhook = create(:webhook, account: account, inbox: inbox, subscriptions: ['contact_created'], url: 'https://filtered.webhook.com')
-
-          expect(WebhookJob).to receive(:perform_later)
-            .with(webhook.url, contact.webhook_data.merge(event: 'contact_created')).once
-          listener.contact_created(contact_event)
-        end
-      end
-    end
-
-    context 'when webhook is not filtered by inbox' do
-      it 'triggers for events with inbox hash' do
-        webhook = create(:webhook, account: account, inbox: nil, url: 'https://unfiltered.webhook.com')
-
+      it 'triggers webhook when inbox matches' do
+        webhook = create(:webhook, account: account, inbox: inbox)
         expect(WebhookJob).to receive(:perform_later)
           .with(webhook.url, message.webhook_data.merge(event: 'message_created')).once
 
-        event = Events::Base.new(:'message.created', Time.zone.now, message: message)
-        listener.message_created(event)
+        listener.message_created(message_created_event)
       end
 
-      it 'triggers for events with inbox_id' do
-        webhook = create(:webhook, account: account, inbox: nil, subscriptions: ['conversation_typing_on'], url: 'https://unfiltered2.webhook.com')
+      it 'does not trigger webhook when inbox does not match' do
+        another_inbox = create(:inbox, account: account)
+        create(:webhook, account: account, inbox: another_inbox, url: 'https://different.webhook.com')
+        expect(WebhookJob).to receive(:perform_later).exactly(0).times
 
+        listener.message_created(message_created_event)
+      end
+    end
+
+    context 'with events containing inbox_id' do
+      let(:event_name) { :'conversation.typing_on' }
+      let(:typing_event) { Events::Base.new(event_name, Time.zone.now, conversation: conversation, user: user) }
+
+      it 'triggers webhook when inbox_id matches' do
+        webhook = create(:webhook, account: account, inbox: inbox, subscriptions: ['conversation_typing_on'])
         payload = {
           event: 'conversation_typing_on',
           user: user.webhook_data,
@@ -100,19 +51,15 @@ describe WebhookListener do
         }
 
         expect(WebhookJob).to receive(:perform_later).with(webhook.url, payload).once
-
-        event = Events::Base.new(:'conversation.typing_on', Time.zone.now, conversation: conversation, user: user)
-        listener.conversation_typing_on(event)
+        listener.conversation_typing_on(typing_event)
       end
 
-      it 'triggers for events without inbox' do
-        webhook = create(:webhook, account: account, inbox: nil, subscriptions: ['contact_created'], url: 'https://unfiltered3.webhook.com')
+      it 'does not trigger webhook when inbox_id does not match' do
+        another_inbox = create(:inbox, account: account)
+        create(:webhook, account: account, inbox: another_inbox, subscriptions: ['conversation_typing_on'], url: 'https://different.webhook.com')
 
-        expect(WebhookJob).to receive(:perform_later)
-          .with(webhook.url, contact.webhook_data.merge(event: 'contact_created')).once
-
-        event = Events::Base.new(:'contact.created', Time.zone.now, contact: contact)
-        listener.contact_created(event)
+        expect(WebhookJob).not_to receive(:perform_later)
+        listener.conversation_typing_on(typing_event)
       end
     end
   end


### PR DESCRIPTION
# Pull Request Template

## Description

The webhook DB model already had an inbox relation from a very old feature that seems to have gotten lost along the way.

This PR makes use of the existing column so we can subscribe to a specific inbox so we don't need to filter events manually on the webhook receiver.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Webhook listener and controller specs, and also tested in production for several months without issue.

| Before | After |
| --- | --- |
|<img width="758" height="906" alt="image-2" src="https://github.com/user-attachments/assets/74f28c32-e4b9-4fcc-98a9-2569d33cfa10" />|<img width="758" height="1006" alt="image-1" src="https://github.com/user-attachments/assets/d902e3d3-2018-47a9-aac2-d167dbdd9a1c" />|
|<img width="1471" height="778" alt="image-3" src="https://github.com/user-attachments/assets/0180b8ba-4775-43d1-8c7b-2a689cadf098" />|<img width="1840" height="981" alt="image" src="https://github.com/user-attachments/assets/dcfe3ed5-60fc-4178-9d45-b1553a719b68" />|

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
