### PR TITLE
fix(whatsapp): resilient media download via Graph API with timeouts and error handling

### DIFF
--- a/.github/workflows/build-fix-whatsapp-media.yml
+++ b/.github/workflows/build-fix-whatsapp-media.yml
@@ -1,5 +1,5 @@
 # Build and push Chatwoot image with WhatsApp media download fix.
-# Image: mikelito859/chatwoot:fix-whatsapp-media-download
+# Image: mikelito85/chatwoot:fix-whatsapp-media-download
 #
 # Required repo secret: DOCKERHUB_TOKEN (Docker Hub Access Token from https://hub.docker.com/settings/security)
 
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_REPO: mikelito859/chatwoot
+  DOCKER_REPO: mikelito85/chatwoot
   DOCKER_TAG: fix-whatsapp-media-download
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: mikelito859
+          username: mikelito85
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push

--- a/.github/workflows/build-fix-whatsapp-media.yml
+++ b/.github/workflows/build-fix-whatsapp-media.yml
@@ -1,0 +1,46 @@
+# Build and push Chatwoot image with WhatsApp media download fix.
+# Image: mikelito859/chatwoot:fix-whatsapp-media-download
+#
+# Required repo secrets: DOCKERHUB_USERNAME (mikelito859), DOCKERHUB_TOKEN (Docker Hub access token).
+
+name: Build and push fix-whatsapp-media image
+
+on:
+  push:
+    branches:
+      - fix-whatsapp-media-download
+  workflow_dispatch:
+
+env:
+  DOCKER_REPO: mikelito859/chatwoot
+  DOCKER_TAG: fix-whatsapp-media-download
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Strip enterprise code (CE build)
+        run: |
+          rm -rf enterprise
+          rm -rf spec/enterprise
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.DOCKER_REPO }}:${{ env.DOCKER_TAG }}

--- a/.github/workflows/build-fix-whatsapp-media.yml
+++ b/.github/workflows/build-fix-whatsapp-media.yml
@@ -1,7 +1,7 @@
 # Build and push Chatwoot image with WhatsApp media download fix.
 # Image: mikelito859/chatwoot:fix-whatsapp-media-download
 #
-# Required repo secrets: DOCKERHUB_USERNAME (mikelito859), DOCKERHUB_TOKEN (Docker Hub access token).
+# Required repo secret: DOCKERHUB_TOKEN (Docker Hub Access Token from https://hub.docker.com/settings/security)
 
 name: Build and push fix-whatsapp-media image
 
@@ -33,7 +33,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: mikelito859
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -37,6 +37,7 @@ import UnsupportedBubble from './bubbles/Unsupported.vue';
 import ContactBubble from './bubbles/Contact.vue';
 import DyteBubble from './bubbles/Dyte.vue';
 import LocationBubble from './bubbles/Location.vue';
+import FallbackBubble from './bubbles/Fallback.vue';
 import CSATBubble from './bubbles/CSAT.vue';
 import FormBubble from './bubbles/Form.vue';
 import VoiceCallBubble from './bubbles/VoiceCall.vue';
@@ -331,9 +332,11 @@ const componentToRender = computed(() => {
       if (fileType === ATTACHMENT_TYPES.IG_REEL) return VideoBubble;
       if (fileType === ATTACHMENT_TYPES.EMBED) return EmbedBubble;
       if (fileType === ATTACHMENT_TYPES.LOCATION) return LocationBubble;
+      if (fileType === ATTACHMENT_TYPES.FALLBACK) return FallbackBubble;
     }
     // Attachment content is the name of the contact
     if (fileType === ATTACHMENT_TYPES.CONTACT) return ContactBubble;
+    if (fileType === ATTACHMENT_TYPES.FALLBACK) return FallbackBubble;
   }
 
   return TextBubble;

--- a/app/javascript/dashboard/components-next/message/bubbles/Fallback.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Fallback.vue
@@ -1,0 +1,24 @@
+<script setup>
+import { computed } from 'vue';
+import BaseBubble from './Base.vue';
+import Icon from 'next/icon/Icon.vue';
+import { useMessageContext } from '../provider.js';
+
+const { attachments } = useMessageContext();
+
+const title = computed(() => {
+  const attachment = attachments.value[0];
+  return attachment?.fallbackTitle ?? attachment?.fallback_title ?? '';
+});
+</script>
+
+<template>
+  <BaseBubble class="overflow-hidden p-3" data-bubble-name="fallback">
+    <div class="flex items-center gap-2 text-n-slate-11">
+      <Icon icon="i-lucide-alert-circle" class="size-4 shrink-0 text-n-amber-11" />
+      <p class="mb-0 text-sm">
+        {{ title }}
+      </p>
+    </div>
+  </BaseBubble>
+</template>

