### PR TITLE
Add API documentation for inbox, agent, and team summary report

### DIFF
--- a/swagger/definitions/index.yml
+++ b/swagger/definitions/index.yml
@@ -229,6 +229,12 @@ first_response_time_distribution:
   $ref: './resource/reports/first_response_time_distribution.yml'
 inbox_label_matrix:
   $ref: './resource/reports/inbox_label_matrix.yml'
+inbox_summary:
+  $ref: './resource/reports/inbox_summary.yml'
+agent_summary:
+  $ref: './resource/reports/agent_summary.yml'
+team_summary:
+  $ref: './resource/reports/team_summary.yml'
 
 contact_detail:
   $ref: ./resource/contact_detail.yml

--- a/swagger/definitions/resource/reports/agent_summary.yml
+++ b/swagger/definitions/resource/reports/agent_summary.yml
@@ -1,0 +1,39 @@
+type: array
+description: Agent summary report containing conversation statistics grouped by agent.
+items:
+  type: object
+  properties:
+    id:
+      type: number
+      description: The agent (user) ID
+    conversations_count:
+      type: number
+      description: Number of conversations assigned to the agent during the date range
+    resolved_conversations_count:
+      type: number
+      description: Number of conversations resolved by the agent during the date range
+    avg_resolution_time:
+      type: number
+      nullable: true
+      description: Average time (in seconds) to resolve conversations. Null if no data available.
+    avg_first_response_time:
+      type: number
+      nullable: true
+      description: Average time (in seconds) for the first response. Null if no data available.
+    avg_reply_time:
+      type: number
+      nullable: true
+      description: Average time (in seconds) between replies. Null if no data available.
+example:
+  - id: 1
+    conversations_count: 150
+    resolved_conversations_count: 120
+    avg_resolution_time: 3600
+    avg_first_response_time: 300
+    avg_reply_time: 600
+  - id: 2
+    conversations_count: 75
+    resolved_conversations_count: 60
+    avg_resolution_time: 1800
+    avg_first_response_time: 180
+    avg_reply_time: 420

--- a/swagger/definitions/resource/reports/inbox_summary.yml
+++ b/swagger/definitions/resource/reports/inbox_summary.yml
@@ -1,0 +1,39 @@
+type: array
+description: Inbox summary report containing conversation statistics grouped by inbox.
+items:
+  type: object
+  properties:
+    id:
+      type: number
+      description: The inbox ID
+    conversations_count:
+      type: number
+      description: Number of conversations created in the inbox during the date range
+    resolved_conversations_count:
+      type: number
+      description: Number of conversations resolved in the inbox during the date range
+    avg_resolution_time:
+      type: number
+      nullable: true
+      description: Average time (in seconds) to resolve conversations. Null if no data available.
+    avg_first_response_time:
+      type: number
+      nullable: true
+      description: Average time (in seconds) for the first response. Null if no data available.
+    avg_reply_time:
+      type: number
+      nullable: true
+      description: Average time (in seconds) between replies. Null if no data available.
+example:
+  - id: 1
+    conversations_count: 150
+    resolved_conversations_count: 120
+    avg_resolution_time: 3600
+    avg_first_response_time: 300
+    avg_reply_time: 600
+  - id: 2
+    conversations_count: 75
+    resolved_conversations_count: 60
+    avg_resolution_time: 1800
+    avg_first_response_time: 180
+    avg_reply_time: 420

