### PR TITLE
fix: Companies card pluralization issue

### DIFF
--- a/app/javascript/dashboard/components-next/Companies/CompaniesCard/CompaniesCard.vue
+++ b/app/javascript/dashboard/components-next/Companies/CompaniesCard/CompaniesCard.vue
@@ -79,7 +79,7 @@ const formattedUpdatedAt = computed(() => {
               class="inline-flex items-center gap-1.5 text-sm text-n-slate-11 truncate"
             >
               <Icon icon="i-lucide-contact" size="size-3.5 text-n-slate-11" />
-              {{ t('COMPANIES.CONTACTS_COUNT', { count: contactsCount }) }}
+              {{ t('COMPANIES.CONTACTS_COUNT', { n: contactsCount }) }}
             </span>
           </div>
           <span

--- a/app/javascript/dashboard/i18n/locale/en/companies.json
+++ b/app/javascript/dashboard/i18n/locale/en/companies.json
@@ -19,7 +19,7 @@
     "SEARCH_PLACEHOLDER": "Search companies...",
     "LOADING": "Loading companies...",
     "UNNAMED": "Unnamed Company",
-    "CONTACTS_COUNT": "{count} contacts",
+    "CONTACTS_COUNT": "{n} contact | {n} contacts",
     "EMPTY_STATE": {
       "TITLE": "No companies found"
     }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the pluralization issue in the company card’s contact count.
Previously, it always displayed “1 contacts.”
With this update, the label now correctly adjusts based on the count—for example:

* **1 contact**
* **10 contacts**

Fixes https://linear.app/chatwoot/issue/CW-5998/one-contacts-vs-one-contact

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="972" height="421" alt="image" src="https://github.com/user-attachments/assets/6c53ee3f-c811-4173-bc04-aefc32346bd0" />


**After**
<img width="972" height="421" alt="image" src="https://github.com/user-attachments/assets/c3673385-2e88-40a2-9829-6ee55d8a6d34" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
