### PR TITLE
fix: Validate status and priority params in search conversations tool

### DIFF
--- a/spec/enterprise/services/captain/tools/copilot/search_conversations_service_spec.rb
+++ b/spec/enterprise/services/captain/tools/copilot/search_conversations_service_spec.rb
@@ -119,5 +119,42 @@ RSpec.describe Captain::Tools::Copilot::SearchConversationsService do
       result = service.execute(status: 'snoozed')
       expect(result).to eq('No conversations found')
     end
+
+    context 'when invalid status is provided' do
+      it 'ignores invalid status and returns all conversations' do
+        result = service.execute(status: 'all')
+        expect(result).to include('Total number of conversations: 2')
+        expect(result).to include(open_conversation.to_llm_text(include_contact_details: true))
+        expect(result).to include(resolved_conversation.to_llm_text(include_contact_details: true))
+      end
+
+      it 'ignores random invalid status values' do
+        result = service.execute(status: 'invalid_status')
+        expect(result).to include('Total number of conversations: 2')
+      end
+    end
+
+    context 'when invalid priority is provided' do
+      it 'ignores invalid priority and returns all conversations' do
+        result = service.execute(priority: 'all')
+        expect(result).to include('Total number of conversations: 2')
+        expect(result).to include(open_conversation.to_llm_text(include_contact_details: true))
+        expect(result).to include(resolved_conversation.to_llm_text(include_contact_details: true))
+      end
+
+      it 'ignores random invalid priority values' do
+        result = service.execute(priority: 'invalid_priority')
+        expect(result).to include('Total number of conversations: 2')
+      end
+    end
+
+    context 'when combining valid and invalid parameters' do
+      it 'applies valid filters and ignores invalid ones' do
+        result = service.execute(status: 'all', contact_id: contact.id)
+        expect(result).to include('Total number of conversations: 1')
+        expect(result).to include(open_conversation.to_llm_text(include_contact_details: true))
+        expect(result).not_to include(resolved_conversation.to_llm_text(include_contact_details: true))
+      end
+    end
   end
 end


### PR DESCRIPTION

When the LLM passes invalid values like "all" for status or priority, the search would return no results because these are not valid enum values. This fix:

- Adds validation to ignore invalid status/priority values
- Updates param descriptions to list valid enum values
- Adds specs for invalid parameter handling
