### PR TITLE
fix: Wrong assignee displayed after switching conversations

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBoxBanner.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBoxBanner.vue
@@ -31,7 +31,10 @@ const assignedAgent = computed({
   },
   set(agent) {
     const agentId = agent ? agent.id : null;
-    store.dispatch('setCurrentChatAssignee', agent);
+    store.dispatch('setCurrentChatAssignee', {
+      conversationId: currentChat.value?.id,
+      assignee: agent,
+    });
     store.dispatch('assignAgent', {
       conversationId: currentChat.value?.id,
       agentId,

--- a/app/javascript/dashboard/routes/dashboard/conversation/ConversationAction.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ConversationAction.vue
@@ -85,7 +85,10 @@ export default {
       },
       set(agent) {
         const agentId = agent ? agent.id : null;
-        this.$store.dispatch('setCurrentChatAssignee', agent);
+        this.$store.dispatch('setCurrentChatAssignee', {
+          conversationId: this.currentChat.id,
+          assignee: agent,
+        });
         this.$store
           .dispatch('assignAgent', {
             conversationId: this.currentChat.id,

--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -212,14 +212,17 @@ const actions = {
         conversationId,
         agentId,
       });
-      dispatch('setCurrentChatAssignee', response.data);
+      dispatch('setCurrentChatAssignee', {
+        conversationId,
+        assignee: response.data,
+      });
     } catch (error) {
       // Handle error
     }
   },
 
-  setCurrentChatAssignee({ commit }, assignee) {
-    commit(types.ASSIGN_AGENT, assignee);
+  setCurrentChatAssignee({ commit }, { conversationId, assignee }) {
+    commit(types.ASSIGN_AGENT, { conversationId, assignee });
   },
 
   assignTeam: async ({ dispatch }, { conversationId, teamId }) => {

--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -276,7 +276,7 @@ export const mutations = {
 
   // Update assignee on action cable message
   [types.UPDATE_ASSIGNEE](_state, payload) {
-    const [chat] = _state.allConversations.filter(c => c.id === payload.id);
+    const chat = getConversationById(_state)(payload.id);
     if (chat) {
       chat.meta.assignee = payload.assignee;
     }

--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -98,7 +98,7 @@ export const mutations = {
   },
 
   [types.ASSIGN_AGENT](_state, { conversationId, assignee }) {
-    const [chat] = _state.allConversations.filter(c => c.id === conversationId);
+    const chat = getConversationById(_state)(conversationId);
     if (chat) {
       chat.meta.assignee = assignee;
     }

--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -97,9 +97,11 @@ export const mutations = {
     }
   },
 
-  [types.ASSIGN_AGENT](_state, assignee) {
-    const [chat] = getSelectedChatConversation(_state);
-    chat.meta.assignee = assignee;
+  [types.ASSIGN_AGENT](_state, { conversationId, assignee }) {
+    const [chat] = _state.allConversations.filter(c => c.id === conversationId);
+    if (chat) {
+      chat.meta.assignee = assignee;
+    }
   },
 
   [types.ASSIGN_TEAM](_state, { team, conversationId }) {
@@ -275,7 +277,9 @@ export const mutations = {
   // Update assignee on action cable message
   [types.UPDATE_ASSIGNEE](_state, payload) {
     const [chat] = _state.allConversations.filter(c => c.id === payload.id);
-    chat.meta.assignee = payload.assignee;
+    if (chat) {
+      chat.meta.assignee = payload.assignee;
+    }
   },
 
   [types.UPDATE_CONVERSATION_CONTACT](_state, { conversationId, ...payload }) {

--- a/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
@@ -355,22 +355,26 @@ describe('#actions', () => {
       axios.post.mockResolvedValue({
         data: { id: 1, name: 'User' },
       });
-      await actions.assignAgent({ commit }, { conversationId: 1, agentId: 1 });
-      expect(commit).toHaveBeenCalledTimes(0);
-      expect(commit.mock.calls).toEqual([]);
+      await actions.assignAgent(
+        { dispatch },
+        { conversationId: 1, agentId: 1 }
+      );
+      expect(dispatch).toHaveBeenCalledWith('setCurrentChatAssignee', {
+        conversationId: 1,
+        assignee: { id: 1, name: 'User' },
+      });
     });
   });
 
   describe('#setCurrentChatAssignee', () => {
     it('sends correct mutations if assignment is successful', async () => {
-      axios.post.mockResolvedValue({
-        data: { id: 1, name: 'User' },
-      });
-      await actions.setCurrentChatAssignee({ commit }, { id: 1, name: 'User' });
+      const payload = {
+        conversationId: 1,
+        assignee: { id: 1, name: 'User' },
+      };
+      await actions.setCurrentChatAssignee({ commit }, payload);
       expect(commit).toHaveBeenCalledTimes(1);
-      expect(commit.mock.calls).toEqual([
-        ['ASSIGN_AGENT', { id: 1, name: 'User' }],
-      ]);
+      expect(commit.mock.calls).toEqual([['ASSIGN_AGENT', payload]]);
     });
   });
 

--- a/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
@@ -640,15 +640,22 @@ describe('#mutations', () => {
   });
 
   describe('#ASSIGN_AGENT', () => {
-    it('should assign agent to selected conversation', () => {
+    it('should assign agent to the correct conversation by ID', () => {
       const assignee = { id: 1, name: 'Agent' };
       const state = {
-        allConversations: [{ id: 1, meta: {} }],
-        selectedChatId: 1,
+        allConversations: [
+          { id: 1, meta: {} },
+          { id: 2, meta: {} },
+        ],
+        selectedChatId: 2,
       };
 
-      mutations[types.ASSIGN_AGENT](state, assignee);
+      mutations[types.ASSIGN_AGENT](state, {
+        conversationId: 1,
+        assignee,
+      });
       expect(state.allConversations[0].meta.assignee).toEqual(assignee);
+      expect(state.allConversations[1].meta.assignee).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
# Pull Request Template

## Description

### Issue
When a user assigns an agent to conversation A and quickly navigates to conversation B, conversation B incorrectly displays the assignee from conversation A instead of its own (unassigned) state.

### Root Cause
The `ASSIGN_AGENT` mutation used `getSelectedChatConversation(_state)` which resolves based on `selectedChatId` — whichever conversation is currently open. When the async API response from conversation A's assignment arrives after the user has already switched to conversation B, the mutation targets B instead of A.

### Solution
Changed `ASSIGN_AGENT` mutation to accept { conversationId, assignee } and look up the conversation by ID directly, consistent with how ASSIGN_TEAM already works.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Before**
https://www.loom.com/share/235a95385b9249368a5688db862a19d0

**After**
https://www.loom.com/share/c742bf66a8af45bf84eb8e65a1035dff

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
