### PR TITLE
fix(account-deletion): normalize deleted email suffix and handle collisions safely

### DIFF
--- a/app/services/account_deletion_service.rb
+++ b/app/services/account_deletion_service.rb
@@ -74,13 +74,14 @@ class AccountDeletionService
       return "#{truncated_email}#{suffix}"
     end
 
-    # Preserve @domain when truncating to stay within the column limit.
-    max_domain_length = [max_email_length - 2, 1].max
-    truncated_domain = domain.first(max_domain_length)
-    max_local_length = [max_email_length - truncated_domain.length - 1, 1].max
-    truncated_local = local_part.first(max_local_length)
+    available_local_length = max_email_length - domain.length - 1
+    if available_local_length.positive?
+      truncated_local = local_part.first(available_local_length)
+      return "#{truncated_local}@#{domain}#{suffix}"
+    end
 
-    "#{truncated_local}@#{truncated_domain}#{suffix}"
+    truncated_domain = domain.first([max_email_length - 2, 1].max)
+    "a@#{truncated_domain}#{suffix}"
   end
 
   def email_taken_by_other_user?(email, user_id)

--- a/app/services/account_deletion_service.rb
+++ b/app/services/account_deletion_service.rb
@@ -1,5 +1,5 @@
 class AccountDeletionService
-  SOFT_DELETE_EMAIL_DOMAIN = '@deleted.com'.freeze
+  SOFT_DELETE_EMAIL_DOMAIN = '@chatwoot-deleted.invalid'.freeze
 
   attr_reader :account, :soft_deleted_users
 
@@ -48,7 +48,7 @@ class AccountDeletionService
 
   def soft_deleted_email_for(user)
     loop do
-      candidate = "#{SecureRandom.uuid}#{SOFT_DELETE_EMAIL_DOMAIN}"
+      candidate = "deleted-user-#{user.id}-#{SecureRandom.hex(6)}#{SOFT_DELETE_EMAIL_DOMAIN}"
       return candidate unless email_taken_by_other_user?(candidate, user.id)
     end
   end

--- a/app/services/account_deletion_service.rb
+++ b/app/services/account_deletion_service.rb
@@ -1,6 +1,5 @@
 class AccountDeletionService
-  SOFT_DELETE_EMAIL_SUFFIX = '-deleted.com'.freeze
-  SOFT_DELETE_EMAIL_REGEX = /(?:-\d*deleted\.com)+\z/
+  SOFT_DELETE_EMAIL_DOMAIN = '@deleted.com'.freeze
 
   attr_reader :account, :soft_deleted_users
 
@@ -48,40 +47,10 @@ class AccountDeletionService
   end
 
   def soft_deleted_email_for(user)
-    original_email = normalized_email(user.email)
-    attempt = 0
-
     loop do
-      suffix = attempt.zero? ? SOFT_DELETE_EMAIL_SUFFIX : "-#{attempt}deleted.com"
-      candidate = email_with_suffix(original_email, suffix)
+      candidate = "#{SecureRandom.uuid}#{SOFT_DELETE_EMAIL_DOMAIN}"
       return candidate unless email_taken_by_other_user?(candidate, user.id)
-
-      attempt += 1
     end
-  end
-
-  def normalized_email(email)
-    email.to_s.sub(SOFT_DELETE_EMAIL_REGEX, '')
-  end
-
-  def email_with_suffix(email, suffix)
-    email_limit = User.columns_hash['email']&.limit || 255
-    max_email_length = email_limit - suffix.length
-    local_part, domain = email.to_s.split('@', 2)
-
-    if domain.blank?
-      truncated_email = local_part.to_s.first(max_email_length)
-      return "#{truncated_email}#{suffix}"
-    end
-
-    available_local_length = max_email_length - domain.length - 1
-    if available_local_length.positive?
-      truncated_local = local_part.first(available_local_length)
-      return "#{truncated_local}@#{domain}#{suffix}"
-    end
-
-    truncated_domain = domain.first([max_email_length - 2, 1].max)
-    "a@#{truncated_domain}#{suffix}"
   end
 
   def email_taken_by_other_user?(email, user_id)

