### PR TITLE
feat: show assignment policy name in auto-assignment activity messages

### DIFF
--- a/app/models/concerns/activity_message_handler.rb
+++ b/app/models/concerns/activity_message_handler.rb
@@ -1,6 +1,7 @@
 module ActivityMessageHandler
   extend ActiveSupport::Concern
 
+  include AssigneeActivityMessageHandler
   include PriorityActivityMessageHandler
   include LabelActivityMessageHandler
   include SlaActivityMessageHandler
@@ -103,27 +104,6 @@ module ActivityMessageHandler
 
     content = I18n.t("conversations.activity.#{change_type}", user_name: Current.user.name)
     ::Conversations::ActivityMessageJob.perform_later(self, activity_message_params(content)) if content
-  end
-
-  def generate_assignee_change_activity_content(user_name)
-    params = { assignee_name: assignee&.name || '', user_name: user_name }
-    key = assignee_id ? 'assigned' : 'removed'
-    key = 'self_assigned' if self_assign? assignee_id
-    I18n.t("conversations.activity.assignee.#{key}", **params)
-  end
-
-  def create_assignee_change_activity(user_name)
-    user_name = activity_message_owner(user_name)
-
-    return unless user_name
-
-    content = generate_assignee_change_activity_content(user_name)
-    ::Conversations::ActivityMessageJob.perform_later(self, activity_message_params(content)) if content
-  end
-
-  def activity_message_owner(user_name)
-    user_name = I18n.t('automation.system_name') if !user_name && Current.executed_by.present?
-    user_name
   end
 end
 

--- a/app/models/concerns/assignee_activity_message_handler.rb
+++ b/app/models/concerns/assignee_activity_message_handler.rb
@@ -23,7 +23,7 @@ module AssigneeActivityMessageHandler
     if !user_name && Current.executed_by.present?
       user_name = case Current.executed_by
                   when AssignmentPolicy
-                    "#{I18n.t('automation.system_name')} via #{Current.executed_by.name}"
+                    I18n.t('auto_assignment.policy_actor', policy_name: Current.executed_by.name)
                   when Inbox
                     I18n.t('auto_assignment.default_policy_name')
                   else

--- a/app/models/concerns/assignee_activity_message_handler.rb
+++ b/app/models/concerns/assignee_activity_message_handler.rb
@@ -1,0 +1,35 @@
+module AssigneeActivityMessageHandler
+  extend ActiveSupport::Concern
+
+  private
+
+  def create_assignee_change_activity(user_name)
+    user_name = activity_message_owner(user_name)
+
+    return unless user_name
+
+    content = generate_assignee_change_activity_content(user_name)
+    ::Conversations::ActivityMessageJob.perform_later(self, activity_message_params(content)) if content
+  end
+
+  def generate_assignee_change_activity_content(user_name)
+    params = { assignee_name: assignee&.name || '', user_name: user_name }
+    key = assignee_id ? 'assigned' : 'removed'
+    key = 'self_assigned' if self_assign? assignee_id
+    I18n.t("conversations.activity.assignee.#{key}", **params)
+  end
+
+  def activity_message_owner(user_name)
+    if !user_name && Current.executed_by.present?
+      user_name = case Current.executed_by
+                  when AssignmentPolicy
+                    "#{I18n.t('automation.system_name')} via #{Current.executed_by.name}"
+                  when Inbox
+                    I18n.t('auto_assignment.default_policy_name')
+                  else
+                    I18n.t('automation.system_name')
+                  end
+    end
+    user_name
+  end
+end

--- a/app/services/auto_assignment/assignment_service.rb
+++ b/app/services/auto_assignment/assignment_service.rb
@@ -72,7 +72,9 @@ class AutoAssignment::AssignmentService
   end
 
   def assign_conversation(conversation, agent)
+    Current.executed_by = inbox.assignment_policy || inbox
     conversation.update!(assignee: agent)
+    Current.executed_by = nil
 
     rate_limiter = build_rate_limiter(agent)
     rate_limiter.track_assignment(conversation)

--- a/app/services/auto_assignment/assignment_service.rb
+++ b/app/services/auto_assignment/assignment_service.rb
@@ -81,6 +81,8 @@ class AutoAssignment::AssignmentService
 
     dispatch_assignment_event(conversation, agent)
     true
+  ensure
+    Current.executed_by = nil
   end
 
   def dispatch_assignment_event(conversation, agent)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -434,6 +434,7 @@ en:
       other: '%{count} seconds'
   auto_assignment:
     default_policy_name: 'Default Policy'
+    policy_actor: 'Automation System via %{policy_name}'
   automation:
     system_name: 'Automation System'
   crm:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -432,6 +432,8 @@ en:
     seconds:
       one: '%{count} second'
       other: '%{count} seconds'
+  auto_assignment:
+    default_policy_name: 'Default Policy'
   automation:
     system_name: 'Automation System'
   crm:


### PR DESCRIPTION
## Description

Auto-assigned conversations showed no activity message in the timeline — the assignee would change silently with no trace of who or what triggered it. 
Fix: Set Current.executed_by in AutoAssignment::AssignmentService#assign_conversation before the conversation update, so the activity message handler has the context it needs. The actor label is derived from what triggered the assignment:

- Named assignment policy → "Conversation was assigned to Pranav by Automation System via X Policy"
- Assignment V2 enabled, no specific policy → "Conversation was assigned to Pranav by Default Policy"
- Automation rule (unchanged) → "Conversation was assigned to Pranav by Automation System"

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Screenshot
<img width="1005" height="366" alt="image" src="https://github.com/user-attachments/assets/c4e58608-9f90-450e-9509-a2fe0b7cde58" />


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
