### PR TITLE
fix: prevent deserialization error on deletion

### DIFF
--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -159,8 +159,11 @@ class ActionCableListener < BaseListener
   end
 
   def contact_deleted(event)
-    contact, account = extract_contact_and_account(event)
-    broadcast(account, [account_token(account)], CONTACT_DELETED, contact.push_event_data)
+    contact_data = event.data[:contact_data]
+    account = Account.find_by(id: contact_data[:account_id])
+    return if account.blank?
+
+    broadcast(account, [account_token(account)], CONTACT_DELETED, contact_data)
   end
 
   def conversation_mentioned(event)

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -179,11 +179,7 @@ class Contact < ApplicationRecord
   end
 
   def self.resolved_contacts(use_crm_v2: false)
-    if use_crm_v2
-      where(contact_type: 'lead')
-    else
-      where("contacts.email <> '' OR contacts.phone_number <> '' OR contacts.identifier <> ''")
-    end
+    use_crm_v2 ? where(contact_type: 'lead') : where("contacts.email <> '' OR contacts.phone_number <> '' OR contacts.identifier <> ''")
   end
 
   def discard_invalid_attrs
@@ -243,7 +239,13 @@ class Contact < ApplicationRecord
   end
 
   def dispatch_destroy_event
-    Rails.configuration.dispatcher.dispatch(CONTACT_DELETED, Time.zone.now, contact: self)
+    # Pass serialized data instead of ActiveRecord object to avoid DeserializationError
+    # when the async EventDispatcherJob runs after the contact has been deleted
+    Rails.configuration.dispatcher.dispatch(
+      CONTACT_DELETED,
+      Time.zone.now,
+      contact_data: push_event_data.merge(account_id: account_id)
+    )
   end
 end
 Contact.include_mod_with('Concerns::Contact')

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -179,7 +179,9 @@ class Contact < ApplicationRecord
   end
 
   def self.resolved_contacts(use_crm_v2: false)
-    use_crm_v2 ? where(contact_type: 'lead') : where("contacts.email <> '' OR contacts.phone_number <> '' OR contacts.identifier <> ''")
+    return where(contact_type: 'lead') if use_crm_v2
+
+    where("contacts.email <> '' OR contacts.phone_number <> '' OR contacts.identifier <> ''")
   end
 
   def discard_invalid_attrs

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -117,13 +117,14 @@ describe ActionCableListener do
   describe '#contact_deleted' do
     let(:event_name) { :'contact.deleted' }
     let!(:contact) { create(:contact, account: account) }
-    let!(:event) { Events::Base.new(event_name, Time.zone.now, contact: contact) }
+    let(:contact_data) { contact.push_event_data.merge(account_id: contact.account_id) }
+    let!(:event) { Events::Base.new(event_name, Time.zone.now, contact_data: contact_data) }
 
     it 'sends message to account admins, inbox agents' do
       expect(ActionCableBroadcastJob).to receive(:perform_later).with(
         ["account_#{account.id}"],
         'contact.deleted',
-        contact.push_event_data.merge(account_id: account.id)
+        contact_data
       )
       listener.contact_deleted(event)
     end


### PR DESCRIPTION
## Fixes
Prevent deserialization error on deletion
<img width="1512" height="766" alt="Screenshot 2026-01-13 at 5 01 47 PM" src="https://github.com/user-attachments/assets/0dc8ffc2-47ad-4f4f-a8d3-b5ec25d70b10" />

## Description

Pass serialized data instead of ActiveRecord object in dispatch_destroy_event to prevent ActiveJob::DeserializationError when the contact is already deleted.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Unit test cases

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents `ActiveJob::DeserializationError` when contacts are deleted before async jobs run.
> 
> - Change `Contact#dispatch_destroy_event` to dispatch `CONTACT_DELETED` with serialized `contact_data` (includes `account_id`) instead of the AR object
> - Update `ActionCableListener#contact_deleted` to consume `contact_data`, lookup `account`, and broadcast the serialized payload
> - Adjust specs to pass/assert `contact_data` for contact deletion
> - Minor refactor in `Contact.resolved_contacts` to early-return for CRM v2
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcb9b70e35779cdb4e89871d4007a101f655fe68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->