### PR TITLE
fix: Prevent WhatsApp campaign duplicate messages by updating status immediately

### DIFF
--- a/app/services/whatsapp/oneoff_campaign_service.rb
+++ b/app/services/whatsapp/oneoff_campaign_service.rb
@@ -3,8 +3,9 @@ class Whatsapp::OneoffCampaignService
 
   def perform
     validate_campaign!
-    process_audience(extract_audience_labels)
+    # marks campaign completed so that other jobs won't pick it up
     campaign.completed!
+    process_audience(extract_audience_labels)
   end
 
   private


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-5918/whatsapp-campaigns-running-in-parallel-and-duplicating-messages