### PR TITLE
fix: allow emoji characters in label titles

### DIFF
--- a/lib/regex_helper.rb
+++ b/lib/regex_helper.rb
@@ -1,10 +1,10 @@
 module RegexHelper
   # user https://rubular.com/ to quickly validate your regex
 
-  # the following regext needs atleast one character which should be
-  # valid unicode letter, unicode number, underscore, hyphen
-  # shouldn't start with a underscore or hyphen
-  UNICODE_CHARACTER_NUMBER_HYPHEN_UNDERSCORE = Regexp.new('\A[\p{L}\p{N}]+[\p{L}\p{N}_-]+\Z')
+  # the following regex needs at least one character which should be
+  # valid unicode letter, unicode number, emoji, underscore, hyphen
+  # shouldn't start with an underscore or hyphen
+  UNICODE_CHARACTER_NUMBER_HYPHEN_UNDERSCORE = Regexp.new('\A[\p{L}\p{N}\p{So}]+[\p{L}\p{N}\p{So}_-]+\Z')
   # Regex to match mention markdown links and extract display names
   # Matches: [@display name](mention://user|team/id/url_encoded_name)
   # Captures: 1) @display name (including emojis), 2) url_encoded_name

--- a/spec/models/label_spec.rb
+++ b/spec/models/label_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe Label do
       expect(label.valid?).to be true
     end
 
+    it 'allows emoji characters' do
+      label = FactoryBot.build(:label, title: '🤮spam')
+      expect(label.valid?).to be true
+    end
+
     it 'converts uppercase letters to lowercase' do
       label = FactoryBot.build(:label, title: 'Hello_World')
       expect(label.valid?).to be true


### PR DESCRIPTION
## Description

Fixes #5046

The label title validation regex (`UNICODE_CHARACTER_NUMBER_HYPHEN_UNDERSCORE`) only allowed Unicode letters (`\p{L}`), numbers (`\p{N}`), hyphens, and underscores. Emoji characters like 🤮, ⭐, ✅ are classified under `\p{So}` (Unicode Symbol, Other) and were rejected with a 422 "Title invalid" error.

This adds `\p{So}` to the regex character classes so that labels like "🤮spam" or "⭐priority" are accepted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added a spec to `spec/models/label_spec.rb` confirming emoji labels are valid
- Verified the updated regex matches emoji titles using Ruby regex testing:
  ```ruby
  r = Regexp.new('\A[\p{L}\p{N}\p{So}]+[\p{L}\p{N}\p{So}_-]+\Z')
  r.match?("🤮spam")  # => true
  r.match?("⭐priority") # => true
  r.match?("test-label") # => true (unchanged)
  r.match?("_invalid") # => false (unchanged)
  ```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*