### PR TITLE
fix(messages): reduce audio transcription 400 retry noise

### DIFF
--- a/enterprise/app/jobs/messages/audio_transcription_job.rb
+++ b/enterprise/app/jobs/messages/audio_transcription_job.rb
@@ -10,10 +10,6 @@ class Messages::AudioTranscriptionJob < ApplicationJob
     }
 
     Rails.logger.warn("Discarding audio transcription job due to bad request: #{log_context}")
-
-    next unless defined?(NewRelic::Agent)
-
-    NewRelic::Agent.notice_error(error, custom_params: log_context)
   end
   retry_on ActiveStorage::FileNotFoundError, wait: 2.seconds, attempts: 3
 

--- a/enterprise/app/jobs/messages/audio_transcription_job.rb
+++ b/enterprise/app/jobs/messages/audio_transcription_job.rb
@@ -5,7 +5,6 @@ class Messages::AudioTranscriptionJob < ApplicationJob
     log_context = {
       attachment_id: job.arguments.first,
       job_id: job.job_id,
-      error_message: error.message,
       status_code: error.response&.dig(:status)
     }
 

--- a/enterprise/app/jobs/messages/audio_transcription_job.rb
+++ b/enterprise/app/jobs/messages/audio_transcription_job.rb
@@ -1,7 +1,11 @@
 class Messages::AudioTranscriptionJob < ApplicationJob
   queue_as :low
 
+  discard_on Faraday::BadRequestError
   retry_on ActiveStorage::FileNotFoundError, wait: 2.seconds, attempts: 3
+  retry_on Faraday::TimeoutError, wait: 2.seconds, attempts: 3
+  retry_on Faraday::ConnectionFailed, wait: 2.seconds, attempts: 3
+  retry_on Faraday::ServerError, wait: 2.seconds, attempts: 3
 
   def perform(attachment_id)
     attachment = Attachment.find_by(id: attachment_id)

--- a/enterprise/app/jobs/messages/audio_transcription_job.rb
+++ b/enterprise/app/jobs/messages/audio_transcription_job.rb
@@ -3,9 +3,6 @@ class Messages::AudioTranscriptionJob < ApplicationJob
 
   discard_on Faraday::BadRequestError
   retry_on ActiveStorage::FileNotFoundError, wait: 2.seconds, attempts: 3
-  retry_on Faraday::TimeoutError, wait: 2.seconds, attempts: 3
-  retry_on Faraday::ConnectionFailed, wait: 2.seconds, attempts: 3
-  retry_on Faraday::ServerError, wait: 2.seconds, attempts: 3
 
   def perform(attachment_id)
     attachment = Attachment.find_by(id: attachment_id)

--- a/enterprise/app/jobs/messages/audio_transcription_job.rb
+++ b/enterprise/app/jobs/messages/audio_transcription_job.rb
@@ -1,7 +1,20 @@
 class Messages::AudioTranscriptionJob < ApplicationJob
   queue_as :low
 
-  discard_on Faraday::BadRequestError
+  discard_on Faraday::BadRequestError do |job, error|
+    log_context = {
+      attachment_id: job.arguments.first,
+      job_id: job.job_id,
+      error_message: error.message,
+      status_code: error.response&.dig(:status)
+    }
+
+    Rails.logger.warn("Discarding audio transcription job due to bad request: #{log_context}")
+
+    next unless defined?(NewRelic::Agent)
+
+    NewRelic::Agent.notice_error(error, custom_params: log_context)
+  end
   retry_on ActiveStorage::FileNotFoundError, wait: 2.seconds, attempts: 3
 
   def perform(attachment_id)

--- a/enterprise/app/services/messages/audio_transcription_service.rb
+++ b/enterprise/app/services/messages/audio_transcription_service.rb
@@ -2,8 +2,6 @@ class Messages::AudioTranscriptionService< Llm::LegacyBaseOpenAiService
   include Integrations::LlmInstrumentation
 
   WHISPER_MODEL = 'whisper-1'.freeze
-  MAX_TRANSCRIPTION_FILE_SIZE = 25.megabytes
-  SUPPORTED_AUDIO_EXTENSIONS = %w[flac mp3 mp4 m4a mpeg mpga oga ogg wav webm].freeze
 
   attr_reader :attachment, :message, :account
 
@@ -50,8 +48,6 @@ class Messages::AudioTranscriptionService< Llm::LegacyBaseOpenAiService
     transcribed_text = attachment.meta&.[]('transcribed_text') || ''
     return transcribed_text if transcribed_text.present?
 
