### PR TITLE
chore: Hide pagination for empty company list

### DIFF
--- a/app/javascript/dashboard/components-next/Companies/CompaniesListLayout.vue
+++ b/app/javascript/dashboard/components-next/Companies/CompaniesListLayout.vue
@@ -9,6 +9,7 @@ defineProps({
   totalItems: { type: Number, default: 100 },
   activeSort: { type: String, default: 'name' },
   activeOrdering: { type: String, default: '' },
+  showPaginationFooter: { type: Boolean, default: true },
 });
 
 const emit = defineEmits(['update:currentPage', 'update:sort', 'search']);
@@ -36,7 +37,7 @@ const updateCurrentPage = page => {
           <slot name="default" />
         </div>
       </main>
-      <footer class="sticky bottom-0 z-0 px-4 pb-4">
+      <footer v-if="showPaginationFooter" class="sticky bottom-0 z-0 px-4 pb-4">
         <PaginationFooter
           current-page-info="COMPANIES_LAYOUT.PAGINATION_FOOTER.SHOWING"
           :current-page="currentPage"

--- a/app/javascript/dashboard/routes/dashboard/companies/pages/CompaniesIndex.vue
+++ b/app/javascript/dashboard/routes/dashboard/companies/pages/CompaniesIndex.vue
@@ -136,6 +136,7 @@ onMounted(() => {
     :active-sort="activeSort"
     :active-ordering="activeOrdering"
     :is-fetching-list="isFetchingList"
+    :show-pagination-footer="!!companies.length"
     @update:current-page="onPageChange"
     @update:sort="handleSort"
     @search="onSearch"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR hides the pagination controls when the company list is empty.

Fixes https://linear.app/chatwoot/issue/CW-5997/hide-pagination-if-there-are-no-companies

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="1151" height="418" alt="image" src="https://github.com/user-attachments/assets/5642b03b-cf73-40ef-9448-b16901e6473b" />


**After**
<img width="1151" height="418" alt="image" src="https://github.com/user-attachments/assets/6f64c4e5-527c-4ceb-b2db-58972cce142b" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
