### PR TITLE
fix: Remove `phone_number_id` param from WhatsApp media retrieval for incoming messages

### DIFF
--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -10,10 +10,7 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
 
   def download_attachment_file(attachment_payload)
     url_response = HTTParty.get(
-      inbox.channel.media_url(
-        attachment_payload[:id],
-        inbox.channel.provider_config['phone_number_id']
-      ),
+      inbox.channel.media_url(attachment_payload[:id]),
       headers: inbox.channel.api_headers
     )
     # This url response will be failure if the access token has expired.

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -75,10 +75,8 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
     csat_template_service.get_template_status(template_name)
   end
 
-  def media_url(media_id, phone_number_id = nil)
-    url = "#{api_base_path}/v13.0/#{media_id}"
-    url += "?phone_number_id=#{phone_number_id}" if phone_number_id
-    url
+  def media_url(media_id)
+    "#{api_base_path}/v13.0/#{media_id}"
   end
 
   private

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -41,10 +41,7 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
       it 'increments reauthorization count if fetching attachment fails' do
         stub_request(
           :get,
-          whatsapp_channel.media_url(
-            'b1c68f38-8734-4ad3-b4a1-ef0c10d683',
-            whatsapp_channel.provider_config['phone_number_id']
-          )
+          whatsapp_channel.media_url('b1c68f38-8734-4ad3-b4a1-ef0c10d683')
         ).to_return(
           status: 401
         )
@@ -112,10 +109,7 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
   def stub_media_url_request
     stub_request(
       :get,
-      whatsapp_channel.media_url(
-        'b1c68f38-8734-4ad3-b4a1-ef0c10d683',
-        whatsapp_channel.provider_config['phone_number_id']
-      )
+      whatsapp_channel.media_url('b1c68f38-8734-4ad3-b4a1-ef0c10d683')
     ).to_return(
       status: 200,
       body: {


### PR DESCRIPTION
Fixes https://github.com/chatwoot/chatwoot/issues/13317
Fixes an issue where WhatsApp attachment messages (images, audio, video, documents) were failing to download. Messages were being created but without attachments.

The `phone_number_id` parameter was being passed to the `GET /<MEDIA_ID>` endpoint when downloading incoming media. According to Meta's documentation:

  > "Note that `phone_number_id` is optional. If included, the request will only be processed if the business phone number ID included in the query matches the ID of the business
  phone number **that the media was uploaded on**."

For incoming messages, media is uploaded by the customer, not by the business phone number. Passing the business's `phone_number_id` causes validation to fail with error: `Param phone_number_id is not a valid whatsapp business phone number id ID`

This PR removes the `phone_number_id` parameter from the media URL request for incoming messages.
