### PR TITLE
chore: Enable Tiktok on paid plans Automatically

### DIFF
--- a/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
+++ b/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
@@ -11,6 +11,7 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
     channel_facebook
     channel_email
     channel_instagram
+    channel_tiktok
     captain_integration
     advanced_search_indexing
     advanced_search


### PR DESCRIPTION
This PR add the ability enable Tiktok integration on all paid plans.