--- a/app/javascript/dashboard/components-next/message/bubbles/Fallback.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Fallback.vue
@@ -15,7 +15,10 @@ const title = computed(() => {
 <template>
   <BaseBubble class="overflow-hidden p-3" data-bubble-name="fallback">
     <div class="flex items-center gap-2 text-n-slate-11">
-      <Icon icon="i-lucide-alert-circle" class="size-4 shrink-0 text-n-amber-11" />
+      <Icon
+        icon="i-lucide-alert-circle"
+        class="size-4 shrink-0 text-n-amber-11"
+      />
       <p class="mb-0 text-sm">
         {{ title }}
       </p>

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -284,7 +284,8 @@
     },
     "MEDIA": {
       "IMAGE_UNAVAILABLE": "This image is no longer available.",
-      "LOADING_FAILED": "Loading failed"
+      "LOADING_FAILED": "Loading failed",
+      "MEDIA_DOWNLOAD_FAILED": "Media could not be downloaded."
     }
   },
   "CONFIRM_EMAIL": "Verifying...",

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -114,8 +114,8 @@ class Attachment < ApplicationRecord
       data_url: file_url,
       thumb_url: thumb_url,
       file_size: file.byte_size,
-      width: file.metadata[:width],
-      height: file.metadata[:height]
+      width: file.metadata&.[](:width),
+      height: file.metadata&.[](:height)
     }
 
     metadata[:data_url] = metadata[:thumb_url] = external_url if message.inbox.instagram? && message.incoming?

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -148,7 +148,10 @@ class Whatsapp::IncomingMessageBaseService
     @message.content ||= attachment_payload[:caption]
 
     attachment_file = download_attachment_file(attachment_payload)
