### PR TITLE
fix: Widget DirectUpload CSRF error

### DIFF
--- a/app/controllers/api/v1/widget/direct_uploads_controller.rb
+++ b/app/controllers/api/v1/widget/direct_uploads_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::Widget::DirectUploadsController < ActiveStorage::DirectUploadsController
+  skip_before_action :verify_authenticity_token
   include WebsiteTokenHelper
   before_action :set_web_widget
   before_action :set_contact


### PR DESCRIPTION
## Problem
Widget file uploads via ActiveStorage DirectUpload fail on production with:

```text
ActionController::InvalidAuthenticityToken (Can't verify CSRF token authenticity.)
```

This occurs because `Api::V1::Widget::DirectUploadsController` inherits from `ActiveStorage::DirectUploadsController` → `ActiveStorage::BaseController`, which has protect_from_forgery with: :exception enabled.

While CSRF works on same-origin, it fails in production because the widget is embedded in an iframe on third-party customer sites (cross-origin)


## Solution
Skip CSRF verification for the widget direct uploads endpoint - this is safe because:

- Widget endpoints authenticate via website_token + X-Auth-Token (token-based auth)
- CSRF protection is designed for session-based auth, not token-based auth