### PR TITLE
fix: invalid language tag in heatmap component in reports page

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/heatmaps/HeatmapDateRangeSelector.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/heatmaps/HeatmapDateRangeSelector.vue
@@ -52,11 +52,12 @@ const dayMenuItemConfigs = computed(() => [
   },
 ]);
 
-const resolvedLocale = computed(
-  () =>
+const resolvedLocale = computed(() => {
+  const currentLocale =
     locale.value ||
-    (typeof navigator !== 'undefined' ? navigator.language : 'en')
-);
+    (typeof navigator !== 'undefined' ? navigator.language : 'en');
+  return currentLocale.replace('_', '-');
+});
 
 const monthFormatter = computed(
   () =>


### PR DESCRIPTION
## Description

This PR fixes a `RangeError: Invalid language tag` that occurs in the Heatmap report when using locales with underscores (e.g., `pt_BR`, `zh_TW`).

The issue was caused by passing the raw locale string from `vue-i18n` (which uses underscores for some regions) directly to `Intl.DateTimeFormat`. The `Intl` API expects BCP 47 language tags which use hyphens (e.g., `pt-BR`).

This change sanitizes the locale string by replacing underscores with hyphens before creating the `DateTimeFormat` instance.

Fixes #12951

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I verified the fix by reproducing the issue locally and confirming the resolution:

1.  **Reproduction:**
    *   Set the site language to **Português Brasileiro (pt-BR)** in Settings -> Account -> Site Language.
    *   Navigated to the Heatmap report.
    *   Confirmed the page crashed with `RangeError: Invalid language tag: pt_BR`.

2.  **Verification:**
    *   Applied the fix.
    *   Reloaded the Heatmap report with `pt_BR` locale

## Checklist:

> About adding specs, as I can see there are generally no specs here for Vue components, so I skipped adding those.

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
