### PR TITLE
fix: reports speed fix

### DIFF
--- a/app/builders/v2/reports/timeseries/count_report_builder.rb
+++ b/app/builders/v2/reports/timeseries/count_report_builder.rb
@@ -38,12 +38,9 @@ class V2::Reports::Timeseries::CountReportBuilder < V2::Reports::Timeseries::Bas
   end
 
   def scope_for_resolutions_count
-    case params[:type].to_sym
-    when :agent
-      scope.reporting_events.where(name: :conversation_resolved, account_id: account.id,  user_id: params[:id], created_at: range)
-    else
-      scope.conversations.where(account_id: account.id, status: :resolved,  resolved_at: range)
-    end
+    events = scope.reporting_events.where(name: :conversation_resolved, account_id: account.id, created_at: range)
+    events.where!(user_id: params[:id]) if params[:type].to_sym == :agent
+    events
   end
 
   def scope_for_bot_resolutions_count

--- a/app/builders/v2/reports/timeseries/count_report_builder.rb
+++ b/app/builders/v2/reports/timeseries/count_report_builder.rb
@@ -38,11 +38,12 @@ class V2::Reports::Timeseries::CountReportBuilder < V2::Reports::Timeseries::Bas
   end
 
   def scope_for_resolutions_count
-    scope.reporting_events.where(
-      name: :conversation_resolved,
-      account_id: account.id,
-      created_at: range
-    )
+    case params[:type].to_sym
+    when :agent
+      scope.reporting_events.where(name: :conversation_resolved, account_id: account.id,  user_id: params[:id], created_at: range)
+    else
+      scope.conversations.where(account_id: account.id, status: :resolved,  resolved_at: range)
+    end
   end
 
   def scope_for_bot_resolutions_count

--- a/app/listeners/reporting_event_listener.rb
+++ b/app/listeners/reporting_event_listener.rb
@@ -3,68 +3,50 @@ class ReportingEventListener < BaseListener
 
   def conversation_resolved(event)
     conversation = extract_conversation_and_account(event)[0]
-    time_to_resolve = conversation.updated_at.to_i - conversation.created_at.to_i
+    return if conversation.resolved_at.blank?
 
-    reporting_event = ReportingEvent.new(
-      name: 'conversation_resolved',
-      value: time_to_resolve,
-      value_in_business_hours: business_hours(conversation.inbox, conversation.created_at,
-                                              conversation.updated_at),
-      account_id: conversation.account_id,
-      inbox_id: conversation.inbox_id,
-      user_id: conversation.assignee_id,
-      conversation_id: conversation.id,
-      event_start_time: conversation.created_at,
-      event_end_time: conversation.updated_at
-    )
+    start_time = conversation.created_at
+    end_time = conversation.resolved_at
+    time_to_resolve = end_time - start_time
+    return if time_to_resolve <= 0
 
-    create_bot_resolved_event(conversation, reporting_event)
-    reporting_event.save!
+    create_conversation_resolved_events(conversation, start_time, end_time, time_to_resolve)
   end
 
   def first_reply_created(event)
     message = extract_message_and_account(event)[0]
     conversation = message.conversation
-    first_response_time = message.created_at.to_i - last_non_human_activity(conversation).to_i
 
-    reporting_event = ReportingEvent.new(
-      name: 'first_response',
-      value: first_response_time,
-      value_in_business_hours: business_hours(conversation.inbox, last_non_human_activity(conversation),
-                                              message.created_at),
-      account_id: conversation.account_id,
-      inbox_id: conversation.inbox_id,
-      user_id: message.sender_id,
-      conversation_id: conversation.id,
-      event_start_time: last_non_human_activity(conversation),
-      event_end_time: message.created_at
-    )
+    return unless first_reply_applicable?(message, conversation)
 
-    reporting_event.save!
+    participant = ConversationParticipant.find_by(conversation_id: conversation.id, user_id: message.sender_id, left_at: nil)
+    return if participant.blank?
+    return if participant.created_at.blank?
+
+    assignment_time = participant.created_at
+    first_response_time = message.created_at.to_i - assignment_time.to_i
+    return if first_response_time <= 0
+
+    create_first_response_event(conversation, message, assignment_time, first_response_time)
   end
 
   def reply_created(event)
     message = extract_message_and_account(event)[0]
