### PR TITLE
fix(whatsapp): Preserve ordered list numbering in messages

### DIFF
--- a/app/services/messages/markdown_renderers/whats_app_renderer.rb
+++ b/app/services/messages/markdown_renderers/whats_app_renderer.rb
@@ -1,4 +1,9 @@
 class Messages::MarkdownRenderers::WhatsAppRenderer < Messages::MarkdownRenderers::BaseMarkdownRenderer
+  def initialize
+    super
+    @list_item_number = 0
+  end
+
   def strong(_node)
     out('*', :children, '*')
   end
@@ -15,13 +20,20 @@ class Messages::MarkdownRenderers::WhatsAppRenderer < Messages::MarkdownRenderer
     out(node.url)
   end
 
-  def list(_node)
+  def list(node)
+    @list_type = node.list_type
+    @list_item_number = @list_type == :ordered_list ? node.list_start : 0
     out(:children)
     cr
   end
 
   def list_item(_node)
-    out('- ', :children)
+    if @list_type == :ordered_list
+      out("#{@list_item_number}. ", :children)
+      @list_item_number += 1
+    else
+      out('- ', :children)
+    end
     cr
   end
 


### PR DESCRIPTION
- Fix ordered lists being sent as unordered lists in WhatsApp integrations
- The WhatsApp markdown renderer was converting all lists to bullet points (-), ignoring numbered list formatting
- Added ordered list support by tracking list_type and list_item_number from CommonMarker AST metadata

Before:
Input: "1. First\n2. Second\n3. Third"
Output: "- First\n- Second\n- Third"

After:

Input: "1. First\n2. Second\n3. Third"
Output: "1. First\n2. Second\n3. Third"
