### PR TITLE
fix: default model for captain assistant

### DIFF
--- a/lib/llm_constants.rb
+++ b/lib/llm_constants.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module LlmConstants
-  DEFAULT_MODEL = 'gpt-4.1-mini'
+  DEFAULT_MODEL = 'gpt-4.1'
   DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small'
   PDF_PROCESSING_MODEL = 'gpt-4.1-mini'
 

--- a/spec/enterprise/models/concerns/agentable_spec.rb
+++ b/spec/enterprise/models/concerns/agentable_spec.rb
@@ -144,13 +144,13 @@ RSpec.describe Concerns::Agentable do
     it 'returns default model when config not found' do
       allow(InstallationConfig).to receive(:find_by).and_return(nil)
 
-      expect(dummy_instance.send(:agent_model)).to eq('gpt-4.1-mini')
+      expect(dummy_instance.send(:agent_model)).to eq('gpt-4.1')
     end
 
     it 'returns default model when config value is nil' do
       allow(mock_installation_config).to receive(:value).and_return(nil)
 
-      expect(dummy_instance.send(:agent_model)).to eq('gpt-4.1-mini')
+      expect(dummy_instance.send(:agent_model)).to eq('gpt-4.1')
     end
   end
 


### PR DESCRIPTION
# Pull Request Template

## Description

For self-hosted users, the default captain assistant model is `gpt-4.1-mini`. It struggles with JSON generation when coupled with tool calls. 
The idea is captain (v1 and v2 both) assistants should use gpt-4.1 for now

Fixes #13213


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
