### PR TITLE
feat(facebook): use `HUMAN_AGENT` tag for Messenger replies when human-agent config is enabled

### DIFF
--- a/app/services/facebook/send_on_facebook_service.rb
+++ b/app/services/facebook/send_on_facebook_service.rb
@@ -49,7 +49,7 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
       recipient: { id: contact.get_source_id(inbox.id) },
       message: fb_text_message_payload,
       messaging_type: 'MESSAGE_TAG',
-      tag: 'ACCOUNT_UPDATE'
+      tag: message_tag
     }
   end
 
@@ -90,8 +90,15 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
         }
       },
       messaging_type: 'MESSAGE_TAG',
-      tag: 'ACCOUNT_UPDATE'
+      tag: message_tag
     }
+  end
+
+  def message_tag
+    global_config = GlobalConfig.get('ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT')
+    return 'HUMAN_AGENT' if global_config['ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT']
+
+    'ACCOUNT_UPDATE'
   end
 
   def attachment_type(attachment)

--- a/app/services/facebook/send_on_facebook_service.rb
+++ b/app/services/facebook/send_on_facebook_service.rb
@@ -95,10 +95,10 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
   end
 
   def message_tag
-    global_config = GlobalConfig.get('ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT')
-    return 'HUMAN_AGENT' if global_config['ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT']
-
-    'ACCOUNT_UPDATE'
+    @message_tag ||= begin
+      global_config = GlobalConfig.get('ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT')
+      global_config['ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT'] ? 'HUMAN_AGENT' : 'ACCOUNT_UPDATE'
+    end
   end
 
   def attachment_type(attachment)

--- a/app/services/facebook/send_on_facebook_service.rb
+++ b/app/services/facebook/send_on_facebook_service.rb
@@ -95,10 +95,7 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
   end
 
   def message_tag
-    @message_tag ||= begin
-      global_config = GlobalConfig.get('ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT')
-      global_config['ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT'] ? 'HUMAN_AGENT' : 'ACCOUNT_UPDATE'
-    end
+    @message_tag ||= GlobalConfigService.load('ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT', nil) ? 'HUMAN_AGENT' : 'ACCOUNT_UPDATE'
   end
 
   def attachment_type(attachment)

--- a/spec/services/facebook/send_on_facebook_service_spec.rb
+++ b/spec/services/facebook/send_on_facebook_service_spec.rb
@@ -7,6 +7,7 @@ describe Facebook::SendOnFacebookService do
     allow(Facebook::Messenger::Subscriptions).to receive(:subscribe).and_return(true)
     allow(bot).to receive(:deliver).and_return({ recipient_id: '1008372609250235', message_id: 'mid.1456970487936:c34767dfe57ee6e339' }.to_json)
     create(:message, message_type: :incoming, inbox: facebook_inbox, account: account, conversation: conversation)
+    GlobalConfig.clear_cache
   end
 
   let!(:account) { create(:account) }

--- a/spec/services/facebook/send_on_facebook_service_spec.rb
+++ b/spec/services/facebook/send_on_facebook_service_spec.rb
@@ -90,6 +90,17 @@ describe Facebook::SendOnFacebookService do
                                                     }, { page_id: facebook_channel.page_id })
       end
 
+      it 'sends with HUMAN_AGENT tag when ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT is enabled' do
+        create(:installation_config, name: 'ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT', value: true)
+        GlobalConfig.clear_cache
+        message = create(:message, message_type: 'outgoing', inbox: facebook_inbox, account: account, conversation: conversation)
+        described_class.new(message: message).perform
+        expect(bot).to have_received(:deliver).with(
+          hash_including(tag: 'HUMAN_AGENT'),
+          { page_id: facebook_channel.page_id }
+        )
+      end
+
       it 'if message is sent with multiple attachments' do
         message = build(:message, content: nil, message_type: 'outgoing', inbox: facebook_inbox, account: account, conversation: conversation)
         avatar = message.attachments.new(account_id: message.account_id, file_type: :image)

--- a/spec/services/facebook/send_on_facebook_service_spec.rb
+++ b/spec/services/facebook/send_on_facebook_service_spec.rb
@@ -91,14 +91,14 @@ describe Facebook::SendOnFacebookService do
       end
 
       it 'sends with HUMAN_AGENT tag when ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT is enabled' do
-        create(:installation_config, name: 'ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT', value: true)
-        GlobalConfig.clear_cache
-        message = create(:message, message_type: 'outgoing', inbox: facebook_inbox, account: account, conversation: conversation)
-        described_class.new(message: message).perform
-        expect(bot).to have_received(:deliver).with(
-          hash_including(tag: 'HUMAN_AGENT'),
-          { page_id: facebook_channel.page_id }
-        )
+        with_modified_env ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT: 'true' do
+          message = create(:message, message_type: 'outgoing', inbox: facebook_inbox, account: account, conversation: conversation)
+          described_class.new(message: message).perform
+          expect(bot).to have_received(:deliver).with(
+            hash_including(tag: 'HUMAN_AGENT'),
+            { page_id: facebook_channel.page_id }
+          )
+        end
       end
 
       it 'if message is sent with multiple attachments' do


### PR DESCRIPTION
This PR updates Facebook Messenger outbound tagging in Chatwoot to support Human Agent messaging when enabled.

Previously, Facebook outbound text and attachment messages were always sent with:

```
messaging_type: MESSAGE_TAG
tag: ACCOUNT_UPDATE
```
With this change, the tag is selected dynamically:

```
HUMAN_AGENT when ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT is enabled
ACCOUNT_UPDATE as fallback when the flag is disabled
```