### PR TITLE
fix: Dyte meeting UI not loading

### DIFF
--- a/app/javascript/shared/helpers/IntegrationHelper.js
+++ b/app/javascript/shared/helpers/IntegrationHelper.js
@@ -1,4 +1,4 @@
-const DYTE_MEETING_LINK = 'https://app.dyte.io/v2/meeting';
+const DYTE_MEETING_LINK = 'https://demo.realtime.cloudflare.com/v2/meeting';
 
 export const buildDyteURL = dyteAuthToken => {
   return `${DYTE_MEETING_LINK}?authToken=${dyteAuthToken}&showSetupScreen=true&disableVideoBackground=true`;


### PR DESCRIPTION
While we haven’t received detailed guidance on how RealtimeKit (Dyte) should behave under Cloudflare, a simple URL update resolves the issue temporarily.  

After reviewing PR #10706 from @tarushnagpal and Cloudflare documentation, this change ensures the meeting UI loads correctly instead of showing an infinite spinner.

## Description
Fixes #13148

This PR updates the Dyte integration URL to restore proper rendering of the meeting UI inside Chatwoot.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Applied the URL change locally.  
- Verified that the meeting UI now loads correctly.  
- Confirmed that bug #13148 no longer occurs.  

## Checklist:
- [X ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
