### PR TITLE
fix(twilio): prevent dead jobs on missing channel lookup

### DIFF
--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -26,10 +26,21 @@ class Twilio::IncomingMessageService
   def twilio_channel
     @twilio_channel ||= ::Channel::TwilioSms.find_by(messaging_service_sid: params[:MessagingServiceSid]) if params[:MessagingServiceSid].present?
     if params[:AccountSid].present? && params[:To].present?
-      @twilio_channel ||= ::Channel::TwilioSms.find_by!(account_sid: params[:AccountSid],
-                                                        phone_number: params[:To])
+      @twilio_channel ||= ::Channel::TwilioSms.find_by(account_sid: params[:AccountSid],
+                                                       phone_number: params[:To])
     end
+    log_channel_not_found if @twilio_channel.blank?
     @twilio_channel
+  end
+
+  def log_channel_not_found
+    Rails.logger.warn(
+      '[TWILIO] Incoming message channel lookup failed ' \
+      "account_sid=#{params[:AccountSid]} " \
+      "to=#{params[:To]} " \
+      "messaging_service_sid=#{params[:MessagingServiceSid]} " \
+      "sms_sid=#{params[:SmsSid]}"
+    )
   end
 
   def inbox


### PR DESCRIPTION
## Why
We observed `Webhooks::TwilioEventsJob` failures ending up in Sidekiq dead jobs when Twilio callback payloads could not be mapped to a `Channel::TwilioSms` record. In this scenario, channel lookup raised `ActiveRecord::RecordNotFound`, which caused retries and eventual dead jobs instead of a graceful drop.

Related Sentry issue/search:
- https://chatwoot-p3.sentry.io/issues/?project=6382945&query=Webhooks%3A%3ATwilioEventsJob%20ActiveRecord%3A%3ARecordNotFound

## What changed
This PR keeps the existing lookup flow but makes it non-raising:
- `app/services/twilio/incoming_message_service.rb`
  - `find_by!` -> `find_by` for account SID + phone lookup
  - Added warning log when channel lookup misses
- `app/services/twilio/delivery_status_service.rb`
  - `find_by!` -> `find_by` for account SID + phone lookup
  - Added warning log when channel lookup misses

## Reproduction
Configure a Twilio webhook callback that reaches Chatwoot but does not match an existing Twilio channel lookup path. Before this change, the job raises `RecordNotFound` and can end up in dead jobs after retries. After this change, the job logs the miss and exits safely.

## Testing
- `bundle exec rspec spec/services/twilio/incoming_message_service_spec.rb spec/services/twilio/delivery_status_service_spec.rb`
- `bundle exec rubocop app/services/twilio/incoming_message_service.rb app/services/twilio/delivery_status_service.rb`
