### PR TITLE
fix: Show WhatsApp templates only for inboxes with templates

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -174,7 +174,12 @@ export default {
       return false;
     },
     showWhatsappTemplates() {
-      return this.isAWhatsAppCloudChannel && !this.isPrivate;
+      // We support WhatsApp templates for API channels if someone updates templates manually via API
+      // That's why we don't explicitly check for WhatsApp channel type here
+      const templates = this.$store.getters['inboxes/getWhatsAppTemplates'](
+        this.inboxId
+      );
+      return !!(templates && templates.length) && !this.isPrivate;
     },
     showContentTemplates() {
       return this.isATwilioWhatsAppChannel && !this.isPrivate;


### PR DESCRIPTION
Fixed the logic to show WhatsApp templates option only for inboxes that have templates available.
