### PR TITLE
feat(inbox): add E keyboard shortcut to delete notification and advance

### DIFF
--- a/app/javascript/dashboard/components/widgets/modal/constants.js
+++ b/app/javascript/dashboard/components/widgets/modal/constants.js
@@ -92,4 +92,10 @@ export const SHORTCUT_KEYS = [
     displayKeys: [KEYS.ALT, 'M'],
     keySet: ['Alt+KeyM'],
   },
+  {
+    id: 15,
+    label: 'DELETE_NOTIFICATION',
+    displayKeys: ['E'],
+    keySet: ['KeyE'],
+  },
 ];

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -540,7 +540,8 @@
       "GO_TO_SETTINGS": "Go to Settings",
       "SWITCH_TO_PRIVATE_NOTE": "Switch to Private Note",
       "SWITCH_TO_REPLY": "Switch to Reply",
-      "TOGGLE_SNOOZE_DROPDOWN": "Toggle snooze dropdown"
+      "TOGGLE_SNOOZE_DROPDOWN": "Toggle snooze dropdown",
+      "DELETE_NOTIFICATION": "Delete notification and go to next"
     }
   },
   "ASSIGNMENT_POLICY": {

--- a/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
@@ -252,6 +252,9 @@ const deleteAndNavigateNext = async () => {
 const keyboardEvents = {
   KeyE: {
     action: e => {
+      // Only handle E key when no conversation is open
+      // InboxView.vue handles it when viewing a conversation
+      if (currentConversationId.value) return;
       e.preventDefault();
       deleteAndNavigateNext();
     },


### PR DESCRIPTION
## Summary

Adds Superhuman-style keyboard shortcut for faster inbox processing:

- **Press E** to delete the current notification and automatically navigate to the next one
- Works in both conversation view (`/inbox-view/conversation/:id`) and sidebar list
- Disabled when cursor is in a text input (reply box, search, etc.)
- Includes analytics tracking and user feedback toast

## Motivation

Power users processing many notifications benefit from keyboard-driven workflows. This matches patterns from Superhuman, Notion Mail, and similar productivity tools where E = archive/delete and advance.

## Implementation

- Uses existing `useKeyboardEvents` composable (same pattern as L key for labels)
- Captures notification ID before delete to avoid race conditions with reactive store updates
- Falls back to inbox view when on the last notification
- Properly separated error handling: if delete fails, don't navigate

## Test plan

- [ ] Press E while viewing a conversation in inbox view → deletes and goes to next
- [ ] Press E while on last notification → deletes and shows inbox empty state
- [ ] Press E while typing in reply box → does nothing (shortcut disabled)
- [ ] Press E in sidebar list with notification selected → deletes and advances
- [ ] Verify toast notification appears after delete
- [ ] Check keyboard shortcuts modal shows new shortcut

## Screenshots

N/A - keyboard shortcut, no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)