### PR TITLE
feat: automatic incoming/outgoing message translation (Google Translate)

### DIFF
--- a/app/jobs/hook_job.rb
+++ b/app/jobs/hook_job.rb
@@ -43,7 +43,9 @@ class HookJob < MutexApplicationJob
     return unless ['message.created'].include?(event_name)
 
     message = event_data[:message]
-    Integrations::GoogleTranslate::DetectLanguageService.new(hook: hook, message: message).perform if message.incoming?
+    return unless message.incoming?
+
+    Integrations::GoogleTranslate::DetectLanguageService.new(hook: hook, message: message).perform
     Integrations::GoogleTranslate::AutoTranslateMessageService.new(hook: hook, message: message).perform
   end
 

--- a/app/jobs/hook_job.rb
+++ b/app/jobs/hook_job.rb
@@ -43,7 +43,8 @@ class HookJob < MutexApplicationJob
     return unless ['message.created'].include?(event_name)
 
     message = event_data[:message]
-    Integrations::GoogleTranslate::DetectLanguageService.new(hook: hook, message: message).perform
+    Integrations::GoogleTranslate::DetectLanguageService.new(hook: hook, message: message).perform if message.incoming?
+    Integrations::GoogleTranslate::AutoTranslateMessageService.new(hook: hook, message: message).perform
   end
 
   def process_leadsquared_integration_with_lock(hook, event_name, event_data)

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -17,8 +17,9 @@ class SendReplyJob < ApplicationJob
 
   def perform(message_id)
     message = Message.find(message_id)
-    channel_name = message.conversation.inbox.channel.class.to_s
+    auto_translate_message(message)
 
+    channel_name = message.conversation.inbox.channel.class.to_s
     return send_on_facebook_page(message) if channel_name == 'Channel::FacebookPage'
 
     service_class = CHANNEL_SERVICES[channel_name]
@@ -28,6 +29,15 @@ class SendReplyJob < ApplicationJob
   end
 
   private
+
+  def auto_translate_message(message)
+    return unless message.outgoing?
+
+    hook = message.account.hooks.find_by(app_id: 'google_translate')
+    return if hook.blank? || hook.disabled?
+
+    Integrations::GoogleTranslate::AutoTranslateMessageService.new(hook: hook, message: message).perform
+  end
 
   def send_on_facebook_page(message)
     if message.conversation.additional_attributes['type'] == 'instagram_direct_message'

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -37,6 +37,8 @@ class SendReplyJob < ApplicationJob
     return if hook.blank? || hook.disabled?
 
     Integrations::GoogleTranslate::AutoTranslateMessageService.new(hook: hook, message: message).perform
+  rescue StandardError => e
+    Rails.logger.error "Auto-translate failed for message #{message.id}: #{e.message}"
   end
 
   def send_on_facebook_page(message)

--- a/app/presenters/message_content_presenter.rb
+++ b/app/presenters/message_content_presenter.rb
@@ -5,7 +5,7 @@ class MessageContentPresenter < SimpleDelegator
                         custom_message = inbox.csat_config&.dig('message')
                         custom_message.present? ? "#{custom_message} #{survey_link}" : I18n.t('conversations.survey.response', link: survey_link)
                       else