--- a/swagger/definitions/resource/reports/team_summary.yml
+++ b/swagger/definitions/resource/reports/team_summary.yml
@@ -1,0 +1,39 @@
+type: array
+description: Team summary report containing conversation statistics grouped by team.
+items:
+  type: object
+  properties:
+    id:
+      type: number
+      description: The team ID
+    conversations_count:
+      type: number
+      description: Number of conversations assigned to the team during the date range
+    resolved_conversations_count:
+      type: number
+      description: Number of conversations resolved by the team during the date range
+    avg_resolution_time:
+      type: number
+      nullable: true
+      description: Average time (in seconds) to resolve conversations. Null if no data available.
+    avg_first_response_time:
+      type: number
+      nullable: true
+      description: Average time (in seconds) for the first response. Null if no data available.
+    avg_reply_time:
+      type: number
+      nullable: true
+      description: Average time (in seconds) between replies. Null if no data available.
+example:
+  - id: 1
+    conversations_count: 250
+    resolved_conversations_count: 200
+    avg_resolution_time: 2800
+    avg_first_response_time: 240
+    avg_reply_time: 500
+  - id: 2
+    conversations_count: 180
+    resolved_conversations_count: 150
+    avg_resolution_time: 2400
+    avg_first_response_time: 200
+    avg_reply_time: 450

--- a/swagger/paths/application/reports/agent_summary.yml
+++ b/swagger/paths/application/reports/agent_summary.yml
@@ -1,0 +1,23 @@
+tags:
+  - Reports
+operationId: get-agent-summary-report
+summary: Get conversation statistics grouped by agent
+security:
+  - userApiKey: []
+description: |
+  Get conversation statistics grouped by agent for a given date range.
+  Returns metrics for each agent including conversation counts, resolution counts,
+  average first response time, average resolution time, and average reply time.
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/agent_summary'
+  '403':
+    description: Access denied
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/application/reports/inbox_summary.yml
+++ b/swagger/paths/application/reports/inbox_summary.yml
@@ -1,0 +1,23 @@
+tags:
+  - Reports
+operationId: get-inbox-summary-report
+summary: Get conversation statistics grouped by inbox
+security:
+  - userApiKey: []
+description: |
+  Get conversation statistics grouped by inbox for a given date range.
+  Returns metrics for each inbox including conversation counts, resolution counts,
+  average first response time, average resolution time, and average reply time.
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/inbox_summary'
+  '403':
+    description: Access denied
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/application/reports/team_summary.yml
+++ b/swagger/paths/application/reports/team_summary.yml
@@ -1,0 +1,23 @@
+tags:
+  - Reports
+operationId: get-team-summary-report
+summary: Get conversation statistics grouped by team
+security:
+  - userApiKey: []
+description: |
+  Get conversation statistics grouped by team for a given date range.
+  Returns metrics for each team including conversation counts, resolution counts,
+  average first response time, average resolution time, and average reply time.
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/team_summary'
+  '403':
+    description: Access denied
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/index.yml
+++ b/swagger/paths/index.yml
@@ -656,6 +656,72 @@
   get:
     $ref: './application/reports/channel_summary.yml'
 
+# Inbox summary report
+/api/v2/accounts/{account_id}/summary_reports/inbox:
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+    - in: query
+      name: since
+      schema:
+        type: string
+      description: The timestamp from where report should start (Unix timestamp).
+    - in: query
+      name: until
+      schema:
+        type: string
+      description: The timestamp from where report should stop (Unix timestamp).
+    - in: query
+      name: business_hours
+      schema:
+        type: boolean
+      description: Whether to calculate metrics using business hours only.
+  get:
+    $ref: './application/reports/inbox_summary.yml'
+
+# Agent summary report
+/api/v2/accounts/{account_id}/summary_reports/agent:
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+    - in: query
+      name: since
+      schema:
+        type: string
+      description: The timestamp from where report should start (Unix timestamp).
+    - in: query
+      name: until
+      schema:
+        type: string
+      description: The timestamp from where report should stop (Unix timestamp).
+    - in: query
+      name: business_hours
+      schema:
+        type: boolean
+      description: Whether to calculate metrics using business hours only.
+  get:
+    $ref: './application/reports/agent_summary.yml'
+
+# Team summary report
+/api/v2/accounts/{account_id}/summary_reports/team:
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+    - in: query
+      name: since
+      schema:
+        type: string
+      description: The timestamp from where report should start (Unix timestamp).
+    - in: query
+      name: until
+      schema:
+        type: string
+      description: The timestamp from where report should stop (Unix timestamp).
+    - in: query
+      name: business_hours
+      schema:
+        type: boolean
+      description: Whether to calculate metrics using business hours only.
+  get:
+    $ref: './application/reports/team_summary.yml'
+
 # First response time distribution report
 /api/v2/accounts/{account_id}/reports/first_response_time_distribution:
   parameters:

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -7938,6 +7938,204 @@
         }
       }
     },
