### PR TITLE
chore: Update report documentation

### DIFF
--- a/swagger/definitions/index.yml
+++ b/swagger/definitions/index.yml
@@ -225,6 +225,10 @@ agent_conversation_metrics:
   $ref: './resource/reports/conversation/agent.yml'
 channel_summary:
   $ref: './resource/reports/channel_summary.yml'
+first_response_time_distribution:
+  $ref: './resource/reports/first_response_time_distribution.yml'
+inbox_label_matrix:
+  $ref: './resource/reports/inbox_label_matrix.yml'
 
 contact_detail:
   $ref: ./resource/contact_detail.yml

--- a/swagger/definitions/resource/reports/first_response_time_distribution.yml
+++ b/swagger/definitions/resource/reports/first_response_time_distribution.yml
@@ -1,0 +1,34 @@
+type: object
+description: First response time distribution report grouped by channel type. Shows the count of conversations with first response times in different time buckets.
+additionalProperties:
+  type: object
+  description: First response time distribution for a specific channel type (e.g., Channel::WebWidget, Channel::Api)
+  properties:
+    0-1h:
+      type: number
+      description: Number of conversations with first response time less than 1 hour
+    1-4h:
+      type: number
+      description: Number of conversations with first response time between 1-4 hours
+    4-8h:
+      type: number
+      description: Number of conversations with first response time between 4-8 hours
+    8-24h:
+      type: number
+      description: Number of conversations with first response time between 8-24 hours
+    24h+:
+      type: number
+      description: Number of conversations with first response time greater than 24 hours
+example:
+  Channel::WebWidget:
+    0-1h: 150
+    1-4h: 80
+    4-8h: 45
+    8-24h: 30
+    24h+: 15
+  Channel::Api:
+    0-1h: 75
+    1-4h: 40
+    4-8h: 20
+    8-24h: 10
+    24h+: 5

--- a/swagger/definitions/resource/reports/inbox_label_matrix.yml
+++ b/swagger/definitions/resource/reports/inbox_label_matrix.yml
@@ -1,0 +1,50 @@
+type: object
+description: Inbox-label matrix report showing the count of conversations for each inbox-label combination.
+properties:
+  inboxes:
+    type: array
+    description: List of inboxes included in the report
+    items:
+      type: object
+      properties:
+        id:
+          type: number
+          description: The inbox ID
+        name:
+          type: string
+          description: The inbox name
+  labels:
+    type: array
+    description: List of labels included in the report
+    items:
+      type: object
+      properties:
+        id:
+          type: number
+          description: The label ID
+        title:
+          type: string
+          description: The label title
+  matrix:
+    type: array
+    description: 2D array where matrix[i][j] represents the count of conversations in inboxes[i] with labels[j]
+    items:
+      type: array
+      items:
+        type: number
+example:
+  inboxes:
+    - id: 1
+      name: Website Chat
+    - id: 2
+      name: Email Support
+  labels:
+    - id: 1
+      title: bug
+    - id: 2
+      title: feature-request
+    - id: 3
+      title: urgent
+  matrix:
+    - [10, 5, 3]
+    - [8, 12, 2]

--- a/swagger/index.html
+++ b/swagger/index.html
@@ -18,6 +18,6 @@
   </head>
   <body>
     <redoc spec-url='/swagger/swagger.json'></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.1.5/bundles/redoc.standalone.js"> </script>
   </body>
 </html>

--- a/swagger/paths/application/reports/first_response_time_distribution.yml
+++ b/swagger/paths/application/reports/first_response_time_distribution.yml
@@ -7,6 +7,8 @@ security:
 description: |
   Get the distribution of first response times grouped by channel type.
   Returns conversation counts in different time buckets (0-1h, 1-4h, 4-8h, 8-24h, 24h+) for each channel type.
+
+  **Note:** This API endpoint is available only in Chatwoot version 4.11.0 and above.
 responses:
   '200':
     description: Success

