### PR TITLE
feat: allow agent bot and captain responses to reset waiting since

### DIFF
--- a/spec/enterprise/models/message_spec.rb
+++ b/spec/enterprise/models/message_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe Message do
 
     create(:message, message_type: :outgoing, conversation: conversation, sender: captain_assistant)
 
+    # Captain::Assistant responses clear waiting_since (like AgentBot)
     expect(conversation.first_reply_created_at).to be_nil
-    expect(conversation.waiting_since).to be_within(0.000001.seconds).of(conversation.created_at)
+    expect(conversation.waiting_since).to be_nil
 
     create(:message, message_type: :outgoing, conversation: conversation)
 

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -978,5 +978,70 @@ RSpec.describe Conversation do
       reply_events = account.reporting_events.where(name: 'reply_time', conversation_id: conversation.id)
       expect(reply_events.count).to eq(0)
     end
+
+    context 'when AgentBot responds between customer messages' do
+      let(:agent_bot) { create(:agent_bot, account: account) }
+
+      def create_bot_message(conversation, created_at: Time.current)
+        message = nil
+        perform_enqueued_jobs do
+          message = create(:message,
+                           message_type: 'outgoing',
+                           account: conversation.account,
+                           inbox: conversation.inbox,
+                           conversation: conversation,
+                           sender: agent_bot,
+                           created_at: created_at)
+        end
+        message
+      end
+
+      it 'calculates reply time from the most recent customer message after bot response' do
+        # Initial conversation: customer message -> agent first reply (to establish first_reply_created_at)
+        create_customer_message(conversation, created_at: 10.hours.ago)
+        create_agent_message(conversation, created_at: 9.hours.ago)
+
+        # Customer message 1
+        create_customer_message(conversation, created_at: 5.hours.ago)
+
+        # Bot responds
+        create_bot_message(conversation, created_at: 4.hours.ago)
+
+        # Customer message 2 (after bot response) - should reset waiting_since
+        create_customer_message(conversation, created_at: 2.hours.ago)
+
+        # Human agent replies - should create reply_time event from customer message 2
+        create_agent_message(conversation, created_at: 1.hour.ago)
+
+        reply_events = account.reporting_events.where(name: 'reply_time', conversation_id: conversation.id)
+        expect(reply_events.count).to eq(1) # Only the second agent reply creates a reply_time event
+        # Reply time should be 1 hour (from customer message 2 to agent reply)
+        expect(reply_events.first.value).to be_within(60).of(3600)
+      end
+
+      it 'handles multiple bot responses before customer messages again' do
+        # Initial conversation: customer message -> agent first reply
+        create_customer_message(conversation, created_at: 10.hours.ago)
+        create_agent_message(conversation, created_at: 9.hours.ago)
+
+        # Customer message 1
+        create_customer_message(conversation, created_at: 6.hours.ago)
+
+        # Bot responds multiple times
+        create_bot_message(conversation, created_at: 5.hours.ago)
+        create_bot_message(conversation, created_at: 4.hours.ago)
+
+        # Customer message 2 (after multiple bot responses) - should reset waiting_since
+        create_customer_message(conversation, created_at: 2.hours.ago)
+
+        # Human agent replies
+        create_agent_message(conversation, created_at: 1.hour.ago)
+
+        reply_events = account.reporting_events.where(name: 'reply_time', conversation_id: conversation.id)
+        expect(reply_events.count).to eq(1) # Only the second agent reply creates a reply_time event
+        # Reply time should be 1 hour (from customer message 2 to agent reply)
+        expect(reply_events.first.value).to be_within(60).of(3600)
+      end
+    end
   end
 end


### PR DESCRIPTION
When AgentBot responds to customer messages, the `waiting_since` timestamp is not reset, causing inflated reply time metrics when a human agent eventually responds. This results in inaccurate reporting that incorrectly includes periods when customers were satisfied with bot responses.

### Timeline from Production Data

```
Dec 12, 16:20:14 - Customer sends message (ID: 368451924)
                   ↓ waiting_since = Dec 12, 16:20:14

Dec 12, 16:20:17 - AgentBot replies (ID: 368451960)
                   ↓ waiting_since STILL = Dec 12, 16:20:14 ❌
                   ↓ (Bot response doesn't clear it)

14-day gap        - Customer satisfied, no messages
                   ↓ waiting_since STILL = Dec 12, 16:20:14 ❌

Dec 26, 22:25:45 - Customer sends new message (ID: 383522275)
                   ↓ waiting_since STILL = Dec 12, 16:20:14 ❌
                   ↓ (New message doesn't reset it)

Dec 26-27         - More AgentBot interactions
                   ↓ waiting_since STILL = Dec 12, 16:20:14 ❌

Dec 27, 07:36:53 - Human agent finally replies (ID: 383799517)
                   ↓ Reply time calculated: 1,268,404 seconds
                   ↓ = 14.7 DAYS ❌
```
## Root Cause

The core issues is in `app/models/message.rb`, where **AgentBot messages does not clear `waiting_since`** - The `human_response?` method only returns true for `User` senders, so bot replies never trigger the clearing logic. This means once `waiting_since` is set, it stays set even when customers send new messages after receiving bot responses.

The solution is to simply reset `waiting_since` **after a bot has responded**. This ensures reply time metrics reflect actual human agent response times, not bot-handled periods.

### What triggers the rest

This is an intentional "gotcha", that only `AgentBot` and `Captain::Assistant` messages trigger the waiting time reset. Automation and campaign messages maintain current behavior (no reset). This is because interactive bot assistants provide conversational help that might satisfy customers. Automation and campaigns are one-way communications and shouldn't affect waiting time calculations.

## Related Work

Extends PR #11787 which fixed `waiting_since` clearing on conversation resolution. This PR addresses the bot interaction scenario which was not covered by that fix.

Scripts to clean data: https://gist.github.com/scmmishra/bd133208e219d0ab52fbfdf03036c48a