### PR TITLE
chore(ci): move linting from circle CI to github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,132 +15,6 @@ defaults: &defaults
     LOG_LEVEL: warn
 
 jobs:
-  # Separate job for linting (no parallelism needed)
-  lint:
-    <<: *defaults
-    steps:
-      - checkout
-
-      # Install minimal system dependencies for linting
-      - run:
-          name: Install System Dependencies
-          command: |
-            sudo apt-get update
-            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
-              libpq-dev \
-              build-essential \
-              git \
-              curl \
-              libssl-dev \
-              zlib1g-dev \
-              libreadline-dev \
-              libyaml-dev \
-              openjdk-11-jdk \
-              jq \
-              software-properties-common \
-              ca-certificates \
-              imagemagick \
-              libxml2-dev \
-              libxslt1-dev \
-              file \
-              g++ \
-              gcc \
-              autoconf \
-              gnupg2 \
-              patch \
-              ruby-dev \
-              liblzma-dev \
-              libgmp-dev \
-              libncurses5-dev \
-              libffi-dev \
-              libgdbm6 \
-              libgdbm-dev \
-              libvips
-
-      - run:
-          name: Install RVM and Ruby 3.4.4
-          command: |
-            sudo apt-get install -y gpg
-            gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-            \curl -sSL https://get.rvm.io | bash -s stable
-            echo 'source ~/.rvm/scripts/rvm' >> $BASH_ENV
-            source ~/.rvm/scripts/rvm
-            rvm install "3.4.4"
-            rvm use 3.4.4 --default
-            gem install bundler -v 2.5.16
-
-      - run:
-          name: Install Application Dependencies
-          command: |
-            source ~/.rvm/scripts/rvm
-            bundle install
-
-      - node/install:
-          node-version: '23.7'
-      - node/install-pnpm
-      - node/install-packages:
-          pkg-manager: pnpm
-          override-ci-command: pnpm i
-
-      # Swagger verification
-      - run:
-          name: Verify swagger API specification
-          command: |
-            bundle exec rake swagger:build
-            if [[ `git status swagger/swagger.json --porcelain` ]]
-            then
-              echo "ERROR: The swagger.json file is not in sync with the yaml specification. Run 'rake swagger:build' and commit 'swagger/swagger.json'."
-              exit 1
-            fi
-            mkdir -p ~/tmp
-            curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar > ~/tmp/openapi-generator-cli-6.3.0.jar
-            java -jar ~/tmp/openapi-generator-cli-6.3.0.jar validate -i swagger/swagger.json
-
-      # Bundle audit
-      - run:
-          name: Bundle audit
-          command: bundle exec bundle audit update && bundle exec bundle audit check -v
-
-      # Rubocop linting
-      - run:
-          name: Rubocop
-          command: bundle exec rubocop --parallel
-
-      # ESLint linting
-      - run:
-          name: eslint
-          command: pnpm run eslint
-
-  # Separate job for frontend tests
-  frontend-tests:
-    <<: *defaults
-    steps:
-      - checkout
-      - node/install:
-          node-version: '23.7'
-      - node/install-pnpm
-      - node/install-packages:
-          pkg-manager: pnpm
-          override-ci-command: pnpm i
-
-      - run:
-          name: Run frontend tests (with coverage)
-          command: pnpm run test:coverage
-
-      - run:
-          name: Move coverage files if they exist
-          command: |
-            if [ -d "coverage" ]; then
-              mkdir -p ~/build/coverage
-              cp -r coverage ~/build/coverage/frontend || true
-            fi
-          when: always
-
-      - persist_to_workspace:
-          root: ~/build
-          paths:
-            - coverage
-
   # Backend tests with parallelization
   backend-tests:
     <<: *defaults
@@ -327,18 +201,13 @@ jobs:
           paths:
             - coverage
 
-  # Collect coverage from all jobs
+  # Collect coverage from backend tests
   coverage:
     <<: *defaults
     steps:
       - checkout
       - attach_workspace:
           at: ~/build
-
-      # Qlty coverage publish
-      - qlty-orb/coverage_publish:
-          files: |
-            coverage/frontend/lcov.info
 
       - run:
           name: List coverage directory contents
@@ -361,14 +230,10 @@ workflows:
   version: 2
   build:
     jobs:
-      - lint
-      - frontend-tests
       - backend-tests
       - coverage:
           requires:
-            - frontend-tests
             - backend-tests
       - build:
           requires:
-            - lint
             - coverage

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,4 +1,4 @@
-name: Frontend Lint & Test
+name: Frontend Tests
 
 on:
   push:
@@ -18,10 +18,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      - uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
@@ -31,9 +27,6 @@ jobs:
 
       - name: Install pnpm dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Run eslint
-        run: pnpm run eslint
 
       - name: Run frontend tests with coverage
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,54 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  lint:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 23
+          cache: 'pnpm'
+
+      - name: Install pnpm dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run eslint
+        run: pnpm run eslint
+
+      - name: Verify swagger API specification
+        run: |
+          bundle exec rake swagger:build
+          if [[ `git status swagger/swagger.json --porcelain` ]]
+          then
+            echo "ERROR: The swagger.json file is not in sync with the yaml specification. Run 'rake swagger:build' and commit 'swagger/swagger.json'."
+            exit 1
+          fi
+          mkdir -p ~/tmp
+          curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar > ~/tmp/openapi-generator-cli-6.3.0.jar
+          java -jar ~/tmp/openapi-generator-cli-6.3.0.jar validate -i swagger/swagger.json
+
+      - name: Bundle audit
+        run: bundle exec bundle audit update && bundle exec bundle audit check -v
+
+      - name: Rubocop
+        run: bundle exec rubocop --parallel


### PR DESCRIPTION
This PR consolidates all linting and frontend tests into GitHub Actions, removing duplication from CircleCI. It seems like Circle CI allows running only two checks at once in a PR. That slows down the time to feedback

### Changes

**GitHub Actions**
- Created `.github/workflows/lint.yml` to run all linting checks: ESLint (frontend), Rubocop (backend), Swagger API verification, and Bundle audit
- Renamed `frontend-fe.yml` to `frontend-tests.yml` and removed duplicate ESLint step, focusing solely on frontend test execution with coverage

**CircleCI**
- Removed `lint` and `frontend-tests` jobs entirely from `.circleci/config.yml`
- Updated workflow to only run backend tests with parallelization (16 runners), followed by coverage collection
- Removed frontend coverage from qlty-orb since frontend tests no longer run in CircleCI

### Result

CircleCI now exclusively handles parallelized backend testing. GitHub Actions handles all linting and frontend tests, eliminating duplication and providing clearer separation of concerns.
