### PR TITLE
fix: Resolve z-index issue in assistant switcher

### DIFF
--- a/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.vue
@@ -108,6 +108,7 @@ watch(
       :placeholder="t('CAPTAIN.ASSISTANTS.FORM.HANDOFF_MESSAGE.PLACEHOLDER')"
       :message="formErrors.handoffMessage"
       :message-type="formErrors.handoffMessage ? 'error' : 'info'"
+      class="z-0"
     />
 
     <Editor
@@ -116,6 +117,7 @@ watch(
       :placeholder="t('CAPTAIN.ASSISTANTS.FORM.RESOLUTION_MESSAGE.PLACEHOLDER')"
       :message="formErrors.resolutionMessage"
       :message-type="formErrors.resolutionMessage ? 'error' : 'info'"
+      class="z-0"
     />
 
     <Editor
@@ -126,6 +128,7 @@ watch(
       :message="formErrors.instructions"
       :max-length="20000"
       :message-type="formErrors.instructions ? 'error' : 'info'"
+      class="z-0"
     />
 
     <div class="flex flex-col gap-2">


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes a UI issue where the assistant switcher appeared behind the editor menu bar due to an incorrect z-index value.
https://github.com/chatwoot/chatwoot/pull/12940

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screencast

https://github.com/user-attachments/assets/0a8cecc0-7e87-411f-bb4e-626f75fcccfa




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
