### PR TITLE
fix: Add Portuguese (Brazil) to CSAT template language options

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/advancedFilterItems/languages.js
+++ b/app/javascript/dashboard/components/widgets/conversation/advancedFilterItems/languages.js
@@ -516,6 +516,10 @@ const languages = [
     id: 'pt',
   },
   {
+    name: 'Portuguese (Brazil)',
+    id: 'pt_BR',
+  },
+  {
     name: 'Punjabi',
     id: 'pa',
   },

--- a/spec/services/whatsapp/csat_template_service_spec.rb
+++ b/spec/services/whatsapp/csat_template_service_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Whatsapp::CsatTemplateService do
       expect(result).to eq({
                              name: expected_template_name,
                              language: 'en',
-                             category: 'MARKETING',
+                             category: 'UTILITY',
                              components: [
                                {
                                  type: 'BODY',
@@ -169,7 +169,7 @@ RSpec.describe Whatsapp::CsatTemplateService do
       expected_body = {
         name: expected_template_name,
         language: 'en',
-        category: 'MARKETING',
+        category: 'UTILITY',
         components: [
           {
             type: 'BODY',

--- a/spec/services/whatsapp/csat_template_service_spec.rb
+++ b/spec/services/whatsapp/csat_template_service_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Whatsapp::CsatTemplateService do
       expect(result).to eq({
                              name: expected_template_name,
                              language: 'en',
-                             category: 'UTILITY',
+                             category: 'MARKETING',
                              components: [
                                {
                                  type: 'BODY',
@@ -169,7 +169,7 @@ RSpec.describe Whatsapp::CsatTemplateService do
       expected_body = {
         name: expected_template_name,
         language: 'en',
-        category: 'UTILITY',
+        category: 'MARKETING',
         components: [
           {
             type: 'BODY',


### PR DESCRIPTION
 Added Portuguese (Brazil) (`pt_BR`) to the CSAT template language dropdown