--- a/swagger/paths/application/reports/first_response_time_distribution.yml
+++ b/swagger/paths/application/reports/first_response_time_distribution.yml
@@ -1,0 +1,22 @@
+tags:
+  - Reports
+operationId: get-first-response-time-distribution
+summary: Get first response time distribution by channel
+security:
+  - userApiKey: []
+description: |
+  Get the distribution of first response times grouped by channel type.
+  Returns conversation counts in different time buckets (0-1h, 1-4h, 4-8h, 8-24h, 24h+) for each channel type.
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/first_response_time_distribution'
+  '403':
+    description: Access denied
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/application/reports/inbox_label_matrix.yml
+++ b/swagger/paths/application/reports/inbox_label_matrix.yml
@@ -1,0 +1,23 @@
+tags:
+  - Reports
+operationId: get-inbox-label-matrix
+summary: Get inbox-label matrix report
+security:
+  - userApiKey: []
+description: |
+  Get a matrix showing the count of conversations for each inbox-label combination.
+  Returns a list of inboxes, labels, and a 2D matrix where each cell contains the count of conversations
+  in a specific inbox that have a specific label applied.
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/inbox_label_matrix'
+  '403':
+    description: Access denied
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/application/reports/inbox_label_matrix.yml
+++ b/swagger/paths/application/reports/inbox_label_matrix.yml
@@ -8,6 +8,8 @@ description: |
   Get a matrix showing the count of conversations for each inbox-label combination.
   Returns a list of inboxes, labels, and a 2D matrix where each cell contains the count of conversations
   in a specific inbox that have a specific label applied.
+
+  **Note:** This API endpoint is available only in Chatwoot version 4.11.0 and above.
 responses:
   '200':
     description: Success

--- a/swagger/paths/index.yml
+++ b/swagger/paths/index.yml
@@ -653,13 +653,56 @@
       schema:
         type: string
       description: The timestamp from where report should stop (Unix timestamp).
-    - in: query
-      name: business_hours
-      schema:
-        type: boolean
-      description: Whether to filter by business hours.
   get:
     $ref: './application/reports/channel_summary.yml'
+
+# First response time distribution report
+/api/v2/accounts/{account_id}/reports/first_response_time_distribution:
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+    - in: query
+      name: since
+      schema:
+        type: string
+      description: The timestamp from where report should start (Unix timestamp).
+    - in: query
+      name: until
+      schema:
+        type: string
+      description: The timestamp from where report should stop (Unix timestamp).
+  get:
+    $ref: './application/reports/first_response_time_distribution.yml'
+
+# Inbox-label matrix report
+/api/v2/accounts/{account_id}/reports/inbox_label_matrix:
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+    - in: query
+      name: since
+      schema:
+        type: string
+      description: The timestamp from where report should start (Unix timestamp).
+    - in: query
+      name: until
+      schema:
+        type: string
+      description: The timestamp from where report should stop (Unix timestamp).
+    - in: query
+      name: inbox_ids
+      schema:
+        type: array
+        items:
+          type: integer
+      description: Filter by specific inbox IDs.
+    - in: query
+      name: label_ids
+      schema:
+        type: array
+        items:
+          type: integer
+      description: Filter by specific label IDs.
+  get:
+    $ref: './application/reports/inbox_label_matrix.yml'
 
 # Conversations Messages
 /accounts/{account_id}/conversations/{conversation_id}/messages:

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -7971,7 +7971,7 @@
             "userApiKey": []
           }
         ],
-        "description": "Get the distribution of first response times grouped by channel type.\nReturns conversation counts in different time buckets (0-1h, 1-4h, 4-8h, 8-24h, 24h+) for each channel type.\n",
+        "description": "Get the distribution of first response times grouped by channel type.\nReturns conversation counts in different time buckets (0-1h, 1-4h, 4-8h, 8-24h, 24h+) for each channel type.\n\n**Note:** This API endpoint is available only in Chatwoot version 4.11.0 and above.\n",
         "responses": {
           "200": {
             "description": "Success",
@@ -8051,7 +8051,7 @@
             "userApiKey": []
           }
         ],
