### PR TITLE
fix: Case-insensitive language matching for WhatsApp template messages

### DIFF
--- a/app/services/whatsapp/template_processor_service.rb
+++ b/app/services/whatsapp/template_processor_service.rb
@@ -20,7 +20,9 @@ class Whatsapp::TemplateProcessorService
 
   def find_template
     channel.message_templates.find do |t|
-      t['name'] == template_params['name'] && t['language'] == template_params['language'] && t['status']&.downcase == 'approved'
+      t['name'] == template_params['name'] &&
+        t['language']&.downcase == template_params['language']&.downcase &&
+        t['status']&.downcase == 'approved'
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/chatwoot/chatwoot/issues/13257
When sending WhatsApp template messages via API with `processed_params`, users receiving error `(#132000) Number of parameters does not match the expected number of params` from WhatsApp. The find template method performed case-sensitive string comparison on language codes. If a user sent `language: "ES"` but the template was stored as `language: "es"`, the template wouldn't be found, resulting in empty `components: []` being sent to WhatsApp.