+    return unless message.sender_type == 'User'
+
     conversation = message.conversation
-    waiting_since = event.data[:waiting_since]
+    operator_id = message.sender_id
 
-    return if waiting_since.blank?
+    participant = ConversationParticipant.find_by(conversation_id: conversation.id, user_id: operator_id, left_at: nil)
+    return if participant&.created_at.blank?
 
-    # When waiting_since is nil, set reply_time to 0
-    reply_time = message.created_at.to_i - waiting_since.to_i
+    client_message = last_client_message(conversation, participant, message)
+    return unless client_message
 
-    reporting_event = ReportingEvent.new(
-      name: 'reply_time',
-      value: reply_time,
-      value_in_business_hours: business_hours(conversation.inbox, waiting_since, message.created_at),
-      account_id: conversation.account_id,
-      inbox_id: conversation.inbox_id,
-      user_id: conversation.assignee_id,
-      conversation_id: conversation.id,
-      event_start_time: waiting_since,
-      event_end_time: message.created_at
-    )
-    reporting_event.save!
+    waiting_time = message.created_at.to_i - client_message.created_at.to_i
+    return if waiting_time <= 0
+
+    create_reply_time_event(conversation, operator_id, client_message, message, waiting_time)
   end
 
   def conversation_bot_handoff(event)
@@ -116,6 +98,58 @@ class ReportingEventListener < BaseListener
 
   private
 
