### PR TITLE
fix: Force account_id to use index on messages query on conversation push_event_data

### DIFF
--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -24,7 +24,7 @@ class Conversations::EventDataPresenter < SimpleDelegator
   private
 
   def push_messages
-    [messages.chat.last&.push_event_data].compact
+    [messages.where(account_id: account_id).chat.last&.push_event_data].compact
   end
 
   def push_meta


### PR DESCRIPTION
Add a where clause. where(account_id: account_id).