### PR TITLE
fix: Strip autolinks `<...>` when links are not supported

### DIFF
--- a/app/javascript/dashboard/constants/editor.js
+++ b/app/javascript/dashboard/constants/editor.js
@@ -237,8 +237,11 @@ export const MARKDOWN_PATTERNS = [
     patterns: [{ pattern: /`([^`]+)`/g, replacement: '$1' }],
   },
   {
-    type: 'link', // PM: link, eg: [text](url)
-    patterns: [{ pattern: /\[([^\]]+)\]\([^)]+\)/g, replacement: '$1' }],
+    type: 'link', // PM: link, eg: [text](url) or <url>
+    patterns: [
+      { pattern: /\[([^\]]+)\]\([^)]+\)/g, replacement: '$1' }, // [text](url) -> text
+      { pattern: /<(https?:\/\/[^>]+)>/g, replacement: '$1' }, // <url> -> url (autolinks)
+    ],
   },
 ];
 

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -896,6 +896,11 @@ describe('stripUnsupportedFormatting', () => {
       expect(stripUnsupportedFormatting(content, fullSchema)).toBe(content);
     });
 
+    it('preserves autolinks when schema supports links', () => {
+      const content = 'Check out <https://cegrafic.com/catalogo/>';
+      expect(stripUnsupportedFormatting(content, fullSchema)).toBe(content);
+    });
+
     it('preserves lists when schema supports them', () => {
       const content = '- item 1\n- item 2\n1. first\n2. second';
       expect(stripUnsupportedFormatting(content, fullSchema)).toBe(content);
@@ -965,6 +970,18 @@ describe('stripUnsupportedFormatting', () => {
           emptySchema
         )
       ).toBe('Check this link');
+    });
+
+    it('converts autolinks to plain URLs when schema does not support links', () => {
+      const content = 'Visit <https://cegrafic.com/catalogo/> for more info';
+      const expected = 'Visit https://cegrafic.com/catalogo/ for more info';
+      expect(stripUnsupportedFormatting(content, emptySchema)).toBe(expected);
+    });
+
+    it('handles multiple autolinks in content', () => {
+      const content = 'Check <https://example.com> and <https://test.com>';
+      const expected = 'Check https://example.com and https://test.com';
+      expect(stripUnsupportedFormatting(content, emptySchema)).toBe(expected);
     });
 
     it('strips bullet list markers', () => {


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the crash that occurred when inserting canned responses containing **autolinks** (e.g. `<https://example.com>`) into reply channels that **do not support links**, such as **Twilio SMS**.

### Steps to reproduce

1. Create a canned response with an autolink, for example: `<https://example.com>`.
2. Open a conversation in a channel that does not support links (e.g. SMS).
3. Insert the canned response into the reply box.

### Cause

* Currently, only standard markdown links (`[text](url)`) are handled when stripping unsupported formats from canned responses.
* Autolinks (`<https://example.com>`) are not handled during this process.
* As a result, **Error: Token type link_open not supported by Markdown parser**

### Solution

* Extended the markdown link parsing logic to explicitly handle **autolinks** in addition to standard markdown links.
* When a canned response containing an autolink is inserted into a reply box for a channel that does not support links (e.g. SMS), the angle brackets (`< >`) are stripped.
* The autolink is safely pasted as **plain text URL**, preventing parser errors and editor crashes.



Fixes https://linear.app/chatwoot/issue/CW-6256/error-token-type-link-open-not-supported-by-markdown-parser
Sentry issues [[1](https://chatwoot-p3.sentry.io/issues/7103543778/?environment=production&project=4507182691975168&query=is%3Aunresolved%20markdown&referrer=issue-stream)], [[2](https://chatwoot-p3.sentry.io/issues/7104325962/?environment=production&project=4507182691975168&query=is%3Aunresolved%20markdown&referrer=issue-stream
)]


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