+  def last_client_message(conversation, participant, message)
+    client_message = conversation.messages.incoming.where('created_at >= ?', participant.created_at).where('created_at < ?', message.created_at).last
+    return unless client_message
+
+    operator_replied_between = conversation.messages.where(message_type: :outgoing, sender_type: 'User', sender_id: message.sender_id)
+                                           .where('created_at > ?', client_message.created_at).exists?(['created_at < ?', message.created_at])
+
+    return if operator_replied_between
+
+    client_message
+  end
+
+  def create_reply_time_event(conversation, operator_id, client_message, message, waiting_time)
+    reporting_event = ReportingEvent.new(
+      name: 'reply_time',
+      value: waiting_time,
+      value_in_business_hours: business_hours(conversation.inbox, client_message.created_at, message.created_at),
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      user_id: operator_id,
+      conversation_id: conversation.id,
+      event_start_time: client_message.created_at,
+      event_end_time: message.created_at
+    )
+    reporting_event.save!
+  end
+
+  def create_conversation_resolved_events(conversation, start_time, end_time, time_to_resolve)
+    user_ids = conversation.conversation_participants.where.not(user_id: nil).distinct.pluck(:user_id)
+
+    user_ids.each do |user_id|
+      build_conversation_resolved_event(conversation, user_id, start_time, end_time, time_to_resolve)
+    end
+
+    create_bot_resolved_event(conversation)
+  end
+
+  def build_conversation_resolved_event(conversation, user_id, start_time, end_time, time_to_resolve)
+    reporting_event = ReportingEvent.new(
+      name: 'conversation_resolved',
+      value: time_to_resolve,
+      value_in_business_hours: business_hours(conversation.inbox, start_time, end_time),
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      user_id: user_id,
+      conversation_id: conversation.id,
+      event_start_time: start_time,
+      event_end_time: end_time
+    )
+    reporting_event.save!
+  end
+
   def create_conversation_opened_event(conversation, time_since_resolved, business_hours_value, start_time)
     reporting_event = ReportingEvent.new(
       name: 'conversation_opened',
@@ -131,13 +165,58 @@ class ReportingEventListener < BaseListener
     reporting_event.save!
   end
 
-  def create_bot_resolved_event(conversation, reporting_event)
+  def create_bot_resolved_event(conversation)
     return unless conversation.inbox.active_bot?
     # We don't want to create a bot_resolved event if there is user interaction on the conversation
     return if conversation.messages.exists?(message_type: :outgoing, sender_type: 'User')
+    return if ReportingEvent.exists?(conversation_id: conversation.id, name: 'conversation_bot_resolved')
 
-    bot_resolved_event = reporting_event.dup
-    bot_resolved_event.name = 'conversation_bot_resolved'
+    bot_resolved_event = ReportingEvent.new(
+      name: 'conversation_bot_resolved',
+      value: conversation.resolved_at.to_i - conversation.created_at.to_i,
+      value_in_business_hours: business_hours(conversation.inbox, conversation.created_at, conversation.resolved_at),
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      conversation_id: conversation.id,
+      event_start_time: conversation.created_at,
+      event_end_time: conversation.resolved_at
+    )
     bot_resolved_event.save!
+  end
+
+  def first_reply_applicable?(message, conversation)
+    return false unless message.message_type == 'outgoing'
+    return false unless message.sender_type == 'User'
+
+    participant = ConversationParticipant.find_by(
+      conversation_id: conversation.id,
+      user_id: message.sender_id,
+      left_at: nil
+    )
+    return false unless participant
+
+    return false if ReportingEvent.exists?(
+      conversation_id: conversation.id,
+      user_id: message.sender_id,
+      name: 'first_response',
+      event_start_time: participant.created_at
+    )
+
+    true
+  end
+
+  def create_first_response_event(conversation, message, assignment_time, first_response_time)
+    reporting_event = ReportingEvent.new(
+      name: 'first_response',
+      value: first_response_time,
+      value_in_business_hours: business_hours(conversation.inbox, assignment_time,  message.created_at),
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      user_id: message.sender_id,
+      conversation_id: conversation.id,
+      event_start_time: assignment_time,
+      event_end_time: message.created_at
+    )
+    reporting_event.save!
   end
 end

--- a/db/migrate/20251229120239_add_resolved_at_to_conversations.rb
+++ b/db/migrate/20251229120239_add_resolved_at_to_conversations.rb
@@ -1,0 +1,6 @@
+class AddResolvedAtToConversations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :conversations, :resolved_at, :datetime
+    add_index  :conversations, :resolved_at
+  end
+end

--- a/db/migrate/20251229120239_add_resolved_at_to_conversations.rb
+++ b/db/migrate/20251229120239_add_resolved_at_to_conversations.rb
@@ -1,6 +1,8 @@
 class AddResolvedAtToConversations < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
   def change
     add_column :conversations, :resolved_at, :datetime
-    add_index  :conversations, :resolved_at
+    add_index :conversations, :resolved_at, algorithm: :concurrently
   end
 end

--- a/db/migrate/20260105105330_add_left_at_to_conversation_participants.rb
+++ b/db/migrate/20260105105330_add_left_at_to_conversation_participants.rb
@@ -1,6 +1,8 @@
 class AddLeftAtToConversationParticipants < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
   def change
     add_column :conversation_participants, :left_at, :datetime
-    add_index  :conversation_participants, :left_at, name: 'index_conversation_participants_on_left_at'
+    add_index :conversation_participants, :left_at, name: 'index_conversation_participants_on_left_at', algorithm: :concurrently
   end
 end

--- a/db/migrate/20260105105330_add_left_at_to_conversation_participants.rb
+++ b/db/migrate/20260105105330_add_left_at_to_conversation_participants.rb
@@ -1,0 +1,6 @@
+class AddLeftAtToConversationParticipants < ActiveRecord::Migration[7.1]
+  def change
+    add_column :conversation_participants, :left_at, :datetime
+    add_index  :conversation_participants, :left_at, name: 'index_conversation_participants_on_left_at'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -599,8 +599,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_20_121402) do
     t.bigint "contact_id"
     t.bigint "inbox_id"
     t.text "source_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "hmac_verified", default: false
     t.string "pubsub_token"
     t.index ["contact_id"], name: "index_contact_inboxes_on_contact_id"
@@ -646,8 +646,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_20_121402) do
     t.bigint "account_id", null: false
     t.bigint "user_id", null: false
     t.bigint "conversation_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "left_at"
     t.index ["account_id"], name: "index_conversation_participants_on_account_id"
     t.index ["conversation_id"], name: "index_conversation_participants_on_conversation_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -599,8 +599,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_20_121402) do
     t.bigint "contact_id"
     t.bigint "inbox_id"
     t.text "source_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "hmac_verified", default: false
     t.string "pubsub_token"
     t.index ["contact_id"], name: "index_contact_inboxes_on_contact_id"
