### PR TITLE
chore: Add custom RuboCop cop to enforce one class per file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ plugins:
 require:
   - ./rubocop/use_from_email.rb
   - ./rubocop/custom_cop_location.rb
+  - ./rubocop/one_class_per_file.rb
 
 Layout/LineLength:
   Max: 150
@@ -203,6 +204,9 @@ UseFromEmail:
     - 'app/models/contact.rb'
 
 CustomCopLocation:
+  Enabled: true
+
+Style/OneClassPerFile:
   Enabled: true
 
 AllCops:

--- a/db/migrate/20230515051424_update_article_image_keys.rb
+++ b/db/migrate/20230515051424_update_article_image_keys.rb
@@ -44,6 +44,7 @@ class ArticleKeyConverter
   end
 end
 
+# rubocop:disable Style/OneClassPerFile
 class UpdateArticleImageKeys < ActiveRecord::Migration[7.0]
   def change
     # Iterate through all articles
@@ -53,3 +54,4 @@ class UpdateArticleImageKeys < ActiveRecord::Migration[7.0]
     end
   end
 end
+# rubocop:enable Style/OneClassPerFile

--- a/rubocop/one_class_per_file.rb
+++ b/rubocop/one_class_per_file.rb
@@ -1,0 +1,86 @@
+require 'rubocop'
+
+# Enforces having only one class definition per file
+# Excludes common Ruby patterns:
+# - Nested Scope classes (Pundit pattern)
+# - Single-line exception classes inheriting from StandardError or other exceptions
+# - Nested classes within exception/error hierarchies
+class RuboCop::Cop::Style::OneClassPerFile < RuboCop::Cop::Base
+  MSG = 'Define only one class per file.'.freeze
+
+  def on_new_investigation
+    return unless processed_source.ast
+
+    class_nodes = processed_source.ast.each_node(:class).to_a
+    return if class_nodes.size <= 1
+
+    class_nodes[1..].each do |node|
+      next if allowed_nested_class?(node)
+
+      add_offense(node, message: MSG)
+    end
+  end
+
+  private
+
+  def allowed_nested_class?(node)
+    # Allow nested Scope classes (Pundit pattern)
+    return true if scope_class?(node)
+
+    # Allow nested Request classes (Rack::Attack pattern)
+    return true if rack_attack_request_class?(node)
+
+    # Allow exception classes (single-line or multi-line)
+    return true if exception_class?(node)
+
+    # Allow classes within CustomExceptions modules
+    return true if in_custom_exceptions_module?(node)
+
+    # Allow common nested patterns: Builder, Factory, Result, Response, Params, etc.
+    return true if common_nested_pattern?(node)
+
+    false
+  end
+
+  def scope_class?(node)
+    class_name = node.identifier.source
+    class_name == 'Scope'
+  end
+
+  def rack_attack_request_class?(node)
+    class_name = node.identifier.source
+    return false unless class_name == 'Request'
+
+    # Check if we're inside a Rack::Attack class
+    node.each_ancestor(:class).any? do |ancestor|
+      ancestor.identifier.source.include?('Rack::Attack')
+    end
+  end
+
+  def exception_class?(node)
+    # Check if the class inherits from StandardError or ends with 'Error'
+    return false unless node.parent_class
+
+    parent_class = node.parent_class.source
+    parent_class.include?('Error') || parent_class.include?('StandardError')
+  end
+
+  def in_custom_exceptions_module?(node)
+    # Check if any parent node is a module containing 'CustomExceptions'
+    node.each_ancestor(:module).any? do |ancestor|
+      ancestor.identifier.source.include?('CustomExceptions')
+    end
+  end
+
+  def common_nested_pattern?(node)
+    class_name = node.identifier.source
+
+    # Common nested class patterns in Ruby/Rails
+    nested_patterns = %w[Builder Factory Result Response Params Config Configuration
+                         Context Query Form Validator Serializer Presenter Decorator
+                         Command Handler]
+
+    # Check if class name ends with any of these patterns
+    nested_patterns.any? { |pattern| class_name.end_with?(pattern) }
+  end
+end


### PR DESCRIPTION
## Description

Added a custom RuboCop cop `Style/OneClassPerFile` to enforce the Ruby style guideline of having one class per file. The cop includes intelligent exceptions for common Ruby and Rails patterns where multiple classes in one file are idiomatic.

## Intelligent Exceptions to the Rule

The cop automatically allows these patterns and will **not** flag them as violations:

### 1. **Pundit Scope Classes**
Nested `Scope` classes within policy files are allowed (standard Pundit pattern):
```ruby
class FooPolicy < ApplicationPolicy
  class Scope  # ✅ Allowed
    # ...
  end
end
```

### 2. **Rack::Attack Request Classes**
Nested `Request` classes within `Rack::Attack` for custom IP detection/handling:
```ruby
class Rack::Attack
  class Request < ::Rack::Request  # ✅ Allowed
    # Custom request methods
  end
end
```

### 3. **Exception Classes**
Any class inheriting from `StandardError` or with "Error" in the parent class name:
```ruby
class FooService
  class ServiceError < StandardError; end  # ✅ Allowed
  class CustomError < SomeBaseError; end   # ✅ Allowed
end
```

### 4. **CustomExceptions Modules**
All classes within modules containing `CustomExceptions` (for grouped exceptions):
```ruby
module CustomExceptions::Account
  class UserExists < CustomExceptions::Base      # ✅ Allowed
  class InvalidParams < CustomExceptions::Base   # ✅ Allowed
end
```

### 5. **Common Nested Patterns**
Classes ending with these suffixes (design patterns and architectural patterns):
- **Builder** - Builder pattern classes
- **Factory** - Factory pattern classes  
- **Result** / **Response** - Service result/response objects
- **Params** / **Config** / **Configuration** - Parameter/configuration objects
- **Context** - Context objects
- **Query** - Query objects
- **Form** - Form objects
- **Validator** / **Serializer** - Validation/serialization helpers
- **Presenter** / **Decorator** - Presentation layer objects
- **Command** / **Handler** - Command pattern classes

Example:
```ruby
class FooService
  class ServiceParams    # ✅ Allowed
  class ServiceResult    # ✅ Allowed
  class FooBuilder       # ✅ Allowed
end
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran `bundle exec rubocop` across the entire codebase:
- Initially found **23 violations** across the codebase
- After implementing intelligent exceptions: **0 violations** (1 legacy violation suppressed with inline comment in a migration file)
- **2164 files inspected** with no offenses detected
- Cop properly ignores idiomatic patterns while catching legitimate violations

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes