### PR TITLE
fix: Localize snooze time-of-day suggestions

### DIFF
--- a/app/javascript/dashboard/helper/snoozeDateParser/localization.js
+++ b/app/javascript/dashboard/helper/snoozeDateParser/localization.js
@@ -1,7 +1,6 @@
 /**
- * Handles non-English input and generates the final suggestion list.
- * Translates localized words to English before parsing, then converts
- * suggestion labels back to the user's language for display.
+ * Localization module for snooze date suggestions.
+ * Translates user input to English for parsing, then converts labels back to locale.
  */
 
 import {
@@ -21,7 +20,7 @@ import { buildSuggestionCandidates, MAX_SUGGESTIONS } from './suggestions';
 
 // ─── English Reference Data ─────────────────────────────────────────────────
 
-const EN_WEEKDAYS_LIST = [
+const EN_WEEKDAYS = [
   'monday',
   'tuesday',
   'wednesday',
@@ -31,7 +30,7 @@ const EN_WEEKDAYS_LIST = [
   'sunday',
 ];
 
-const EN_MONTHS_LIST = [
+const EN_MONTHS = [
   'january',
   'february',
   'march',
@@ -62,6 +61,8 @@ const EN_DEFAULTS = {
     YEARS: 'years',
   },
   RELATIVE: {
+    TODAY: 'today',
+    TONIGHT: 'tonight',
     TOMORROW: 'tomorrow',
     DAY_AFTER_TOMORROW: 'day after tomorrow',
     NEXT_WEEK: 'next week',
@@ -148,8 +149,8 @@ const ENGLISH_VOCAB = new Set([
   ...Object.keys(WORD_NUMBER_MAP),
   ...Object.keys(RELATIVE_DAY_MAP),
   ...Object.keys(TIME_OF_DAY_MAP),
-  ...EN_WEEKDAYS_LIST,
-  ...EN_MONTHS_LIST,
+  ...EN_WEEKDAYS,
+  ...EN_MONTHS,
   ...STRUCTURAL_WORDS,
 ]);
 
@@ -170,8 +171,11 @@ const TOD_TO_MERIDIEM = {
 // ─── Translation Cache ──────────────────────────────────────────────────────
 
 const safeString = v => (v == null ? '' : String(v));
+const escapeRegex = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const MAX_PAIRS_CACHE = 20;
 const pairsCache = new Map();
+
 const CACHE_SECTIONS = [
   'UNITS',
   'RELATIVE',
@@ -180,6 +184,7 @@ const CACHE_SECTIONS = [
   'ORDINALS',
   'MERIDIEM',
 ];
+
 const SINGLE_KEYS = [
   'HALF',
   'NEXT',
@@ -194,7 +199,7 @@ const SINGLE_KEYS = [
   'NEXT_YEAR',
 ];
 
-/** Create a string key from translations so we can cache results. */
+/** Creates a cache key from translations object. */
 const translationSignature = translations => {
   if (!translations || typeof translations !== 'object') return 'none';
   return [
@@ -210,7 +215,7 @@ const translationSignature = translations => {
   ].join('|');
 };
 
-/** Build a list of [localWord, englishWord] pairs from the translations and browser locale. */
+/** Builds [localWord, englishWord] pairs from translations and Intl.DateTimeFormat. */
 const buildReplacementPairsUncached = (translations, locale) => {
   const pairs = [];
   const seen = new Set();
@@ -238,8 +243,7 @@ const buildReplacementPairsUncached = (translations, locale) => {
 
   try {
     const wdFmt = new Intl.DateTimeFormat(locale, { weekday: 'long' });
-    // Jan 1, 2024 is a Monday — aligns with EN_WEEKDAYS_LIST[0]='monday'
-    EN_WEEKDAYS_LIST.forEach((en, i) => {
+    EN_WEEKDAYS.forEach((en, i) => {
       addPair(wdFmt.format(new Date(2024, 0, i + 1)), en);
     });
   } catch {
@@ -248,7 +252,7 @@ const buildReplacementPairsUncached = (translations, locale) => {
 
   try {
     const moFmt = new Intl.DateTimeFormat(locale, { month: 'long' });
-    EN_MONTHS_LIST.forEach((en, i) => {
+    EN_MONTHS.forEach((en, i) => {
       addPair(moFmt.format(new Date(2024, i, 1)), en);
     });
   } catch {
@@ -259,32 +263,33 @@ const buildReplacementPairsUncached = (translations, locale) => {
   return pairs;
 };
 
-/** Same as above but cached. Keeps up to 20 entries to avoid rebuilding every call. */
+/** Returns cached replacement pairs or builds new ones. */
 const buildReplacementPairs = (translations, locale) => {
   const cacheKey = `${locale || ''}:${translationSignature(translations)}`;
   if (pairsCache.has(cacheKey)) return pairsCache.get(cacheKey);
+
   const pairs = buildReplacementPairsUncached(translations, locale);
-  if (pairsCache.size >= MAX_PAIRS_CACHE)
+
+  if (pairsCache.size >= MAX_PAIRS_CACHE) {
     pairsCache.delete(pairsCache.keys().next().value);
+  }
   pairsCache.set(cacheKey, pairs);
   return pairs;
 };
 
 // ─── Token Replacement ──────────────────────────────────────────────────────
 
-const escapeRegex = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-/** Swap localized words for their English versions in the text. */
+/** Replaces localized words with English equivalents. */
 const substituteLocalTokens = (text, pairs) => {
-  let r = text;
+  let result = text;
   pairs.forEach(([local, en]) => {
     const re = new RegExp(`(?<=^|\\s)${escapeRegex(local)}(?=\\s|$)`, 'g');
-    r = r.replace(re, en);
+    result = result.replace(re, en);
   });
-  return r;
+  return result;
 };
 
-/** Drop any words the parser wouldn't understand (keeps English words and numbers). */
+/** Filters text to only English vocabulary words and numbers. */
 const filterToEnglishVocab = text =>
   normalizeDigits(text)
     .replace(/(\d+)h\b/g, '$1:00')
@@ -294,26 +299,28 @@ const filterToEnglishVocab = text =>
     .replace(/\s+/g, ' ')
     .trim();
 
-/** Move "next year" to the right spot so the parser can read it (after the month, before time). */
+/** Repositions "next year" after month name for proper parsing. */
 const repositionNextYear = text => {
   if (!MONTH_NAME_RE.test(text)) return text;
-  let r = text.replace(/\b(?:next\s+)?year\b/i, m =>
+
+  let result = text.replace(/\b(?:next\s+)?year\b/i, m =>
     /next/i.test(m) ? m : 'next year'
   );
-  if (!/\bnext\s+year\b/i.test(r)) return r;
-  const withoutNY = r.replace(/\bnext\s+year\b/i, '').trim();
+
+  if (!/\bnext\s+year\b/i.test(result)) return result;
+
+  const withoutNY = result.replace(/\bnext\s+year\b/i, '').trim();
   const timeRe = /(?:(?:at\s+)?\d{1,2}(?::\d{2})?\s*(?:am|pm)?)\s*$/i;
   const timePart = withoutNY.match(timeRe);
+
   if (timePart) {
     const beforeTime = withoutNY.slice(0, timePart.index).trim();
-    r = `${beforeTime} next year ${timePart[0].trim()}`;
-  } else {
-    r = `${withoutNY} next year`;
+    return `${beforeTime} next year ${timePart[0].trim()}`;
   }
-  return r;
+  return `${withoutNY} next year`;
 };
 
-/** Run the full translation pipeline: swap tokens, filter, fix am/pm, reposition "next year". */
+/** Translates localized input to English for the parser. */
 const replaceTokens = (text, pairs) => {
   const substituted = substituteLocalTokens(text, pairs);
   const filtered = filterToEnglishVocab(substituted);
@@ -324,28 +331,107 @@ const replaceTokens = (text, pairs) => {
   return stripNoise(repositionNextYear(fixed));
 };
 
-/** Convert English words back to the user's language for display. */
-const reverseTokens = (text, pairs) =>
-  pairs.reduce(
-    (r, [local, en]) =>
-      r.replace(
-        new RegExp(`(?<=^|\\s)${escapeRegex(en)}(?=\\s|$)`, 'g'),
-        local
-      ),
-    text
-  );
+/** Converts English words back to the user's locale for display. */
+const reverseTokens = (text, pairs) => {
+  const enToLocal = new Map();
+  pairs.forEach(([local, en]) => {
+    if (!enToLocal.has(en)) {
+      enToLocal.set(en, local);
+    }
+  });
+
+  return text
+    .split(/(\s+)/)
+    .map(token => {
+      const lower = token.toLowerCase();
+      return enToLocal.has(lower) ? enToLocal.get(lower) : token;
+    })
+    .join('');
+};
+
+// ─── Localized Suggestions ──────────────────────────────────────────────────
+
+/** Generates localized phrase combinations (weekday + time-of-day, relative + time). */
+const buildLocalizedPhrases = pairs => {
+  if (!pairs.length) return [];
+
+  const enToLocal = new Map();
+  pairs.forEach(([local, en]) => {
+    if (!enToLocal.has(en)) enToLocal.set(en, local);
+  });
+
+  const getLocal = en => enToLocal.get(en) || en;
+
+  const weekdays = [
+    'sunday',
+    'monday',
+    'tuesday',
+    'wednesday',
+    'thursday',
+    'friday',
+    'saturday',
+  ]
+    .map(en => ({ en, local: getLocal(en) }))
+    .filter(w => w.local !== w.en);
+
+  const timesOfDay = ['morning', 'noon', 'afternoon', 'evening', 'night']
+    .map(en => ({ en, local: getLocal(en) }))
+    .filter(t => t.local !== t.en);
+
+  const relativeDays = ['today', 'tonight', 'tomorrow']
+    .map(en => ({ en, local: getLocal(en) }))
+    .filter(r => r.local !== r.en);
+
+  const phrases = [];
+
+  weekdays.forEach(w => {
+    phrases.push({ local: w.local, en: w.en });
+    timesOfDay.forEach(t => {
+      phrases.push({ local: `${w.local} ${t.local}`, en: `${w.en} ${t.en}` });
+    });
+  });
+
+  relativeDays.forEach(r => {
+    phrases.push({ local: r.local, en: r.en });
+    if (r.en !== 'tonight') {
+      timesOfDay
+        .filter(t => t.en !== 'noon')
+        .forEach(t => {
+          phrases.push({
+            local: `${r.local} ${t.local}`,
+            en: `${r.en} ${t.en}`,
+          });
+        });
+    }
+  });
+
+  return phrases;
+};
+
+/** Scores how well a candidate matches the search text. Returns -1 for no match. */
+const matchesSearch = (candidate, search) => {
+  if (candidate.startsWith(search)) return 0;
+  const words = candidate.split(' ');
+  const searchWords = search.split(' ');
+  const allMatch = searchWords.every(sw => words.some(w => w.startsWith(sw)));
+  return allMatch ? searchWords.length : -1;
+};
+
+/** Finds localized phrases matching user input. */
+const buildLocalizedCandidates = (search, pairs) => {
+  const phrases = buildLocalizedPhrases(pairs);
+  return phrases
+    .map(p => ({ ...p, score: matchesSearch(p.local, search) }))
+    .filter(p => p.score >= 0)
+    .sort((a, b) => a.score - b.score)
+    .slice(0, MAX_SUGGESTIONS * 2);
+};
 
 // ─── Main Suggestion Generator ──────────────────────────────────────────────
 
 /**
- * Generate snooze suggestions from what the user has typed so far.
- * Works with any language if translations are provided. Returns up to 5
- * unique results, each with a label, date, and unix timestamp.
- *
- * @param {string} text - what the user typed
- * @param {Date} [referenceDate] - treat as "now" (defaults to current time)
- * @param {{ translations?: object, locale?: string }} [options] - i18n config
- * @returns {Array<{ label: string, date: Date, unix: number }>}
+ * Generates snooze date suggestions from user input.
+ * Supports any language when translations are provided.
  */
 export const generateDateSuggestions = (
   text,
@@ -353,6 +439,7 @@ export const generateDateSuggestions = (
   { translations, locale } = {}
 ) => {
   if (!text || typeof text !== 'string') return [];
+
   const normalized = sanitize(text);
   if (!normalized) return [];
 
@@ -362,18 +449,13 @@ export const generateDateSuggestions = (
       ? buildReplacementPairs(translations, locale)
       : [];
 
-  // Try English parse first, then translated parse if we have locale pairs.
-  // This avoids the problem where a single overlapping word (e.g. "in" in German)
-  // would skip token translation entirely.
   const directParse = parseDateFromText(stripped, referenceDate);
-
   const translated = pairs.length ? replaceTokens(normalized, pairs) : null;
   const translatedParse =
     translated && translated !== stripped
       ? parseDateFromText(translated, referenceDate)
       : null;
 
-  // Prefer direct English parse; fall back to translated parse
   const useTranslated = !directParse && !!translatedParse;
   const englishInput = useTranslated ? translated : stripped;
 
@@ -390,15 +472,30 @@ export const generateDateSuggestions = (
     results.push({ label: exactLabel, query: englishInput, ...exact });
   }
 
-  buildSuggestionCandidates(englishInput).some(candidate => {
+  if (pairs.length) {
+    const localizedCandidates = buildLocalizedCandidates(stripped, pairs);
+
+    localizedCandidates.some(({ local, en }) => {
+      if (results.length >= MAX_SUGGESTIONS) return true;
+      const result = parseDateFromText(en, referenceDate);
+      if (result && !seen.has(result.unix)) {
+        seen.add(result.unix);
+        results.push({ label: local, query: en, ...result });
+      }
+      return false;
+    });
+
+    if (results.length) return results;
+  }
+
+  const englishCandidates = buildSuggestionCandidates(englishInput);
+
+  englishCandidates.some(candidate => {
     if (results.length >= MAX_SUGGESTIONS) return true;
     const result = parseDateFromText(candidate, referenceDate);
     if (result && !seen.has(result.unix)) {
       seen.add(result.unix);
-      const label =
-        useTranslated && pairs.length
-          ? reverseTokens(candidate, pairs)
-          : candidate;
+      const label = pairs.length ? reverseTokens(candidate, pairs) : candidate;
       results.push({ label, query: candidate, ...result });
     }
     return false;

--- a/app/javascript/dashboard/helper/snoozeDateParser/localization.js
+++ b/app/javascript/dashboard/helper/snoozeDateParser/localization.js
@@ -333,14 +333,23 @@ const replaceTokens = (text, pairs) => {
 
 /** Converts English words back to the user's locale for display. */
 const reverseTokens = (text, pairs) => {
+  let result = text;
+
+  pairs.forEach(([local, en]) => {
+    if (en.includes(' ')) {
+      const re = new RegExp(`(?<=^|\\s)${escapeRegex(en)}(?=\\s|$)`, 'gi');
+      result = result.replace(re, local);
+    }
+  });
+
   const enToLocal = new Map();
   pairs.forEach(([local, en]) => {
-    if (!enToLocal.has(en)) {
+    if (!en.includes(' ') && !enToLocal.has(en)) {
       enToLocal.set(en, local);
     }
   });
 
-  return text
+  return result
     .split(/(\s+)/)
     .map(token => {
       const lower = token.toLowerCase();
@@ -484,8 +493,6 @@ export const generateDateSuggestions = (
       }
       return false;
     });
-
-    if (results.length) return results;
   }
 
   const englishCandidates = buildSuggestionCandidates(englishInput);

--- a/app/javascript/dashboard/helper/snoozeDateParser/specs/localization.spec.js
+++ b/app/javascript/dashboard/helper/snoozeDateParser/specs/localization.spec.js
@@ -3,7 +3,6 @@ import { generateDateSuggestions } from '../localization';
 describe('Snooze Date Parser Localization', () => {
   const referenceDate = new Date('2024-03-14T10:00:00');
 
-  // Generic mock translations - not tied to any specific language
   const mockTranslations = {
     UNITS: {
       MINUTE: 'mock_minute',
@@ -17,6 +16,8 @@ describe('Snooze Date Parser Localization', () => {
       TODAY: 'mock_today',
       TONIGHT: 'mock_tonight',
       TOMORROW: 'mock_tomorrow',
+      DAY_AFTER_TOMORROW: 'mock_day_after_tomorrow',
+      NEXT_WEEK: 'mock_next_week',
     },
     TIME_OF_DAY: {
       MORNING: 'mock_morning',
@@ -25,14 +26,13 @@ describe('Snooze Date Parser Localization', () => {
       NIGHT: 'mock_night',
       NOON: 'mock_noon',
     },
+    FROM_NOW: 'mock_from_now',
   };
 
   describe('with locale translations', () => {
-    // Use a fake locale that triggers Intl.DateTimeFormat to return localized weekdays
     const options = { translations: mockTranslations, locale: 'pt-BR' };
 
     it('generates localized weekday suggestions', () => {
-      // When typing a localized weekday prefix, should return matches
       const results = generateDateSuggestions('sáb', referenceDate, options);
       expect(results.length).toBeGreaterThan(0);
     });
@@ -41,7 +41,6 @@ describe('Snooze Date Parser Localization', () => {
       const results = generateDateSuggestions('sábado', referenceDate, options);
       expect(results.length).toBeGreaterThan(1);
 
-      // Should have multiple suggestions (base + time-of-day variants)
       const queries = results.map(r => r.query.toLowerCase());
       expect(queries.some(q => q.includes('saturday'))).toBe(true);
     });
@@ -49,8 +48,6 @@ describe('Snooze Date Parser Localization', () => {
     it('keeps English query for parsing while showing localized label', () => {
       const results = generateDateSuggestions('sábado', referenceDate, options);
       expect(results.length).toBeGreaterThan(0);
-
-      // Label should be localized, query should be English
       expect(results[0].query.toLowerCase()).toContain('saturday');
     });
 
@@ -61,12 +58,10 @@ describe('Snooze Date Parser Localization', () => {
         options
       );
       expect(results.length).toBeGreaterThan(0);
-
-      // Query should contain English equivalent
       expect(results[0].query.toLowerCase()).toContain('tomorrow');
     });
 
-    it('uses localized time-of-day from translations when available', () => {
+    it('uses localized time-of-day from translations', () => {
       const results = generateDateSuggestions(
         'mock_tomorrow',
         referenceDate,
@@ -74,11 +69,33 @@ describe('Snooze Date Parser Localization', () => {
       );
       expect(results.length).toBeGreaterThan(0);
 
-      // Labels should use mock translations, not English
       const hasLocalizedLabel = results.some(
         r => r.label.includes('mock_') || !r.label.includes('tomorrow')
       );
       expect(hasLocalizedLabel).toBe(true);
+    });
+
+    it('handles multi-word phrases like next week', () => {
+      const results = generateDateSuggestions(
+        'mock_next_week',
+        referenceDate,
+        options
+      );
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].query.toLowerCase()).toContain('next week');
+    });
+
+    it('includes numeric unit suggestions for localized users', () => {
+      const results = generateDateSuggestions('5', referenceDate, options);
+      const queries = results.map(r => r.query.toLowerCase());
+      expect(
+        queries.some(q => q.includes('hour') || q.includes('minute'))
+      ).toBe(true);
+    });
+
+    it('merges localized and English suggestions', () => {
+      const results = generateDateSuggestions('sáb', referenceDate, options);
+      expect(results.length).toBeGreaterThanOrEqual(2);
     });
   });
 

--- a/app/javascript/dashboard/helper/snoozeDateParser/specs/localization.spec.js
+++ b/app/javascript/dashboard/helper/snoozeDateParser/specs/localization.spec.js
@@ -1,0 +1,146 @@
+import { generateDateSuggestions } from '../localization';
+
+describe('Snooze Date Parser Localization', () => {
+  const referenceDate = new Date('2024-03-14T10:00:00');
+
+  // Generic mock translations - not tied to any specific language
+  const mockTranslations = {
+    UNITS: {
+      MINUTE: 'mock_minute',
+      MINUTES: 'mock_minutes',
+      HOUR: 'mock_hour',
+      HOURS: 'mock_hours',
+      DAY: 'mock_day',
+      DAYS: 'mock_days',
+    },
+    RELATIVE: {
+      TODAY: 'mock_today',
+      TONIGHT: 'mock_tonight',
+      TOMORROW: 'mock_tomorrow',
+    },
+    TIME_OF_DAY: {
+      MORNING: 'mock_morning',
+      AFTERNOON: 'mock_afternoon',
+      EVENING: 'mock_evening',
+      NIGHT: 'mock_night',
+      NOON: 'mock_noon',
+    },
+  };
+
+  describe('with locale translations', () => {
+    // Use a fake locale that triggers Intl.DateTimeFormat to return localized weekdays
+    const options = { translations: mockTranslations, locale: 'pt-BR' };
+
+    it('generates localized weekday suggestions', () => {
+      // When typing a localized weekday prefix, should return matches
+      const results = generateDateSuggestions('sáb', referenceDate, options);
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('includes time-of-day combinations with weekdays', () => {
+      const results = generateDateSuggestions('sábado', referenceDate, options);
+      expect(results.length).toBeGreaterThan(1);
+
+      // Should have multiple suggestions (base + time-of-day variants)
+      const queries = results.map(r => r.query.toLowerCase());
+      expect(queries.some(q => q.includes('saturday'))).toBe(true);
+    });
+
+    it('keeps English query for parsing while showing localized label', () => {
+      const results = generateDateSuggestions('sábado', referenceDate, options);
+      expect(results.length).toBeGreaterThan(0);
+
+      // Label should be localized, query should be English
+      expect(results[0].query.toLowerCase()).toContain('saturday');
+    });
+
+    it('translates relative days from mock translations', () => {
+      const results = generateDateSuggestions(
+        'mock_tomorrow',
+        referenceDate,
+        options
+      );
+      expect(results.length).toBeGreaterThan(0);
+
+      // Query should contain English equivalent
+      expect(results[0].query.toLowerCase()).toContain('tomorrow');
+    });
+
+    it('uses localized time-of-day from translations when available', () => {
+      const results = generateDateSuggestions(
+        'mock_tomorrow',
+        referenceDate,
+        options
+      );
+      expect(results.length).toBeGreaterThan(0);
+
+      // Labels should use mock translations, not English
+      const hasLocalizedLabel = results.some(
+        r => r.label.includes('mock_') || !r.label.includes('tomorrow')
+      );
+      expect(hasLocalizedLabel).toBe(true);
+    });
+  });
+
+  describe('without locale (English default)', () => {
+    it('returns English suggestions', () => {
+      const results = generateDateSuggestions('tomorrow', referenceDate);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].label.toLowerCase()).toContain('tomorrow');
+    });
+
+    it('includes time-of-day in English', () => {
+      const results = generateDateSuggestions('saturday', referenceDate);
+      const labels = results.map(r => r.label.toLowerCase());
+      expect(labels.some(l => /morning|afternoon|evening/.test(l))).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    const options = { translations: mockTranslations, locale: 'pt-BR' };
+
+    it('returns empty array for empty input', () => {
+      expect(generateDateSuggestions('', referenceDate, options)).toEqual([]);
+    });
+
+    it('returns empty array for null input', () => {
+      expect(generateDateSuggestions(null, referenceDate, options)).toEqual([]);
+    });
+
+    it('returns empty array for no matches', () => {
+      expect(generateDateSuggestions('xyz123', referenceDate, options)).toEqual(
+        []
+      );
+    });
+
+    it('is case insensitive', () => {
+      const lower = generateDateSuggestions('sábado', referenceDate, options);
+      const upper = generateDateSuggestions('SÁBADO', referenceDate, options);
+      expect(lower.length).toBe(upper.length);
+    });
+  });
+
+  describe('result structure', () => {
+    it('returns objects with required properties', () => {
+      const results = generateDateSuggestions('tomorrow', referenceDate);
+      expect(results.length).toBeGreaterThan(0);
+
+      const result = results[0];
+      expect(result).toHaveProperty('label');
+      expect(result).toHaveProperty('query');
+      expect(result).toHaveProperty('date');
+      expect(result).toHaveProperty('unix');
+      expect(typeof result.label).toBe('string');
+      expect(typeof result.query).toBe('string');
+      expect(result.date).toBeInstanceOf(Date);
+      expect(typeof result.unix).toBe('number');
+    });
+
+    it('returns future dates', () => {
+      const results = generateDateSuggestions('tomorrow', referenceDate);
+      results.forEach(r => {
+        expect(r.date.getTime()).toBeGreaterThan(referenceDate.getTime());
+      });
+    });
+  });
+});

--- a/app/javascript/dashboard/i18n/locale/en/snooze.json
+++ b/app/javascript/dashboard/i18n/locale/en/snooze.json
@@ -26,6 +26,8 @@
       "PM": "pm"
     },
     "RELATIVE": {
+      "TODAY": "today",
+      "TONIGHT": "tonight",
       "TOMORROW": "tomorrow",
       "DAY_AFTER_TOMORROW": "day after tomorrow",
       "NEXT_WEEK": "next week",


### PR DESCRIPTION
Snooze date suggestions now display time-of-day labels (morning, afternoon, evening, etc.) in the user's locale instead of always showing English words.

## Old Behavior(You need to fully write a suggestion for it to appear as an valid option, giving the fake feeling of bug while user is writing): 
<img width="1302" height="836" alt="image" src="https://github.com/user-attachments/assets/33312d2c-8d71-409f-a1f7-c2262eb200e0" />

<img width="752" height="341" alt="image" src="https://github.com/user-attachments/assets/57e3f89d-e93a-4832-b609-5f809d0031eb" />

<img width="736" height="217" alt="image" src="https://github.com/user-attachments/assets/40782e41-eb77-47bb-8667-5530c6483bad" />


<img width="832" height="499" alt="image" src="https://github.com/user-attachments/assets/0eccf484-2f5f-4803-84cf-d2adef3fd05e" />

## New Behavior(Now it's no longer necessary to type the entire word before it shows up some suggestions):
<img width="772" height="466" alt="image" src="https://github.com/user-attachments/assets/4fe94baa-6f14-45ad-b38f-0ee322c90be7" />
<img width="820" height="409" alt="image" src="https://github.com/user-attachments/assets/16c539e4-47b4-4f12-9e92-e5e90829217f" />
 

## What changed

- Added localized phrase generation that combines weekdays and relative days with time-of-day translations
- The parser still uses English internally, but labels are displayed in the user's language
- Added `TODAY` and `TONIGHT` keys to English snooze translations for consistency

## How to test

1. Set your browser/system locale to a non-English language (e.g., Portuguese)
2. Open a conversation and click the snooze button
3. Type a weekday name in your language (e.g., "sábado" for Saturday)
4. Verify suggestions show time-of-day combinations in your language:
   - [x] "sábado manhã" (Saturday morning)
   - [x] "sábado tarde" (Saturday afternoon)