### PR TITLE
feat: include contact verified status with each tool call

### DIFF
--- a/enterprise/app/models/concerns/toolable.rb
+++ b/enterprise/app/models/concerns/toolable.rb
@@ -71,6 +71,7 @@ module Concerns::Toolable
       add_base_headers(headers, state)
       add_conversation_headers(headers, state[:conversation]) if state[:conversation]
       add_contact_headers(headers, state[:contact]) if state[:contact]
+      add_contact_inbox_headers(headers, state[:contact_inbox])
     end
   end
 
@@ -89,6 +90,11 @@ module Concerns::Toolable
     headers['X-Chatwoot-Contact-Id'] = contact[:id].to_s if contact[:id]
     headers['X-Chatwoot-Contact-Email'] = contact[:email].to_s if contact[:email].present?
     headers['X-Chatwoot-Contact-Phone'] = contact[:phone_number].to_s if contact[:phone_number].present?
+  end
+
+  def add_contact_inbox_headers(headers, contact_inbox)
+    headers['X-Chatwoot-Contact-Inbox-Id'] = contact_inbox[:id].to_s if contact_inbox&.[](:id)
+    headers['X-Chatwoot-Contact-Inbox-Verified'] = (contact_inbox&.[](:hmac_verified) || false).to_s
   end
 
   def format_response(raw_response_body)

--- a/enterprise/app/services/captain/assistant/agent_runner_service.rb
+++ b/enterprise/app/services/captain/assistant/agent_runner_service.rb
@@ -129,18 +129,19 @@ class Captain::Assistant::AgentRunnerService
       assistant_config: @assistant.config
     }
 
-    if @conversation
-      state[:conversation] = @conversation.attributes.symbolize_keys.slice(*CONVERSATION_STATE_ATTRIBUTES)
-      state[:channel_type] = @conversation.inbox&.channel_type
-      if @conversation.contact_inbox
-        state[:contact_inbox] =
-          @conversation.contact_inbox.attributes.symbolize_keys.slice(*CONTACT_INBOX_STATE_ATTRIBUTES)
-      end
-      state[:contact] = @conversation.contact.attributes.symbolize_keys.slice(*CONTACT_STATE_ATTRIBUTES) if @conversation.contact
-      state[:campaign] = @conversation.campaign.attributes.symbolize_keys.slice(*CAMPAIGN_STATE_ATTRIBUTES) if @conversation.campaign
-    end
-
+    build_conversation_state(state) if @conversation
     state
+  end
+
+  def build_conversation_state(state)
+    state[:conversation] = @conversation.attributes.symbolize_keys.slice(*CONVERSATION_STATE_ATTRIBUTES)
+    state[:channel_type] = @conversation.inbox&.channel_type
+    state[:contact] = @conversation.contact.attributes.symbolize_keys.slice(*CONTACT_STATE_ATTRIBUTES) if @conversation.contact
+    state[:campaign] = @conversation.campaign.attributes.symbolize_keys.slice(*CAMPAIGN_STATE_ATTRIBUTES) if @conversation.campaign
+    return unless @conversation.contact_inbox
+
+    state[:contact_inbox] =
+      @conversation.contact_inbox.attributes.symbolize_keys.slice(*CONTACT_INBOX_STATE_ATTRIBUTES)
   end
 
   def build_and_wire_agents

--- a/enterprise/app/services/captain/assistant/agent_runner_service.rb
+++ b/enterprise/app/services/captain/assistant/agent_runner_service.rb
@@ -16,6 +16,8 @@ class Captain::Assistant::AgentRunnerService
     custom_attributes additional_attributes
   ].freeze
 
+  CONTACT_INBOX_STATE_ATTRIBUTES = %i[id hmac_verified].freeze
+
   CAMPAIGN_STATE_ATTRIBUTES = %i[id title message campaign_type description].freeze
 
   def initialize(assistant:, conversation: nil, callbacks: {})
