### PR TITLE
fix: switch label suggestions to gpt-5-nano 

### DIFF
--- a/enterprise/lib/enterprise/integrations/openai_processor_service.rb
+++ b/enterprise/lib/enterprise/integrations/openai_processor_service.rb
@@ -65,7 +65,7 @@ module Enterprise::Integrations::OpenaiProcessorService
     return value_from_cache if content.blank?
 
     {
-      model: self.class::GPT_MODEL,
+      model: self.class::LABEL_SUGGESTION_MODEL,
       messages: [
         {
           role: 'system',

--- a/lib/integrations/openai_base_service.rb
+++ b/lib/integrations/openai_base_service.rb
@@ -7,7 +7,7 @@ class Integrations::OpenaiBaseService
   # 120000 * 4 = 480,000 characters (rounding off downwards to 400,000 to be safe)
   TOKEN_LIMIT = 400_000
   GPT_MODEL = ENV.fetch('OPENAI_GPT_MODEL', 'gpt-4o-mini').freeze
-
+  LABEL_SUGGESTION_MODEL = 'gpt-5-nano'.freeze
   ALLOWED_EVENT_NAMES = %w[rephrase summarize reply_suggestion fix_spelling_grammar shorten expand make_friendly make_formal simplify].freeze
   CACHEABLE_EVENTS = %w[].freeze
 


### PR DESCRIPTION
Small change to the label-suggestions model from gpt-4o-mini to gpt-5-nano

I don't think we should change other models just yet, hence the separate constant

tested locally:
<img width="854" height="582" alt="image" src="https://github.com/user-attachments/assets/613fcf1e-60d9-414c-9ae7-49c8d2c13f12" />