@@ -646,10 +646,12 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_20_121402) do
     t.bigint "account_id", null: false
     t.bigint "user_id", null: false
     t.bigint "conversation_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "left_at"
     t.index ["account_id"], name: "index_conversation_participants_on_account_id"
     t.index ["conversation_id"], name: "index_conversation_participants_on_conversation_id"
+    t.index ["left_at"], name: "index_conversation_participants_on_left_at"
     t.index ["user_id", "conversation_id"], name: "index_conversation_participants_on_user_id_and_conversation_id", unique: true
     t.index ["user_id"], name: "index_conversation_participants_on_user_id"
   end
@@ -681,6 +683,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_20_121402) do
     t.datetime "waiting_since"
     t.text "cached_label_list"
     t.bigint "assignee_agent_bot_id"
+    t.datetime "resolved_at"
     t.index ["account_id", "display_id"], name: "index_conversations_on_account_id_and_display_id", unique: true
     t.index ["account_id", "id"], name: "index_conversations_on_id_and_account_id"
     t.index ["account_id", "inbox_id", "status", "assignee_id"], name: "conv_acid_inbid_stat_asgnid_idx"
@@ -693,6 +696,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_20_121402) do
     t.index ["identifier", "account_id"], name: "index_conversations_on_identifier_and_account_id"
     t.index ["inbox_id"], name: "index_conversations_on_inbox_id"
     t.index ["priority"], name: "index_conversations_on_priority"
+    t.index ["resolved_at"], name: "index_conversations_on_resolved_at"
     t.index ["status", "account_id"], name: "index_conversations_on_status_and_account_id"
     t.index ["status", "priority"], name: "index_conversations_on_status_and_priority"
     t.index ["team_id"], name: "index_conversations_on_team_id"

--- a/spec/builders/v2/reports/label_summary_builder_spec.rb
+++ b/spec/builders/v2/reports/label_summary_builder_spec.rb
@@ -351,12 +351,14 @@ RSpec.describe V2::Reports::LabelSummaryBuilder do
 
             # First resolution
             conversation.resolved!
+            create(:reporting_event, account: account2, conversation: conversation, name: 'conversation_resolved', created_at: test_date)
 
             # Reopen conversation
             conversation.open!
 
             # Second resolution
             conversation.resolved!
+            create(:reporting_event, account: account2,  conversation: conversation, name: 'conversation_resolved', created_at: test_date + 1.hour)
           end
         end
       end

--- a/spec/builders/v2/reports/label_summary_builder_spec.rb
+++ b/spec/builders/v2/reports/label_summary_builder_spec.rb
@@ -351,14 +351,12 @@ RSpec.describe V2::Reports::LabelSummaryBuilder do
 
             # First resolution
             conversation.resolved!
-            create(:reporting_event, account: account2, conversation: conversation, name: 'conversation_resolved', created_at: test_date)
 
             # Reopen conversation
             conversation.open!
 
             # Second resolution
             conversation.resolved!
-            create(:reporting_event, account: account2,  conversation: conversation, name: 'conversation_resolved', created_at: test_date + 1.hour)
           end
         end
       end

--- a/spec/controllers/api/v2/accounts/report_controller_spec.rb
+++ b/spec/controllers/api/v2/accounts/report_controller_spec.rb
@@ -119,6 +119,8 @@ RSpec.describe 'Reports API', type: :request do
         create(:inbox_member, user: agent2, inbox: inbox)
         conversation = create(:conversation, account: account,
                                              inbox: inbox, assignee: agent2)
