### PR TITLE
fix: preserve HTML block content in markdown renderers

### DIFF
--- a/app/services/messages/markdown_renderers/base_markdown_renderer.rb
+++ b/app/services/messages/markdown_renderers/base_markdown_renderer.rb
@@ -26,6 +26,14 @@ class Messages::MarkdownRenderers::BaseMarkdownRenderer < CommonMarker::Renderer
     out('</del>')
   end
 
+  def html(node)
+    out(node.string_content)
+  end
+
+  def inline_html(node)
+    out(node.string_content)
+  end
+
   def method_missing(method_name, node = nil, *args, **kwargs, &)
     return super unless node.is_a?(CommonMarker::Node)
 


### PR DESCRIPTION
## Summary

Fixes #13493

**Root cause:** CommonMarker's `html` and `inline_html` node types store their content in `string_content`, not as child nodes. The `method_missing` fallback in `BaseMarkdownRenderer` only outputs `:children`, which is empty for these nodes, causing HTML content to be silently dropped.

## Changes

- `app/services/messages/markdown_renderers/base_markdown_renderer.rb`: Added explicit `html(node)` and `inline_html(node)` handlers that output `node.string_content`.

## Risk Assessment

**Low** - Only adds handling for previously unhandled node types. All existing node type handlers are unchanged.