--- a/app/services/account_deletion_service.rb
+++ b/app/services/account_deletion_service.rb
@@ -42,18 +42,11 @@ class AccountDeletionService
 
       soft_deleted_users << user_info
 
-      Rails.logger.info("Soft deleted user #{user.id} with email #{original_email}")
+      Rails.logger.info("Deleted user #{user.id} with email #{original_email}")
     end
   end
 
   def soft_deleted_email_for(user)
-    loop do
-      candidate = "deleted-user-#{user.id}-#{SecureRandom.hex(6)}#{SOFT_DELETE_EMAIL_DOMAIN}"
-      return candidate unless email_taken_by_other_user?(candidate, user.id)
-    end
-  end
-
-  def email_taken_by_other_user?(email, user_id)
-    User.where.not(id: user_id).exists?(email: email)
+    "#{user.id}#{SOFT_DELETE_EMAIL_DOMAIN}"
   end
 end

--- a/app/services/account_deletion_service.rb
+++ b/app/services/account_deletion_service.rb
@@ -42,7 +42,7 @@ class AccountDeletionService
 
       soft_deleted_users << user_info
 
-      Rails.logger.info("Deleted user #{user.id} with email #{original_email}")
+      Rails.logger.info("Soft deleted user #{user.id} with email #{original_email}")
     end
   end
 

--- a/app/services/account_deletion_service.rb
+++ b/app/services/account_deletion_service.rb
@@ -66,8 +66,21 @@ class AccountDeletionService
 
   def email_with_suffix(email, suffix)
     email_limit = User.columns_hash['email']&.limit || 255
-    truncated_email = email.to_s.first(email_limit - suffix.length)
-    "#{truncated_email}#{suffix}"
+    max_email_length = email_limit - suffix.length
+    local_part, domain = email.to_s.split('@', 2)
+
+    if domain.blank?
+      truncated_email = local_part.to_s.first(max_email_length)
+      return "#{truncated_email}#{suffix}"
+    end
+
+    # Preserve @domain when truncating to stay within the column limit.
+    max_domain_length = [max_email_length - 2, 1].max
+    truncated_domain = domain.first(max_domain_length)
+    max_local_length = [max_email_length - truncated_domain.length - 1, 1].max
+    truncated_local = local_part.first(max_local_length)
+
+    "#{truncated_local}@#{truncated_domain}#{suffix}"
   end
 
   def email_taken_by_other_user?(email, user_id)

--- a/app/services/account_deletion_service.rb
+++ b/app/services/account_deletion_service.rb
@@ -1,4 +1,7 @@
 class AccountDeletionService
+  SOFT_DELETE_EMAIL_SUFFIX = '-deleted.com'.freeze
+  SOFT_DELETE_EMAIL_REGEX = /(?:-\d*deleted\.com)+\z/
+
   attr_reader :account, :soft_deleted_users
 
   def initialize(account:)
@@ -25,15 +28,11 @@ class AccountDeletionService
 
   def soft_delete_orphaned_users
     account.users.each do |user|
-      # Find all account_users for this user excluding the current account
-      other_accounts = user.account_users.where.not(account_id: account.id).count
+      # Skip users who are still associated with another account.
+      next if user.account_users.where.not(account_id: account.id).exists?
 
-      # If user has no other accounts, soft delete them
-      next unless other_accounts.zero?
-
-      # Soft delete user by appending -deleted.com to email
       original_email = user.email
-      user.email = "#{original_email}-deleted.com"
+      user.email = soft_deleted_email_for(user)
       user.skip_reconfirmation!
       user.save!
 
@@ -46,5 +45,32 @@ class AccountDeletionService
 
       Rails.logger.info("Soft deleted user #{user.id} with email #{original_email}")
     end