-        "description": "Get a matrix showing the count of conversations for each inbox-label combination.\nReturns a list of inboxes, labels, and a 2D matrix where each cell contains the count of conversations\nin a specific inbox that have a specific label applied.\n",
+        "description": "Get a matrix showing the count of conversations for each inbox-label combination.\nReturns a list of inboxes, labels, and a 2D matrix where each cell contains the count of conversations\nin a specific inbox that have a specific label applied.\n\n**Note:** This API endpoint is available only in Chatwoot version 4.11.0 and above.\n",
         "responses": {
           "200": {
             "description": "Success",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -7890,14 +7890,6 @@
             "type": "string"
           },
           "description": "The timestamp from where report should stop (Unix timestamp)."
-        },
-        {
-          "in": "query",
-          "name": "business_hours",
-          "schema": {
-            "type": "boolean"
-          },
-          "description": "Whether to filter by business hours."
         }
       ],
       "get": {
@@ -7929,6 +7921,144 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/accounts/{account_id}/reports/first_response_time_distribution": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "in": "query",
+          "name": "since",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should start (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "until",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should stop (Unix timestamp)."
+        }
+      ],
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "operationId": "get-first-response-time-distribution",
+        "summary": "Get first response time distribution by channel",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Get the distribution of first response times grouped by channel type.\nReturns conversation counts in different time buckets (0-1h, 1-4h, 4-8h, 8-24h, 24h+) for each channel type.\n",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/first_response_time_distribution"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/accounts/{account_id}/reports/inbox_label_matrix": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "in": "query",
+          "name": "since",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should start (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "until",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should stop (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "inbox_ids",
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "description": "Filter by specific inbox IDs."
+        },
+        {
+          "in": "query",
+          "name": "label_ids",
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "description": "Filter by specific label IDs."
+        }
+      ],
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "operationId": "get-inbox-label-matrix",
+        "summary": "Get inbox-label matrix report",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Get a matrix showing the count of conversations for each inbox-label combination.\nReturns a list of inboxes, labels, and a 2D matrix where each cell contains the count of conversations\nin a specific inbox that have a specific label applied.\n",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/inbox_label_matrix"
                 }
               }
             }
@@ -11779,6 +11909,140 @@
             "snoozed": 1,
             "total": 24
           }
+        }
+      },
+      "first_response_time_distribution": {
+        "type": "object",
+        "description": "First response time distribution report grouped by channel type. Shows the count of conversations with first response times in different time buckets.",
+        "additionalProperties": {
+          "type": "object",
+          "description": "First response time distribution for a specific channel type (e.g., Channel::WebWidget, Channel::Api)",
+          "properties": {
+            "0-1h": {
+              "type": "number",
+              "description": "Number of conversations with first response time less than 1 hour"
+            },
+            "1-4h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 1-4 hours"
+            },
+            "4-8h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 4-8 hours"
+            },
+            "8-24h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 8-24 hours"
+            },
+            "24h+": {
+              "type": "number",
+              "description": "Number of conversations with first response time greater than 24 hours"
+            }
+          }
+        },
+        "example": {
+          "Channel::WebWidget": {
+            "0-1h": 150,
+            "1-4h": 80,
+            "4-8h": 45,
+            "8-24h": 30,
+            "24h+": 15
+          },
+          "Channel::Api": {
+            "0-1h": 75,
+            "1-4h": 40,
+            "4-8h": 20,
+            "8-24h": 10,
+            "24h+": 5
+          }
+        }
+      },
+      "inbox_label_matrix": {
+        "type": "object",
+        "description": "Inbox-label matrix report showing the count of conversations for each inbox-label combination.",
+        "properties": {
+          "inboxes": {
+            "type": "array",
+            "description": "List of inboxes included in the report",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number",
+                  "description": "The inbox ID"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The inbox name"
+                }
+              }
+            }
+          },
+          "labels": {
+            "type": "array",
+            "description": "List of labels included in the report",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number",
+                  "description": "The label ID"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "The label title"
+                }
+              }
+            }
+          },
+          "matrix": {
+            "type": "array",
+            "description": "2D array where matrix[i][j] represents the count of conversations in inboxes[i] with labels[j]",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "example": {
+          "inboxes": [
+            {
+              "id": 1,
+              "name": "Website Chat"
+            },
+            {
+              "id": 2,
+              "name": "Email Support"
+            }
+          ],
+          "labels": [
+            {
+              "id": 1,
+              "title": "bug"
+            },
+            {
+              "id": 2,
+              "title": "feature-request"
+            },
+            {
+              "id": 3,
+              "title": "urgent"
+            }
+          ],
+          "matrix": [
+            [
+              10,
+              5,
+              3
+            ],
+            [
+              8,
+              12,
+              2
+            ]
+          ]
         }
       },
       "contact_detail": {

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -6433,14 +6433,6 @@
             "type": "string"
           },
           "description": "The timestamp from where report should stop (Unix timestamp)."
