### PR TITLE
test(leadsquared): make ApiError specs reload-safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,14 @@
 - Avoid writing specs unless explicitly asked
 - Remove dead/unreachable/unused code
 - Don’t write multiple versions or backups for the same logic — pick the best approach and implement it
-- Don't reference Claude in commit messages
 - Prefer `with_modified_env` (from spec helpers) over stubbing `ENV` directly in specs
+- Specs in parallel/reloading environments: prefer comparing `error.class.name` over constant class equality when asserting raised errors
+
+## Commit Messages
+
+- Prefer Conventional Commits: `type(scope): subject` (scope optional)
+- Example: `feat(auth): add user authentication`
+- Don't reference Claude in commit messages
 
 ## Project-Specific
 

--- a/spec/services/crm/leadsquared/api/activity_client_spec.rb
+++ b/spec/services/crm/leadsquared/api/activity_client_spec.rb
@@ -101,7 +101,9 @@ RSpec.describe Crm::Leadsquared::Api::ActivityClient do
 
       it 'raises ApiError when activity creation fails' do
         expect { client.post_activity(prospect_id, activity_event, activity_note) }
-          .to raise_error(Crm::Leadsquared::Api::BaseClient::ApiError)
+          .to raise_error do |error|
+            expect(error.class.name).to eq('Crm::Leadsquared::Api::BaseClient::ApiError')
+          end
       end
     end
   end
@@ -186,7 +188,9 @@ RSpec.describe Crm::Leadsquared::Api::ActivityClient do
 
       it 'raises ApiError when activity type creation fails' do
         expect { client.create_activity_type(**activity_params) }
-          .to raise_error(Crm::Leadsquared::Api::BaseClient::ApiError)
+          .to raise_error do |error|
+            expect(error.class.name).to eq('Crm::Leadsquared::Api::BaseClient::ApiError')
+          end
       end
     end
 
@@ -210,7 +214,9 @@ RSpec.describe Crm::Leadsquared::Api::ActivityClient do
 
       it 'raises ApiError when the request fails' do
         expect { client.create_activity_type(**activity_params) }
-          .to raise_error(Crm::Leadsquared::Api::BaseClient::ApiError)
+          .to raise_error do |error|
+            expect(error.class.name).to eq('Crm::Leadsquared::Api::BaseClient::ApiError')
+          end
       end
     end
   end


### PR DESCRIPTION
- fix the flaky lead-squared spec