### PR TITLE
fix: make llm aware about signatures in editor replies

### DIFF
--- a/lib/integrations/openai/openai_prompts/fix_spelling_grammar.liquid
+++ b/lib/integrations/openai/openai_prompts/fix_spelling_grammar.liquid
@@ -10,8 +10,9 @@ Important guidelines:
 - Ensure the output remains appropriate for customer support
 
 Super Important:
-- If the message has some markdown formatting, keep the formatting as it is. 
+- If the message has some markdown formatting, keep the formatting as it is.
 - Block quotes (lines starting with >) contain quoted text from the customer's previous message. Preserve this quoted text exactly as written (do not modify the customer's words inside the block quote), but DO improve the agent's reply that follows the block quote.
 - Ensure the output is in the user's original language
+- If the message contains a signature block (text after a `--` line), preserve the signature exactly as written without any modification. Do not add a signature if one is not already present.
 
 Output only the corrected message, with no preamble, tags, or explanation.

--- a/lib/integrations/openai/openai_prompts/improve.liquid
+++ b/lib/integrations/openai/openai_prompts/improve.liquid
@@ -38,6 +38,7 @@ Do NOT use the context to fill in gaps or add information the agent didn't inclu
 - Keep the improved message at a similar length to the draft (brief stays brief)
 - Preserve any markdown formatting
 - Block quotes (lines starting with `>`) contain quoted customer text—keep this unchanged, only improve the agent's reply
+- If the message contains a signature block (text after a `--` line), preserve the signature exactly as written without any modification. Do not add a signature if one is not already present.
 - Output in the same language as the draft
 - Output only the improved message, no commentary
 

--- a/lib/integrations/openai/openai_prompts/tone_rewrite.liquid
+++ b/lib/integrations/openai/openai_prompts/tone_rewrite.liquid
@@ -28,8 +28,9 @@ Important guidelines:
 - Do not remove critical details or instructions
 
 Super Important:
-- If the message has some markdown formatting, keep the formatting as it is. 
+- If the message has some markdown formatting, keep the formatting as it is.
 - Block quotes (lines starting with >) contain quoted text from the customer's previous message. Preserve this quoted text exactly as written (do not modify the customer's words inside the block quote), but DO improve the agent's reply that follows the block quote.
 - Ensure the output is in the user's original language
+- If the message contains a signature block (text after a `--` line), preserve the signature exactly as written without any modification. Do not add a signature if one is not already present.
 
 Output only the rewritten message without any preamble, tags or explanation.


### PR DESCRIPTION
Fixes signatures being generated on top of existing signature in draft for improve, tone change and grammar