### PR TITLE
feat: Add a priority + created at sort for conversations

### DIFF
--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -11,6 +11,7 @@ class ConversationFinder
     'priority_desc' => %w[sort_on_priority desc],
     'waiting_since_asc' => %w[sort_on_waiting_since asc],
     'waiting_since_desc' => %w[sort_on_waiting_since desc],
+    'priority_desc_created_at_asc' => %w[sort_on_priority_created_at desc],
 
     # To be removed in v3.5.0
     'latest' => %w[sort_on_last_activity_at desc],

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
@@ -27,7 +27,6 @@ const chatStatusFilter = useMapGetter('getChatStatusFilter');
 const chatSortFilter = useMapGetter('getChatSortFilter');
 
 const [showActionsDropdown, toggleDropdown] = useToggle();
-const [showSortMenu, toggleSortMenu] = useToggle();
 
 const currentStatusFilter = computed(() => {
   return chatStatusFilter.value || wootConstants.STATUS_TYPE.OPEN;
@@ -62,68 +61,42 @@ const chatStatusOptions = computed(() => [
   },
 ]);
 
-const chatSortGroups = computed(() => [
+const chatSortOptions = computed(() => [
   {
-    icon: 'i-lucide-activity',
-    title: t('CHAT_LIST.SORT_ORDER_GROUPS.LAST_ACTIVITY'),
-    options: [
-      {
-        label: t('CHAT_LIST.SORT_ORDER_ITEMS.last_activity_at_desc.SHORT'),
-        value: 'last_activity_at_desc',
-      },
-      {
-        label: t('CHAT_LIST.SORT_ORDER_ITEMS.last_activity_at_asc.SHORT'),
-        value: 'last_activity_at_asc',
-      },
-    ],
+    label: t('CHAT_LIST.SORT_ORDER_ITEMS.last_activity_at_asc.TEXT'),
+    value: 'last_activity_at_asc',
   },
   {
-    icon: 'i-lucide-calendar',
-    title: t('CHAT_LIST.SORT_ORDER_GROUPS.CREATED_AT'),
-    options: [
-      {
-        label: t('CHAT_LIST.SORT_ORDER_ITEMS.created_at_desc.SHORT'),
-        value: 'created_at_desc',
-      },
-      {
-        label: t('CHAT_LIST.SORT_ORDER_ITEMS.created_at_asc.SHORT'),
-        value: 'created_at_asc',
-      },
-    ],
+    label: t('CHAT_LIST.SORT_ORDER_ITEMS.last_activity_at_desc.TEXT'),
+    value: 'last_activity_at_desc',
   },
   {
-    icon: 'i-lucide-signal',
-    title: t('CHAT_LIST.SORT_ORDER_GROUPS.PRIORITY'),
-    options: [
-      {
-        label: t('CHAT_LIST.SORT_ORDER_ITEMS.priority_desc.SHORT'),
-        value: 'priority_desc',
-      },
-      {
-        label: t('CHAT_LIST.SORT_ORDER_ITEMS.priority_asc.SHORT'),
-        value: 'priority_asc',
-      },
-      {
-        label: t(
-          'CHAT_LIST.SORT_ORDER_ITEMS.priority_desc_created_at_asc.SHORT'
-        ),
-        value: 'priority_desc_created_at_asc',
-      },
-    ],
+    label: t('CHAT_LIST.SORT_ORDER_ITEMS.created_at_desc.TEXT'),
+    value: 'created_at_desc',
   },
   {
-    icon: 'i-lucide-clock',
-    title: t('CHAT_LIST.SORT_ORDER_GROUPS.WAITING_SINCE'),
-    options: [
-      {
-        label: t('CHAT_LIST.SORT_ORDER_ITEMS.waiting_since_asc.SHORT'),
-        value: 'waiting_since_asc',
-      },
-      {
-        label: t('CHAT_LIST.SORT_ORDER_ITEMS.waiting_since_desc.SHORT'),
-        value: 'waiting_since_desc',
-      },
-    ],
+    label: t('CHAT_LIST.SORT_ORDER_ITEMS.created_at_asc.TEXT'),
+    value: 'created_at_asc',
+  },
+  {
+    label: t('CHAT_LIST.SORT_ORDER_ITEMS.priority_desc.TEXT'),
+    value: 'priority_desc',
+  },
+  {
+    label: t('CHAT_LIST.SORT_ORDER_ITEMS.priority_asc.TEXT'),
+    value: 'priority_asc',
+  },
+  {
+    label: t('CHAT_LIST.SORT_ORDER_ITEMS.priority_desc_created_at_asc.TEXT'),
+    value: 'priority_desc_created_at_asc',
+  },
+  {
+    label: t('CHAT_LIST.SORT_ORDER_ITEMS.waiting_since_asc.TEXT'),
+    value: 'waiting_since_asc',
+  },
+  {
+    label: t('CHAT_LIST.SORT_ORDER_ITEMS.waiting_since_desc.TEXT'),
+    value: 'waiting_since_desc',
   },
 ]);
 
@@ -133,13 +106,11 @@ const activeChatStatusLabel = computed(
       ?.label || ''
 );
 
-const activeChatSortLabel = computed(() => {
-  const allOptions = chatSortGroups.value.flatMap(group =>
-    group.options.map(o => ({ ...o, groupTitle: group.title }))
-  );
-  const match = allOptions.find(o => o.value === chatSortFilter.value);
-  return match ? `${match.groupTitle}: ${match.label}` : '';
-});
+const activeChatSortLabel = computed(
+  () =>
+    chatSortOptions.value.find(m => m.value === chatSortFilter.value)?.label ||
+    ''
+);
 
 const saveSelectedFilter = (type, value) => {
   updateUISettings({
@@ -161,11 +132,6 @@ const handleSortChange = value => {
   store.dispatch('setChatSortFilter', value);
   saveSelectedFilter('sort', value);
 };
-
-const handleSortSelect = value => {
-  handleSortChange(value);
-  toggleSortMenu(false);
-};
 </script>
 
 <template>
@@ -176,19 +142,11 @@ const handleSortSelect = value => {
       slate
       faded
       xs
-      @click="
-        toggleDropdown();
-        toggleSortMenu(false);
-      "
+      @click="toggleDropdown()"
     />
     <div
       v-if="showActionsDropdown"
-      v-on-click-outside="
-        () => {
-          toggleDropdown(false);
-          toggleSortMenu(false);
-        }
-      "
+      v-on-click-outside="() => toggleDropdown()"
       class="mt-1 bg-n-alpha-3 backdrop-blur-[100px] border border-n-weak w-72 rounded-xl p-4 absolute z-40 top-full"
       :class="{
         'ltr:left-0 rtl:right-0': !isOnExpandedLayout,
@@ -211,68 +169,13 @@ const handleSortSelect = value => {
         <span class="text-sm truncate text-n-slate-12">
           {{ $t('CHAT_LIST.CHAT_SORT.ORDER_BY') }}
         </span>
-        <div
-          v-on-click-outside="() => toggleSortMenu(false)"
-          class="relative flex flex-col gap-1 w-fit"
-        >
-          <NextButton
-            icon="i-lucide-chevron-down"
-            size="sm"
-            trailing-icon
-            color="slate"
-            variant="faded"
-            class="!w-fit max-w-40"
-            :class="{ 'dark:!bg-n-alpha-2 !bg-n-slate-9/20': showSortMenu }"
-            :label="activeChatSortLabel"
-            @click="toggleSortMenu()"
-          />
-          <div
-            v-if="showSortMenu"
-            class="absolute select-none w-56 flex flex-col bg-n-alpha-3 backdrop-blur-[100px] py-2 px-1 top-0 shadow-lg z-40 rounded-lg border border-n-weak dark:border-n-strong/50"
-            :class="{
-              'ltr:left-full rtl:right-full ltr:ml-1 rtl:mr-1':
-                !isOnExpandedLayout,
-              'ltr:right-full rtl:left-full ltr:mr-1 rtl:ml-1':
-                isOnExpandedLayout,
-            }"
-          >
-            <template
-              v-for="(group, gIdx) in chatSortGroups"
-              :key="group.title"
-            >
-              <div v-if="gIdx > 0" class="h-px bg-n-alpha-2 mx-1 my-1" />
-              <div class="flex items-center gap-1.5 px-2 pt-1.5 pb-0.5">
-                <span class="size-3 text-n-slate-10" :class="group.icon" />
-                <span
-                  class="text-[11px] font-medium text-n-slate-10 uppercase tracking-wide"
-                >
-                  {{ group.title }}
-                </span>
-              </div>
-              <button
-                v-for="option in group.options"
-                :key="option.value"
-                type="button"
-                class="flex items-center gap-2 w-full px-2 py-1 rounded-lg text-sm text-n-slate-12 hover:bg-n-alpha-1 dark:hover:bg-n-alpha-2 transition-colors"
-                :class="{
-                  'bg-n-alpha-1 dark:bg-n-alpha-2':
-                    option.value === chatSortFilter,
-                }"
-                @click="handleSortSelect(option.value)"
-              >
-                <span
-                  class="size-3.5 flex-shrink-0"
-                  :class="
-                    option.value === chatSortFilter
-                      ? 'i-lucide-check text-n-blue-11'
-                      : ''
-                  "
-                />
-                <span>{{ option.label }}</span>
-              </button>
-            </template>
-          </div>
-        </div>
+        <SelectMenu
+          :model-value="chatSortFilter"
+          :options="chatSortOptions"
+          :label="activeChatSortLabel"
+          :sub-menu-position="isOnExpandedLayout ? 'left' : 'right'"
+          @update:model-value="handleSortChange"
+        />
       </div>
     </div>
   </div>

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
@@ -27,6 +27,7 @@ const chatStatusFilter = useMapGetter('getChatStatusFilter');
 const chatSortFilter = useMapGetter('getChatSortFilter');
 
 const [showActionsDropdown, toggleDropdown] = useToggle();
+const [showSortMenu, toggleSortMenu] = useToggle();
 
 const currentStatusFilter = computed(() => {
   return chatStatusFilter.value || wootConstants.STATUS_TYPE.OPEN;
@@ -61,38 +62,68 @@ const chatStatusOptions = computed(() => [
   },
 ]);
 
-const chatSortOptions = computed(() => [
+const chatSortGroups = computed(() => [
   {
-    label: t('CHAT_LIST.SORT_ORDER_ITEMS.last_activity_at_asc.TEXT'),
-    value: 'last_activity_at_asc',
+    icon: 'i-lucide-activity',
+    title: t('CHAT_LIST.SORT_ORDER_GROUPS.LAST_ACTIVITY'),
+    options: [
+      {
+        label: t('CHAT_LIST.SORT_ORDER_ITEMS.last_activity_at_desc.SHORT'),
+        value: 'last_activity_at_desc',
+      },
+      {
+        label: t('CHAT_LIST.SORT_ORDER_ITEMS.last_activity_at_asc.SHORT'),
+        value: 'last_activity_at_asc',
+      },
+    ],
   },
   {
-    label: t('CHAT_LIST.SORT_ORDER_ITEMS.last_activity_at_desc.TEXT'),
-    value: 'last_activity_at_desc',
+    icon: 'i-lucide-calendar',
+    title: t('CHAT_LIST.SORT_ORDER_GROUPS.CREATED_AT'),
+    options: [
+      {
+        label: t('CHAT_LIST.SORT_ORDER_ITEMS.created_at_desc.SHORT'),
+        value: 'created_at_desc',
+      },
+      {
+        label: t('CHAT_LIST.SORT_ORDER_ITEMS.created_at_asc.SHORT'),
+        value: 'created_at_asc',
+      },
+    ],
   },
   {
-    label: t('CHAT_LIST.SORT_ORDER_ITEMS.created_at_desc.TEXT'),
-    value: 'created_at_desc',
+    icon: 'i-lucide-signal',
+    title: t('CHAT_LIST.SORT_ORDER_GROUPS.PRIORITY'),
+    options: [
+      {
+        label: t('CHAT_LIST.SORT_ORDER_ITEMS.priority_desc.SHORT'),
+        value: 'priority_desc',
+      },
+      {
+        label: t('CHAT_LIST.SORT_ORDER_ITEMS.priority_asc.SHORT'),
+        value: 'priority_asc',
+      },
+      {
+        label: t(
+          'CHAT_LIST.SORT_ORDER_ITEMS.priority_desc_created_at_asc.SHORT'
+        ),
+        value: 'priority_desc_created_at_asc',
+      },
+    ],
   },
   {
-    label: t('CHAT_LIST.SORT_ORDER_ITEMS.created_at_asc.TEXT'),
-    value: 'created_at_asc',
-  },
-  {
-    label: t('CHAT_LIST.SORT_ORDER_ITEMS.priority_desc.TEXT'),
-    value: 'priority_desc',
-  },
-  {
-    label: t('CHAT_LIST.SORT_ORDER_ITEMS.priority_asc.TEXT'),
-    value: 'priority_asc',
-  },
-  {
-    label: t('CHAT_LIST.SORT_ORDER_ITEMS.waiting_since_asc.TEXT'),
-    value: 'waiting_since_asc',
-  },
-  {
-    label: t('CHAT_LIST.SORT_ORDER_ITEMS.waiting_since_desc.TEXT'),
-    value: 'waiting_since_desc',
+    icon: 'i-lucide-clock',
+    title: t('CHAT_LIST.SORT_ORDER_GROUPS.WAITING_SINCE'),
+    options: [
+      {
+        label: t('CHAT_LIST.SORT_ORDER_ITEMS.waiting_since_asc.SHORT'),
+        value: 'waiting_since_asc',
+      },
+      {
+        label: t('CHAT_LIST.SORT_ORDER_ITEMS.waiting_since_desc.SHORT'),
+        value: 'waiting_since_desc',
+      },
+    ],
   },
 ]);
 
@@ -102,11 +133,13 @@ const activeChatStatusLabel = computed(
       ?.label || ''
 );
 
-const activeChatSortLabel = computed(
-  () =>
-    chatSortOptions.value.find(m => m.value === chatSortFilter.value)?.label ||
-    ''
-);
+const activeChatSortLabel = computed(() => {
+  const allOptions = chatSortGroups.value.flatMap(group =>
+    group.options.map(o => ({ ...o, groupTitle: group.title }))
+  );
+  const match = allOptions.find(o => o.value === chatSortFilter.value);
+  return match ? `${match.groupTitle}: ${match.label}` : '';
+});
 
 const saveSelectedFilter = (type, value) => {
   updateUISettings({
@@ -128,6 +161,11 @@ const handleSortChange = value => {
   store.dispatch('setChatSortFilter', value);
   saveSelectedFilter('sort', value);
 };
+
+const handleSortSelect = value => {
+  handleSortChange(value);
+  toggleSortMenu(false);
+};
 </script>
 
 <template>
@@ -138,11 +176,19 @@ const handleSortChange = value => {
       slate
       faded
       xs
-      @click="toggleDropdown()"
+      @click="
+        toggleDropdown();
+        toggleSortMenu(false);
+      "
     />
     <div
       v-if="showActionsDropdown"
-      v-on-click-outside="() => toggleDropdown()"
+      v-on-click-outside="
+        () => {
+          toggleDropdown(false);
+          toggleSortMenu(false);
+        }
+      "
       class="mt-1 bg-n-alpha-3 backdrop-blur-[100px] border border-n-weak w-72 rounded-xl p-4 absolute z-40 top-full"
       :class="{
         'ltr:left-0 rtl:right-0': !isOnExpandedLayout,
@@ -165,13 +211,68 @@ const handleSortChange = value => {
         <span class="text-sm truncate text-n-slate-12">
           {{ $t('CHAT_LIST.CHAT_SORT.ORDER_BY') }}
         </span>
-        <SelectMenu
-          :model-value="chatSortFilter"
-          :options="chatSortOptions"
-          :label="activeChatSortLabel"
-          :sub-menu-position="isOnExpandedLayout ? 'left' : 'right'"
-          @update:model-value="handleSortChange"
-        />
+        <div
+          v-on-click-outside="() => toggleSortMenu(false)"
+          class="relative flex flex-col gap-1 w-fit"
+        >
+          <NextButton
+            icon="i-lucide-chevron-down"
+            size="sm"
+            trailing-icon
+            color="slate"
+            variant="faded"
+            class="!w-fit max-w-40"
+            :class="{ 'dark:!bg-n-alpha-2 !bg-n-slate-9/20': showSortMenu }"
+            :label="activeChatSortLabel"
+            @click="toggleSortMenu()"
+          />
+          <div
+            v-if="showSortMenu"
+            class="absolute select-none w-56 flex flex-col bg-n-alpha-3 backdrop-blur-[100px] py-2 px-1 top-0 shadow-lg z-40 rounded-lg border border-n-weak dark:border-n-strong/50"
+            :class="{
+              'ltr:left-full rtl:right-full ltr:ml-1 rtl:mr-1':
+                !isOnExpandedLayout,
+              'ltr:right-full rtl:left-full ltr:mr-1 rtl:ml-1':
+                isOnExpandedLayout,
+            }"
+          >
+            <template
+              v-for="(group, gIdx) in chatSortGroups"
+              :key="group.title"
+            >
+              <div v-if="gIdx > 0" class="h-px bg-n-alpha-2 mx-1 my-1" />
+              <div class="flex items-center gap-1.5 px-2 pt-1.5 pb-0.5">
+                <span class="size-3 text-n-slate-10" :class="group.icon" />
+                <span
+                  class="text-[11px] font-medium text-n-slate-10 uppercase tracking-wide"
+                >
+                  {{ group.title }}
+                </span>
+              </div>
+              <button
+                v-for="option in group.options"
+                :key="option.value"
+                type="button"
+                class="flex items-center gap-2 w-full px-2 py-1 rounded-lg text-sm text-n-slate-12 hover:bg-n-alpha-1 dark:hover:bg-n-alpha-2 transition-colors"
+                :class="{
+                  'bg-n-alpha-1 dark:bg-n-alpha-2':
+                    option.value === chatSortFilter,
+                }"
+                @click="handleSortSelect(option.value)"
+              >
+                <span
+                  class="size-3.5 flex-shrink-0"
+                  :class="
+                    option.value === chatSortFilter
+                      ? 'i-lucide-check text-n-blue-11'
+                      : ''
+                  "
+                />
+                <span>{{ option.label }}</span>
+              </button>
+            </template>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/javascript/dashboard/constants/globals.js
+++ b/app/javascript/dashboard/constants/globals.js
@@ -21,6 +21,7 @@ export default {
     PRIORITY_DESC: 'priority_desc',
     WAITING_SINCE_ASC: 'waiting_since_asc',
     WAITING_SINCE_DESC: 'waiting_since_desc',
+    PRIORITY_DESC_CREATED_AT_ASC: 'priority_desc_created_at_asc',
   },
   ARTICLE_STATUS_TYPES: {
     DRAFT: 0,

--- a/app/javascript/dashboard/i18n/locale/en/chatlist.json
+++ b/app/javascript/dashboard/i18n/locale/en/chatlist.json
@@ -52,48 +52,33 @@
         "ACTIVE": "Last activity"
       }
     },
-    "SORT_ORDER_GROUPS": {
-      "LAST_ACTIVITY": "Last Activity",
-      "CREATED_AT": "Created At",
-      "PRIORITY": "Priority",
-      "WAITING_SINCE": "Pending Response"
-    },
     "SORT_ORDER_ITEMS": {
       "last_activity_at_asc": {
-        "TEXT": "Last activity: Oldest first",
-        "SHORT": "Oldest first"
+        "TEXT": "Last activity: Oldest first"
       },
       "last_activity_at_desc": {
-        "TEXT": "Last activity: Newest first",
-        "SHORT": "Newest first"
+        "TEXT": "Last activity: Newest first"
       },
       "created_at_desc": {
-        "TEXT": "Created at: Newest first",
-        "SHORT": "Newest first"
+        "TEXT": "Created at: Newest first"
       },
       "created_at_asc": {
-        "TEXT": "Created at: Oldest first",
-        "SHORT": "Oldest first"
+        "TEXT": "Created at: Oldest first"
       },
       "priority_desc": {
-        "TEXT": "Priority: Highest first",
-        "SHORT": "Highest first"
+        "TEXT": "Priority: Highest first"
       },
       "priority_asc": {
-        "TEXT": "Priority: Lowest first",
-        "SHORT": "Lowest first"
+        "TEXT": "Priority: Lowest first"
       },
       "waiting_since_asc": {
-        "TEXT": "Pending Response: Longest first",
-        "SHORT": "Longest first"
+        "TEXT": "Pending Response: Longest first"
       },
       "waiting_since_desc": {
-        "TEXT": "Pending Response: Shortest first",
-        "SHORT": "Shortest first"
+        "TEXT": "Pending Response: Shortest first"
       },
       "priority_desc_created_at_asc": {
-        "TEXT": "Priority: Highest first, Created: Oldest first",
-        "SHORT": "Highest, oldest created"
+        "TEXT": "Priority: Highest first, Created: Oldest first"
       }
     },
     "ATTACHMENTS": {

--- a/app/javascript/dashboard/i18n/locale/en/chatlist.json
+++ b/app/javascript/dashboard/i18n/locale/en/chatlist.json
@@ -52,30 +52,48 @@
         "ACTIVE": "Last activity"
       }
     },
+    "SORT_ORDER_GROUPS": {
+      "LAST_ACTIVITY": "Last Activity",
+      "CREATED_AT": "Created At",
+      "PRIORITY": "Priority",
+      "WAITING_SINCE": "Pending Response"
+    },
     "SORT_ORDER_ITEMS": {
       "last_activity_at_asc": {
-        "TEXT": "Last activity: Oldest first"
+        "TEXT": "Last activity: Oldest first",
+        "SHORT": "Oldest first"
       },
       "last_activity_at_desc": {
-        "TEXT": "Last activity: Newest first"
+        "TEXT": "Last activity: Newest first",
+        "SHORT": "Newest first"
       },
       "created_at_desc": {
-        "TEXT": "Created at: Newest first"
+        "TEXT": "Created at: Newest first",
+        "SHORT": "Newest first"
       },
       "created_at_asc": {
-        "TEXT": "Created at: Oldest first"
+        "TEXT": "Created at: Oldest first",
+        "SHORT": "Oldest first"
       },
       "priority_desc": {
-        "TEXT": "Priority: Highest first"
+        "TEXT": "Priority: Highest first",
+        "SHORT": "Highest first"
       },
       "priority_asc": {
-        "TEXT": "Priority: Lowest first"
+        "TEXT": "Priority: Lowest first",
+        "SHORT": "Lowest first"
       },
       "waiting_since_asc": {
-        "TEXT": "Pending Response: Longest first"
+        "TEXT": "Pending Response: Longest first",
+        "SHORT": "Longest first"
       },
       "waiting_since_desc": {
-        "TEXT": "Pending Response: Shortest first"
+        "TEXT": "Pending Response: Shortest first",
+        "SHORT": "Shortest first"
+      },
+      "priority_desc_created_at_asc": {
+        "TEXT": "Priority: Highest first, Created: Oldest first",
+        "SHORT": "Highest, oldest created"
       }
     },
     "ATTACHMENTS": {

--- a/app/javascript/dashboard/store/modules/conversations/helpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers.js
@@ -116,6 +116,7 @@ const SORT_OPTIONS = {
   priority_desc: ['sortOnPriority', 'desc'],
   waiting_since_asc: ['sortOnWaitingSince', 'asc'],
   waiting_since_desc: ['sortOnWaitingSince', 'desc'],
+  priority_desc_created_at_asc: ['sortOnPriorityCreatedAt', 'desc'],
 };
 const sortAscending = (valueA, valueB) => valueA - valueB;
 const sortDescending = (valueA, valueB) => valueB - valueA;
@@ -137,6 +138,14 @@ const sortConfig = {
     const p2 = CONVERSATION_PRIORITY_ORDER[b.priority] || DEFAULT_FOR_NULL;
 
     return getSortOrderFunction(sortDirection)(p1, p2);
+  },
+
+  sortOnPriorityCreatedAt: (a, b) => {
+    const DEFAULT_FOR_NULL = 0;
+    const p1 = CONVERSATION_PRIORITY_ORDER[a.priority] || DEFAULT_FOR_NULL;
+    const p2 = CONVERSATION_PRIORITY_ORDER[b.priority] || DEFAULT_FOR_NULL;
+    if (p1 !== p2) return p2 - p1;
+    return a.created_at - b.created_at;
   },
 
   sortOnWaitingSince: (a, b, sortDirection) => {

--- a/app/models/concerns/sort_handler.rb
+++ b/app/models/concerns/sort_handler.rb
@@ -14,6 +14,10 @@ module SortHandler
       order(generate_sql_query("priority #{sort_direction.to_s.upcase} NULLS LAST, last_activity_at DESC"))
     end
 
+    def sort_on_priority_created_at(sort_direction = :desc)
+      order(generate_sql_query("priority #{sort_direction.to_s.upcase} NULLS LAST, created_at ASC"))
+    end
+
     def sort_on_waiting_since(sort_direction = :asc)
       order(generate_sql_query("waiting_since #{sort_direction.to_s.upcase} NULLS LAST, created_at ASC"))
     end


### PR DESCRIPTION
- Add a new conversation sort option "Priority: Highest first, Created: Oldest first" that sorts by priority descending (urgent > high > medium > low > none) with created_at ascending as the tiebreaker