-    return if attachment_file.blank?
+    if attachment_file.blank?
+      attach_media_download_failed(attachment_payload) if respond_to?(:attach_media_download_failed, true)
+      return
+    end
 
     @message.attachments.new(
       account_id: @message.account_id,

--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -23,6 +23,10 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
     media_url = fetch_media_url_from_graph(media_id)
     return if media_url.blank?
 
+    Rails.logger.info(
+      "WhatsApp media download: media_id=#{media_id} url=#{media_url}"
+    )
+
     # 2) Download from lookaside URL; Cloud API requires Authorization header on this request too.
     Down.download(
       media_url,
@@ -49,6 +53,9 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
     response = HTTParty.get(
       inbox.channel.media_url(media_id),
       headers: inbox.channel.api_headers
+    )
+    Rails.logger.info(
+      "WhatsApp Graph media metadata: media_id=#{media_id} status=#{response.code} body=#{response.body}"
     )
     inbox.channel.authorization_error! if response.unauthorized?
     return unless response.success?

--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -6,6 +6,7 @@
 class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageBaseService
   DOWNLOAD_OPEN_TIMEOUT = 20
   DOWNLOAD_READ_TIMEOUT = 20
+  DOWNLOAD_MAX_RETRIES = 2 # retry connection resets / transient network errors
 
   private
 
@@ -27,18 +28,36 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
       "WhatsApp media download: media_id=#{media_id} url=#{media_url}"
     )
 
-    # 2) Download from lookaside URL; Cloud API requires Authorization header on this request too.
-    Down.download(
-      media_url,
-      headers: inbox.channel.api_headers,
-      open_timeout: DOWNLOAD_OPEN_TIMEOUT,
-      read_timeout: DOWNLOAD_READ_TIMEOUT
-    )
+    # 2) Download; Cloud API requires Authorization header. Retry on connection resets (transient).
+    download_with_retries(media_url, media_id)
   rescue Down::Error, IOError => e
     Rails.logger.warn(
       "WhatsApp media download failed for media_id=#{media_id}: #{e.class} - #{e.message}"
     )
     nil
+  end
+
+  def download_with_retries(media_url, media_id)
+    attempt = 0
+    begin
+      Down.download(
+        media_url,
+        headers: inbox.channel.api_headers,
+        open_timeout: DOWNLOAD_OPEN_TIMEOUT,
+        read_timeout: DOWNLOAD_READ_TIMEOUT
+      )
+    rescue Down::ConnectionError, IOError => e
+      attempt += 1
+      retryable = e.is_a?(Down::ConnectionError) || e.message.to_s.include?('reset')
+      if retryable && attempt <= DOWNLOAD_MAX_RETRIES
+        Rails.logger.warn(
+          "WhatsApp media download retry #{attempt}/#{DOWNLOAD_MAX_RETRIES} media_id=#{media_id}: #{e.message}"
+        )
+        sleep(1 * attempt)
+        retry
+      end
+      raise
+    end
   end
 
   def attach_media_download_failed(_attachment_payload)

--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -37,6 +37,14 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
     nil
   end
 
+  def attach_media_download_failed(_attachment_payload)
+    @message.attachments.new(
+      account_id: @message.account_id,
+      file_type: :fallback,
+      fallback_title: I18n.t('errors.whatsapp.media_download_failed')
+    )
+  end
+
   def fetch_media_url_from_graph(media_id)
     response = HTTParty.get(
       inbox.channel.media_url(media_id),

--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -1,20 +1,51 @@
 # https://docs.360dialog.com/whatsapp-api/whatsapp-api/media
 # https://developers.facebook.com/docs/whatsapp/api/media/
+# Media must be fetched via Graph API (GET /{media_id}) to get a stable download URL;
+# the webhook's lookaside.fbsbx.com URL is ephemeral and often fails with Connection reset.
 
 class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageBaseService
+  DOWNLOAD_OPEN_TIMEOUT = 20
+  DOWNLOAD_READ_TIMEOUT = 20
+
   private
 
   def processed_params
     @processed_params ||= params[:entry].try(:first).try(:[], 'changes').try(:first).try(:[], 'value')
   end
 
+  # Called from base service with the full attachment hash (e.g. message["image"], message["document"]).
+  # We only use media_id from it; we never use any "url" field from the webhook payload.
   def download_attachment_file(attachment_payload)
-    url_response = HTTParty.get(
-      inbox.channel.media_url(attachment_payload[:id]),
+    media_id = attachment_payload[:id] || attachment_payload['id']
+    return if media_id.blank?
+
+    # 1) Get stable download URL from Graph API (do not use any url from the webhook payload)
+    media_url = fetch_media_url_from_graph(media_id)
+    return if media_url.blank?
+
+    # 2) Download from lookaside URL; Cloud API requires Authorization header on this request too.
+    tempfile = Down.download(
+      media_url,
+      headers: inbox.channel.api_headers,
+      open_timeout: DOWNLOAD_OPEN_TIMEOUT,
+      read_timeout: DOWNLOAD_READ_TIMEOUT
+    )
+    tempfile
+  rescue Down::Error, IOError => e
+    Rails.logger.warn(
+      "WhatsApp media download failed for media_id=#{media_id}: #{e.class} - #{e.message}"
+    )
+    nil
+  end
+
+  def fetch_media_url_from_graph(media_id)
+    response = HTTParty.get(
+      inbox.channel.media_url(media_id),
       headers: inbox.channel.api_headers
     )
-    # This url response will be failure if the access token has expired.
-    inbox.channel.authorization_error! if url_response.unauthorized?
-    Down.download(url_response.parsed_response['url'], headers: inbox.channel.api_headers) if url_response.success?
+    inbox.channel.authorization_error! if response.unauthorized?
+    return unless response.success?
+
+    response.parsed_response&.dig('url')
   end
 end

--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -24,13 +24,12 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
     return if media_url.blank?
 
     # 2) Download from lookaside URL; Cloud API requires Authorization header on this request too.
-    tempfile = Down.download(
+    Down.download(
       media_url,
       headers: inbox.channel.api_headers,
       open_timeout: DOWNLOAD_OPEN_TIMEOUT,
       read_timeout: DOWNLOAD_READ_TIMEOUT
     )
-    tempfile
   rescue Down::Error, IOError => e
     Rails.logger.warn(
       "WhatsApp media download failed for media_id=#{media_id}: #{e.class} - #{e.message}"

--- a/config/locales/am.yml
+++ b/config/locales/am.yml
@@ -81,6 +81,7 @@ am:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'ሜዲያ ማውረድ አልተቻለም።'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -81,6 +81,7 @@ ar:
     slack:
       invalid_channel_id: 'قناة Slack غير صحيحة. الرجاء المحاولة مرة أخرى'
     whatsapp:
+      media_download_failed: 'تعذر تنزيل الملف.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -81,6 +81,7 @@ az:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Media yüklənə bilmədi.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -81,6 +81,7 @@ bg:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Файлът не може да бъде изтеглен.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -81,6 +81,7 @@ bn:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'মিডিয়া ডাউনলোড করা যায়নি।'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -81,7 +81,7 @@ ca:
     slack:
       invalid_channel_id: 'Canal slack no vàlid. Torna-ho a provar'
     whatsapp:
-      media_download_failed: 'No s\'ha pogut descarregar el fitxer.'
+      media_download_failed: 'No s''ha pogut descarregar el fitxer.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -81,6 +81,7 @@ ca:
     slack:
       invalid_channel_id: 'Canal slack no vàlid. Torna-ho a provar'
     whatsapp:
+      media_download_failed: 'No s\'ha pogut descarregar el fitxer.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -81,6 +81,7 @@ cs:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Soubor se nepodařilo stáhnout.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -81,6 +81,7 @@ da:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Mediet kunne ikke hentes.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -81,6 +81,7 @@ de:
     slack:
       invalid_channel_id: 'Ungültiger Slack Channel. Bitte erneut versuchen'
     whatsapp:
+      media_download_failed: 'Medien konnten nicht heruntergeladen werden.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -81,6 +81,7 @@ el:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Δεν ήταν δυνατή η λήψη του αρχείου.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,7 @@ en:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Media could not be downloaded.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -81,6 +81,7 @@ es:
     slack:
       invalid_channel_id: 'Canal de slack inválido. Por favor, inténtalo de nuevo'
     whatsapp:
+      media_download_failed: 'No se pudo descargar el archivo.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -81,6 +81,7 @@ et:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Faili alla laadimine ebaõnnestus.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -81,6 +81,7 @@ fa:
     slack:
       invalid_channel_id: 'کانال اسلک نامعتبر است. لطفا دوباره تلاش کنید'
     whatsapp:
+      media_download_failed: 'بارگیری رسانه امکان‌پذیر نبود.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -81,6 +81,7 @@ fi:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Tiedostoa ei voitu ladata.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -81,6 +81,7 @@ fr:
     slack:
       invalid_channel_id: 'Canal Slack invalide. Veuillez réessayer'
     whatsapp:
+      media_download_failed: 'Impossible de télécharger le fichier.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -81,6 +81,7 @@ he:
     slack:
       invalid_channel_id: 'ערוץ Slack לא תקין. אנא נסה שוב'
     whatsapp:
+      media_download_failed: 'לא ניתן להוריד את הקובץ.'
       token_exchange_failed: 'החלפת קוד לאסימון גישה נכשלה. אנא נסה שוב.'
       invalid_token_permissions: 'לאסימון הגישה אין את ההרשאות הנדרשות עבור WhatsApp.'
       phone_info_fetch_failed: 'הבאת מידע מספר טלפון נכשלה. אנא נסה שוב.'

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -81,6 +81,7 @@ hi:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'मीडिया डाउनलोड नहीं हो सका।'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -81,6 +81,7 @@ hr:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Nije moguće preuzeti datoteku.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -81,6 +81,7 @@ hu:
     slack:
       invalid_channel_id: 'Érvénytelen Slack csatorna. Kérjük, próbálja újra'
     whatsapp:
+      media_download_failed: 'A fájl letöltése nem sikerült.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -81,6 +81,7 @@ hy:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Չհաջողվեց բեռնել ֆայլը։'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -81,6 +81,7 @@ id:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Tidak dapat mengunduh media.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -81,6 +81,7 @@ is:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Tókst ekki að sækja skrá.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -81,6 +81,7 @@ it:
     slack:
       invalid_channel_id: 'Canale slack non valido. Riprova'
     whatsapp:
+      media_download_failed: 'Impossibile scaricare il file.'
       token_exchange_failed: 'Impossibile scambiare il codice con il token di accesso. Riprova.'
       invalid_token_permissions: 'Il token di accesso non dispone dei permessi richiesti per WhatsApp.'
       phone_info_fetch_failed: 'Impossibile recuperare le informazioni sul numero di telefono. Riprova.'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -81,6 +81,7 @@ ja:
     slack:
       invalid_channel_id: '無効なSlackチャンネルです。もう一度お試しください。'
     whatsapp:
+      media_download_failed: 'メディアをダウンロードできませんでした。'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -81,6 +81,7 @@ ka:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'მედიის ჩამოტვირთვა ვერ მოხერხდა.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -81,6 +81,7 @@ ko:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: '미디어를 다운로드할 수 없습니다.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -81,6 +81,7 @@ lt:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Nepavyko atsisiųsti failo.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -81,6 +81,7 @@ lv:
     slack:
       invalid_channel_id: 'Nepareizs Slack kanāls. Lūdzu, mēģiniet vēlreiz'
     whatsapp:
+      media_download_failed: 'Neizdevās lejupielādēt failu.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/ml.yml
+++ b/config/locales/ml.yml
@@ -81,6 +81,7 @@ ml:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'മീഡിയ ഡൗൺലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -81,6 +81,7 @@ ms:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Media tidak dapat dimuat turun.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -81,6 +81,7 @@ ne:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'मिडिया डाउनलोड गर्न सकिएन।'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -81,6 +81,7 @@ nl:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Bestand kon niet worden gedownload.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -81,6 +81,7 @@
     slack:
       invalid_channel_id: 'Ugyldig slack kanal. Vennligst prøv på nytt'
     whatsapp:
+      media_download_failed: 'Kunne ikke laste ned filen.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -81,6 +81,7 @@ pl:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Nie udało się pobrać pliku.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -81,6 +81,7 @@ pt:
     slack:
       invalid_channel_id: 'Canal de slack inválido. Por favor, tente novamente'
     whatsapp:
+      media_download_failed: 'Não foi possível transferir o ficheiro.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -81,6 +81,7 @@ pt_BR:
     slack:
       invalid_channel_id: 'Canal de slack inválido. Por favor, tente novamente'
     whatsapp:
+      media_download_failed: 'Não foi possível baixar o arquivo.'
       token_exchange_failed: 'Falha ao trocar o código por um token de acesso. Por favor, tente novamente.'
       invalid_token_permissions: 'O token de acesso não tem as permissões necessárias para o WhatsApp.'
       phone_info_fetch_failed: 'Falha ao obter a informação do número de telefone. Por favor, tente novamente.'

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -81,6 +81,7 @@ ro:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Nu s-a putut descărca fișierul.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -81,6 +81,7 @@ ru:
     slack:
       invalid_channel_id: 'Неправильный канал slack - попробуйте еще раз'
     whatsapp:
+      media_download_failed: 'Не удалось загрузить файл.'
       token_exchange_failed: 'Не удалось обменять код на токена доступа. Пожалуйста, попробуйте еще раз.'
       invalid_token_permissions: 'Токен доступа не имеет необходимых прав для WhatsApp.'
       phone_info_fetch_failed: 'Не удалось получить информацию о номере телефона. Пожалуйста, попробуйте еще раз.'

--- a/config/locales/sh.yml
+++ b/config/locales/sh.yml
@@ -81,6 +81,7 @@ sh:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Mediji nisu mogli biti preuzeti.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -81,6 +81,7 @@ sk:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Médiá sa nepodarilo stiahnuť.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -81,6 +81,7 @@ sl:
     slack:
       invalid_channel_id: 'Neveljaven slack kanal. Prosimo poskusite ponovno'
     whatsapp:
+      media_download_failed: 'Medijev ni mogoče prenesti.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -81,6 +81,7 @@ sq:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Media nuk mund të shkarkohej.'
       token_exchange_failed: 'Dështoi shkëmbimi i kodit për tokenin e aksesit. Ju lutemi, provoni përsëri.'
       invalid_token_permissions: 'Tokeni i aksesit nuk ka lejet e nevojshme për WhatsApp.'
       phone_info_fetch_failed: 'Dështoi marrja e informacionit të numrit të telefonit. Ju lutemi, provoni përsëri.'

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -81,6 +81,7 @@ sr-Latn:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Медија се не може преузети.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -81,6 +81,7 @@ sv:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Kunde inte ladda ner filen.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -81,6 +81,7 @@ ta:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'ஊடகத்தைப் பதிவிறக்கம் செய்ய முடியவில்லை.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -81,6 +81,7 @@ th:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'ไม่สามารถดาวน์โหลดสื่อได้'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/tl.yml
+++ b/config/locales/tl.yml
@@ -81,6 +81,7 @@ tl:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Hindi madaling ma-download ang media.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -81,6 +81,7 @@ tr:
     slack:
       invalid_channel_id: 'Geçersiz Slack kanalı. Lütfen tekrar deneyin'
     whatsapp:
+      media_download_failed: 'Medya indirilemedi.'
       token_exchange_failed: 'Erişim tokeni için kod değişimi başarısız oldu. Lütfen tekrar deneyin.'
       invalid_token_permissions: 'Erişim tokeni WhatsApp için gerekli izinlere sahip değildir.'
       phone_info_fetch_failed: 'Telefon numarası bilgisi alınamadı. Lütfen tekrar deneyin.'

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -81,6 +81,7 @@ uk:
     slack:
       invalid_channel_id: 'Недійсний канал slack. Будь ласка, спробуйте ще раз'
     whatsapp:
+      media_download_failed: 'Не вдалося завантажити файл.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -81,6 +81,7 @@ ur:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'میڈیا ڈاؤن لوڈ نہیں ہو سکا۔'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/ur_IN.yml
+++ b/config/locales/ur_IN.yml
@@ -81,6 +81,7 @@ ur:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'میڈیا ڈاؤن لوڈ نہیں ہو سکا۔'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -81,6 +81,7 @@ vi:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: 'Không thể tải xuống tệp.'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/zh_CN.yml
+++ b/config/locales/zh_CN.yml
@@ -81,6 +81,7 @@ zh_CN:
     slack:
       invalid_channel_id: '无效的Slack频道。请重试'
     whatsapp:
+      media_download_failed: '无法下载媒体。'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/config/locales/zh_TW.yml
+++ b/config/locales/zh_TW.yml
@@ -81,6 +81,7 @@ zh_TW:
     slack:
       invalid_channel_id: 'Invalid slack channel. Please try again'
     whatsapp:
+      media_download_failed: '無法下載媒體。'
       token_exchange_failed: 'Failed to exchange code for access token. Please try again.'
       invalid_token_permissions: 'The access token does not have the required permissions for WhatsApp.'
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'

--- a/spec/enterprise/services/enterprise/billing/topup_checkout_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/topup_checkout_service_spec.rb
@@ -45,7 +45,7 @@ describe Enterprise::Billing::TopupCheckoutService do
 
     it 'raises error for invalid credits' do
       error = nil
-      expect { service.create_checkout_session(credits: 500) }.to raise_error { |e| error = e }
+      expect { service.create_checkout_session(credits: 500) }.to(raise_error { |e| error = e })
       expect(error.class.name).to eq('Enterprise::Billing::TopupCheckoutService::Error')
     end
 
@@ -53,7 +53,7 @@ describe Enterprise::Billing::TopupCheckoutService do
       account.update!(custom_attributes: { plan_name: 'Hacker', stripe_customer_id: stripe_customer_id })
 
       error = nil
-      expect { service.create_checkout_session(credits: 1000) }.to raise_error { |e| error = e }
+      expect { service.create_checkout_session(credits: 1000) }.to(raise_error { |e| error = e })
       expect(error.class.name).to eq('Enterprise::Billing::TopupCheckoutService::Error')
     end
   end

--- a/spec/enterprise/services/enterprise/billing/topup_checkout_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/topup_checkout_service_spec.rb
@@ -46,7 +46,9 @@ describe Enterprise::Billing::TopupCheckoutService do
     it 'raises error for invalid credits' do
       expect do
         service.create_checkout_session(credits: 500)
-      end.to raise_error(Enterprise::Billing::TopupCheckoutService::Error)
+      end.to raise_error do |error|
+        expect(error.class.name).to eq('Enterprise::Billing::TopupCheckoutService::Error')
+      end
     end
 
     it 'raises error when account is on free plan' do
@@ -54,7 +56,9 @@ describe Enterprise::Billing::TopupCheckoutService do
 
       expect do
         service.create_checkout_session(credits: 1000)
-      end.to raise_error(Enterprise::Billing::TopupCheckoutService::Error)
+      end.to raise_error do |error|
+        expect(error.class.name).to eq('Enterprise::Billing::TopupCheckoutService::Error')
+      end
     end
   end
 end

--- a/spec/enterprise/services/enterprise/billing/topup_checkout_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/topup_checkout_service_spec.rb
@@ -44,21 +44,17 @@ describe Enterprise::Billing::TopupCheckoutService do
     end
 
     it 'raises error for invalid credits' do
-      expect do
-        service.create_checkout_session(credits: 500)
-      end.to raise_error do |error|
-        expect(error.class.name).to eq('Enterprise::Billing::TopupCheckoutService::Error')
-      end
+      error = nil
+      expect { service.create_checkout_session(credits: 500) }.to raise_error { |e| error = e }
+      expect(error.class.name).to eq('Enterprise::Billing::TopupCheckoutService::Error')
     end
 
     it 'raises error when account is on free plan' do
       account.update!(custom_attributes: { plan_name: 'Hacker', stripe_customer_id: stripe_customer_id })
 
-      expect do
-        service.create_checkout_session(credits: 1000)
-      end.to raise_error do |error|
-        expect(error.class.name).to eq('Enterprise::Billing::TopupCheckoutService::Error')
-      end
+      error = nil
+      expect { service.create_checkout_session(credits: 1000) }.to raise_error { |e| error = e }
+      expect(error.class.name).to eq('Enterprise::Billing::TopupCheckoutService::Error')
     end
   end
 end

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -54,7 +54,11 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
         expect(whatsapp_channel.inbox.conversations.count).not_to eq(0)
         expect(Contact.all.first.name).to eq('Sojan Jose')
         expect(whatsapp_channel.inbox.messages.first.content).to eq('Check out my product!')
-        expect(whatsapp_channel.inbox.messages.first.attachments.present?).to be false
+        # Message still has a fallback attachment when download fails (e.g. 401)
+        attachment = whatsapp_channel.inbox.messages.first.attachments.first
+        expect(attachment).to be_present
+        expect(attachment.file_type).to eq('fallback')
+        expect(attachment.fallback_title).to eq(I18n.t('errors.whatsapp.media_download_failed'))
         expect(whatsapp_channel.authorization_error_count).to eq(1)
       end
     end


### PR DESCRIPTION
# Fix: Resilient WhatsApp Cloud API media download

## Summary

Makes incoming WhatsApp Cloud media (image, document, audio, video) handling resilient to intermittent download failures (connection reset, 500) so that the message is still created and only the attachment is skipped when the download fails.

## Problem

When a contact sends an image or other attachment via WhatsApp Cloud, the webhook triggers `Webhooks::WhatsappEventsJob` and `Whatsapp::IncomingMessageWhatsappCloudService#download_attachment_file`. The file is downloaded from the URL returned by the Graph API (lookaside.fbsbx.com). This download can intermittently fail with:

- **`Down::ConnectionError`** (e.g. "Connection reset by peer")
- **`Down::ServerError`** (500 Internal Server Error)

When that happens, the job raises and the **entire message** is never created in Chatwoot, so the conversation shows no trace of the contact's message.

Related context: [Meta Cloud API Media docs](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media/) — the download URL is temporary and the endpoint can be unreliable under load.

## Solution

1. **Explicit Graph API flow**  
   Obtain the download URL only via `GET /{media_id}` on the Graph API. We do not use any `url` field from the webhook payload (ephemeral and not intended for backend use).

2. **Timeouts**  
   Use `open_timeout: 20` and `read_timeout: 20` on the download request to avoid hanging on slow or stuck connections.

3. **Graceful degradation**  
   Rescue `Down::Error` and `IOError` in `download_attachment_file`, log a warning with `media_id`, and return `nil`. The base service already treats a blank result as "no attachment": the **message is still created**, only the attachment is missing. The conversation continues without breaking the job.

4. **Payload key handling**  
   Support both symbol and string keys for `attachment_payload["id"]` / `attachment_payload[:id]` for robustness with different param structures.

5. **Documentation**  
   Comments clarify that the Cloud API requires the `Authorization` header on the final download request and that we expect the full attachment hash from the base service.

## Testing

- [ ] Receive an image via WhatsApp Cloud → message and attachment appear.
- [ ] (Optional) Simulate or wait for a download failure → message is created, attachment missing; job does not raise; warning is logged.

## Refs

- Same code path as **#9809** (there the cause was token permissions; here we harden against transient network/server errors).