+    "/api/v2/accounts/{account_id}/summary_reports/inbox": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "in": "query",
+          "name": "since",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should start (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "until",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should stop (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "business_hours",
+          "schema": {
+            "type": "boolean"
+          },
+          "description": "Whether to calculate metrics using business hours only."
+        }
+      ],
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "operationId": "get-inbox-summary-report",
+        "summary": "Get conversation statistics grouped by inbox",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Get conversation statistics grouped by inbox for a given date range.\nReturns metrics for each inbox including conversation counts, resolution counts,\naverage first response time, average resolution time, and average reply time.\n",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/inbox_summary"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/accounts/{account_id}/summary_reports/agent": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "in": "query",
+          "name": "since",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should start (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "until",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should stop (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "business_hours",
+          "schema": {
+            "type": "boolean"
+          },
+          "description": "Whether to calculate metrics using business hours only."
+        }
+      ],
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "operationId": "get-agent-summary-report",
+        "summary": "Get conversation statistics grouped by agent",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Get conversation statistics grouped by agent for a given date range.\nReturns metrics for each agent including conversation counts, resolution counts,\naverage first response time, average resolution time, and average reply time.\n",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/agent_summary"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/accounts/{account_id}/summary_reports/team": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "in": "query",
+          "name": "since",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should start (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "until",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should stop (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "business_hours",
+          "schema": {
+            "type": "boolean"
+          },
+          "description": "Whether to calculate metrics using business hours only."
+        }
+      ],
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "operationId": "get-team-summary-report",
+        "summary": "Get conversation statistics grouped by team",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Get conversation statistics grouped by team for a given date range.\nReturns metrics for each team including conversation counts, resolution counts,\naverage first response time, average resolution time, and average reply time.\n",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/team_summary"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/accounts/{account_id}/reports/first_response_time_distribution": {
       "parameters": [
         {
@@ -12044,6 +12242,168 @@
             ]
           ]
         }
+      },
+      "inbox_summary": {
+        "type": "array",
+        "description": "Inbox summary report containing conversation statistics grouped by inbox.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The inbox ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations created in the inbox during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved in the inbox during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 150,
+            "resolved_conversations_count": 120,
+            "avg_resolution_time": 3600,
+            "avg_first_response_time": 300,
+            "avg_reply_time": 600
+          },
+          {
+            "id": 2,
+            "conversations_count": 75,
+            "resolved_conversations_count": 60,
+            "avg_resolution_time": 1800,
+            "avg_first_response_time": 180,
+            "avg_reply_time": 420
+          }
+        ]
+      },
+      "agent_summary": {
+        "type": "array",
+        "description": "Agent summary report containing conversation statistics grouped by agent.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The agent (user) ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations assigned to the agent during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved by the agent during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 150,
+            "resolved_conversations_count": 120,
+            "avg_resolution_time": 3600,
+            "avg_first_response_time": 300,
+            "avg_reply_time": 600
+          },
+          {
+            "id": 2,
+            "conversations_count": 75,
+            "resolved_conversations_count": 60,
+            "avg_resolution_time": 1800,
+            "avg_first_response_time": 180,
+            "avg_reply_time": 420
+          }
+        ]
+      },
+      "team_summary": {
+        "type": "array",
+        "description": "Team summary report containing conversation statistics grouped by team.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The team ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations assigned to the team during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved by the team during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 250,
+            "resolved_conversations_count": 200,
+            "avg_resolution_time": 2800,
+            "avg_first_response_time": 240,
+            "avg_reply_time": 500
+          },
+          {
+            "id": 2,
+            "conversations_count": 180,
+            "resolved_conversations_count": 150,
+            "avg_resolution_time": 2400,
+            "avg_first_response_time": 200,
+            "avg_reply_time": 450
+          }
+        ]
       },
       "contact_detail": {
         "type": "object",

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -6481,6 +6481,204 @@
         }
       }
     },
