### PR TITLE
feat: Allow filtering conversations by multiple statuses (array)

### DIFF
--- a/swagger/paths/application/contacts/conversations.yml
+++ b/swagger/paths/application/contacts/conversations.yml
@@ -20,6 +20,17 @@ get:
       schema:
         type: number
       description: ID of the contact
+    - name: status
+      in: query
+      schema:
+        oneOf:
+          - type: string
+            enum: ['all', 'open', 'resolved', 'pending', 'snoozed']
+          - type: array
+            items:
+              type: string
+              enum: ['open', 'resolved', 'pending', 'snoozed']
+      description: Filter by conversation status. Can be a single status or an array of statuses (e.g., status[]=open&status[]=pending). Returns all statuses if not specified.
   security:
     - userApiKey: []
   responses:

--- a/swagger/paths/application/conversation/index.yml
+++ b/swagger/paths/application/conversation/index.yml
@@ -20,10 +20,15 @@ get:
     - name: status
       in: query
       schema:
-        type: string
-        enum: ['all', 'open', 'resolved', 'pending', 'snoozed']
+        oneOf:
+          - type: string
+            enum: ['all', 'open', 'resolved', 'pending', 'snoozed']
+          - type: array
+            items:
+              type: string
+              enum: ['open', 'resolved', 'pending', 'snoozed']
         default: 'open'
-      description: Filter by conversation status.
+      description: Filter by conversation status. Can be a single status or an array of statuses (e.g., status[]=open&status[]=pending).
     - name: q
       in: query
       schema:


### PR DESCRIPTION
## Summary
- Enables filtering conversations by multiple statuses using an array parameter
- Adds `filter_by_contact` method to ConversationFinder for contact-based filtering  
- Refactors contacts/conversations controller to use ConversationFinder (eliminates code duplication)
- Includes edge case handling for empty arrays and blank strings

Closes #5401

## API Usage

**Single status (unchanged):**
```
GET /api/v1/accounts/:id/conversations?status=open
```

**Multiple statuses (new):**
```
GET /api/v1/accounts/:id/conversations?status[]=open&status[]=pending&status[]=snoozed
```

**All non-resolved conversations:**
```
GET /api/v1/accounts/:id/conversations?status[]=open&status[]=pending&status[]=snoozed
```

## Implementation Notes

Per maintainer guidance in #5401:
> "Rather than introducing a `not_closed` status, let's look at making ConversationFinder accept an array of statuses instead of a single value."

This implementation leverages Rails' native array handling in WHERE clauses (`where(status: ['open', 'pending'])` generates `WHERE status IN (0, 2)`), maintaining full backwards compatibility.

## Test plan
- [x] Added tests for array status filtering in ConversationFinder
- [x] Added tests for contact_id filtering in ConversationFinder
- [x] Added edge case tests (empty array, empty string, mixed blank/valid values)
- [x] Added status filter tests for contacts/conversations endpoint
- [x] Verified backwards compatibility with single status string

🤖 Generated with [Claude Code](https://claude.com/claude-code)