### PR TITLE
fix: do not send notifications for failed messages

### DIFF
--- a/app/services/messages/new_message_notification_service.rb
+++ b/app/services/messages/new_message_notification_service.rb
@@ -3,6 +3,7 @@ class Messages::NewMessageNotificationService
 
   def perform
     return unless message.notifiable?
+    return if message.status == 'failed'
 
     notify_conversation_assignee
     notify_participating_users


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents notifications from being sent for failed messages.
> 
> - Adds an early return `return if message.status == 'failed'` in `Messages::NewMessageNotificationService#perform`, avoiding assignee and participant notifications when a message fails
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08cefb2bb88d40f987ce448a8c727432203adea2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->