### PR TITLE
chore: Hide reply-to when copilot is active

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/CopilotEditorSection.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/CopilotEditorSection.vue
@@ -78,7 +78,7 @@ const onSend = () => {
     <div
       v-else-if="isGeneratingContent"
       key="loading-state"
-      class="bg-n-iris-5 rounded min-h-16 w-full mb-4 p-4 flex items-start"
+      class="bg-n-iris-5 rounded min-h-[4.75rem] w-full mb-4 p-4 flex items-start"
     >
       <div class="flex items-center gap-2">
         <CaptainLoader class="text-n-iris-10 size-4" />

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -162,7 +162,8 @@ export default {
         this.inReplyTo?.id &&
         !this.isPrivate &&
         this.inboxHasFeature(INBOX_FEATURES.REPLY_TO) &&
-        !this.is360DialogWhatsAppChannel
+        !this.is360DialogWhatsAppChannel &&
+        !this.copilot.isActive.value
       );
     },
     showWhatsappTemplates() {
@@ -1464,7 +1465,7 @@ export default {
 }
 
 .reply-box__top {
-  @apply relative py-0 px-4 -mt-px;
+  @apply relative py-0 px-3 -mt-px;
 }
 
 .emoji-dialog {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyToMessage.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyToMessage.vue
@@ -14,7 +14,7 @@ const emit = defineEmits(['dismiss']);
 
 <template>
   <div
-    class="reply-editor bg-n-slate-9/10 rounded-md py-1 pl-2 pr-1 text-xs tracking-wide mt-2 flex items-center gap-1.5 -mx-2"
+    class="reply-editor bg-n-slate-9/10 rounded-md py-1 pl-2 pr-1 text-xs tracking-wide mt-2 flex items-center gap-1.5"
   >
     <fluent-icon class="flex-shrink-0 icon" icon="arrow-reply" size="14" />
     <div class="flex-grow gap-1 mt-px text-xs truncate">


### PR DESCRIPTION
# Pull Request Template

## Description

This PR includes,
- Hide reply-to message UI when copilot is active to prevent layout conflicts
- Changed the Copilot loading state `min-height` from `min-h-16` to `min-h-[4.75rem]` to reduce layout shifting between the editor and Copilot loading states.
- Reduced reply-box padding from `px-4` to `px-3`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screencast

**Before**

https://github.com/user-attachments/assets/3cb329dc-4c85-4695-9ff1-75936d317cc1



**After**

https://github.com/user-attachments/assets/067bf7ef-76e2-42a1-a2df-659bb78b6602




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
