### PR TITLE
feat(captain): Add MCP server integration for external tool providers

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,1 +1,1 @@
-/spec
+/specifications

--- a/Gemfile
+++ b/Gemfile
@@ -196,6 +196,7 @@ gem 'ai-agents', '>= 0.7.0'
 # TODO: Move this gem as a dependency of ai-agents
 gem 'ruby_llm', '>= 1.8.2'
 gem 'ruby_llm-schema'
+gem 'ruby-mcp-client'
 
 # OpenTelemetry for LLM observability
 gem 'opentelemetry-sdk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -810,6 +810,10 @@ GEM
     rubocop-rspec (3.6.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
+    ruby-mcp-client (0.9.1)
+      faraday (~> 2.0)
+      faraday-follow_redirects (~> 0.3)
+      faraday-retry (~> 2.0)
     ruby-openai (7.3.1)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
@@ -1124,6 +1128,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  ruby-mcp-client
   ruby-openai
   ruby_llm (>= 1.8.2)
   ruby_llm-schema

--- a/app/javascript/dashboard/api/captain/assistantMcpServers.js
+++ b/app/javascript/dashboard/api/captain/assistantMcpServers.js
@@ -1,0 +1,30 @@
+/* global axios */
+import ApiClient from '../ApiClient';
+
+class CaptainAssistantMcpServersAPI extends ApiClient {
+  constructor() {
+    super('', { accountScoped: true });
+  }
+
+  getUrl(assistantId) {
+    return `${this.baseUrl()}/captain/assistants/${assistantId}/mcp_servers`;
+  }
+
+  get(assistantId) {
+    return axios.get(this.getUrl(assistantId));
+  }
+
+  create(assistantId, data) {
+    return axios.post(this.getUrl(assistantId), data);
+  }
+
+  update(assistantId, id, data) {
+    return axios.patch(`${this.getUrl(assistantId)}/${id}`, data);
+  }
+
+  delete(assistantId, id) {
+    return axios.delete(`${this.getUrl(assistantId)}/${id}`);
+  }
+}
+
+export default new CaptainAssistantMcpServersAPI();

--- a/app/javascript/dashboard/api/captain/assistantMcpServers.js
+++ b/app/javascript/dashboard/api/captain/assistantMcpServers.js
@@ -10,12 +10,18 @@ class CaptainAssistantMcpServersAPI extends ApiClient {
     return `${this.baseUrl()}/captain/assistants/${assistantId}/mcp_servers`;
   }
 
-  get(assistantId) {
+  get({ assistantId } = {}) {
     return axios.get(this.getUrl(assistantId));
   }
 
-  create(assistantId, data) {
-    return axios.post(this.getUrl(assistantId), data);
+  create({ assistantId, mcpServerId, enabled = true, toolFilters = {} } = {}) {
+    return axios.post(this.getUrl(assistantId), {
+      assistant_mcp_server: {
+        captain_mcp_server_id: mcpServerId,
+        enabled,
+        tool_filters: toolFilters,
+      },
+    });
   }
 
   update(assistantId, id, data) {

--- a/app/javascript/dashboard/api/captain/mcpServers.js
+++ b/app/javascript/dashboard/api/captain/mcpServers.js
@@ -1,0 +1,22 @@
+/* global axios */
+import ApiClient from '../ApiClient';
+
+class CaptainMcpServersAPI extends ApiClient {
+  constructor() {
+    super('captain/mcp_servers', { accountScoped: true });
+  }
+
+  connect(id) {
+    return axios.post(`${this.url}/${id}/connect`);
+  }
+
+  disconnect(id) {
+    return axios.post(`${this.url}/${id}/disconnect`);
+  }
+
+  refresh(id) {
+    return axios.post(`${this.url}/${id}/refresh`);
+  }
+}
+
+export default new CaptainMcpServersAPI();

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/AssistantMcpServerCard.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/AssistantMcpServerCard.vue
@@ -1,0 +1,78 @@
+<script setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import CardLayout from 'dashboard/components-next/CardLayout.vue';
+import Button from 'dashboard/components-next/button/Button.vue';
+import Policy from 'dashboard/components/policy.vue';
+
+const props = defineProps({
+  record: {
+    type: Object,
+    required: true,
+  },
+});
+
+const emit = defineEmits(['detach']);
+
+const { t } = useI18n();
+
+const server = computed(() => props.record.mcp_server || {});
+
+const statusLabel = computed(() => {
+  const status = server.value.status || 'disconnected';
+  if (status === 'connected') {
+    return t('CAPTAIN_SETTINGS.MCP_SERVERS.STATUS.CONNECTED');
+  }
+  if (status === 'connecting') {
+    return t('CAPTAIN_SETTINGS.MCP_SERVERS.STATUS.CONNECTING');
+  }
+  if (status === 'error') {
+    return t('CAPTAIN_SETTINGS.MCP_SERVERS.STATUS.ERROR');
+  }
+  return t('CAPTAIN_SETTINGS.MCP_SERVERS.STATUS.DISCONNECTED');
+});
+
+const statusClass = computed(() => {
+  const status = server.value.status;
+  if (status === 'connected') return 'text-n-teal-11 bg-n-teal-3';
+  if (status === 'connecting') return 'text-n-amber-11 bg-n-amber-3';
+  if (status === 'error') return 'text-n-ruby-11 bg-n-ruby-3';
+  return 'text-n-slate-11 bg-n-slate-3';
+});
+</script>
+
+<template>
+  <CardLayout>
+    <div class="flex items-start justify-between gap-4">
+      <div class="flex flex-col gap-1 min-w-0">
+        <div class="flex items-center gap-2">
+          <span class="text-base font-medium text-n-slate-12 truncate">
+            {{ server.name }}
+          </span>
+          <span
+            class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+            :class="statusClass"
+          >
+            {{ statusLabel }}
+          </span>
+        </div>
+        <p v-if="server.description" class="text-sm text-n-slate-11">
+          {{ server.description }}
+        </p>
+        <span class="text-xs text-n-slate-10 truncate">
+          {{ server.url }}
+        </span>
+      </div>
+
+      <Policy :permissions="['administrator']">
+        <Button
+          color="slate"
+          size="xs"
+          :label="t('CAPTAIN.MCP_SERVERS.DETACH')"
+          @click="emit('detach', record)"
+        />
+      </Policy>
+    </div>
+  </CardLayout>
+</template>

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/ConnectMcpServerDialog.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/ConnectMcpServerDialog.vue
@@ -1,0 +1,66 @@
+<script setup>
+import { ref } from 'vue';
+import { useStore } from 'dashboard/composables/store';
+import { useAlert } from 'dashboard/composables';
+import { useI18n } from 'vue-i18n';
+
+import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
+import ConnectMcpServerForm from './ConnectMcpServerForm.vue';
+
+const props = defineProps({
+  assistantId: {
+    type: Number,
+    required: true,
+  },
+});
+
+const emit = defineEmits(['close']);
+const { t } = useI18n();
+const store = useStore();
+
+const dialogRef = ref(null);
+
+const handleSubmit = async payload => {
+  try {
+    await store.dispatch('captainAssistantMcpServers/create', {
+      assistantId: props.assistantId,
+      ...payload,
+    });
+    useAlert(t('CAPTAIN.MCP_SERVERS.CREATE.SUCCESS_MESSAGE'));
+    dialogRef.value.close();
+  } catch (error) {
+    const errorMessage =
+      error?.message || t('CAPTAIN.MCP_SERVERS.CREATE.ERROR_MESSAGE');
+    useAlert(errorMessage);
+  }
+};
+
+const handleClose = () => {
+  emit('close');
+};
+
+const handleCancel = () => {
+  dialogRef.value.close();
+};
+
+defineExpose({ dialogRef });
+</script>
+
+<template>
+  <Dialog
+    ref="dialogRef"
+    type="create"
+    :title="$t('CAPTAIN.MCP_SERVERS.CREATE.TITLE')"
+    :description="$t('CAPTAIN.MCP_SERVERS.FORM_DESCRIPTION')"
+    :show-cancel-button="false"
+    :show-confirm-button="false"
+    @close="handleClose"
+  >
+    <ConnectMcpServerForm
+      :assistant-id="assistantId"
+      @submit="handleSubmit"
+      @cancel="handleCancel"
+    />
+    <template #footer />
+  </Dialog>
+</template>

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/ConnectMcpServerForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/ConnectMcpServerForm.vue
@@ -1,0 +1,218 @@
+<script setup>
+import { reactive, computed, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import { useMapGetter } from 'dashboard/composables/store';
+
+import Button from 'dashboard/components-next/button/Button.vue';
+import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
+import Checkbox from 'dashboard/components-next/checkbox/Checkbox.vue';
+
+const emit = defineEmits(['submit', 'cancel']);
+
+const { t } = useI18n();
+
+const formState = {
+  uiFlags: useMapGetter('captainAssistantMcpServers/getUIFlags'),
+  assistantMcpServers: useMapGetter('captainAssistantMcpServers/getRecords'),
+  mcpServers: useMapGetter('captainMcpServers/getRecords'),
+};
+
+const initialState = {
+  mcpServerId: null,
+  selectedTools: [],
+};
+
+const state = reactive({ ...initialState });
+
+const validationRules = {
+  mcpServerId: { required },
+};
+
+const availableServers = computed(() => {
+  const attachedIds = formState.assistantMcpServers.value.map(
+    record => record.captain_mcp_server_id
+  );
+
+  return formState.mcpServers.value
+    .filter(server => !attachedIds.includes(server.id))
+    .map(server => ({
+      value: server.id,
+      label: server.name,
+    }));
+});
+
+const selectedServer = computed(() => {
+  return formState.mcpServers.value.find(
+    server => server.id === state.mcpServerId
+  );
+});
+
+const availableTools = computed(() => {
+  return selectedServer.value?.cached_tools || [];
+});
+
+const toolNames = computed(() => availableTools.value.map(tool => tool.name));
+
+const allToolsSelected = computed(
+  () =>
+    toolNames.value.length > 0 &&
+    state.selectedTools.length === toolNames.value.length
+);
+
+const isIndeterminate = computed(
+  () =>
+    state.selectedTools.length > 0 &&
+    state.selectedTools.length < toolNames.value.length
+);
+
+const v$ = useVuelidate(validationRules, state);
+
+const isLoading = computed(() => formState.uiFlags.value.creatingItem);
+
+const formErrors = computed(() => ({
+  mcpServerId: v$.value.mcpServerId.$error
+    ? t('CAPTAIN.MCP_SERVERS.FORM.MCP_SERVER.ERROR')
+    : '',
+}));
+
+const handleCancel = () => emit('cancel');
+
+const toggleAllTools = () => {
+  if (allToolsSelected.value) {
+    state.selectedTools = [];
+  } else {
+    state.selectedTools = [...toolNames.value];
+  }
+};
+
+const toggleTool = toolName => {
+  if (state.selectedTools.includes(toolName)) {
+    state.selectedTools = state.selectedTools.filter(name => name !== toolName);
+  } else {
+    state.selectedTools = [...state.selectedTools, toolName];
+  }
+};
+
+const buildToolFilters = () => {
+  if (!toolNames.value.length) return {};
+  if (allToolsSelected.value) return {};
+  if (!state.selectedTools.length) {
+    return { exclude: toolNames.value };
+  }
+  return { include: state.selectedTools };
+};
+
+const handleSubmit = async () => {
+  const isFormValid = await v$.value.$validate();
+  if (!isFormValid) {
+    return;
+  }
+
+  emit('submit', {
+    mcpServerId: state.mcpServerId,
+    toolFilters: buildToolFilters(),
+  });
+};
+
+watch(
+  () => state.mcpServerId,
+  () => {
+    state.selectedTools = [...toolNames.value];
+  }
+);
+</script>
+
+<template>
+  <form class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+    <div class="flex flex-col gap-1">
+      <label
+        for="mcp-server"
+        class="mb-0.5 text-sm font-medium text-n-slate-12"
+      >
+        {{ t('CAPTAIN.MCP_SERVERS.FORM.MCP_SERVER.LABEL') }}
+      </label>
+      <ComboBox
+        id="mcp-server"
+        v-model="state.mcpServerId"
+        :options="availableServers"
+        :has-error="!!formErrors.mcpServerId"
+        :placeholder="t('CAPTAIN.MCP_SERVERS.FORM.MCP_SERVER.PLACEHOLDER')"
+        class="[&>div>button]:bg-n-alpha-black2 [&>div>button:not(.focused)]:dark:outline-n-weak [&>div>button:not(.focused)]:hover:!outline-n-slate-6"
+        :message="formErrors.mcpServerId"
+      />
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center justify-between">
+        <span class="text-sm font-medium text-n-slate-12">
+          {{ t('CAPTAIN.MCP_SERVERS.TOOLS.TITLE') }}
+        </span>
+        <div class="flex items-center gap-2">
+          <Checkbox
+            :model-value="allToolsSelected"
+            :indeterminate="isIndeterminate"
+            :disabled="!toolNames.length"
+            @change="toggleAllTools"
+          />
+          <span class="text-xs text-n-slate-11">
+            {{ t('CAPTAIN.MCP_SERVERS.TOOLS.SELECT_ALL') }}
+          </span>
+        </div>
+      </div>
+
+      <p class="text-xs text-n-slate-10">
+        {{ t('CAPTAIN.MCP_SERVERS.TOOLS.DESCRIPTION') }}
+      </p>
+
+      <div
+        v-if="!toolNames.length"
+        class="rounded-lg border border-n-container bg-n-solid-2 p-3 text-xs text-n-slate-11"
+      >
+        {{ t('CAPTAIN.MCP_SERVERS.TOOLS.EMPTY') }}
+      </div>
+
+      <div v-else class="flex flex-col gap-2">
+        <div
+          v-for="tool in availableTools"
+          :key="tool.name"
+          class="flex items-start gap-3 rounded-lg border border-n-container bg-n-solid-2 p-3"
+        >
+          <div class="pt-0.5">
+            <Checkbox
+              :model-value="state.selectedTools.includes(tool.name)"
+              @change="toggleTool(tool.name)"
+            />
+          </div>
+          <div class="flex flex-col gap-1">
+            <span class="text-xs font-medium text-n-slate-12">
+              {{ tool.name }}
+            </span>
+            <span v-if="tool.description" class="text-xs text-n-slate-10">
+              {{ tool.description }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex items-center justify-between w-full gap-3">
+      <Button
+        type="button"
+        variant="faded"
+        color="slate"
+        :label="t('CAPTAIN.FORM.CANCEL')"
+        class="w-full bg-n-alpha-2 text-n-blue-11 hover:bg-n-alpha-3"
+        @click="handleCancel"
+      />
+      <Button
+        type="submit"
+        :label="t('CAPTAIN.FORM.CREATE')"
+        class="w-full"
+        :is-loading="isLoading"
+        :disabled="isLoading"
+      />
+    </div>
+  </form>
+</template>

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/ConnectMcpServerForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/ConnectMcpServerForm.vue
@@ -173,7 +173,7 @@ watch(
         {{ t('CAPTAIN.MCP_SERVERS.TOOLS.EMPTY') }}
       </div>
 
-      <div v-else class="flex flex-col gap-2">
+      <div v-else class="flex flex-col gap-2 max-h-64 overflow-y-auto">
         <div
           v-for="tool in availableTools"
           :key="tool.name"

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/CreateMcpServerDialog.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/CreateMcpServerDialog.vue
@@ -73,7 +73,7 @@ defineExpose({ dialogRef });
     ref="dialogRef"
     width="xl"
     :title="$t(`${i18nKey}.TITLE`)"
-    :description="$t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.DESCRIPTION')"
+    :description="$t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.HELP_TEXT')"
     :show-cancel-button="false"
     :show-confirm-button="false"
     @close="handleClose"

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/CreateMcpServerDialog.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/CreateMcpServerDialog.vue
@@ -26,9 +26,22 @@ const store = useStore();
 
 const dialogRef = ref(null);
 
-const i18nKey = computed(
-  () => `CAPTAIN_SETTINGS.MCP_SERVERS.${props.type.toUpperCase()}`
-);
+const dialogCopy = computed(() => {
+  const copyMap = {
+    create: {
+      title: t('CAPTAIN_SETTINGS.MCP_SERVERS.CREATE.TITLE'),
+      successMessage: t('CAPTAIN_SETTINGS.MCP_SERVERS.CREATE.SUCCESS_MESSAGE'),
+      errorMessage: t('CAPTAIN_SETTINGS.MCP_SERVERS.CREATE.ERROR_MESSAGE'),
+    },
+    edit: {
+      title: t('CAPTAIN_SETTINGS.MCP_SERVERS.EDIT.TITLE'),
+      successMessage: t('CAPTAIN_SETTINGS.MCP_SERVERS.EDIT.SUCCESS_MESSAGE'),
+      errorMessage: t('CAPTAIN_SETTINGS.MCP_SERVERS.EDIT.ERROR_MESSAGE'),
+    },
+  };
+
+  return copyMap[props.type] || copyMap.create;
+});
 
 const updateServer = serverDetails =>
   store.dispatch('captainMcpServers/update', {
@@ -47,12 +60,12 @@ const handleSubmit = async serverData => {
     } else {
       result = await createServer(serverData);
     }
-    useAlert(t(`${i18nKey.value}.SUCCESS_MESSAGE`));
+    useAlert(dialogCopy.value.successMessage);
     emit('created', result);
     dialogRef.value.close();
   } catch (error) {
     const errorMessage =
-      parseAPIErrorResponse(error) || t(`${i18nKey.value}.ERROR_MESSAGE`);
+      parseAPIErrorResponse(error) || dialogCopy.value.errorMessage;
     useAlert(errorMessage);
   }
 };
@@ -72,7 +85,7 @@ defineExpose({ dialogRef });
   <Dialog
     ref="dialogRef"
     width="xl"
-    :title="$t(`${i18nKey}.TITLE`)"
+    :title="dialogCopy.title"
     :description="$t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.HELP_TEXT')"
     :show-cancel-button="false"
     :show-confirm-button="false"

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/CreateMcpServerDialog.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/CreateMcpServerDialog.vue
@@ -1,0 +1,89 @@
+<script setup>
+import { ref, computed } from 'vue';
+import { useStore } from 'dashboard/composables/store';
+import { useAlert } from 'dashboard/composables';
+import { useI18n } from 'vue-i18n';
+import { parseAPIErrorResponse } from 'dashboard/store/utils/api';
+
+import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
+import McpServerForm from './McpServerForm.vue';
+
+const props = defineProps({
+  selectedServer: {
+    type: Object,
+    default: () => ({}),
+  },
+  type: {
+    type: String,
+    default: 'create',
+    validator: value => ['create', 'edit'].includes(value),
+  },
+});
+
+const emit = defineEmits(['close', 'created']);
+const { t } = useI18n();
+const store = useStore();
+
+const dialogRef = ref(null);
+
+const i18nKey = computed(
+  () => `CAPTAIN_SETTINGS.MCP_SERVERS.${props.type.toUpperCase()}`
+);
+
+const updateServer = serverDetails =>
+  store.dispatch('captainMcpServers/update', {
+    id: props.selectedServer.id,
+    ...serverDetails,
+  });
+
+const createServer = serverDetails =>
+  store.dispatch('captainMcpServers/create', serverDetails);
+
+const handleSubmit = async serverData => {
+  try {
+    let result;
+    if (props.type === 'edit') {
+      result = await updateServer(serverData);
+    } else {
+      result = await createServer(serverData);
+    }
+    useAlert(t(`${i18nKey.value}.SUCCESS_MESSAGE`));
+    emit('created', result);
+    dialogRef.value.close();
+  } catch (error) {
+    const errorMessage =
+      parseAPIErrorResponse(error) || t(`${i18nKey.value}.ERROR_MESSAGE`);
+    useAlert(errorMessage);
+  }
+};
+
+const handleClose = () => {
+  emit('close');
+};
+
+const handleCancel = () => {
+  dialogRef.value.close();
+};
+
+defineExpose({ dialogRef });
+</script>
+
+<template>
+  <Dialog
+    ref="dialogRef"
+    width="xl"
+    :title="$t(`${i18nKey}.TITLE`)"
+    :description="$t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.DESCRIPTION')"
+    :show-cancel-button="false"
+    :show-confirm-button="false"
+    @close="handleClose"
+  >
+    <McpServerForm
+      :mode="type"
+      :server="selectedServer"
+      @submit="handleSubmit"
+      @cancel="handleCancel"
+    />
+    <template #footer />
+  </Dialog>
+</template>

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerCard.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerCard.vue
@@ -255,7 +255,10 @@ const handleQuickConnect = () => {
         <i
           class="i-lucide-alert-circle text-n-ruby-11 text-base mt-0.5 shrink-0"
         />
-        <p class="text-sm text-n-ruby-11">
+        <p
+          class="text-sm text-n-ruby-11 line-clamp-2"
+          :title="server.last_error"
+        >
           {{ server.last_error }}
         </p>
       </div>

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerCard.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerCard.vue
@@ -109,10 +109,12 @@ const timestamp = computed(() => {
 });
 
 const authTypeLabel = computed(() => {
-  if (props.server.auth_type === 'none') return null;
-  return t(
-    `CAPTAIN_SETTINGS.MCP_SERVERS.AUTH_TYPES.${props.server.auth_type.toUpperCase()}`
-  );
+  const labels = {
+    bearer: t('CAPTAIN_SETTINGS.MCP_SERVERS.AUTH_TYPES.BEARER'),
+    api_key: t('CAPTAIN_SETTINGS.MCP_SERVERS.AUTH_TYPES.API_KEY'),
+  };
+
+  return labels[props.server.auth_type] || null;
 });
 
 const handleAction = ({ action }) => {

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerCard.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerCard.vue
@@ -1,0 +1,299 @@
+<script setup>
+import { computed } from 'vue';
+import { useToggle } from '@vueuse/core';
+import { useI18n } from 'vue-i18n';
+import { dynamicTime } from 'shared/helpers/timeHelper';
+
+import CardLayout from 'dashboard/components-next/CardLayout.vue';
+import DropdownMenu from 'dashboard/components-next/dropdown-menu/DropdownMenu.vue';
+import Button from 'dashboard/components-next/button/Button.vue';
+import Policy from 'dashboard/components/policy.vue';
+
+const props = defineProps({
+  server: {
+    type: Object,
+    required: true,
+  },
+  isUpdating: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['action']);
+
+const { t } = useI18n();
+const [showActionsDropdown, toggleDropdown] = useToggle();
+
+const statusConfig = computed(() => {
+  const configs = {
+    connected: {
+      label: t('CAPTAIN_SETTINGS.MCP_SERVERS.STATUS.CONNECTED'),
+      color: 'bg-n-teal-9',
+      textColor: 'text-n-teal-11',
+      bgColor: 'bg-n-teal-3',
+    },
+    connecting: {
+      label: t('CAPTAIN_SETTINGS.MCP_SERVERS.STATUS.CONNECTING'),
+      color: 'bg-n-amber-9',
+      textColor: 'text-n-amber-11',
+      bgColor: 'bg-n-amber-3',
+    },
+    disconnected: {
+      label: t('CAPTAIN_SETTINGS.MCP_SERVERS.STATUS.DISCONNECTED'),
+      color: 'bg-n-slate-8',
+      textColor: 'text-n-slate-11',
+      bgColor: 'bg-n-slate-3',
+    },
+    error: {
+      label: t('CAPTAIN_SETTINGS.MCP_SERVERS.STATUS.ERROR'),
+      color: 'bg-n-ruby-9',
+      textColor: 'text-n-ruby-11',
+      bgColor: 'bg-n-ruby-3',
+    },
+  };
+  return configs[props.server.status] || configs.disconnected;
+});
+
+const menuItems = computed(() => {
+  const items = [];
+
+  if (props.server.status === 'connected') {
+    items.push({
+      label: t('CAPTAIN_SETTINGS.MCP_SERVERS.OPTIONS.REFRESH'),
+      value: 'refresh',
+      action: 'refresh',
+      icon: 'i-lucide-refresh-cw',
+    });
+    items.push({
+      label: t('CAPTAIN_SETTINGS.MCP_SERVERS.OPTIONS.DISCONNECT'),
+      value: 'disconnect',
+      action: 'disconnect',
+      icon: 'i-lucide-unplug',
+    });
+  } else {
+    items.push({
+      label: t('CAPTAIN_SETTINGS.MCP_SERVERS.OPTIONS.CONNECT'),
+      value: 'connect',
+      action: 'connect',
+      icon: 'i-lucide-plug',
+    });
+  }
+
+  items.push({
+    label: t('CAPTAIN_SETTINGS.MCP_SERVERS.OPTIONS.EDIT'),
+    value: 'edit',
+    action: 'edit',
+    icon: 'i-lucide-pencil-line',
+  });
+
+  items.push({
+    label: t('CAPTAIN_SETTINGS.MCP_SERVERS.OPTIONS.DELETE'),
+    value: 'delete',
+    action: 'delete',
+    icon: 'i-lucide-trash',
+  });
+
+  return items;
+});
+
+const toolsCount = computed(() => props.server.cached_tools?.length || 0);
+
+const timestamp = computed(() => {
+  if (props.server.last_connected_at) {
+    return t('CAPTAIN_SETTINGS.MCP_SERVERS.LAST_CONNECTED', {
+      time: dynamicTime(props.server.last_connected_at),
+    });
+  }
+  return dynamicTime(props.server.updated_at || props.server.created_at);
+});
+
+const authTypeLabel = computed(() => {
+  if (props.server.auth_type === 'none') return null;
+  return t(
+    `CAPTAIN_SETTINGS.MCP_SERVERS.AUTH_TYPES.${props.server.auth_type.toUpperCase()}`
+  );
+});
+
+const handleAction = ({ action }) => {
+  toggleDropdown(false);
+  emit('action', { action, id: props.server.id });
+};
+
+const handleQuickConnect = () => {
+  emit('action', {
+    action: props.server.status === 'connected' ? 'disconnect' : 'connect',
+    id: props.server.id,
+  });
+};
+</script>
+
+<template>
+  <CardLayout class="relative group">
+    <div class="flex items-start justify-between w-full gap-4">
+      <div class="flex items-start gap-3 flex-1 min-w-0">
+        <!-- Status indicator -->
+        <div
+          class="w-10 h-10 rounded-xl flex items-center justify-center shrink-0 transition-colors"
+          :class="statusConfig.bgColor"
+        >
+          <i
+            class="text-xl"
+            :class="[
+              server.status === 'connected'
+                ? 'i-lucide-plug-2'
+                : 'i-lucide-plug',
+              statusConfig.textColor,
+            ]"
+          />
+        </div>
+
+        <div class="flex flex-col gap-1 min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <span class="text-base text-n-slate-12 font-medium truncate">
+              {{ server.name }}
+            </span>
+            <span
+              class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+              :class="[statusConfig.bgColor, statusConfig.textColor]"
+            >
+              <span
+                class="w-1.5 h-1.5 rounded-full"
+                :class="statusConfig.color"
+              />
+              {{ statusConfig.label }}
+            </span>
+          </div>
+
+          <p
+            v-if="server.description"
+            class="text-sm text-n-slate-11 line-clamp-1"
+          >
+            {{ server.description }}
+          </p>
+
+          <div class="flex items-center gap-3 mt-1">
+            <span
+              class="text-xs text-n-slate-10 truncate max-w-xs"
+              :title="server.url"
+            >
+              {{ server.url }}
+            </span>
+
+            <span
+              v-if="authTypeLabel"
+              class="text-xs text-n-slate-10 inline-flex items-center gap-1"
+            >
+              <i class="i-lucide-lock text-xs" />
+              {{ authTypeLabel }}
+            </span>
+
+            <span
+              v-if="toolsCount > 0"
+              class="text-xs text-n-slate-10 inline-flex items-center gap-1"
+            >
+              <i class="i-lucide-wrench text-xs" />
+              {{
+                t('CAPTAIN_SETTINGS.MCP_SERVERS.TOOLS_COUNT', {
+                  count: toolsCount,
+                })
+              }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-2 shrink-0">
+        <span class="text-xs text-n-slate-10 hidden sm:block">
+          {{ timestamp }}
+        </span>
+
+        <Policy :permissions="['administrator']">
+          <Button
+            v-if="server.status !== 'connecting'"
+            :icon="
+              server.status === 'connected'
+                ? 'i-lucide-unplug'
+                : 'i-lucide-plug'
+            "
+            :color="server.status === 'connected' ? 'slate' : 'blue'"
+            size="xs"
+            :is-loading="isUpdating"
+            class="opacity-0 group-hover:opacity-100 transition-opacity"
+            @click="handleQuickConnect"
+          />
+        </Policy>
+
+        <Policy
+          v-on-clickaway="() => toggleDropdown(false)"
+          :permissions="['administrator']"
+          class="relative flex items-center"
+        >
+          <Button
+            icon="i-lucide-ellipsis-vertical"
+            color="slate"
+            size="xs"
+            class="rounded-md hover:bg-n-alpha-2"
+            @click="toggleDropdown()"
+          />
+          <DropdownMenu
+            v-if="showActionsDropdown"
+            :menu-items="menuItems"
+            class="mt-1 ltr:right-0 rtl:right-0 top-full"
+            @action="handleAction($event)"
+          />
+        </Policy>
+      </div>
+    </div>
+
+    <!-- Error message -->
+    <div
+      v-if="server.status === 'error' && server.last_error"
+      class="mt-3 p-3 rounded-lg bg-n-ruby-2 border border-n-ruby-6"
+    >
+      <div class="flex items-start gap-2">
+        <i
+          class="i-lucide-alert-circle text-n-ruby-11 text-base mt-0.5 shrink-0"
+        />
+        <p class="text-sm text-n-ruby-11">
+          {{ server.last_error }}
+        </p>
+      </div>
+    </div>
+
+    <!-- Tools preview -->
+    <div
+      v-if="server.status === 'connected' && server.cached_tools?.length"
+      class="mt-3 pt-3 border-t border-n-slate-6"
+    >
+      <div class="flex items-center gap-2 mb-2">
+        <i class="i-lucide-wrench text-sm text-n-slate-11" />
+        <span
+          class="text-xs font-medium text-n-slate-11 uppercase tracking-wide"
+        >
+          {{ t('CAPTAIN_SETTINGS.MCP_SERVERS.AVAILABLE_TOOLS') }}
+        </span>
+      </div>
+      <div class="flex flex-wrap gap-1.5">
+        <span
+          v-for="tool in server.cached_tools.slice(0, 8)"
+          :key="tool.name"
+          class="inline-flex items-center px-2 py-1 rounded-md bg-n-slate-3 text-xs text-n-slate-11"
+          :title="tool.description"
+        >
+          {{ tool.name }}
+        </span>
+        <span
+          v-if="server.cached_tools.length > 8"
+          class="inline-flex items-center px-2 py-1 rounded-md bg-n-slate-3 text-xs text-n-slate-10"
+        >
+          {{
+            t('CAPTAIN_SETTINGS.MCP_SERVERS.TOOLS_MORE', {
+              count: server.cached_tools.length - 8,
+            })
+          }}
+        </span>
+      </div>
+    </div>
+  </CardLayout>
+</template>

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerForm.vue
@@ -1,0 +1,265 @@
+<script setup>
+import { reactive, computed, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useVuelidate } from '@vuelidate/core';
+import { required, url } from '@vuelidate/validators';
+import { useMapGetter } from 'dashboard/composables/store';
+
+import Input from 'dashboard/components-next/input/Input.vue';
+import TextArea from 'dashboard/components-next/textarea/TextArea.vue';
+import Button from 'dashboard/components-next/button/Button.vue';
+import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
+
+const props = defineProps({
+  mode: {
+    type: String,
+    default: 'create',
+    validator: value => ['create', 'edit'].includes(value),
+  },
+  server: {
+    type: Object,
+    default: () => ({}),
+  },
+});
+
+const emit = defineEmits(['submit', 'cancel']);
+
+const { t } = useI18n();
+
+const formState = {
+  uiFlags: useMapGetter('captainMcpServers/getUIFlags'),
+};
+
+const initialState = {
+  name: '',
+  description: '',
+  url: '',
+  auth_type: 'none',
+  auth_config: {},
+  enabled: true,
+};
+
+const state = reactive({ ...initialState });
+
+watch(
+  () => props.server,
+  newServer => {
+    if (props.mode === 'edit' && newServer && newServer.id) {
+      state.name = newServer.name || '';
+      state.description = newServer.description || '';
+      state.url = newServer.url || '';
+      state.auth_type = newServer.auth_type || 'none';
+      state.auth_config = newServer.auth_config || {};
+      state.enabled = newServer.enabled ?? true;
+    }
+  },
+  { immediate: true }
+);
+
+const httpsUrl = value => {
+  if (!value) return true;
+  return value.startsWith('https://');
+};
+
+const validationRules = {
+  name: { required },
+  url: { required, url, httpsUrl },
+  auth_type: { required },
+};
+
+const authTypeOptions = computed(() => [
+  { value: 'none', label: t('CAPTAIN_SETTINGS.MCP_SERVERS.AUTH_TYPES.NONE') },
+  {
+    value: 'bearer',
+    label: t('CAPTAIN_SETTINGS.MCP_SERVERS.AUTH_TYPES.BEARER'),
+  },
+  {
+    value: 'api_key',
+    label: t('CAPTAIN_SETTINGS.MCP_SERVERS.AUTH_TYPES.API_KEY'),
+  },
+]);
+
+const v$ = useVuelidate(validationRules, state);
+
+const isLoading = computed(() =>
+  props.mode === 'edit'
+    ? formState.uiFlags.value.updatingItem
+    : formState.uiFlags.value.creatingItem
+);
+
+const getErrorMessage = field => {
+  if (!v$.value[field].$error) return '';
+
+  const errors = v$.value[field].$errors;
+  if (errors.length === 0) return '';
+
+  const firstError = errors[0].$validator;
+
+  const errorMessages = {
+    name: {
+      required: t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.NAME.ERROR'),
+    },
+    url: {
+      required: t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.URL.ERROR'),
+      url: t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.URL.INVALID'),
+      httpsUrl: t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.URL.HTTPS_REQUIRED'),
+    },
+  };
+
+  return (
+    errorMessages[field]?.[firstError] ||
+    t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.GENERIC_ERROR')
+  );
+};
+
+const formErrors = computed(() => ({
+  name: getErrorMessage('name'),
+  url: getErrorMessage('url'),
+}));
+
+const handleAuthConfigChange = (key, value) => {
+  state.auth_config = { ...state.auth_config, [key]: value };
+};
+
+const handleCancel = () => emit('cancel');
+
+const handleSubmit = async () => {
+  const isFormValid = await v$.value.$validate();
+  if (!isFormValid) return;
+
+  const submitData = {
+    name: state.name,
+    description: state.description,
+    url: state.url,
+    auth_type: state.auth_type,
+    enabled: state.enabled,
+  };
+
+  if (state.auth_type !== 'none') {
+    submitData.auth_config = state.auth_config;
+  }
+
+  emit('submit', submitData);
+};
+</script>
+
+<template>
+  <form
+    class="flex flex-col px-4 -mx-4 gap-4 max-h-[calc(100vh-200px)] overflow-y-scroll"
+    @submit.prevent="handleSubmit"
+  >
+    <Input
+      v-model="state.name"
+      :label="t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.NAME.LABEL')"
+      :placeholder="t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.NAME.PLACEHOLDER')"
+      :message="formErrors.name"
+      :message-type="formErrors.name ? 'error' : ''"
+    />
+
+    <TextArea
+      v-model="state.description"
+      :label="t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.DESCRIPTION.LABEL')"
+      :placeholder="
+        t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.DESCRIPTION.PLACEHOLDER')
+      "
+      rows="2"
+    />
+
+    <Input
+      v-model="state.url"
+      :label="t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.URL.LABEL')"
+      :placeholder="t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.URL.PLACEHOLDER')"
+      :message="formErrors.url"
+      :message-type="formErrors.url ? 'error' : ''"
+    >
+      <template #message>
+        <span v-if="!formErrors.url" class="text-xs text-n-slate-10">
+          {{ t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.URL.HINT') }}
+        </span>
+      </template>
+    </Input>
+
+    <div class="flex flex-col gap-2">
+      <label class="text-sm font-medium text-n-slate-12">
+        {{ t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.AUTH_TYPE.LABEL') }}
+      </label>
+      <ComboBox
+        v-model="state.auth_type"
+        :options="authTypeOptions"
+        :placeholder="
+          t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.AUTH_TYPE.PLACEHOLDER')
+        "
+      />
+    </div>
+
+    <!-- Bearer Token Auth -->
+    <div
+      v-if="state.auth_type === 'bearer'"
+      class="flex flex-col gap-4 p-4 rounded-lg bg-n-slate-2 border border-n-slate-6"
+    >
+      <Input
+        :model-value="state.auth_config.token || ''"
+        type="password"
+        :label="
+          t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.AUTH_CONFIG.BEARER_TOKEN.LABEL')
+        "
+        :placeholder="
+          t(
+            'CAPTAIN_SETTINGS.MCP_SERVERS.FORM.AUTH_CONFIG.BEARER_TOKEN.PLACEHOLDER'
+          )
+        "
+        @update:model-value="handleAuthConfigChange('token', $event)"
+      />
+    </div>
+
+    <!-- API Key Auth -->
+    <div
+      v-if="state.auth_type === 'api_key'"
+      class="flex flex-col gap-4 p-4 rounded-lg bg-n-slate-2 border border-n-slate-6"
+    >
+      <Input
+        :model-value="state.auth_config.header_name || ''"
+        :label="
+          t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.AUTH_CONFIG.HEADER_NAME.LABEL')
+        "
+        :placeholder="
+          t(
+            'CAPTAIN_SETTINGS.MCP_SERVERS.FORM.AUTH_CONFIG.HEADER_NAME.PLACEHOLDER'
+          )
+        "
+        @update:model-value="handleAuthConfigChange('header_name', $event)"
+      />
+      <Input
+        :model-value="state.auth_config.key || ''"
+        type="password"
+        :label="
+          t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.AUTH_CONFIG.API_KEY.LABEL')
+        "
+        :placeholder="
+          t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.AUTH_CONFIG.API_KEY.PLACEHOLDER')
+        "
+        @update:model-value="handleAuthConfigChange('key', $event)"
+      />
+    </div>
+
+    <div class="flex justify-end gap-2 pt-4 mt-2 border-t border-n-slate-6">
+      <Button
+        type="button"
+        color="slate"
+        variant="faded"
+        :label="t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.CANCEL')"
+        @click="handleCancel"
+      />
+      <Button
+        type="submit"
+        color="blue"
+        :label="
+          mode === 'edit'
+            ? t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.UPDATE')
+            : t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.CREATE')
+        "
+        :is-loading="isLoading"
+      />
+    </div>
+  </form>
+</template>

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerForm.vue
@@ -9,6 +9,7 @@ import Input from 'dashboard/components-next/input/Input.vue';
 import TextArea from 'dashboard/components-next/textarea/TextArea.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
 import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
+import Switch from 'dashboard/components-next/switch/Switch.vue';
 
 const props = defineProps({
   mode: {
@@ -194,6 +195,20 @@ const handleSubmit = async () => {
       "
       rows="2"
     />
+
+    <div
+      class="flex items-center justify-between gap-4 rounded-lg border border-n-slate-6 bg-n-slate-2 p-3"
+    >
+      <div class="flex flex-col gap-1">
+        <span class="text-sm font-medium text-n-slate-12">
+          {{ t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.ENABLED.LABEL') }}
+        </span>
+        <span class="text-xs text-n-slate-10">
+          {{ t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.ENABLED.HINT') }}
+        </span>
+      </div>
+      <Switch v-model="state.enabled" />
+    </div>
 
     <Input
       v-model="state.url"

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerForm.vue
@@ -36,6 +36,8 @@ const initialState = {
   url: '',
   auth_type: 'none',
   auth_config: {},
+  transport: 'auto',
+  rpc_endpoint: '',
   enabled: true,
 };
 
@@ -50,20 +52,17 @@ watch(
       state.url = newServer.url || '';
       state.auth_type = newServer.auth_type || 'none';
       state.auth_config = newServer.auth_config || {};
+      state.transport = newServer.auth_config?.transport || 'auto';
+      state.rpc_endpoint = newServer.auth_config?.rpc_endpoint || '';
       state.enabled = newServer.enabled ?? true;
     }
   },
   { immediate: true }
 );
 
-const httpsUrl = value => {
-  if (!value) return true;
-  return value.startsWith('https://');
-};
-
 const validationRules = {
   name: { required },
-  url: { required, url, httpsUrl },
+  url: { required, url },
   auth_type: { required },
 };
 
@@ -76,6 +75,25 @@ const authTypeOptions = computed(() => [
   {
     value: 'api_key',
     label: t('CAPTAIN_SETTINGS.MCP_SERVERS.AUTH_TYPES.API_KEY'),
+  },
+]);
+
+const transportOptions = computed(() => [
+  {
+    value: 'auto',
+    label: t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.TRANSPORT.AUTO'),
+  },
+  {
+    value: 'streamable_http',
+    label: t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.TRANSPORT.STREAMABLE_HTTP'),
+  },
+  {
+    value: 'sse',
+    label: t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.TRANSPORT.SSE'),
+  },
+  {
+    value: 'http',
+    label: t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.TRANSPORT.HTTP'),
   },
 ]);
 
@@ -102,7 +120,6 @@ const getErrorMessage = field => {
     url: {
       required: t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.URL.ERROR'),
       url: t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.URL.INVALID'),
-      httpsUrl: t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.URL.HTTPS_REQUIRED'),
     },
   };
 
@@ -115,6 +132,7 @@ const getErrorMessage = field => {
 const formErrors = computed(() => ({
   name: getErrorMessage('name'),
   url: getErrorMessage('url'),
+  rpc_endpoint: '',
 }));
 
 const handleAuthConfigChange = (key, value) => {
@@ -135,8 +153,20 @@ const handleSubmit = async () => {
     enabled: state.enabled,
   };
 
+  const authConfig = {
+    transport: state.transport,
+  };
+
+  if (state.rpc_endpoint) {
+    authConfig.rpc_endpoint = state.rpc_endpoint;
+  }
+
   if (state.auth_type !== 'none') {
-    submitData.auth_config = state.auth_config;
+    Object.assign(authConfig, state.auth_config);
+  }
+
+  if (Object.keys(authConfig).length > 0) {
+    submitData.auth_config = authConfig;
   }
 
   emit('submit', submitData);
@@ -175,6 +205,35 @@ const handleSubmit = async () => {
       <template #message>
         <span v-if="!formErrors.url" class="text-xs text-n-slate-10">
           {{ t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.URL.HINT') }}
+        </span>
+      </template>
+    </Input>
+
+    <div class="flex flex-col gap-2">
+      <label class="text-sm font-medium text-n-slate-12">
+        {{ t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.TRANSPORT.LABEL') }}
+      </label>
+      <ComboBox
+        v-model="state.transport"
+        :options="transportOptions"
+        :placeholder="
+          t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.TRANSPORT.PLACEHOLDER')
+        "
+      />
+    </div>
+
+    <Input
+      v-model="state.rpc_endpoint"
+      :label="t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.RPC_ENDPOINT.LABEL')"
+      :placeholder="
+        t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.RPC_ENDPOINT.PLACEHOLDER')
+      "
+      :message="formErrors.rpc_endpoint"
+      :message-type="formErrors.rpc_endpoint ? 'error' : ''"
+    >
+      <template #message>
+        <span v-if="!formErrors.rpc_endpoint" class="text-xs text-n-slate-10">
+          {{ t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.RPC_ENDPOINT.HINT') }}
         </span>
       </template>
     </Input>

--- a/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/McpServerForm.vue
@@ -44,6 +44,13 @@ const initialState = {
 
 const state = reactive({ ...initialState });
 
+// Track if credentials exist on server (for edit mode hints)
+const hasExistingCredentials = computed(() => {
+  if (props.mode !== 'edit') return false;
+  const config = props.server?.auth_config || {};
+  return config.has_token || config.has_key;
+});
+
 watch(
   () => props.server,
   newServer => {
@@ -52,7 +59,11 @@ watch(
       state.description = newServer.description || '';
       state.url = newServer.url || '';
       state.auth_type = newServer.auth_type || 'none';
-      state.auth_config = newServer.auth_config || {};
+      // Don't copy masked credential flags (has_token, has_key) to auth_config
+      // Only copy non-sensitive config like header_name
+      state.auth_config = {
+        header_name: newServer.auth_config?.header_name || '',
+      };
       state.transport = newServer.auth_config?.transport || 'auto';
       state.rpc_endpoint = newServer.auth_config?.rpc_endpoint || '';
       state.enabled = newServer.enabled ?? true;
@@ -283,7 +294,20 @@ const handleSubmit = async () => {
           )
         "
         @update:model-value="handleAuthConfigChange('token', $event)"
-      />
+      >
+        <template #message>
+          <span
+            v-if="hasExistingCredentials && !state.auth_config.token"
+            class="text-xs text-n-slate-10"
+          >
+            {{
+              t(
+                'CAPTAIN_SETTINGS.MCP_SERVERS.FORM.AUTH_CONFIG.CREDENTIALS_CONFIGURED'
+              )
+            }}
+          </span>
+        </template>
+      </Input>
     </div>
 
     <!-- API Key Auth -->
@@ -313,7 +337,20 @@ const handleSubmit = async () => {
           t('CAPTAIN_SETTINGS.MCP_SERVERS.FORM.AUTH_CONFIG.API_KEY.PLACEHOLDER')
         "
         @update:model-value="handleAuthConfigChange('key', $event)"
-      />
+      >
+        <template #message>
+          <span
+            v-if="hasExistingCredentials && !state.auth_config.key"
+            class="text-xs text-n-slate-10"
+          >
+            {{
+              t(
+                'CAPTAIN_SETTINGS.MCP_SERVERS.FORM.AUTH_CONFIG.CREDENTIALS_CONFIGURED'
+              )
+            }}
+          </span>
+        </template>
+      </Input>
     </div>
 
     <div class="flex justify-end gap-2 pt-4 mt-2 border-t border-n-slate-6">

--- a/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
+++ b/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
@@ -566,12 +566,12 @@ const menuItems = computed(() => {
           icon: 'i-lucide-briefcase',
           to: accountScopedRoute('general_settings_index'),
         },
-        // {
-        //   name: 'Settings Captain',
-        //   label: t('SIDEBAR.CAPTAIN_AI'),
-        //   icon: 'i-woot-captain',
-        //   to: accountScopedRoute('captain_settings_index'),
-        // },
+        {
+          name: 'Settings Captain',
+          label: t('SIDEBAR.CAPTAIN_AI'),
+          icon: 'i-woot-captain',
+          to: accountScopedRoute('captain_settings_index'),
+        },
         {
           name: 'Settings Agents',
           label: t('SIDEBAR.AGENTS'),

--- a/app/javascript/dashboard/composables/spec/useCaptain.spec.js
+++ b/app/javascript/dashboard/composables/spec/useCaptain.spec.js
@@ -55,10 +55,16 @@ describe('useCaptain', () => {
   });
 
   it('initializes computed properties correctly', async () => {
-    const { captainEnabled, captainTasksEnabled, currentChat, draftMessage } =
-      useCaptain();
+    const {
+      captainEnabled,
+      captainMcpEnabled,
+      captainTasksEnabled,
+      currentChat,
+      draftMessage,
+    } = useCaptain();
 
     expect(captainEnabled.value).toBe(true);
+    expect(captainMcpEnabled.value).toBe(true);
     expect(captainTasksEnabled.value).toBe(true);
     expect(currentChat.value).toEqual({ id: '123' });
     expect(draftMessage.value).toBe('Draft message');

--- a/app/javascript/dashboard/composables/useCaptain.js
+++ b/app/javascript/dashboard/composables/useCaptain.js
@@ -31,6 +31,10 @@ export function useCaptain() {
     return isCloudFeatureEnabled(FEATURE_FLAGS.CAPTAIN);
   });
 
+  const captainMcpEnabled = computed(() => {
+    return isCloudFeatureEnabled(FEATURE_FLAGS.CAPTAIN_MCP);
+  });
+
   const captainTasksEnabled = computed(() => {
     return isCloudFeatureEnabled(FEATURE_FLAGS.CAPTAIN_TASKS);
   });
@@ -197,6 +201,7 @@ export function useCaptain() {
   return {
     // Feature flags
     captainEnabled,
+    captainMcpEnabled,
     captainTasksEnabled,
 
     // Limits (Enterprise)

--- a/app/javascript/dashboard/featureFlags.js
+++ b/app/javascript/dashboard/featureFlags.js
@@ -40,6 +40,7 @@ export const FEATURE_FLAGS = {
   CHANNEL_TIKTOK: 'channel_tiktok',
   CONTACT_CHATWOOT_SUPPORT_TEAM: 'contact_chatwoot_support_team',
   CAPTAIN_V2: 'captain_integration_v2',
+  CAPTAIN_MCP: 'captain_mcp',
   CAPTAIN_TASKS: 'captain_tasks',
   SAML: 'saml',
   QUOTED_EMAIL_REPLY: 'quoted_email_reply',

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -877,6 +877,51 @@
         }
       }
     },
+    "MCP_SERVERS": {
+      "HEADER": "MCP Servers",
+      "DESCRIPTION": "Attach MCP servers to allow this assistant to use external tools.",
+      "ADD_NEW": "Attach MCP Server",
+      "FORM_DESCRIPTION": "Select an MCP server to attach to this assistant.",
+      "FORM": {
+        "MCP_SERVER": {
+          "LABEL": "MCP server",
+          "PLACEHOLDER": "Select MCP server",
+          "ERROR": "MCP server selection is required"
+        }
+      },
+      "TOOLS": {
+        "TITLE": "Allowed tools",
+        "DESCRIPTION": "Select which tools this assistant can use from the MCP server.",
+        "SELECT_ALL": "Select all",
+        "EMPTY": "No tools found for this server. Connect and refresh tools first."
+      },
+      "EMPTY": {
+        "TITLE": "No MCP servers attached",
+        "DESCRIPTION": "Attach an MCP server to enable external tools for this assistant."
+      },
+      "CREATE": {
+        "TITLE": "Attach MCP Server",
+        "SUCCESS_MESSAGE": "MCP server attached successfully",
+        "ERROR_MESSAGE": "Failed to attach MCP server"
+      },
+      "DETACH": "Detach",
+      "DELETE": {
+        "TITLE": "Delete MCP Server",
+        "DESCRIPTION": "Are you sure you want to delete this MCP server? This will disconnect it from all assistants.",
+        "CONFIRM": "Yes, delete",
+        "SUCCESS_MESSAGE": "MCP server deleted successfully",
+        "ERROR_MESSAGE": "Failed to delete MCP server"
+      }
+    },
+    "ASSISTANT_MCP_SERVERS": {
+      "DELETE": {
+        "TITLE": "Detach MCP Server",
+        "DESCRIPTION": "Are you sure you want to detach this MCP server from the assistant?",
+        "CONFIRM": "Detach",
+        "SUCCESS_MESSAGE": "MCP server detached successfully",
+        "ERROR_MESSAGE": "Failed to detach MCP server"
+      }
+    },
     "RESPONSES": {
       "HEADER": "FAQs",
       "PENDING_FAQS": "Pending FAQs",

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -433,6 +433,11 @@
     "MCP_SERVERS": {
       "TITLE": "MCP Servers",
       "DESCRIPTION": "Connect to Model Context Protocol (MCP) servers to extend your AI agents with external tools and capabilities.",
+      "SECTION_TITLE": "External Tools",
+      "SECTION_DESCRIPTION": "Extend your AI agents with tools from external MCP servers.",
+      "CARD_TITLE": "MCP Servers",
+      "CARD_DESCRIPTION": "Connect to external tool providers via Model Context Protocol",
+      "CONFIGURE": "Configure",
       "LOADING": "Loading MCP servers...",
       "NOT_ENABLED": "MCP servers are not enabled for your account.",
       "ADD_NEW": "Add MCP Server",
@@ -480,7 +485,7 @@
         "ERROR_MESSAGE": "Failed to delete MCP server. Please try again."
       },
       "FORM": {
-        "DESCRIPTION": "Configure the connection details for your MCP server.",
+        "HELP_TEXT": "Configure the connection details for your MCP server.",
         "NAME": {
           "LABEL": "Server name",
           "PLACEHOLDER": "My MCP Server",
@@ -492,11 +497,24 @@
         },
         "URL": {
           "LABEL": "Server URL",
-          "PLACEHOLDER": "https://mcp.example.com/sse",
-          "HINT": "The SSE endpoint URL for the MCP server (must use HTTPS)",
+          "PLACEHOLDER": "https://mcp.example.com/mcp",
+          "HINT": "The MCP server endpoint URL (HTTP or HTTPS)",
           "ERROR": "Please enter a valid URL",
           "INVALID": "Please enter a valid URL",
-          "HTTPS_REQUIRED": "URL must use HTTPS protocol"
+          "HTTPS_REQUIRED": "URL must use HTTP or HTTPS protocol"
+        },
+        "TRANSPORT": {
+          "LABEL": "Transport",
+          "PLACEHOLDER": "Auto-detect transport",
+          "AUTO": "Auto-detect",
+          "STREAMABLE_HTTP": "Streamable HTTP (/mcp)",
+          "SSE": "SSE (/sse)",
+          "HTTP": "HTTP JSON-RPC"
+        },
+        "RPC_ENDPOINT": {
+          "LABEL": "RPC endpoint (optional)",
+          "PLACEHOLDER": "/rpc",
+          "HINT": "Override the JSON-RPC endpoint path if your server uses a custom route."
         },
         "AUTH_TYPE": {
           "LABEL": "Authentication type",

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -536,7 +536,8 @@
           "API_KEY": {
             "LABEL": "API key",
             "PLACEHOLDER": "Enter your API key"
-          }
+          },
+          "CREDENTIALS_CONFIGURED": "Credentials are already configured. Leave empty to keep existing credentials."
         },
         "GENERIC_ERROR": "Please check this field",
         "CANCEL": "Cancel",

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -495,6 +495,10 @@
           "LABEL": "Description",
           "PLACEHOLDER": "Optional description of this MCP server"
         },
+        "ENABLED": {
+          "LABEL": "Enable server",
+          "HINT": "Disable to prevent assistants from using this server."
+        },
         "URL": {
           "LABEL": "Server URL",
           "PLACEHOLDER": "https://mcp.example.com/mcp",

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -429,6 +429,98 @@
     "API": {
       "SUCCESS": "Captain settings updated successfully.",
       "ERROR": "Failed to update Captain settings. Please try again."
+    },
+    "MCP_SERVERS": {
+      "TITLE": "MCP Servers",
+      "DESCRIPTION": "Connect to Model Context Protocol (MCP) servers to extend your AI agents with external tools and capabilities.",
+      "LOADING": "Loading MCP servers...",
+      "NOT_ENABLED": "MCP servers are not enabled for your account.",
+      "ADD_NEW": "Add MCP Server",
+      "LAST_CONNECTED": "Connected {time}",
+      "TOOLS_COUNT": "{count} tools",
+      "AVAILABLE_TOOLS": "Available Tools",
+      "TOOLS_MORE": "+{count} more",
+      "EMPTY": {
+        "TITLE": "No MCP servers configured",
+        "DESCRIPTION": "Connect to MCP servers to provide your AI agents with additional tools and capabilities from external services."
+      },
+      "STATUS": {
+        "CONNECTED": "Connected",
+        "CONNECTING": "Connecting",
+        "DISCONNECTED": "Disconnected",
+        "ERROR": "Error"
+      },
+      "AUTH_TYPES": {
+        "NONE": "No authentication",
+        "BEARER": "Bearer token",
+        "API_KEY": "API key"
+      },
+      "OPTIONS": {
+        "CONNECT": "Connect",
+        "DISCONNECT": "Disconnect",
+        "REFRESH": "Refresh tools",
+        "EDIT": "Edit server",
+        "DELETE": "Delete server"
+      },
+      "CREATE": {
+        "TITLE": "Add MCP Server",
+        "SUCCESS_MESSAGE": "MCP server created successfully.",
+        "ERROR_MESSAGE": "Failed to create MCP server. Please try again."
+      },
+      "EDIT": {
+        "TITLE": "Edit MCP Server",
+        "SUCCESS_MESSAGE": "MCP server updated successfully.",
+        "ERROR_MESSAGE": "Failed to update MCP server. Please try again."
+      },
+      "DELETE": {
+        "TITLE": "Delete MCP Server",
+        "DESCRIPTION": "Are you sure you want to delete this MCP server? This will disconnect it from all assistants.",
+        "CONFIRM": "Delete",
+        "SUCCESS_MESSAGE": "MCP server deleted successfully.",
+        "ERROR_MESSAGE": "Failed to delete MCP server. Please try again."
+      },
+      "FORM": {
+        "DESCRIPTION": "Configure the connection details for your MCP server.",
+        "NAME": {
+          "LABEL": "Server name",
+          "PLACEHOLDER": "My MCP Server",
+          "ERROR": "Please enter a server name"
+        },
+        "DESCRIPTION": {
+          "LABEL": "Description",
+          "PLACEHOLDER": "Optional description of this MCP server"
+        },
+        "URL": {
+          "LABEL": "Server URL",
+          "PLACEHOLDER": "https://mcp.example.com/sse",
+          "HINT": "The SSE endpoint URL for the MCP server (must use HTTPS)",
+          "ERROR": "Please enter a valid URL",
+          "INVALID": "Please enter a valid URL",
+          "HTTPS_REQUIRED": "URL must use HTTPS protocol"
+        },
+        "AUTH_TYPE": {
+          "LABEL": "Authentication type",
+          "PLACEHOLDER": "Select authentication method"
+        },
+        "AUTH_CONFIG": {
+          "BEARER_TOKEN": {
+            "LABEL": "Bearer token",
+            "PLACEHOLDER": "Enter your bearer token"
+          },
+          "HEADER_NAME": {
+            "LABEL": "Header name",
+            "PLACEHOLDER": "X-API-Key"
+          },
+          "API_KEY": {
+            "LABEL": "API key",
+            "PLACEHOLDER": "Enter your API key"
+          }
+        },
+        "GENERIC_ERROR": "Please check this field",
+        "CANCEL": "Cancel",
+        "CREATE": "Create server",
+        "UPDATE": "Update server"
+      }
     }
   },
   "BILLING_SETTINGS": {

--- a/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
@@ -1,6 +1,8 @@
 <script setup>
-import { computed, onMounted, ref, nextTick } from 'vue';
+import { computed, onMounted, ref, nextTick, watch } from 'vue';
 import { useMapGetter, useStore } from 'dashboard/composables/store';
+import { useRoute } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 
 import PageLayout from 'dashboard/components-next/captain/PageLayout.vue';
@@ -9,21 +11,53 @@ import CustomToolsPageEmptyState from 'dashboard/components-next/captain/pageCom
 import CreateCustomToolDialog from 'dashboard/components-next/captain/pageComponents/customTool/CreateCustomToolDialog.vue';
 import CustomToolCard from 'dashboard/components-next/captain/pageComponents/customTool/CustomToolCard.vue';
 import DeleteDialog from 'dashboard/components-next/captain/pageComponents/DeleteDialog.vue';
+import Button from 'dashboard/components-next/button/Button.vue';
+import AssistantMcpServerCard from 'dashboard/components-next/captain/pageComponents/mcpServer/AssistantMcpServerCard.vue';
+import ConnectMcpServerDialog from 'dashboard/components-next/captain/pageComponents/mcpServer/ConnectMcpServerDialog.vue';
 
 const store = useStore();
+const route = useRoute();
+const { t } = useI18n();
 
 const uiFlags = useMapGetter('captainCustomTools/getUIFlags');
 const customTools = useMapGetter('captainCustomTools/getRecords');
+const assistantMcpServers = useMapGetter(
+  'captainAssistantMcpServers/getRecords'
+);
+const assistantMcpUiFlags = useMapGetter(
+  'captainAssistantMcpServers/getUIFlags'
+);
+const mcpServersUiFlags = useMapGetter('captainMcpServers/getUIFlags');
 const isFetching = computed(() => uiFlags.value.fetchingList);
+const isFetchingMcp = computed(
+  () =>
+    assistantMcpUiFlags.value.fetchingList ||
+    mcpServersUiFlags.value.fetchingList
+);
 const customToolsMeta = useMapGetter('captainCustomTools/getMeta');
 
 const createDialogRef = ref(null);
 const deleteDialogRef = ref(null);
+const detachDialogRef = ref(null);
+const connectMcpServerDialog = ref(null);
 const selectedTool = ref(null);
+const selectedMcpServer = ref(null);
 const dialogType = ref('');
+const mcpDialogType = ref('');
+
+const assistantId = computed(() => Number(route.params.assistantId));
 
 const fetchCustomTools = (page = 1) => {
   store.dispatch('captainCustomTools/get', { page });
+};
+
+const fetchMcpServers = () => {
+  store.dispatch('captainMcpServers/get');
+};
+
+const fetchAssistantMcpServers = id => {
+  if (!id) return;
+  store.dispatch('captainAssistantMcpServers/get', { assistantId: id });
 };
 
 const onPageChange = page => fetchCustomTools(page);
@@ -32,6 +66,11 @@ const openCreateDialog = () => {
   dialogType.value = 'create';
   selectedTool.value = null;
   nextTick(() => createDialogRef.value.dialogRef.open());
+};
+
+const openMcpDialog = () => {
+  mcpDialogType.value = 'create';
+  nextTick(() => connectMcpServerDialog.value.dialogRef.open());
 };
 
 const handleEdit = tool => {
@@ -45,8 +84,13 @@ const handleDelete = tool => {
   nextTick(() => deleteDialogRef.value.dialogRef.open());
 };
 
+const handleDetach = record => {
+  selectedMcpServer.value = record;
+  nextTick(() => detachDialogRef.value.dialogRef.open());
+};
+
 const handleAction = ({ action, id }) => {
-  const tool = customTools.value.find(t => t.id === id);
+  const tool = customTools.value.find(toolItem => toolItem.id === id);
   if (action === 'edit') {
     handleEdit(tool);
   } else if (action === 'delete') {
@@ -57,6 +101,15 @@ const handleAction = ({ action, id }) => {
 const handleDialogClose = () => {
   dialogType.value = '';
   selectedTool.value = null;
+};
+
+const handleMcpDialogClose = () => {
+  mcpDialogType.value = '';
+};
+
+const handleDetachSuccess = () => {
+  selectedMcpServer.value = null;
+  fetchAssistantMcpServers(assistantId.value);
 };
 
 const onDeleteSuccess = () => {
@@ -71,9 +124,20 @@ const onDeleteSuccess = () => {
   }
 };
 
+const isPageEmpty = computed(() => false);
+
 onMounted(() => {
+  fetchMcpServers();
   fetchCustomTools();
 });
+
+watch(
+  assistantId,
+  newId => {
+    fetchAssistantMcpServers(newId);
+  },
+  { immediate: true }
+);
 </script>
 
 <template>
@@ -84,8 +148,8 @@ onMounted(() => {
     :total-count="customToolsMeta.totalCount"
     :current-page="customToolsMeta.page"
     :show-pagination-footer="!isFetching && !!customTools.length"
-    :is-fetching="isFetching"
-    :is-empty="!customTools.length"
+    :is-fetching="isFetching || isFetchingMcp"
+    :is-empty="isPageEmpty"
     :feature-flag="FEATURE_FLAGS.CAPTAIN_V2"
     :show-know-more="false"
     @update:current-page="onPageChange"
@@ -95,27 +159,85 @@ onMounted(() => {
       <CaptainPaywall />
     </template>
 
-    <template #emptyState>
-      <CustomToolsPageEmptyState @click="openCreateDialog" />
-    </template>
-
     <template #body>
-      <div class="flex flex-col gap-4">
-        <CustomToolCard
-          v-for="tool in customTools"
-          :id="tool.id"
-          :key="tool.id"
-          :title="tool.title"
-          :description="tool.description"
-          :endpoint-url="tool.endpoint_url"
-          :http-method="tool.http_method"
-          :auth-type="tool.auth_type"
-          :param-schema="tool.param_schema"
-          :enabled="tool.enabled"
-          :created-at="tool.created_at"
-          :updated-at="tool.updated_at"
-          @action="handleAction"
-        />
+      <div class="flex flex-col gap-8">
+        <section class="flex flex-col gap-4">
+          <div class="flex items-start justify-between gap-4">
+            <div class="flex flex-col gap-1">
+              <h3 class="text-base font-medium text-n-slate-12">
+                {{ t('CAPTAIN.MCP_SERVERS.HEADER') }}
+              </h3>
+              <p class="text-sm text-n-slate-11">
+                {{ t('CAPTAIN.MCP_SERVERS.DESCRIPTION') }}
+              </p>
+            </div>
+            <Button
+              color="blue"
+              size="sm"
+              icon="i-lucide-plus"
+              :label="t('CAPTAIN.MCP_SERVERS.ADD_NEW')"
+              @click="openMcpDialog"
+            />
+          </div>
+
+          <div
+            v-if="!assistantMcpServers.length && !isFetchingMcp"
+            class="rounded-xl border border-n-container bg-n-solid-2 p-6 text-center"
+          >
+            <h4 class="text-sm font-medium text-n-slate-12">
+              {{ t('CAPTAIN.MCP_SERVERS.EMPTY.TITLE') }}
+            </h4>
+            <p class="text-xs text-n-slate-11 mt-1">
+              {{ t('CAPTAIN.MCP_SERVERS.EMPTY.DESCRIPTION') }}
+            </p>
+          </div>
+
+          <div v-else class="flex flex-col gap-4">
+            <AssistantMcpServerCard
+              v-for="record in assistantMcpServers"
+              :key="record.id"
+              :record="record"
+              @detach="handleDetach"
+            />
+          </div>
+        </section>
+
+        <section class="flex flex-col gap-4">
+          <div class="flex items-center justify-between gap-4">
+            <h3 class="text-base font-medium text-n-slate-12">
+              {{ t('CAPTAIN.CUSTOM_TOOLS.HEADER') }}
+            </h3>
+            <Button
+              color="blue"
+              size="sm"
+              icon="i-lucide-plus"
+              :label="t('CAPTAIN.CUSTOM_TOOLS.ADD_NEW')"
+              @click="openCreateDialog"
+            />
+          </div>
+
+          <div v-if="!customTools.length && !isFetching" class="pt-2">
+            <CustomToolsPageEmptyState @click="openCreateDialog" />
+          </div>
+
+          <div v-else class="flex flex-col gap-4">
+            <CustomToolCard
+              v-for="tool in customTools"
+              :id="tool.id"
+              :key="tool.id"
+              :title="tool.title"
+              :description="tool.description"
+              :endpoint-url="tool.endpoint_url"
+              :http-method="tool.http_method"
+              :auth-type="tool.auth_type"
+              :param-schema="tool.param_schema"
+              :enabled="tool.enabled"
+              :created-at="tool.created_at"
+              :updated-at="tool.updated_at"
+              @action="handleAction"
+            />
+          </div>
+        </section>
       </div>
     </template>
   </PageLayout>
@@ -135,5 +257,25 @@ onMounted(() => {
     type="CustomTools"
     translation-key="CUSTOM_TOOLS"
     @delete-success="onDeleteSuccess"
+  />
+
+  <DeleteDialog
+    v-if="selectedMcpServer"
+    ref="detachDialogRef"
+    :entity="selectedMcpServer"
+    :delete-payload="{
+      assistantId: assistantId,
+      id: selectedMcpServer.id,
+    }"
+    type="AssistantMcpServers"
+    translation-key="ASSISTANT_MCP_SERVERS"
+    @delete-success="handleDetachSuccess"
+  />
+
+  <ConnectMcpServerDialog
+    v-if="mcpDialogType"
+    ref="connectMcpServerDialog"
+    :assistant-id="assistantId"
+    @close="handleMcpDialogClose"
   />
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/captain/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/captain/Index.vue
@@ -19,7 +19,7 @@ import CaptainPaywall from 'next/captain/pageComponents/Paywall.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
 
 const { t } = useI18n();
-const { captainEnabled } = useCaptain();
+const { captainEnabled, captainMcpEnabled } = useCaptain();
 const { isEnterprise, enterprisePlanName } = useConfig();
 const { isOnChatwootCloud } = useAccount();
 
@@ -69,7 +69,7 @@ const featureToggles = computed(() => [
 
 const shouldShowFeature = feature => {
   // Cloud will always see these features as long as captain is enabled
-  if (isOnChatwootCloud.value && captainEnabled) {
+  if (isOnChatwootCloud.value && captainEnabled.value) {
     return true;
   }
 
@@ -84,7 +84,7 @@ const shouldShowFeature = feature => {
 
 const isFeatureAccessible = feature => {
   // Cloud will always see these features as long as captain is enabled
-  if (isOnChatwootCloud.value && captainEnabled) {
+  if (isOnChatwootCloud.value && captainEnabled.value) {
     return true;
   }
 
@@ -184,6 +184,7 @@ onMounted(() => {
 
         <!-- MCP Servers Section -->
         <SectionLayout
+          v-if="captainMcpEnabled"
           :title="t('CAPTAIN_SETTINGS.MCP_SERVERS.SECTION_TITLE')"
           :description="t('CAPTAIN_SETTINGS.MCP_SERVERS.SECTION_DESCRIPTION')"
           with-border

--- a/app/javascript/dashboard/routes/dashboard/settings/captain/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/captain/Index.vue
@@ -7,6 +7,8 @@ import { useAccount } from 'dashboard/composables/useAccount';
 import { useCaptain } from 'dashboard/composables/useCaptain';
 import { useConfig } from 'dashboard/composables/useConfig';
 import { useCaptainConfigStore } from 'dashboard/store/captain/preferences';
+import { useMapGetter } from 'dashboard/composables/store';
+import { frontendURL } from 'dashboard/helper/URLHelper';
 
 import SettingsLayout from '../SettingsLayout.vue';
 import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';
@@ -14,6 +16,7 @@ import SectionLayout from '../account/components/SectionLayout.vue';
 import ModelSelector from './components/ModelSelector.vue';
 import FeatureToggle from './components/FeatureToggle.vue';
 import CaptainPaywall from 'next/captain/pageComponents/Paywall.vue';
+import Button from 'dashboard/components-next/button/Button.vue';
 
 const { t } = useI18n();
 const { captainEnabled } = useCaptain();
@@ -22,8 +25,13 @@ const { isOnChatwootCloud } = useAccount();
 
 const captainConfigStore = useCaptainConfigStore();
 const { uiFlags } = storeToRefs(captainConfigStore);
+const currentAccountId = useMapGetter('getCurrentAccountId');
 
 const isLoading = computed(() => uiFlags.value.isFetching);
+
+const mcpServersUrl = computed(() =>
+  frontendURL(`accounts/${currentAccountId.value}/settings/captain/mcp-servers`)
+);
 
 const modelFeatures = computed(() => [
   {
@@ -171,6 +179,41 @@ onMounted(() => {
               @change="handleFeatureToggle"
               @model-change="handleModelChange"
             />
+          </div>
+        </SectionLayout>
+
+        <!-- MCP Servers Section -->
+        <SectionLayout
+          :title="t('CAPTAIN_SETTINGS.MCP_SERVERS.SECTION_TITLE')"
+          :description="t('CAPTAIN_SETTINGS.MCP_SERVERS.SECTION_DESCRIPTION')"
+          with-border
+        >
+          <div
+            class="flex items-center justify-between p-4 rounded-lg bg-n-alpha-2 border border-n-container"
+          >
+            <div class="flex items-center gap-3">
+              <div
+                class="w-10 h-10 rounded-xl bg-n-alpha-3 flex items-center justify-center"
+              >
+                <i class="i-lucide-plug text-xl text-n-slate-11" />
+              </div>
+              <div>
+                <h4 class="text-sm font-medium text-n-slate-12">
+                  {{ t('CAPTAIN_SETTINGS.MCP_SERVERS.CARD_TITLE') }}
+                </h4>
+                <p class="text-xs text-n-slate-11">
+                  {{ t('CAPTAIN_SETTINGS.MCP_SERVERS.CARD_DESCRIPTION') }}
+                </p>
+              </div>
+            </div>
+            <router-link :to="mcpServersUrl">
+              <Button
+                :label="t('CAPTAIN_SETTINGS.MCP_SERVERS.CONFIGURE')"
+                color="slate"
+                variant="faded"
+                icon="i-lucide-settings"
+              />
+            </router-link>
           </div>
         </SectionLayout>
       </div>

--- a/app/javascript/dashboard/routes/dashboard/settings/captain/captain.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/captain/captain.routes.js
@@ -39,7 +39,7 @@ export default {
           component: McpServersIndex,
           meta: {
             permissions: ['administrator'],
-            featureFlag: FEATURE_FLAGS.CAPTAIN,
+            featureFlag: FEATURE_FLAGS.CAPTAIN_MCP,
             installationTypes: [
               INSTALLATION_TYPES.ENTERPRISE,
               INSTALLATION_TYPES.CLOUD,

--- a/app/javascript/dashboard/routes/dashboard/settings/captain/captain.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/captain/captain.routes.js
@@ -3,6 +3,7 @@ import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import { INSTALLATION_TYPES } from 'dashboard/constants/installationTypes';
 import SettingsWrapper from '../SettingsWrapper.vue';
 import Index from './Index.vue';
+import McpServersIndex from './mcpServers/Index.vue';
 
 export default {
   routes: [
@@ -23,6 +24,19 @@ export default {
           path: '',
           name: 'captain_settings_index',
           component: Index,
+          meta: {
+            permissions: ['administrator'],
+            featureFlag: FEATURE_FLAGS.CAPTAIN,
+            installationTypes: [
+              INSTALLATION_TYPES.ENTERPRISE,
+              INSTALLATION_TYPES.CLOUD,
+            ],
+          },
+        },
+        {
+          path: 'mcp-servers',
+          name: 'captain_settings_mcp_servers',
+          component: McpServersIndex,
           meta: {
             permissions: ['administrator'],
             featureFlag: FEATURE_FLAGS.CAPTAIN,

--- a/app/javascript/dashboard/routes/dashboard/settings/captain/mcpServers/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/captain/mcpServers/Index.vue
@@ -17,7 +17,7 @@ import Policy from 'dashboard/components/policy.vue';
 
 const { t } = useI18n();
 const store = useStore();
-const { captainEnabled } = useCaptain();
+const { captainMcpEnabled } = useCaptain();
 const { isEnterprise, enterprisePlanName } = useConfig();
 const { isOnChatwootCloud } = useAccount();
 
@@ -33,7 +33,7 @@ const selectedServer = ref(null);
 const dialogType = ref('');
 
 const isFeatureAccessible = computed(() => {
-  if (isOnChatwootCloud.value && captainEnabled) return true;
+  if (isOnChatwootCloud.value && captainMcpEnabled.value) return true;
   return isEnterprise && enterprisePlanName === 'enterprise';
 });
 
@@ -115,7 +115,7 @@ onMounted(() => {
     </template>
     <template #body>
       <div
-        v-if="captainEnabled && isFeatureAccessible"
+        v-if="captainMcpEnabled && isFeatureAccessible"
         class="flex flex-col gap-4"
       >
         <div

--- a/app/javascript/dashboard/routes/dashboard/settings/captain/mcpServers/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/captain/mcpServers/Index.vue
@@ -1,0 +1,179 @@
+<script setup>
+import { computed, onMounted, ref, nextTick } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useMapGetter, useStore } from 'dashboard/composables/store';
+import { useAccount } from 'dashboard/composables/useAccount';
+import { useCaptain } from 'dashboard/composables/useCaptain';
+import { useConfig } from 'dashboard/composables/useConfig';
+
+import SettingsLayout from '../../SettingsLayout.vue';
+import BaseSettingsHeader from '../../components/BaseSettingsHeader.vue';
+import CaptainPaywall from 'next/captain/pageComponents/Paywall.vue';
+import McpServerCard from 'dashboard/components-next/captain/pageComponents/mcpServer/McpServerCard.vue';
+import CreateMcpServerDialog from 'dashboard/components-next/captain/pageComponents/mcpServer/CreateMcpServerDialog.vue';
+import DeleteDialog from 'dashboard/components-next/captain/pageComponents/DeleteDialog.vue';
+import Button from 'dashboard/components-next/button/Button.vue';
+import Policy from 'dashboard/components/policy.vue';
+
+const { t } = useI18n();
+const store = useStore();
+const { captainEnabled } = useCaptain();
+const { isEnterprise, enterprisePlanName } = useConfig();
+const { isOnChatwootCloud } = useAccount();
+
+const uiFlags = useMapGetter('captainMcpServers/getUIFlags');
+const mcpServers = useMapGetter('captainMcpServers/getRecords');
+
+const isFetching = computed(() => uiFlags.value.fetchingList);
+const isUpdating = computed(() => uiFlags.value.updatingItem);
+
+const createDialogRef = ref(null);
+const deleteDialogRef = ref(null);
+const selectedServer = ref(null);
+const dialogType = ref('');
+
+const isFeatureAccessible = computed(() => {
+  if (isOnChatwootCloud.value && captainEnabled) return true;
+  return isEnterprise && enterprisePlanName === 'enterprise';
+});
+
+const fetchMcpServers = () => {
+  store.dispatch('captainMcpServers/get');
+};
+
+const openCreateDialog = () => {
+  dialogType.value = 'create';
+  selectedServer.value = null;
+  nextTick(() => createDialogRef.value?.dialogRef?.open());
+};
+
+const handleEdit = server => {
+  dialogType.value = 'edit';
+  selectedServer.value = server;
+  nextTick(() => createDialogRef.value?.dialogRef?.open());
+};
+
+const handleDelete = server => {
+  selectedServer.value = server;
+  nextTick(() => deleteDialogRef.value?.dialogRef?.open());
+};
+
+const handleAction = ({ action, id }) => {
+  const server = mcpServers.value.find(s => s.id === id);
+  if (action === 'edit') {
+    handleEdit(server);
+  } else if (action === 'delete') {
+    handleDelete(server);
+  } else if (action === 'connect') {
+    store.dispatch('captainMcpServers/connect', id);
+  } else if (action === 'disconnect') {
+    store.dispatch('captainMcpServers/disconnect', id);
+  } else if (action === 'refresh') {
+    store.dispatch('captainMcpServers/refresh', id);
+  }
+};
+
+const handleDialogClose = () => {
+  dialogType.value = '';
+  selectedServer.value = null;
+};
+
+const onDeleteSuccess = () => {
+  selectedServer.value = null;
+  fetchMcpServers();
+};
+
+onMounted(() => {
+  fetchMcpServers();
+});
+</script>
+
+<template>
+  <SettingsLayout
+    :is-loading="isFetching"
+    :no-records-message="t('CAPTAIN_SETTINGS.MCP_SERVERS.NOT_ENABLED')"
+    :loading-message="t('CAPTAIN_SETTINGS.MCP_SERVERS.LOADING')"
+  >
+    <template #header>
+      <BaseSettingsHeader
+        :title="t('CAPTAIN_SETTINGS.MCP_SERVERS.TITLE')"
+        :description="t('CAPTAIN_SETTINGS.MCP_SERVERS.DESCRIPTION')"
+        icon-name="i-lucide-plug"
+        feature-name="captain_mcp"
+      >
+        <template #actions>
+          <Policy :permissions="['administrator']">
+            <Button
+              :label="t('CAPTAIN_SETTINGS.MCP_SERVERS.ADD_NEW')"
+              color="blue"
+              icon="i-lucide-plus"
+              @click="openCreateDialog"
+            />
+          </Policy>
+        </template>
+      </BaseSettingsHeader>
+    </template>
+    <template #body>
+      <div
+        v-if="captainEnabled && isFeatureAccessible"
+        class="flex flex-col gap-4"
+      >
+        <div
+          v-if="mcpServers.length === 0 && !isFetching"
+          class="flex flex-col items-center justify-center py-16 text-center"
+        >
+          <div
+            class="w-16 h-16 rounded-2xl bg-n-alpha-2 flex items-center justify-center mb-4"
+          >
+            <i class="i-lucide-plug text-3xl text-n-slate-11" />
+          </div>
+          <h3 class="text-lg font-medium text-n-slate-12 mb-2">
+            {{ t('CAPTAIN_SETTINGS.MCP_SERVERS.EMPTY.TITLE') }}
+          </h3>
+          <p class="text-sm text-n-slate-11 max-w-md mb-6">
+            {{ t('CAPTAIN_SETTINGS.MCP_SERVERS.EMPTY.DESCRIPTION') }}
+          </p>
+          <Policy :permissions="['administrator']">
+            <Button
+              :label="t('CAPTAIN_SETTINGS.MCP_SERVERS.ADD_NEW')"
+              color="blue"
+              icon="i-lucide-plus"
+              @click="openCreateDialog"
+            />
+          </Policy>
+        </div>
+
+        <div v-else class="flex flex-col gap-4">
+          <McpServerCard
+            v-for="server in mcpServers"
+            :key="server.id"
+            :server="server"
+            :is-updating="isUpdating"
+            @action="handleAction"
+          />
+        </div>
+      </div>
+      <div v-else>
+        <CaptainPaywall />
+      </div>
+    </template>
+  </SettingsLayout>
+
+  <CreateMcpServerDialog
+    v-if="dialogType"
+    ref="createDialogRef"
+    :type="dialogType"
+    :selected-server="selectedServer"
+    @close="handleDialogClose"
+    @created="fetchMcpServers"
+  />
+
+  <DeleteDialog
+    v-if="selectedServer"
+    ref="deleteDialogRef"
+    :entity="selectedServer"
+    type="McpServers"
+    translation-key="MCP_SERVERS"
+    @delete-success="onDeleteSuccess"
+  />
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/captain/mcpServers/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/captain/mcpServers/Index.vue
@@ -98,7 +98,7 @@ onMounted(() => {
       <BaseSettingsHeader
         :title="t('CAPTAIN_SETTINGS.MCP_SERVERS.TITLE')"
         :description="t('CAPTAIN_SETTINGS.MCP_SERVERS.DESCRIPTION')"
-        icon-name="i-lucide-plug"
+        icon-name="link"
         feature-name="captain_mcp"
       >
         <template #actions>

--- a/app/javascript/dashboard/store/captain/assistantMcpServers.js
+++ b/app/javascript/dashboard/store/captain/assistantMcpServers.js
@@ -1,0 +1,41 @@
+import CaptainAssistantMcpServers from 'dashboard/api/captain/assistantMcpServers';
+import { createStore } from '../storeFactory';
+import { throwErrorMessage } from 'dashboard/store/utils/api';
+
+export default createStore({
+  name: 'CaptainAssistantMcpServer',
+  API: CaptainAssistantMcpServers,
+  actions: mutations => ({
+    update: async ({ commit }, { assistantId, id, ...updateObj }) => {
+      commit(mutations.SET_UI_FLAG, { updatingItem: true });
+      try {
+        const response = await CaptainAssistantMcpServers.update(
+          assistantId,
+          id,
+          {
+            assistant_mcp_server: updateObj,
+          }
+        );
+        commit(mutations.EDIT, response.data);
+        commit(mutations.SET_UI_FLAG, { updatingItem: false });
+        return response.data;
+      } catch (error) {
+        commit(mutations.SET_UI_FLAG, { updatingItem: false });
+        return throwErrorMessage(error);
+      }
+    },
+
+    delete: async ({ commit }, { assistantId, id }) => {
+      commit(mutations.SET_UI_FLAG, { deletingItem: true });
+      try {
+        await CaptainAssistantMcpServers.delete(assistantId, id);
+        commit(mutations.DELETE, id);
+        commit(mutations.SET_UI_FLAG, { deletingItem: false });
+        return id;
+      } catch (error) {
+        commit(mutations.SET_UI_FLAG, { deletingItem: false });
+        return throwErrorMessage(error);
+      }
+    },
+  }),
+});

--- a/app/javascript/dashboard/store/captain/mcpServers.js
+++ b/app/javascript/dashboard/store/captain/mcpServers.js
@@ -1,0 +1,77 @@
+import CaptainMcpServers from 'dashboard/api/captain/mcpServers';
+import { createStore } from '../storeFactory';
+import { throwErrorMessage } from 'dashboard/store/utils/api';
+
+export default createStore({
+  name: 'CaptainMcpServer',
+  API: CaptainMcpServers,
+  actions: mutations => ({
+    update: async ({ commit }, { id, ...updateObj }) => {
+      commit(mutations.SET_UI_FLAG, { updatingItem: true });
+      try {
+        const response = await CaptainMcpServers.update(id, updateObj);
+        commit(mutations.EDIT, response.data);
+        commit(mutations.SET_UI_FLAG, { updatingItem: false });
+        return response.data;
+      } catch (error) {
+        commit(mutations.SET_UI_FLAG, { updatingItem: false });
+        return throwErrorMessage(error);
+      }
+    },
+
+    delete: async ({ commit }, id) => {
+      commit(mutations.SET_UI_FLAG, { deletingItem: true });
+      try {
+        await CaptainMcpServers.delete(id);
+        commit(mutations.DELETE, id);
+        commit(mutations.SET_UI_FLAG, { deletingItem: false });
+        return id;
+      } catch (error) {
+        commit(mutations.SET_UI_FLAG, { deletingItem: false });
+        return throwErrorMessage(error);
+      }
+    },
+
+    connect: async ({ commit }, id) => {
+      commit(mutations.SET_UI_FLAG, { updatingItem: true });
+      try {
+        const response = await CaptainMcpServers.connect(id);
+        // Refetch to get updated cached_tools
+        const serverResponse = await CaptainMcpServers.show(id);
+        commit(mutations.EDIT, serverResponse.data);
+        commit(mutations.SET_UI_FLAG, { updatingItem: false });
+        return response.data;
+      } catch (error) {
+        commit(mutations.SET_UI_FLAG, { updatingItem: false });
+        return throwErrorMessage(error);
+      }
+    },
+
+    disconnect: async ({ commit }, id) => {
+      commit(mutations.SET_UI_FLAG, { updatingItem: true });
+      try {
+        const response = await CaptainMcpServers.disconnect(id);
+        const serverResponse = await CaptainMcpServers.show(id);
+        commit(mutations.EDIT, serverResponse.data);
+        commit(mutations.SET_UI_FLAG, { updatingItem: false });
+        return response.data;
+      } catch (error) {
+        commit(mutations.SET_UI_FLAG, { updatingItem: false });
+        return throwErrorMessage(error);
+      }
+    },
+
+    refresh: async ({ commit }, id) => {
+      commit(mutations.SET_UI_FLAG, { updatingItem: true });
+      try {
+        const response = await CaptainMcpServers.refresh(id);
+        commit(mutations.EDIT, response.data);
+        commit(mutations.SET_UI_FLAG, { updatingItem: false });
+        return response.data;
+      } catch (error) {
+        commit(mutations.SET_UI_FLAG, { updatingItem: false });
+        return throwErrorMessage(error);
+      }
+    },
+  }),
+});

--- a/app/javascript/dashboard/store/index.js
+++ b/app/javascript/dashboard/store/index.js
@@ -59,6 +59,7 @@ import captainScenarios from './captain/scenarios';
 import captainTools from './captain/tools';
 import captainCustomTools from './captain/customTools';
 import captainMcpServers from './captain/mcpServers';
+import captainAssistantMcpServers from './captain/assistantMcpServers';
 
 const plugins = [];
 
@@ -123,6 +124,7 @@ export default createStore({
     captainTools,
     captainCustomTools,
     captainMcpServers,
+    captainAssistantMcpServers,
   },
   plugins,
 });

--- a/app/javascript/dashboard/store/index.js
+++ b/app/javascript/dashboard/store/index.js
@@ -58,6 +58,7 @@ import copilotMessages from './captain/copilotMessages';
 import captainScenarios from './captain/scenarios';
 import captainTools from './captain/tools';
 import captainCustomTools from './captain/customTools';
+import captainMcpServers from './captain/mcpServers';
 
 const plugins = [];
 
@@ -121,6 +122,7 @@ export default createStore({
     captainScenarios,
     captainTools,
     captainCustomTools,
+    captainMcpServers,
   },
   plugins,
 });

--- a/config/features.yml
+++ b/config/features.yml
@@ -218,6 +218,10 @@
   # Once the migration is done, this feature can be removed
   display_name: Reply Mailer Migration
   enabled: false
+- name: captain_mcp
+  display_name: Captain MCP
+  enabled: false
+  premium: true
   chatwoot_internal: true
 - name: quoted_email_reply
   display_name: Quoted Email Reply

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -375,6 +375,8 @@ en:
       page_processing_error: 'Error processing pages %{start}-%{end}: %{error}'
     custom_tool:
       slug_generation_failed: 'Unable to generate unique slug after 5 attempts'
+    mcp_server:
+      slug_generation_failed: 'Unable to generate unique slug after 5 attempts'
   public_portal:
     search:
       search_placeholder: Search for article by title or body...

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,6 +119,8 @@ en:
       invalid_value: Invalid value. The values provided for %{attribute_name} are invalid
     custom_attribute_definition:
       key_conflict: The provided key is not allowed as it might conflict with default attributes.
+    captain:
+      mcp_not_enabled: 'MCP servers feature is not enabled for this account'
     mfa:
       already_enabled: MFA is already enabled
       not_enabled: MFA is not enabled
@@ -377,6 +379,15 @@ en:
       slug_generation_failed: 'Unable to generate unique slug after 5 attempts'
     mcp_server:
       slug_generation_failed: 'Unable to generate unique slug after 5 attempts'
+    captain:
+      mcp_not_enabled: 'MCP servers are not enabled for this account'
+      errors:
+        url_must_be_valid: 'must be a valid URL'
+        url_must_use_http: 'must use HTTP or HTTPS protocol'
+        url_must_have_hostname: 'must have a valid hostname'
+        url_cannot_be_self: 'cannot point to the application itself'
+        url_disallowed_hostname: 'cannot use disallowed hostname'
+        url_cannot_be_ip: 'cannot be an IP address, must be a hostname'
   public_portal:
     search:
       search_placeholder: Search for article by title or body...

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -73,6 +73,8 @@ es:
     messages:
       search:
         time_range_limit_exceeded: 'Search is limited to the last %{days} days'
+    captain:
+      mcp_not_enabled: 'Los servidores MCP no están habilitados para esta cuenta'
     categories:
       locale:
         unique: debe ser único en la categoría y el portal
@@ -346,6 +348,8 @@ es:
       chunk_generated: 'Chunk generated %{chunk_faqs} FAQs. Total so far: %{total_faqs}'
       page_processing_error: 'Error processing pages %{start}-%{end}: %{error}'
     custom_tool:
+      slug_generation_failed: 'Unable to generate unique slug after 5 attempts'
+    mcp_server:
       slug_generation_failed: 'Unable to generate unique slug after 5 attempts'
   public_portal:
     search:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,14 @@ Rails.application.routes.draw do
               end
               resources :inboxes, only: [:index, :create, :destroy], param: :inbox_id
               resources :scenarios
+              resources :mcp_servers, only: [:index, :create, :update, :destroy], controller: 'assistants/mcp_servers'
+            end
+            resources :mcp_servers do
+              member do
+                post :connect
+                post :disconnect
+                post :refresh
+              end
             end
             resources :assistant_responses
             resources :bulk_actions, only: [:create]

--- a/db/migrate/20260131000001_create_captain_mcp_servers.rb
+++ b/db/migrate/20260131000001_create_captain_mcp_servers.rb
@@ -1,0 +1,24 @@
+class CreateCaptainMcpServers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :captain_mcp_servers, if_not_exists: true do |t|
+      t.references :account, null: false, index: true
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.text :description
+      t.string :url, null: false
+      t.string :auth_type, default: 'none'
+      t.jsonb :auth_config, default: {}
+      t.boolean :enabled, default: true, null: false
+      t.string :status, default: 'disconnected'
+      t.text :last_error
+      t.datetime :last_connected_at
+      t.jsonb :cached_tools, default: []
+      t.datetime :cache_refreshed_at
+
+      t.timestamps
+    end
+
+    add_index :captain_mcp_servers, [:account_id, :slug], unique: true, if_not_exists: true
+    add_index :captain_mcp_servers, [:account_id, :enabled], if_not_exists: true
+  end
+end

--- a/db/migrate/20260131000001_create_captain_mcp_servers.rb
+++ b/db/migrate/20260131000001_create_captain_mcp_servers.rb
@@ -7,7 +7,7 @@ class CreateCaptainMcpServers < ActiveRecord::Migration[7.1]
       t.text :description
       t.string :url, null: false
       t.string :auth_type, default: 'none'
-      t.jsonb :auth_config, default: {}
+      t.text :auth_config
       t.boolean :enabled, default: true, null: false
       t.string :status, default: 'disconnected'
       t.text :last_error

--- a/db/migrate/20260131000002_create_captain_assistant_mcp_servers.rb
+++ b/db/migrate/20260131000002_create_captain_assistant_mcp_servers.rb
@@ -1,0 +1,17 @@
+class CreateCaptainAssistantMcpServers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :captain_assistant_mcp_servers do |t|
+      t.references :captain_assistant, null: false, index: true
+      t.references :captain_mcp_server, null: false, index: true
+      t.jsonb :tool_filters, default: {}
+      t.boolean :enabled, default: true, null: false
+
+      t.timestamps
+    end
+
+    add_index :captain_assistant_mcp_servers,
+              [:captain_assistant_id, :captain_mcp_server_id],
+              unique: true,
+              name: 'idx_captain_assistant_mcp_server_unique'
+  end
+end

--- a/db/migrate/20260206000001_change_captain_mcp_servers_auth_config_to_text.rb
+++ b/db/migrate/20260206000001_change_captain_mcp_servers_auth_config_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeCaptainMcpServersAuthConfigToText < ActiveRecord::Migration[7.1]
+  def up
+    change_column :captain_mcp_servers, :auth_config, :text, default: nil
+  end
+
+  def down
+    change_column :captain_mcp_servers, :auth_config, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_01_31_000002) do
+ActiveRecord::Schema[7.1].define(version: 2026_02_06_000001) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -430,7 +430,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_31_000002) do
     t.text "description"
     t.string "url", null: false
     t.string "auth_type", default: "none"
-    t.jsonb "auth_config", default: {}
+    t.text "auth_config"
     t.boolean "enabled", default: true, null: false
     t.string "status", default: "disconnected"
     t.text "last_error"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_01_30_061021) do
+ActiveRecord::Schema[7.1].define(version: 2026_01_31_000002) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -293,6 +293,43 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_30_061021) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
+  create_table "captain_agent_runs", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "assistant_id"
+    t.bigint "inbox_id"
+    t.bigint "conversation_id"
+    t.string "trigger"
+    t.string "status", default: "started", null: false
+    t.string "idempotency_key"
+    t.jsonb "metadata", default: {}
+    t.datetime "started_at"
+    t.datetime "finished_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["idempotency_key"], name: "index_captain_agent_runs_on_idempotency_key", unique: true
+  end
+
+  create_table "captain_assistant_mcp_servers", force: :cascade do |t|
+    t.bigint "captain_assistant_id", null: false
+    t.bigint "captain_mcp_server_id", null: false
+    t.jsonb "tool_filters", default: {}
+    t.boolean "enabled", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["captain_assistant_id", "captain_mcp_server_id"], name: "idx_captain_assistant_mcp_server_unique", unique: true
+    t.index ["captain_assistant_id"], name: "index_captain_assistant_mcp_servers_on_captain_assistant_id"
+    t.index ["captain_mcp_server_id"], name: "index_captain_assistant_mcp_servers_on_captain_mcp_server_id"
+  end
+
+  create_table "captain_assistant_mcp_tools", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "assistant_id", null: false
+    t.bigint "captain_mcp_tool_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assistant_id", "captain_mcp_tool_id"], name: "idx_captain_assistant_mcp_tools_unique", unique: true
+  end
+
   create_table "captain_assistant_responses", force: :cascade do |t|
     t.string "question", null: false
     t.text "answer", null: false
@@ -358,6 +395,24 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_30_061021) do
     t.index ["status"], name: "index_captain_documents_on_status"
   end
 
+  create_table "captain_followups", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "conversation_id", null: false
+    t.bigint "captain_assistant_id", null: false
+    t.datetime "scheduled_at", null: false
+    t.string "status", default: "pending", null: false
+    t.string "cancel_reason"
+    t.jsonb "payload"
+    t.string "idempotency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_captain_followups_on_account_id"
+    t.index ["captain_assistant_id"], name: "index_captain_followups_on_captain_assistant_id"
+    t.index ["conversation_id", "status"], name: "index_captain_followups_on_conversation_id_and_status"
+    t.index ["conversation_id"], name: "index_captain_followups_on_conversation_id"
+    t.index ["scheduled_at"], name: "index_captain_followups_on_scheduled_at"
+  end
+
   create_table "captain_inboxes", force: :cascade do |t|
     t.bigint "captain_assistant_id", null: false
     t.bigint "inbox_id", null: false
@@ -366,6 +421,38 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_30_061021) do
     t.index ["captain_assistant_id", "inbox_id"], name: "index_captain_inboxes_on_captain_assistant_id_and_inbox_id", unique: true
     t.index ["captain_assistant_id"], name: "index_captain_inboxes_on_captain_assistant_id"
     t.index ["inbox_id"], name: "index_captain_inboxes_on_inbox_id"
+  end
+
+  create_table "captain_mcp_servers", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.text "description"
+    t.string "url", null: false
+    t.string "auth_type", default: "none"
+    t.jsonb "auth_config", default: {}
+    t.boolean "enabled", default: true, null: false
+    t.string "status", default: "disconnected"
+    t.text "last_error"
+    t.datetime "last_connected_at"
+    t.jsonb "cached_tools", default: []
+    t.datetime "cache_refreshed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "enabled"], name: "index_captain_mcp_servers_on_account_id_and_enabled"
+    t.index ["account_id", "slug"], name: "index_captain_mcp_servers_on_account_id_and_slug", unique: true
+    t.index ["account_id"], name: "index_captain_mcp_servers_on_account_id"
+  end
+
+  create_table "captain_mcp_tools", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "captain_mcp_server_id", null: false
+    t.string "tool_name", null: false
+    t.jsonb "tool_schema", default: {}
+    t.boolean "enabled", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["captain_mcp_server_id", "tool_name"], name: "idx_captain_mcp_tools_unique_tool", unique: true
   end
 
   create_table "captain_scenarios", force: :cascade do |t|
@@ -1180,6 +1267,17 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_30_061021) do
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
+  create_table "team_chat_messages", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "user_id", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "created_at"], name: "index_team_chat_messages_on_account_id_and_created_at"
+    t.index ["account_id"], name: "index_team_chat_messages_on_account_id"
+    t.index ["user_id"], name: "index_team_chat_messages_on_user_id"
+  end
+
   create_table "team_members", force: :cascade do |t|
     t.bigint "team_id", null: false
     t.bigint "user_id", null: false
@@ -1231,7 +1329,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_30_061021) do
     t.text "message_signature"
     t.string "otp_secret"
     t.integer "consumed_timestep"
-    t.boolean "otp_required_for_login", default: false
+    t.boolean "otp_required_for_login", default: false, null: false
     t.text "otp_backup_codes"
     t.index ["email"], name: "index_users_on_email"
     t.index ["otp_required_for_login"], name: "index_users_on_otp_required_for_login"
@@ -1271,7 +1369,12 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_30_061021) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "captain_followups", "accounts"
+  add_foreign_key "captain_followups", "captain_assistants"
+  add_foreign_key "captain_followups", "conversations"
   add_foreign_key "inboxes", "portals"
+  add_foreign_key "team_chat_messages", "accounts"
+  add_foreign_key "team_chat_messages", "users"
   create_trigger("accounts_after_insert_row_tr", :generated => true, :compatibility => 1).
       on("accounts").
       after(:insert).

--- a/docs/captain-mcp-servers.md
+++ b/docs/captain-mcp-servers.md
@@ -1,0 +1,257 @@
+# Captain MCP Servers
+
+## Overview
+
+Captain MCP Servers integrate external [Model Context Protocol](https://modelcontextprotocol.io/) services into Chatwoot's Captain AI assistants. MCP servers expose tools (functions) that the LLM can call during conversations, allowing assistants to search documentation, query APIs, browse the web, and more.
+
+**Feature flag:** `captain_mcp` (requires `captain` to also be enabled)
+**Enterprise only:** Requires Enterprise installation or Chatwoot Cloud with the Captain plan.
+
+---
+
+## Architecture
+
+```
+User Message
+    |
+    v
+Captain Assistant (LLM)
+    |
+    v
+Tool Selection (RubyLLM)
+    |
+    +--> SearchDocumentation (built-in)
+    +--> MCP Tool 1 (dynamic)
+    +--> MCP Tool 2 (dynamic)
+         |
+         v
+    Captain::Mcp::ClientService
+         |
+         v
+    ruby-mcp-client gem (HTTP)
+         |
+         v
+    Remote MCP Server
+```
+
+### Key Components
+
+| File | Purpose |
+|------|---------|
+| `enterprise/app/models/captain/mcp_server.rb` | Model: stores server config, auth, cached tools |
+| `enterprise/app/models/concerns/mcp_toolable.rb` | Dynamically builds RubyLLM tool classes from cached MCP tool schemas |
+| `enterprise/app/services/captain/mcp/client_service.rb` | Connects to MCP servers, calls tools, handles SSRF protection |
+| `enterprise/app/services/captain/mcp/discovery_service.rb` | Connects + discovers available tools from an MCP server |
+| `enterprise/lib/captain/tools/mcp_tool.rb` | Base class for dynamically generated MCP tool instances |
+| `enterprise/app/models/captain/assistant_mcp_server.rb` | Join model: links assistants to MCP servers with optional tool filters |
+| `enterprise/app/services/captain/llm/assistant_chat_service.rb` | Builds the tool list (built-in + MCP) for LLM chat completion |
+| `enterprise/app/controllers/api/v1/accounts/captain/mcp_servers_controller.rb` | REST API for CRUD, connect, disconnect, refresh |
+
+---
+
+## Supported MCP Servers
+
+### Transport Protocols
+
+The integration uses the [`ruby-mcp-client`](https://rubygems.org/gems/ruby-mcp-client) gem (v0.9.1). Supported transports:
+
+| Transport | Supported | Notes |
+|-----------|-----------|-------|
+| **Streamable HTTP** | Yes | Default. Most modern MCP servers use this. The gem auto-detects transport from the URL. |
+| **SSE (Server-Sent Events)** | Yes | Legacy transport. Some older MCP servers still use this. |
+| **stdio** | No | Requires spawning a local subprocess. Not supported in this integration (server-side only). |
+
+### What Works
+
+- **Public HTTPS MCP servers** with streamable HTTP or SSE transport
+- **Authentication:** None, Bearer token, or API key (custom header name supported)
+- **Tool discovery:** Automatic on connect, manual refresh available
+- **Tool filtering:** Per-assistant include/exclude lists for which tools to expose
+- **Tool execution:** LLM calls tools during chat, results returned as text
+- **Response types:** Text, image placeholders (`[Image: mime/type]`), resource links
+- **Response truncation:** Responses larger than 1MB are safely truncated (UTF-8 aware)
+- **Multiple assistants:** Same MCP server can be attached to multiple assistants with different tool filters
+- **Credential encryption:** `auth_config` is encrypted at rest when `Chatwoot.encryption_configured?` is true
+
+### What Does Not Work
+
+| Limitation | Reason |
+|------------|--------|
+| **stdio transport** | The `ruby-mcp-client` gem supports it, but this integration only connects via HTTP. Stdio requires spawning a local process, which isn't suitable for a multi-tenant server. |
+| **Private/internal MCP servers** | SSRF protection blocks connections to private IPs (10.x, 172.16.x, 192.168.x, 127.x, link-local, CGN, IPv6 private). |
+| **IP address URLs** | URL validation rejects raw IP addresses. Must use hostnames. |
+| **localhost / .local domains** | Explicitly blocked for security. |
+| **Complex tool parameter types** | RubyLLM's `Parameter` only supports scalar types (`string`, `integer`, `number`, `boolean`). Tool params with `array` or `object` types are **coerced to `string`**. The LLM will typically pass JSON-formatted strings, but MCP servers that strictly validate types may reject them. |
+| **Binary/streaming tool responses** | Only text-based responses are supported. Images are represented as placeholders. |
+| **OAuth / session-based auth** | Only static Bearer tokens and API keys are supported. No OAuth flow, no session cookies. |
+| **Bidirectional communication** | MCP servers can't push notifications back to Chatwoot. Communication is request-response only. |
+
+---
+
+## Tested MCP Servers
+
+| Server | URL | Status | Notes |
+|--------|-----|--------|-------|
+| Cloudflare Docs | `https://developers.cloudflare.com/mcp` | Works | Streamable HTTP, no auth required |
+| OpenAI Docs | `https://developers.openai.com/mcp` | Partial | Connects and discovers tools, but `get_openapi_spec` tool has a `languages` array param without `items` schema. Coerced to string; may not work perfectly. |
+| Context7 | `https://mcp.context7.com/mcp` | Works | Documentation search, streamable HTTP |
+
+### How to Test a New MCP Server
+
+1. Go to **Settings > Captain > MCP Servers**
+2. Click **Add Server**, provide name and HTTPS URL
+3. Click **Connect** - the system will:
+   - Resolve the hostname and verify it's not a private IP
+   - Connect via the detected transport (streamable HTTP or SSE)
+   - Discover all available tools
+4. Attach the server to an assistant (Settings > Captain > Assistants > Edit > MCP Servers)
+5. Optionally filter which tools the assistant can use
+6. Test in the assistant playground
+
+---
+
+## Auth Configuration
+
+The `auth_config` field is a JSON object stored as encrypted text. Structure depends on `auth_type`:
+
+### `none` (default)
+```json
+{}
+```
+
+### `bearer`
+```json
+{
+  "token": "your-bearer-token"
+}
+```
+Sent as: `Authorization: Bearer your-bearer-token`
+
+### `api_key`
+```json
+{
+  "key": "your-api-key",
+  "header_name": "X-API-Key"
+}
+```
+`header_name` defaults to `X-API-Key` if not specified.
+
+### Advanced Options
+
+These can be set in `auth_config` for non-standard MCP servers:
+
+```json
+{
+  "token": "...",
+  "transport": "streamable_http",
+  "rpc_endpoint": "/custom/rpc"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `transport` | Force transport type: `streamable_http` or `sse`. Auto-detected if omitted. |
+| `rpc_endpoint` | Custom JSON-RPC endpoint path. Only needed if the server uses a non-standard path. |
+
+---
+
+## Security
+
+### SSRF Protection
+
+Before connecting, the system resolves the hostname and checks the IP against a blocklist:
+
+| Range | Description |
+|-------|-------------|
+| `0.0.0.0/8` | Current network |
+| `127.0.0.0/8` | Loopback |
+| `10.0.0.0/8` | Private class A |
+| `172.16.0.0/12` | Private class B |
+| `192.168.0.0/16` | Private class C |
+| `169.254.0.0/16` | Link-local (includes AWS/GCP metadata at 169.254.169.254) |
+| `100.64.0.0/10` | Carrier-grade NAT (RFC 6598) |
+| `::1/128` | IPv6 loopback |
+| `fc00::/7` | IPv6 unique local |
+| `fe80::/10` | IPv6 link-local |
+| `::ffff:0:0/96` | IPv4-mapped IPv6 |
+
+### URL Validation (Model-level)
+
+- Must use `http://` or `https://` scheme
+- Must have a hostname (no bare IPs)
+- Cannot point to `localhost`, `.local` domains, or the Chatwoot frontend host
+- Raw IP addresses (IPv4, IPv6, octal, hex) are rejected
+
+### Credential Security
+
+- `auth_config` is stored as encrypted text (when encryption is configured)
+- `auth_config` is excluded from audit logs (`audited except: [:auth_config]`)
+- API responses mask credentials (show `has_token: true` instead of actual token)
+- Credentials are preserved on update if not explicitly provided
+
+### Response Limits
+
+- Tool responses are truncated to **1MB** using `truncate_bytes` (UTF-8 safe)
+- Connection timeout: **30 seconds**
+
+---
+
+## API Endpoints
+
+All endpoints require administrator permissions and the `captain_mcp` feature flag.
+
+```
+GET    /api/v1/accounts/:account_id/captain/mcp_servers
+POST   /api/v1/accounts/:account_id/captain/mcp_servers
+GET    /api/v1/accounts/:account_id/captain/mcp_servers/:id
+PATCH  /api/v1/accounts/:account_id/captain/mcp_servers/:id
+DELETE /api/v1/accounts/:account_id/captain/mcp_servers/:id
+POST   /api/v1/accounts/:account_id/captain/mcp_servers/:id/connect
+POST   /api/v1/accounts/:account_id/captain/mcp_servers/:id/disconnect
+POST   /api/v1/accounts/:account_id/captain/mcp_servers/:id/refresh
+```
+
+---
+
+## Data Model
+
+### captain_mcp_servers
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `name` | string | Display name |
+| `slug` | string | Auto-generated, unique per account. Format: `mcp_{parameterized_name}` |
+| `url` | string | MCP server endpoint URL |
+| `auth_type` | enum | `none`, `bearer`, `api_key` |
+| `auth_config` | text | Encrypted JSON with credentials and advanced options |
+| `enabled` | boolean | Whether the server is active |
+| `status` | enum | `disconnected`, `connecting`, `connected`, `error` |
+| `last_error` | text | Last connection error message |
+| `last_connected_at` | datetime | Timestamp of last successful connection |
+| `cached_tools` | jsonb | Array of tool definitions discovered from the server |
+| `cache_refreshed_at` | datetime | When tools were last refreshed |
+
+### captain_assistant_mcp_servers
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `captain_assistant_id` | bigint | FK to assistant |
+| `captain_mcp_server_id` | bigint | FK to MCP server |
+| `enabled` | boolean | Whether this link is active |
+| `tool_filters` | jsonb | `{"include": ["tool1"], "exclude": ["tool2"]}` |
+
+---
+
+## Known Limitations and Future Work
+
+1. **Complex parameter types (array/object):** Currently coerced to `string`. A future improvement could generate proper nested JSON Schema by extending the tool registration to pass raw `inputSchema` directly to the LLM provider instead of going through RubyLLM's `param` abstraction.
+
+2. **No retry on transient failures:** Connection retries are set to 0. Tool calls that fail due to transient network issues are not retried.
+
+3. **No webhook/push support:** MCP servers can't notify Chatwoot when tools change. Must manually refresh.
+
+4. **Single DNS resolution:** The SSRF check resolves the hostname once at connect time. A DNS rebinding attack could theoretically change the IP after the check. The `ruby-mcp-client` gem uses Faraday which re-resolves DNS on each request.
+
+5. **No connection pooling:** Each tool call creates a new `ClientService` instance and reconnects. This adds latency but avoids stale connection issues.
+
+6. **Tool name length:** Function names are capped at 64 characters (`mcp_{slug}_{tool_name}`). Very long tool names may be truncated and collide.

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistants/mcp_servers_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistants/mcp_servers_controller.rb
@@ -10,6 +10,7 @@ class Api::V1::Accounts::Captain::Assistants::McpServersController < Api::V1::Ac
   end
 
   def create
+    validate_mcp_server_account!
     @assistant_mcp_server = @assistant.assistant_mcp_servers.create!(assistant_mcp_server_params)
     render :show
   end
@@ -40,11 +41,16 @@ class Api::V1::Accounts::Captain::Assistants::McpServersController < Api::V1::Ac
     @assistant_mcp_server = @assistant.assistant_mcp_servers.find(params[:id])
   end
 
+  def validate_mcp_server_account!
+    server_id = params.dig(:assistant_mcp_server, :captain_mcp_server_id)
+    Current.account.captain_mcp_servers.find(server_id)
+  end
+
   def assistant_mcp_server_params
     params.require(:assistant_mcp_server).permit(
       :captain_mcp_server_id,
       :enabled,
-      tool_filters: {}
+      tool_filters: { include: [], exclude: [] }
     )
   end
 end

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistants/mcp_servers_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistants/mcp_servers_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Accounts::Captain::Assistants::McpServersController < Api::V1::Accounts::BaseController
   before_action :current_account
+  before_action :check_captain_mcp_feature
   before_action :set_assistant
   before_action -> { check_authorization(@assistant) }
   before_action :set_assistant_mcp_server, only: [:update, :destroy]
@@ -24,6 +25,12 @@ class Api::V1::Accounts::Captain::Assistants::McpServersController < Api::V1::Ac
   end
 
   private
+
+  def check_captain_mcp_feature
+    return if Current.account.feature_enabled?('captain_mcp')
+
+    render json: { error: I18n.t('errors.captain.mcp_not_enabled') }, status: :forbidden
+  end
 
   def set_assistant
     @assistant = Current.account.captain_assistants.find(params[:assistant_id])

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistants/mcp_servers_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistants/mcp_servers_controller.rb
@@ -1,0 +1,43 @@
+class Api::V1::Accounts::Captain::Assistants::McpServersController < Api::V1::Accounts::BaseController
+  before_action :current_account
+  before_action :set_assistant
+  before_action -> { check_authorization(@assistant) }
+  before_action :set_assistant_mcp_server, only: [:update, :destroy]
+
+  def index
+    @assistant_mcp_servers = @assistant.assistant_mcp_servers.includes(:mcp_server)
+  end
+
+  def create
+    @assistant_mcp_server = @assistant.assistant_mcp_servers.create!(assistant_mcp_server_params)
+    render :show
+  end
+
+  def update
+    @assistant_mcp_server.update!(assistant_mcp_server_params)
+    render :show
+  end
+
+  def destroy
+    @assistant_mcp_server.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_assistant
+    @assistant = Current.account.captain_assistants.find(params[:assistant_id])
+  end
+
+  def set_assistant_mcp_server
+    @assistant_mcp_server = @assistant.assistant_mcp_servers.find(params[:id])
+  end
+
+  def assistant_mcp_server_params
+    params.require(:assistant_mcp_server).permit(
+      :captain_mcp_server_id,
+      :enabled,
+      tool_filters: {}
+    )
+  end
+end

--- a/enterprise/app/controllers/api/v1/accounts/captain/mcp_servers_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/mcp_servers_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::Accounts::Captain::McpServersController < Api::V1::Accounts::Base
   before_action :set_mcp_server, only: [:show, :update, :destroy, :connect, :disconnect, :refresh]
 
   def index
-    @mcp_servers = account_mcp_servers.enabled.order(created_at: :desc).page(params[:page]).per(RESULTS_PER_PAGE)
+    @mcp_servers = account_mcp_servers.order(created_at: :desc).page(params[:page]).per(RESULTS_PER_PAGE)
   end
 
   def show; end

--- a/enterprise/app/controllers/api/v1/accounts/captain/mcp_servers_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/mcp_servers_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::Accounts::Captain::McpServersController < Api::V1::Accounts::Base
   RESULTS_PER_PAGE = 15
 
   before_action :current_account
+  before_action :check_captain_mcp_feature
   before_action -> { check_authorization(Captain::McpServer) }
   before_action :set_mcp_server, only: [:show, :update, :destroy, :connect, :disconnect, :refresh]
 
@@ -16,7 +17,7 @@ class Api::V1::Accounts::Captain::McpServersController < Api::V1::Accounts::Base
   end
 
   def update
-    @mcp_server.update!(mcp_server_params)
+    @mcp_server.update!(merged_update_params)
   end
 
   def destroy
@@ -47,6 +48,12 @@ class Api::V1::Accounts::Captain::McpServersController < Api::V1::Accounts::Base
 
   private
 
+  def check_captain_mcp_feature
+    return if Current.account.feature_enabled?('captain_mcp')
+
+    render json: { error: I18n.t('errors.captain.mcp_not_enabled') }, status: :forbidden
+  end
+
   def set_mcp_server
     @mcp_server = account_mcp_servers.find(params[:id])
   end
@@ -64,5 +71,22 @@ class Api::V1::Accounts::Captain::McpServersController < Api::V1::Accounts::Base
       :enabled,
       auth_config: {}
     )
+  end
+
+  def merged_update_params
+    update_params = mcp_server_params.to_h
+    return update_params unless update_params.key?(:auth_config)
+
+    # Preserve existing credentials if not provided in update
+    existing_config = @mcp_server.auth_config || {}
+    new_config = update_params[:auth_config]
+
+    # Keep existing token if new one not provided
+    new_config['token'] = existing_config['token'] if existing_config['token'].present? && new_config['token'].blank?
+    # Keep existing key if new one not provided
+    new_config['key'] = existing_config['key'] if existing_config['key'].present? && new_config['key'].blank?
+
+    update_params[:auth_config] = new_config
+    update_params
   end
 end

--- a/enterprise/app/controllers/api/v1/accounts/captain/mcp_servers_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/mcp_servers_controller.rb
@@ -1,10 +1,12 @@
 class Api::V1::Accounts::Captain::McpServersController < Api::V1::Accounts::BaseController
+  RESULTS_PER_PAGE = 15
+
   before_action :current_account
   before_action -> { check_authorization(Captain::McpServer) }
   before_action :set_mcp_server, only: [:show, :update, :destroy, :connect, :disconnect, :refresh]
 
   def index
-    @mcp_servers = account_mcp_servers.enabled
+    @mcp_servers = account_mcp_servers.enabled.order(created_at: :desc).page(params[:page]).per(RESULTS_PER_PAGE)
   end
 
   def show; end

--- a/enterprise/app/controllers/api/v1/accounts/captain/mcp_servers_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/mcp_servers_controller.rb
@@ -1,0 +1,66 @@
+class Api::V1::Accounts::Captain::McpServersController < Api::V1::Accounts::BaseController
+  before_action :current_account
+  before_action -> { check_authorization(Captain::McpServer) }
+  before_action :set_mcp_server, only: [:show, :update, :destroy, :connect, :disconnect, :refresh]
+
+  def index
+    @mcp_servers = account_mcp_servers.enabled
+  end
+
+  def show; end
+
+  def create
+    @mcp_server = account_mcp_servers.create!(mcp_server_params)
+  end
+
+  def update
+    @mcp_server.update!(mcp_server_params)
+  end
+
+  def destroy
+    @mcp_server.destroy
+    head :no_content
+  end
+
+  def connect
+    discovery_service = Captain::Mcp::DiscoveryService.new(@mcp_server)
+    discovery_service.connect_and_discover
+    render json: { status: 'connected', tools_count: @mcp_server.cached_tools.size }
+  rescue Captain::Mcp::Error => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
+  def disconnect
+    Captain::Mcp::ClientService.new(@mcp_server).disconnect
+    render json: { status: 'disconnected' }
+  end
+
+  def refresh
+    discovery_service = Captain::Mcp::DiscoveryService.new(@mcp_server)
+    discovery_service.refresh_tools
+    render :show
+  rescue Captain::Mcp::Error => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
+  private
+
+  def set_mcp_server
+    @mcp_server = account_mcp_servers.find(params[:id])
+  end
+
+  def account_mcp_servers
+    @account_mcp_servers ||= Current.account.captain_mcp_servers
+  end
+
+  def mcp_server_params
+    params.require(:mcp_server).permit(
+      :name,
+      :description,
+      :url,
+      :auth_type,
+      :enabled,
+      auth_config: {}
+    )
+  end
+end

--- a/enterprise/app/controllers/api/v1/accounts/captain/mcp_servers_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/mcp_servers_controller.rb
@@ -74,7 +74,7 @@ class Api::V1::Accounts::Captain::McpServersController < Api::V1::Accounts::Base
   end
 
   def merged_update_params
-    update_params = mcp_server_params.to_h
+    update_params = mcp_server_params.to_h.with_indifferent_access
     return update_params unless update_params.key?(:auth_config)
 
     # Preserve existing credentials if not provided in update

--- a/enterprise/app/jobs/captain/mcp/cache_refresh_job.rb
+++ b/enterprise/app/jobs/captain/mcp/cache_refresh_job.rb
@@ -1,0 +1,15 @@
+class Captain::Mcp::CacheRefreshJob < ApplicationJob
+  queue_as :low
+
+  def perform(mcp_server_id)
+    mcp_server = Captain::McpServer.find_by(id: mcp_server_id)
+    return unless mcp_server&.enabled?
+
+    discovery_service = Captain::Mcp::DiscoveryService.new(mcp_server)
+    discovery_service.refresh_tools
+  rescue Captain::Mcp::Error => e
+    Rails.logger.error("MCP cache refresh failed for server #{mcp_server_id}: #{e.message}")
+  rescue ActiveRecord::RecordNotFound
+    Rails.logger.warn("MCP server #{mcp_server_id} not found for cache refresh")
+  end
+end

--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -35,6 +35,13 @@ class Captain::Assistant < ApplicationRecord
   has_many :messages, as: :sender, dependent: :nullify
   has_many :copilot_threads, dependent: :destroy_async
   has_many :scenarios, class_name: 'Captain::Scenario', dependent: :destroy_async
+  has_many :assistant_mcp_servers,
+           class_name: 'Captain::AssistantMcpServer',
+           foreign_key: :captain_assistant_id,
+           inverse_of: :assistant,
+           dependent: :destroy
+  has_many :mcp_servers,
+           through: :assistant_mcp_servers
 
   store_accessor :config, :temperature, :feature_faq, :feature_memory, :product_name
 
@@ -55,6 +62,9 @@ class Captain::Assistant < ApplicationRecord
 
     custom_tools = account.captain_custom_tools.enabled.map(&:to_tool_metadata)
     tools.concat(custom_tools)
+
+    mcp_tools = mcp_servers.enabled.flat_map(&:to_tool_metadata)
+    tools.concat(mcp_tools)
 
     tools
   end

--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -63,7 +63,7 @@ class Captain::Assistant < ApplicationRecord
     custom_tools = account.captain_custom_tools.enabled.map(&:to_tool_metadata)
     tools.concat(custom_tools)
 
-    mcp_tools = mcp_servers.enabled.flat_map(&:to_tool_metadata)
+    mcp_tools = assistant_mcp_servers.enabled.flat_map(&:to_tool_metadata)
     tools.concat(mcp_tools)
 
     tools

--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -63,7 +63,10 @@ class Captain::Assistant < ApplicationRecord
     custom_tools = account.captain_custom_tools.enabled.map(&:to_tool_metadata)
     tools.concat(custom_tools)
 
-    mcp_tools = assistant_mcp_servers.enabled.flat_map(&:to_tool_metadata)
+    mcp_tools = assistant_mcp_servers.enabled
+                                     .joins(:mcp_server)
+                                     .merge(Captain::McpServer.enabled)
+                                     .flat_map(&:to_tool_metadata)
     tools.concat(mcp_tools)
 
     tools

--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -105,10 +105,28 @@ class Captain::Assistant < ApplicationRecord
   end
 
   def agent_tools
-    [
+    tools = [
       self.class.resolve_tool_class('faq_lookup').new(self),
       self.class.resolve_tool_class('handoff').new(self)
     ]
+
+    # Add custom tools
+    account.captain_custom_tools.enabled.each do |custom_tool|
+      tools << custom_tool.tool(self)
+    end
+
+    # Add MCP tools from attached, enabled, connected servers
+    assistant_mcp_servers.enabled
+                         .joins(:mcp_server)
+                         .merge(Captain::McpServer.enabled.connected)
+                         .each do |ams|
+      ams.filtered_tools.each do |tool_def|
+        tool_instance = ams.mcp_server.build_tool_instance(self, tool_def['name'])
+        tools << tool_instance if tool_instance
+      end
+    end
+
+    tools
   end
 
   def prompt_context

--- a/enterprise/app/models/captain/assistant_mcp_server.rb
+++ b/enterprise/app/models/captain/assistant_mcp_server.rb
@@ -1,0 +1,55 @@
+# == Schema Information
+#
+# Table name: captain_assistant_mcp_servers
+#
+#  id                    :bigint           not null, primary key
+#  enabled               :boolean          default(TRUE), not null
+#  tool_filters          :jsonb
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  captain_assistant_id  :bigint           not null
+#  captain_mcp_server_id :bigint           not null
+#
+# Indexes
+#
+#  idx_captain_assistant_mcp_server_unique                        (captain_assistant_id,captain_mcp_server_id) UNIQUE
+#  index_captain_assistant_mcp_servers_on_captain_assistant_id    (captain_assistant_id)
+#  index_captain_assistant_mcp_servers_on_captain_mcp_server_id   (captain_mcp_server_id)
+#
+class Captain::AssistantMcpServer < ApplicationRecord
+  self.table_name = 'captain_assistant_mcp_servers'
+
+  belongs_to :assistant,
+             class_name: 'Captain::Assistant',
+             foreign_key: :captain_assistant_id,
+             inverse_of: :assistant_mcp_servers
+  belongs_to :mcp_server,
+             class_name: 'Captain::McpServer',
+             foreign_key: :captain_mcp_server_id,
+             inverse_of: :assistant_mcp_servers
+
+  validates :captain_assistant_id, uniqueness: { scope: :captain_mcp_server_id }
+
+  scope :enabled, -> { where(enabled: true) }
+
+  def filtered_tools
+    all_tools = mcp_server.cached_tools || []
+    return all_tools if tool_filters.blank?
+
+    all_tools.select { |tool| matches_filters?(tool) }
+  end
+
+  private
+
+  def matches_filters?(tool)
+    include_list = tool_filters['include']
+    exclude_list = tool_filters['exclude']
+
+    return true if include_list.blank? && exclude_list.blank?
+
+    included = include_list.blank? || include_list.include?(tool['name'])
+    excluded = exclude_list.present? && exclude_list.include?(tool['name'])
+
+    included && !excluded
+  end
+end

--- a/enterprise/app/models/captain/assistant_mcp_server.rb
+++ b/enterprise/app/models/captain/assistant_mcp_server.rb
@@ -39,6 +39,19 @@ class Captain::AssistantMcpServer < ApplicationRecord
     all_tools.select { |tool| matches_filters?(tool) }
   end
 
+  def to_tool_metadata
+    (filtered_tools || []).map do |tool|
+      {
+        id: "#{mcp_server.slug}_#{tool['name']}",
+        title: tool['name'].to_s.titleize,
+        description: tool['description'],
+        mcp: true,
+        mcp_server_id: mcp_server.id,
+        mcp_tool_name: tool['name']
+      }
+    end
+  end
+
   private
 
   def matches_filters?(tool)
@@ -51,18 +64,5 @@ class Captain::AssistantMcpServer < ApplicationRecord
     excluded = exclude_list.present? && exclude_list.include?(tool['name'])
 
     included && !excluded
-  end
-
-  def to_tool_metadata
-    (filtered_tools || []).map do |tool|
-      {
-        id: "#{mcp_server.slug}_#{tool['name']}",
-        title: tool['name'].to_s.titleize,
-        description: tool['description'],
-        mcp: true,
-        mcp_server_id: mcp_server.id,
-        mcp_tool_name: tool['name']
-      }
-    end
   end
 end

--- a/enterprise/app/models/captain/assistant_mcp_server.rb
+++ b/enterprise/app/models/captain/assistant_mcp_server.rb
@@ -52,4 +52,17 @@ class Captain::AssistantMcpServer < ApplicationRecord
 
     included && !excluded
   end
+
+  def to_tool_metadata
+    (filtered_tools || []).map do |tool|
+      {
+        id: "#{mcp_server.slug}_#{tool['name']}",
+        title: tool['name'].to_s.titleize,
+        description: tool['description'],
+        mcp: true,
+        mcp_server_id: mcp_server.id,
+        mcp_tool_name: tool['name']
+      }
+    end
+  end
 end

--- a/enterprise/app/models/captain/mcp_server.rb
+++ b/enterprise/app/models/captain/mcp_server.rb
@@ -135,9 +135,9 @@ class Captain::McpServer < ApplicationRecord
   end
 
   def validate_url_scheme(uri)
-    return if uri.scheme == 'https'
+    return if %w[http https].include?(uri.scheme)
 
-    errors.add(:url, 'must use HTTPS protocol')
+    errors.add(:url, 'must use HTTP or HTTPS protocol')
   end
 
   def validate_url_host(uri)

--- a/enterprise/app/models/captain/mcp_server.rb
+++ b/enterprise/app/models/captain/mcp_server.rb
@@ -30,6 +30,11 @@ class Captain::McpServer < ApplicationRecord
 
   self.table_name = 'captain_mcp_servers'
 
+  # Security note: auth_config contains sensitive credentials (tokens, API keys).
+  # Credentials are masked in API responses (see _mcp_server.json.jbuilder).
+  # For encryption at rest, consider migrating auth_config to a text column
+  # and using: encrypts :auth_config, type: :json if Chatwoot.encryption_configured?
+
   NAME_PREFIX = 'mcp'.freeze
   NAME_SEPARATOR = '_'.freeze
 
@@ -121,7 +126,7 @@ class Captain::McpServer < ApplicationRecord
     return if url.blank?
 
     uri = parse_url
-    return errors.add(:url, 'must be a valid URL') unless uri
+    return errors.add(:url, I18n.t('captain.mcp_server.errors.url_must_be_valid')) unless uri
 
     validate_url_scheme(uri)
     validate_url_host(uri)
@@ -137,17 +142,17 @@ class Captain::McpServer < ApplicationRecord
   def validate_url_scheme(uri)
     return if %w[http https].include?(uri.scheme)
 
-    errors.add(:url, 'must use HTTP or HTTPS protocol')
+    errors.add(:url, I18n.t('captain.mcp_server.errors.url_must_use_http'))
   end
 
   def validate_url_host(uri)
     if uri.host.blank?
-      errors.add(:url, 'must have a valid hostname')
+      errors.add(:url, I18n.t('captain.mcp_server.errors.url_must_have_hostname'))
       return
     end
 
     if uri.host == FRONTEND_HOST
-      errors.add(:url, 'cannot point to the application itself')
+      errors.add(:url, I18n.t('captain.mcp_server.errors.url_cannot_be_self'))
       return
     end
 
@@ -155,19 +160,18 @@ class Captain::McpServer < ApplicationRecord
       matched = pattern.is_a?(Regexp) ? uri.host =~ pattern : uri.host.downcase == pattern
       next unless matched
 
-      errors.add(:url, 'cannot use disallowed hostname')
+      errors.add(:url, I18n.t('captain.mcp_server.errors.url_disallowed_hostname'))
       break
     end
   end
 
   def validate_not_ip_address(uri)
-    if /\A\d+\.\d+\.\d+\.\d+\z/.match?(uri.host)
-      errors.add(:url, 'cannot be an IP address, must be a hostname')
-      return
-    end
+    return if uri.host.blank?
 
-    return unless uri.host&.include?(':')
-
-    errors.add(:url, 'cannot be an IP address, must be a hostname')
+    # Use IPAddr to properly detect all IP formats (decimal, octal, hex, IPv6)
+    IPAddr.new(uri.host)
+    errors.add(:url, I18n.t('captain.mcp_server.errors.url_cannot_be_ip'))
+  rescue IPAddr::InvalidAddressError
+    # Not an IP address, which is what we want - hostname is valid
   end
 end

--- a/enterprise/app/models/captain/mcp_server.rb
+++ b/enterprise/app/models/captain/mcp_server.rb
@@ -1,0 +1,173 @@
+# == Schema Information
+#
+# Table name: captain_mcp_servers
+#
+#  id                 :bigint           not null, primary key
+#  auth_config        :jsonb
+#  auth_type          :string           default("none")
+#  cached_tools       :jsonb
+#  cache_refreshed_at :datetime
+#  description        :text
+#  enabled            :boolean          default(TRUE), not null
+#  last_connected_at  :datetime
+#  last_error         :text
+#  name               :string           not null
+#  slug               :string           not null
+#  status             :string           default("disconnected")
+#  url                :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  account_id         :bigint           not null
+#
+# Indexes
+#
+#  index_captain_mcp_servers_on_account_id              (account_id)
+#  index_captain_mcp_servers_on_account_id_and_enabled  (account_id,enabled)
+#  index_captain_mcp_servers_on_account_id_and_slug     (account_id,slug) UNIQUE
+#
+class Captain::McpServer < ApplicationRecord
+  include Concerns::McpToolable
+
+  self.table_name = 'captain_mcp_servers'
+
+  NAME_PREFIX = 'mcp'.freeze
+  NAME_SEPARATOR = '_'.freeze
+
+  FRONTEND_HOST = URI.parse(ENV.fetch('FRONTEND_URL', 'http://localhost:3000')).host.freeze
+  DISALLOWED_HOSTS = ['localhost', /\.local\z/i].freeze
+
+  belongs_to :account
+  has_many :assistant_mcp_servers,
+           class_name: 'Captain::AssistantMcpServer',
+           foreign_key: :captain_mcp_server_id,
+           inverse_of: :mcp_server,
+           dependent: :destroy
+  has_many :assistants,
+           through: :assistant_mcp_servers,
+           source: :assistant
+
+  enum :auth_type, %w[none bearer api_key].index_by(&:itself), default: :none, validate: true, prefix: :auth
+  enum :status, %w[disconnected connecting connected error].index_by(&:itself), default: :disconnected, prefix: :connection
+
+  before_validation :generate_slug
+
+  validates :name, presence: true
+  validates :slug, presence: true, uniqueness: { scope: :account_id }
+  validates :url, presence: true
+  validate :validate_url_format
+
+  scope :enabled, -> { where(enabled: true) }
+  scope :connected, -> { where(status: 'connected') }
+
+  def to_tool_metadata
+    (cached_tools || []).map do |tool|
+      {
+        id: "#{slug}_#{tool['name']}",
+        title: tool['name'].titleize,
+        description: tool['description'],
+        mcp: true,
+        mcp_server_id: id,
+        mcp_tool_name: tool['name']
+      }
+    end
+  end
+
+  def mark_connected!
+    update!(
+      status: 'connected',
+      last_connected_at: Time.current,
+      last_error: nil
+    )
+  end
+
+  def mark_error!(error_message)
+    update!(
+      status: 'error',
+      last_error: error_message
+    )
+  end
+
+  def mark_disconnected!
+    update!(status: 'disconnected')
+  end
+
+  private
+
+  def generate_slug
+    return if slug.present?
+    return if name.blank?
+
+    parameterized_name = name.parameterize(separator: NAME_SEPARATOR)
+    base_slug = "#{NAME_PREFIX}#{NAME_SEPARATOR}#{parameterized_name}"
+    self.slug = find_unique_slug(base_slug)
+  end
+
+  def find_unique_slug(base_slug)
+    return base_slug unless slug_exists?(base_slug)
+
+    5.times do
+      slug_candidate = "#{base_slug}#{NAME_SEPARATOR}#{SecureRandom.alphanumeric(6).downcase}"
+      return slug_candidate unless slug_exists?(slug_candidate)
+    end
+
+    raise ActiveRecord::RecordNotUnique, I18n.t('captain.mcp_server.slug_generation_failed')
+  end
+
+  def slug_exists?(candidate)
+    self.class.exists?(account_id: account_id, slug: candidate)
+  end
+
+  def validate_url_format
+    return if url.blank?
+
+    uri = parse_url
+    return errors.add(:url, 'must be a valid URL') unless uri
+
+    validate_url_scheme(uri)
+    validate_url_host(uri)
+    validate_not_ip_address(uri)
+  end
+
+  def parse_url
+    URI.parse(url)
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def validate_url_scheme(uri)
+    return if uri.scheme == 'https'
+
+    errors.add(:url, 'must use HTTPS protocol')
+  end
+
+  def validate_url_host(uri)
+    if uri.host.blank?
+      errors.add(:url, 'must have a valid hostname')
+      return
+    end
+
+    if uri.host == FRONTEND_HOST
+      errors.add(:url, 'cannot point to the application itself')
+      return
+    end
+
+    DISALLOWED_HOSTS.each do |pattern|
+      matched = pattern.is_a?(Regexp) ? uri.host =~ pattern : uri.host.downcase == pattern
+      next unless matched
+
+      errors.add(:url, 'cannot use disallowed hostname')
+      break
+    end
+  end
+
+  def validate_not_ip_address(uri)
+    if /\A\d+\.\d+\.\d+\.\d+\z/.match?(uri.host)
+      errors.add(:url, 'cannot be an IP address, must be a hostname')
+      return
+    end
+
+    return unless uri.host&.include?(':')
+
+    errors.add(:url, 'cannot be an IP address, must be a hostname')
+  end
+end

--- a/enterprise/app/models/captain/mcp_server.rb
+++ b/enterprise/app/models/captain/mcp_server.rb
@@ -3,7 +3,7 @@
 # Table name: captain_mcp_servers
 #
 #  id                 :bigint           not null, primary key
-#  auth_config        :jsonb
+#  auth_config        :text
 #  auth_type          :string           default("none")
 #  cached_tools       :jsonb
 #  cache_refreshed_at :datetime
@@ -27,13 +27,11 @@
 #
 class Captain::McpServer < ApplicationRecord
   include Concerns::McpToolable
+  include Enterprise::Audit::CaptainMcpServer if defined?(Enterprise::Audit::CaptainMcpServer)
 
   self.table_name = 'captain_mcp_servers'
 
-  # Security note: auth_config contains sensitive credentials (tokens, API keys).
-  # Credentials are masked in API responses (see _mcp_server.json.jbuilder).
-  # For encryption at rest, consider migrating auth_config to a text column
-  # and using: encrypts :auth_config, type: :json if Chatwoot.encryption_configured?
+  encrypts :auth_config, type: :json if Chatwoot.encryption_configured?
 
   NAME_PREFIX = 'mcp'.freeze
   NAME_SEPARATOR = '_'.freeze

--- a/enterprise/app/models/captain/mcp_server.rb
+++ b/enterprise/app/models/captain/mcp_server.rb
@@ -31,7 +31,11 @@ class Captain::McpServer < ApplicationRecord
 
   self.table_name = 'captain_mcp_servers'
 
-  encrypts :auth_config, type: :json if Chatwoot.encryption_configured?
+  if Chatwoot.encryption_configured?
+    encrypts :auth_config, type: :json
+  else
+    serialize :auth_config, coder: JSON
+  end
 
   NAME_PREFIX = 'mcp'.freeze
   NAME_SEPARATOR = '_'.freeze

--- a/enterprise/app/models/captain/scenario.rb
+++ b/enterprise/app/models/captain/scenario.rb
@@ -79,7 +79,10 @@ class Captain::Scenario < ApplicationRecord
   def resolve_tool_instance(tool_metadata)
     tool_id = tool_metadata[:id]
 
-    if tool_metadata[:custom]
+    if tool_metadata[:mcp]
+      mcp_server = Captain::McpServer.find_by(id: tool_metadata[:mcp_server_id], account_id: account_id, enabled: true)
+      mcp_server&.build_tool_instance(assistant, tool_metadata[:mcp_tool_name])
+    elsif tool_metadata[:custom]
       custom_tool = Captain::CustomTool.find_by(slug: tool_id, account_id: account_id, enabled: true)
       custom_tool&.tool(assistant)
     else

--- a/enterprise/app/models/concerns/mcp_toolable.rb
+++ b/enterprise/app/models/concerns/mcp_toolable.rb
@@ -1,0 +1,40 @@
+module Concerns::McpToolable
+  extend ActiveSupport::Concern
+
+  def build_tool_instance(assistant, tool_name)
+    tool_def = cached_tools.find { |t| t['name'] == tool_name }
+    return nil unless tool_def
+
+    mcp_server = self
+    class_name = "#{slug.underscore.camelize}#{tool_name.underscore.camelize}"
+
+    tool_class = Class.new(Captain::Tools::McpTool) do
+      description tool_def['description'] || "MCP tool: #{tool_name}"
+
+      (tool_def.dig('inputSchema', 'properties') || {}).each do |param_name, param_schema|
+        required = tool_def.dig('inputSchema', 'required')&.include?(param_name) || false
+        param param_name.to_sym,
+              type: param_schema['type'] || 'string',
+              desc: param_schema['description'] || param_name,
+              required: required
+      end
+    end
+
+    Captain::Tools.send(:remove_const, class_name) if Captain::Tools.const_defined?(class_name, false)
+    Captain::Tools.const_set(class_name, tool_class)
+
+    tool_class.new(assistant, mcp_server, tool_name)
+  end
+
+  def build_auth_headers
+    case auth_type
+    when 'bearer'
+      { 'Authorization' => "Bearer #{auth_config['token']}" }
+    when 'api_key'
+      header_name = auth_config['header_name'] || 'X-API-Key'
+      { header_name => auth_config['key'] }
+    else
+      {}
+    end
+  end
+end

--- a/enterprise/app/models/concerns/mcp_toolable.rb
+++ b/enterprise/app/models/concerns/mcp_toolable.rb
@@ -5,25 +5,8 @@ module Concerns::McpToolable
     tool_def = cached_tools.find { |t| t['name'] == tool_name }
     return nil unless tool_def
 
-    mcp_server = self
-    class_name = "#{slug.underscore.camelize}#{tool_name.underscore.camelize}"
-
-    tool_class = Class.new(Captain::Tools::McpTool) do
-      description tool_def['description'] || "MCP tool: #{tool_name}"
-
-      (tool_def.dig('inputSchema', 'properties') || {}).each do |param_name, param_schema|
-        required = tool_def.dig('inputSchema', 'required')&.include?(param_name) || false
-        param param_name.to_sym,
-              type: param_schema['type'] || 'string',
-              desc: param_schema['description'] || param_name,
-              required: required
-      end
-    end
-
-    Captain::Tools.send(:remove_const, class_name) if Captain::Tools.const_defined?(class_name, false)
-    Captain::Tools.const_set(class_name, tool_class)
-
-    tool_class.new(assistant, mcp_server, tool_name)
+    tool_class = create_tool_class(tool_name, tool_def)
+    tool_class.new(assistant, self, tool_name)
   end
 
   def build_auth_headers
@@ -36,5 +19,56 @@ module Concerns::McpToolable
     else
       {}
     end
+  end
+
+  private
+
+  def create_tool_class(tool_name, tool_def)
+    class_name = "#{slug.underscore.camelize}#{tool_name.underscore.camelize}"
+    tool_class = build_dynamic_tool_class(tool_name, tool_def)
+    register_tool_class(class_name, tool_class)
+    tool_class
+  end
+
+  def build_dynamic_tool_class(tool_name, tool_def)
+    mcp_tool_name = build_tool_function_name(tool_name)
+    tool_description = tool_def['description'] || "MCP tool: #{tool_name}"
+    param_definitions = extract_param_definitions(tool_def)
+
+    Class.new(Captain::Tools::McpTool) do
+      description tool_description
+      define_method(:name) { mcp_tool_name }
+
+      param_definitions.each do |param_def|
+        param param_def[:name], type: param_def[:type], desc: param_def[:desc], required: param_def[:required]
+      end
+    end
+  end
+
+  def extract_param_definitions(tool_def)
+    properties = tool_def.dig('inputSchema', 'properties') || {}
+    required_params = tool_def.dig('inputSchema', 'required') || []
+
+    properties.map do |param_name, param_schema|
+      {
+        name: param_name.to_sym,
+        type: param_schema['type'] || 'string',
+        desc: param_schema['description'] || param_name,
+        required: required_params.include?(param_name)
+      }
+    end
+  end
+
+  def build_tool_function_name(tool_name)
+    # Build a compliant function name: max 64 chars, alphanumeric + underscore/hyphen
+    # Format: mcp_{short_slug}_{tool_name}, truncated if needed
+    short_slug = slug.sub(/^mcp_/, '')[0, 20]
+    base_name = "mcp_#{short_slug}_#{tool_name}"
+    base_name[0, 64]
+  end
+
+  def register_tool_class(class_name, tool_class)
+    Captain::Tools.send(:remove_const, class_name) if Captain::Tools.const_defined?(class_name, false)
+    Captain::Tools.const_set(class_name, tool_class)
   end
 end

--- a/enterprise/app/models/concerns/mcp_toolable.rb
+++ b/enterprise/app/models/concerns/mcp_toolable.rb
@@ -45,14 +45,20 @@ module Concerns::McpToolable
     end
   end
 
+  # RubyLLM::Parameter only supports simple scalar types (string, integer, number, boolean).
+  # Complex types like array/object produce invalid JSON schemas (e.g. array missing `items`).
+  # Coerce unsupported types to string so the LLM receives a valid schema.
+  SUPPORTED_PARAM_TYPES = %w[string integer number boolean].freeze
+
   def extract_param_definitions(tool_def)
     properties = tool_def.dig('inputSchema', 'properties') || {}
     required_params = tool_def.dig('inputSchema', 'required') || []
 
     properties.map do |param_name, param_schema|
+      raw_type = param_schema['type'] || 'string'
       {
         name: param_name.to_sym,
-        type: param_schema['type'] || 'string',
+        type: SUPPORTED_PARAM_TYPES.include?(raw_type) ? raw_type : 'string',
         desc: param_schema['description'] || param_name,
         required: required_params.include?(param_name)
       }

--- a/enterprise/app/models/enterprise/audit/captain_mcp_server.rb
+++ b/enterprise/app/models/enterprise/audit/captain_mcp_server.rb
@@ -1,0 +1,7 @@
+module Enterprise::Audit::CaptainMcpServer
+  extend ActiveSupport::Concern
+
+  included do
+    audited associated_with: :account, except: [:auth_config]
+  end
+end

--- a/enterprise/app/models/enterprise/concerns/account.rb
+++ b/enterprise/app/models/enterprise/concerns/account.rb
@@ -13,6 +13,7 @@ module Enterprise::Concerns::Account
     has_many :captain_assistant_responses, dependent: :destroy_async, class_name: 'Captain::AssistantResponse'
     has_many :captain_documents, dependent: :destroy_async, class_name: 'Captain::Document'
     has_many :captain_custom_tools, dependent: :destroy_async, class_name: 'Captain::CustomTool'
+    has_many :captain_mcp_servers, dependent: :destroy_async, class_name: 'Captain::McpServer'
 
     has_many :copilot_threads, dependent: :destroy_async
     has_many :companies, dependent: :destroy_async

--- a/enterprise/app/policies/captain/mcp_server_policy.rb
+++ b/enterprise/app/policies/captain/mcp_server_policy.rb
@@ -1,10 +1,10 @@
 class Captain::McpServerPolicy < ApplicationPolicy
   def index?
-    true
+    @account_user.administrator?
   end
 
   def show?
-    true
+    @account_user.administrator?
   end
 
   def create?

--- a/enterprise/app/policies/captain/mcp_server_policy.rb
+++ b/enterprise/app/policies/captain/mcp_server_policy.rb
@@ -1,0 +1,33 @@
+class Captain::McpServerPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    @account_user.administrator?
+  end
+
+  def update?
+    @account_user.administrator?
+  end
+
+  def destroy?
+    @account_user.administrator?
+  end
+
+  def connect?
+    @account_user.administrator?
+  end
+
+  def disconnect?
+    @account_user.administrator?
+  end
+
+  def refresh?
+    @account_user.administrator?
+  end
+end

--- a/enterprise/app/services/captain/llm/assistant_chat_service.rb
+++ b/enterprise/app/services/captain/llm/assistant_chat_service.rb
@@ -28,7 +28,24 @@ class Captain::Llm::AssistantChatService < Llm::BaseAiService
   private
 
   def build_tools
-    [Captain::Tools::SearchDocumentationService.new(@assistant, user: nil)]
+    tools = [Captain::Tools::SearchDocumentationService.new(@assistant, user: nil)]
+    tools.concat(build_mcp_tools)
+    tools
+  end
+
+  def build_mcp_tools
+    @assistant.assistant_mcp_servers
+              .enabled
+              .joins(:mcp_server)
+              .merge(Captain::McpServer.enabled.connected)
+              .flat_map { |ams| build_mcp_server_tools(ams) }
+  end
+
+  def build_mcp_server_tools(assistant_mcp_server)
+    mcp_server = assistant_mcp_server.mcp_server
+    assistant_mcp_server.filtered_tools.filter_map do |tool|
+      mcp_server.build_tool_instance(@assistant, tool['name'])
+    end
   end
 
   def system_message

--- a/enterprise/app/services/captain/mcp/client_service.rb
+++ b/enterprise/app/services/captain/mcp/client_service.rb
@@ -1,0 +1,251 @@
+require 'net/http'
+require 'json'
+require 'uri'
+
+class Captain::Mcp::ClientService
+  MCP_PROTOCOL_VERSION = '2024-11-05'.freeze
+  CLIENT_NAME = 'chatwoot-captain'.freeze
+  READ_TIMEOUT = 30
+  OPEN_TIMEOUT = 10
+  MAX_RESPONSE_SIZE = 1.megabyte
+
+  PRIVATE_IP_RANGES = [
+    IPAddr.new('127.0.0.0/8'),
+    IPAddr.new('10.0.0.0/8'),
+    IPAddr.new('172.16.0.0/12'),
+    IPAddr.new('192.168.0.0/16'),
+    IPAddr.new('169.254.0.0/16'),
+    IPAddr.new('::1'),
+    IPAddr.new('fc00::/7'),
+    IPAddr.new('fe80::/10')
+  ].freeze
+
+  attr_reader :mcp_server
+
+  def initialize(mcp_server)
+    @mcp_server = mcp_server
+    @message_id = 0
+    @session_endpoint = nil
+  end
+
+  def connect
+    @mcp_server.update!(status: 'connecting')
+
+    establish_session
+    initialize_protocol
+
+    @mcp_server.mark_connected!
+    Result.success
+  rescue StandardError => e
+    Rails.logger.error("MCP connection error for #{@mcp_server.slug}: #{e.class} - #{e.message}")
+    @mcp_server.mark_error!(e.message)
+    Result.failure(e.message)
+  end
+
+  def disconnect
+    @session_endpoint = nil
+    @mcp_server.mark_disconnected!
+  end
+
+  def call_tool(tool_name, arguments = {})
+    ensure_connected!
+
+    response = send_request('tools/call', {
+                              name: tool_name,
+                              arguments: arguments
+                            })
+
+    raise Captain::Mcp::ToolExecutionError, response['error']['message'] if response['error']
+
+    format_tool_result(response['result'])
+  end
+
+  def list_tools
+    ensure_connected!
+
+    response = send_request('tools/list', {})
+    response.dig('result', 'tools') || []
+  end
+
+  private
+
+  def establish_session
+    uri = URI.parse(@mcp_server.url)
+    check_private_ip!(uri.host)
+
+    http = build_http_client(uri)
+    request = Net::HTTP::Get.new(uri.request_uri)
+    apply_authentication(request)
+    request['Accept'] = 'text/event-stream'
+
+    response = http.request(request)
+
+    raise Captain::Mcp::ConnectionError, "Failed to establish SSE connection: HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+    parse_session_endpoint(response)
+  end
+
+  def parse_session_endpoint(response)
+    @session_endpoint = @mcp_server.url
+
+    if response['x-mcp-session-url']
+      @session_endpoint = response['x-mcp-session-url']
+    elsif response.body.present?
+      response.body.each_line do |line|
+        next unless line.start_with?('data:')
+
+        data = begin
+          JSON.parse(line.sub('data:', '').strip)
+        rescue StandardError
+          nil
+        end
+        @session_endpoint = data['endpoint'] if data&.dig('endpoint')
+        break
+      end
+    end
+  end
+
+  def initialize_protocol
+    response = send_request('initialize', {
+                              protocolVersion: MCP_PROTOCOL_VERSION,
+                              capabilities: {
+                                tools: {}
+                              },
+                              clientInfo: {
+                                name: CLIENT_NAME,
+                                version: Chatwoot.config[:version] || '1.0.0'
+                              }
+                            })
+
+    raise Captain::Mcp::ProtocolError, "Initialize failed: #{response['error']['message']}" if response['error']
+
+    send_notification('notifications/initialized', {})
+  end
+
+  def ensure_connected!
+    return if @session_endpoint.present?
+
+    result = connect
+    raise Captain::Mcp::ConnectionError, result.error unless result.success?
+  end
+
+  def send_request(method, params)
+    uri = URI.parse(@session_endpoint)
+    check_private_ip!(uri.host)
+
+    http = build_http_client(uri)
+    request = build_json_rpc_request(uri, method, params)
+
+    response = http.request(request)
+
+    raise Captain::Mcp::ProtocolError, "Request failed: HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+    validate_response_size!(response)
+    JSON.parse(response.body)
+  end
+
+  def send_notification(method, params)
+    uri = URI.parse(@session_endpoint)
+    http = build_http_client(uri)
+
+    request = Net::HTTP::Post.new(uri.request_uri)
+    apply_authentication(request)
+    request['Content-Type'] = 'application/json'
+    request.body = {
+      jsonrpc: '2.0',
+      method: method,
+      params: params
+    }.to_json
+
+    http.request(request)
+  end
+
+  def build_json_rpc_request(uri, method, params)
+    request = Net::HTTP::Post.new(uri.request_uri)
+    apply_authentication(request)
+    request['Content-Type'] = 'application/json'
+    request.body = {
+      jsonrpc: '2.0',
+      id: next_message_id,
+      method: method,
+      params: params
+    }.to_json
+    request
+  end
+
+  def build_http_client(uri)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+    http.read_timeout = READ_TIMEOUT
+    http.open_timeout = OPEN_TIMEOUT
+    http.max_retries = 0
+    http
+  end
+
+  def apply_authentication(request)
+    headers = @mcp_server.build_auth_headers
+    headers.each { |key, value| request[key] = value }
+  end
+
+  def check_private_ip!(hostname)
+    ip_address = IPAddr.new(Resolv.getaddress(hostname))
+
+    if PRIVATE_IP_RANGES.any? { |range| range.include?(ip_address) }
+      raise Captain::Mcp::ConnectionError, 'Request blocked: hostname resolves to private IP address'
+    end
+  rescue Resolv::ResolvError, SocketError => e
+    raise Captain::Mcp::ConnectionError, "DNS resolution failed: #{e.message}"
+  end
+
+  def validate_response_size!(response)
+    content_length = response['content-length']&.to_i
+    if content_length && content_length > MAX_RESPONSE_SIZE
+      raise Captain::Mcp::ProtocolError, "Response size #{content_length} bytes exceeds maximum allowed #{MAX_RESPONSE_SIZE} bytes"
+    end
+
+    return unless response.body && response.body.bytesize > MAX_RESPONSE_SIZE
+
+    raise Captain::Mcp::ProtocolError, "Response body size #{response.body.bytesize} bytes exceeds maximum allowed #{MAX_RESPONSE_SIZE} bytes"
+  end
+
+  def next_message_id
+    @message_id += 1
+  end
+
+  def format_tool_result(result)
+    content = result['content'] || []
+    content.filter_map do |item|
+      case item['type']
+      when 'text'
+        item['text']
+      when 'image'
+        "[Image: #{item['mimeType']}]"
+      when 'resource'
+        "[Resource: #{item.dig('resource', 'uri')}]"
+      else
+        item.to_json
+      end
+    end.join("\n")
+  end
+
+  class Result
+    attr_reader :error
+
+    def initialize(success:, error: nil)
+      @success = success
+      @error = error
+    end
+
+    def success?
+      @success
+    end
+
+    def self.success
+      new(success: true)
+    end
+
+    def self.failure(error)
+      new(success: false, error: error)
+    end
+  end
+end

--- a/enterprise/app/services/captain/mcp/client_service.rb
+++ b/enterprise/app/services/captain/mcp/client_service.rb
@@ -11,14 +11,16 @@ class Captain::Mcp::ClientService
   RETRY_BACKOFF = 1
 
   PRIVATE_IP_RANGES = [
-    IPAddr.new('127.0.0.0/8'),
-    IPAddr.new('10.0.0.0/8'),
-    IPAddr.new('172.16.0.0/12'),
-    IPAddr.new('192.168.0.0/16'),
-    IPAddr.new('169.254.0.0/16'),
-    IPAddr.new('::1'),
-    IPAddr.new('fc00::/7'),
-    IPAddr.new('fe80::/10')
+    IPAddr.new('0.0.0.0/8'),       # Current network
+    IPAddr.new('127.0.0.0/8'),     # Loopback
+    IPAddr.new('10.0.0.0/8'),      # Private class A
+    IPAddr.new('172.16.0.0/12'),   # Private class B
+    IPAddr.new('192.168.0.0/16'),  # Private class C
+    IPAddr.new('169.254.0.0/16'), # Link-local
+    IPAddr.new('::1/128'),         # IPv6 loopback
+    IPAddr.new('fc00::/7'),        # IPv6 unique local
+    IPAddr.new('fe80::/10'),       # IPv6 link-local
+    IPAddr.new('::ffff:0:0/96')   # IPv4-mapped IPv6 addresses
   ].freeze
 
   attr_reader :mcp_server
@@ -94,17 +96,13 @@ class Captain::Mcp::ClientService
     endpoint = auth_config['rpc_endpoint'] || ENV.fetch('MCP_RPC_ENDPOINT', nil)
     options[:endpoint] = endpoint if endpoint.present?
 
-    MCPClient.connect(@mcp_server.url, **options, &method(:configure_faraday))
+    MCPClient.connect(@mcp_server.url, **options) { |faraday| configure_faraday(faraday) }
   end
 
   def configure_faraday(faraday)
-    if ENV['MCP_SSL_VERIFY'].to_s == 'false'
-      faraday.ssl.verify = false
-    else
-      faraday.ssl.verify = true
-      ca_file = ENV.fetch('MCP_SSL_CA_FILE', nil)
-      faraday.ssl.ca_file = ca_file if ca_file.present?
-    end
+    faraday.ssl.verify = ENV['MCP_SSL_VERIFY'].to_s != 'false'
+    ca_file = ENV.fetch('MCP_SSL_CA_FILE', nil)
+    faraday.ssl.ca_file = ca_file if ca_file.present? && faraday.ssl.verify
   end
 
   def ensure_public_host!
@@ -139,19 +137,17 @@ class Captain::Mcp::ClientService
     return result.to_json unless result.is_a?(Hash)
 
     content = result['content'] || result[:content] || []
-    content.filter_map do |item|
-      item = item.transform_keys(&:to_s) if item.is_a?(Hash)
-      case item['type']
-      when 'text'
-        item['text']
-      when 'image'
-        "[Image: #{item['mimeType']}]"
-      when 'resource'
-        "[Resource: #{item.dig('resource', 'uri')}]"
-      else
-        item.to_json
-      end
-    end.join("\n")
+    content.filter_map { |item| format_content_item(item) }.join("\n")
+  end
+
+  def format_content_item(item)
+    item = item.transform_keys(&:to_s) if item.is_a?(Hash)
+    case item['type']
+    when 'text' then item['text']
+    when 'image' then "[Image: #{item['mimeType']}]"
+    when 'resource' then "[Resource: #{item.dig('resource', 'uri')}]"
+    else item.to_json
+    end
   end
 
   def handle_connection_error(error)

--- a/enterprise/app/services/captain/mcp/client_service.rb
+++ b/enterprise/app/services/captain/mcp/client_service.rb
@@ -1,13 +1,14 @@
-require 'net/http'
-require 'json'
+require 'ipaddr'
+require 'resolv'
 require 'uri'
 
+require 'mcp_client'
+require 'captain/mcp/errors'
+
 class Captain::Mcp::ClientService
-  MCP_PROTOCOL_VERSION = '2024-11-05'.freeze
-  CLIENT_NAME = 'chatwoot-captain'.freeze
   READ_TIMEOUT = 30
-  OPEN_TIMEOUT = 10
-  MAX_RESPONSE_SIZE = 1.megabyte
+  RETRIES = 0
+  RETRY_BACKOFF = 1
 
   PRIVATE_IP_RANGES = [
     IPAddr.new('127.0.0.0/8'),
@@ -24,167 +25,93 @@ class Captain::Mcp::ClientService
 
   def initialize(mcp_server)
     @mcp_server = mcp_server
-    @message_id = 0
-    @session_endpoint = nil
+    @client = nil
   end
 
   def connect
     @mcp_server.update!(status: 'connecting')
-
-    establish_session
-    initialize_protocol
-
+    ensure_public_host!
+    @client = build_client
     @mcp_server.mark_connected!
     Result.success
-  rescue StandardError => e
-    Rails.logger.error("MCP connection error for #{@mcp_server.slug}: #{e.class} - #{e.message}")
-    @mcp_server.mark_error!(e.message)
-    Result.failure(e.message)
+  rescue MCPClient::Errors::MCPError, StandardError => e
+    handle_connection_error(e)
   end
 
   def disconnect
-    @session_endpoint = nil
+    @client&.cleanup
+    @client = nil
     @mcp_server.mark_disconnected!
   end
 
   def call_tool(tool_name, arguments = {})
-    ensure_connected!
-
-    response = send_request('tools/call', {
-                              name: tool_name,
-                              arguments: arguments
-                            })
-
-    raise Captain::Mcp::ToolExecutionError, response['error']['message'] if response['error']
-
-    format_tool_result(response['result'])
+    client = ensure_client!
+    result = client.call_tool(tool_name, arguments)
+    format_tool_result(result)
+  rescue MCPClient::Errors::ToolCallError => e
+    raise Captain::Mcp::ToolExecutionError, e.message
+  rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError => e
+    raise Captain::Mcp::ConnectionError, e.message
+  rescue MCPClient::Errors::MCPError => e
+    raise Captain::Mcp::Error, e.message
   end
 
   def list_tools
-    ensure_connected!
-
-    response = send_request('tools/list', {})
-    response.dig('result', 'tools') || []
+    client = ensure_client!
+    tools = client.list_tools(cache: false)
+    tools.map { |tool| serialize_tool(tool) }
+  rescue MCPClient::Errors::ConnectionError, MCPClient::Errors::TransportError => e
+    raise Captain::Mcp::ConnectionError, e.message
+  rescue MCPClient::Errors::MCPError => e
+    raise Captain::Mcp::Error, e.message
   end
 
   private
 
-  def establish_session
-    uri = URI.parse(@mcp_server.url)
-    check_private_ip!(uri.host)
-
-    http = build_http_client(uri)
-    request = Net::HTTP::Get.new(uri.request_uri)
-    apply_authentication(request)
-    request['Accept'] = 'text/event-stream'
-
-    response = http.request(request)
-
-    raise Captain::Mcp::ConnectionError, "Failed to establish SSE connection: HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
-
-    parse_session_endpoint(response)
-  end
-
-  def parse_session_endpoint(response)
-    @session_endpoint = @mcp_server.url
-
-    if response['x-mcp-session-url']
-      @session_endpoint = response['x-mcp-session-url']
-    elsif response.body.present?
-      response.body.each_line do |line|
-        next unless line.start_with?('data:')
-
-        data = begin
-          JSON.parse(line.sub('data:', '').strip)
-        rescue StandardError
-          nil
-        end
-        @session_endpoint = data['endpoint'] if data&.dig('endpoint')
-        break
-      end
-    end
-  end
-
-  def initialize_protocol
-    response = send_request('initialize', {
-                              protocolVersion: MCP_PROTOCOL_VERSION,
-                              capabilities: {
-                                tools: {}
-                              },
-                              clientInfo: {
-                                name: CLIENT_NAME,
-                                version: Chatwoot.config[:version] || '1.0.0'
-                              }
-                            })
-
-    raise Captain::Mcp::ProtocolError, "Initialize failed: #{response['error']['message']}" if response['error']
-
-    send_notification('notifications/initialized', {})
-  end
-
-  def ensure_connected!
-    return if @session_endpoint.present?
+  def ensure_client!
+    return @client if @client
 
     result = connect
     raise Captain::Mcp::ConnectionError, result.error unless result.success?
+
+    @client
   end
 
-  def send_request(method, params)
-    uri = URI.parse(@session_endpoint)
-    check_private_ip!(uri.host)
-
-    http = build_http_client(uri)
-    request = build_json_rpc_request(uri, method, params)
-
-    response = http.request(request)
-
-    raise Captain::Mcp::ProtocolError, "Request failed: HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
-
-    validate_response_size!(response)
-    JSON.parse(response.body)
-  end
-
-  def send_notification(method, params)
-    uri = URI.parse(@session_endpoint)
-    http = build_http_client(uri)
-
-    request = Net::HTTP::Post.new(uri.request_uri)
-    apply_authentication(request)
-    request['Content-Type'] = 'application/json'
-    request.body = {
-      jsonrpc: '2.0',
-      method: method,
-      params: params
-    }.to_json
-
-    http.request(request)
-  end
-
-  def build_json_rpc_request(uri, method, params)
-    request = Net::HTTP::Post.new(uri.request_uri)
-    apply_authentication(request)
-    request['Content-Type'] = 'application/json'
-    request.body = {
-      jsonrpc: '2.0',
-      id: next_message_id,
-      method: method,
-      params: params
-    }.to_json
-    request
-  end
-
-  def build_http_client(uri)
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = uri.scheme == 'https'
-    http.read_timeout = READ_TIMEOUT
-    http.open_timeout = OPEN_TIMEOUT
-    http.max_retries = 0
-    http
-  end
-
-  def apply_authentication(request)
+  def build_client
     headers = @mcp_server.build_auth_headers
-    headers.each { |key, value| request[key] = value }
+    auth_config = @mcp_server.auth_config || {}
+    options = {
+      headers: headers,
+      read_timeout: READ_TIMEOUT,
+      retries: RETRIES,
+      retry_backoff: RETRY_BACKOFF,
+      logger: Rails.logger
+    }
+
+    transport = auth_config['transport'] || ENV.fetch('MCP_TRANSPORT', nil)
+    options[:transport] = transport.to_sym if transport.present?
+
+    endpoint = auth_config['rpc_endpoint'] || ENV.fetch('MCP_RPC_ENDPOINT', nil)
+    options[:endpoint] = endpoint if endpoint.present?
+
+    MCPClient.connect(@mcp_server.url, **options, &method(:configure_faraday))
+  end
+
+  def configure_faraday(faraday)
+    if ENV['MCP_SSL_VERIFY'].to_s == 'false'
+      faraday.ssl.verify = false
+    else
+      faraday.ssl.verify = true
+      ca_file = ENV.fetch('MCP_SSL_CA_FILE', nil)
+      faraday.ssl.ca_file = ca_file if ca_file.present?
+    end
+  end
+
+  def ensure_public_host!
+    uri = URI.parse(@mcp_server.url)
+    return if uri.host.blank?
+
+    check_private_ip!(uri.host)
   end
 
   def check_private_ip!(hostname)
@@ -197,24 +124,23 @@ class Captain::Mcp::ClientService
     raise Captain::Mcp::ConnectionError, "DNS resolution failed: #{e.message}"
   end
 
-  def validate_response_size!(response)
-    content_length = response['content-length']&.to_i
-    if content_length && content_length > MAX_RESPONSE_SIZE
-      raise Captain::Mcp::ProtocolError, "Response size #{content_length} bytes exceeds maximum allowed #{MAX_RESPONSE_SIZE} bytes"
-    end
-
-    return unless response.body && response.body.bytesize > MAX_RESPONSE_SIZE
-
-    raise Captain::Mcp::ProtocolError, "Response body size #{response.body.bytesize} bytes exceeds maximum allowed #{MAX_RESPONSE_SIZE} bytes"
-  end
-
-  def next_message_id
-    @message_id += 1
+  def serialize_tool(tool)
+    {
+      'name' => tool.name,
+      'description' => tool.description,
+      'inputSchema' => tool.schema,
+      'outputSchema' => tool.output_schema,
+      'annotations' => tool.annotations
+    }.compact
   end
 
   def format_tool_result(result)
-    content = result['content'] || []
+    return result if result.is_a?(String)
+    return result.to_json unless result.is_a?(Hash)
+
+    content = result['content'] || result[:content] || []
     content.filter_map do |item|
+      item = item.transform_keys(&:to_s) if item.is_a?(Hash)
       case item['type']
       when 'text'
         item['text']
@@ -226,6 +152,12 @@ class Captain::Mcp::ClientService
         item.to_json
       end
     end.join("\n")
+  end
+
+  def handle_connection_error(error)
+    Rails.logger.error("MCP connection error for #{@mcp_server.slug}: #{error.class} - #{error.message}")
+    @mcp_server.mark_error!(error.message)
+    Result.failure(error.message)
   end
 
   class Result

--- a/enterprise/app/services/captain/mcp/client_service.rb
+++ b/enterprise/app/services/captain/mcp/client_service.rb
@@ -9,6 +9,7 @@ class Captain::Mcp::ClientService
   READ_TIMEOUT = 30
   RETRIES = 0
   RETRY_BACKOFF = 1
+  MAX_RESPONSE_SIZE = 1.megabyte
 
   PRIVATE_IP_RANGES = [
     IPAddr.new('0.0.0.0/8'),       # Current network
@@ -17,6 +18,7 @@ class Captain::Mcp::ClientService
     IPAddr.new('172.16.0.0/12'),   # Private class B
     IPAddr.new('192.168.0.0/16'),  # Private class C
     IPAddr.new('169.254.0.0/16'), # Link-local
+    IPAddr.new('100.64.0.0/10'),  # Carrier-grade NAT (RFC 6598)
     IPAddr.new('::1/128'),         # IPv6 loopback
     IPAddr.new('fc00::/7'),        # IPv6 unique local
     IPAddr.new('fe80::/10'),       # IPv6 link-local
@@ -133,11 +135,23 @@ class Captain::Mcp::ClientService
   end
 
   def format_tool_result(result)
+    formatted = format_tool_content(result)
+    truncate_response(formatted)
+  end
+
+  def format_tool_content(result)
     return result if result.is_a?(String)
     return result.to_json unless result.is_a?(Hash)
 
     content = result['content'] || result[:content] || []
     content.filter_map { |item| format_content_item(item) }.join("\n")
+  end
+
+  def truncate_response(text)
+    return text if text.bytesize <= MAX_RESPONSE_SIZE
+
+    Rails.logger.warn("MCP response truncated from #{text.bytesize} bytes to #{MAX_RESPONSE_SIZE} bytes for #{@mcp_server.slug}")
+    text.truncate_bytes(MAX_RESPONSE_SIZE, omission: '')
   end
 
   def format_content_item(item)

--- a/enterprise/app/services/captain/mcp/discovery_service.rb
+++ b/enterprise/app/services/captain/mcp/discovery_service.rb
@@ -1,0 +1,27 @@
+class Captain::Mcp::DiscoveryService
+  attr_reader :mcp_server
+
+  def initialize(mcp_server)
+    @mcp_server = mcp_server
+    @client = Captain::Mcp::ClientService.new(mcp_server)
+  end
+
+  def refresh_tools
+    tools = @client.list_tools
+    @mcp_server.update!(
+      cached_tools: tools,
+      cache_refreshed_at: Time.current
+    )
+    tools
+  rescue StandardError => e
+    Rails.logger.error("MCP tool discovery failed for #{@mcp_server.slug}: #{e.class} - #{e.message}")
+    raise Captain::Mcp::Error, "Failed to discover tools: #{e.message}"
+  end
+
+  def connect_and_discover
+    result = @client.connect
+    raise Captain::Mcp::ConnectionError, result.error unless result.success?
+
+    refresh_tools
+  end
+end

--- a/enterprise/app/views/api/v1/accounts/captain/assistants/mcp_servers/index.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/assistants/mcp_servers/index.json.jbuilder
@@ -1,0 +1,10 @@
+json.payload do
+  json.array! @assistant_mcp_servers do |assistant_mcp_server|
+    json.partial! 'api/v1/models/captain/assistant_mcp_server', assistant_mcp_server: assistant_mcp_server
+  end
+end
+
+json.meta do
+  json.total_count @assistant_mcp_servers.count
+  json.page 1
+end

--- a/enterprise/app/views/api/v1/accounts/captain/assistants/mcp_servers/show.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/assistants/mcp_servers/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/v1/models/captain/assistant_mcp_server', assistant_mcp_server: @assistant_mcp_server

--- a/enterprise/app/views/api/v1/accounts/captain/mcp_servers/create.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/mcp_servers/create.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/v1/models/captain/mcp_server', mcp_server: @mcp_server

--- a/enterprise/app/views/api/v1/accounts/captain/mcp_servers/index.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/mcp_servers/index.json.jbuilder
@@ -5,6 +5,8 @@ json.payload do
 end
 
 json.meta do
-  json.total_count @mcp_servers.count
-  json.page 1
+  json.total_count @mcp_servers.total_count
+  json.current_page @mcp_servers.current_page
+  json.per_page @mcp_servers.limit_value
+  json.total_pages @mcp_servers.total_pages
 end

--- a/enterprise/app/views/api/v1/accounts/captain/mcp_servers/index.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/mcp_servers/index.json.jbuilder
@@ -1,0 +1,10 @@
+json.payload do
+  json.array! @mcp_servers do |mcp_server|
+    json.partial! 'api/v1/models/captain/mcp_server', mcp_server: mcp_server
+  end
+end
+
+json.meta do
+  json.total_count @mcp_servers.count
+  json.page 1
+end

--- a/enterprise/app/views/api/v1/accounts/captain/mcp_servers/show.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/mcp_servers/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/v1/models/captain/mcp_server', mcp_server: @mcp_server

--- a/enterprise/app/views/api/v1/accounts/captain/mcp_servers/update.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/mcp_servers/update.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/v1/models/captain/mcp_server', mcp_server: @mcp_server

--- a/enterprise/app/views/api/v1/models/captain/_assistant_mcp_server.json.jbuilder
+++ b/enterprise/app/views/api/v1/models/captain/_assistant_mcp_server.json.jbuilder
@@ -1,0 +1,11 @@
+json.id assistant_mcp_server.id
+json.captain_assistant_id assistant_mcp_server.captain_assistant_id
+json.captain_mcp_server_id assistant_mcp_server.captain_mcp_server_id
+json.tool_filters assistant_mcp_server.tool_filters
+json.enabled assistant_mcp_server.enabled
+json.created_at assistant_mcp_server.created_at.to_i
+json.updated_at assistant_mcp_server.updated_at.to_i
+
+json.mcp_server do
+  json.partial! 'api/v1/models/captain/mcp_server', mcp_server: assistant_mcp_server.mcp_server
+end

--- a/enterprise/app/views/api/v1/models/captain/_mcp_server.json.jbuilder
+++ b/enterprise/app/views/api/v1/models/captain/_mcp_server.json.jbuilder
@@ -4,7 +4,6 @@ json.name mcp_server.name
 json.description mcp_server.description
 json.url mcp_server.url
 json.auth_type mcp_server.auth_type
-json.auth_config mcp_server.auth_config
 json.enabled mcp_server.enabled
 json.status mcp_server.status
 json.last_error mcp_server.last_error

--- a/enterprise/app/views/api/v1/models/captain/_mcp_server.json.jbuilder
+++ b/enterprise/app/views/api/v1/models/captain/_mcp_server.json.jbuilder
@@ -4,6 +4,7 @@ json.name mcp_server.name
 json.description mcp_server.description
 json.url mcp_server.url
 json.auth_type mcp_server.auth_type
+json.auth_config mcp_server.auth_config
 json.enabled mcp_server.enabled
 json.status mcp_server.status
 json.last_error mcp_server.last_error

--- a/enterprise/app/views/api/v1/models/captain/_mcp_server.json.jbuilder
+++ b/enterprise/app/views/api/v1/models/captain/_mcp_server.json.jbuilder
@@ -1,0 +1,16 @@
+json.id mcp_server.id
+json.slug mcp_server.slug
+json.name mcp_server.name
+json.description mcp_server.description
+json.url mcp_server.url
+json.auth_type mcp_server.auth_type
+json.auth_config mcp_server.auth_config
+json.enabled mcp_server.enabled
+json.status mcp_server.status
+json.last_error mcp_server.last_error
+json.last_connected_at mcp_server.last_connected_at&.to_i
+json.cached_tools mcp_server.cached_tools
+json.cache_refreshed_at mcp_server.cache_refreshed_at&.to_i
+json.account_id mcp_server.account_id
+json.created_at mcp_server.created_at.to_i
+json.updated_at mcp_server.updated_at.to_i

--- a/enterprise/app/views/api/v1/models/captain/_mcp_server.json.jbuilder
+++ b/enterprise/app/views/api/v1/models/captain/_mcp_server.json.jbuilder
@@ -4,7 +4,18 @@ json.name mcp_server.name
 json.description mcp_server.description
 json.url mcp_server.url
 json.auth_type mcp_server.auth_type
-json.auth_config mcp_server.auth_config
+json.auth_config do
+  auth_config = mcp_server.auth_config || {}
+  case mcp_server.auth_type
+  when 'bearer'
+    json.has_token auth_config['token'].present?
+  when 'api_key'
+    json.has_key auth_config['key'].present?
+    json.header_name auth_config['header_name']
+  end
+  json.transport auth_config['transport']
+  json.rpc_endpoint auth_config['rpc_endpoint']
+end
 json.enabled mcp_server.enabled
 json.status mcp_server.status
 json.last_error mcp_server.last_error

--- a/enterprise/config/premium_features.yml
+++ b/enterprise/config/premium_features.yml
@@ -5,5 +5,6 @@
 - sla
 - custom_roles
 - captain_integration
+- captain_mcp
 - csat_review_notes
 - conversation_required_attributes

--- a/enterprise/lib/captain/mcp/errors.rb
+++ b/enterprise/lib/captain/mcp/errors.rb
@@ -1,0 +1,10 @@
+module Captain
+  module Mcp
+    class Error < StandardError; end
+    class ConnectionError < Error; end
+    class ProtocolError < Error; end
+    class AuthenticationError < Error; end
+    class TimeoutError < Error; end
+    class ToolExecutionError < Error; end
+  end
+end

--- a/enterprise/lib/captain/mcp/errors.rb
+++ b/enterprise/lib/captain/mcp/errors.rb
@@ -6,5 +6,14 @@ module Captain
     class AuthenticationError < Error; end
     class TimeoutError < Error; end
     class ToolExecutionError < Error; end
+
+    module Errors
+      Error = Captain::Mcp::Error
+      ConnectionError = Captain::Mcp::ConnectionError
+      ProtocolError = Captain::Mcp::ProtocolError
+      AuthenticationError = Captain::Mcp::AuthenticationError
+      TimeoutError = Captain::Mcp::TimeoutError
+      ToolExecutionError = Captain::Mcp::ToolExecutionError
+    end
   end
 end

--- a/enterprise/lib/captain/mcp/errors.rb
+++ b/enterprise/lib/captain/mcp/errors.rb
@@ -1,19 +1,15 @@
-module Captain
-  module Mcp
-    class Error < StandardError; end
-    class ConnectionError < Error; end
-    class ProtocolError < Error; end
-    class AuthenticationError < Error; end
-    class TimeoutError < Error; end
-    class ToolExecutionError < Error; end
+class Captain::Mcp::Error < StandardError; end
+class Captain::Mcp::ConnectionError < Captain::Mcp::Error; end
+class Captain::Mcp::ProtocolError < Captain::Mcp::Error; end
+class Captain::Mcp::AuthenticationError < Captain::Mcp::Error; end
+class Captain::Mcp::TimeoutError < Captain::Mcp::Error; end
+class Captain::Mcp::ToolExecutionError < Captain::Mcp::Error; end
 
-    module Errors
-      Error = Captain::Mcp::Error
-      ConnectionError = Captain::Mcp::ConnectionError
-      ProtocolError = Captain::Mcp::ProtocolError
-      AuthenticationError = Captain::Mcp::AuthenticationError
-      TimeoutError = Captain::Mcp::TimeoutError
-      ToolExecutionError = Captain::Mcp::ToolExecutionError
-    end
-  end
+module Captain::Mcp::Errors
+  Error = Captain::Mcp::Error
+  ConnectionError = Captain::Mcp::ConnectionError
+  ProtocolError = Captain::Mcp::ProtocolError
+  AuthenticationError = Captain::Mcp::AuthenticationError
+  TimeoutError = Captain::Mcp::TimeoutError
+  ToolExecutionError = Captain::Mcp::ToolExecutionError
 end

--- a/enterprise/lib/captain/tools/mcp_tool.rb
+++ b/enterprise/lib/captain/tools/mcp_tool.rb
@@ -12,6 +12,13 @@ class Captain::Tools::McpTool < Agents::Tool
     @mcp_server.enabled? && @mcp_server.connection_connected?
   end
 
+  # Override execute to support both RubyLLM and Agents framework calling patterns.
+  # RubyLLM calls: execute(**params) - no tool_context
+  # Agents framework calls: execute(tool_context, **params) - with tool_context
+  def execute(tool_context = nil, **params)
+    perform(tool_context, **params)
+  end
+
   def perform(_tool_context, **params)
     return 'MCP server is disabled' unless @mcp_server.enabled?
 

--- a/enterprise/lib/captain/tools/mcp_tool.rb
+++ b/enterprise/lib/captain/tools/mcp_tool.rb
@@ -1,0 +1,31 @@
+require 'agents'
+
+class Captain::Tools::McpTool < Agents::Tool
+  def initialize(assistant, mcp_server, tool_name)
+    @assistant = assistant
+    @mcp_server = mcp_server
+    @tool_name = tool_name
+    super()
+  end
+
+  def active?
+    @mcp_server.enabled? && @mcp_server.connection_connected?
+  end
+
+  def perform(_tool_context, **params)
+    return 'MCP server is disabled' unless @mcp_server.enabled?
+
+    client = Captain::Mcp::ClientService.new(@mcp_server)
+    client.call_tool(@tool_name, params)
+
+  rescue Captain::Mcp::ConnectionError => e
+    Rails.logger.error("MCP connection error for #{@tool_name}: #{e.message}")
+    "MCP server connection error: #{e.message}"
+  rescue Captain::Mcp::ToolExecutionError => e
+    Rails.logger.error("MCP tool execution error for #{@tool_name}: #{e.message}")
+    "Tool execution failed: #{e.message}"
+  rescue StandardError => e
+    Rails.logger.error("MCP tool error for #{@tool_name}: #{e.class} - #{e.message}")
+    'An error occurred while executing the MCP tool'
+  end
+end

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -2,60 +2,65 @@
 # NOTE: are sensitive to local FS writes, and besides -- it's just not proper
 # NOTE: to have a dev-mode tool do its thing in production.
 if Rails.env.development?
-  require 'annotate_rb'
+  skip_annotation = ENV['SKIP_ANNOTATE'] == 'true' ||
+                    (defined?(Rake) && Rake.application.top_level_tasks.any? { |task| task.start_with?('db:') })
 
-  AnnotateRb::Core.load_rake_tasks
+  unless skip_annotation
+    require 'annotate_rb'
 
-  task :set_annotation_options do
-    # You can override any of these by setting an environment variable of the
-    # same name.
-    AnnotateRb::Options.set_defaults(
-      'additional_file_patterns' => [],
-      'routes' => 'false',
-      'models' => 'true',
-      'position_in_routes' => 'before',
-      'position_in_class' => 'before',
-      'position_in_test' => 'before',
-      'position_in_fixture' => 'before',
-      'position_in_factory' => 'before',
-      'position_in_serializer' => 'before',
-      'show_foreign_keys' => 'true',
-      'show_complete_foreign_keys' => 'false',
-      'show_indexes' => 'true',
-      'simple_indexes' => 'false',
-      'model_dir' => [
-        'app/models',
-        'enterprise/app/models',
-      ],
-      'root_dir' => '',
-      'include_version' => 'false',
-      'require' => '',
-      'exclude_tests' => 'true',
-      'exclude_fixtures' => 'true',
-      'exclude_factories' => 'true',
-      'exclude_serializers' => 'true',
-      'exclude_scaffolds' => 'true',
-      'exclude_controllers' => 'true',
-      'exclude_helpers' => 'true',
-      'exclude_sti_subclasses' => 'false',
-      'ignore_model_sub_dir' => 'false',
-      'ignore_columns' => nil,
-      'ignore_routes' => nil,
-      'ignore_unknown_models' => 'false',
-      'hide_limit_column_types' => 'integer,bigint,boolean',
-      'hide_default_column_types' => 'json,jsonb,hstore',
-      'skip_on_db_migrate' => 'false',
-      'format_bare' => 'true',
-      'format_rdoc' => 'false',
-      'format_markdown' => 'false',
-      'sort' => 'false',
-      'force' => 'false',
-      'frozen' => 'false',
-      'classified_sort' => 'true',
-      'trace' => 'false',
-      'wrapper_open' => nil,
-      'wrapper_close' => nil,
-      'with_comment' => 'true'
-    )
+    AnnotateRb::Core.load_rake_tasks
+
+    task :set_annotation_options do
+      # You can override any of these by setting an environment variable of the
+      # same name.
+      AnnotateRb::Options.set_defaults(
+        'additional_file_patterns' => [],
+        'routes' => 'false',
+        'models' => 'true',
+        'position_in_routes' => 'before',
+        'position_in_class' => 'before',
+        'position_in_test' => 'before',
+        'position_in_fixture' => 'before',
+        'position_in_factory' => 'before',
+        'position_in_serializer' => 'before',
+        'show_foreign_keys' => 'true',
+        'show_complete_foreign_keys' => 'false',
+        'show_indexes' => 'true',
+        'simple_indexes' => 'false',
+        'model_dir' => [
+          'app/models',
+          'enterprise/app/models',
+        ],
+        'root_dir' => '',
+        'include_version' => 'false',
+        'require' => '',
+        'exclude_tests' => 'true',
+        'exclude_fixtures' => 'true',
+        'exclude_factories' => 'true',
+        'exclude_serializers' => 'true',
+        'exclude_scaffolds' => 'true',
+        'exclude_controllers' => 'true',
+        'exclude_helpers' => 'true',
+        'exclude_sti_subclasses' => 'false',
+        'ignore_model_sub_dir' => 'false',
+        'ignore_columns' => nil,
+        'ignore_routes' => nil,
+        'ignore_unknown_models' => 'false',
+        'hide_limit_column_types' => 'integer,bigint,boolean',
+        'hide_default_column_types' => 'json,jsonb,hstore',
+        'skip_on_db_migrate' => 'true',
+        'format_bare' => 'true',
+        'format_rdoc' => 'false',
+        'format_markdown' => 'false',
+        'sort' => 'false',
+        'force' => 'false',
+        'frozen' => 'false',
+        'classified_sort' => 'true',
+        'trace' => 'false',
+        'wrapper_open' => nil,
+        'wrapper_close' => nil,
+        'with_comment' => 'true'
+      )
+    end
   end
 end

--- a/spec/enterprise/controllers/api/v1/accounts/captain/assistants/mcp_servers_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/assistants/mcp_servers_controller_spec.rb
@@ -1,0 +1,265 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Accounts::Captain::Assistants::McpServers', type: :request do
+  let(:account) { create(:account) }
+  let(:admin) { create(:user, account: account, role: :administrator) }
+  let(:agent) { create(:user, account: account, role: :agent) }
+  let(:assistant) { create(:captain_assistant, account: account) }
+  let(:mcp_server) { create(:captain_mcp_server, :connected, account: account) }
+
+  def json_response
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  before do
+    account.enable_features('captain_mcp')
+  end
+
+  describe 'GET /api/v1/accounts/{account.id}/captain/assistants/{assistant.id}/mcp_servers' do
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized status' do
+        get "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an agent' do
+      it 'returns success status (agents can view assistants)' do
+        get "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers",
+            headers: agent.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'when it is an admin' do
+      it 'returns success status and attached MCP servers' do
+        create_list(:captain_assistant_mcp_server, 2, assistant: assistant)
+
+        get "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:payload].length).to eq(2)
+      end
+
+      it 'includes mcp_server details in response' do
+        attachment = create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server)
+
+        get "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:payload].first[:id]).to eq(attachment.id)
+        expect(json_response[:payload].first[:mcp_server][:id]).to eq(mcp_server.id)
+      end
+
+      it 'returns empty payload when no servers attached' do
+        get "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:payload]).to eq([])
+      end
+    end
+
+    context 'when captain_mcp feature is disabled' do
+      before { account.disable_features('captain_mcp') }
+
+      it 'returns forbidden status' do
+        get "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/accounts/{account.id}/captain/assistants/{assistant.id}/mcp_servers' do
+    let(:valid_attributes) do
+      {
+        assistant_mcp_server: {
+          captain_mcp_server_id: mcp_server.id,
+          enabled: true,
+          tool_filters: { include: ['search_docs'] }
+        }
+      }
+    end
+
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized status' do
+        post "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers",
+             params: valid_attributes
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an agent' do
+      it 'returns unauthorized status' do
+        post "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers",
+             params: valid_attributes,
+             headers: agent.create_new_auth_token
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an admin' do
+      it 'attaches MCP server to assistant and returns success status' do
+        post "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers",
+             params: valid_attributes,
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:captain_mcp_server_id]).to eq(mcp_server.id)
+        expect(json_response[:enabled]).to be(true)
+        expect(json_response[:tool_filters][:include]).to eq(['search_docs'])
+      end
+
+      it 'creates association in database' do
+        expect do
+          post "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers",
+               params: valid_attributes,
+               headers: admin.create_new_auth_token,
+               as: :json
+        end.to change(Captain::AssistantMcpServer, :count).by(1)
+      end
+
+      context 'when server is already attached' do
+        before do
+          create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server)
+        end
+
+        it 'returns unprocessable entity status' do
+          post "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers",
+               params: valid_attributes,
+               headers: admin.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context 'with invalid MCP server ID' do
+        let(:invalid_attributes) do
+          {
+            assistant_mcp_server: {
+              captain_mcp_server_id: 999_999
+            }
+          }
+        end
+
+        it 'returns not found or unprocessable entity status' do
+          post "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers",
+               params: invalid_attributes,
+               headers: admin.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/accounts/{account.id}/captain/assistants/{assistant.id}/mcp_servers/{id}' do
+    let!(:attachment) { create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server) }
+    let(:update_attributes) do
+      {
+        assistant_mcp_server: {
+          enabled: false,
+          tool_filters: { exclude: ['get_page'] }
+        }
+      }
+    end
+
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized status' do
+        patch "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers/#{attachment.id}",
+              params: update_attributes
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an agent' do
+      it 'returns unauthorized status' do
+        patch "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers/#{attachment.id}",
+              params: update_attributes,
+              headers: agent.create_new_auth_token
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an admin' do
+      it 'updates the attachment and returns success status' do
+        patch "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers/#{attachment.id}",
+              params: update_attributes,
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:enabled]).to be(false)
+        expect(json_response[:tool_filters][:exclude]).to eq(['get_page'])
+      end
+
+      it 'updates tool_filters in database' do
+        patch "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers/#{attachment.id}",
+              params: update_attributes,
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(attachment.reload.tool_filters['exclude']).to eq(['get_page'])
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/accounts/{account.id}/captain/assistants/{assistant.id}/mcp_servers/{id}' do
+    let!(:attachment) { create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server) }
+
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized status' do
+        delete "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers/#{attachment.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an agent' do
+      it 'returns unauthorized status' do
+        delete "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers/#{attachment.id}",
+               headers: agent.create_new_auth_token
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an admin' do
+      it 'detaches MCP server and returns no content status' do
+        expect do
+          delete "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers/#{attachment.id}",
+                 headers: admin.create_new_auth_token
+        end.to change(Captain::AssistantMcpServer, :count).by(-1)
+
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'does not delete the MCP server itself' do
+        expect do
+          delete "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers/#{attachment.id}",
+                 headers: admin.create_new_auth_token
+        end.not_to change(Captain::McpServer, :count)
+      end
+
+      context 'when attachment does not exist' do
+        it 'returns not found status' do
+          delete "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers/999999",
+                 headers: admin.create_new_auth_token
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
+end

--- a/spec/enterprise/controllers/api/v1/accounts/captain/assistants/mcp_servers_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/assistants/mcp_servers_controller_spec.rb
@@ -154,13 +154,13 @@ RSpec.describe 'Api::V1::Accounts::Captain::Assistants::McpServers', type: :requ
           }
         end
 
-        it 'returns not found or unprocessable entity status' do
+        it 'returns not found status' do
           post "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/mcp_servers",
                params: invalid_attributes,
                headers: admin.create_new_auth_token,
                as: :json
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:not_found)
         end
       end
     end

--- a/spec/enterprise/controllers/api/v1/accounts/captain/mcp_servers_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/mcp_servers_controller_spec.rb
@@ -1,0 +1,439 @@
+require 'rails_helper'
+require 'captain/mcp/errors'
+
+RSpec.describe 'Api::V1::Accounts::Captain::McpServers', type: :request do
+  let(:account) { create(:account) }
+  let(:admin) { create(:user, account: account, role: :administrator) }
+  let(:agent) { create(:user, account: account, role: :agent) }
+
+  def json_response
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  before do
+    account.enable_features('captain_mcp')
+  end
+
+  describe 'GET /api/v1/accounts/{account.id}/captain/mcp_servers' do
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized status' do
+        get "/api/v1/accounts/#{account.id}/captain/mcp_servers"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an agent' do
+      it 'returns unauthorized status' do
+        get "/api/v1/accounts/#{account.id}/captain/mcp_servers",
+            headers: agent.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an admin' do
+      it 'returns success status and MCP servers' do
+        create_list(:captain_mcp_server, 3, account: account)
+        get "/api/v1/accounts/#{account.id}/captain/mcp_servers",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:payload].length).to eq(3)
+      end
+
+      it 'returns servers ordered by created_at desc' do
+        old_server = create(:captain_mcp_server, account: account, created_at: 2.days.ago)
+        new_server = create(:captain_mcp_server, account: account, created_at: 1.day.ago)
+
+        get "/api/v1/accounts/#{account.id}/captain/mcp_servers",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(json_response[:payload].first[:id]).to eq(new_server.id)
+        expect(json_response[:payload].last[:id]).to eq(old_server.id)
+      end
+    end
+
+    context 'when captain_mcp feature is disabled' do
+      before { account.disable_features('captain_mcp') }
+
+      it 'returns forbidden status' do
+        get "/api/v1/accounts/#{account.id}/captain/mcp_servers",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/accounts/{account.id}/captain/mcp_servers/{id}' do
+    let(:mcp_server) { create(:captain_mcp_server, account: account) }
+
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized status' do
+        get "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an agent' do
+      it 'returns unauthorized status' do
+        get "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}",
+            headers: agent.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an admin' do
+      it 'returns success status and MCP server' do
+        get "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:id]).to eq(mcp_server.id)
+        expect(json_response[:name]).to eq(mcp_server.name)
+        expect(json_response[:url]).to eq(mcp_server.url)
+      end
+
+      it 'masks credentials in response' do
+        server = create(:captain_mcp_server, :with_bearer_auth, account: account)
+
+        get "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{server.id}",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(json_response[:auth_config][:has_token]).to be true
+        expect(json_response[:auth_config]).not_to have_key(:token)
+      end
+    end
+
+    context 'when MCP server does not exist' do
+      it 'returns not found status' do
+        get "/api/v1/accounts/#{account.id}/captain/mcp_servers/999999",
+            headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/accounts/{account.id}/captain/mcp_servers' do
+    let(:valid_attributes) do
+      {
+        mcp_server: {
+          name: 'Cloudflare Docs',
+          description: 'Cloudflare documentation MCP server',
+          url: 'https://mcp.cloudflare.com/api',
+          auth_type: 'bearer',
+          auth_config: { token: 'cf_token_xxx' },
+          enabled: true
+        }
+      }
+    end
+
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized status' do
+        post "/api/v1/accounts/#{account.id}/captain/mcp_servers",
+             params: valid_attributes
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an agent' do
+      it 'returns unauthorized status' do
+        post "/api/v1/accounts/#{account.id}/captain/mcp_servers",
+             params: valid_attributes,
+             headers: agent.create_new_auth_token
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an admin' do
+      it 'creates a new MCP server and returns success status' do
+        post "/api/v1/accounts/#{account.id}/captain/mcp_servers",
+             params: valid_attributes,
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:name]).to eq('Cloudflare Docs')
+        expect(json_response[:slug]).to eq('mcp_cloudflare_docs')
+        expect(json_response[:url]).to eq('https://mcp.cloudflare.com/api')
+        expect(json_response[:auth_type]).to eq('bearer')
+      end
+
+      context 'with invalid parameters' do
+        let(:invalid_attributes) do
+          {
+            mcp_server: {
+              name: '',
+              url: ''
+            }
+          }
+        end
+
+        it 'returns unprocessable entity status' do
+          post "/api/v1/accounts/#{account.id}/captain/mcp_servers",
+               params: invalid_attributes,
+               headers: admin.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context 'with localhost URL' do
+        let(:localhost_attributes) do
+          {
+            mcp_server: {
+              name: 'Local Server',
+              url: 'http://localhost/api'
+            }
+          }
+        end
+
+        it 'returns unprocessable entity status' do
+          post "/api/v1/accounts/#{account.id}/captain/mcp_servers",
+               params: localhost_attributes,
+               headers: admin.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/accounts/{account.id}/captain/mcp_servers/{id}' do
+    let(:mcp_server) { create(:captain_mcp_server, account: account) }
+    let(:update_attributes) do
+      {
+        mcp_server: {
+          name: 'Updated Server Name',
+          enabled: false
+        }
+      }
+    end
+
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized status' do
+        patch "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}",
+              params: update_attributes
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an agent' do
+      it 'returns unauthorized status' do
+        patch "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}",
+              params: update_attributes,
+              headers: agent.create_new_auth_token
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an admin' do
+      it 'updates the MCP server and returns success status' do
+        patch "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}",
+              params: update_attributes,
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:name]).to eq('Updated Server Name')
+        expect(json_response[:enabled]).to be(false)
+      end
+
+      it 'preserves existing credentials when not provided in update' do
+        server = create(:captain_mcp_server, :with_bearer_auth, account: account)
+
+        patch "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{server.id}",
+              params: { mcp_server: { name: 'New Name', auth_config: {} } },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(server.reload.auth_config['token']).to eq('test_bearer_token_123')
+      end
+
+      context 'with invalid parameters' do
+        let(:invalid_attributes) do
+          {
+            mcp_server: {
+              name: ''
+            }
+          }
+        end
+
+        it 'returns unprocessable entity status' do
+          patch "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}",
+                params: invalid_attributes,
+                headers: admin.create_new_auth_token,
+                as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/accounts/{account.id}/captain/mcp_servers/{id}' do
+    let!(:mcp_server) { create(:captain_mcp_server, account: account) }
+
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized status' do
+        delete "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an agent' do
+      it 'returns unauthorized status' do
+        delete "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}",
+               headers: agent.create_new_auth_token
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an admin' do
+      it 'deletes the MCP server and returns no content status' do
+        expect do
+          delete "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}",
+                 headers: admin.create_new_auth_token
+        end.to change(Captain::McpServer, :count).by(-1)
+
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'also deletes associated assistant attachments' do
+        assistant = create(:captain_assistant, account: account)
+        create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server)
+
+        expect do
+          delete "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}",
+                 headers: admin.create_new_auth_token
+        end.to change(Captain::AssistantMcpServer, :count).by(-1)
+      end
+
+      context 'when MCP server does not exist' do
+        it 'returns not found status' do
+          delete "/api/v1/accounts/#{account.id}/captain/mcp_servers/999999",
+                 headers: admin.create_new_auth_token
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
+
+  describe 'POST /api/v1/accounts/{account.id}/captain/mcp_servers/{id}/connect' do
+    let(:mcp_server) { create(:captain_mcp_server, account: account) }
+
+    context 'when it is an admin' do
+      let(:mock_discovery_service) { instance_double(Captain::Mcp::DiscoveryService) }
+
+      before do
+        allow(Captain::Mcp::DiscoveryService).to receive(:new).and_return(mock_discovery_service)
+      end
+
+      it 'connects and returns tools count' do
+        allow(mock_discovery_service).to receive(:connect_and_discover)
+        mcp_server.update!(cached_tools: [{ 'name' => 'tool1' }, { 'name' => 'tool2' }])
+
+        post "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}/connect",
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:status]).to eq('connected')
+        expect(json_response[:tools_count]).to eq(2)
+      end
+
+      it 'returns error when connection fails' do
+        allow(mock_discovery_service).to receive(:connect_and_discover)
+          .and_raise(Captain::Mcp::ConnectionError.new('Connection refused'))
+
+        post "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}/connect",
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response[:error]).to include('Connection refused')
+      end
+    end
+
+    context 'when it is an agent' do
+      it 'returns unauthorized status' do
+        post "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}/connect",
+             headers: agent.create_new_auth_token
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/accounts/{account.id}/captain/mcp_servers/{id}/disconnect' do
+    let(:mcp_server) { create(:captain_mcp_server, :connected, account: account) }
+
+    context 'when it is an admin' do
+      let(:mock_client_service) { instance_double(Captain::Mcp::ClientService) }
+
+      before do
+        allow(Captain::Mcp::ClientService).to receive(:new).and_return(mock_client_service)
+        allow(mock_client_service).to receive(:disconnect)
+      end
+
+      it 'disconnects and returns status' do
+        post "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}/disconnect",
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:status]).to eq('disconnected')
+      end
+    end
+  end
+
+  describe 'POST /api/v1/accounts/{account.id}/captain/mcp_servers/{id}/refresh' do
+    let(:mcp_server) { create(:captain_mcp_server, :connected, account: account) }
+
+    context 'when it is an admin' do
+      let(:mock_discovery_service) { instance_double(Captain::Mcp::DiscoveryService) }
+      let(:new_tools) { [{ 'name' => 'new_tool', 'description' => 'A new tool' }] }
+
+      before do
+        allow(Captain::Mcp::DiscoveryService).to receive(:new).and_return(mock_discovery_service)
+      end
+
+      it 'refreshes tools and returns updated server' do
+        allow(mock_discovery_service).to receive(:refresh_tools).and_return(new_tools)
+        mcp_server.update!(cached_tools: new_tools)
+
+        post "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}/refresh",
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:cached_tools]).to eq([{ name: 'new_tool', description: 'A new tool' }])
+      end
+
+      it 'returns error when refresh fails' do
+        allow(mock_discovery_service).to receive(:refresh_tools)
+          .and_raise(Captain::Mcp::Error.new('Failed to refresh'))
+
+        post "/api/v1/accounts/#{account.id}/captain/mcp_servers/#{mcp_server.id}/refresh",
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response[:error]).to include('Failed to refresh')
+      end
+    end
+  end
+end

--- a/spec/enterprise/models/captain/assistant_mcp_server_spec.rb
+++ b/spec/enterprise/models/captain/assistant_mcp_server_spec.rb
@@ -1,0 +1,140 @@
+require 'rails_helper'
+
+RSpec.describe Captain::AssistantMcpServer, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:assistant).class_name('Captain::Assistant') }
+    it { is_expected.to belong_to(:mcp_server).class_name('Captain::McpServer') }
+  end
+
+  describe 'validations' do
+    let(:account) { create(:account) }
+    let(:assistant) { create(:captain_assistant, account: account) }
+    let(:mcp_server) { create(:captain_mcp_server, account: account) }
+
+    it 'validates uniqueness of assistant and mcp_server combination' do
+      create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server)
+      duplicate = build(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:captain_assistant_id]).to include('has already been taken')
+    end
+
+    it 'allows same server attached to different assistants' do
+      assistant2 = create(:captain_assistant, account: account)
+      create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server)
+      different_assistant_attachment = build(:captain_assistant_mcp_server, assistant: assistant2, mcp_server: mcp_server)
+
+      expect(different_assistant_attachment).to be_valid
+    end
+  end
+
+  describe 'scopes' do
+    let(:account) { create(:account) }
+    let(:assistant) { create(:captain_assistant, account: account) }
+    let(:mcp_server) { create(:captain_mcp_server, :connected, account: account) }
+
+    describe '.enabled' do
+      it 'returns only enabled attachments' do
+        enabled = create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server, enabled: true)
+        create(:captain_assistant_mcp_server, :disabled, assistant: create(:captain_assistant, account: account), mcp_server: mcp_server)
+
+        expect(described_class.enabled).to contain_exactly(enabled)
+      end
+    end
+  end
+
+  describe '#filtered_tools' do
+    let(:account) { create(:account) }
+    let(:assistant) { create(:captain_assistant, account: account) }
+    let(:mcp_server) { create(:captain_mcp_server, :connected, account: account) }
+
+    it 'returns all tools when no filters' do
+      attachment = create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server, tool_filters: {})
+
+      expect(attachment.filtered_tools.length).to eq(2)
+      expect(attachment.filtered_tools.map { |t| t['name'] }).to contain_exactly('search_docs', 'get_page')
+    end
+
+    it 'filters tools by include list' do
+      attachment = create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server,
+                                                         tool_filters: { 'include' => ['search_docs'] })
+
+      expect(attachment.filtered_tools.length).to eq(1)
+      expect(attachment.filtered_tools.first['name']).to eq('search_docs')
+    end
+
+    it 'filters tools by exclude list' do
+      attachment = create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server,
+                                                         tool_filters: { 'exclude' => ['get_page'] })
+
+      expect(attachment.filtered_tools.length).to eq(1)
+      expect(attachment.filtered_tools.first['name']).to eq('search_docs')
+    end
+
+    it 'applies both include and exclude filters' do
+      attachment = create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server,
+                                                         tool_filters: { 'include' => %w[search_docs get_page], 'exclude' => ['get_page'] })
+
+      expect(attachment.filtered_tools.length).to eq(1)
+      expect(attachment.filtered_tools.first['name']).to eq('search_docs')
+    end
+
+    it 'returns empty array when server has no cached tools' do
+      mcp_server.update!(cached_tools: nil)
+      attachment = create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server)
+
+      expect(attachment.filtered_tools).to eq([])
+    end
+  end
+
+  describe '#to_tool_metadata' do
+    let(:account) { create(:account) }
+    let(:assistant) { create(:captain_assistant, account: account) }
+    let(:mcp_server) { create(:captain_mcp_server, :connected, account: account) }
+
+    it 'returns metadata for filtered tools' do
+      attachment = create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server,
+                                                         tool_filters: { 'include' => ['search_docs'] })
+
+      metadata = attachment.to_tool_metadata
+
+      expect(metadata.length).to eq(1)
+      expect(metadata.first[:id]).to eq("#{mcp_server.slug}_search_docs")
+      expect(metadata.first[:title]).to eq('Search Docs')
+      expect(metadata.first[:mcp]).to be true
+      expect(metadata.first[:mcp_server_id]).to eq(mcp_server.id)
+    end
+
+    it 'returns all tool metadata when no filters' do
+      attachment = create(:captain_assistant_mcp_server, assistant: assistant, mcp_server: mcp_server)
+
+      metadata = attachment.to_tool_metadata
+
+      expect(metadata.length).to eq(2)
+    end
+  end
+
+  describe 'factory' do
+    it 'creates a valid assistant MCP server with default attributes' do
+      attachment = create(:captain_assistant_mcp_server)
+
+      expect(attachment).to be_valid
+      expect(attachment.assistant).to be_present
+      expect(attachment.mcp_server).to be_present
+      expect(attachment.enabled).to be true
+      expect(attachment.tool_filters).to eq({})
+    end
+
+    it 'creates valid attachment with include filter trait' do
+      attachment = create(:captain_assistant_mcp_server, :with_include_filter)
+
+      expect(attachment.tool_filters['include']).to eq(['search_docs'])
+    end
+
+    it 'creates valid attachment with exclude filter trait' do
+      attachment = create(:captain_assistant_mcp_server, :with_exclude_filter)
+
+      expect(attachment.tool_filters['exclude']).to eq(['get_page'])
+    end
+  end
+end

--- a/spec/enterprise/models/captain/mcp_server_spec.rb
+++ b/spec/enterprise/models/captain/mcp_server_spec.rb
@@ -1,0 +1,265 @@
+require 'rails_helper'
+
+RSpec.describe Captain::McpServer, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:account) }
+    it { is_expected.to have_many(:assistant_mcp_servers).dependent(:destroy) }
+    it { is_expected.to have_many(:assistants).through(:assistant_mcp_servers) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:url) }
+
+    it {
+      expect(subject).to define_enum_for(:auth_type)
+        .with_values('none' => 'none', 'bearer' => 'bearer', 'api_key' => 'api_key')
+        .backed_by_column_of_type(:string)
+        .with_prefix(:auth)
+    }
+
+    it {
+      expect(subject).to define_enum_for(:status)
+        .with_values('disconnected' => 'disconnected', 'connecting' => 'connecting',
+                     'connected' => 'connected', 'error' => 'error')
+        .backed_by_column_of_type(:string)
+        .with_prefix(:connection)
+    }
+
+    describe 'slug uniqueness' do
+      let(:account) { create(:account) }
+
+      it 'validates uniqueness of slug scoped to account' do
+        create(:captain_mcp_server, account: account, slug: 'mcp_test_server')
+        duplicate = build(:captain_mcp_server, account: account, slug: 'mcp_test_server')
+
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:slug]).to include('has already been taken')
+      end
+
+      it 'allows same slug across different accounts' do
+        account2 = create(:account)
+        create(:captain_mcp_server, account: account, slug: 'mcp_test_server')
+        different_account_server = build(:captain_mcp_server, account: account2, slug: 'mcp_test_server')
+
+        expect(different_account_server).to be_valid
+      end
+    end
+
+    describe 'URL validation' do
+      let(:account) { create(:account) }
+
+      it 'is valid with HTTPS URL' do
+        server = build(:captain_mcp_server, account: account, url: 'https://mcp.example.com/api')
+        expect(server).to be_valid
+      end
+
+      it 'is valid with HTTP URL' do
+        server = build(:captain_mcp_server, account: account, url: 'http://mcp.example.com/api')
+        expect(server).to be_valid
+      end
+
+      it 'is invalid with non-HTTP URL' do
+        server = build(:captain_mcp_server, account: account, url: 'ftp://mcp.example.com')
+        expect(server).not_to be_valid
+        expect(server.errors[:url]).to be_present
+      end
+
+      it 'is invalid with malformed URL' do
+        server = build(:captain_mcp_server, account: account, url: 'not-a-url')
+        expect(server).not_to be_valid
+        expect(server.errors[:url]).to be_present
+      end
+
+      it 'is invalid with localhost URL' do
+        server = build(:captain_mcp_server, account: account, url: 'http://localhost/api')
+        expect(server).not_to be_valid
+        expect(server.errors[:url]).to be_present
+      end
+
+      it 'is invalid with .local domain URL' do
+        server = build(:captain_mcp_server, account: account, url: 'http://myserver.local/api')
+        expect(server).not_to be_valid
+        expect(server.errors[:url]).to be_present
+      end
+
+      it 'is invalid with IP address URL' do
+        server = build(:captain_mcp_server, account: account, url: 'http://192.168.1.1/api')
+        expect(server).not_to be_valid
+        expect(server.errors[:url]).to be_present
+      end
+
+      it 'is invalid with IPv6 address URL' do
+        server = build(:captain_mcp_server, account: account, url: 'http://[::1]/api')
+        expect(server).not_to be_valid
+        expect(server.errors[:url]).to be_present
+      end
+    end
+  end
+
+  describe 'scopes' do
+    let(:account) { create(:account) }
+
+    describe '.enabled' do
+      it 'returns only enabled MCP servers' do
+        enabled_server = create(:captain_mcp_server, account: account, enabled: true)
+        create(:captain_mcp_server, account: account, enabled: false)
+
+        expect(described_class.enabled).to contain_exactly(enabled_server)
+      end
+    end
+
+    describe '.connected' do
+      it 'returns only connected MCP servers' do
+        connected_server = create(:captain_mcp_server, :connected, account: account)
+        create(:captain_mcp_server, account: account, status: 'disconnected')
+
+        expect(described_class.connected).to contain_exactly(connected_server)
+      end
+    end
+  end
+
+  describe 'slug generation' do
+    let(:account) { create(:account) }
+
+    it 'generates slug from name on creation' do
+      server = create(:captain_mcp_server, account: account, name: 'Cloudflare Docs')
+      expect(server.slug).to eq('mcp_cloudflare_docs')
+    end
+
+    it 'adds mcp_ prefix to generated slug' do
+      server = create(:captain_mcp_server, account: account, name: 'My Server')
+      expect(server.slug).to start_with('mcp_')
+    end
+
+    it 'does not override manually set slug' do
+      server = create(:captain_mcp_server, account: account, name: 'Test Server', slug: 'mcp_manual_slug')
+      expect(server.slug).to eq('mcp_manual_slug')
+    end
+
+    it 'handles slug collisions by appending random suffix' do
+      create(:captain_mcp_server, account: account, name: 'Test Server', slug: 'mcp_test_server')
+      server2 = create(:captain_mcp_server, account: account, name: 'Test Server')
+
+      expect(server2.slug).to match(/^mcp_test_server_[a-z0-9]{6}$/)
+    end
+
+    it 'parameterizes name correctly' do
+      server = create(:captain_mcp_server, account: account, name: 'My Server & Tools!')
+      expect(server.slug).to eq('mcp_my_server_tools')
+    end
+  end
+
+  describe 'status management' do
+    let(:account) { create(:account) }
+    let(:server) { create(:captain_mcp_server, account: account) }
+
+    describe '#mark_connected!' do
+      it 'updates status to connected' do
+        server.mark_connected!
+
+        expect(server.status).to eq('connected')
+        expect(server.last_connected_at).to be_present
+        expect(server.last_error).to be_nil
+      end
+    end
+
+    describe '#mark_error!' do
+      it 'updates status to error with message' do
+        server.mark_error!('Connection refused')
+
+        expect(server.status).to eq('error')
+        expect(server.last_error).to eq('Connection refused')
+      end
+    end
+
+    describe '#mark_disconnected!' do
+      it 'updates status to disconnected' do
+        server.update!(status: 'connected')
+        server.mark_disconnected!
+
+        expect(server.status).to eq('disconnected')
+      end
+    end
+  end
+
+  describe '#to_tool_metadata' do
+    let(:account) { create(:account) }
+    let(:server) { create(:captain_mcp_server, :connected, account: account) }
+
+    it 'returns array of tool metadata hashes' do
+      metadata = server.to_tool_metadata
+
+      expect(metadata).to be_an(Array)
+      expect(metadata.length).to eq(2)
+
+      first_tool = metadata.first
+      expect(first_tool[:id]).to eq("#{server.slug}_search_docs")
+      expect(first_tool[:title]).to eq('Search Docs')
+      expect(first_tool[:description]).to eq('Search documentation')
+      expect(first_tool[:mcp]).to be true
+      expect(first_tool[:mcp_server_id]).to eq(server.id)
+      expect(first_tool[:mcp_tool_name]).to eq('search_docs')
+    end
+
+    it 'returns empty array when no cached tools' do
+      server.update!(cached_tools: nil)
+      expect(server.to_tool_metadata).to eq([])
+    end
+  end
+
+  describe '#build_auth_headers' do
+    let(:account) { create(:account) }
+
+    it 'returns empty hash for none auth type' do
+      server = create(:captain_mcp_server, account: account, auth_type: 'none')
+      expect(server.build_auth_headers).to eq({})
+    end
+
+    it 'returns bearer token header' do
+      server = create(:captain_mcp_server, :with_bearer_auth, account: account)
+      expect(server.build_auth_headers).to eq({ 'Authorization' => 'Bearer test_bearer_token_123' })
+    end
+
+    it 'returns API key header' do
+      server = create(:captain_mcp_server, :with_api_key, account: account)
+      expect(server.build_auth_headers).to eq({ 'X-API-Key' => 'test_api_key' })
+    end
+  end
+
+  describe 'factory' do
+    it 'creates a valid MCP server with default attributes' do
+      server = create(:captain_mcp_server)
+
+      expect(server).to be_valid
+      expect(server.name).to be_present
+      expect(server.slug).to be_present
+      expect(server.url).to be_present
+      expect(server.auth_type).to eq('none')
+      expect(server.status).to eq('disconnected')
+      expect(server.enabled).to be true
+    end
+
+    it 'creates valid server with connected trait' do
+      server = create(:captain_mcp_server, :connected)
+
+      expect(server.status).to eq('connected')
+      expect(server.cached_tools).to be_present
+      expect(server.last_connected_at).to be_present
+    end
+
+    it 'creates valid server with bearer auth trait' do
+      server = create(:captain_mcp_server, :with_bearer_auth)
+
+      expect(server.auth_type).to eq('bearer')
+      expect(server.auth_config['token']).to eq('test_bearer_token_123')
+    end
+
+    it 'creates valid server with API key trait' do
+      server = create(:captain_mcp_server, :with_api_key)
+
+      expect(server.auth_type).to eq('api_key')
+      expect(server.auth_config['key']).to eq('test_api_key')
+    end
+  end
+end

--- a/spec/enterprise/models/captain/mcp_server_spec.rb
+++ b/spec/enterprise/models/captain/mcp_server_spec.rb
@@ -194,12 +194,14 @@ RSpec.describe Captain::McpServer, type: :model do
       expect(metadata.length).to eq(2)
 
       first_tool = metadata.first
-      expect(first_tool[:id]).to eq("#{server.slug}_search_docs")
-      expect(first_tool[:title]).to eq('Search Docs')
-      expect(first_tool[:description]).to eq('Search documentation')
-      expect(first_tool[:mcp]).to be true
-      expect(first_tool[:mcp_server_id]).to eq(server.id)
-      expect(first_tool[:mcp_tool_name]).to eq('search_docs')
+      expect(first_tool).to include(
+        id: "#{server.slug}_search_docs",
+        title: 'Search Docs',
+        description: 'Search documentation',
+        mcp: true,
+        mcp_server_id: server.id,
+        mcp_tool_name: 'search_docs'
+      )
     end
 
     it 'returns empty array when no cached tools' do

--- a/spec/enterprise/policies/captain/mcp_server_policy_spec.rb
+++ b/spec/enterprise/policies/captain/mcp_server_policy_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Captain::McpServerPolicy, type: :policy do
+  subject(:policy) { described_class }
+
+  let(:account) { create(:account) }
+  let(:mcp_server) { create(:captain_mcp_server, account: account) }
+
+  let(:administrator) { create(:user, :administrator, account: account) }
+  let(:agent) { create(:user, account: account) }
+
+  let(:administrator_context) { { user: administrator, account: account, account_user: account.account_users.find_by(user: administrator) } }
+  let(:agent_context) { { user: agent, account: account, account_user: account.account_users.find_by(user: agent) } }
+
+  permissions :index?, :show?, :create?, :update?, :destroy? do
+    context 'when administrator' do
+      it { expect(policy).to permit(administrator_context, mcp_server) }
+    end
+
+    context 'when agent' do
+      it { expect(policy).not_to permit(agent_context, mcp_server) }
+    end
+  end
+
+  permissions :connect?, :disconnect?, :refresh? do
+    context 'when administrator' do
+      it { expect(policy).to permit(administrator_context, mcp_server) }
+    end
+
+    context 'when agent' do
+      it { expect(policy).not_to permit(agent_context, mcp_server) }
+    end
+  end
+end

--- a/spec/enterprise/services/captain/mcp/client_service_spec.rb
+++ b/spec/enterprise/services/captain/mcp/client_service_spec.rb
@@ -1,0 +1,238 @@
+require 'rails_helper'
+
+RSpec.describe Captain::Mcp::ClientService do
+  let(:account) { create(:account) }
+  let(:mcp_server) { create(:captain_mcp_server, account: account) }
+  let(:service) { described_class.new(mcp_server) }
+
+  describe '#connect' do
+    context 'when connection succeeds' do
+      before do
+        allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
+        allow(MCPClient).to receive(:connect).and_return(double('client', list_tools: []))
+      end
+
+      it 'returns success result' do
+        result = service.connect
+        expect(result).to be_success
+      end
+
+      it 'updates server status to connected' do
+        service.connect
+        expect(mcp_server.reload.status).to eq('connected')
+      end
+
+      it 'sets last_connected_at timestamp' do
+        freeze_time do
+          service.connect
+          expect(mcp_server.reload.last_connected_at).to eq(Time.current)
+        end
+      end
+    end
+
+    context 'when hostname resolves to private IP' do
+      before do
+        allow(Resolv).to receive(:getaddress).and_return('192.168.1.1')
+      end
+
+      it 'returns failure result' do
+        result = service.connect
+        expect(result).not_to be_success
+        expect(result.error).to include('private IP')
+      end
+
+      it 'marks server as error' do
+        service.connect
+        expect(mcp_server.reload.status).to eq('error')
+      end
+    end
+
+    context 'when hostname resolves to localhost' do
+      before do
+        allow(Resolv).to receive(:getaddress).and_return('127.0.0.1')
+      end
+
+      it 'returns failure result' do
+        result = service.connect
+        expect(result).not_to be_success
+      end
+    end
+
+    context 'when DNS resolution fails' do
+      before do
+        allow(Resolv).to receive(:getaddress).and_raise(Resolv::ResolvError.new('DNS failed'))
+      end
+
+      it 'returns failure result with DNS error' do
+        result = service.connect
+        expect(result).not_to be_success
+        expect(result.error).to include('DNS')
+      end
+    end
+
+    context 'when MCP client raises error' do
+      before do
+        allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
+        allow(MCPClient).to receive(:connect).and_raise(MCPClient::Errors::ConnectionError.new('Connection refused'))
+      end
+
+      it 'returns failure result' do
+        result = service.connect
+        expect(result).not_to be_success
+        expect(result.error).to include('Connection refused')
+      end
+
+      it 'marks server as error with message' do
+        service.connect
+        expect(mcp_server.reload.status).to eq('error')
+        expect(mcp_server.last_error).to include('Connection refused')
+      end
+    end
+  end
+
+  describe '#disconnect' do
+    let(:mock_client) { double('client', cleanup: nil) }
+
+    before do
+      allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
+      allow(MCPClient).to receive(:connect).and_return(mock_client)
+      service.connect
+    end
+
+    it 'cleans up the client' do
+      expect(mock_client).to receive(:cleanup)
+      service.disconnect
+    end
+
+    it 'marks server as disconnected' do
+      service.disconnect
+      expect(mcp_server.reload.status).to eq('disconnected')
+    end
+  end
+
+  describe '#list_tools' do
+    let(:mock_tool) do
+      double('tool',
+             name: 'search_docs',
+             description: 'Search documentation',
+             schema: { 'type' => 'object', 'properties' => { 'query' => { 'type' => 'string' } } },
+             output_schema: nil,
+             annotations: nil)
+    end
+    let(:mock_client) { double('client', list_tools: [mock_tool]) }
+
+    before do
+      allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
+      allow(MCPClient).to receive(:connect).and_return(mock_client)
+    end
+
+    it 'returns serialized tools' do
+      tools = service.list_tools
+
+      expect(tools.length).to eq(1)
+      expect(tools.first['name']).to eq('search_docs')
+      expect(tools.first['description']).to eq('Search documentation')
+      expect(tools.first['inputSchema']).to be_present
+    end
+
+    context 'when connection error occurs' do
+      before do
+        allow(mock_client).to receive(:list_tools).and_raise(MCPClient::Errors::ConnectionError.new('Lost connection'))
+      end
+
+      it 'raises ConnectionError' do
+        service.connect
+        expect { service.list_tools }.to raise_error(Captain::Mcp::ConnectionError, 'Lost connection')
+      end
+    end
+  end
+
+  describe '#call_tool' do
+    let(:mock_client) { double('client') }
+
+    before do
+      allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
+      allow(MCPClient).to receive(:connect).and_return(mock_client)
+    end
+
+    context 'when tool returns text content' do
+      before do
+        allow(mock_client).to receive(:call_tool).and_return({
+                                                               'content' => [{ 'type' => 'text', 'text' => 'Search results here' }]
+                                                             })
+      end
+
+      it 'formats and returns the text' do
+        result = service.call_tool('search_docs', { query: 'test' })
+        expect(result).to eq('Search results here')
+      end
+    end
+
+    context 'when tool returns string directly' do
+      before do
+        allow(mock_client).to receive(:call_tool).and_return('Direct response')
+      end
+
+      it 'returns the string as-is' do
+        result = service.call_tool('search_docs', {})
+        expect(result).to eq('Direct response')
+      end
+    end
+
+    context 'when tool returns image content' do
+      before do
+        allow(mock_client).to receive(:call_tool).and_return({
+                                                               'content' => [{ 'type' => 'image', 'mimeType' => 'image/png' }]
+                                                             })
+      end
+
+      it 'formats image as placeholder text' do
+        result = service.call_tool('get_image', {})
+        expect(result).to eq('[Image: image/png]')
+      end
+    end
+
+    context 'when tool execution fails' do
+      before do
+        allow(mock_client).to receive(:call_tool).and_raise(MCPClient::Errors::ToolCallError.new('Tool failed'))
+      end
+
+      it 'raises ToolExecutionError' do
+        service.connect
+        expect { service.call_tool('failing_tool', {}) }.to raise_error(Captain::Mcp::ToolExecutionError, 'Tool failed')
+      end
+    end
+  end
+
+  describe 'SSRF protection' do
+    describe 'private IP ranges' do
+      let(:private_ips) do
+        [
+          '127.0.0.1',      # Loopback
+          '10.0.0.1',       # Private class A
+          '172.16.0.1',     # Private class B
+          '192.168.1.1',    # Private class C
+          '169.254.1.1',    # Link-local
+          '0.0.0.1'         # Current network
+        ]
+      end
+
+      it 'blocks all private IP ranges' do
+        private_ips.each do |ip|
+          allow(Resolv).to receive(:getaddress).and_return(ip)
+
+          result = service.connect
+          expect(result).not_to be_success, "Expected #{ip} to be blocked"
+        end
+      end
+    end
+
+    it 'allows public IP addresses' do
+      allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
+      allow(MCPClient).to receive(:connect).and_return(double('client', list_tools: []))
+
+      result = service.connect
+      expect(result).to be_success
+    end
+  end
+end

--- a/spec/enterprise/services/captain/mcp/client_service_spec.rb
+++ b/spec/enterprise/services/captain/mcp/client_service_spec.rb
@@ -1,5 +1,20 @@
 require 'rails_helper'
 
+# Mock interfaces for external MCP library
+module MockMcpClient
+  def list_tools(**_options); end
+  def call_tool(_name, _args = {}); end
+  def cleanup; end
+end
+
+module MockMcpTool
+  def name; end
+  def description; end
+  def schema; end
+  def output_schema; end
+  def annotations; end
+end
+
 RSpec.describe Captain::Mcp::ClientService do
   let(:account) { create(:account) }
   let(:mcp_server) { create(:captain_mcp_server, account: account) }
@@ -9,7 +24,7 @@ RSpec.describe Captain::Mcp::ClientService do
     context 'when connection succeeds' do
       before do
         allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
-        allow(MCPClient).to receive(:connect).and_return(double('client', list_tools: []))
+        allow(MCPClient).to receive(:connect).and_return(instance_double(MockMcpClient, list_tools: []))
       end
 
       it 'returns success result' do
@@ -91,7 +106,7 @@ RSpec.describe Captain::Mcp::ClientService do
   end
 
   describe '#disconnect' do
-    let(:mock_client) { double('client', cleanup: nil) }
+    let(:mock_client) { instance_double(MockMcpClient, cleanup: nil, list_tools: []) }
 
     before do
       allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
@@ -112,14 +127,14 @@ RSpec.describe Captain::Mcp::ClientService do
 
   describe '#list_tools' do
     let(:mock_tool) do
-      double('tool',
-             name: 'search_docs',
-             description: 'Search documentation',
-             schema: { 'type' => 'object', 'properties' => { 'query' => { 'type' => 'string' } } },
-             output_schema: nil,
-             annotations: nil)
+      instance_double(MockMcpTool,
+                      name: 'search_docs',
+                      description: 'Search documentation',
+                      schema: { 'type' => 'object', 'properties' => { 'query' => { 'type' => 'string' } } },
+                      output_schema: nil,
+                      annotations: nil)
     end
-    let(:mock_client) { double('client', list_tools: [mock_tool]) }
+    let(:mock_client) { instance_double(MockMcpClient, list_tools: [mock_tool]) }
 
     before do
       allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
@@ -148,7 +163,7 @@ RSpec.describe Captain::Mcp::ClientService do
   end
 
   describe '#call_tool' do
-    let(:mock_client) { double('client') }
+    let(:mock_client) { instance_double(MockMcpClient, list_tools: []) }
 
     before do
       allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
@@ -229,7 +244,7 @@ RSpec.describe Captain::Mcp::ClientService do
 
     it 'allows public IP addresses' do
       allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
-      allow(MCPClient).to receive(:connect).and_return(double('client', list_tools: []))
+      allow(MCPClient).to receive(:connect).and_return(instance_double(MockMcpClient, list_tools: []))
 
       result = service.connect
       expect(result).to be_success

--- a/spec/enterprise/services/captain/mcp/client_service_spec.rb
+++ b/spec/enterprise/services/captain/mcp/client_service_spec.rb
@@ -1,21 +1,21 @@
 require 'rails_helper'
 
-# Mock interfaces for external MCP library
-module MockMcpClient
-  def list_tools(**_options); end
-  def call_tool(_name, _args = {}); end
-  def cleanup; end
-end
-
-module MockMcpTool
-  def name; end
-  def description; end
-  def schema; end
-  def output_schema; end
-  def annotations; end
-end
-
 RSpec.describe Captain::Mcp::ClientService do
+  # Mock interfaces scoped inside the describe block to avoid polluting the global namespace
+  mock_mcp_client = Module.new do
+    def list_tools(**_options); end
+    def call_tool(_name, _args = {}); end
+    def cleanup; end
+  end
+
+  mock_mcp_tool = Module.new do
+    def name; end
+    def description; end
+    def schema; end
+    def output_schema; end
+    def annotations; end
+  end
+
   let(:account) { create(:account) }
   let(:mcp_server) { create(:captain_mcp_server, account: account) }
   let(:service) { described_class.new(mcp_server) }
@@ -24,7 +24,7 @@ RSpec.describe Captain::Mcp::ClientService do
     context 'when connection succeeds' do
       before do
         allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
-        allow(MCPClient).to receive(:connect).and_return(instance_double(MockMcpClient, list_tools: []))
+        allow(MCPClient).to receive(:connect).and_return(instance_double(mock_mcp_client, list_tools: []))
       end
 
       it 'returns success result' do
@@ -106,7 +106,7 @@ RSpec.describe Captain::Mcp::ClientService do
   end
 
   describe '#disconnect' do
-    let(:mock_client) { instance_double(MockMcpClient, cleanup: nil, list_tools: []) }
+    let(:mock_client) { instance_double(mock_mcp_client, cleanup: nil, list_tools: []) }
 
     before do
       allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
@@ -127,14 +127,14 @@ RSpec.describe Captain::Mcp::ClientService do
 
   describe '#list_tools' do
     let(:mock_tool) do
-      instance_double(MockMcpTool,
+      instance_double(mock_mcp_tool,
                       name: 'search_docs',
                       description: 'Search documentation',
                       schema: { 'type' => 'object', 'properties' => { 'query' => { 'type' => 'string' } } },
                       output_schema: nil,
                       annotations: nil)
     end
-    let(:mock_client) { instance_double(MockMcpClient, list_tools: [mock_tool]) }
+    let(:mock_client) { instance_double(mock_mcp_client, list_tools: [mock_tool]) }
 
     before do
       allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
@@ -163,7 +163,7 @@ RSpec.describe Captain::Mcp::ClientService do
   end
 
   describe '#call_tool' do
-    let(:mock_client) { instance_double(MockMcpClient, list_tools: []) }
+    let(:mock_client) { instance_double(mock_mcp_client, list_tools: []) }
 
     before do
       allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
@@ -242,12 +242,144 @@ RSpec.describe Captain::Mcp::ClientService do
       end
     end
 
+    describe 'Carrier-grade NAT (RFC 6598)' do
+      it 'blocks CGN addresses' do
+        allow(Resolv).to receive(:getaddress).and_return('100.64.0.1')
+
+        result = service.connect
+        expect(result).not_to be_success
+        expect(result.error).to include('private IP')
+      end
+
+      it 'blocks upper end of CGN range' do
+        allow(Resolv).to receive(:getaddress).and_return('100.127.255.254')
+
+        result = service.connect
+        expect(result).not_to be_success
+      end
+    end
+
+    describe 'cloud metadata endpoint IPs' do
+      it 'blocks AWS/GCP metadata endpoint' do
+        allow(Resolv).to receive(:getaddress).and_return('169.254.169.254')
+
+        result = service.connect
+        expect(result).not_to be_success
+        expect(result.error).to include('private IP')
+      end
+    end
+
+    describe 'IPv6 private addresses' do
+      let(:ipv6_private_ips) do
+        [
+          '::1',            # IPv6 loopback
+          'fc00::1',        # IPv6 unique local
+          'fe80::1'         # IPv6 link-local
+        ]
+      end
+
+      it 'blocks all IPv6 private address ranges' do
+        ipv6_private_ips.each do |ip|
+          allow(Resolv).to receive(:getaddress).and_return(ip)
+
+          result = service.connect
+          expect(result).not_to be_success, "Expected #{ip} to be blocked"
+        end
+      end
+    end
+
+    describe 'IPv4-mapped IPv6 addresses' do
+      it 'blocks IPv4-mapped IPv6 loopback' do
+        allow(Resolv).to receive(:getaddress).and_return('::ffff:127.0.0.1')
+
+        result = service.connect
+        expect(result).not_to be_success
+        expect(result.error).to include('private IP')
+      end
+
+      it 'blocks IPv4-mapped IPv6 private addresses' do
+        allow(Resolv).to receive(:getaddress).and_return('::ffff:192.168.1.1')
+
+        result = service.connect
+        expect(result).not_to be_success
+      end
+    end
+
+    describe 'DNS rebinding prevention' do
+      it 'does not connect to MCP server when hostname resolves to private IP' do
+        allow(Resolv).to receive(:getaddress).and_return('10.0.0.1')
+
+        expect(MCPClient).not_to receive(:connect)
+        service.connect
+      end
+    end
+
     it 'allows public IP addresses' do
       allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
-      allow(MCPClient).to receive(:connect).and_return(instance_double(MockMcpClient, list_tools: []))
+      allow(MCPClient).to receive(:connect).and_return(instance_double(mock_mcp_client, list_tools: []))
 
       result = service.connect
       expect(result).to be_success
+    end
+  end
+
+  describe 'response size limits' do
+    let(:mock_client) { instance_double(mock_mcp_client, list_tools: []) }
+
+    before do
+      allow(Resolv).to receive(:getaddress).and_return('203.0.113.1')
+      allow(MCPClient).to receive(:connect).and_return(mock_client)
+    end
+
+    it 'returns response as-is when within size limit' do
+      allow(mock_client).to receive(:call_tool).and_return('Normal response')
+
+      result = service.call_tool('test_tool', {})
+      expect(result).to eq('Normal response')
+    end
+
+    it 'truncates responses exceeding MAX_RESPONSE_SIZE' do
+      oversized_text = 'x' * (described_class::MAX_RESPONSE_SIZE + 1000)
+      allow(mock_client).to receive(:call_tool).and_return(oversized_text)
+
+      result = service.call_tool('test_tool', {})
+      expect(result.bytesize).to eq(described_class::MAX_RESPONSE_SIZE)
+    end
+  end
+
+  describe 'audit logging' do
+    let(:mcp_server) { create(:captain_mcp_server, account: account) }
+
+    it 'creates audit record on create' do
+      expect(mcp_server.audits.count).to eq(1)
+      expect(mcp_server.audits.last.action).to eq('create')
+    end
+
+    it 'creates audit record on update' do
+      mcp_server.update!(name: 'Updated Server Name')
+      expect(mcp_server.audits.where(action: 'update').count).to eq(1)
+    end
+
+    it 'creates audit record on destroy' do
+      mcp_server.destroy!
+      expect(mcp_server.audits.where(action: 'destroy').count).to eq(1)
+    end
+
+    it 'excludes auth_config from audited changes' do
+      mcp_server.update!(auth_type: 'bearer', auth_config: { 'token' => 'secret_value' })
+      audit = mcp_server.audits.where(action: 'update').last
+
+      expect(audit.audited_changes.keys).not_to include('auth_config')
+    end
+  end
+
+  describe 'encryption', if: Chatwoot.respond_to?(:encryption_configured?) && Chatwoot.encryption_configured? do
+    it 'round-trips auth_config through encryption' do
+      config = { 'token' => 'my-secret-token', 'header_name' => 'Authorization' }
+      server = create(:captain_mcp_server, account: account, auth_type: 'bearer', auth_config: config)
+
+      server.reload
+      expect(server.auth_config).to eq(config)
     end
   end
 end

--- a/spec/enterprise/services/captain/mcp/discovery_service_spec.rb
+++ b/spec/enterprise/services/captain/mcp/discovery_service_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe Captain::Mcp::DiscoveryService do
+  let(:account) { create(:account) }
+  let(:mcp_server) { create(:captain_mcp_server, account: account) }
+  let(:service) { described_class.new(mcp_server) }
+
+  let(:mock_tools) do
+    [
+      {
+        'name' => 'search_docs',
+        'description' => 'Search documentation',
+        'inputSchema' => { 'type' => 'object', 'properties' => { 'query' => { 'type' => 'string' } } }
+      },
+      {
+        'name' => 'get_page',
+        'description' => 'Get a page by URL',
+        'inputSchema' => { 'type' => 'object', 'properties' => { 'url' => { 'type' => 'string' } } }
+      }
+    ]
+  end
+
+  describe '#connect_and_discover' do
+    let(:mock_client_service) { instance_double(Captain::Mcp::ClientService) }
+
+    before do
+      allow(Captain::Mcp::ClientService).to receive(:new).and_return(mock_client_service)
+    end
+
+    context 'when connection succeeds' do
+      before do
+        allow(mock_client_service).to receive(:connect).and_return(Captain::Mcp::ClientService::Result.success)
+        allow(mock_client_service).to receive(:list_tools).and_return(mock_tools)
+      end
+
+      it 'connects and discovers tools' do
+        result = service.connect_and_discover
+
+        expect(result).to eq(mock_tools)
+      end
+
+      it 'caches discovered tools on the server' do
+        service.connect_and_discover
+
+        expect(mcp_server.reload.cached_tools).to eq(mock_tools)
+      end
+
+      it 'updates cache_refreshed_at timestamp' do
+        freeze_time do
+          service.connect_and_discover
+          expect(mcp_server.reload.cache_refreshed_at).to eq(Time.current)
+        end
+      end
+    end
+
+    context 'when connection fails' do
+      before do
+        allow(mock_client_service).to receive(:connect)
+          .and_return(Captain::Mcp::ClientService::Result.failure('Connection refused'))
+      end
+
+      it 'raises ConnectionError' do
+        expect { service.connect_and_discover }.to raise_error(Captain::Mcp::ConnectionError, 'Connection refused')
+      end
+    end
+  end
+
+  describe '#refresh_tools' do
+    let(:mock_client_service) { instance_double(Captain::Mcp::ClientService) }
+
+    before do
+      allow(Captain::Mcp::ClientService).to receive(:new).and_return(mock_client_service)
+    end
+
+    context 'when list_tools succeeds' do
+      before do
+        allow(mock_client_service).to receive(:list_tools).and_return(mock_tools)
+      end
+
+      it 'returns discovered tools' do
+        result = service.refresh_tools
+        expect(result).to eq(mock_tools)
+      end
+
+      it 'updates cached_tools on server' do
+        service.refresh_tools
+        expect(mcp_server.reload.cached_tools).to eq(mock_tools)
+      end
+
+      it 'updates cache_refreshed_at' do
+        freeze_time do
+          service.refresh_tools
+          expect(mcp_server.reload.cache_refreshed_at).to eq(Time.current)
+        end
+      end
+    end
+
+    context 'when list_tools fails' do
+      before do
+        allow(mock_client_service).to receive(:list_tools).and_raise(StandardError.new('Network error'))
+      end
+
+      it 'raises MCP Error with context' do
+        expect { service.refresh_tools }.to raise_error(Captain::Mcp::Error, /Failed to discover tools/)
+      end
+
+      it 'logs the error' do
+        expect(Rails.logger).to receive(:error).with(/MCP tool discovery failed/)
+        expect { service.refresh_tools }.to raise_error(Captain::Mcp::Error)
+      end
+    end
+
+    context 'when server has existing cached tools' do
+      let(:mcp_server) { create(:captain_mcp_server, :connected, account: account) }
+
+      before do
+        allow(mock_client_service).to receive(:list_tools).and_return(mock_tools)
+      end
+
+      it 'replaces existing cached tools' do
+        old_tools = mcp_server.cached_tools
+        service.refresh_tools
+
+        expect(mcp_server.reload.cached_tools).to eq(mock_tools)
+        expect(mcp_server.cached_tools).not_to eq(old_tools)
+      end
+    end
+  end
+end

--- a/spec/factories/captain/assistant_mcp_servers.rb
+++ b/spec/factories/captain/assistant_mcp_servers.rb
@@ -1,0 +1,24 @@
+FactoryBot.define do
+  factory :captain_assistant_mcp_server, class: 'Captain::AssistantMcpServer' do
+    association :assistant, factory: :captain_assistant
+    association :mcp_server, factory: :captain_mcp_server
+    enabled { true }
+    tool_filters { {} }
+
+    trait :with_include_filter do
+      tool_filters { { 'include' => ['search_docs'] } }
+    end
+
+    trait :with_exclude_filter do
+      tool_filters { { 'exclude' => ['get_page'] } }
+    end
+
+    trait :with_both_filters do
+      tool_filters { { 'include' => %w[search_docs get_page], 'exclude' => ['get_page'] } }
+    end
+
+    trait :disabled do
+      enabled { false }
+    end
+  end
+end

--- a/spec/factories/captain/mcp_servers.rb
+++ b/spec/factories/captain/mcp_servers.rb
@@ -1,0 +1,63 @@
+FactoryBot.define do
+  factory :captain_mcp_server, class: 'Captain::McpServer' do
+    sequence(:name) { |n| "MCP Server #{n}" }
+    description { 'A test MCP server' }
+    url { 'https://mcp.example.com/api' }
+    auth_type { 'none' }
+    auth_config { {} }
+    enabled { true }
+    status { 'disconnected' }
+    association :account
+
+    trait :with_bearer_auth do
+      auth_type { 'bearer' }
+      auth_config { { 'token' => 'test_bearer_token_123' } }
+    end
+
+    trait :with_api_key do
+      auth_type { 'api_key' }
+      auth_config { { 'key' => 'test_api_key', 'header_name' => 'X-API-Key' } }
+    end
+
+    trait :connected do
+      status { 'connected' }
+      last_connected_at { Time.current }
+      cached_tools do
+        [
+          {
+            'name' => 'search_docs',
+            'description' => 'Search documentation',
+            'inputSchema' => {
+              'type' => 'object',
+              'properties' => {
+                'query' => { 'type' => 'string', 'description' => 'Search query' }
+              },
+              'required' => ['query']
+            }
+          },
+          {
+            'name' => 'get_page',
+            'description' => 'Get a specific page',
+            'inputSchema' => {
+              'type' => 'object',
+              'properties' => {
+                'url' => { 'type' => 'string', 'description' => 'Page URL' }
+              },
+              'required' => ['url']
+            }
+          }
+        ]
+      end
+      cache_refreshed_at { Time.current }
+    end
+
+    trait :with_error do
+      status { 'error' }
+      last_error { 'Connection refused' }
+    end
+
+    trait :disabled do
+      enabled { false }
+    end
+  end
+end


### PR DESCRIPTION
## Description

Add MCP (Model Context Protocol) server integration to Captain AI, enabling connection to external tool providers like Cloudflare, GitHub, and custom MCP servers.

This feature allows:
- Creating and managing MCP servers with various authentication methods (Bearer, API Key, Headers)
- Automatic discovery of available tools from connected MCP servers
- Attaching MCP servers to specific assistants with optional tool filtering
- Using MCP tools in scenarios and directly with the main assistant

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

### Automated Tests
- 132 RSpec tests covering models, controllers, and services
- Test files:
  - `spec/enterprise/models/captain/mcp_server_spec.rb` (36 tests)
  - `spec/enterprise/models/captain/assistant_mcp_server_spec.rb` (15 tests)
  - `spec/enterprise/controllers/api/v1/accounts/captain/mcp_servers_controller_spec.rb` (31 tests)
  - `spec/enterprise/controllers/api/v1/accounts/captain/assistants/mcp_servers_controller_spec.rb`
  - `spec/enterprise/services/captain/mcp/client_service_spec.rb` (21 tests)
  - `spec/enterprise/services/captain/mcp/discovery_service_spec.rb`

### Manual Testing
- [x] Create MCP server with bearer authentication
- [x] Connect to server and verify tool discovery
- [x] Attach server to assistant with tool filters
- [x] Create scenario using MCP tool
- [x] Verify tool execution in conversation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Key Changes

### Backend (Enterprise)
| File | Purpose |
|------|---------|
| `enterprise/app/models/captain/mcp_server.rb` | MCP server model with validation and SSRF protection |
| `enterprise/app/models/captain/assistant_mcp_server.rb` | Junction table for assistant-server relationship |
| `enterprise/app/models/concerns/mcp_toolable.rb` | Concern for building MCP tools |
| `enterprise/app/controllers/api/v1/accounts/captain/mcp_servers_controller.rb` | Account-level MCP server API |
| `enterprise/app/controllers/api/v1/accounts/captain/assistants/mcp_servers_controller.rb` | Assistant-level attachment API |
| `enterprise/app/services/captain/mcp/client_service.rb` | MCP client wrapper |
| `enterprise/app/services/captain/mcp/discovery_service.rb` | Tool discovery service |
| `enterprise/lib/captain/tools/mcp_tool.rb` | Dynamic tool class for MCP tools |

### Frontend
| File | Purpose |
|------|---------|
| `app/javascript/dashboard/store/captain/mcpServers.js` | Vuex store module |
| `app/javascript/dashboard/api/captain/mcpServers.js` | API client |
| `app/javascript/dashboard/components-next/captain/pageComponents/mcpServer/` | UI components |
| `app/javascript/dashboard/routes/dashboard/settings/captain/mcpServers/` | Settings page |

## Security Considerations

- SSRF protection via URL validation (blocks private IPs, localhost)
- Credentials are masked in API responses
- Feature flag `captain_mcp` controls availability