+    "/api/v2/accounts/{account_id}/summary_reports/inbox": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "in": "query",
+          "name": "since",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should start (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "until",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should stop (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "business_hours",
+          "schema": {
+            "type": "boolean"
+          },
+          "description": "Whether to calculate metrics using business hours only."
+        }
+      ],
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "operationId": "get-inbox-summary-report",
+        "summary": "Get conversation statistics grouped by inbox",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Get conversation statistics grouped by inbox for a given date range.\nReturns metrics for each inbox including conversation counts, resolution counts,\naverage first response time, average resolution time, and average reply time.\n",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/inbox_summary"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/accounts/{account_id}/summary_reports/agent": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "in": "query",
+          "name": "since",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should start (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "until",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should stop (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "business_hours",
+          "schema": {
+            "type": "boolean"
+          },
+          "description": "Whether to calculate metrics using business hours only."
+        }
+      ],
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "operationId": "get-agent-summary-report",
+        "summary": "Get conversation statistics grouped by agent",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Get conversation statistics grouped by agent for a given date range.\nReturns metrics for each agent including conversation counts, resolution counts,\naverage first response time, average resolution time, and average reply time.\n",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/agent_summary"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/accounts/{account_id}/summary_reports/team": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "in": "query",
+          "name": "since",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should start (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "until",
+          "schema": {
+            "type": "string"
+          },
+          "description": "The timestamp from where report should stop (Unix timestamp)."
+        },
+        {
+          "in": "query",
+          "name": "business_hours",
+          "schema": {
+            "type": "boolean"
+          },
+          "description": "Whether to calculate metrics using business hours only."
+        }
+      ],
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "operationId": "get-team-summary-report",
+        "summary": "Get conversation statistics grouped by team",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Get conversation statistics grouped by team for a given date range.\nReturns metrics for each team including conversation counts, resolution counts,\naverage first response time, average resolution time, and average reply time.\n",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/team_summary"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/accounts/{account_id}/reports/first_response_time_distribution": {
       "parameters": [
         {
@@ -10551,6 +10749,168 @@
             ]
           ]
         }
+      },
+      "inbox_summary": {
+        "type": "array",
+        "description": "Inbox summary report containing conversation statistics grouped by inbox.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The inbox ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations created in the inbox during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved in the inbox during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 150,
+            "resolved_conversations_count": 120,
+            "avg_resolution_time": 3600,
+            "avg_first_response_time": 300,
+            "avg_reply_time": 600
+          },
+          {
+            "id": 2,
+            "conversations_count": 75,
+            "resolved_conversations_count": 60,
+            "avg_resolution_time": 1800,
+            "avg_first_response_time": 180,
+            "avg_reply_time": 420
+          }
+        ]
+      },
+      "agent_summary": {
+        "type": "array",
+        "description": "Agent summary report containing conversation statistics grouped by agent.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The agent (user) ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations assigned to the agent during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved by the agent during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 150,
+            "resolved_conversations_count": 120,
+            "avg_resolution_time": 3600,
+            "avg_first_response_time": 300,
+            "avg_reply_time": 600
+          },
+          {
+            "id": 2,
+            "conversations_count": 75,
+            "resolved_conversations_count": 60,
+            "avg_resolution_time": 1800,
+            "avg_first_response_time": 180,
+            "avg_reply_time": 420
+          }
+        ]
+      },
+      "team_summary": {
+        "type": "array",
+        "description": "Team summary report containing conversation statistics grouped by team.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The team ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations assigned to the team during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved by the team during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 250,
+            "resolved_conversations_count": 200,
+            "avg_resolution_time": 2800,
+            "avg_first_response_time": 240,
+            "avg_reply_time": 500
+          },
+          {
+            "id": 2,
+            "conversations_count": 180,
+            "resolved_conversations_count": 150,
+            "avg_resolution_time": 2400,
+            "avg_first_response_time": 200,
+            "avg_reply_time": 450
+          }
+        ]
       },
       "contact_detail": {
         "type": "object",

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -4558,6 +4558,168 @@
           ]
         }
       },