@@ -130,6 +132,10 @@ class Captain::Assistant::AgentRunnerService
     if @conversation
       state[:conversation] = @conversation.attributes.symbolize_keys.slice(*CONVERSATION_STATE_ATTRIBUTES)
       state[:channel_type] = @conversation.inbox&.channel_type
+      if @conversation.contact_inbox
+        state[:contact_inbox] =
+          @conversation.contact_inbox.attributes.symbolize_keys.slice(*CONTACT_INBOX_STATE_ATTRIBUTES)
+      end
       state[:contact] = @conversation.contact.attributes.symbolize_keys.slice(*CONTACT_STATE_ATTRIBUTES) if @conversation.contact
       state[:campaign] = @conversation.campaign.attributes.symbolize_keys.slice(*CAMPAIGN_STATE_ATTRIBUTES) if @conversation.campaign
     end

--- a/enterprise/lib/captain/prompts/assistant.liquid
+++ b/enterprise/lib/captain/prompts/assistant.liquid
@@ -22,7 +22,7 @@ Here's the metadata we have about the current conversation and the contact assoc
 {% endif -%}
 
 {% if campaign.id -%}
-{% render 'campaign' %}
+{% render 'campaign', campaign: campaign %}
 {% endif -%}
 {% endif -%}
 

--- a/enterprise/lib/captain/prompts/scenario.liquid
+++ b/enterprise/lib/captain/prompts/scenario.liquid
@@ -22,7 +22,7 @@ Here's the metadata we have about the current conversation and the contact assoc
 {% endif -%}
 
 {% if campaign.id -%}
-{% render 'campaign' %}
+{% render 'campaign', campaign: campaign %}
 {% endif -%}
 {% endif -%}
 

--- a/spec/enterprise/lib/captain/tools/http_tool_spec.rb
+++ b/spec/enterprise/lib/captain/tools/http_tool_spec.rb
@@ -249,6 +249,10 @@ RSpec.describe Captain::Tools::HttpTool, type: :model do
                                    id: conversation.id,
                                    display_id: conversation.display_id
                                  },
+                                 contact_inbox: {
+                                   id: conversation.contact_inbox.id,
+                                   hmac_verified: conversation.contact_inbox.hmac_verified
+                                 },
                                  contact: {
                                    id: contact.id,
                                    email: contact.email,
@@ -272,6 +276,8 @@ RSpec.describe Captain::Tools::HttpTool, type: :model do
                   'X-Chatwoot-Tool-Slug' => custom_tool.slug,
                   'X-Chatwoot-Conversation-Id' => conversation.id.to_s,
                   'X-Chatwoot-Conversation-Display-Id' => conversation.display_id.to_s,
+                  'X-Chatwoot-Contact-Inbox-Id' => conversation.contact_inbox.id.to_s,
+                  'X-Chatwoot-Contact-Inbox-Verified' => conversation.contact_inbox.hmac_verified.to_s,
                   'X-Chatwoot-Contact-Id' => contact.id.to_s,
                   'X-Chatwoot-Contact-Email' => contact.email
                 })
@@ -282,6 +288,7 @@ RSpec.describe Captain::Tools::HttpTool, type: :model do
         expect(WebMock).to have_requested(:get, 'https://example.com/api/data')
           .with(headers: {
                   'X-Chatwoot-Account-Id' => account.id.to_s,
+                  'X-Chatwoot-Contact-Inbox-Verified' => conversation.contact_inbox.hmac_verified.to_s,
                   'X-Chatwoot-Contact-Email' => contact.email
                 })
       end
@@ -296,6 +303,7 @@ RSpec.describe Captain::Tools::HttpTool, type: :model do
               'Content-Type' => 'application/json',
               'X-Chatwoot-Account-Id' => account.id.to_s,
               'X-Chatwoot-Tool-Slug' => custom_tool.slug,
+              'X-Chatwoot-Contact-Inbox-Verified' => conversation.contact_inbox.hmac_verified.to_s,
               'X-Chatwoot-Contact-Email' => contact.email
             }
           )