-    return '' unless transcription_input_valid?
-
     temp_file_path = fetch_audio_file
     transcribed_text = transcribe_with_openai(temp_file_path)
     return '' if transcribed_text.blank?
@@ -75,7 +71,7 @@ class Messages::AudioTranscriptionService< Llm::LegacyBaseOpenAiService
   def update_transcription(transcribed_text)
     return if transcribed_text.blank?
 
-    attachment.update!(meta: attachment_meta.merge('transcribed_text' => transcribed_text).except('transcription_error'))
+    attachment.update!(meta: { transcribed_text: transcribed_text })
     message.reload.send_update_event
     message.account.increment_response_usage
 
@@ -97,70 +93,17 @@ class Messages::AudioTranscriptionService< Llm::LegacyBaseOpenAiService
       response['text']
     end
   rescue Faraday::BadRequestError => e
-    handle_transcription_bad_request(e)
+    Rails.logger.warn("Audio transcription request failed with bad request: #{bad_request_log_context(e)}")
     nil
   end
 
-  def transcription_input_valid?
-    return unsupported_input('missing_file') if audio_blob.blank?
-    return unsupported_input('unsupported_format') unless supported_audio_format?
-    return unsupported_input('file_too_large') unless supported_audio_size?
-
-    true
-  end
-
-  def supported_audio_format?
-    extension = audio_blob.filename.extension_without_delimiter.to_s.downcase
-    return SUPPORTED_AUDIO_EXTENSIONS.include?(extension) if extension.present?
-
-    audio_blob.content_type.to_s.start_with?('audio/')
-  end
-
-  def supported_audio_size?
-    audio_blob.byte_size <= MAX_TRANSCRIPTION_FILE_SIZE
-  end
-
-  def unsupported_input(error_code)
-    persist_transcription_error(error_code)
-    Rails.logger.info("Audio transcription skipped for unsupported input: #{transcription_log_context(error_code: error_code)}")
-    false
-  end
-
-  def handle_transcription_bad_request(error)
-    status_code = error.response&.dig(:status)
-    response_body = error.response&.dig(:body).to_s
-    persist_transcription_error('upstream_bad_request')
-    log_context = transcription_log_context(
-      error_code: 'upstream_bad_request',
-      status_code: status_code,
-      response_body: response_body.truncate(500),
-      error_message: error.message
-    )
-
-    Rails.logger.warn("Audio transcription request failed with bad request: #{log_context}")
-  end
-
-  def persist_transcription_error(error_code)
-    attachment.update(meta: attachment_meta.merge('transcription_error' => error_code))
-  end
-
-  def attachment_meta
-    attachment.meta.is_a?(Hash) ? attachment.meta : {}
-  end
-
-  def audio_blob
-    attachment.file&.blob
-  end
-
-  def transcription_log_context(extra = {})
+  def bad_request_log_context(error)
     {
       attachment_id: attachment.id,
       message_id: message&.id,
       account_id: account&.id,
-      filename: audio_blob&.filename&.to_s,
-      content_type: audio_blob&.content_type,
-      byte_size: audio_blob&.byte_size,
-      endpoint: uri_base
-    }.merge(extra)
+      status_code: error.response&.dig(:status),
+      error_message: error.message
+    }
   end
 end

--- a/enterprise/app/services/messages/audio_transcription_service.rb
+++ b/enterprise/app/services/messages/audio_transcription_service.rb
@@ -2,6 +2,8 @@ class Messages::AudioTranscriptionService< Llm::LegacyBaseOpenAiService
   include Integrations::LlmInstrumentation
 
   WHISPER_MODEL = 'whisper-1'.freeze
+  MAX_TRANSCRIPTION_FILE_SIZE = 25.megabytes
+  SUPPORTED_AUDIO_EXTENSIONS = %w[flac mp3 mp4 m4a mpeg mpga oga ogg wav webm].freeze
 
   attr_reader :attachment, :message, :account
 
@@ -48,25 +50,16 @@ class Messages::AudioTranscriptionService< Llm::LegacyBaseOpenAiService
     transcribed_text = attachment.meta&.[]('transcribed_text') || ''
     return transcribed_text if transcribed_text.present?
 
+    return '' unless transcription_input_valid?
+
     temp_file_path = fetch_audio_file
-
-    transcribed_text = nil
-
-    File.open(temp_file_path, 'rb') do |file|
-      response = @client.audio.transcribe(
-        parameters: {
-          model: 'whisper-1',
-          file: file,
-          temperature: 0.4
-        }
-      )
-      transcribed_text = response['text']
-    end
-
-    FileUtils.rm_f(temp_file_path)
+    transcribed_text = transcribe_with_openai(temp_file_path)
+    return '' if transcribed_text.blank?
 
     update_transcription(transcribed_text)
     transcribed_text
