### PR TITLE
fix: guard against nil contact in conversation jbuilder partial

### DIFF
--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -160,6 +160,9 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
 
   def conversation
     @conversation ||= Current.account.conversations.find_by!(display_id: params[:id])
+    # Return 404 if conversation has no valid contact or contact_inbox
+    raise ActiveRecord::RecordNotFound if @conversation.contact.blank?
+
     authorize @conversation, :show?
   end
 

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -63,6 +63,7 @@ class ConversationFinder
     set_assignee_type
 
     find_all_conversations
+    filter_orphan_conversations
     filter_by_status unless params[:q]
     filter_by_team
     filter_by_labels
@@ -164,6 +165,12 @@ class ConversationFinder
 
     @conversations = @conversations.joins(:contact_inbox)
     @conversations = @conversations.where(contact_inboxes: { source_id: params[:source_id] })
+  end
+
+  def filter_orphan_conversations
+    # Filter out conversations where the contact has been deleted
+    # Using INNER JOIN is most efficient - only returns conversations with existing contacts
+    @conversations = @conversations.joins(:contact)
   end
 
   def set_count_for_all_conversations

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -3,12 +3,8 @@
 # Everywhere else we use conversation builder in partials folder
 
 json.meta do
-  if conversation.contact
-    json.sender do
-      json.partial! 'api/v1/models/contact', formats: [:json], resource: conversation.contact
-    end
-  else
-    json.sender nil
+  json.sender do
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: conversation.contact
   end
   json.channel conversation.inbox.try(:channel_type)
   if conversation.assigned_entity.is_a?(AgentBot)

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -3,8 +3,12 @@
 # Everywhere else we use conversation builder in partials folder
 
 json.meta do
-  json.sender do
-    json.partial! 'api/v1/models/contact', formats: [:json], resource: conversation.contact
+  if conversation.contact
+    json.sender do
+      json.partial! 'api/v1/models/contact', formats: [:json], resource: conversation.contact
+    end
+  else
+    json.sender nil
   end
   json.channel conversation.inbox.try(:channel_type)
   if conversation.assigned_entity.is_a?(AgentBot)


### PR DESCRIPTION
## Linear ticker 
- https://linear.app/chatwoot/issue/CW-6322/actionviewtemplateerror-undefined-method-additional-attributes-for-nil

## Description

Fixes a crash when rendering conversations where the associated contact is nil. The API endpoint /api/v1/accounts/{account_id}/conversations throws NoMethodError: undefined method 'additional_attributes' for nil when a conversation exists with a missing/deleted contact.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures API endpoints don’t crash on conversations with deleted/missing contacts.
> 
> - In `ConversationFinder#set_up`, add `filter_orphan_conversations` (INNER JOIN on `contact`) to exclude orphaned conversations from lists and searches
> - In `Api::V1::Accounts::ConversationsController#conversation`, raise `ActiveRecord::RecordNotFound` when `@conversation.contact` is blank to return 404
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7ab3a689cd186ceef2b294ec58d2205ce4ae728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->