+  end
+
+  def soft_deleted_email_for(user)
+    original_email = normalized_email(user.email)
+    attempt = 0
+
+    loop do
+      suffix = attempt.zero? ? SOFT_DELETE_EMAIL_SUFFIX : "-#{attempt}deleted.com"
+      candidate = email_with_suffix(original_email, suffix)
+      return candidate unless email_taken_by_other_user?(candidate, user.id)
+
+      attempt += 1
+    end
+  end
+
+  def normalized_email(email)
+    email.to_s.sub(SOFT_DELETE_EMAIL_REGEX, '')
+  end
+
+  def email_with_suffix(email, suffix)
+    email_limit = User.columns_hash['email']&.limit || 255
+    truncated_email = email.to_s.first(email_limit - suffix.length)
+    "#{truncated_email}#{suffix}"
+  end
+
+  def email_taken_by_other_user?(email, user_id)
+    User.where.not(id: user_id).exists?(email: email)
   end
 end

--- a/spec/services/account_deletion_service_spec.rb
+++ b/spec/services/account_deletion_service_spec.rb
@@ -46,19 +46,18 @@ RSpec.describe AccountDeletionService do
 
         # Reload the user to get the updated email
         user_with_one_account.reload
-        expect(user_with_one_account.email).to end_with('@chatwoot-deleted.invalid')
-        expect(user_with_one_account.email).to start_with("deleted-user-#{user_with_one_account.id}-")
+        expect(user_with_one_account.email).to eq("#{user_with_one_account.id}@chatwoot-deleted.invalid")
         expect(user_with_one_account.email).not_to eq(original_email)
       end
 
-      it 'retries with a new random email if generated one is already taken' do
-        create(:user, email: "deleted-user-#{user_with_one_account.id}-collision123abc@chatwoot-deleted.invalid")
-        allow(SecureRandom).to receive(:hex).with(6).and_return('collision123abc', 'unique456def')
+      it 'replaces previously mutated emails with deterministic deleted email' do
+        user_with_one_account.skip_reconfirmation!
+        user_with_one_account.update!(email: 'weird@example.com-deleted.com')
 
         described_class.new(account: account).perform
 
         user_with_one_account.reload
-        expect(user_with_one_account.email).to eq("deleted-user-#{user_with_one_account.id}-unique456def@chatwoot-deleted.invalid")
+        expect(user_with_one_account.email).to eq("#{user_with_one_account.id}@chatwoot-deleted.invalid")
       end
 
       it 'does not modify emails for users belonging to multiple accounts' do

--- a/spec/services/account_deletion_service_spec.rb
+++ b/spec/services/account_deletion_service_spec.rb
@@ -46,56 +46,18 @@ RSpec.describe AccountDeletionService do
 
         # Reload the user to get the updated email
         user_with_one_account.reload
-        expect(user_with_one_account.email).to eq("#{original_email}-deleted.com")
+        expect(user_with_one_account.email).to end_with('@deleted.com')
+        expect(user_with_one_account.email).not_to eq(original_email)
       end
 
-      it 'keeps only one deleted suffix when email already has deleted suffixes' do
-        original_email = user_with_one_account.email
-        user_with_one_account.update!(email: "#{original_email}-deleted.com-deleted.com")
+      it 'retries with a new random email if generated one is already taken' do
+        create(:user, email: 'existing@deleted.com')
+        allow(SecureRandom).to receive(:uuid).and_return('existing', 'unique')
 
         described_class.new(account: account).perform
 
         user_with_one_account.reload
