### PR TITLE
fix(docker): remove Alpine ruby packages that break Ruby 3.4 boot

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,7 @@ COPY Gemfile Gemfile.lock ./
 # https://github.com/googleapis/google-cloud-ruby/issues/13306
 # adding xz as nokogiri was failing to build libxml
 # https://github.com/chatwoot/chatwoot/issues/4045
-RUN apk update && apk add --no-cache build-base musl ruby-full ruby-dev gcc make musl-dev openssl openssl-dev g++ linux-headers xz vips
+RUN apk update && apk add --no-cache build-base musl gcc make musl-dev openssl openssl-dev g++ linux-headers xz vips
 RUN bundle config set --local force_ruby_platform true
 
 # Do not install development or test gems in production

--- a/docker/entrypoints/rails.sh
+++ b/docker/entrypoints/rails.sh
@@ -24,9 +24,17 @@ echo "Database ready to accept connections."
 bundle install
 
 BUNDLE="bundle check"
+MAX_RETRIES=30
+RETRY_COUNT=0
 
 until $BUNDLE
 do
+  RETRY_COUNT=$((RETRY_COUNT + 1))
+  if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
+    echo "ERROR: bundle check failed after $MAX_RETRIES attempts. Exiting."
+    exit 1
+  fi
+  echo "Bundle not ready, retrying ($RETRY_COUNT/$MAX_RETRIES)..."
   sleep 2;
 done
 


### PR DESCRIPTION
Alpine's `ruby-full` and `ruby-dev` system packages conflict with the Docker base image's Ruby 3.4.4, causing `uninitialized constant RbConfig (NameError)` in bundled_gems.rb during early boot. This prevents bundle commands from running, making the container loop forever on `bundle check`.

Remove `ruby-full` and `ruby-dev` from the pre-builder stage — they are unnecessary since the base image already provides Ruby and `build-base` supplies the C toolchain for native gem extensions.

Also add a retry limit (30 attempts) to the `bundle check` loop in the entrypoint so the container exits with a clear error instead of looping indefinitely when bundle setup fails.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
