### PR TITLE
fix: Use SignedId instead of regular ID in portal update

### DIFF
--- a/app/models/portal.rb
+++ b/app/models/portal.rb
@@ -53,7 +53,7 @@ class Portal < ApplicationRecord
       file_type: logo.content_type,
       account_id: account_id,
       file_url: url_for(logo),
-      blob_id: logo.blob_id,
+      blob_id: logo.blob.signed_id,
       filename: logo.filename.to_s
     }
   end


### PR DESCRIPTION
The Active Storage blob ids were handled inconsistently across the API.

- When a new logo was uploaded, the upload controller returned a signed_id
- When loading an existing portal that already had a logo, the portal model returned a blob_id.

This caused the API portal API to fail. There are about 107 instances of this in production, so this change will fix that. 