### PR TITLE
fix: use safe DOM manipulation for article heading permalinks

### DIFF
--- a/app/javascript/portal/portalHelpers.js
+++ b/app/javascript/portal/portalHelpers.js
@@ -29,7 +29,7 @@ export const getHeadingsfromTheArticle = () => {
 
     rows.push({
       slug,
-      title: element.innerText,
+      title: headingText,
       tag: element.tagName.toLowerCase(),
     });
   });

--- a/app/javascript/portal/portalHelpers.js
+++ b/app/javascript/portal/portalHelpers.js
@@ -14,10 +14,19 @@ export const getHeadingsfromTheArticle = () => {
   const rows = [];
   const articleElement = document.getElementById('cw-article-content');
   articleElement.querySelectorAll('h1, h2, h3').forEach(element => {
-    const slug = slugifyWithCounter(element.innerText);
+    const headingText = element.innerText;
+    const slug = slugifyWithCounter(headingText);
     element.id = slug;
     element.className = 'scroll-mt-24 heading';
-    element.innerHTML += `<a class="permalink text-slate-600 ml-3" href="#${slug}" title="${element.innerText}" data-turbolinks="false">#</a>`;
+
+    const permalink = document.createElement('a');
+    permalink.className = 'permalink text-slate-600 ml-3';
+    permalink.href = `#${slug}`;
+    permalink.title = headingText;
+    permalink.dataset.turbolinks = 'false';
+    permalink.textContent = '#';
+    element.appendChild(permalink);
+
     rows.push({
       slug,
       title: element.innerText,


### PR DESCRIPTION
## Summary

Fixes [CW-6300](https://linear.app/chatwoot/issue/CW-6300/advisory-stored-dom-xss-in-chatwoot-help-center-article-heading)

Uses safe DOM manipulation methods instead of string interpolation when creating permalink anchors for Help Center article headings.

## Test plan

- [ ] Verify permalink anchors still render correctly on Help Center articles
- [ ] Verify clicking permalink anchors navigates to the correct heading
- [ ] Verify Table of Contents still populates correctly