### PR TITLE
fix: skip orphaned inbox members in widget api endpoint

### DIFF
--- a/app/views/api/v1/widget/inbox_members/index.json.jbuilder
+++ b/app/views/api/v1/widget/inbox_members/index.json.jbuilder
@@ -1,5 +1,7 @@
 json.payload do
   json.array! @inbox_members do |inbox_member|
+    next if inbox_member.user.blank?
+
     json.id inbox_member.user.id
     json.name inbox_member.user.available_name
     json.avatar_url inbox_member.user.avatar_url


### PR DESCRIPTION

# Pull Request Template

## Description

Prrevents NoMethodError when InboxMember references a deleted User.
The widget endpoint was crashing with 'undefined method id for nil'
when trying to render inbox members whose associated users had been
deleted.

Added nil check in jbuilder to gracefully skip orphaned records
instead of crashing.


<img width="1040" height="138" alt="image" src="https://github.com/user-attachments/assets/c3debee8-d736-4a7b-a81d-38163bc505be" />


Fixes https://linear.app/chatwoot/issue/CW-6127/actionviewtemplateerror-undefined-method-id-for-nil

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
