### PR TITLE
fix(email): scope conversation threading by contact for bulk/newsletter replies

### DIFF
--- a/app/mailboxes/imap/imap_mailbox.rb
+++ b/app/mailboxes/imap/imap_mailbox.rb
@@ -44,9 +44,13 @@ class Imap::ImapMailbox
 
     message = @inbox.messages.find_by(source_id: in_reply_to)
     if message.nil?
-      @inbox.conversations.find_by("additional_attributes->>'in_reply_to' = ?", in_reply_to)
+      conversations = @inbox.conversations.where("additional_attributes->>'in_reply_to' = ?", in_reply_to)
+      conversations = conversations.where(contact_id: @contact.id) if @account.feature_enabled?('email_thread_contact_scoping')
+      conversations.first
     else
-      @inbox.conversations.find(message.conversation_id)
+      conversation = @inbox.conversations.find_by(id: message.conversation_id)
+      return nil if conversation && @account.feature_enabled?('email_thread_contact_scoping') && conversation.contact_id != @contact.id
+      conversation
     end
   end
 
@@ -56,12 +60,19 @@ class Imap::ImapMailbox
     message = find_message_by_references
     if message.present?
       conversation = @inbox.conversations.find_by(id: message.conversation_id)
-      return conversation if conversation.present?
+      if conversation.present?
+        return nil if @account.feature_enabled?('email_thread_contact_scoping') && conversation.contact_id != @contact.id
+        return conversation
+      end
     end
 
     # FALLBACK_PATTERN use to find a conversation that is started by an agent (no incoming message yet)
     conversation_id = find_conversation_by_references
-    @inbox.conversations.find_by(uuid: conversation_id) if conversation_id.present?
+    if conversation_id.present?
+      conversation = @inbox.conversations.find_by(uuid: conversation_id)
+      return nil if conversation && @account.feature_enabled?('email_thread_contact_scoping') && conversation.contact_id != @contact.id
+      conversation
+    end
   end
 
   def in_reply_to

--- a/app/services/mailbox/conversation_finder_strategies/new_conversation_strategy.rb
+++ b/app/services/mailbox/conversation_finder_strategies/new_conversation_strategy.rb
@@ -24,12 +24,14 @@ class Mailbox::ConversationFinderStrategies::NewConversationStrategy < Mailbox::
     return nil unless @channel # No valid channel found
     return nil unless incoming_email_from_valid_email? # Skip edge cases
 
+    # Resolve contact first so we can scope conversation lookup by contact
+    find_or_create_contact
+
     # Check if conversation already exists by in_reply_to
     existing_conversation = find_conversation_by_in_reply_to
     return existing_conversation if existing_conversation
 
-    # Prepare contact (persisted) and build conversation (not persisted)
-    find_or_create_contact
+    # Build conversation (not persisted)
     build_conversation
   end
 
@@ -78,6 +80,8 @@ class Mailbox::ConversationFinderStrategies::NewConversationStrategy < Mailbox::
   def find_conversation_by_in_reply_to
     return if in_reply_to.blank?
 
-    @account.conversations.where("additional_attributes->>'in_reply_to' = ?", in_reply_to).first
+    conversations = @account.conversations.where("additional_attributes->>'in_reply_to' = ?", in_reply_to)
+    conversations = conversations.where(contact_id: @contact.id) if @account.feature_enabled?('email_thread_contact_scoping')
+    conversations.first
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -241,3 +241,6 @@
   display_name: Required Conversation Attributes
   enabled: false
   premium: true
+- name: email_thread_contact_scoping
+  display_name: Email Thread Contact Scoping
+  enabled: false

--- a/spec/mailboxes/imap/imap_mailbox_spec.rb
+++ b/spec/mailboxes/imap/imap_mailbox_spec.rb
@@ -289,6 +289,124 @@ RSpec.describe Imap::ImapMailbox do
       end
     end
 
