### PR TITLE
feat: Add call-to-action template support for Twilio

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ContentTemplates/ContentTemplatesPicker.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ContentTemplates/ContentTemplatesPicker.vue
@@ -41,6 +41,9 @@ const getTemplateType = template => {
   if (template.template_type === TWILIO_CONTENT_TEMPLATE_TYPES.QUICK_REPLY) {
     return t('CONTENT_TEMPLATES.PICKER.TYPES.QUICK_REPLY');
   }
+  if (template.template_type === TWILIO_CONTENT_TEMPLATE_TYPES.CALL_TO_ACTION) {
+    return t('CONTENT_TEMPLATES.PICKER.TYPES.CALL_TO_ACTION');
+  }
   return t('CONTENT_TEMPLATES.PICKER.TYPES.TEXT');
 };
 

--- a/app/javascript/dashboard/i18n/locale/en/contentTemplates.json
+++ b/app/javascript/dashboard/i18n/locale/en/contentTemplates.json
@@ -28,6 +28,7 @@
       "TYPES": {
         "MEDIA": "Media",
         "QUICK_REPLY": "Quick Reply",
+        "CALL_TO_ACTION": "Call to Action",
         "TEXT": "Text"
       }
     },

--- a/app/javascript/shared/constants/messages.js
+++ b/app/javascript/shared/constants/messages.js
@@ -164,4 +164,5 @@ export const TWILIO_CONTENT_TEMPLATE_TYPES = {
   TEXT: 'text',
   MEDIA: 'media',
   QUICK_REPLY: 'quick_reply',
+  CALL_TO_ACTION: 'call_to_action',
 };

--- a/app/services/twilio/template_processor_service.rb
+++ b/app/services/twilio/template_processor_service.rb
@@ -23,8 +23,8 @@ class Twilio::TemplateProcessorService
 
   def build_content_variables(template)
     case template['template_type']
-    when 'text', 'quick_reply'
-      convert_text_template(template_params) # Text and quick reply templates use body variables
+    when 'text', 'quick_reply', 'call_to_action'
+      convert_text_template(template_params) # Text, quick reply and call-to-action templates use body variables
     when 'media'
       convert_media_template(template_params)
     else

--- a/app/services/twilio/template_sync_service.rb
+++ b/app/services/twilio/template_sync_service.rb
@@ -63,6 +63,8 @@ class Twilio::TemplateSyncService
       'media'
     elsif template_types.include?('twilio/quick-reply')
       'quick_reply'
+    elsif template_types.include?('twilio/call-to-action')
+      'call_to_action'
     elsif template_types.include?('twilio/catalog')
       'catalog'
     else
@@ -107,6 +109,8 @@ class Twilio::TemplateSyncService
       template_types['twilio/media']['body']
     elsif template_types['twilio/quick-reply']
       template_types['twilio/quick-reply']['body']
+    elsif template_types['twilio/call-to-action']
+      template_types['twilio/call-to-action']['body']
     elsif template_types['twilio/catalog']
       template_types['twilio/catalog']['body']
     else


### PR DESCRIPTION
Fixes https://linear.app/chatwoot/issue/CW-6228/add-call-to-action-template-support-for-twilio-whatsapp-templates

Adds support for Twilio WhatsApp call-to-action templates, enabling customers to use URL button templates with variable inputs.

<img width="2982" height="1388" alt="CleanShot 2026-01-05 at 16 25 55@2x" src="https://github.com/user-attachments/assets/7cf332f5-3f3e-4ffb-a461-71c60a0156c8" />
