### PR TITLE
fix: skip Enter key submission during IME composition in AI inputs

### DIFF
--- a/app/javascript/dashboard/components-next/captain/assistant/AssistantPlayground.vue
+++ b/app/javascript/dashboard/components-next/captain/assistant/AssistantPlayground.vue
@@ -80,6 +80,11 @@ const sendMessage = async () => {
     isLoading.value = false;
   }
 };
+
+const handleEnterKey = event => {
+  if (event.isComposing) return;
+  sendMessage();
+};
 </script>
 
 <template>
@@ -113,7 +118,7 @@ const sendMessage = async () => {
         v-model="newMessage"
         class="flex-1 bg-transparent border-none focus:outline-none text-sm mb-0 text-n-slate-12 placeholder:text-n-slate-10"
         :placeholder="t('CAPTAIN.PLAYGROUND.MESSAGE_PLACEHOLDER')"
-        @keyup.enter="sendMessage"
+        @keyup.enter="handleEnterKey"
       />
       <NextButton
         ghost

--- a/app/javascript/dashboard/components-next/captain/assistant/AssistantPlayground.vue
+++ b/app/javascript/dashboard/components-next/captain/assistant/AssistantPlayground.vue
@@ -118,7 +118,7 @@ const handleEnterKey = event => {
         v-model="newMessage"
         class="flex-1 bg-transparent border-none focus:outline-none text-sm mb-0 text-n-slate-12 placeholder:text-n-slate-10"
         :placeholder="t('CAPTAIN.PLAYGROUND.MESSAGE_PLACEHOLDER')"
-        @keyup.enter="handleEnterKey"
+        @keydown.enter.exact.prevent="handleEnterKey"
       />
       <NextButton
         ghost

--- a/app/javascript/dashboard/components-next/captain/assistant/AssistantPlayground.vue
+++ b/app/javascript/dashboard/components-next/captain/assistant/AssistantPlayground.vue
@@ -83,6 +83,7 @@ const sendMessage = async () => {
 
 const handleEnterKey = event => {
   if (event.isComposing) return;
+  event.preventDefault();
   sendMessage();
 };
 </script>
@@ -118,7 +119,7 @@ const handleEnterKey = event => {
         v-model="newMessage"
         class="flex-1 bg-transparent border-none focus:outline-none text-sm mb-0 text-n-slate-12 placeholder:text-n-slate-10"
         :placeholder="t('CAPTAIN.PLAYGROUND.MESSAGE_PLACEHOLDER')"
-        @keydown.enter.exact.prevent="handleEnterKey"
+        @keydown.enter.exact="handleEnterKey"
       />
       <NextButton
         ghost

--- a/app/javascript/dashboard/components-next/copilot/CopilotInput.vue
+++ b/app/javascript/dashboard/components-next/copilot/CopilotInput.vue
@@ -31,6 +31,7 @@ const handleInput = () => {
 
 const handleEnterKey = event => {
   if (event.isComposing) return;
+  event.preventDefault();
   sendMessage();
 };
 
@@ -48,7 +49,7 @@ onMounted(() => {
       class="w-full reset-base bg-n-alpha-3 ltr:pl-4 ltr:pr-12 rtl:pl-12 rtl:pr-4 py-3 text-sm border border-n-weak rounded-lg focus:outline-0 focus:outline-none focus:ring-2 focus:ring-n-blue-11 focus:border-n-blue-11 resize-none overflow-hidden max-h-[200px] mb-0 text-n-slate-12"
       rows="1"
       @input="handleInput"
-      @keydown.enter.exact.prevent="handleEnterKey"
+      @keydown.enter.exact="handleEnterKey"
     />
     <button
       class="absolute ltr:right-1 rtl:left-1 top-1/2 -translate-y-1/2 h-9 w-10 flex items-center justify-center text-n-slate-11 hover:text-n-blue-11"

--- a/app/javascript/dashboard/components-next/copilot/CopilotInput.vue
+++ b/app/javascript/dashboard/components-next/copilot/CopilotInput.vue
@@ -29,6 +29,11 @@ const handleInput = () => {
   nextTick(adjustHeight);
 };
 
+const handleEnterKey = event => {
+  if (event.isComposing) return;
+  sendMessage();
+};
+
 onMounted(() => {
   nextTick(adjustHeight);
 });
@@ -43,7 +48,7 @@ onMounted(() => {
       class="w-full reset-base bg-n-alpha-3 ltr:pl-4 ltr:pr-12 rtl:pl-12 rtl:pr-4 py-3 text-sm border border-n-weak rounded-lg focus:outline-0 focus:outline-none focus:ring-2 focus:ring-n-blue-11 focus:border-n-blue-11 resize-none overflow-hidden max-h-[200px] mb-0 text-n-slate-12"
       rows="1"
       @input="handleInput"
-      @keydown.enter.exact.prevent="sendMessage"
+      @keydown.enter.exact.prevent="handleEnterKey"
     />
     <button
       class="absolute ltr:right-1 rtl:left-1 top-1/2 -translate-y-1/2 h-9 w-10 flex items-center justify-center text-n-slate-11 hover:text-n-blue-11"

--- a/app/javascript/dashboard/components/widgets/WootWriter/CopilotEditor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/CopilotEditor.vue
@@ -107,7 +107,8 @@ function onKeydown(view, event) {
   emit('keydown');
 
   // Handle Enter key to send message (Shift+Enter for new line)
-  if (event.key === 'Enter' && !event.shiftKey) {
+  // Skip if IME composition is active (CJK character confirmation)
+  if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
     event.preventDefault();
     handleSubmit();
     return true; // Prevent ProseMirror's default Enter handling


### PR DESCRIPTION

# Pull Request Template

## Description

CJK language users (Chinese, Japanese, Korean, etc.) use IME where Enter confirms character selection. AI input components were intercepting Enter unconditionally, making them unusable for IME users.

Add `event.isComposing` check to CopilotEditor, CopilotInput, and AssistantPlayground so Enter during active IME composition is ignored.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

Before:

Add a Japenese keyboard, then go to AI follow-ups, type some word, selecting it with enter submits the follow up. So CJK users cannot use follow-ups.


https://github.com/user-attachments/assets/53517432-d97b-47fc-a802-81675e31d5c9



After:

Type a word, press enter to choose it, press enter again to unselect it and enter again to send

https://github.com/user-attachments/assets/6c2a420b-7ee6-4c71-82a6-d9f1d7bbf31a



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