+  ensure
+    FileUtils.rm_f(temp_file_path) if temp_file_path.present?
   end
 
   def instrumentation_params(file_path)
@@ -82,12 +75,90 @@ class Messages::AudioTranscriptionService< Llm::LegacyBaseOpenAiService
   def update_transcription(transcribed_text)
     return if transcribed_text.blank?
 
-    attachment.update!(meta: { transcribed_text: transcribed_text })
+    attachment.update!(meta: attachment_meta.merge('transcribed_text' => transcribed_text).except('transcription_error'))
     message.reload.send_update_event
     message.account.increment_response_usage
 
     return unless ChatwootApp.advanced_search_allowed?
 
     message.reindex
+  end
+
+  def transcribe_with_openai(temp_file_path)
+    File.open(temp_file_path, 'rb') do |file|
+      response = @client.audio.transcribe(
+        parameters: {
+          model: WHISPER_MODEL,
+          file: file,
+          temperature: 0.4
+        }
+      )
+
+      response['text']
+    end
+  rescue Faraday::BadRequestError => e
+    handle_transcription_bad_request(e)
+    nil
+  end
+
+  def transcription_input_valid?
+    return unsupported_input('missing_file') if audio_blob.blank?
+    return unsupported_input('unsupported_format') unless supported_audio_format?
+    return unsupported_input('file_too_large') unless supported_audio_size?
+
+    true
+  end
+
+  def supported_audio_format?
+    extension = audio_blob.filename.extension_without_delimiter.to_s.downcase
+    SUPPORTED_AUDIO_EXTENSIONS.include?(extension)
+  end
+
+  def supported_audio_size?
+    audio_blob.byte_size <= MAX_TRANSCRIPTION_FILE_SIZE
+  end
+
+  def unsupported_input(error_code)
+    persist_transcription_error(error_code)
+    Rails.logger.info("Audio transcription skipped for unsupported input: #{transcription_log_context(error_code: error_code)}")
+    false
+  end
+
+  def handle_transcription_bad_request(error)
+    status_code = error.response&.dig(:status)
+    response_body = error.response&.dig(:body).to_s
+    persist_transcription_error('upstream_bad_request')
+    log_context = transcription_log_context(
+      error_code: 'upstream_bad_request',
+      status_code: status_code,
+      response_body: response_body.truncate(500),
+      error_message: error.message
+    )
+
+    Rails.logger.warn("Audio transcription request failed with bad request: #{log_context}")
+  end
+
+  def persist_transcription_error(error_code)
+    attachment.update(meta: attachment_meta.merge('transcription_error' => error_code))
+  end
+
+  def attachment_meta
+    attachment.meta.is_a?(Hash) ? attachment.meta : {}
+  end
+
+  def audio_blob
+    attachment.file&.blob
+  end
+
+  def transcription_log_context(extra = {})
+    {
+      attachment_id: attachment.id,
+      message_id: message&.id,
+      account_id: account&.id,
+      filename: audio_blob&.filename&.to_s,
+      content_type: audio_blob&.content_type,
+      byte_size: audio_blob&.byte_size,
+      endpoint: uri_base
+    }.merge(extra)
   end
 end

--- a/enterprise/app/services/messages/audio_transcription_service.rb
+++ b/enterprise/app/services/messages/audio_transcription_service.rb
@@ -111,7 +111,9 @@ class Messages::AudioTranscriptionService< Llm::LegacyBaseOpenAiService
 
   def supported_audio_format?
     extension = audio_blob.filename.extension_without_delimiter.to_s.downcase
-    SUPPORTED_AUDIO_EXTENSIONS.include?(extension)
+    return SUPPORTED_AUDIO_EXTENSIONS.include?(extension) if extension.present?
+
+    audio_blob.content_type.to_s.start_with?('audio/')
   end
 
   def supported_audio_size?

--- a/enterprise/app/services/messages/audio_transcription_service.rb
+++ b/enterprise/app/services/messages/audio_transcription_service.rb
@@ -31,12 +31,20 @@ class Messages::AudioTranscriptionService< Llm::LegacyBaseOpenAiService
   end
 
   def fetch_audio_file
+    blob = attachment.file.blob
     temp_dir = Rails.root.join('tmp/uploads/audio-transcriptions')
     FileUtils.mkdir_p(temp_dir)
