### PR TITLE
fix(slack): handle archived channel errors in SendOnSlackJob

### DIFF
--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -102,7 +102,8 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
   def send_message
     post_message if message_content.present?
     upload_files if message.attachments.any?
-  rescue Slack::Web::Api::Errors::IsArchived, Slack::Web::Api::Errors::AccountInactive, Slack::Web::Api::Errors::MissingScope, Slack::Web::Api::Errors::InvalidAuth,
+  rescue Slack::Web::Api::Errors::IsArchived, Slack::Web::Api::Errors::AccountInactive, Slack::Web::Api::Errors::MissingScope,
+         Slack::Web::Api::Errors::InvalidAuth,
          Slack::Web::Api::Errors::ChannelNotFound, Slack::Web::Api::Errors::NotInChannel => e
     Rails.logger.error e
     hook.prompt_reauthorization!

--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -102,7 +102,7 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
   def send_message
     post_message if message_content.present?
     upload_files if message.attachments.any?
-  rescue Slack::Web::Api::Errors::AccountInactive, Slack::Web::Api::Errors::MissingScope, Slack::Web::Api::Errors::InvalidAuth,
+  rescue Slack::Web::Api::Errors::IsArchived, Slack::Web::Api::Errors::AccountInactive, Slack::Web::Api::Errors::MissingScope, Slack::Web::Api::Errors::InvalidAuth,
          Slack::Web::Api::Errors::ChannelNotFound, Slack::Web::Api::Errors::NotInChannel => e
     Rails.logger.error e
     hook.prompt_reauthorization!


### PR DESCRIPTION
When a Slack-integrated channel is archived, posting from Chatwoot raises `Slack::Web::Api::Errors::IsArchived` in `SendOnSlackJob`, which retries and can end up in dead jobs. This can be reproduced by archiving the connected Slack channel for a valid hook  and creating outgoing messages. This change adds `IsArchived` to the existing handled Slack API rescue path in `Integrations::Slack::SendOnSlackService#send_message`, so archived-channel failures now follow the same flow as related Slack failures (`prompt_reauthorization!` + `disable`) instead of bubbling and retrying repeatedly. I tested this by running `bundle exec rubocop lib/integrations/slack/send_on_slack_service.rb` (with `rbenv` initialized), and it passes with no offenses.

Sentry issue: https://chatwoot-p3.sentry.io/issues/7150427066/
