### PR TITLE
feat: remove captain v2 from chatwoot internal list

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -180,7 +180,6 @@
   display_name: Captain V2
   enabled: false
   premium: true
-  chatwoot_internal: true
 - name: whatsapp_embedded_signup
   display_name: WhatsApp Embedded Signup
   enabled: false


### PR DESCRIPTION
Self hosted customers are unable to see the V2 Flag, since it was marked as internal. 
This PR fixes it.