### PR TITLE
feat: trigger assignment on resolve

### DIFF
--- a/app/models/concerns/auto_assignment_handler.rb
+++ b/app/models/concerns/auto_assignment_handler.rb
@@ -9,6 +9,8 @@ module AutoAssignmentHandler
   private
 
   def run_auto_assignment
+    # Assignment V2: Also trigger assignment when conversation is resolved or snoozed,
+    # bypassing the open-only condition so the AssignmentJob can redistribute capacity.
     return unless conversation_status_changed_to_open? || conversation_status_changed_to_resolved_or_snoozed?
     return unless should_run_auto_assignment?
 
@@ -35,6 +37,8 @@ module AutoAssignmentHandler
 
   def should_run_auto_assignment?
     return false unless inbox.enable_auto_assignment?
+    # Assignment V2: Resolved/snoozed conversations still have an assignee, so bypass the
+    # assignee-blank check below. The AssignmentJob needs to run to rebalance assignments.
     return true if conversation_status_changed_to_resolved_or_snoozed?
 
     # run only if assignee is blank or doesn't have access to inbox


### PR DESCRIPTION
## Description

When an agent resolves or snoozes a conversation, their capacity frees up — but under Assignment V2, no new conversation was assigned until the next event triggered the assignment job. This meant agents could sit idle despite having queued conversations waiting. This change triggers the AssignmentJob immediately on resolve/snooze so freed capacity is utilized right away.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Enable auto assignment v2 on an inbox                                                                                                                
- Create a conversation (gets auto-assigned to an available agent)                                                                                     
- Resolve the conversation                                                                                                                             
- Verify that another unassigned conversation in the inbox gets assigned to the freed-up agent

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
