### PR TITLE
chore: temporarily disable `ProcessStaleContactsJob`

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -33,12 +33,13 @@ remove_stale_redis_keys_job.rb:
   class: 'Internal::RemoveStaleRedisKeysJob'
   queue: scheduled_jobs
 
-#executed daily at 0430 UTC
-# which will be IST 10:00 AM
-process_stale_contacts_job:
-  cron: '30 04 * * *'
-  class: 'Internal::ProcessStaleContactsJob'
-  queue: housekeeping
+# DISABLED: investigating if this job is the source of orphan conversations
+# #executed daily at 0430 UTC
+# # which will be IST 10:00 AM
+# process_stale_contacts_job:
+#   cron: '30 04 * * *'
+#   class: 'Internal::ProcessStaleContactsJob'
+#   queue: housekeeping
 
 # executed daily at 0100 UTC
 # to delete accounts marked for deletion


### PR DESCRIPTION
We've been seeing orphan conversations (conversations whose contact has been deleted) on high-frequency accounts. These orphans cause 500 errors when the API attempts to render conversation data, since the jbuilder partials expect a valid contact association.

The `ProcessStaleContactsJob` triggers `RemoveStaleContactsService`, which uses `delete_all` to remove contacts. While the query only selects contacts without conversations, `delete_all` bypasses ActiveRecord callbacks and does not re-verify at deletion time. We suspect this creates a window where a new conversation can be created for a contact between query evaluation and the actual delete, leaving the conversation orphaned. 

**This is unverified — disabling the job is the experiment to confirm or rule out this theory.**

This PR disables the job for a monitoring period. If orphan conversations stop appearing, we'll have confirmation and can work on a proper fix for the service. If they continue, we'll investigate other deletion paths.

Stale contacts will accumulate while the job is disabled, but this is a controlled tradeoff — they are inert records with no user-facing impact, and can be cleaned up in bulk once we re-enable or fix the job.