-        },
-        {
-          "in": "query",
-          "name": "business_hours",
-          "schema": {
-            "type": "boolean"
-          },
-          "description": "Whether to filter by business hours."
         }
       ],
       "get": {
@@ -6472,6 +6464,144 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/accounts/{account_id}/reports/first_response_time_distribution": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "in": "query",
+          "name": "since",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should start (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "until",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should stop (Unix timestamp)."
+        }
+      ],
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "operationId": "get-first-response-time-distribution",
+        "summary": "Get first response time distribution by channel",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Get the distribution of first response times grouped by channel type.\nReturns conversation counts in different time buckets (0-1h, 1-4h, 4-8h, 8-24h, 24h+) for each channel type.\n",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/first_response_time_distribution"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/accounts/{account_id}/reports/inbox_label_matrix": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "in": "query",
+          "name": "since",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should start (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "until",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should stop (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "inbox_ids",
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "description": "Filter by specific inbox IDs."
+        },
+        {
+          "in": "query",
+          "name": "label_ids",
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "description": "Filter by specific label IDs."
+        }
+      ],
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "operationId": "get-inbox-label-matrix",
+        "summary": "Get inbox-label matrix report",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Get a matrix showing the count of conversations for each inbox-label combination.\nReturns a list of inboxes, labels, and a 2D matrix where each cell contains the count of conversations\nin a specific inbox that have a specific label applied.\n",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/inbox_label_matrix"
                 }
               }
             }
@@ -10286,6 +10416,140 @@
             "snoozed": 1,
             "total": 24
           }
+        }
+      },
+      "first_response_time_distribution": {
+        "type": "object",
+        "description": "First response time distribution report grouped by channel type. Shows the count of conversations with first response times in different time buckets.",
+        "additionalProperties": {
+          "type": "object",
+          "description": "First response time distribution for a specific channel type (e.g., Channel::WebWidget, Channel::Api)",
+          "properties": {
+            "0-1h": {
+              "type": "number",
+              "description": "Number of conversations with first response time less than 1 hour"
+            },
+            "1-4h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 1-4 hours"
+            },
+            "4-8h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 4-8 hours"
+            },
+            "8-24h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 8-24 hours"
+            },
+            "24h+": {
+              "type": "number",
+              "description": "Number of conversations with first response time greater than 24 hours"
+            }
+          }
+        },
+        "example": {
+          "Channel::WebWidget": {
+            "0-1h": 150,
+            "1-4h": 80,
+            "4-8h": 45,
+            "8-24h": 30,
+            "24h+": 15
+          },
+          "Channel::Api": {
+            "0-1h": 75,
+            "1-4h": 40,
+            "4-8h": 20,
+            "8-24h": 10,
+            "24h+": 5
+          }
+        }
+      },
+      "inbox_label_matrix": {
+        "type": "object",
+        "description": "Inbox-label matrix report showing the count of conversations for each inbox-label combination.",
+        "properties": {
+          "inboxes": {
+            "type": "array",
+            "description": "List of inboxes included in the report",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number",
+                  "description": "The inbox ID"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The inbox name"
+                }
+              }
+            }
+          },
+          "labels": {
+            "type": "array",
+            "description": "List of labels included in the report",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number",
+                  "description": "The label ID"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "The label title"
+                }
+              }
+            }
+          },
+          "matrix": {
+            "type": "array",
+            "description": "2D array where matrix[i][j] represents the count of conversations in inboxes[i] with labels[j]",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "example": {
+          "inboxes": [
+            {
+              "id": 1,
+              "name": "Website Chat"
+            },
+            {
+              "id": 2,
+              "name": "Email Support"
+            }
+          ],
+          "labels": [
+            {
+              "id": 1,
+              "title": "bug"
+            },
+            {
+              "id": 2,
+              "title": "feature-request"
+            },
+            {
+              "id": 3,
+              "title": "urgent"
+            }
+          ],
+          "matrix": [
+            [
+              10,
+              5,
+              3
+            ],
+            [
+              8,
+              12,
+              2
+            ]
+          ]
         }
       },
       "contact_detail": {

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -6514,7 +6514,7 @@
             "userApiKey": []
           }
         ],
-        "description": "Get the distribution of first response times grouped by channel type.\nReturns conversation counts in different time buckets (0-1h, 1-4h, 4-8h, 8-24h, 24h+) for each channel type.\n",
+        "description": "Get the distribution of first response times grouped by channel type.\nReturns conversation counts in different time buckets (0-1h, 1-4h, 4-8h, 8-24h, 24h+) for each channel type.\n\n**Note:** This API endpoint is available only in Chatwoot version 4.11.0 and above.\n",
         "responses": {
           "200": {
             "description": "Success",
@@ -6594,7 +6594,7 @@
             "userApiKey": []
           }
         ],