-    temp_file_path = File.join(temp_dir, "#{attachment.file.blob.key}-#{attachment.file.filename}")
+    temp_file_name = "#{blob.key}-#{blob.filename}"
+
+    if blob.filename.extension_without_delimiter.blank?
+      extension = extension_from_content_type(blob.content_type)
+      temp_file_name = "#{temp_file_name}.#{extension}" if extension.present?
+    end
+
+    temp_file_path = File.join(temp_dir, temp_file_name)
 
     File.open(temp_file_path, 'wb') do |file|
-      attachment.file.blob.open do |blob_file|
+      blob.open do |blob_file|
         IO.copy_stream(blob_file, file)
       end
     end
@@ -88,5 +96,16 @@ class Messages::AudioTranscriptionService< Llm::LegacyBaseOpenAiService
     return unless ChatwootApp.advanced_search_allowed?
 
     message.reindex
+  end
+
+  def extension_from_content_type(content_type)
+    subtype = content_type.to_s.downcase.split(';').first.to_s.split('/').last.to_s
+    return if subtype.blank?
+
+    {
+      'x-m4a' => 'm4a',
+      'x-wav' => 'wav',
+      'x-mp3' => 'mp3'
+    }.fetch(subtype, subtype)
   end
 end

--- a/enterprise/app/services/messages/audio_transcription_service.rb
+++ b/enterprise/app/services/messages/audio_transcription_service.rb
@@ -49,8 +49,18 @@ class Messages::AudioTranscriptionService< Llm::LegacyBaseOpenAiService
     return transcribed_text if transcribed_text.present?
 
     temp_file_path = fetch_audio_file
-    transcribed_text = transcribe_with_openai(temp_file_path)
-    return '' if transcribed_text.blank?
+    transcribed_text = nil
+
+    File.open(temp_file_path, 'rb') do |file|
+      response = @client.audio.transcribe(
+        parameters: {
+          model: WHISPER_MODEL,
+          file: file,
+          temperature: 0.4
+        }
+      )
+      transcribed_text = response['text']
+    end
 
     update_transcription(transcribed_text)
     transcribed_text
@@ -78,32 +88,5 @@ class Messages::AudioTranscriptionService< Llm::LegacyBaseOpenAiService
     return unless ChatwootApp.advanced_search_allowed?
 
     message.reindex
-  end
-
-  def transcribe_with_openai(temp_file_path)
-    File.open(temp_file_path, 'rb') do |file|
-      response = @client.audio.transcribe(
-        parameters: {
-          model: WHISPER_MODEL,
-          file: file,
-          temperature: 0.4
-        }
-      )
-
-      response['text']
-    end
-  rescue Faraday::BadRequestError => e
-    Rails.logger.warn("Audio transcription request failed with bad request: #{bad_request_log_context(e)}")
-    nil
-  end
-
-  def bad_request_log_context(error)
-    {
-      attachment_id: attachment.id,
-      message_id: message&.id,
-      account_id: account&.id,
-      status_code: error.response&.dig(:status),
-      error_message: error.message
-    }
   end
 end


### PR DESCRIPTION
## Summary
This PR reduces duplicate failure noise for audio transcription jobs that fail with permanent HTTP 400 responses, and fixes a file-format edge case causing intermittent 400s.

Sentry issue: [CHATWOOT-99E / 6660541334](https://chatwoot-p3.sentry.io/issues/6660541334/)

## Confirmed root cause
For some attachments, the stored filename had no extension (example: `speech`, content type `audio/mpeg`).
When the temporary transcription upload file was created without an extension, OpenAI returned:
`Unrecognized file format` (HTTP 400).

## Scope of changes
1. `Messages::AudioTranscriptionJob`
- Keeps `discard_on Faraday::BadRequestError` to avoid retry storms on permanent request errors.
- Adds explicit Rails warning logs for discarded jobs with attachment/job/status context.

2. `Messages::AudioTranscriptionService`
- Keeps guaranteed temp file cleanup via `ensure`.
- Ensures temp upload files include an extension when the original filename has none, derived from blob `content_type`.
  - This addresses intermittent failures like extensionless `audio/mpeg` files.

## Reproduction
Enable audio transcription for an account and process an audio attachment whose stored filename has no extension (for example `speech`) but valid audio content type (`audio/mpeg`).
Before this fix, OpenAI transcription could return HTTP 400 `Unrecognized file format` for that attachment while similar attachments with extensions succeeded.

## Testing
Ran:
`bundle exec rubocop enterprise/app/jobs/messages/audio_transcription_job.rb enterprise/app/services/messages/audio_transcription_service.rb`

Result: both modified files pass lint with no offenses.