-                        content
+                        translated_outgoing_content || content
                       end
 
     Messages::MarkdownRendererService.new(
@@ -16,6 +16,29 @@ class MessageContentPresenter < SimpleDelegator
   end
 
   private
+
+  def translated_outgoing_content
+    return unless outgoing?
+    return unless auto_translate_outgoing_enabled?
+
+    target_language = conversation_language
+    return if target_language.blank?
+
+    translations&.[](target_language)
+  end
+
+  def auto_translate_outgoing_enabled?
+    hook = google_translate_hook
+    hook&.enabled? && hook.settings&.[]('auto_translate_outgoing') == true
+  end
+
+  def google_translate_hook
+    @google_translate_hook ||= account.hooks.find_by(app_id: 'google_translate')
+  end
+
+  def conversation_language
+    conversation.additional_attributes['conversation_language']&.tr('-', '_')
+  end
 
   def should_append_survey_link?
     input_csat? && !inbox.web_widget?

--- a/config/integration/apps.yml
+++ b/config/integration/apps.yml
@@ -142,6 +142,8 @@ google_translate:
         {
           'project_id': { 'type': 'string' },
           'credentials': { 'type': 'object' },
+          'auto_translate_incoming': { 'type': 'boolean' },
+          'auto_translate_outgoing': { 'type': 'boolean' },
         },
       'required': ['project_id', 'credentials'],
       'additionalProperties': false,
@@ -164,8 +166,18 @@ google_translate:
         'validation-messages':
           { 'JSON': 'Invalid JSON', 'required': 'Credentials is required' },
       },
+      {
+        'label': 'Auto-translate incoming customer messages',
+        'type': 'checkbox',
+        'name': 'auto_translate_incoming',
+      },
+      {
+        'label': 'Auto-translate outgoing agent messages',
+        'type': 'checkbox',
+        'name': 'auto_translate_outgoing',
+      },
     ]
-  visible_properties: ['project_id']
+  visible_properties: ['project_id', 'auto_translate_incoming', 'auto_translate_outgoing']
 dyte:
   id: dyte
   logo: dyte.png

--- a/lib/integrations/google_translate/auto_translate_message_service.rb
+++ b/lib/integrations/google_translate/auto_translate_message_service.rb
@@ -1,0 +1,68 @@
+class Integrations::GoogleTranslate::AutoTranslateMessageService
+  pattr_initialize [:hook!, :message!]
+
+  def perform
+    return unless valid_message?
+
+    target_language = normalize_language(target_language_for_message)
+    return if target_language.blank?
+    return if same_as_source_language?(target_language)
+    return if translated_content_for(target_language).present?
+
+    translated_content = Integrations::GoogleTranslate::ProcessorService.new(
+      message: message,
+      target_language: target_language
+    ).perform
+
+    return if translated_content.blank?
+
+    message.update!(translations: merged_translations(target_language, translated_content))
+  end
+
+  private
+
+  def valid_message?
+    message.present? &&
+      message.content.present? &&
+      !message.private? &&
+      (message.incoming? || message.outgoing?)
+  end
+
+  def target_language_for_message
+    return message.account.locale if message.incoming? && auto_translate_incoming?
+    return conversation_language if message.outgoing? && auto_translate_outgoing?
+
+    nil
+  end
+
+  def auto_translate_incoming?
+    return true if hook.settings['auto_translate_incoming'].nil?
+
+    hook.settings['auto_translate_incoming']
+  end
+
+  def auto_translate_outgoing?
+    hook.settings['auto_translate_outgoing'] == true
+  end
+
+  def conversation_language
+    message.conversation.additional_attributes['conversation_language']
+  end
+
+  def same_as_source_language?(target_language)
+    source_language = message.incoming? ? conversation_language : message.account.locale
+    normalize_language(source_language) == target_language
+  end
+
+  def translated_content_for(target_language)
+    message.translations&.[](target_language)
+  end
+
+  def merged_translations(target_language, translated_content)
+    (message.translations || {}).merge(target_language => translated_content)
+  end
+
+  def normalize_language(language)
+    language.to_s.tr('-', '_').presence
+  end
+end

--- a/lib/integrations/google_translate/auto_translate_message_service.rb
+++ b/lib/integrations/google_translate/auto_translate_message_service.rb
@@ -11,7 +11,8 @@ class Integrations::GoogleTranslate::AutoTranslateMessageService
 
     translated_content = Integrations::GoogleTranslate::ProcessorService.new(
       message: message,
-      target_language: target_language
+      target_language: target_language,
+      integration_hook: hook
     ).perform
 
     return if translated_content.blank?
