### PR TITLE
fix: increase the alfred connection pool size to 10

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -274,3 +274,5 @@ AZURE_APP_SECRET=
 # Set to true if you want to remove stale contact inboxes
 # contact_inboxes with no conversation older than 90 days will be removed
 # REMOVE_STALE_CONTACT_INBOX_JOB_STATUS=false
+
+# REDIS_ALFRED_SIZE=10

--- a/config/initializers/01_redis.rb
+++ b/config/initializers/01_redis.rb
@@ -5,7 +5,7 @@
 # Alfred
 # Add here as you use it for more features
 # Used for Round Robin, Conversation Emails & Online Presence
-$alfred = ConnectionPool.new(size: 5, timeout: 1) do
+$alfred = ConnectionPool.new(size: 10, timeout: 1) do
   redis = Rails.env.test? ? MockRedis.new : Redis.new(Redis::Config.app)
   Redis::Namespace.new('alfred', redis: redis, warning: true)
 end

--- a/config/initializers/01_redis.rb
+++ b/config/initializers/01_redis.rb
@@ -5,7 +5,8 @@
 # Alfred
 # Add here as you use it for more features
 # Used for Round Robin, Conversation Emails & Online Presence
-$alfred = ConnectionPool.new(size: 10, timeout: 1) do
+alfred_size = ENV.fetch('REDIS_ALFRED_SIZE', 5)
+$alfred = ConnectionPool.new(size: alfred_size, timeout: 1) do
   redis = Rails.env.test? ? MockRedis.new : Redis.new(Redis::Config.app)
   Redis::Namespace.new('alfred', redis: redis, warning: true)
 end


### PR DESCRIPTION
## Description
Increased the alfred pool size to 10, so that each worker has enough redis connection thread pool to work

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurability for the Redis pool used by `alfred`.
> 
> - `$alfred` `ConnectionPool` size now reads from `ENV['REDIS_ALFRED_SIZE']` with a default of `5`
> - Adds `REDIS_ALFRED_SIZE=10` to `.env.example`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96cdff8c0ea40f82a57d70be053780e87384ed47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->