+      "inbox_summary": {
+        "type": "array",
+        "description": "Inbox summary report containing conversation statistics grouped by inbox.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The inbox ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations created in the inbox during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved in the inbox during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 150,
+            "resolved_conversations_count": 120,
+            "avg_resolution_time": 3600,
+            "avg_first_response_time": 300,
+            "avg_reply_time": 600
+          },
+          {
+            "id": 2,
+            "conversations_count": 75,
+            "resolved_conversations_count": 60,
+            "avg_resolution_time": 1800,
+            "avg_first_response_time": 180,
+            "avg_reply_time": 420
+          }
+        ]
+      },
+      "agent_summary": {
+        "type": "array",
+        "description": "Agent summary report containing conversation statistics grouped by agent.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The agent (user) ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations assigned to the agent during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved by the agent during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 150,
+            "resolved_conversations_count": 120,
+            "avg_resolution_time": 3600,
+            "avg_first_response_time": 300,
+            "avg_reply_time": 600
+          },
+          {
+            "id": 2,
+            "conversations_count": 75,
+            "resolved_conversations_count": 60,
+            "avg_resolution_time": 1800,
+            "avg_first_response_time": 180,
+            "avg_reply_time": 420
+          }
+        ]
+      },
+      "team_summary": {
+        "type": "array",
+        "description": "Team summary report containing conversation statistics grouped by team.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The team ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations assigned to the team during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved by the team during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 250,
+            "resolved_conversations_count": 200,
+            "avg_resolution_time": 2800,
+            "avg_first_response_time": 240,
+            "avg_reply_time": 500
+          },
+          {
+            "id": 2,
+            "conversations_count": 180,
+            "resolved_conversations_count": 150,
+            "avg_resolution_time": 2400,
+            "avg_first_response_time": 200,
+            "avg_reply_time": 450
+          }
+        ]
+      },
       "contact_detail": {
         "type": "object",
         "properties": {

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -3973,6 +3973,168 @@
           ]
         }
       },
+      "inbox_summary": {
+        "type": "array",
+        "description": "Inbox summary report containing conversation statistics grouped by inbox.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The inbox ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations created in the inbox during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved in the inbox during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 150,
+            "resolved_conversations_count": 120,
+            "avg_resolution_time": 3600,
+            "avg_first_response_time": 300,
+            "avg_reply_time": 600
+          },
+          {
+            "id": 2,
+            "conversations_count": 75,
+            "resolved_conversations_count": 60,
+            "avg_resolution_time": 1800,
+            "avg_first_response_time": 180,
+            "avg_reply_time": 420
+          }
+        ]
+      },
+      "agent_summary": {
+        "type": "array",
+        "description": "Agent summary report containing conversation statistics grouped by agent.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The agent (user) ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations assigned to the agent during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved by the agent during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 150,
+            "resolved_conversations_count": 120,
+            "avg_resolution_time": 3600,
+            "avg_first_response_time": 300,
+            "avg_reply_time": 600
+          },
+          {
+            "id": 2,
+            "conversations_count": 75,
+            "resolved_conversations_count": 60,
+            "avg_resolution_time": 1800,
+            "avg_first_response_time": 180,
+            "avg_reply_time": 420
+          }
+        ]
+      },
+      "team_summary": {
+        "type": "array",
+        "description": "Team summary report containing conversation statistics grouped by team.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The team ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations assigned to the team during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved by the team during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 250,
+            "resolved_conversations_count": 200,
+            "avg_resolution_time": 2800,
+            "avg_first_response_time": 240,
+            "avg_reply_time": 500
+          },
+          {
+            "id": 2,
+            "conversations_count": 180,
+            "resolved_conversations_count": 150,
+            "avg_resolution_time": 2400,
+            "avg_first_response_time": 200,
+            "avg_reply_time": 450
+          }
+        ]
+      },
       "contact_detail": {
         "type": "object",
         "properties": {

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -4734,6 +4734,168 @@
           ]
         }
       },