@@ -36,9 +37,7 @@ class Integrations::GoogleTranslate::AutoTranslateMessageService
   end
 
   def auto_translate_incoming?
-    return true if hook.settings['auto_translate_incoming'].nil?
-
-    hook.settings['auto_translate_incoming']
+    hook.settings['auto_translate_incoming'] != false
   end
 
   def auto_translate_outgoing?

--- a/lib/integrations/google_translate/processor_service.rb
+++ b/lib/integrations/google_translate/processor_service.rb
@@ -1,7 +1,7 @@
 require 'google/cloud/translate/v3'
 
 class Integrations::GoogleTranslate::ProcessorService
-  pattr_initialize [:message!, :target_language!]
+  pattr_initialize [:message!, :target_language!, :integration_hook]
 
   def perform
     return if hook.blank?
@@ -65,7 +65,7 @@ class Integrations::GoogleTranslate::ProcessorService
   end
 
   def hook
-    @hook ||= message.account.hooks.find_by(app_id: 'google_translate')
+    @hook ||= integration_hook || message.account.hooks.find_by(app_id: 'google_translate')
   end
 
   def client

--- a/spec/factories/integrations/hooks.rb
+++ b/spec/factories/integrations/hooks.rb
@@ -19,7 +19,14 @@ FactoryBot.define do
 
     trait :google_translate do
       app_id { 'google_translate' }
-      settings { { project_id: 'test', credentials: {} } }
+      settings do
+        {
+          project_id: 'test',
+          credentials: {},
+          auto_translate_incoming: true,
+          auto_translate_outgoing: false
+        }
+      end
     end
 
     trait :openai do

--- a/spec/jobs/hook_job_spec.rb
+++ b/spec/jobs/hook_job_spec.rb
@@ -21,9 +21,11 @@ RSpec.describe HookJob do
       allow(SendOnSlackJob).to receive(:perform_later)
       allow(Integrations::Dialogflow::ProcessorService).to receive(:new)
       allow(Integrations::GoogleTranslate::DetectLanguageService).to receive(:new)
+      allow(Integrations::GoogleTranslate::AutoTranslateMessageService).to receive(:new)
 
       expect(SendOnSlackJob).not_to receive(:perform_later)
       expect(Integrations::GoogleTranslate::DetectLanguageService).not_to receive(:new)
+      expect(Integrations::GoogleTranslate::AutoTranslateMessageService).not_to receive(:new)
       expect(Integrations::Dialogflow::ProcessorService).not_to receive(:new)
       described_class.perform_now(hook, event_name, event_data)
     end
@@ -59,11 +61,25 @@ RSpec.describe HookJob do
       described_class.perform_now(hook, event_name, event_data)
     end
 
-    it 'calls Conversations::DetectLanguageJob when its a google_translate intergation' do
+    it 'calls translation services when it is a google_translate integration' do
       hook = create(:integrations_hook, :google_translate, account: account)
       allow(Integrations::GoogleTranslate::DetectLanguageService).to receive(:new).and_return(process_service)
+      allow(Integrations::GoogleTranslate::AutoTranslateMessageService).to receive(:new).and_return(process_service)
+
       expect(Integrations::GoogleTranslate::DetectLanguageService).to receive(:new).with(hook: hook, message: event_data[:message])
+      expect(Integrations::GoogleTranslate::AutoTranslateMessageService).to receive(:new).with(hook: hook, message: event_data[:message])
       described_class.perform_now(hook, event_name, event_data)
+    end
+
+    it 'skips language detection for outgoing messages but still runs auto translation' do
+      outgoing_message = create(:message, account: account, message_type: :outgoing)
+      hook = create(:integrations_hook, :google_translate, account: account)
+      allow(Integrations::GoogleTranslate::DetectLanguageService).to receive(:new).and_return(process_service)
+      allow(Integrations::GoogleTranslate::AutoTranslateMessageService).to receive(:new).and_return(process_service)
+
+      expect(Integrations::GoogleTranslate::DetectLanguageService).not_to receive(:new)
+      expect(Integrations::GoogleTranslate::AutoTranslateMessageService).to receive(:new).with(hook: hook, message: outgoing_message)
+      described_class.perform_now(hook, event_name, { message: outgoing_message })
     end
   end
 

