### PR TITLE
feat: Add a setting to keep conversations pending on bot failures

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -40,6 +40,7 @@ class Account < ApplicationRecord
         'auto_resolve_ignore_waiting': { 'type': %w[boolean null] },
         'audio_transcriptions': { 'type': %w[boolean null] },
         'auto_resolve_label': { 'type': %w[string null] },
+        'keep_pending_on_bot_failure': { 'type': %w[boolean null] },
         'conversation_required_attributes': {
           'type': %w[array null],
           'items': { 'type': 'string' }
@@ -88,6 +89,7 @@ class Account < ApplicationRecord
 
   store_accessor :settings, :audio_transcriptions, :auto_resolve_label
   store_accessor :settings, :captain_models, :captain_features
+  store_accessor :settings, :keep_pending_on_bot_failure
 
   has_many :account_users, dependent: :destroy_async
   has_many :agent_bot_inboxes, dependent: :destroy_async

--- a/lib/webhooks/trigger.rb
+++ b/lib/webhooks/trigger.rb
@@ -38,6 +38,7 @@ class Webhooks::Trigger
     when :agent_bot_webhook
       conversation = message.conversation
       return unless conversation&.pending?
+      return if conversation&.account&.keep_pending_on_bot_failure
 
       conversation.open!
       create_agent_bot_error_activity(conversation)

--- a/lib/webhooks/trigger.rb
+++ b/lib/webhooks/trigger.rb
@@ -36,15 +36,19 @@ class Webhooks::Trigger
 
     case @webhook_type
     when :agent_bot_webhook
-      conversation = message.conversation
-      return unless conversation&.pending?
-      return if conversation&.account&.keep_pending_on_bot_failure
-
-      conversation.open!
-      create_agent_bot_error_activity(conversation)
+      update_conversation_status(message)
     when :api_inbox_webhook
       update_message_status(error)
     end
+  end
+
+  def update_conversation_status(message)
+    conversation = message.conversation
+    return unless conversation&.pending?
+    return if conversation&.account&.keep_pending_on_bot_failure
+
+    conversation.open!
+    create_agent_bot_error_activity(conversation)
   end
 
   def create_agent_bot_error_activity(conversation)


### PR DESCRIPTION
Adds an account-level setting `keep_pending_on_bot_failure` to control whether conversations should move from pending to open when agent bot webhooks fail.

Some users experience occasional message drops and don't want conversations to automatically reopen due to transient bot failures. This setting gives accounts control over that behavior. This is a temporary setting which will be removed in future once a proper fix for it is done, so it is not added in the UI.