+    context 'when email_thread_contact_scoping is enabled' do
+      let(:channel_account) { channel.account }
+      let!(:contact_a) { create(:contact, email: 'contact_a@gmail.com', account: channel_account) }
+      let!(:contact_b) { create(:contact, email: 'contact_b@gmail.com', account: channel_account) }
+
+      before do
+        create(:contact_inbox, contact: contact_a, inbox: inbox)
+        create(:contact_inbox, contact: contact_b, inbox: inbox)
+        channel_account.enable_features!('email_thread_contact_scoping')
+      end
+
+      context 'when different contacts reply to the same in_reply_to thread' do
+        let!(:existing_conversation) do
+          create(:conversation, account: channel_account, inbox: inbox, contact: contact_a,
+                                additional_attributes: { 'in_reply_to' => 'newsletter-message-id@example.com', 'source' => 'email' })
+        end
+
+        it 'creates a new conversation for a different contact' do
+          reply_from_b = create_inbound_email_from_mail(
+            from: 'contact_b@gmail.com', to: inbox.channel.email, subject: 'Re: Newsletter',
+            in_reply_to: 'newsletter-message-id@example.com'
+          )
+
+          expect do
+            class_instance.process(reply_from_b.mail, channel)
+          end.to change(Conversation, :count).by(1)
+
+          new_conversation = Conversation.last
+          expect(new_conversation.id).not_to eq(existing_conversation.id)
+          expect(new_conversation.contact_id).to eq(contact_b.id)
+        end
+
+        it 'appends to the existing conversation for the same contact' do
+          reply_from_a = create_inbound_email_from_mail(
+            from: 'contact_a@gmail.com', to: inbox.channel.email, subject: 'Re: Newsletter',
+            in_reply_to: 'newsletter-message-id@example.com'
+          )
+
+          expect do
+            class_instance.process(reply_from_a.mail, channel)
+          end.not_to change(Conversation, :count)
+
+          expect(existing_conversation.reload.messages.count).to eq(1)
+        end
+      end
+
+      context 'when different contacts reply to a thread matched by message source_id' do
+        let!(:existing_conversation) do
+          create(:conversation, account: channel_account, inbox: inbox, contact: contact_a)
+        end
+        let!(:outgoing_message) do
+          create(:message, conversation: existing_conversation, inbox: inbox, account: channel_account,
+                           message_type: 'outgoing', source_id: 'outgoing-msg-id@example.com')
+        end
+
+        it 'creates a new conversation for a different contact' do
+          reply_from_b = create_inbound_email_from_mail(
+            from: 'contact_b@gmail.com', to: inbox.channel.email, subject: 'Re: Hello',
+            in_reply_to: 'outgoing-msg-id@example.com'
+          )
+
+          expect do
+            class_instance.process(reply_from_b.mail, channel)
+          end.to change(Conversation, :count).by(1)
+        end
+      end
+
+      context 'when different contacts reply to a thread matched by references' do
+        let!(:existing_conversation) do
+          create(:conversation, account: channel_account, inbox: inbox, contact: contact_a)
+        end
+        let!(:referenced_message) do
+          create(:message, conversation: existing_conversation, inbox: inbox, account: channel_account,
+                           message_type: 'outgoing', source_id: 'ref-msg-id@example.com')
+        end
+
+        it 'creates a new conversation for a different contact' do
+          reply_from_b = create_inbound_email_from_mail(
+            from: 'contact_b@gmail.com', to: inbox.channel.email, subject: 'Re: Hello',
+            references: ['ref-msg-id@example.com']
+          )
+
+          expect do
+            class_instance.process(reply_from_b.mail, channel)
+          end.to change(Conversation, :count).by(1)
+        end
+      end
+    end
+
+    context 'when email_thread_contact_scoping is disabled' do
+      let(:channel_account) { channel.account }
+      let!(:contact_a) { create(:contact, email: 'contact_a@gmail.com', account: channel_account) }
+      let!(:contact_b) { create(:contact, email: 'contact_b@gmail.com', account: channel_account) }
+
+      before do
+        create(:contact_inbox, contact: contact_a, inbox: inbox)
+        create(:contact_inbox, contact: contact_b, inbox: inbox)
+      end
+
+      context 'when different contacts reply to the same in_reply_to thread' do
+        let!(:existing_conversation) do
+          create(:conversation, account: channel_account, inbox: inbox, contact: contact_a,
+                                additional_attributes: { 'in_reply_to' => 'newsletter-message-id@example.com', 'source' => 'email' })
+        end
+
+        it 'appends to the existing conversation (backward compatible)' do
+          reply_from_b = create_inbound_email_from_mail(
+            from: 'contact_b@gmail.com', to: inbox.channel.email, subject: 'Re: Newsletter',
+            in_reply_to: 'newsletter-message-id@example.com'
+          )
+
+          expect do
+            class_instance.process(reply_from_b.mail, channel)
+          end.not_to change(Conversation, :count)
+        end
+      end
+    end
+
     context 'when references contain both message and fallback patterns' do
       let(:agent_conversation) { create(:conversation, account: account, inbox: channel.inbox, assignee: agent) }
       let(:reply_mail_with_multiple_references) do

--- a/spec/services/mailbox/conversation_finder_strategies/new_conversation_strategy_spec.rb
+++ b/spec/services/mailbox/conversation_finder_strategies/new_conversation_strategy_spec.rb
@@ -108,6 +108,75 @@ RSpec.describe Mailbox::ConversationFinderStrategies::NewConversationStrategy do
       end
     end
 
