### PR TITLE
fix: Convert literal \\n strings to newlines in API channel messages

### DIFF
--- a/app/services/messages/markdown_renderer_service.rb
+++ b/app/services/messages/markdown_renderer_service.rb
@@ -9,7 +9,8 @@ class Messages::MarkdownRendererService
     'Channel::Line' => :render_line,
     'Channel::TwitterProfile' => :render_plain_text,
     'Channel::Sms' => :render_plain_text,
-    'Channel::TwilioSms' => :render_plain_text
+    'Channel::TwilioSms' => :render_plain_text,
+    'Channel::Api' => :render_api_message
   }.freeze
 
   def initialize(content, channel_type, channel = nil)
@@ -54,6 +55,11 @@ class Messages::MarkdownRendererService
     doc = CommonMarker.render_doc(content_with_preserved_newlines, [:STRIKETHROUGH_DOUBLE_TILDE], [:strikethrough])
     result = renderer.render(doc).gsub(/\n+\z/, '')
     restore_multiple_newlines(result)
+  end
+
+  def render_api_message
+    # Convert literal \n strings to actual newlines for API channel messages
+    @content.gsub('\\n', "\n")
   end
 
   def render_whatsapp

--- a/spec/services/messages/markdown_renderer_service_spec.rb
+++ b/spec/services/messages/markdown_renderer_service_spec.rb
@@ -493,6 +493,31 @@ RSpec.describe Messages::MarkdownRendererService, type: :service do
         result = described_class.new(content, channel_type).render
         expect(result).to eq("- Item 1\n- Item 2")
       end
+
+      it 'converts literal \\n strings to actual newlines' do
+        content = 'Hi \\ntext message \\nwith line \\nbreak'
+        result = described_class.new(content, channel_type).render
+        expect(result).to eq("Hi \ntext message \nwith line \nbreak")
+      end
+
+      it 'handles multiple literal \\n in sequence' do
+        content = 'Line 1\\n\\n\\nLine 2'
+        result = described_class.new(content, channel_type).render
+        expect(result).to eq("Line 1\n\n\nLine 2")
+      end
+
+      it 'preserves markdown formatting while converting \\n' do
+        content = '**bold**\\n_italic_\\n`code`'
+        result = described_class.new(content, channel_type).render
+        expect(result).to eq("**bold**\n_italic_\n`code`")
+      end
+
+      it 'handles real-world API payload with literal \\n strings' do
+        content = 'Hi \\ntext message \\nwith line \\nbreak'
+        result = described_class.new(content, channel_type).render
+        expect(result).to eq("Hi \ntext message \nwith line \nbreak")
+        expect(result).not_to include('\\n')
+      end
     end
 
     context 'when channel is Channel::TwitterProfile' do


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes https://linear.app/chatwoot/issue/CW-6389/messages-with-enter-are-being-rendered-incorrectly-on-whatsapp-with

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
