### PR TITLE
fix(contacts): avoid unnecessary contact_inboxes preload

### DIFF
--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -201,7 +201,9 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def fetch_contact
-    @contact = Current.account.contacts.includes(contact_inboxes: [:inbox]).find(params[:id])
+    contact_scope = Current.account.contacts
+    contact_scope = contact_scope.includes(contact_inboxes: [:inbox]) if @include_contact_inboxes
+    @contact = contact_scope.find(params[:id])
   end
 
   def process_avatar_from_url


### PR DESCRIPTION
This reduces unnecessary load on the contacts hot path by only preloading `contact_inboxes` when the request explicitly asks for them. This avoids extra `contact_inboxes` reads for contact show/update calls that set `include_contact_inboxes=false`.

## Closes
- N/A

## How to reproduce
1. Open the contact details endpoint with `include_contact_inboxes=false`.
2. Observe SQL logs before this change: `SELECT "contact_inboxes".* FROM "contact_inboxes" WHERE "contact_inboxes"."contact_id" = $1` still runs due to unconditional includes.
3. After this change, that query is skipped unless `include_contact_inboxes=true`.

## What changed
- Updated `Api::V1::Accounts::ContactsController#fetch_contact` to conditionally include `contact_inboxes` based on `@include_contact_inboxes`.