+    context 'when email_thread_contact_scoping is enabled' do
+      let!(:contact_a) { create(:contact, email: 'contact_a@example.com', account: account) }
+      let!(:contact_b) { create(:contact, email: 'contact_b@example.com', account: account) }
+
+      before do
+        create(:contact_inbox, contact: contact_a, inbox: email_channel.inbox)
+        create(:contact_inbox, contact: contact_b, inbox: email_channel.inbox)
+        account.enable_features!('email_thread_contact_scoping')
+      end
+
+      context 'when different contacts reply to the same in_reply_to thread' do
+        let!(:existing_conversation) do
+          create(:conversation, account: account, inbox: email_channel.inbox, contact: contact_a,
+                                additional_attributes: { 'in_reply_to' => '<newsletter@example.com>' })
+        end
+
+        it 'builds a new conversation for a different contact' do
+          mail.from = 'contact_b@example.com'
+          mail['In-Reply-To'] = '<newsletter@example.com>'
+
+          strategy = described_class.new(mail)
+          conversation = strategy.find
+
+          expect(conversation).to be_a(Conversation)
+          expect(conversation.new_record?).to be(true)
+          expect(conversation.contact).to eq(contact_b)
+        end
+
+        it 'returns existing conversation for the same contact' do
+          mail.from = 'contact_a@example.com'
+          mail['In-Reply-To'] = '<newsletter@example.com>'
+
+          strategy = described_class.new(mail)
+          conversation = strategy.find
+
+          expect(conversation).to eq(existing_conversation)
+          expect(conversation.persisted?).to be(true)
+        end
+      end
+    end
+
+    context 'when email_thread_contact_scoping is disabled' do
+      let!(:contact_a) { create(:contact, email: 'contact_a@example.com', account: account) }
+      let!(:contact_b) { create(:contact, email: 'contact_b@example.com', account: account) }
+
+      before do
+        create(:contact_inbox, contact: contact_a, inbox: email_channel.inbox)
+        create(:contact_inbox, contact: contact_b, inbox: email_channel.inbox)
+      end
+
+      context 'when different contacts reply to the same in_reply_to thread' do
+        let!(:existing_conversation) do
+          create(:conversation, account: account, inbox: email_channel.inbox, contact: contact_a,
+                                additional_attributes: { 'in_reply_to' => '<newsletter@example.com>' })
+        end
+
+        it 'returns existing conversation for a different contact (backward compatible)' do
+          mail.from = 'contact_b@example.com'
+          mail['In-Reply-To'] = '<newsletter@example.com>'
+
+          strategy = described_class.new(mail)
+          conversation = strategy.find
+
+          expect(conversation).to eq(existing_conversation)
+          expect(conversation.persisted?).to be(true)
+        end
+      end
+    end
+
     context 'when channel is not found' do
       before do
         mail.to = ['nonexistent@example.com']


### PR DESCRIPTION
## Summary

When newsletters or bulk emails are sent from an address that Chatwoot monitors as an inbox (e.g. via a newsletter tool or email marketing service), and multiple subscribers reply, their replies all share the same `In-Reply-To` header pointing to the original newsletter's Message-ID. Currently, Chatwoot matches conversations purely by this header, which causes **all replies from different subscribers to be merged into a single conversation** — mixing completely unrelated people's messages into one ticket.

This PR adds an account-level feature flag **`email_thread_contact_scoping`** that, when enabled, also verifies that the sender matches the conversation's contact during email thread matching. Different senders = different conversations, even when replying to the same email thread.

### Why a feature flag?

This threading behavior has existed since Chatwoot's inception, so it's likely expected by some users (e.g. shared inboxes where multiple people reply on behalf of one identity). For my use case — sending newsletters and announcements to customers — it's a deal-breaker, as replies from unrelated contacts get jumbled together. The feature flag lets users who need the new behavior opt in, while keeping the default unchanged for everyone else.

### What changed

- **`config/features.yml`** — new `email_thread_contact_scoping` flag (disabled by default)
- **`app/mailboxes/imap/imap_mailbox.rb`** — `find_conversation_by_in_reply_to` and `find_conversation_by_reference_ids` now verify contact matches the conversation when the flag is enabled
- **`app/services/mailbox/conversation_finder_strategies/new_conversation_strategy.rb`** — moved contact resolution before conversation lookup so it can be used for scoping; `find_conversation_by_in_reply_to` now scopes by contact when enabled
- **Specs** — 8 new test cases covering flag on/off, different contacts, same contact, across all matching strategies (in_reply_to, source_id, references)

## Test plan

- [x] `bundle exec rspec spec/mailboxes/imap/imap_mailbox_spec.rb` — 27 examples, 0 failures
- [x] `bundle exec rspec spec/services/mailbox/conversation_finder_strategies/new_conversation_strategy_spec.rb` — 8 examples, 0 failures  
- [x] Full mailbox suite: `bundle exec rspec spec/mailboxes/ spec/services/mailbox/` — 133 examples, 0 failures
- [x] Manual test: enable flag on account, send newsletter, reply from two different contacts, verify separate conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)