### PR TITLE
fix: sanitize integer fields to prevent Elasticsearch mapping errors

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -39,7 +39,21 @@
 #
 
 class Message < ApplicationRecord
-  searchkick callbacks: false if ChatwootApp.advanced_search_allowed?
+  # Use merge_mappings to keep Searchkick defaults while adding custom field types
+  # campaign_id needs keyword type to support both integer (internal campaigns) and string (API channels) values
+  if ChatwootApp.advanced_search_allowed?
+    searchkick callbacks: false,
+               merge_mappings: true,
+               mappings: {
+                 properties: {
+                   additional_attributes: {
+                     properties: {
+                       campaign_id: { type: 'keyword' }
+                     }
+                   }
+                 }
+               }
+  end
 
   include MessageFilterHelpers
   include Liquidable

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -39,21 +39,7 @@
 #
 
 class Message < ApplicationRecord
-  # Use merge_mappings to keep Searchkick defaults while adding custom field types
-  # campaign_id needs keyword type to support both integer (internal campaigns) and string (API channels) values
-  if ChatwootApp.advanced_search_allowed?
-    searchkick callbacks: false,
-               merge_mappings: true,
-               mappings: {
-                 properties: {
-                   additional_attributes: {
-                     properties: {
-                       campaign_id: { type: 'keyword' }
-                     }
-                   }
-                 }
-               }
-  end
+  searchkick callbacks: false if ChatwootApp.advanced_search_allowed?
 
   include MessageFilterHelpers
   include Liquidable

--- a/app/presenters/messages/search_data_presenter.rb
+++ b/app/presenters/messages/search_data_presenter.rb
@@ -51,7 +51,6 @@ class Messages::SearchDataPresenter < SimpleDelegator
 
   def additional_attributes_data
     {
-      campaign_id: additional_attributes&.dig('campaign_id'),
       automation_rule_id: content_attributes&.dig('automation_rule_id')
     }
   end

--- a/spec/presenters/messages/search_data_presenter_spec.rb
+++ b/spec/presenters/messages/search_data_presenter_spec.rb
@@ -61,13 +61,8 @@ RSpec.describe Messages::SearchDataPresenter do
     context 'with campaign and automation data' do
       before do
         message.update(
-          additional_attributes: { 'campaign_id' => '123' },
           content_attributes: { 'automation_rule_id' => '456' }
         )
-      end
-
-      it 'includes campaign_id' do
-        expect(presenter.search_data[:additional_attributes][:campaign_id]).to eq('123')
       end
 
       it 'includes automation_rule_id' do


### PR DESCRIPTION
## Linear task:
https://linear.app/chatwoot/issue/CW-6318/searchkickimporterror-type-=-mapper-parsing-exception-reason-=-failed

## Description

Fixes Elasticsearch `mapper_parsing_exception` errors that occur when `campaign_id` contain non-numeric string values 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Unit tests
- use a local OpenSearch 3.4.0 cluster to verify actual indexing behavior.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `campaign_id` from the message search index payload to simplify `additional_attributes`, keeping only `automation_rule_id`.
> 
> - `Messages::SearchDataPresenter#additional_attributes_data` now returns only `automation_rule_id`
> - Specs updated to stop asserting `campaign_id` and continue validating `automation_rule_id` and email subject handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a9c8eb794a044e3f258b644f67a6731de9e904c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->