### PR TITLE
fix(sidebar): improve active child route matching logic

### DIFF
--- a/app/javascript/dashboard/components-next/sidebar/SidebarGroup.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarGroup.vue
@@ -158,9 +158,11 @@ const activeChild = computed(() => {
     return rankedPage ?? activeOnPages[0];
   }
 
-  return navigableChildren.value.find(
-    child => child.to && route.path.startsWith(resolvePath(child.to))
-  );
+  return navigableChildren.value.find(child => {
+    if (!child.to) return false;
+    const childPath = resolvePath(child.to);
+    return route.path === childPath || route.path.startsWith(childPath + '/');
+  });
 });
 
 const hasActiveChild = computed(() => {

--- a/app/javascript/dashboard/components-next/sidebar/SidebarGroup.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarGroup.vue
@@ -161,7 +161,7 @@ const activeChild = computed(() => {
   return navigableChildren.value.find(child => {
     if (!child.to) return false;
     const childPath = resolvePath(child.to);
-    return route.path === childPath || route.path.startsWith(childPath + '/');
+    return route.path === childPath || route.path.startsWith(`${childPath}/`);
   });
 });
 


### PR DESCRIPTION
## Description

This PR fixes a visual bug in the sidebar where selecting a conversation inside a custom view (folder) would incorrectly highlight a different folder in the sidebar.

### The Problem
When navigating to a conversation within a custom view (e.g., folder with ID 10), the sidebar would incorrectly highlight the folder with ID 1. Similarly, folder ID 20 would highlight folder ID 2, and so on.

### Root Cause
The `activeChild` computed property in `SidebarGroup.vue` uses a fallback path matching mechanism with `startsWith()`. This caused `/custom_view/1` to incorrectly match routes like `/custom_view/10/conversations/123` because the string "10" starts with "1".

### The Fix
Updated the path matching logic to require either:
1. An exact path match, OR
2. The route path starts with the child path followed by a `/`

This ensures `/custom_view/1` only matches routes like `/custom_view/1/...` and not `/custom_view/10/...`.

### Key Changes
- Fixed path prefix matching in `SidebarGroup.vue` to use proper path boundary detection

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

| Before | After |
| --- | --- |
|<img width="678" height="652" alt="image" src="https://github.com/user-attachments/assets/6c402275-4f66-45e0-864e-93f2024165c2" />|<img width="677" height="595" alt="image" src="https://github.com/user-attachments/assets/6824f7ca-c16a-44b8-9e1e-cae2f74b6ecb" />|

1. Create multiple custom views/folders (e.g., with IDs 1, 10, 11, 20)
2. Navigate to folder 10 and select a conversation
3. Verify that folder 10 remains highlighted in the sidebar (not folder 1)
4. Navigate to folder 1 and select a conversation
5. Verify that folder 1 is correctly highlighted
6. Repeat for other ID combinations (11, 12, 20, 21, etc.)