### PR TITLE
fix: update help center sitemap XML structure

### DIFF
--- a/app/views/public/api/v1/portals/sitemap.xml.erb
+++ b/app/views/public/api/v1/portals/sitemap.xml.erb
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <% @portal.articles.where(status: :published).each do |article| %>
-    <sitemap>
+    <url>
       <loc><%= @help_center_url %><%= generate_article_link(@portal.slug, article.slug, false, false) %></loc>
-      <lastmod><%= article.updated_at.strftime("%Y-%m-%d") %></lastmod>
-    </sitemap>
+      <lastmod><%= article.updated_at.to_date.iso8601 %></lastmod>
+    </url>
   <% end %>
-</sitemapindex>
+</urlset>


### PR DESCRIPTION
# Pull Request Template

## Description
The Help Center sitemap endpoint (`/hc/:portal_slug/sitemap.xml`) previously rendered a `<sitemapindex>` element while embedding article URLs directly, which does not align with the sitemap specification.

This change fixes the structure by:
- Replacing `<sitemapindex>` with `<urlset>`
- Adding the required sitemap XML namespace
- Rendering each published article as a `<url>` entry with `<loc>` and `<lastmod>`

This ensures the endpoint outputs a valid, self-contained sitemap document.

Fixes #13334

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Updated the existing `portals_controller_spec.rb`
- Adjusted assertions to validate a `<urlset>` root element and the sitemap XML namespace
- Verified that the sitemap returns only published article URLs
- Ran the updated RSpec controller specs locally


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
