### PR TITLE
feat(CW-6187): include headers from incoming emails

### DIFF
--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -95,6 +95,7 @@ class MailPresenter < SimpleDelegator
       content_type: content_type,
       date: date,
       from: from,
+      headers: headers_data,
       html_content: html_content,
       in_reply_to: in_reply_to,
       message_id: message_id,
@@ -134,6 +135,16 @@ class MailPresenter < SimpleDelegator
 
   def original_sender
     from_email_address(@mail[:reply_to].try(:value)) || @mail['X-Original-Sender'].try(:value) || from_email_address(from.first)
+  end
+
+  def headers_data
+    headers = {
+      'x-original-from' => @mail['X-Original-From']&.value,
+      'x-original-sender' => @mail['X-Original-Sender']&.value,
+      'x-forwarded-for' => @mail['X-Forwarded-For']&.value
+    }.compact
+
+    headers.presence
   end
 
   def from_email_address(email)

--- a/spec/mailboxes/reply_mailbox_spec.rb
+++ b/spec/mailboxes/reply_mailbox_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe ReplyMailbox do
     let(:conversation) { create(:conversation, assignee: agent, inbox: create(:inbox, account: account, greeting_enabled: false), account: account) }
     let(:described_subject) { described_class.receive reply_mail }
     let(:serialized_attributes) do
-      %w[bcc cc content_type date from html_content in_reply_to message_id multipart number_of_attachments references subject text_content to
-         auto_reply]
+      %w[bcc cc content_type date from headers html_content in_reply_to message_id multipart number_of_attachments references subject text_content
+         to auto_reply]
     end
 
     context 'with reply uuid present' do
@@ -397,7 +397,7 @@ RSpec.describe ReplyMailbox do
     let(:support_in_reply_to_mail) { create_inbound_email_from_fixture('support_in_reply_to.eml') }
     let(:described_subject) { described_class.receive support_mail }
     let(:serialized_attributes) do
-      %w[bcc cc content_type date from html_content in_reply_to message_id multipart number_of_attachments references subject
+      %w[bcc cc content_type date from headers html_content in_reply_to message_id multipart number_of_attachments references subject
          text_content to auto_reply]
     end
     let(:conversation) { Conversation.where(inbox_id: channel_email.inbox).last }

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe MailPresenter do
       mail_with_headers = Mail.new do
         from 'Sender <sender@example.com>'
         to 'Inbox <inbox@example.com>'
-        subject :'Header test'
+        subject :header
         body 'Hi'
         header['X-Original-From'] = 'Original <original@example.com>'
         header['X-Original-Sender'] = 'original@example.com'
@@ -85,7 +85,7 @@ RSpec.describe MailPresenter do
       mail_without_headers = Mail.new do
         from 'Sender <sender@example.com>'
         to 'Inbox <inbox@example.com>'
-        subject :'Header test'
+        subject :header
         body 'Hi'
       end
 

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe MailPresenter do
                                 :content_type,
                                 :date,
                                 :from,
+                                :headers,
                                 :html_content,
                                 :in_reply_to,
                                 :message_id,
@@ -58,6 +59,39 @@ RSpec.describe MailPresenter do
       expect(data[:multipart]).to be(true)
       expect(data[:subject]).to eq(decorated_mail.subject)
       expect(data[:auto_reply]).to eq(decorated_mail.auto_reply?)
+    end
+
+    it 'includes forwarded headers in serialized_data' do
+      mail_with_headers = Mail.new do
+        from 'Sender <sender@example.com>'
+        to 'Inbox <inbox@example.com>'
+        subject :'Header test'
+        body 'Hi'
+        header['X-Original-From'] = 'Original <original@example.com>'
+        header['X-Original-Sender'] = 'original@example.com'
+        header['X-Forwarded-For'] = 'forwarder@example.com'
+      end
+
+      data = described_class.new(mail_with_headers).serialized_data
+
+      expect(data[:headers]).to eq(
+        'x-original-from' => 'Original <original@example.com>',
+        'x-original-sender' => 'original@example.com',
+        'x-forwarded-for' => 'forwarder@example.com'
+      )
+    end
+
+    it 'returns nil headers when forwarding headers are missing' do
+      mail_without_headers = Mail.new do
+        from 'Sender <sender@example.com>'
+        to 'Inbox <inbox@example.com>'
+        subject :'Header test'
+        body 'Hi'
+      end
+
+      data = described_class.new(mail_without_headers).serialized_data
+
+      expect(data[:headers]).to be_nil
     end
 
     it 'give email from in downcased format' do


### PR DESCRIPTION
Forwarded email flows (Google Groups, aliases, relays) commonly rewrite headers so the `Reply-To` header points at the list or group address. 

In Chatwoot, `MailPresenter#from` intentionally prefers Reply-To when building the `from` field because that is the correct reply target for end users. The downside is that in a forwarded flow, the original technical sender (for example `reply@idealista.pt`) gets obscured, even though it is still present in the raw headers as `X-Original-From` or `X-Original-Sender`.

https://github.com/chatwoot/chatwoot/blob/65bdf99d5627c0260bc19ec52acfc57eab367eec/app/presenters/mail_presenter.rb#L127-L130

Any inbox that receives messages via mailing lists, shared addresses, or domain forwarding can lose sender identity if only normalized `from` is preserved. Persisting a small, curated headers map (for example `X-Original-From`, `X-Original-Sender`, and `X-Forwarded-For`) in `serialized_data` keeps the original evidence without changing conversation semantics or reply behavior.

This issue came to light when a Chatwoot user was trying to process emails via webhooks. The webhook service read `content_attributes.email` from the serialized email data, but we do not persist raw forwarding headers today. The result is that `content_attributes.email.from` reflects the forwarding address (the group) and the `headers` object is missing, so downstream integrations cannot distinguish between senders that matter for routing or any other task.

> Note: A follow-up for this can be where we use the X-Original-Sender in the from address if we're able to detect that the email is from a mailing list