### PR TITLE
docs: document relay ingress for custom HTTP pipelines (Cloudflare Email Workers, AWS Lambda)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,7 +100,8 @@ SMTP_OPENSSL_VERIFY_MODE=peer
 MAILER_INBOUND_EMAIL_DOMAIN=
 # Set this to the appropriate ingress channel with regards to incoming emails
 # Possible values are :
-# relay for Exim, Postfix, Qmail
+# relay for Exim, Postfix, Qmail, or any custom HTTP pipeline
+#   (Cloudflare Email Workers, AWS SES + Lambda, custom webhooks, etc.)
 # mailgun for Mailgun
 # mandrill for Mandrill
 # postmark for Postmark
@@ -126,6 +127,12 @@ ACTION_MAILBOX_SES_SNS_TOPIC=
 # Example: https://actionmailbox:mYRandomPassword3@chatwoot.example.com/rails/action_mailbox/postmark/inbound_emails
 # For Postmark
 # Ensure the 'Include raw email content in JSON payload' checkbox is selected in the inbound webhook section.
+#
+# Custom HTTP Ingress (Cloudflare Email Workers, AWS Lambda, etc.):
+# Set RAILS_INBOUND_EMAIL_SERVICE=relay and POST raw RFC 822 email to:
+#    https://actionmailbox:[YOUR_RAILS_INBOUND_EMAIL_PASSWORD]@[YOUR_CHATWOOT_DOMAIN.COM]/rails/action_mailbox/relay/inbound_emails
+# Content-Type must be message/rfc822
+# Ref: https://developers.chatwoot.com/self-hosted/configuration/features/email-channel/ingress-providers#calling-the-http-endpoint-directly
 
 # Storage
 ACTIVE_STORAGE_SERVICE=local

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,7 +95,8 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set this to appropriate ingress service for which the options are :
-  # :relay for Exim, Postfix, Qmail
+  # :relay for Exim, Postfix, Qmail, or custom HTTP pipelines
+  #   (Cloudflare Email Workers, AWS Lambda, etc.)
   # :mailgun for Mailgun
   # :mandrill for Mandrill
   # :postmark for Postmark

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -41,7 +41,8 @@ Rails.application.configure do
   #########################################
 
   # Set this to appropriate ingress service for which the options are :
-  # :relay for Exim, Postfix, Qmail
+  # :relay for Exim, Postfix, Qmail, or custom HTTP pipelines
+  #   (Cloudflare Email Workers, AWS Lambda, etc.)
   # :mailgun for Mailgun
   # :mandrill for Mandrill
   # :postmark for Postmark


### PR DESCRIPTION
## Description
Explicitly document the existing Action Mailbox `relay` ingress as supporting custom HTTP pipelines such as Cloudflare Email Workers, AWS Lambda, and other edge/serverless email solutions.

Fixes #13571

## Changes
- **`.env.example`**: Expanded the `relay` option description to mention Cloudflare Email Workers, AWS SES + Lambda, and custom webhooks. Added a dedicated section showing the webhook URL format, required `Content-Type`, and a link to the official docs.
- **`config/initializers/mailer.rb`**: Updated the relay comment to mention custom HTTP pipelines.
- **`config/environments/production.rb`**: Same comment update.

## Why
The relay ingress already supports receiving raw RFC 822 emails over HTTP, but this capability is not well-documented. Users wanting to use edge/serverless email pipelines (e.g., Cloudflare Email Workers) have no clear guidance on how to point them at Chatwoot. These doc changes make the existing functionality discoverable.

## No Backend Changes
The relay ingress endpoint (`/rails/action_mailbox/relay/inbound_emails`) already works out of the box. No new code is needed — only documentation.