--- a/spec/jobs/hook_job_spec.rb
+++ b/spec/jobs/hook_job_spec.rb
@@ -71,14 +71,14 @@ RSpec.describe HookJob do
       described_class.perform_now(hook, event_name, event_data)
     end
 
-    it 'skips language detection for outgoing messages but still runs auto translation' do
+    it 'skips both language detection and auto translation for outgoing messages' do
       outgoing_message = create(:message, account: account, message_type: :outgoing)
       hook = create(:integrations_hook, :google_translate, account: account)
       allow(Integrations::GoogleTranslate::DetectLanguageService).to receive(:new).and_return(process_service)
       allow(Integrations::GoogleTranslate::AutoTranslateMessageService).to receive(:new).and_return(process_service)
 
       expect(Integrations::GoogleTranslate::DetectLanguageService).not_to receive(:new)
-      expect(Integrations::GoogleTranslate::AutoTranslateMessageService).to receive(:new).with(hook: hook, message: outgoing_message)
+      expect(Integrations::GoogleTranslate::AutoTranslateMessageService).not_to receive(:new)
       described_class.perform_now(hook, event_name, { message: outgoing_message })
     end
   end

--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -16,6 +16,37 @@ RSpec.describe SendReplyJob do
 
     before do
       allow(process_service).to receive(:perform)
+      allow(Integrations::GoogleTranslate::AutoTranslateMessageService).to receive(:new).and_return(process_service)
+    end
+
+    it 'runs outgoing auto translation when google_translate hook is enabled' do
+      api_channel = create(:channel_api)
+      account = api_channel.account
+      hook = create(:integrations_hook, :google_translate, account: account, settings: {
+                      project_id: 'test',
+                      credentials: {},
+                      auto_translate_incoming: true,
+                      auto_translate_outgoing: true
+                    })
+      message = create(:message, :bot_message, account: account, conversation: create(:conversation, account: account, inbox: api_channel.inbox))
+      allow(Messages::SendEmailNotificationService).to receive(:new).with(message: message).and_return(process_service)
+
+      described_class.perform_now(message.id)
+
+      expect(Integrations::GoogleTranslate::AutoTranslateMessageService).to have_received(:new).with(
+        hook: hook,
+        message: message
+      )
+    end
+
+    it 'does not run outgoing auto translation for incoming messages' do
+      api_channel = create(:channel_api)
+      message = create(:message, conversation: create(:conversation, inbox: api_channel.inbox))
+      allow(Messages::SendEmailNotificationService).to receive(:new).with(message: message).and_return(process_service)
+
+      described_class.perform_now(message.id)
+
+      expect(Integrations::GoogleTranslate::AutoTranslateMessageService).not_to have_received(:new)
     end
 
     it 'calls Facebook::SendOnFacebookService when its facebook message' do

--- a/spec/lib/integrations/google_translate/auto_translate_message_service_spec.rb
+++ b/spec/lib/integrations/google_translate/auto_translate_message_service_spec.rb
@@ -10,10 +10,12 @@ describe Integrations::GoogleTranslate::AutoTranslateMessageService do
     let(:translated_text) { 'Hello there' }
 
     before do
-      allow(Integrations::GoogleTranslate::ProcessorService).to receive(:new).and_return(instance_double(
-                                                                                          Integrations::GoogleTranslate::ProcessorService,
-                                                                                          perform: translated_text
-                                                                                        ))
+      allow(Integrations::GoogleTranslate::ProcessorService).to receive(:new).and_return(
+        instance_double(
+          Integrations::GoogleTranslate::ProcessorService,
+          perform: translated_text
+        )
+      )
     end
 
     context 'when message is incoming' do