-        "description": "Get a matrix showing the count of conversations for each inbox-label combination.\nReturns a list of inboxes, labels, and a 2D matrix where each cell contains the count of conversations\nin a specific inbox that have a specific label applied.\n",
+        "description": "Get a matrix showing the count of conversations for each inbox-label combination.\nReturns a list of inboxes, labels, and a 2D matrix where each cell contains the count of conversations\nin a specific inbox that have a specific label applied.\n\n**Note:** This API endpoint is available only in Chatwoot version 4.11.0 and above.\n",
         "responses": {
           "200": {
             "description": "Success",

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -4424,6 +4424,140 @@
           }
         }
       },
+      "first_response_time_distribution": {
+        "type": "object",
+        "description": "First response time distribution report grouped by channel type. Shows the count of conversations with first response times in different time buckets.",
+        "additionalProperties": {
+          "type": "object",
+          "description": "First response time distribution for a specific channel type (e.g., Channel::WebWidget, Channel::Api)",
+          "properties": {
+            "0-1h": {
+              "type": "number",
+              "description": "Number of conversations with first response time less than 1 hour"
+            },
+            "1-4h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 1-4 hours"
+            },
+            "4-8h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 4-8 hours"
+            },
+            "8-24h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 8-24 hours"
+            },
+            "24h+": {
+              "type": "number",
+              "description": "Number of conversations with first response time greater than 24 hours"
+            }
+          }
+        },
+        "example": {
+          "Channel::WebWidget": {
+            "0-1h": 150,
+            "1-4h": 80,
+            "4-8h": 45,
+            "8-24h": 30,
+            "24h+": 15
+          },
+          "Channel::Api": {
+            "0-1h": 75,
+            "1-4h": 40,
+            "4-8h": 20,
+            "8-24h": 10,
+            "24h+": 5
+          }
+        }
+      },
+      "inbox_label_matrix": {
+        "type": "object",
+        "description": "Inbox-label matrix report showing the count of conversations for each inbox-label combination.",
+        "properties": {
+          "inboxes": {
+            "type": "array",
+            "description": "List of inboxes included in the report",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number",
+                  "description": "The inbox ID"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The inbox name"
+                }
+              }
+            }
+          },
+          "labels": {
+            "type": "array",
+            "description": "List of labels included in the report",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number",
+                  "description": "The label ID"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "The label title"
+                }
+              }
+            }
+          },
+          "matrix": {
+            "type": "array",
+            "description": "2D array where matrix[i][j] represents the count of conversations in inboxes[i] with labels[j]",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "example": {
+          "inboxes": [
+            {
+              "id": 1,
+              "name": "Website Chat"
+            },
+            {
+              "id": 2,
+              "name": "Email Support"
+            }
+          ],
+          "labels": [
+            {
+              "id": 1,
+              "title": "bug"
+            },
+            {
+              "id": 2,
+              "title": "feature-request"
+            },
+            {
+              "id": 3,
+              "title": "urgent"
+            }
+          ],
+          "matrix": [
+            [
+              10,
+              5,
+              3
+            ],
+            [
+              8,
+              12,
+              2
+            ]
+          ]
+        }
+      },
       "contact_detail": {
         "type": "object",
         "properties": {

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -3839,6 +3839,140 @@
           }
         }
       },
+      "first_response_time_distribution": {
+        "type": "object",
+        "description": "First response time distribution report grouped by channel type. Shows the count of conversations with first response times in different time buckets.",
+        "additionalProperties": {
+          "type": "object",
+          "description": "First response time distribution for a specific channel type (e.g., Channel::WebWidget, Channel::Api)",
+          "properties": {
+            "0-1h": {
+              "type": "number",
+              "description": "Number of conversations with first response time less than 1 hour"
+            },
+            "1-4h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 1-4 hours"
+            },
+            "4-8h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 4-8 hours"
+            },
+            "8-24h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 8-24 hours"
+            },
+            "24h+": {
+              "type": "number",
+              "description": "Number of conversations with first response time greater than 24 hours"
+            }
+          }
+        },
+        "example": {
+          "Channel::WebWidget": {
+            "0-1h": 150,
+            "1-4h": 80,
+            "4-8h": 45,
+            "8-24h": 30,
+            "24h+": 15
+          },
+          "Channel::Api": {
+            "0-1h": 75,
+            "1-4h": 40,
+            "4-8h": 20,
+            "8-24h": 10,
+            "24h+": 5
+          }
+        }
+      },
+      "inbox_label_matrix": {
+        "type": "object",
+        "description": "Inbox-label matrix report showing the count of conversations for each inbox-label combination.",
+        "properties": {
+          "inboxes": {
+            "type": "array",
+            "description": "List of inboxes included in the report",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number",
+                  "description": "The inbox ID"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The inbox name"
+                }
+              }
+            }
+          },
+          "labels": {
+            "type": "array",
+            "description": "List of labels included in the report",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number",
+                  "description": "The label ID"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "The label title"
+                }
+              }
+            }
+          },
+          "matrix": {
+            "type": "array",
+            "description": "2D array where matrix[i][j] represents the count of conversations in inboxes[i] with labels[j]",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "example": {
+          "inboxes": [
+            {
+              "id": 1,
+              "name": "Website Chat"
+            },
+            {
+              "id": 2,
+              "name": "Email Support"
+            }
+          ],
+          "labels": [
+            {
+              "id": 1,
+              "title": "bug"
+            },
+            {
+              "id": 2,
+              "title": "feature-request"
+            },
+            {
+              "id": 3,
+              "title": "urgent"
+            }
+          ],
+          "matrix": [
+            [
+              10,
+              5,
+              3
+            ],
+            [
+              8,
+              12,
+              2
+            ]
+          ]
+        }
+      },
       "contact_detail": {
         "type": "object",
         "properties": {

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -4600,6 +4600,140 @@
           }
         }
       },
