### PR TITLE
fix: Preserve multiple consecutive newlines in text-based messaging channels

### DIFF
--- a/app/services/messages/markdown_renderer_service.rb
+++ b/app/services/messages/markdown_renderer_service.rb
@@ -53,22 +53,49 @@ class Messages::MarkdownRendererService
   end
 
   def render_whatsapp
+    content_with_preserved_newlines = preserve_multiple_newlines(@content)
     renderer = Messages::MarkdownRenderers::WhatsAppRenderer.new
-    renderer.render(commonmarker_doc).gsub(/\n+\z/, '')
+    doc = CommonMarker.render_doc(content_with_preserved_newlines, [:DEFAULT, :STRIKETHROUGH_DOUBLE_TILDE])
+    result = renderer.render(doc).gsub(/\n+\z/, '')
+    restore_multiple_newlines(result)
   end
 
   def render_instagram
+    content_with_preserved_newlines = preserve_multiple_newlines(@content)
     renderer = Messages::MarkdownRenderers::InstagramRenderer.new
-    renderer.render(commonmarker_doc).gsub(/\n+\z/, '')
+    doc = CommonMarker.render_doc(content_with_preserved_newlines, [:DEFAULT, :STRIKETHROUGH_DOUBLE_TILDE])
+    result = renderer.render(doc).gsub(/\n+\z/, '')
+    restore_multiple_newlines(result)
   end
 
   def render_line
+    content_with_preserved_newlines = preserve_multiple_newlines(@content)
     renderer = Messages::MarkdownRenderers::LineRenderer.new
-    renderer.render(commonmarker_doc).gsub(/\n+\z/, '')
+    doc = CommonMarker.render_doc(content_with_preserved_newlines, [:DEFAULT, :STRIKETHROUGH_DOUBLE_TILDE])
+    result = renderer.render(doc).gsub(/\n+\z/, '')
+    restore_multiple_newlines(result)
   end
 
   def render_plain_text
+    content_with_preserved_newlines = preserve_multiple_newlines(@content)
     renderer = Messages::MarkdownRenderers::PlainTextRenderer.new
-    renderer.render(commonmarker_doc).gsub(/\n+\z/, '')
+    doc = CommonMarker.render_doc(content_with_preserved_newlines, [:DEFAULT, :STRIKETHROUGH_DOUBLE_TILDE])
+    result = renderer.render(doc).gsub(/\n+\z/, '')
+    restore_multiple_newlines(result)
+  end
+
+  # Preserve multiple consecutive newlines (3+) by replacing them with placeholders
+  # Standard markdown treats 2 newlines as paragraph break, we preserve 3+
+  def preserve_multiple_newlines(content)
+    content.gsub(/\n{3,}/) do |match|
+      "{{PRESERVE_#{match.length}_NEWLINES}}"
+    end
+  end
+
+  # Restore multiple newlines from placeholders
+  def restore_multiple_newlines(content)
+    content.gsub(/\{\{PRESERVE_(\d+)_NEWLINES\}\}/) do |_match|
+      "\n" * Regexp.last_match(1).to_i
+    end
   end
 end

--- a/spec/services/messages/markdown_renderer_service_spec.rb
+++ b/spec/services/messages/markdown_renderer_service_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe Messages::MarkdownRendererService, type: :service do
         expect(result).to include("Line 1\nLine 2\nLine 3")
         expect(result).not_to include('Line 1 Line 2')
       end
+
+      it 'preserves multiple consecutive newlines for spacing' do
+        content = "Para 1\n\n\n\nPara 2"
+        result = described_class.new(content, channel_type).render
+        expect(result.scan("\n").count).to eq(4)
+        expect(result).to include("Para 1\n\n\n\nPara 2")
+      end
     end
 
     context 'when channel is Channel::Instagram' do
@@ -115,6 +122,13 @@ RSpec.describe Messages::MarkdownRendererService, type: :service do
         result = described_class.new(content, channel_type).render
         expect(result).to include("Line 1\nLine 2\nLine 3")
         expect(result).not_to include('Line 1 Line 2')
+      end
+
+      it 'preserves multiple consecutive newlines for spacing' do
+        content = "Para 1\n\n\n\nPara 2"
+        result = described_class.new(content, channel_type).render
+        expect(result.scan("\n").count).to eq(4)
+        expect(result).to include("Para 1\n\n\n\nPara 2")
       end
     end
 
@@ -200,6 +214,13 @@ RSpec.describe Messages::MarkdownRendererService, type: :service do
         result = described_class.new(content, channel_type).render
         expect(result).to include("Line 1\nLine 2\nLine 3")
         expect(result).not_to include('Line 1 Line 2')
+      end
+
+      it 'preserves multiple consecutive newlines for spacing' do
+        content = "Para 1\n\n\n\nPara 2"
+        result = described_class.new(content, channel_type).render
+        expect(result.scan("\n").count).to eq(4)
+        expect(result).to include("Para 1\n\n\n\nPara 2")
       end
     end
 


### PR DESCRIPTION
## Description

This PR fixes an issue where multiple consecutive newlines (blank lines for visual spacing) were being collapsed in text-based messaging channels like WhatsApp, Instagram, and SMS. 

When users send messages via API with intentional spacing using multiple newlines (e.g., `\n\n\n\n`), the markdown renderer was following standard Markdown spec and collapsing them into single blank lines. While this is correct for document formatting, messaging platforms like WhatsApp and Instagram support and preserve multiple blank lines for visual spacing.

The fix adds preprocessing to preserve multiple consecutive newlines (3+) by converting them to placeholder tokens before CommonMarker processing, then restoring the exact number of newlines in the final output.

## Changes

- Added `preserve_multiple_newlines` and `restore_multiple_newlines` helper methods to `MarkdownRendererService`
- Updated `render_whatsapp` to preserve multiple consecutive newlines
- Updated `render_instagram` to preserve multiple consecutive newlines
- Updated `render_plain_text` (affects SMS, Twilio SMS, Twitter) to preserve multiple consecutive newlines
- Updated `render_line` to preserve multiple consecutive newlines
- HTML-based renderers (Email, Telegram, WebWidget) remain unchanged as they handle spacing via HTML tags

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added comprehensive test coverage:
- 3 new tests for multi-newline preservation across WhatsApp, Instagram, and SMS channels
- All 56 tests passing (up from 53)

Testing scenarios:
- Single newlines preserved: `"Line 1\nLine 2"` remains `"Line 1\nLine 2"`
- Multiple newlines preserved: `"Para 1\n\n\n\nPara 2"` remains `"Para 1\n\n\n\nPara 2"`
- Standard paragraph breaks (2 newlines) work as before
- Markdown formatting (bold, italic, links) continues to work correctly
- Backward compatibility maintained for all channels

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules