### PR TITLE
fix: handle missing AccountUser in inbox_member API

### DIFF
--- a/app/views/api/v1/widget/inbox_members/index.json.jbuilder
+++ b/app/views/api/v1/widget/inbox_members/index.json.jbuilder
@@ -3,6 +3,6 @@ json.payload do
     json.id inbox_member.user.id
     json.name inbox_member.user.available_name
     json.avatar_url inbox_member.user.avatar_url
-    json.availability_status inbox_member.user.account_users.find_by(account_id: @current_account.id).availability_status
+    json.availability_status inbox_member.user.account_users.find_by(account_id: @current_account.id)&.availability_status
   end
 end


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-6065/actionviewtemplateerror-undefined-method-availability-status-for-nil