### PR TITLE
feat: Exposing setWidgetColor function through javascript

### DIFF
--- a/app/javascript/entrypoints/sdk.js
+++ b/app/javascript/entrypoints/sdk.js
@@ -192,10 +192,6 @@ const runSDK = ({ baseUrl, websiteToken }) => {
       });
     },
     
-    setWidgetColor(color = '') {
-      IFrameHelper.sendMessage('set-widget-color', { color });
-    },
-    
     reset() {
       if (window.$chatwoot.isOpen) {
         IFrameHelper.events.toggleBubble();

--- a/app/javascript/entrypoints/sdk.js
+++ b/app/javascript/entrypoints/sdk.js
@@ -191,7 +191,11 @@ const runSDK = ({ baseUrl, websiteToken }) => {
         darkMode: getDarkMode(darkMode),
       });
     },
-
+    
+    setWidgetColor(color = '') {
+      IFrameHelper.sendMessage('set-widget-color', { color });
+    },
+    
     reset() {
       if (window.$chatwoot.isOpen) {
         IFrameHelper.events.toggleBubble();

--- a/app/javascript/entrypoints/sdk.js
+++ b/app/javascript/entrypoints/sdk.js
@@ -191,7 +191,11 @@ const runSDK = ({ baseUrl, websiteToken }) => {
         darkMode: getDarkMode(darkMode),
       });
     },
-    
+
+    setWidgetColor(color = '') {
+      IFrameHelper.sendMessage('set-widget-color', { color });
+    },
+
     reset() {
       if (window.$chatwoot.isOpen) {
         IFrameHelper.events.toggleBubble();

--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -307,6 +307,8 @@ export default {
           this.setBubbleLabel();
         } else if (message.event === 'set-color-scheme') {
           this.setColorScheme(message.darkMode);
+        } else if (message.event === 'set-widget-color') {
+          this.setWidgetColor(message.color);
         } else if (message.event === 'toggle-open') {
           this.$store.dispatch('appConfig/toggleWidgetOpen', message.isOpen);
 


### PR DESCRIPTION
## Description

Exposed setWidgetColor to make color changes easier, this is very useful especially when switching to dark mode (with setColorScheme function calls)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

By calling window.$chatwoot.setWidgetColor('#FFFFFF'); through javascript, the widget color adapts to color changes


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
