### PR TITLE
fix: Prevent invalid attachments from blocking text paste

### DIFF
--- a/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
@@ -171,10 +171,13 @@ const onPaste = e => {
   const files = e.clipboardData?.files;
   if (!files?.length) return;
 
-  Array.from(files).forEach(file => {
-    const { name, type, size } = file;
-    onFileUpload({ file, name, type, size });
-  });
+  // Filter valid files (non-zero size)
+  Array.from(files)
+    .filter(file => file.size > 0)
+    .forEach(file => {
+      const { name, type, size } = file;
+      onFileUpload({ file, name, type, size });
+    });
 };
 
 useEventListener(document, 'paste', onPaste);

--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -676,11 +676,18 @@ function createEditorView() {
         typingIndicator.stop();
         emit('blur');
       },
-      paste: (_view, event) => {
+      paste: (view, event) => {
         if (props.disabled) return;
-        const data = event.clipboardData.files;
-        if (data.length > 0) {
-          event.preventDefault();
+        const { files } = event.clipboardData;
+        if (!files.length) return;
+        event.preventDefault();
+        // Paste text content alongside files (e.g., spreadsheet data from Numbers app)
+        // Numbers app includes invalid 0-byte attachments with text, so we paste the text here
+        // while ReplyBox filters and handles valid file attachments
+        const text = event.clipboardData.getData('text/plain');
+        if (text) {
+          view.dispatch(view.state.tr.insertText(text));
+          emitOnChange();
         }
       },
     },

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -692,20 +692,20 @@ export default {
     },
     onPaste(e) {
       // Don't handle paste if compose new conversation modal is open
-      if (this.newConversationModalActive) {
-        return;
-      }
+      if (this.newConversationModalActive) return;
+
       const data = e.clipboardData.files;
       if (!this.showRichContentEditor && data.length !== 0) {
         this.$refs.messageInput?.$el?.blur();
       }
-      if (!data.length || !data[0]) {
-        return;
-      }
-      data.forEach(file => {
-        const { name, type, size } = file;
-        this.onFileUpload({ name, type, size, file: file });
-      });
+
+      // Filter valid files (non-zero size)
+      Array.from(e.clipboardData.files)
+        .filter(file => file.size > 0)
+        .forEach(file => {
+          const { name, type, size } = file;
+          this.onFileUpload({ name, type, size, file });
+        });
     },
     toggleUserMention(currentMentionState) {
       this.showUserMentions = currentMentionState;


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where invalid (0-byte) clipboard attachments blocked text from being pasted into the editor, commonly occurring when copying spreadsheet data from the Numbers app on macOS. It ensures text content is always pasted, while only valid attachments are processed and invalid files are ignored.

Fixes https://linear.app/chatwoot/issue/CW-6185/fix-paste-behavior-when-copying-spreadsheet-data-with-invalid

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video

https://www.loom.com/share/0a3fa7706e0f4202b49880ccc3729e2f


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
