### PR TITLE
fix: TypeError: can't access property "emitsOptions", r is null

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
@@ -234,8 +234,7 @@ onMounted(() => {
       />
       <div
         ref="notificationList"
-        class="flex flex-col gap-0.5 w-full h-[calc(100%-56px)] pb-4 overflow-x-hidden px-2 divide-y divide-n-weak [&>*:hover]:!border-y-transparent [&>*.active]:!border-y-transparent [&>*:hover+*]:!border-t-transparent [&>*.active+*]:!border-t-transparent"
-        :class="isInboxContextMenuOpen ? 'overflow-hidden' : 'overflow-y-auto'"
+        class="flex flex-col gap-0.5 w-full h-[calc(100%-56px)] pb-4 overflow-x-hidden px-2 overflow-y-auto divide-y divide-n-weak [&>*:hover]:!border-y-transparent [&>*.active]:!border-y-transparent [&>*:hover+*]:!border-t-transparent [&>*.active+*]:!border-t-transparent"
       >
         <InboxCard
           v-for="notificationItem in notifications"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes a Sentry error: **`TypeError: can't access property "emitsOptions", r is null`** originating from the Vue runtime core.

### Cause

The issue was caused by a race condition triggered by an **event storm**. When multiple `InboxCard` components mounted at the same time (for example, during inbox navigation), each card executed `onBeforeMount(contextMenuActions.close)`, which emitted a `contextMenuClose` event.
This resulted in a burst of simultaneous events, causing Vue to process updates on components that were not yet fully initialized, eventually leading to null component instances when accessing `emitsOptions`.

### Solution

Updated `onBeforeMount` to reset the local context menu state directly (`isContextMenuOpen.value = false`) instead of emitting the `contextMenuClose` event.
This avoids the event storm during initialization while preserving the intended behavior and state consistency.

### Reproducibility

I wasn’t able to reproduce this issue locally. Hopefully, this fix resolves the problem.



Fixes https://linear.app/chatwoot/issue/CW-6330/typeerror-cant-access-property-emitsoptions-r-is-null

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