-        expect(user_with_one_account.email).to eq("#{original_email}-deleted.com")
-      end
-
-      it 'appends numeric deleted suffix when deleted email is already taken' do
-        original_email = user_with_one_account.email
-        create(:user, email: "#{original_email}-deleted.com")
-        create(:user, email: "#{original_email}-1deleted.com")
-
-        described_class.new(account: account).perform
-
-        user_with_one_account.reload
-        expect(user_with_one_account.email).to eq("#{original_email}-2deleted.com")
-      end
-
-      it 'soft deletes long emails without exceeding the column length limit' do
-        email_limit = User.columns_hash['email']&.limit || 255
-        local_part = 'a' * 64
-        domain_prefix = 'b' * (email_limit - local_part.length - 5)
-        max_length_email = "#{local_part}@#{domain_prefix}.com"
-        user_with_one_account.skip_reconfirmation!
-        user_with_one_account.update!(email: max_length_email)
-
-        described_class.new(account: account).perform
-
-        user_with_one_account.reload
-        expect(user_with_one_account.email.length).to be <= email_limit
-        expect(user_with_one_account.email).to include('@')
-      end
-
-      it 'preserves the domain when truncating long local-part emails' do
-        email_limit = User.columns_hash['email']&.limit || 255
-        long_local_email = "#{'a' * 244}@x.com"
-        user_with_one_account.skip_reconfirmation!
-        user_with_one_account.update!(email: long_local_email)
-
-        described_class.new(account: account).perform
-
-        user_with_one_account.reload
-        expect(user_with_one_account.email.length).to be <= email_limit
-        expect(user_with_one_account.email).to end_with('@x.com-deleted.com')
+        expect(user_with_one_account.email).to eq('unique@deleted.com')
       end
 
       it 'does not modify emails for users belonging to multiple accounts' do

--- a/spec/services/account_deletion_service_spec.rb
+++ b/spec/services/account_deletion_service_spec.rb
@@ -46,18 +46,19 @@ RSpec.describe AccountDeletionService do
 
         # Reload the user to get the updated email
         user_with_one_account.reload
-        expect(user_with_one_account.email).to end_with('@deleted.com')
+        expect(user_with_one_account.email).to end_with('@chatwoot-deleted.invalid')
+        expect(user_with_one_account.email).to start_with("deleted-user-#{user_with_one_account.id}-")
         expect(user_with_one_account.email).not_to eq(original_email)
       end
 
       it 'retries with a new random email if generated one is already taken' do
-        create(:user, email: 'existing@deleted.com')
-        allow(SecureRandom).to receive(:uuid).and_return('existing', 'unique')
+        create(:user, email: "deleted-user-#{user_with_one_account.id}-collision123abc@chatwoot-deleted.invalid")
+        allow(SecureRandom).to receive(:hex).with(6).and_return('collision123abc', 'unique456def')
 
         described_class.new(account: account).perform
 
         user_with_one_account.reload
-        expect(user_with_one_account.email).to eq('unique@deleted.com')
+        expect(user_with_one_account.email).to eq("deleted-user-#{user_with_one_account.id}-unique456def@chatwoot-deleted.invalid")
       end
 
       it 'does not modify emails for users belonging to multiple accounts' do

--- a/spec/services/account_deletion_service_spec.rb
+++ b/spec/services/account_deletion_service_spec.rb
@@ -49,6 +49,41 @@ RSpec.describe AccountDeletionService do
         expect(user_with_one_account.email).to eq("#{original_email}-deleted.com")
       end
 
+      it 'keeps only one deleted suffix when email already has deleted suffixes' do
+        original_email = user_with_one_account.email
+        user_with_one_account.update!(email: "#{original_email}-deleted.com-deleted.com")
+
+        described_class.new(account: account).perform
+
+        user_with_one_account.reload
+        expect(user_with_one_account.email).to eq("#{original_email}-deleted.com")
+      end
+
+      it 'appends numeric deleted suffix when deleted email is already taken' do
+        original_email = user_with_one_account.email
+        create(:user, email: "#{original_email}-deleted.com")
+        create(:user, email: "#{original_email}-1deleted.com")
+
+        described_class.new(account: account).perform
+
+        user_with_one_account.reload
+        expect(user_with_one_account.email).to eq("#{original_email}-2deleted.com")
+      end
+
+      it 'soft deletes long emails without exceeding the column length limit' do
+        email_limit = User.columns_hash['email']&.limit || 255
+        local_part = 'a' * 64
+        domain_prefix = 'b' * (email_limit - local_part.length - 5)
+        max_length_email = "#{local_part}@#{domain_prefix}.com"
+        user_with_one_account.update!(email: max_length_email)
+
+        described_class.new(account: account).perform
+
+        user_with_one_account.reload
+        expect(user_with_one_account.email.length).to be <= email_limit
+        expect(user_with_one_account.email).to include('@')
+      end
+
       it 'does not modify emails for users belonging to multiple accounts' do
         original_email = user_with_multiple_accounts.email
 