@@ -316,6 +324,7 @@ RSpec.describe Captain::Tools::HttpTool, type: :model do
           .with(headers: {
                   'Authorization' => 'Bearer test_token',
                   'X-Chatwoot-Account-Id' => account.id.to_s,
+                  'X-Chatwoot-Contact-Inbox-Verified' => conversation.contact_inbox.hmac_verified.to_s,
                   'X-Chatwoot-Contact-Id' => contact.id.to_s
                 })
           .to_return(status: 200, body: '{"success": true}')
@@ -336,19 +345,50 @@ RSpec.describe Captain::Tools::HttpTool, type: :model do
                                                            conversation: {
                                                              id: conversation.id,
                                                              display_id: conversation.display_id
+                                                           },
+                                                           contact_inbox: {
+                                                             id: conversation.contact_inbox.id,
+                                                             hmac_verified: conversation.contact_inbox.hmac_verified
                                                            }
                                                          })
 
         stub_request(:get, 'https://example.com/api/data')
           .with(headers: {
                   'X-Chatwoot-Account-Id' => account.id.to_s,
-                  'X-Chatwoot-Conversation-Id' => conversation.id.to_s
+                  'X-Chatwoot-Conversation-Id' => conversation.id.to_s,
+                  'X-Chatwoot-Contact-Inbox-Verified' => conversation.contact_inbox.hmac_verified.to_s
                 })
           .to_return(status: 200, body: '{"success": true}')
 
         tool.perform(tool_context_no_contact)
 
         expect(WebMock).to have_requested(:get, 'https://example.com/api/data')
+      end
+
+      it 'defaults contact inbox verified header to false when contact inbox is missing' do
+        tool_context_without_contact_inbox = Struct.new(:state).new({
+                                                                      account_id: account.id,
+                                                                      assistant_id: assistant.id,
+                                                                      conversation: {
+                                                                        id: conversation.id,
+                                                                        display_id: conversation.display_id
+                                                                      },
+                                                                      contact: {
+                                                                        id: contact.id,
+                                                                        email: contact.email
+                                                                      }
+                                                                    })
+
+        stub_request(:get, 'https://example.com/api/data')
+          .with(headers: {
+                  'X-Chatwoot-Contact-Inbox-Verified' => 'false'
+                })
+          .to_return(status: 200, body: '{"success": true}')
+
+        tool.perform(tool_context_without_contact_inbox)
+
+        expect(WebMock).to have_requested(:get, 'https://example.com/api/data')
+          .with(headers: { 'X-Chatwoot-Contact-Inbox-Verified' => 'false' })
       end
 
       it 'includes contact phone when present' do
@@ -365,6 +405,22 @@ RSpec.describe Captain::Tools::HttpTool, type: :model do
 
         expect(WebMock).to have_requested(:get, 'https://example.com/api/data')
           .with(headers: { 'X-Chatwoot-Contact-Phone' => '+1234567890' })
+      end
+
+      it 'includes unverified contact inbox status explicitly as false' do
+        conversation.contact_inbox.update!(hmac_verified: false)
+        tool_context_with_state.state[:contact_inbox][:hmac_verified] = false
+
+        stub_request(:get, 'https://example.com/api/data')
+          .with(headers: {
+                  'X-Chatwoot-Contact-Inbox-Verified' => 'false'
+                })
+          .to_return(status: 200, body: '{"success": true}')
+
+        tool.perform(tool_context_with_state)
+
+        expect(WebMock).to have_requested(:get, 'https://example.com/api/data')
+          .with(headers: { 'X-Chatwoot-Contact-Inbox-Verified' => 'false' })
       end
     end
   end

--- a/spec/enterprise/models/captain/custom_tool_spec.rb
+++ b/spec/enterprise/models/captain/custom_tool_spec.rb
@@ -341,6 +341,10 @@ RSpec.describe Captain::CustomTool, type: :model do
             id: conversation.id,
             display_id: conversation.display_id
           },