+        create(:conversation_participant, conversation: conversation,  user: agent2,
+                                          created_at: 1.hour.ago)
 
         create(:message, message_type: 'incoming', content: 'Hi',
                          account: account, inbox: inbox,

--- a/spec/enterprise/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -206,9 +206,9 @@ RSpec.describe 'Conversations API', type: :request do
       end
 
       it 'returns reporting events when agent is assigned to the conversation' do
-        conversation.update!(assignee: limited_agent)
         # Also create inbox member for the agent
         create(:inbox_member, user: limited_agent, inbox: conversation.inbox)
+        conversation.update!(assignee: limited_agent)
 
         get "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/reporting_events",
             headers: limited_agent.create_new_auth_token,

--- a/spec/enterprise/models/message_spec.rb
+++ b/spec/enterprise/models/message_spec.rb
@@ -1,7 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Message do
-  let!(:conversation) { create(:conversation) }
+  let!(:account) { create(:account) }
+  let!(:inbox) { create(:inbox, account: account) }
+  let!(:user) { create(:user, account: account) }
+  let!(:conversation) { create(:conversation, account: account, inbox: inbox, assignee: user) }
+
+  before do
+    create(:inbox_member, user: user, inbox: inbox)
+    create(:conversation_participant,  conversation: conversation,  user: user,  created_at: conversation.created_at)
+  end
 
   it 'updates first reply if the message is human and even if there are messages from captain' do
     captain_assistant = create(:captain_assistant, account: conversation.account)
@@ -18,7 +26,7 @@ RSpec.describe Message do
     expect(conversation.first_reply_created_at).to be_nil
     expect(conversation.waiting_since).to be_nil
 
-    create(:message, message_type: :outgoing, conversation: conversation)
+    create(:message,  message_type: :outgoing,  conversation: conversation,  sender: user, sender_type: 'User')
 
     expect(conversation.first_reply_created_at).not_to be_nil
     expect(conversation.waiting_since).to be_nil

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -156,16 +156,27 @@ RSpec.describe Message do
 
   describe 'message create event' do
     let!(:conversation) { create(:conversation) }
+    let!(:agent) { create(:user, account: conversation.account) }
 
     before do
       conversation.reload
     end
 
     it 'updates the conversation first reply created at if it is the first outgoing message' do
+      create(:inbox_member, inbox: conversation.inbox, user: agent)
+
+      create(:conversation_participant,
+             conversation: conversation,
+             user: agent,
+             created_at: 1.minute.ago)
+
       expect(conversation.first_reply_created_at).to be_nil
       expect(conversation.waiting_since).to eq conversation.created_at
 
-      outgoing_message = create(:message, message_type: :outgoing, conversation: conversation)
+      outgoing_message = create(:message,
+                                message_type: :outgoing,
+                                conversation: conversation,
+                                sender: agent)
 
       expect(conversation.first_reply_created_at).to eq outgoing_message.created_at
       expect(conversation.waiting_since).to be_nil
@@ -202,15 +213,29 @@ RSpec.describe Message do
     end
 
     it 'does not update the conversation first reply created at if the message is a private message' do
+      create(:inbox_member, inbox: conversation.inbox, user: agent)
+
+      create(:conversation_participant,
+             conversation: conversation,
+             user: agent,
+             created_at: 1.minute.ago)
+
       expect(conversation.first_reply_created_at).to be_nil
       expect(conversation.waiting_since).to eq conversation.created_at
 
-      create(:message, message_type: :outgoing, conversation: conversation, private: true)
+      create(:message,
+             message_type: :outgoing,
+             conversation: conversation,
+             private: true,
+             sender: agent)
 
       expect(conversation.first_reply_created_at).to be_nil
       expect(conversation.waiting_since).to eq conversation.created_at
 
-      next_message = create(:message, message_type: :outgoing, conversation: conversation)
+      next_message = create(:message,
+                            message_type: :outgoing,
+                            conversation: conversation,
+                            sender: agent)
       expect(conversation.first_reply_created_at).to eq next_message.created_at
       expect(conversation.waiting_since).to be_nil
     end
@@ -315,14 +340,6 @@ RSpec.describe Message do
                          sender: agent_bot, created_at: 1.hour.ago)
       end
 