+      "first_response_time_distribution": {
+        "type": "object",
+        "description": "First response time distribution report grouped by channel type. Shows the count of conversations with first response times in different time buckets.",
+        "additionalProperties": {
+          "type": "object",
+          "description": "First response time distribution for a specific channel type (e.g., Channel::WebWidget, Channel::Api)",
+          "properties": {
+            "0-1h": {
+              "type": "number",
+              "description": "Number of conversations with first response time less than 1 hour"
+            },
+            "1-4h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 1-4 hours"
+            },
+            "4-8h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 4-8 hours"
+            },
+            "8-24h": {
+              "type": "number",
+              "description": "Number of conversations with first response time between 8-24 hours"
+            },
+            "24h+": {
+              "type": "number",
+              "description": "Number of conversations with first response time greater than 24 hours"
+            }
+          }
+        },
+        "example": {
+          "Channel::WebWidget": {
+            "0-1h": 150,
+            "1-4h": 80,
+            "4-8h": 45,
+            "8-24h": 30,
+            "24h+": 15
+          },
+          "Channel::Api": {
+            "0-1h": 75,
+            "1-4h": 40,
+            "4-8h": 20,
+            "8-24h": 10,
+            "24h+": 5
+          }
+        }
+      },
+      "inbox_label_matrix": {
+        "type": "object",
+        "description": "Inbox-label matrix report showing the count of conversations for each inbox-label combination.",
+        "properties": {
+          "inboxes": {
+            "type": "array",
+            "description": "List of inboxes included in the report",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number",
+                  "description": "The inbox ID"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The inbox name"
+                }
+              }
+            }
+          },
+          "labels": {
+            "type": "array",
+            "description": "List of labels included in the report",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number",
+                  "description": "The label ID"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "The label title"
+                }
+              }
+            }
+          },
+          "matrix": {
+            "type": "array",
+            "description": "2D array where matrix[i][j] represents the count of conversations in inboxes[i] with labels[j]",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "example": {
+          "inboxes": [
+            {
+              "id": 1,
+              "name": "Website Chat"
+            },
+            {
+              "id": 2,
+              "name": "Email Support"
+            }
+          ],
+          "labels": [
+            {
+              "id": 1,
+              "title": "bug"
+            },
+            {
+              "id": 2,
+              "title": "feature-request"
+            },
+            {
+              "id": 3,
+              "title": "urgent"
+            }
+          ],
+          "matrix": [
+            [
+              10,
+              5,
+              3
+            ],
+            [
+              8,
+              12,
+              2
+            ]
+          ]
+        }
+      },
       "contact_detail": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
New API Documentation

  GET /api/v2/accounts/{account_id}/reports/first_response_time_distribution
  - Returns first response time distribution grouped by channel type
  - Shows conversation counts in time buckets: 0-1h, 1-4h, 4-8h, 8-24h, 24h+
  - Parameters: since, until (Unix timestamps)

  GET /api/v2/accounts/{account_id}/reports/inbox_label_matrix
  - Returns a matrix of conversation counts for inbox-label combinations
  - Parameters: since, until, inbox_ids[], label_ids[]

  Fixes

  - Removed unused business_hours boolean parameter from
  /api/v2/accounts/{account_id}/summary_reports/channel
  - Updated ReDoc script from unstable @next to stable @2.1.5 version to fix empty swagger page