### PR TITLE
fix: handle string return values in MailPresenter#from method

### DIFF
--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -125,7 +125,7 @@ class MailPresenter < SimpleDelegator
 
   def from
     # changing to downcase to avoid case mismatch while finding contact
-    (@mail.reply_to.presence || @mail.from).map(&:downcase)
+    Array.wrap(@mail.reply_to.presence || @mail.from).map(&:downcase)
   end
 
   def sender_name


### PR DESCRIPTION
## Description

Fixes a `NoMethodError` in `MailPresenter#from` where the code assumed `@mail.reply_to` or `@mail.from` would always return an array, but in some edge cases with malformed emails, these methods return a String.

The fix wraps the expression with `Array.wrap()` to handle both arrays and strings, following the same defensive pattern already used in the `references` method (line 123).

Fixes CW-4567 / [Sentry Issue CHATWOOT-8WN](https://chatwoot-p3.sentry.io/issues/6593664157/)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran existing specs: `bundle exec rspec spec/presenters/mail_presenter_spec.rb` - all 16 examples pass
- The fix handles both the expected case (array) and edge case (string) by using `Array.wrap()`
- Pattern follows existing defensive code in the same file (references method)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

**Note:** No new test added yet - awaiting discussion on whether to add a regression test for this edge case.