### PR TITLE
fix: add linear integration for the startup plan

### DIFF
--- a/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
+++ b/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
@@ -18,6 +18,7 @@ class Enterprise::Billing::HandleStripeEventService
     captain_integration
     advanced_search_indexing
     advanced_search
+    linear_integration
   ].freeze
 
   # Additional features available starting with the Business plan


### PR DESCRIPTION
## Description

Enable linear by default for premium plans.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `linear_integration` to `STARTUP_PLAN_FEATURES`, enabling it for Startups and higher during plan feature sync.
> 
> - **Billing/Plans**:
>   - Update `enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb` to include `linear_integration` in `STARTUP_PLAN_FEATURES`, enabling it for Startups, Business, and Enterprise during feature toggling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 591853abd9996b3a682a07b79ce3aa7ef26a3261. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->