### PR TITLE
fix: Use page_title with fallback to name for portal display titles

### DIFF
--- a/app/models/portal.rb
+++ b/app/models/portal.rb
@@ -68,6 +68,10 @@ class Portal < ApplicationRecord
     self[:color].presence || DEFAULT_COLOR
   end
 
+  def display_title
+    page_title.presence || name
+  end
+
   private
 
   def config_json_format

--- a/app/views/layouts/portal.html.erb
+++ b/app/views/layouts/portal.html.erb
@@ -34,7 +34,7 @@ By default, it renders:
     <% if content_for?(:head) %>
       <%= yield(:head) %>
     <% else %>
-      <title><%= @portal.page_title%></title>
+      <title><%= @portal.display_title %></title>
     <% end %>
     
     <% if @portal.logo.present? %>

--- a/app/views/public/api/v1/portals/_hero.html.erb
+++ b/app/views/public/api/v1/portals/_hero.html.erb
@@ -1,7 +1,7 @@
 <% if !@is_plain_layout_enabled %>
 <% content_for :head do %>
-  <title><%= @portal.name %></title>
-  <meta name="title" content="<%= @portal.name %>">
+  <title><%= @portal.display_title %></title>
+  <meta name="title" content="<%= @portal.display_title %>">
 
   <% if @og_image_url.present? %>
     <meta name="twitter:card" content="summary_large_image">

--- a/app/views/public/api/v1/portals/articles/show.html.erb
+++ b/app/views/public/api/v1/portals/articles/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head do %>
-  <title><%= @article.title %> | <%= @portal.name %></title>
+  <title><%= @article.title %> | <%= @portal.display_title %></title>
   <% if @article.meta["title"].present? %>
     <meta name="title" content="<%= @article.meta["title"] %>">
     <meta property="og:title" content="<%= @article.meta["title"] %>">

--- a/app/views/public/api/v1/portals/categories/show.html.erb
+++ b/app/views/public/api/v1/portals/categories/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :head do %>
-  <title><%= @category.name %> | <%= @portal.name %></title>
-  <meta name="title" content="<%= @category.name %> | <%= @portal.name %>">
+  <title><%= @category.name %> | <%= @portal.display_title %></title>
+  <meta name="title" content="<%= @category.name %> | <%= @portal.display_title %>">
   <% if @category.description.present? %>
     <meta name="description" content="<%= @category.description %>">
     <meta property="og:description" content="<%= @category.description %>">


### PR DESCRIPTION
# Pull Request Template

## Description

This PR includes a fix for the Help Center `<title>` tag ignoring the "Page title" portal setting.

**Problem**
The Help Center settings provides a "Page title" field (`page_title` column on portals), but all public-facing view templates hardcoded `@portal.name` (the Portal Name) in the HTML `<title>` tag. This made the Page title setting completely ineffective, users could not control the SEO site-name suffix without renaming the portal itself.

**Before**
`<title>Article Title | Helpcenter</title>` (always uses Portal Name)

**After**
`<title>Article Title | Brand – Helpcenter</title>` (uses Page title when set, falls back to Portal Name)

Fixes https://linear.app/chatwoot/issue/CW-6561/help-center-ignores-page-title-setting-and-always-uses-portal-name-in

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**

| Settings  | Home page | Articles page | Categories page |
| ------------- | ------------- | ------------- | ------------- |
| <img width="474" height="514" alt="image" src="https://github.com/user-attachments/assets/44221b9d-bfa7-4652-b6f7-df210566f669" />  | <img width="1133" height="518" alt="image" src="https://github.com/user-attachments/assets/82a3e3d2-9d39-4e08-ab57-35c574244e37" />  | <img width="1133" height="518" alt="image" src="https://github.com/user-attachments/assets/b26c9883-5428-4587-9393-13e1917dd527" /> | <img width="1143" height="518" alt="image" src="https://github.com/user-attachments/assets/21451ab2-eec8-40c1-bd83-b751455fbdf6" /> |

**After**

| Settings  | Home page | Articles page | Categories page |
| ------------- | ------------- | ------------- | ------------- |
| <img width="474" height="514" alt="image" src="https://github.com/user-attachments/assets/acbb6430-2123-48d1-8432-b4fc31613730" />  | <img width="1133" height="518" alt="image" src="https://github.com/user-attachments/assets/85eb1823-2486-454c-895c-631b073d6ff0" />  | <img width="1133" height="518" alt="image" src="https://github.com/user-attachments/assets/5959ffde-7ac7-4058-92c4-234ce8723144" /> | <img width="1133" height="518" alt="image" src="https://github.com/user-attachments/assets/c551c123-225f-4731-84fa-a7910fb17ff2" /> |


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
