### PR TITLE
feat: make assignment_v2 feature available to all accounts

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -191,7 +191,6 @@
 - name: assignment_v2
   display_name: Assignment V2
   enabled: false
-  chatwoot_internal: true
 - name: twilio_content_templates
   display_name: Twilio Content Templates
   enabled: false


### PR DESCRIPTION
## Description

Makes the assignment_v2 feature flag available to all installations by removing the chatwoot_internal restriction. Previously this feature was hidden from self-hosted installations; this change surfaces it in the feature flags UI so any Chatwoot instance can enable it.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
