### PR TITLE
fix(ui): show delivered state for Instagram external echo messages

### DIFF
--- a/app/javascript/dashboard/components-next/message/MessageMeta.vue
+++ b/app/javascript/dashboard/components-next/message/MessageMeta.vue
@@ -81,6 +81,7 @@ const isDelivered = computed(() => {
     isATwilioChannel.value ||
     isASmsInbox.value ||
     isAFacebookInbox.value ||
+    isAnInstagramChannel.value ||
     isATiktokChannel.value
   ) {
     return sourceId.value && status.value === MESSAGE_STATUS.DELIVERED;


### PR DESCRIPTION
Instagram external echo messages were being saved with status: delivered, but the message meta UI did not treat Instagram as a channel eligible for delivered-state rendering. As a result, these messages fell back to progress and showed as “Sending”. This change updates the message status mapping in the new message UI to include Instagram in the delivered-state condition.