### PR TITLE
fix: Resolve z-index issue in assistant switcher

### DIFF
--- a/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantBasicSettingsForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantBasicSettingsForm.vue
@@ -118,6 +118,7 @@ watch(
       :placeholder="t('CAPTAIN.ASSISTANTS.FORM.DESCRIPTION.PLACEHOLDER')"
       :message="formErrors.description"
       :message-type="formErrors.description ? 'error' : 'info'"
+      class="z-0"
     />
 
     <div class="flex flex-col gap-2">


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes a UI issue where the assistant switcher appeared behind the editor menu bar due to an incorrect z-index value.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshot

**Before**
<img width="1035" height="561" alt="image" src="https://github.com/user-attachments/assets/da4a10e4-6717-43db-bb1c-6fa3b8610bc9" />

**After**
<img width="1035" height="561" alt="image" src="https://github.com/user-attachments/assets/44d3cc23-6ea2-48cd-aef7-0ba7da9d9faf" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
