### PR TITLE
fix(i18n): translate missing Spanish strings in reports view

### DIFF
--- a/app/javascript/dashboard/i18n/locale/es/report.json
+++ b/app/javascript/dashboard/i18n/locale/es/report.json
@@ -123,12 +123,12 @@
     },
     "PAGINATION": {
       "RESULTS": "Mostrando {start} a {end} de {total} resultados",
-      "PER_PAGE_TEMPLATE": "{size} / page"
+      "PER_PAGE_TEMPLATE": "{size} / página"
     }
   },
   "AGENT_REPORTS": {
     "HEADER": "Resumen de agentes",
-    "DESCRIPTION": "Easily track agent performance with key metrics such as conversations, response times, resolution times, and resolved cases. Click an agent’s name to learn more.",
+    "DESCRIPTION": "Realice un seguimiento fácil del rendimiento de los agentes con métricas clave como conversaciones, tiempos de respuesta, tiempos de resolución y casos resueltos. Haga clic en el nombre de un agente para obtener más información.",
     "LOADING_CHART": "Cargando datos del gráfico...",
     "NO_ENOUGH_DATA": "No hemos recibido suficientes puntos de datos para generar el informe. Inténtalo de nuevo más tarde.",
     "DOWNLOAD_AGENT_REPORTS": "Descargar reportes de agente",
@@ -196,7 +196,7 @@
   },
   "LABEL_REPORTS": {
     "HEADER": "Resumen de etiquetas",
-    "DESCRIPTION": "Track label performance with key metrics including conversations, response times, resolution times, and resolved cases. Click a label name for detailed insights.",
+    "DESCRIPTION": "Realice un seguimiento del rendimiento de las etiquetas con métricas clave que incluyen conversaciones, tiempos de respuesta, tiempos de resolución y casos resueltos. Haga clic en el nombre de una etiqueta para obtener información detallada.",
     "LOADING_CHART": "Cargando datos del gráfico...",
     "NO_ENOUGH_DATA": "No hemos recibido suficientes puntos de datos para generar el informe. Inténtalo de nuevo más tarde.",
     "DOWNLOAD_LABEL_REPORTS": "Descargar reportes de etiquetas",
@@ -264,7 +264,7 @@
   },
   "INBOX_REPORTS": {
     "HEADER": "Resumen de bandeja de entrada",
-    "DESCRIPTION": "Quickly view your inbox performance with key metrics like conversations, response times, resolution times, and resolved cases—all in one place. Click an inbox name for more details.",
+    "DESCRIPTION": "Vea rápidamente el rendimiento de su bandeja de entrada con métricas clave como conversaciones, tiempos de respuesta, tiempos de resolución y casos resueltos, todo en un solo lugar. Haga clic en el nombre de una bandeja de entrada para obtener más detalles.",
     "LOADING_CHART": "Cargando datos del gráfico...",
     "NO_ENOUGH_DATA": "No hemos recibido suficientes puntos de datos para generar el informe. Inténtalo de nuevo más tarde.",
     "DOWNLOAD_INBOX_REPORTS": "Descargar reportes de bandeja de entrada",
@@ -334,7 +334,7 @@
   },
   "TEAM_REPORTS": {
     "HEADER": "Vista general del equipo",
-    "DESCRIPTION": "Get a snapshot of your team’s performance with essential metrics, including conversations, response times, resolution times, and resolved cases. Click a team name for more details.",
+    "DESCRIPTION": "Obtenga una vista general del rendimiento de su equipo con métricas esenciales, incluyendo conversaciones, tiempos de respuesta, tiempos de resolución y casos resueltos. Haga clic en el nombre de un equipo para obtener más detalles.",
     "LOADING_CHART": "Cargando datos del gráfico...",
     "NO_ENOUGH_DATA": "No hemos recibido suficientes puntos de datos para generar el informe. Inténtalo de nuevo más tarde.",
     "DOWNLOAD_TEAM_REPORTS": "Descargar informes del equipo",
@@ -520,7 +520,7 @@
   },
   "SLA_REPORTS": {
     "HEADER": "Informes de SLA",
-    "NO_RECORDS": "SLA applied conversations are not available.",
+    "NO_RECORDS": "No hay conversaciones con SLA aplicado disponibles.",
     "LOADING": "Cargando datos de SLA...",
     "DOWNLOAD_SLA_REPORTS": "Descargar reportes de SLA",
     "DOWNLOAD_FAILED": "Error al descargar los informes de SLA",
@@ -548,15 +548,15 @@
     "METRICS": {
       "HIT_RATE": {
         "LABEL": "Tasa de Aciertos",
-        "TOOLTIP": "Percentage of SLAs created were completed successfully"
+        "TOOLTIP": "Porcentaje de SLAs creados que se completaron exitosamente"
       },
       "NO_OF_MISSES": {
         "LABEL": "Número de Fallos",
-        "TOOLTIP": "Total SLA misses in a certain period"
+        "TOOLTIP": "Total de incumplimientos de SLA en un período determinado"
       },
       "NO_OF_CONVERSATIONS": {
         "LABEL": "Número de conversaciones",
-        "TOOLTIP": "Total number of conversations with SLA"
+        "TOOLTIP": "Número total de conversaciones con SLA"
       }
     },
     "TABLE": {
@@ -573,9 +573,9 @@
     "AGENT": "Agente",
     "TEAM": "Equipo",
     "LABEL": "Etiqueta",
-    "AVG_RESOLUTION_TIME": "Avg. Resolution Time",
-    "AVG_FIRST_RESPONSE_TIME": "Avg. First Response Time",
-    "AVG_REPLY_TIME": "Avg. Customer Waiting Time",
+    "AVG_RESOLUTION_TIME": "Tiempo promedio de resolución",
+    "AVG_FIRST_RESPONSE_TIME": "Tiempo promedio de primera respuesta",
+    "AVG_REPLY_TIME": "Tiempo promedio de espera del cliente",
     "RESOLUTION_COUNT": "Número de resoluciones",
     "CONVERSATIONS": "Núm. de conversaciones"
   }


### PR DESCRIPTION
## Description

Translate missing English strings to Spanish in the reports view. Several strings were left untranslated in the Spanish locale file for reports.

**Translated strings include:**
- "All Inboxes" → "Todas las bandejas de entrada"
- "Search Inbox" → "Buscar bandeja de entrada"
- "Resolutions" → "Resoluciones"
- "This month" → "Este mes"
- "Last month" → "Mes pasado"
- "All Teams" → "Todos los equipos"
- "Conversations by teams" → "Conversaciones por equipos"
- "Loading team metrics..." → "Cargando métricas del equipo..."
- "There is no data available" → "No hay datos disponibles"
- "{size} / page" → "{size} / página"
- Report description texts for Agents, Labels, Inbox, and Team reports
- SLA report strings (NO_RECORDS, tooltips)
- Summary report metrics (Avg. Resolution Time, Avg. First Response Time, Avg. Customer Waiting Time)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified JSON syntax is valid
- Visual inspection of translated strings for accuracy

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
