### PR TITLE
fix: reduce sidekiq memorymax to 1.2gb

### DIFF
--- a/deployment/chatwoot-worker.1.service
+++ b/deployment/chatwoot-worker.1.service
@@ -16,7 +16,7 @@ KillMode=mixed
 StandardInput=null
 SyslogIdentifier=%p
 
-MemoryMax=1.5G
+MemoryMax=1.2G
 MemoryHigh=infinity
 MemorySwapMax=0
 OOMPolicy=stop


### PR DESCRIPTION
- reduce sidekiq memorymax to 1.2GB to ensure OOM restarts work on a 2GB machine

