### PR TITLE
fix(whatsapp): prevent duplicate conversations in incoming message processing

### DIFF
--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -69,11 +69,6 @@ module Whatsapp::IncomingMessageServiceHelpers
     @message = Message.find_by(source_id: source_id)
   end
 
-  def message_under_process?
-    key = format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: @processed_params[:messages].first[:id])
-    Redis::Alfred.get(key)
-  end
-
   def cache_message_source_id_in_redis
     return if @processed_params.try(:[], :messages).blank?
 
@@ -84,5 +79,36 @@ module Whatsapp::IncomingMessageServiceHelpers
   def clear_message_source_id_from_redis
     key = format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: @processed_params[:messages].first[:id])
     ::Redis::Alfred.delete(key)
+  end
+
+  def acquire_message_processing_lock
+    return false if @processed_params.try(:[], :messages).blank?
+
+    key = format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: "#{inbox.id}_#{@processed_params[:messages].first[:id]}")
+    Redis::Alfred.set(key, true, nx: true, ex: 1.day)
+  end
+
+  def with_contact_lock(phone, timeout: 5.seconds)
+    raise ArgumentError, 'A block is required for with_contact_lock' unless block_given?
+    return yield if phone.blank?
+
+    key = "WHATSAPP::CONTACT_LOCK::#{inbox.id}_#{phone}"
+    start_time = Time.now.to_i
+    lock_acquired = false
+
+    while (Time.now.to_i - start_time) < timeout
+      if Redis::Alfred.set(key, 1, nx: true, ex: timeout)
+        lock_acquired = true
+        break
+      end
+
+      sleep(0.1)
+    end
+
+    raise Timeout::Error, "Timeout acquiring contact lock for #{phone}" unless lock_acquired
+
+    yield
+  ensure
+    Redis::Alfred.delete(key) if lock_acquired
   end
 end

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -78,6 +78,84 @@ describe Whatsapp::IncomingMessageService do
         described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
         expect(whatsapp_channel.inbox.messages.count).to eq(1)
       end
+
+      it 'will not create duplicate conversations when same message is received for new contact' do
+        # First call creates contact, conversation and message
+        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+        expect(whatsapp_channel.inbox.conversations.count).to eq(1)
+        expect(whatsapp_channel.inbox.messages.count).to eq(1)
+
+        # Second call with same message ID should not create duplicate conversation
+        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+        expect(whatsapp_channel.inbox.conversations.count).to eq(1)
+        expect(whatsapp_channel.inbox.messages.count).to eq(1)
+      end
+
+      it 'only allows one of two concurrent requests to process the same message' do
+        # Simulates atomic SETNX: first caller gets the lock, second is rejected
+        message_source_key = format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: "#{whatsapp_channel.inbox.id}_#{params[:messages].first[:id]}")
+        lock_acquired = false
+
+        # Allow all Redis::Alfred calls (contact lock uses different keys)
+        allow(Redis::Alfred).to receive(:set).and_call_original
+        allow(Redis::Alfred).to receive(:delete).and_call_original
+
+        # Stub message lock specifically
+        allow(Redis::Alfred).to receive(:set).with(message_source_key, true, nx: true, ex: 1.day) do
+          result = !lock_acquired
+          lock_acquired = true
+          result
+        end
+
+        service1 = described_class.new(inbox: whatsapp_channel.inbox, params: params)
+        service2 = described_class.new(inbox: whatsapp_channel.inbox, params: params)
+
+        # Both bypass find_message_by_source_id (simulating race before DB commit)
+        allow(service1).to receive(:find_message_by_source_id).and_return(nil)
+        allow(service2).to receive(:find_message_by_source_id).and_return(nil)
+
+        service1.perform
+        service2.perform
+
+        expect(whatsapp_channel.inbox.messages.count).to eq(1)
+        expect(whatsapp_channel.inbox.conversations.count).to eq(1)
+      end
+
+      it 'clears lock outside transaction to prevent race conditions' do
+        message_source_key = format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: "#{whatsapp_channel.inbox.id}_#{params[:messages].first[:id]}")
+        lock_cleared_at_depth = nil
+
+        # Allow all Redis::Alfred calls (contact lock uses different keys)
+        allow(Redis::Alfred).to receive(:set).and_call_original
+        allow(Redis::Alfred).to receive(:delete).and_call_original
+
+        # Stub message lock specifically
+        allow(Redis::Alfred).to receive(:set).with(message_source_key, true, nx: true, ex: 1.day).and_return(true)
+        allow(Redis::Alfred).to receive(:delete).with(message_source_key) do
+          lock_cleared_at_depth = ActiveRecord::Base.connection.open_transactions
+        end
+
+        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+
+        # Depth 1 = only RSpec's wrapper transaction, meaning our transaction completed
+        expect(lock_cleared_at_depth).to eq(1),
+                                         "Lock cleared at depth #{lock_cleared_at_depth}, expected 1. " \
+                                         'Lock must be cleared AFTER transaction commits to prevent duplicates.'
+      end
+
+      it 'creates message in second inbox when same source_id exists in different inbox' do
+        other_whatsapp_channel = create(:channel_whatsapp, sync_templates: false)
+        other_inbox = other_whatsapp_channel.inbox
+        other_contact = create(:contact, account: other_inbox.account)
+        other_contact_inbox = create(:contact_inbox, inbox: other_inbox, contact: other_contact)
+        other_conversation = create(:conversation, inbox: other_inbox, contact_inbox: other_contact_inbox)
+        create(:message, conversation: other_conversation, inbox: other_inbox, source_id: params[:messages].first[:id])
+
+        # Should still create message in our inbox since source_id check should be inbox-scoped
+        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+        expect(whatsapp_channel.inbox.conversations.count).to eq(1)
+        expect(whatsapp_channel.inbox.messages.count).to eq(1)
+      end
     end
 
     context 'when unsupported message types' do


### PR DESCRIPTION
## Description

This PR fixes two related race conditions in WhatsApp message processing that were causing duplicate conversations and messages. Closes #13261

### Issue 1: Duplicate webhook deliveries for the same message

Meta's webhook system uses an "at-least-once" delivery policy, meaning the same message can be delivered multiple times. The existing Redis lock was being cleared *inside* the database transaction before it committed, creating a race window where:
1. Request A creates the message, clears the lock (transaction uncommitted)
2. Request B acquires the lock, doesn't see A's message (transaction isolation)
3. Both requests create duplicates

**Fix:** Lock is now cleared in an `ensure` block *after* the transaction commits. Lock key is also scoped to `inbox_id` to prevent cross-inbox collisions.

### Issue 2: Multiple different messages arriving simultaneously for the same contact

When a user sends an album (multiple images at once), each image arrives as a separate webhook request. These parallel requests could each create their own conversation before any of them completed.

**Fix:** Added `with_contact_lock` to serialize message processing per contact within an inbox, ensuring only one request at a time can create a conversation for a given contact.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Send a WhatsApp message and verify it creates one conversation and one message.
2. Send the same message again (simulating duplicate webhook) and verify no duplicates are created.
3. Send an album (multiple images at once) and verify only one conversation is created.
4. Run the new specs that verify:
   - Only one of two concurrent requests can acquire the lock for the same message.
   - Lock is cleared at the correct transaction depth (outside the transaction).
   - Messages with the same `source_id` in different inboxes are processed independently. Unlikely, but possible, ex.: two inboxes in the same Chatwoot messaging each other.
