### PR TITLE
fix: Use system API key for completion

### DIFF
--- a/enterprise/lib/captain/conversation_completion_service.rb
+++ b/enterprise/lib/captain/conversation_completion_service.rb
@@ -56,6 +56,14 @@ class Captain::ConversationCompletionService < Captain::BaseTaskService
     { complete: false, reason: reason }
   end
 
+  # Prefer the system API key over the account's OpenAI hook key.
+  # This is an internal operational evaluation, not a customer-triggered feature,
+  # so it should not consume the customer's OpenAI credits on hosted platforms.
+  # Falls back to the account hook for self-hosted deployments without a system key.
+  def api_key
+    @api_key ||= system_api_key.presence || openai_hook&.settings&.dig('api_key')
+  end
+
   def event_name
     'captain.conversation_completion'
   end

--- a/spec/enterprise/lib/captain/conversation_completion_service_spec.rb
+++ b/spec/enterprise/lib/captain/conversation_completion_service_spec.rb
@@ -126,6 +126,33 @@ RSpec.describe Captain::ConversationCompletionService do
       end
     end
 
+    context 'when account has its own OpenAI hook' do
+      before do
+        create(:message, conversation: conversation, message_type: :incoming, content: 'Hello')
+        create(:integrations_hook, :openai, account: account, settings: { 'api_key' => 'customer-own-key' })
+      end
+
+      it 'uses the system API key instead of the account hook key' do
+        expect(Llm::Config).to receive(:with_api_key).with('test-key', api_base: anything).and_yield(mock_context)
+        allow(mock_chat).to receive(:ask).and_return(
+          instance_double(RubyLLM::Message, content: { 'complete' => true, 'reason' => 'Done' }, input_tokens: 10, output_tokens: 5)
+        )
+
+        service.perform
+      end
+
+      it 'falls back to the account hook key when no system key exists' do
+        InstallationConfig.find_by(name: 'CAPTAIN_OPEN_AI_API_KEY').update!(value: nil)
+
+        expect(Llm::Config).to receive(:with_api_key).with('customer-own-key', api_base: anything).and_yield(mock_context)
+        allow(mock_chat).to receive(:ask).and_return(
+          instance_double(RubyLLM::Message, content: { 'complete' => true, 'reason' => 'Done' }, input_tokens: 10, output_tokens: 5)
+        )
+
+        service.perform
+      end
+    end
+
     context 'when customer quota is exhausted' do
       let(:mock_response) do
         instance_double(


### PR DESCRIPTION


# Pull Request Template

## Description

Add an api_key override so internal conversation completions prefers using the system API key and do not consume customer OpenAI credits. 
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

specs and locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
