### PR TITLE
Show reauthorization only for embedded signup

### DIFF
--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -127,7 +127,11 @@ json.bot_name resource.channel.try(:bot_name) if resource.telegram?
 if resource.whatsapp?
   json.message_templates resource.channel.try(:message_templates)
   json.provider_config resource.channel.try(:provider_config) if Current.account_user&.administrator?
-  json.reauthorization_required resource.channel.try(:reauthorization_required?)
+  # Only show reauthorization for embedded signup; manual flow uses API keys, not OAuth
+  json.reauthorization_required(
+    (resource.channel.try(:provider_config) || {}).to_h['source'] == 'embedded_signup' &&
+    resource.channel.try(:reauthorization_required?)
+  )
 end
 
 ## Voice Channel Attributes


### PR DESCRIPTION
Restrict the WhatsApp reauthorization flag to channels whose provider_config source is 'embedded_signup'. Previously the view exposed resource.channel.reauthorization_required? for all WhatsApp channels; now it only returns true when (provider_config || {}).to_h['source'] == 'embedded_signup' && resource.channel.reauthorization_required?. This prevents showing reauthorization prompts for manual/API-key flows (non-OAuth) and safely handles nil provider_config.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes  #13553 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
