### PR TITLE
chore: Remove message touch:true, use combined update query

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -429,7 +429,7 @@ class Message < ApplicationRecord
 
   def set_conversation_activity
     # rubocop:disable Rails/SkipsModelValidations
-    conversation.update_columns(last_activity_at: created_at, updated_at: created_at)
+    conversation.update_columns(last_activity_at: created_at, updated_at: Time.current)
     # rubocop:enable Rails/SkipsModelValidations
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -125,7 +125,7 @@ class Message < ApplicationRecord
 
   belongs_to :account
   belongs_to :inbox
-  belongs_to :conversation, touch: true
+  belongs_to :conversation
   belongs_to :sender, polymorphic: true, optional: true
 
   has_many :attachments, dependent: :destroy, autosave: true, before_add: :validate_attachments_limit
@@ -429,7 +429,7 @@ class Message < ApplicationRecord
 
   def set_conversation_activity
     # rubocop:disable Rails/SkipsModelValidations
-    conversation.update_columns(last_activity_at: created_at)
+    conversation.update_columns(last_activity_at: created_at, updated_at: created_at)
     # rubocop:enable Rails/SkipsModelValidations
   end
 


### PR DESCRIPTION
Removes touch: true from the belongs_to :conversation association on Message and consolidates the conversation timestamp update into the existing set_conversation_activity callback.

Previously, every message save triggered two separate UPDATE queries on the conversation — one from Rails' touch (updating updated_at) and another from set_conversation_activity (updating last_activity_at). This combines both into a single update_columns call, reducing write load on the conversations table on every message creation.

### What changed
- Removed touch: true from belongs_to :conversation in Message
- Added updated_at: created_at to the existing update_columns call in set_conversation_activity