--- a/spec/lib/integrations/google_translate/auto_translate_message_service_spec.rb
+++ b/spec/lib/integrations/google_translate/auto_translate_message_service_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+describe Integrations::GoogleTranslate::AutoTranslateMessageService do
+  describe '#perform' do
+    let(:account) { create(:account, locale: 'en') }
+    let(:conversation) do
+      create(:conversation, account: account, additional_attributes: { conversation_language: 'es' })
+    end
+    let(:hook) { create(:integrations_hook, :google_translate, account: account, settings: hook_settings) }
+    let(:translated_text) { 'Hello there' }
+
+    before do
+      allow(Integrations::GoogleTranslate::ProcessorService).to receive(:new).and_return(instance_double(
+                                                                                          Integrations::GoogleTranslate::ProcessorService,
+                                                                                          perform: translated_text
+                                                                                        ))
+    end
+
+    context 'when message is incoming' do
+      let(:message) { create(:message, account: account, conversation: conversation, message_type: :incoming, content: 'Hola') }
+
+      context 'when incoming auto translation is enabled' do
+        let(:hook_settings) do
+          {
+            project_id: 'test',
+            credentials: {},
+            auto_translate_incoming: true,
+            auto_translate_outgoing: false
+          }
+        end
+
+        it 'stores translated content in message translations' do
+          described_class.new(hook: hook, message: message).perform
+
+          expect(Integrations::GoogleTranslate::ProcessorService).to have_received(:new).with(
+            message: message,
+            target_language: 'en'
+          )
+          expect(message.reload.translations).to include('en' => translated_text)
+        end
+      end
+
+      context 'when incoming auto translation is disabled' do
+        let(:hook_settings) do
+          {
+            project_id: 'test',
+            credentials: {},
+            auto_translate_incoming: false,
+            auto_translate_outgoing: false
+          }
+        end
+
+        it 'does not translate the message' do
+          described_class.new(hook: hook, message: message).perform
+
+          expect(Integrations::GoogleTranslate::ProcessorService).not_to have_received(:new)
+          expect(message.reload.translations).to be_nil
+        end
+      end
+    end
+
+    context 'when message is outgoing' do
+      let(:message) { create(:message, account: account, conversation: conversation, message_type: :outgoing, content: 'Hello') }
+
+      context 'when outgoing auto translation is enabled' do
+        let(:hook_settings) do
+          {
+            project_id: 'test',
+            credentials: {},
+            auto_translate_incoming: true,
+            auto_translate_outgoing: true
+          }
+        end
+
+        it 'stores translated content in conversation language' do
+          described_class.new(hook: hook, message: message).perform
+
+          expect(Integrations::GoogleTranslate::ProcessorService).to have_received(:new).with(
+            message: message,
+            target_language: 'es'
+          )
+          expect(message.reload.translations).to include('es' => translated_text)
+        end
+      end
+
+      context 'when outgoing auto translation is disabled' do
+        let(:hook_settings) do
+          {
+            project_id: 'test',
+            credentials: {},
+            auto_translate_incoming: true,
+            auto_translate_outgoing: false
+          }
+        end
+
+        it 'does not translate the message' do
+          described_class.new(hook: hook, message: message).perform
+
+          expect(Integrations::GoogleTranslate::ProcessorService).not_to have_received(:new)
+          expect(message.reload.translations).to be_nil
+        end
+      end
+
+      context 'when translation already exists' do
+        let(:hook_settings) do
+          {
+            project_id: 'test',
+            credentials: {},
+            auto_translate_incoming: true,
+            auto_translate_outgoing: true
+          }
+        end
+
+        before do
+          message.update!(translations: { 'es' => 'Existing translation' })
+        end
+
+        it 'does not call translator again' do
+          described_class.new(hook: hook, message: message).perform
+
+          expect(Integrations::GoogleTranslate::ProcessorService).not_to have_received(:new)
+          expect(message.reload.translations['es']).to eq('Existing translation')
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/integrations/google_translate/auto_translate_message_service_spec.rb
+++ b/spec/lib/integrations/google_translate/auto_translate_message_service_spec.rb
@@ -34,7 +34,8 @@ describe Integrations::GoogleTranslate::AutoTranslateMessageService do
 
           expect(Integrations::GoogleTranslate::ProcessorService).to have_received(:new).with(
             message: message,
-            target_language: 'en'
+            target_language: 'en',
+            integration_hook: hook
           )
           expect(message.reload.translations).to include('en' => translated_text)
         end
