### PR TITLE
fix: skip captain auto-open for templates

### DIFF
--- a/enterprise/app/models/enterprise/message.rb
+++ b/enterprise/app/models/enterprise/message.rb
@@ -5,6 +5,7 @@ module Enterprise::Message
     return unless captain_pending_conversation?
     return unless human_response?
     return if private?
+    return if template_bootstrap_message?
 
     previous_user = Current.user
     previous_executed_by = Current.executed_by
@@ -26,6 +27,11 @@ module Enterprise::Message
     return false unless conversation.pending?
 
     ::CaptainInbox.exists?(inbox_id: conversation.inbox_id)
+  end
+
+  def template_bootstrap_message?
+    additional_attributes['template_params'].present? &&
+      !conversation.messages.incoming.exists?
   end
 
   def create_captain_auto_open_activity_message


### PR DESCRIPTION
# Pull Request Template

## Description

WhatsApp template messages are treated as outgoing human messages so conversations are automatically marked Open, preventing Captain from responding. #13673

This PR fixes the behaviour for template messages, so that captain can respond to them.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
