### PR TITLE
chore: Improve widget attachment button display logic

### DIFF
--- a/app/javascript/widget/components/ChatInputWrap.vue
+++ b/app/javascript/widget/components/ChatInputWrap.vue
@@ -46,8 +46,7 @@ export default {
     }),
     showAttachment() {
       return (
-        this.shouldShowFilePicker &&
-        this.hasAttachmentsEnabled &&
+        (this.shouldShowFilePicker || this.hasAttachmentsEnabled) &&
         this.userInput.length === 0
       );
     },


### PR DESCRIPTION
# Pull Request Template

## Description

This PR updates the attachment button visibility logic to show the button when **either** `shouldShowFilePicker` **or** `hasAttachmentsEnabled` is enabled (previously required both).


## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