+      "inbox_summary": {
+        "type": "array",
+        "description": "Inbox summary report containing conversation statistics grouped by inbox.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The inbox ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations created in the inbox during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved in the inbox during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 150,
+            "resolved_conversations_count": 120,
+            "avg_resolution_time": 3600,
+            "avg_first_response_time": 300,
+            "avg_reply_time": 600
+          },
+          {
+            "id": 2,
+            "conversations_count": 75,
+            "resolved_conversations_count": 60,
+            "avg_resolution_time": 1800,
+            "avg_first_response_time": 180,
+            "avg_reply_time": 420
+          }
+        ]
+      },
+      "agent_summary": {
+        "type": "array",
+        "description": "Agent summary report containing conversation statistics grouped by agent.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The agent (user) ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations assigned to the agent during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved by the agent during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 150,
+            "resolved_conversations_count": 120,
+            "avg_resolution_time": 3600,
+            "avg_first_response_time": 300,
+            "avg_reply_time": 600
+          },
+          {
+            "id": 2,
+            "conversations_count": 75,
+            "resolved_conversations_count": 60,
+            "avg_resolution_time": 1800,
+            "avg_first_response_time": 180,
+            "avg_reply_time": 420
+          }
+        ]
+      },
+      "team_summary": {
+        "type": "array",
+        "description": "Team summary report containing conversation statistics grouped by team.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number",
+              "description": "The team ID"
+            },
+            "conversations_count": {
+              "type": "number",
+              "description": "Number of conversations assigned to the team during the date range"
+            },
+            "resolved_conversations_count": {
+              "type": "number",
+              "description": "Number of conversations resolved by the team during the date range"
+            },
+            "avg_resolution_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) to resolve conversations. Null if no data available."
+            },
+            "avg_first_response_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) for the first response. Null if no data available."
+            },
+            "avg_reply_time": {
+              "type": "number",
+              "nullable": true,
+              "description": "Average time (in seconds) between replies. Null if no data available."
+            }
+          }
+        },
+        "example": [
+          {
+            "id": 1,
+            "conversations_count": 250,
+            "resolved_conversations_count": 200,
+            "avg_resolution_time": 2800,
+            "avg_first_response_time": 240,
+            "avg_reply_time": 500
+          },
+          {
+            "id": 2,
+            "conversations_count": 180,
+            "resolved_conversations_count": 150,
+            "avg_resolution_time": 2400,
+            "avg_first_response_time": 200,
+            "avg_reply_time": 450
+          }
+        ]
+      },
       "contact_detail": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
- Add API documentation for inbox, agent, and team summary report endpoints
- These endpoints return conversation statistics grouped by inbox/agent/team for a given date range

Endpoints documented:
GET /api/v2/accounts/{account_id}/summary_reports/inbox │ Conversation stats grouped by inbox │
GET /api/v2/accounts/{account_id}/summary_reports/agent │ Conversation stats grouped by agent │
GET /api/v2/accounts/{account_id}/summary_reports/team  │ Conversation stats grouped by team  │

Query parameters (all endpoints):
- since - Start timestamp (Unix)
- until - End timestamp (Unix)
- business_hours - Calculate metrics using business hours only

Response fields:
- id - Inbox/Agent/Team ID
- conversations_count - Total conversations in date range
- resolved_conversations_count - Resolved conversations in date range
- avg_resolution_time - Average resolution time (seconds)
- avg_first_response_time - Average first response time (seconds)
- avg_reply_time - Average reply time (seconds)