--- a/spec/services/account_deletion_service_spec.rb
+++ b/spec/services/account_deletion_service_spec.rb
@@ -50,16 +50,6 @@ RSpec.describe AccountDeletionService do
         expect(user_with_one_account.email).not_to eq(original_email)
       end
 
-      it 'replaces previously mutated emails with deterministic deleted email' do
-        user_with_one_account.skip_reconfirmation!
-        user_with_one_account.update!(email: 'weird@example.com-deleted.com')
-
-        described_class.new(account: account).perform
-
-        user_with_one_account.reload
-        expect(user_with_one_account.email).to eq("#{user_with_one_account.id}@chatwoot-deleted.invalid")
-      end
-
       it 'does not modify emails for users belonging to multiple accounts' do
         original_email = user_with_multiple_accounts.email
 

--- a/spec/services/account_deletion_service_spec.rb
+++ b/spec/services/account_deletion_service_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe AccountDeletionService do
         local_part = 'a' * 64
         domain_prefix = 'b' * (email_limit - local_part.length - 5)
         max_length_email = "#{local_part}@#{domain_prefix}.com"
+        user_with_one_account.skip_reconfirmation!
         user_with_one_account.update!(email: max_length_email)
 
         described_class.new(account: account).perform
@@ -82,6 +83,19 @@ RSpec.describe AccountDeletionService do
         user_with_one_account.reload
         expect(user_with_one_account.email.length).to be <= email_limit
         expect(user_with_one_account.email).to include('@')
+      end
+
+      it 'preserves the domain when truncating long local-part emails' do
+        email_limit = User.columns_hash['email']&.limit || 255
+        long_local_email = "#{'a' * 244}@x.com"
+        user_with_one_account.skip_reconfirmation!
+        user_with_one_account.update!(email: long_local_email)
+
+        described_class.new(account: account).perform
+
+        user_with_one_account.reload
+        expect(user_with_one_account.email.length).to be <= email_limit
+        expect(user_with_one_account.email).to end_with('@x.com-deleted.com')
       end
 
       it 'does not modify emails for users belonging to multiple accounts' do


### PR DESCRIPTION
## Summary
This PR fixes account deletion failures by changing how orphaned user emails are rewritten during `AccountDeletionService`.

Ref: https://chatwoot-p3.sentry.io/issues/6715254765/events/e228a5d045ad47348d6c32448bc33b7a/

## Changes (develop -> this branch)
- Updated soft-delete email rewrite from:
  - `#{original_email}-deleted.com`
- To deterministic value:
  - `#{user.id}@chatwoot-deleted.invalid`
- Added reserved non-deliverable domain constant:
  - `@chatwoot-deleted.invalid`
- Replaced the "other accounts" check from `count.zero?` to `exists?` (same behavior, cheaper query).
- Updated service spec expectation to match deterministic email value and assert it differs from original email.

## Files changed
- `app/services/account_deletion_service.rb`
- `spec/services/account_deletion_service_spec.rb`

## How to verify
- Run: `bundle exec rspec spec/services/account_deletion_service_spec.rb`
- Run: `bundle exec rubocop app/services/account_deletion_service.rb spec/services/account_deletion_service_spec.rb`
