### PR TITLE
fix: Rendering of translations based on the user's locale

### DIFF
--- a/app/javascript/dashboard/components-next/message/MessageList.vue
+++ b/app/javascript/dashboard/components-next/message/MessageList.vue
@@ -42,7 +42,10 @@ const props = defineProps({
 const emit = defineEmits(['retry']);
 
 const allMessages = computed(() => {
-  return useCamelCase(props.messages, { deep: true });
+  return useCamelCase(props.messages, {
+    deep: true,
+    stopPaths: ['content_attributes.translations'],
+  });
 });
 
 const currentChat = useMapGetter('getSelectedChat');

--- a/app/javascript/dashboard/composables/spec/useTranslations.spec.js
+++ b/app/javascript/dashboard/composables/spec/useTranslations.spec.js
@@ -1,39 +1,31 @@
-import { ref } from 'vue';
-import { useTranslations } from '../useTranslations';
+import { selectTranslation } from '../useTranslations';
 
-describe('useTranslations', () => {
-  it('returns false and null when contentAttributes is null', () => {
-    const contentAttributes = ref(null);
-    const { hasTranslations, translationContent } =
-      useTranslations(contentAttributes);
-    expect(hasTranslations.value).toBe(false);
-    expect(translationContent.value).toBeNull();
+describe('selectTranslation', () => {
+  it('returns null when translations is null', () => {
+    expect(selectTranslation(null, 'en', 'en')).toBeNull();
   });
 
-  it('returns false and null when translations are missing', () => {
-    const contentAttributes = ref({});
-    const { hasTranslations, translationContent } =
-      useTranslations(contentAttributes);
-    expect(hasTranslations.value).toBe(false);
-    expect(translationContent.value).toBeNull();
+  it('returns null when translations is empty', () => {
+    expect(selectTranslation({}, 'en', 'en')).toBeNull();
   });
 
-  it('returns false and null when translations is an empty object', () => {
-    const contentAttributes = ref({ translations: {} });
-    const { hasTranslations, translationContent } =
-      useTranslations(contentAttributes);
-    expect(hasTranslations.value).toBe(false);
-    expect(translationContent.value).toBeNull();
+  it('returns first translation when no locale matches', () => {
+    const translations = { en: 'Hello', es: 'Hola' };
+    expect(selectTranslation(translations, 'fr', 'de')).toBe('Hello');
   });
 
-  it('returns true and correct translation content when translations exist', () => {
-    const contentAttributes = ref({
-      translations: { en: 'Hello' },
-    });
-    const { hasTranslations, translationContent } =
-      useTranslations(contentAttributes);
-    expect(hasTranslations.value).toBe(true);
-    // Should return the first translation (en: 'Hello')
-    expect(translationContent.value).toBe('Hello');
+  it('returns translation matching agent locale', () => {
+    const translations = { en: 'Hello', es: 'Hola', zh_CN: '你好' };
+    expect(selectTranslation(translations, 'es', 'en')).toBe('Hola');
+  });
+
+  it('falls back to account locale when agent locale not found', () => {
+    const translations = { en: 'Hello', zh_CN: '你好' };
+    expect(selectTranslation(translations, 'fr', 'zh_CN')).toBe('你好');
+  });
+
+  it('returns first translation when both locales are undefined', () => {
+    const translations = { en: 'Hello', es: 'Hola' };
+    expect(selectTranslation(translations, undefined, undefined)).toBe('Hello');
   });
 });

--- a/app/javascript/dashboard/composables/useTranslations.js
+++ b/app/javascript/dashboard/composables/useTranslations.js
@@ -3,6 +3,25 @@ import { useUISettings } from './useUISettings';
 import { useAccount } from './useAccount';
 
 /**
+ * Select translation based on locale priority.
+ * @param {Object} translations - Translations object with locale keys
+ * @param {string} agentLocale - Agent's preferred locale
+ * @param {string} accountLocale - Account's default locale
+ * @returns {string|null} Selected translation or null
+ */
+export function selectTranslation(translations, agentLocale, accountLocale) {
+  if (!translations || Object.keys(translations).length === 0) return null;
+
+  if (agentLocale && translations[agentLocale]) {
+    return translations[agentLocale];
+  }
+  if (accountLocale && translations[accountLocale]) {
+    return translations[accountLocale];
+  }
+  return translations[Object.keys(translations)[0]];
+}
+
+/**
  * Composable to extract translation state/content from contentAttributes.
  * @param {Ref|Reactive} contentAttributes - Ref or reactive object containing `translations` property
  * @returns {Object} { hasTranslations, translationContent }
@@ -19,18 +38,11 @@ export function useTranslations(contentAttributes) {
 
   const translationContent = computed(() => {
     if (!hasTranslations.value) return null;
-    const translations = contentAttributes.value.translations;
-    const agentLocale = uiSettings.value?.locale;
-    const accountLocale = currentAccount.value?.locale;
-
-    // Try agent locale first, then account locale, then fallback to first available
-    if (agentLocale && translations[agentLocale]) {
-      return translations[agentLocale];
-    }
-    if (accountLocale && translations[accountLocale]) {
-      return translations[accountLocale];
-    }
-    return translations[Object.keys(translations)[0]];
+    return selectTranslation(
+      contentAttributes.value.translations,
+      uiSettings.value?.locale,
+      currentAccount.value?.locale
+    );
   });
 
   return { hasTranslations, translationContent };

--- a/app/javascript/dashboard/composables/useTranslations.js
+++ b/app/javascript/dashboard/composables/useTranslations.js
@@ -1,4 +1,6 @@
 import { computed } from 'vue';
+import { useUISettings } from './useUISettings';
+import { useAccount } from './useAccount';
 
 /**
  * Composable to extract translation state/content from contentAttributes.
@@ -6,6 +8,9 @@ import { computed } from 'vue';
  * @returns {Object} { hasTranslations, translationContent }
  */
 export function useTranslations(contentAttributes) {
+  const { uiSettings } = useUISettings();
+  const { currentAccount } = useAccount();
+
   const hasTranslations = computed(() => {
     if (!contentAttributes.value) return false;
     const { translations = {} } = contentAttributes.value;
@@ -15,6 +20,16 @@ export function useTranslations(contentAttributes) {
   const translationContent = computed(() => {
     if (!hasTranslations.value) return null;
     const translations = contentAttributes.value.translations;
+    const agentLocale = uiSettings.value?.locale;
+    const accountLocale = currentAccount.value?.locale;
+
+    // Try agent locale first, then account locale, then fallback to first available
+    if (agentLocale && translations[agentLocale]) {
+      return translations[agentLocale];
+    }
+    if (accountLocale && translations[accountLocale]) {
+      return translations[accountLocale];
+    }
     return translations[Object.keys(translations)[0]];
   });
 

--- a/app/javascript/dashboard/modules/conversations/components/MessageContextMenu.vue
+++ b/app/javascript/dashboard/modules/conversations/components/MessageContextMenu.vue
@@ -62,6 +62,7 @@ export default {
     ...mapGetters({
       getAccount: 'accounts/getAccount',
       currentAccountId: 'getCurrentAccountId',
+      getUISettings: 'getUISettings',
     }),
     plainTextContent() {
       return this.getPlainText(this.messageContent);
@@ -117,11 +118,13 @@ export default {
       this.$emit('close', e);
     },
     handleTranslate() {
-      const { locale } = this.getAccount(this.currentAccountId);
+      const { locale: accountLocale } = this.getAccount(this.currentAccountId);
+      const agentLocale = this.getUISettings?.locale;
+      const targetLanguage = agentLocale || accountLocale || 'en';
       this.$store.dispatch('translateMessage', {
         conversationId: this.conversationId,
         messageId: this.messageId,
-        targetLanguage: locale || 'en',
+        targetLanguage,
       });
       useTrack(CONVERSATION_EVENTS.TRANSLATE_A_MESSAGE);
       this.handleClose();

--- a/lib/integrations/google_translate/processor_service.rb
+++ b/lib/integrations/google_translate/processor_service.rb
@@ -11,7 +11,7 @@ class Integrations::GoogleTranslate::ProcessorService
 
     response = client.translate_text(
       contents: [content],
-      target_language_code: target_language,
+      target_language_code: bcp47_language_code,
       parent: "projects/#{hook.settings['project_id']}",
       mime_type: mime_type
     )
@@ -22,6 +22,10 @@ class Integrations::GoogleTranslate::ProcessorService
   end
 
   private
+
+  def bcp47_language_code
+    target_language.tr('_', '-')
+  end
 
   def email_channel?
     message&.inbox&.email?


### PR DESCRIPTION
Previously, translations were generated and resolved purely based on the account locale. This caused issues in multi-team, multi-region setups where agents often work in different languages than the account default.

For example, an account might be set to English, while an agent prefers Spanish. In this setup:
- Translations were always created using the account locale.
- Agents could not view content in their preferred language.
- This did not scale well for global teams.

There was also an issue with locale resolution during rendering, where the system would incorrectly default to the account locale even when a more appropriate locale should have been used.

With this update, During rendering, the system first attempts to use the agent’s locale. If a translation for that locale does not exist, it falls back to the account locale.


**How to test:**

  - Set agent locale to a specific language (e.g., zh_CN) and account language to en.
  - Translate a message.
  - Verify translated content displays correctly for the agent's selected locale
  - Do the same for another locale for agent.
  - With multiple translations on a message (e.g., zh_CN, es, ml), verify the UI shows the one matching agent's locale
  - Change agent locale and verify the displayed translation updates accordingly