+          contact_inbox: {
+            id: conversation.contact_inbox.id,
+            hmac_verified: conversation.contact_inbox.hmac_verified
+          },
           contact: {
             id: contact.id,
             email: contact.email,
@@ -376,6 +380,13 @@ RSpec.describe Captain::CustomTool, type: :model do
         expect(headers['X-Chatwoot-Contact-Email']).to eq(contact.email)
       end
 
+      it 'includes contact inbox verification metadata when present' do
+        headers = tool.build_metadata_headers(state)
+
+        expect(headers['X-Chatwoot-Contact-Inbox-Id']).to eq(conversation.contact_inbox.id.to_s)
+        expect(headers['X-Chatwoot-Contact-Inbox-Verified']).to eq(conversation.contact_inbox.hmac_verified.to_s)
+      end
+
       it 'handles missing conversation gracefully' do
         state[:conversation] = nil
 
@@ -396,11 +407,21 @@ RSpec.describe Captain::CustomTool, type: :model do
         expect(headers['X-Chatwoot-Account-Id']).to eq(account.id.to_s)
       end
 
+      it 'handles missing contact inbox gracefully' do
+        state[:contact_inbox] = nil
+
+        headers = tool.build_metadata_headers(state)
+
+        expect(headers['X-Chatwoot-Contact-Inbox-Id']).to be_nil
+        expect(headers['X-Chatwoot-Contact-Inbox-Verified']).to eq('false')
+      end
+
       it 'handles empty state' do
         headers = tool.build_metadata_headers({})
 
         expect(headers).to be_a(Hash)
         expect(headers['X-Chatwoot-Tool-Slug']).to eq('custom_test_tool')
+        expect(headers['X-Chatwoot-Contact-Inbox-Verified']).to eq('false')
       end
 
       it 'omits contact email header when email is blank' do
@@ -417,6 +438,22 @@ RSpec.describe Captain::CustomTool, type: :model do
         headers = tool.build_metadata_headers(state)
 
         expect(headers).not_to have_key('X-Chatwoot-Contact-Phone')
+      end
+
+      it 'includes contact inbox verified header when false' do
+        state[:contact_inbox][:hmac_verified] = false
+
+        headers = tool.build_metadata_headers(state)
+
+        expect(headers['X-Chatwoot-Contact-Inbox-Verified']).to eq('false')
+      end
+
+      it 'defaults contact inbox verified header to false when value is nil' do
+        state[:contact_inbox][:hmac_verified] = nil
+
+        headers = tool.build_metadata_headers(state)
+
+        expect(headers['X-Chatwoot-Contact-Inbox-Verified']).to eq('false')
       end
     end
 

--- a/spec/enterprise/services/captain/assistant/agent_runner_service_spec.rb
+++ b/spec/enterprise/services/captain/assistant/agent_runner_service_spec.rb
@@ -384,6 +384,15 @@ RSpec.describe Captain::Assistant::AgentRunnerService do
       expect(state[:channel_type]).to eq(inbox.channel_type)
     end
 
+    it 'includes contact inbox attributes when conversation is present' do
+      state = service.send(:build_state)
+
+      expect(state[:contact_inbox]).to include(
+        id: conversation.contact_inbox.id,
+        hmac_verified: conversation.contact_inbox.hmac_verified
+      )
+    end
+
     it 'includes contact attributes when contact is present' do
       state = service.send(:build_state)
 


### PR DESCRIPTION
This is a follow-up to https://github.com/chatwoot/chatwoot/pull/12907

This PR adds contact inbox verified status to each Captain custom call with `X-Chatwoot-Contact-Inbox-Verified` and `X-Chatwoot-Contact-Inbox-Id` headers. This indicates that the contact which triggered the request is HMAC verified or not.

`X-Chatwoot-Contact-Inbox-Verified` defaults to false always unless it's verified with HMAC


