### PR TITLE
chore(revert): switch label suggestions back gpt 4 mini

### DIFF
--- a/enterprise/lib/enterprise/integrations/openai_processor_service.rb
+++ b/enterprise/lib/enterprise/integrations/openai_processor_service.rb
@@ -65,7 +65,7 @@ module Enterprise::Integrations::OpenaiProcessorService
     return value_from_cache if content.blank?
 
     {
-      model: self.class::LABEL_SUGGESTION_MODEL,
+      model: self.class::GPT_MODEL,
       messages: [
         {
           role: 'system',

--- a/lib/integrations/openai_base_service.rb
+++ b/lib/integrations/openai_base_service.rb
@@ -7,7 +7,7 @@ class Integrations::OpenaiBaseService
   # 120000 * 4 = 480,000 characters (rounding off downwards to 400,000 to be safe)
   TOKEN_LIMIT = 400_000
   GPT_MODEL = ENV.fetch('OPENAI_GPT_MODEL', 'gpt-4o-mini').freeze
-  LABEL_SUGGESTION_MODEL = 'gpt-5-nano'.freeze
+
   ALLOWED_EVENT_NAMES = %w[rephrase summarize reply_suggestion fix_spelling_grammar shorten expand make_friendly make_formal simplify].freeze
   CACHEABLE_EVENTS = %w[].freeze
 


### PR DESCRIPTION
This reverts commit fa07b9158a10cb259b65a2e94c2b1b56229ef836.

while gpt-5-nano is cheaper for input and output tokens, it seems to generate a lot more tokens via reasoning so it becomes more expensive than 4o-mini

even with reasoning_effort = minimal it takes roughly the same tokens as 4o-mini