@@ -77,7 +78,8 @@ describe Integrations::GoogleTranslate::AutoTranslateMessageService do
 
           expect(Integrations::GoogleTranslate::ProcessorService).to have_received(:new).with(
             message: message,
-            target_language: 'es'
+            target_language: 'es',
+            integration_hook: hook
           )
           expect(message.reload.translations).to include('es' => translated_text)
         end

--- a/spec/presenters/message_content_presenter_spec.rb
+++ b/spec/presenters/message_content_presenter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe MessageContentPresenter do
   let(:conversation) { create(:conversation) }
-  let(:message) { create(:message, conversation: conversation, content_type: content_type, content: content) }
+  let(:message) { create(:message, :bot_message, conversation: conversation, content_type: content_type, content: content) }
   let(:presenter) { described_class.new(message) }
 
   describe '#outgoing_content' do
@@ -11,6 +11,46 @@ RSpec.describe MessageContentPresenter do
       let(:content) { 'Regular message' }
 
       it 'returns content transformed for channel (HTML for WebWidget)' do
+        expect(presenter.outgoing_content).to eq("<p>Regular message</p>\n")
+      end
+    end
+
+    context 'when outgoing translation is available' do
+      let(:content_type) { 'text' }
+      let(:content) { 'Regular message' }
+
+      before do
+        conversation.update!(additional_attributes: { conversation_language: 'es' })
+        create(:integrations_hook, :google_translate, account: message.account, settings: {
+                 project_id: 'test',
+                 credentials: {},
+                 auto_translate_incoming: true,
+                 auto_translate_outgoing: true
+               })
+        message.update!(translations: { 'es' => 'Mensaje traducido' })
+      end
+
+      it 'uses translated content for outgoing delivery' do
+        expect(presenter.outgoing_content).to eq("<p>Mensaje traducido</p>\n")
+      end
+    end
+
+    context 'when outgoing translation is available but auto translate is disabled' do
+      let(:content_type) { 'text' }
+      let(:content) { 'Regular message' }
+
+      before do
+        conversation.update!(additional_attributes: { conversation_language: 'es' })
+        create(:integrations_hook, :google_translate, account: message.account, settings: {
+                 project_id: 'test',
+                 credentials: {},
+                 auto_translate_incoming: true,
+                 auto_translate_outgoing: false
+               })
+        message.update!(translations: { 'es' => 'Mensaje traducido' })
+      end
+
+      it 'falls back to original content' do
         expect(presenter.outgoing_content).to eq("<p>Regular message</p>\n")
       end
     end


### PR DESCRIPTION
Implements automatic translation flows requested in #2011.

Key points:
- Adds Integrations::GoogleTranslate::AutoTranslateMessageService to auto-store translations on message.created.
- Incoming: auto-translates customer messages to account locale (configurable; defaults to enabled if unset).
- Outgoing: optionally auto-translates agent messages to detected conversation_language for delivery.
- Adds integration settings toggles: auto_translate_incoming / auto_translate_outgoing.
- Ensures failures in auto-translation do not block message delivery.

Tests: added unit specs (note: I couldn't run the full suite locally due to Ruby version manager not set up on this machine).