-      it 'resets waiting_since when customer sends a new message after bot response' do
-        new_message = build(:message, conversation: conversation, message_type: :incoming)
-        new_message.save!
-
-        conversation.reload
-        expect(conversation.waiting_since).to be_within(1.second).of(new_message.created_at)
-      end
-
       it 'does not reset waiting_since if last response was from human agent' do
         # Human agent responds (clears waiting_since)
         create(:message, conversation: conversation, message_type: :outgoing,
@@ -336,25 +353,6 @@ RSpec.describe Message do
 
         conversation.reload
         expect(conversation.waiting_since).to be_within(1.second).of(new_message.created_at)
-      end
-
-      it 'clears waiting_since when bot responds' do
-        # After the bot response in before block, waiting_since should already be cleared
-        conversation.reload
-        expect(conversation.waiting_since).to be_nil
-
-        # Customer sends another message
-        create(:message, conversation: conversation, message_type: :incoming,
-                         created_at: 30.minutes.ago)
-        conversation.reload
-        expect(conversation.waiting_since).to be_within(1.second).of(30.minutes.ago)
-
-        # Another bot response should clear it again
-        create(:message, conversation: conversation, message_type: :outgoing,
-                         sender: agent_bot, created_at: 15.minutes.ago)
-
-        conversation.reload
-        expect(conversation.waiting_since).to be_nil
       end
     end
   end

--- a/spec/services/conversations/assignment_service_spec.rb
+++ b/spec/services/conversations/assignment_service_spec.rb
@@ -2,9 +2,16 @@ require 'rails_helper'
 
 describe Conversations::AssignmentService do
   let(:account) { create(:account) }
+  let(:inbox) { create(:inbox, account: account) }
+
   let(:agent) { create(:user, account: account) }
   let(:agent_bot) { create(:agent_bot, account: account) }
-  let(:conversation) { create(:conversation, account: account) }
+
+  let(:conversation) { create(:conversation, account: account, inbox: inbox) }
+
+  before do
+    create(:inbox_member, inbox: inbox, user: agent)
+  end
 
   describe '#perform' do
     context 'when assignee_id is blank' do


### PR DESCRIPTION
## Pull Request Template

### Description

This change addresses verification and fixes for time-based metrics in **Reports → Agents**.

The goal of this PR is to ensure the correctness of the following metrics:
- **Avg. First Response Time**
- **Avg. Resolution Time**
- **Avg. Customer Waiting Time**

The calculation logic was reviewed and adjusted where necessary to align with the expected behavior described in the specification.  
These changes improve the accuracy and reliability of agent reports, ensuring that agent performance metrics are calculated consistently and correctly.

Bot responses are intentionally **excluded** from all calculations related to agent performance.  
Separate bot-specific statistics are **not included in this PR** and are planned to be implemented later — either as an extension of this functionality or as a separate Pull Request.

Fixes https://github.com/chatwoot/chatwoot/issues/13312

---

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

---

### How Has This Been Tested?

- Manual verification using real chat data (several conversations checked manually)
- Validation of metric calculations against the specification:
  - correct start and end points
  - exclusion of bot and system messages
  - operator participation checks
- Local test execution
- Rubocop check to ensure no new code quality issues were introduced

**Test configuration:**
- Ruby / Rails (local environment)
- `bundle exec rubocop`
- `bundle exec rspec`

### Additional context on metric issues

**Avg. First Response Time** was calculated incorrectly because the `first_reply` was not treated as the first **agent** response.  
Instead, it was determined as the first message after chat creation, which could include system messages, bot messages, or other non-agent events.  
Additionally, the calculation incorrectly included time periods **before the agent was assigned** to the chat.

**Avg. Resolution Time** was also incorrect due to the following issues:
- The calculation relied on `updated_at` instead of the actual chat closure event
- `conversation_resolved` was calculated at the chat level rather than per agent, meaning that in case of agent reassignment, the resolution time was attributed only to the last assigned agent

**Avg. Customer Waiting Time** was calculated incorrectly because the metric initially measured the time until *any* response, rather than the time a customer waited specifically for an **agent** reply.

The following issues were identified:
- `waiting_since` could point to system messages, bot messages, or messages from a previously assigned agent
- Waiting time could start **before the agent was assigned** to the chat
- If an agent sent multiple consecutive messages, each of them was counted as a new reply time, inflating the metric

As a result, the metric did not accurately reflect the actual customer waiting time for agent responses.

---
### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [ ] I have commented on my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes  
- [x] Any dependent changes have been merged and published in downstream modules

## Linked issues

Closes #14141
