### PR TITLE
fix: Handle rich message signatures & attachment overflow

### DIFF
--- a/app/javascript/dashboard/components-next/NewConversation/components/AttachmentPreviews.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/AttachmentPreviews.vue
@@ -39,7 +39,7 @@ const removeAttachment = id => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-4 p-4">
+  <div class="flex flex-col gap-4 p-4 max-h-48 overflow-y-auto">
     <div
       v-if="filteredImageAttachments.length > 0"
       class="flex flex-wrap gap-3"

--- a/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue
@@ -6,7 +6,6 @@ import { INBOX_TYPES } from 'dashboard/helper/inbox';
 import {
   appendSignature,
   removeSignature,
-  extractTextFromMarkdown,
 } from 'dashboard/helper/editorHelper';
 import {
   buildContactableInboxesList,
@@ -202,11 +201,8 @@ const handleInboxAction = ({ value, action, ...rest }) => {
 const removeSignatureFromMessage = () => {
   // Always remove the signature from message content when inbox/contact is removed
   // to ensure no leftover signature content remains
-  const signatureToRemove = inboxTypes.value.isEmailOrWebWidget
-    ? props.messageSignature
-    : extractTextFromMarkdown(props.messageSignature);
-  if (signatureToRemove) {
-    state.message = removeSignature(state.message, signatureToRemove);
+  if (props.messageSignature) {
+    state.message = removeSignature(state.message, props.messageSignature);
   }
 };
 
@@ -228,7 +224,11 @@ const onClickInsertEmoji = emoji => {
 };
 
 const handleAddSignature = signature => {
-  state.message = appendSignature(state.message, signature);
+  state.message = appendSignature(
+    state.message,
+    signature,
+    inboxChannelType.value
+  );
 };
 
 const handleRemoveSignature = signature => {

--- a/app/javascript/dashboard/components-next/NewConversation/components/MessageEditor.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/MessageEditor.vue
@@ -1,9 +1,8 @@
 <script setup>
-import { ref, watch, computed, nextTick } from 'vue';
+import { ref, watch, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
   appendSignature,
-  extractTextFromMarkdown,
   removeSignature,
 } from 'dashboard/helper/editorHelper';
 
@@ -33,17 +32,13 @@ const state = ref({
   mentionSearchKey: '',
 });
 
-const plainTextSignature = computed(() =>
-  extractTextFromMarkdown(props.messageSignature)
-);
-
 watch(
   modelValue,
   newValue => {
     if (props.isEmailOrWebWidgetInbox) return;
 
     const bodyWithoutSignature = newValue
-      ? removeSignature(newValue, plainTextSignature.value)
+      ? removeSignature(newValue, props.messageSignature)
       : '';
 
     // Check if message starts with slash
@@ -67,7 +62,7 @@ const hideMention = () => {
 const replaceText = async message => {
   // Only append signature on replace if sendWithSignature is true
   const finalMessage = props.sendWithSignature
-    ? appendSignature(message, plainTextSignature.value)
+    ? appendSignature(message, props.messageSignature, props.channelType)
     : message;
 
   await nextTick();

--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -370,7 +370,7 @@ function addSignature() {
   // see if the content is empty, if it is before appending the signature
   // we need to add a paragraph node and move the cursor at the start of the editor
   const contentWasEmpty = isBodyEmpty(content);
-  content = appendSignature(content, props.signature);
+  content = appendSignature(content, props.signature, props.channelType);
   // need to reload first, ensuring that the editorView is updated
   reloadState(content);
 

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -565,7 +565,7 @@ export default {
       }
 
       return this.sendWithSignature
-        ? appendSignature(message, this.messageSignature)
+        ? appendSignature(message, this.messageSignature, this.channelType)
         : removeSignature(message, this.messageSignature);
     },
     removeFromDraft() {
@@ -757,7 +757,11 @@ export default {
         // if signature is enabled, append it to the message
         // appendSignature ensures that the signature is not duplicated
         // so we don't need to check if the signature is already present
-        message = appendSignature(message, this.messageSignature);
+        message = appendSignature(
+          message,
+          this.messageSignature,
+          this.channelType
+        );
       }
 
       const updatedMessage = replaceVariablesInMessage({
@@ -796,7 +800,11 @@ export default {
       this.message = '';
       if (this.sendWithSignature && !this.isPrivate) {
         // if signature is enabled, append it to the message
-        this.message = appendSignature(this.message, this.messageSignature);
+        this.message = appendSignature(
+          this.message,
+          this.messageSignature,
+          this.channelType
+        );
       }
       this.attachedFiles = [];
       this.isRecordingAudio = false;

--- a/app/javascript/dashboard/constants/editor.js
+++ b/app/javascript/dashboard/constants/editor.js
@@ -5,7 +5,7 @@ export const FORMATTING = {
   // Channel formatting
   'Channel::Email': {
     marks: ['strong', 'em', 'code', 'link'],
-    nodes: ['bulletList', 'orderedList', 'codeBlock', 'blockquote'],
+    nodes: ['bulletList', 'orderedList', 'codeBlock', 'blockquote', 'image'],
     menu: [
       'strong',
       'em',
@@ -19,7 +19,7 @@ export const FORMATTING = {
   },
   'Channel::WebWidget': {
     marks: ['strong', 'em', 'code', 'link', 'strike'],
-    nodes: ['bulletList', 'orderedList', 'codeBlock', 'blockquote'],
+    nodes: ['bulletList', 'orderedList', 'codeBlock', 'blockquote', 'image'],
     menu: [
       'strong',
       'em',
@@ -127,7 +127,7 @@ export const FORMATTING = {
   },
   'Context::MessageSignature': {
     marks: ['strong', 'em', 'link'],
-    nodes: [],
+    nodes: ['image'],
     menu: ['strong', 'em', 'link', 'undo', 'redo', 'imageUpload'],
   },
   'Context::InboxSettings': {
@@ -225,6 +225,11 @@ export const MARKDOWN_PATTERNS = [
     type: 'link', // PM: link, eg: [text](url)
     patterns: [{ pattern: /\[([^\]]+)\]\([^)]+\)/g, replacement: '$1' }],
   },
+];
+
+export const CHANNEL_WITH_RICH_SIGNATURE = [
+  'Channel::Email',
+  'Channel::WebWidget',
 ];
 
 // Editor image resize options for Message Editor


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the following issues introduced after merging the PRs below:

* [https://github.com/chatwoot/chatwoot/pull/12600](https://github.com/chatwoot/chatwoot/pull/12600)
* [https://github.com/chatwoot/chatwoot/pull/13028](https://github.com/chatwoot/chatwoot/pull/13028)

### 1. Message Signature with Rich Content (Images, Bold, Links, Italics)

Rich message signatures (images, bold, links, italics) are supported only for **Email** and **Web Widget** channels.
For other channels (WhatsApp, API, Telegram, etc.), rich formatting and images are now **automatically stripped** from the signature before appending. This prevents editor rendering issues and avoids errors.

### 2. New Message Modal – Attachment Overflow

Fixed an issue in the **new conversation modal** where attachment previews could overflow and hide the **Send** button.
Attachments are now properly contained, ensuring the Send action is always visible.

Fixes https://linear.app/chatwoot/issue/CW-6111/send-button-disappears-in-new-conversation-form-after-the-page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/3803b31003b9481ab637038c3fb8aaca

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
