### PR TITLE
fix: Add support for `ig_post` attachment type in Instagram messages

### DIFF
--- a/app/builders/messages/messenger/message_builder.rb
+++ b/app/builders/messages/messenger/message_builder.rb
@@ -27,7 +27,7 @@ class Messages::Messenger::MessageBuilder
     file_type = attachment['type'].to_sym
     params = { file_type: file_type, account_id: @message.account_id }
 
-    if [:image, :file, :audio, :video, :share, :story_mention, :ig_reel].include? file_type
+    if [:image, :file, :audio, :video, :share, :story_mention, :ig_reel, :ig_post].include? file_type
       params.merge!(file_type_params(attachment))
     elsif file_type == :location
       params.merge!(location_params(attachment))

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -40,7 +40,7 @@ class Attachment < ApplicationRecord
   validate :acceptable_file
   validates :external_url, length: { maximum: Limits::URL_LENGTH_LIMIT }
   enum file_type: { :image => 0, :audio => 1, :video => 2, :file => 3, :location => 4, :fallback => 5, :share => 6, :story_mention => 7,
-                    :contact => 8, :ig_reel => 9 }
+                    :contact => 8, :ig_reel => 9, :ig_post => 10 }
 
   def push_event_data
     return unless file_type


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-6055/argumenterror-ig-post-is-not-a-valid-file-type-argumenterror

This PR fixes an issue where Instagram sends webhooks with both "type": "share" and "type": "ig_post" attachments when users share Instagram posts in direct messages. The system was failing on the ig_post type because it wasn't defined, causing ArgumentError exceptions.

https://github.com/user-attachments/assets/577b8ebd-80e3-4c11-95f5-d8a8c3e16534


