### PR TITLE
feat: add lightweight /health endpoint

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,4 +1,6 @@
-class HealthController < ActionController::Base
+# Inherits from ActionController::Base to skip all middleware,
+# authentication, and callbacks. Used for health checks
+class HealthController < ActionController::Base # rubocop:disable Rails/ApplicationController
   def show
     render json: { status: 'woot' }
   end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,5 @@
+class HealthController < ActionController::Base
+  def show
+    render json: { status: 'woot' }
+  end
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -47,6 +47,12 @@ class Rack::Attack
 
   Rack::Attack.safelist('trusted IPs', &:allowed_ip?)
 
+  # Safelist health check endpoint so it never touches Redis for throttle tracking.
+  # This keeps /health fully dependency-free for ALB liveness checks.
+  Rack::Attack.safelist('health check') do |req|
+    req.path == '/health'
+  end
+
   ### Throttle Spammy Clients ###
 
   # If any single client IP is making tons of requests, then they're

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
     resource :slack_uploads, only: [:show]
   end
 
+  get '/health', to: 'health#show'
   get '/api', to: 'api#index'
   namespace :api, defaults: { format: 'json' } do
     namespace :v1 do

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe 'Health Check', type: :request do
+  describe 'GET /health' do
+    it 'returns success status' do
+      get '/health'
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body['status']).to eq('woot')
+    end
+  end
+end


### PR DESCRIPTION

# Pull Request Template

## Description

The existing /api health check endpoint creates a new Redis connection  on every request and checks both Redis and Postgres availability. During peak traffic, this creates unnecessary load and can cause cascading failures when either service is slow - instances get marked unhealthy, traffic shifts to remaining  instances, which then also fail health checks.

The new /health endpoint:
  - Returns immediately with 200 {"status":"woot"}
  - Skips all middleware and authentication
  - No Redis or Postgres dependency
  - Suitable for health checks that only need to verify the web server is responding

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Added specs
- Tested locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
