### PR TITLE
fix: show last 2 digits for phone number avatars

### DIFF
--- a/app/javascript/dashboard/components-next/avatar/Avatar.vue
+++ b/app/javascript/dashboard/components-next/avatar/Avatar.vue
@@ -83,9 +83,20 @@ const STATUS_CLASSES = computed(() => ({
 
 const showDefaultAvatar = computed(() => !props.src && !props.name);
 
+// Check if string looks like a phone number (e.g., "+44 7123456789", "+1234567890")
+const isPhoneNumber = str => /^\+[\d\s-]+$/.test(str.trim());
+
 const initials = computed(() => {
   if (!props.name) return '';
-  const words = removeEmoji(props.name).split(/\s+/);
+  const cleanName = removeEmoji(props.name);
+
+  // For phone numbers, use last 2 digits to avoid confusing initials like "+7"
+  if (isPhoneNumber(cleanName)) {
+    const digits = cleanName.replace(/\D/g, '');
+    return digits.slice(-2) || '#';
+  }
+
+  const words = cleanName.split(/\s+/);
   return words.length === 1
     ? words[0].charAt(0).toUpperCase()
     : words

--- a/app/javascript/dashboard/components-next/avatar/specs/Avatar.spec.js
+++ b/app/javascript/dashboard/components-next/avatar/specs/Avatar.spec.js
@@ -1,0 +1,81 @@
+import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import Avatar from '../Avatar.vue';
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      THUMBNAIL: {
+        AUTHOR: {
+          NOT_AVAILABLE: 'Author not available',
+        },
+      },
+    },
+  },
+});
+
+describe('Avatar', () => {
+  const createWrapper = (props = {}) => {
+    return mount(Avatar, {
+      props: {
+        name: 'John Doe',
+        ...props,
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          Icon: true,
+          ChannelIcon: true,
+        },
+      },
+    });
+  };
+
+  describe('initials generation', () => {
+    it('generates initials from two-word name', () => {
+      const wrapper = createWrapper({ name: 'John Doe' });
+      expect(wrapper.text()).toContain('JD');
+    });
+
+    it('generates single initial from single-word name', () => {
+      const wrapper = createWrapper({ name: 'John' });
+      expect(wrapper.text()).toContain('J');
+    });
+
+    it('generates initials from three-word name using first two words', () => {
+      const wrapper = createWrapper({ name: 'John Doe Smith' });
+      expect(wrapper.text()).toContain('JD');
+    });
+
+    describe('phone number handling', () => {
+      it('uses last 2 digits for phone numbers with spaces', () => {
+        // Issue #2641: "+44 7123456789" was incorrectly showing "+7"
+        const wrapper = createWrapper({ name: '+44 7123456789' });
+        expect(wrapper.text()).toContain('89');
+      });
+
+      it('uses last 2 digits for phone numbers without spaces', () => {
+        const wrapper = createWrapper({ name: '+14155551234' });
+        expect(wrapper.text()).toContain('34');
+      });
+
+      it('uses last 2 digits for phone numbers with dashes', () => {
+        const wrapper = createWrapper({ name: '+1-415-555-1234' });
+        expect(wrapper.text()).toContain('34');
+      });
+
+      it('uses last 2 digits for phone numbers with mixed formatting', () => {
+        const wrapper = createWrapper({ name: '+44 (0) 7700-900123' });
+        expect(wrapper.text()).toContain('23');
+      });
+
+      it('does not treat names starting with + but containing letters as phone numbers', () => {
+        const wrapper = createWrapper({ name: '+John Doe' });
+        // Should use normal initials, not phone number logic
+        expect(wrapper.text()).toContain('+J');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes the confusing avatar initials display for WhatsApp/Twilio contacts whose name is a phone number.

### What changed
- Added phone number detection in Avatar component's initials computation
- For phone numbers (strings matching `^\+[\d\s-]+$`), display last 2 digits instead of splitting by whitespace

### Why it failed before
When a contact's name was `+44 7123456789`, the code split by whitespace into `["+44", "7123456789"]` and took first character of each word, producing `+7` - confusing and uninformative.

### Why this fix works
Phone numbers are now detected and handled separately. The last 2 digits provide a recognizable identifier without the confusing `+X` pattern.

### Risk assessment
Low. Change is isolated to the Avatar component's initials computation. Existing behavior for non-phone-number names is unchanged. Test coverage added.

Fixes #2641

---

To make this production-safe, the remaining work is:
- Full international phone number parsing using libphonenumber or similar
- Configurable avatar display preferences per channel type
- Consider showing a phone icon instead of initials for phone-only contacts

This is ~3-5 days.
I can own this as a short paid engagement; otherwise this PR stands on its own.