### PR TITLE
feat: add mark pending action to automation

### DIFF
--- a/app/javascript/dashboard/helper/validations.js
+++ b/app/javascript/dashboard/helper/validations.js
@@ -127,6 +127,7 @@ const validateSingleAction = action => {
     'resolve_conversation',
     'remove_assigned_team',
     'open_conversation',
+    'pending_conversation',
   ];
 
   if (

--- a/app/javascript/dashboard/i18n/locale/en/automation.json
+++ b/app/javascript/dashboard/i18n/locale/en/automation.json
@@ -150,7 +150,8 @@
       "ADD_PRIVATE_NOTE": "Add a Private Note",
       "CHANGE_PRIORITY": "Change Priority",
       "ADD_SLA": "Add SLA",
-      "OPEN_CONVERSATION": "Open conversation"
+      "OPEN_CONVERSATION": "Open conversation",
+      "PENDING_CONVERSATION": "Mark conversation as pending"
     },
     "MESSAGE_TYPES": {
       "INCOMING": "Incoming Message",

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
@@ -117,6 +117,10 @@ export const AUTOMATIONS = {
         name: 'OPEN_CONVERSATION',
       },
       {
+        key: 'pending_conversation',
+        name: 'PENDING_CONVERSATION',
+      },
+      {
         key: 'resolve_conversation',
         name: 'RESOLVE_CONVERSATION',
       },
@@ -231,6 +235,10 @@ export const AUTOMATIONS = {
       {
         key: 'snooze_conversation',
         name: 'SNOOZE_CONVERSATION',
+      },
+      {
+        key: 'pending_conversation',
+        name: 'PENDING_CONVERSATION',
       },
       {
         key: 'resolve_conversation',
@@ -361,6 +369,10 @@ export const AUTOMATIONS = {
         name: 'SNOOZE_CONVERSATION',
       },
       {
+        key: 'pending_conversation',
+        name: 'PENDING_CONVERSATION',
+      },
+      {
         key: 'resolve_conversation',
         name: 'RESOLVE_CONVERSATION',
       },
@@ -481,6 +493,10 @@ export const AUTOMATIONS = {
       {
         key: 'snooze_conversation',
         name: 'SNOOZE_CONVERSATION',
+      },
+      {
+        key: 'pending_conversation',
+        name: 'PENDING_CONVERSATION',
       },
       {
         key: 'send_webhook_event',
@@ -666,6 +682,11 @@ export const AUTOMATION_ACTION_TYPES = [
   {
     key: 'open_conversation',
     label: 'OPEN_CONVERSATION',
+    inputType: null,
+  },
+  {
+    key: 'pending_conversation',
+    label: 'PENDING_CONVERSATION',
     inputType: null,
   },
   {

--- a/app/models/automation_rule.rb
+++ b/app/models/automation_rule.rb
@@ -41,8 +41,8 @@ class AutomationRule < ApplicationRecord
 
   def actions_attributes
     %w[send_message add_label remove_label send_email_to_team assign_team assign_agent send_webhook_event mute_conversation
-       send_attachment change_status resolve_conversation open_conversation snooze_conversation change_priority send_email_transcript
-       add_private_note].freeze
+       send_attachment change_status resolve_conversation open_conversation pending_conversation snooze_conversation change_priority
+       send_email_transcript add_private_note].freeze
   end
 
   def file_base_data

--- a/app/services/action_service.rb
+++ b/app/services/action_service.rb
@@ -22,6 +22,10 @@ class ActionService
     @conversation.open!
   end
 
+  def pending_conversation(_params)
+    @conversation.pending!
+  end
+
   def change_status(status)
     @conversation.update!(status: status[0])
   end


### PR DESCRIPTION
Adds `pending_conversation` action to automation rules, allowing conversations to be automatically marked as pending based on defined conditions.

## Changes

- Added `pending_conversation` to automation actions in backend and frontend
- Added validation support (no parameters required)
- Added translation: "Mark conversation as pending"
- Available in events: message_created, conversation_created, conversation_updated, conversation_opened

<img width="3158" height="1552" alt="CleanShot 2026-01-28 at 11 07 06@2x" src="https://github.com/user-attachments/assets/369c2c0a-f11e-461f-98ce-f511fd14c1f7" />

<img width="2114" height="1600" alt="CleanShot 2026-01-28 at 11 07 21@2x" src="https://github.com/user-attachments/assets/26bb009b-f88f-4316-b3c6-07ad56227d2c" />
