### PR TITLE
feat: Add force legacy auto-resolve flag

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -41,7 +41,7 @@ class Account < ApplicationRecord
         'audio_transcriptions': { 'type': %w[boolean null] },
         'auto_resolve_label': { 'type': %w[string null] },
         'keep_pending_on_bot_failure': { 'type': %w[boolean null] },
-        'captain_auto_resolve_mode': { 'type': %w[string null], 'enum': %w[evaluated legacy disabled] },
+        'captain_auto_resolve_mode': { 'type': %w[string null], 'enum': ['evaluated', 'legacy', 'disabled', nil] },
         'conversation_required_attributes': {
           'type': %w[array null],
           'items': { 'type': 'string' }

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -200,7 +200,6 @@ class Account < ApplicationRecord
     mode = settings&.[]('captain_auto_resolve_mode')
     return mode if %w[evaluated legacy disabled].include?(mode)
     return 'disabled' if settings&.[]('captain_disable_auto_resolve') == true
-    return 'legacy' if settings&.[]('captain_force_legacy_auto_resolve') == true
 
     'evaluated'
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -42,6 +42,7 @@ class Account < ApplicationRecord
         'auto_resolve_label': { 'type': %w[string null] },
         'keep_pending_on_bot_failure': { 'type': %w[boolean null] },
         'captain_disable_auto_resolve': { 'type': %w[boolean null] },
+        'captain_force_legacy_auto_resolve': { 'type': %w[boolean null] },
         'conversation_required_attributes': {
           'type': %w[array null],
           'items': { 'type': 'string' }
@@ -91,7 +92,7 @@ class Account < ApplicationRecord
   store_accessor :settings, :audio_transcriptions, :auto_resolve_label
   store_accessor :settings, :captain_models, :captain_features
   store_accessor :settings, :keep_pending_on_bot_failure
-  store_accessor :settings, :captain_disable_auto_resolve
+  store_accessor :settings, :captain_disable_auto_resolve, :captain_force_legacy_auto_resolve
 
   has_many :account_users, dependent: :destroy_async
   has_many :agent_bot_inboxes, dependent: :destroy_async

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -41,8 +41,7 @@ class Account < ApplicationRecord
         'audio_transcriptions': { 'type': %w[boolean null] },
         'auto_resolve_label': { 'type': %w[string null] },
         'keep_pending_on_bot_failure': { 'type': %w[boolean null] },
-        'captain_disable_auto_resolve': { 'type': %w[boolean null] },
-        'captain_force_legacy_auto_resolve': { 'type': %w[boolean null] },
+        'captain_auto_resolve_mode': { 'type': %w[string null], 'enum': %w[evaluated legacy disabled] },
         'conversation_required_attributes': {
           'type': %w[array null],
           'items': { 'type': 'string' }
@@ -92,7 +91,7 @@ class Account < ApplicationRecord
   store_accessor :settings, :audio_transcriptions, :auto_resolve_label
   store_accessor :settings, :captain_models, :captain_features
   store_accessor :settings, :keep_pending_on_bot_failure
-  store_accessor :settings, :captain_disable_auto_resolve, :captain_force_legacy_auto_resolve
+  store_accessor :settings, :captain_auto_resolve_mode
 
   has_many :account_users, dependent: :destroy_async
   has_many :agent_bot_inboxes, dependent: :destroy_async
@@ -195,6 +194,27 @@ class Account < ApplicationRecord
     # we need to extract the language code from the locale
     account_locale = locale&.split('_')&.first
     ISO_639.find(account_locale)&.english_name&.downcase || 'english'
+  end
+
+  def captain_auto_resolve_mode
+    mode = settings&.[]('captain_auto_resolve_mode')
+    return mode if %w[evaluated legacy disabled].include?(mode)
+    return 'disabled' if settings&.[]('captain_disable_auto_resolve') == true
+    return 'legacy' if settings&.[]('captain_force_legacy_auto_resolve') == true
+
+    'evaluated'
+  end
+
+  def captain_auto_resolve_disabled?
+    captain_auto_resolve_mode == 'disabled'
+  end
+
+  def captain_auto_resolve_legacy?
+    captain_auto_resolve_mode == 'legacy'
+  end
+
+  def captain_auto_resolve_evaluated?
+    captain_auto_resolve_mode == 'evaluated'
   end
 
   private

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -92,6 +92,7 @@ class Account < ApplicationRecord
   store_accessor :settings, :captain_models, :captain_features
   store_accessor :settings, :keep_pending_on_bot_failure
   store_accessor :settings, :captain_auto_resolve_mode
+  include AccountCaptainAutoResolve
 
   has_many :account_users, dependent: :destroy_async
   has_many :agent_bot_inboxes, dependent: :destroy_async
@@ -194,26 +195,6 @@ class Account < ApplicationRecord
     # we need to extract the language code from the locale
     account_locale = locale&.split('_')&.first
     ISO_639.find(account_locale)&.english_name&.downcase || 'english'
-  end
-
-  def captain_auto_resolve_mode
-    mode = settings&.[]('captain_auto_resolve_mode')
-    return mode if %w[evaluated legacy disabled].include?(mode)
-    return 'disabled' if settings&.[]('captain_disable_auto_resolve') == true
-
-    'evaluated'
-  end
-
-  def captain_auto_resolve_disabled?
-    captain_auto_resolve_mode == 'disabled'
-  end
-
-  def captain_auto_resolve_legacy?
-    captain_auto_resolve_mode == 'legacy'
-  end
-
-  def captain_auto_resolve_evaluated?
-    captain_auto_resolve_mode == 'evaluated'
   end
 
   private

--- a/app/models/concerns/account_captain_auto_resolve.rb
+++ b/app/models/concerns/account_captain_auto_resolve.rb
@@ -16,6 +16,6 @@ module AccountCaptainAutoResolve
     return mode if VALID_CAPTAIN_AUTO_RESOLVE_MODES.include?(mode)
     return 'disabled' if settings&.[]('captain_disable_auto_resolve') == true
 
-    'evaluated'
+    feature_enabled?('captain_tasks') ? 'evaluated' : 'legacy'
   end
 end

--- a/app/models/concerns/account_captain_auto_resolve.rb
+++ b/app/models/concerns/account_captain_auto_resolve.rb
@@ -1,0 +1,21 @@
+module AccountCaptainAutoResolve
+  extend ActiveSupport::Concern
+
+  VALID_CAPTAIN_AUTO_RESOLVE_MODES = %w[evaluated legacy disabled].freeze
+
+  included do
+    VALID_CAPTAIN_AUTO_RESOLVE_MODES.each do |mode|
+      define_method("captain_auto_resolve_#{mode}?") do
+        captain_auto_resolve_mode == mode
+      end
+    end
+  end
+
+  def captain_auto_resolve_mode
+    mode = settings&.[]('captain_auto_resolve_mode')
+    return mode if VALID_CAPTAIN_AUTO_RESOLVE_MODES.include?(mode)
+    return 'disabled' if settings&.[]('captain_disable_auto_resolve') == true
+
+    'evaluated'
+  end
+end

--- a/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
+++ b/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
@@ -7,7 +7,7 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
   def perform(inbox)
     return if inbox.account.captain_disable_auto_resolve
 
-    if inbox.account.feature_enabled?('captain_tasks')
+    if evaluate_conversation_completion?(inbox.account)
       perform_with_evaluation(inbox)
     else
       perform_time_based(inbox)
@@ -17,6 +17,10 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
   end
 
   private
+
+  def evaluate_conversation_completion?(account)
+    account.feature_enabled?('captain_tasks') && !account.captain_force_legacy_auto_resolve
+  end
 
   def perform_time_based(inbox)
     Current.executed_by = inbox.captain_assistant

--- a/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
+++ b/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
@@ -5,7 +5,7 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
   queue_as :low
 
   def perform(inbox)
-    return if inbox.account.captain_disable_auto_resolve
+    return if inbox.account.captain_auto_resolve_disabled?
 
     if evaluate_conversation_completion?(inbox.account)
       perform_with_evaluation(inbox)
@@ -19,7 +19,7 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
   private
 
   def evaluate_conversation_completion?(account)
-    account.feature_enabled?('captain_tasks') && !account.captain_force_legacy_auto_resolve
+    account.feature_enabled?('captain_tasks') && account.captain_auto_resolve_evaluated?
   end
 
   def perform_time_based(inbox)

--- a/enterprise/app/jobs/enterprise/account/conversations_resolution_scheduler_job.rb
+++ b/enterprise/app/jobs/enterprise/account/conversations_resolution_scheduler_job.rb
@@ -12,7 +12,7 @@ module Enterprise::Account::ConversationsResolutionSchedulerJob
       inbox = captain_inbox.inbox
 
       next if inbox.email?
-      next if inbox.account.captain_disable_auto_resolve
+      next if inbox.account.captain_auto_resolve_disabled?
 
       Captain::InboxPendingConversationsResolutionJob.perform_later(
         inbox

--- a/enterprise/lib/captain/tools/resolve_conversation_tool.rb
+++ b/enterprise/lib/captain/tools/resolve_conversation_tool.rb
@@ -6,7 +6,7 @@ class Captain::Tools::ResolveConversationTool < Captain::Tools::BasePublicTool
     conversation = find_conversation(tool_context.state)
     return 'Conversation not found' unless conversation
     return "Conversation ##{conversation.display_id} is already resolved" if conversation.resolved?
-    return 'Auto-resolve is disabled for this account' if conversation.account.captain_disable_auto_resolve
+    return 'Auto-resolve is disabled for this account' if conversation.account.captain_auto_resolve_disabled?
 
     log_tool_usage('resolve_conversation', { conversation_id: conversation.id, reason: reason })
 

--- a/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
+++ b/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
@@ -84,6 +84,16 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
       expect(resolvable_pending_conversation.reload.status).to eq('pending')
       expect(resolvable_pending_conversation.messages.outgoing).to be_empty
     end
+
+    it 'falls back to legacy time-based resolve when legacy auto-resolve is forced' do
+      inbox.account.update!(captain_force_legacy_auto_resolve: true)
+      allow(Captain::ConversationCompletionService).to receive(:new)
+
+      described_class.perform_now(inbox)
+
+      expect(Captain::ConversationCompletionService).not_to have_received(:new)
+      expect(resolvable_pending_conversation.reload.status).to eq('resolved')
+    end
   end
 
   context 'when LLM evaluation returns complete' do

--- a/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
+++ b/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
     end
 
     it 'falls back to legacy time-based resolve when legacy auto-resolve is forced' do
-      inbox.account.update!(captain_force_legacy_auto_resolve: true)
+      inbox.account.update!(captain_auto_resolve_mode: 'legacy')
       allow(Captain::ConversationCompletionService).to receive(:new)
 
       described_class.perform_now(inbox)
@@ -332,7 +332,7 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
   end
 
   it 'does not resolve conversations when auto-resolve is disabled at execution time' do
-    inbox.account.update!(captain_disable_auto_resolve: true)
+    inbox.account.update!(captain_auto_resolve_mode: 'disabled')
 
     expect do
       described_class.perform_now(inbox)
@@ -340,5 +340,15 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
 
     expect(resolvable_pending_conversation.reload.status).to eq('pending')
     expect(resolvable_pending_conversation.messages.outgoing).to be_empty
+  end
+
+  it 'falls back to disabled mode from legacy settings key' do
+    inbox.account.update!(settings: inbox.account.settings.merge('captain_disable_auto_resolve' => true))
+
+    expect do
+      described_class.perform_now(inbox)
+    end.not_to(change { resolvable_pending_conversation.reload.status })
+
+    expect(resolvable_pending_conversation.reload.status).to eq('pending')
   end
 end

--- a/spec/enterprise/jobs/enterprise/account/conversations_resolution_scheduler_job_spec.rb
+++ b/spec/enterprise/jobs/enterprise/account/conversations_resolution_scheduler_job_spec.rb
@@ -30,12 +30,28 @@ RSpec.describe Account::ConversationsResolutionSchedulerJob, type: :job do
       end
     end
 
-    context 'when account has captain_disable_auto_resolve enabled' do
+    context 'when account has captain auto resolve disabled' do
       let!(:regular_inbox) { create(:inbox, account: account) }
 
       before do
         create(:captain_inbox, captain_assistant: assistant, inbox: regular_inbox)
-        account.update!(captain_disable_auto_resolve: true)
+        account.update!(captain_auto_resolve_mode: 'disabled')
+      end
+
+      it 'does not enqueue resolution jobs' do
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Captain::InboxPendingConversationsResolutionJob)
+          .with(regular_inbox)
+      end
+    end
+
+    context 'when account uses legacy disabled settings key' do
+      let!(:regular_inbox) { create(:inbox, account: account) }
+
+      before do
+        create(:captain_inbox, captain_assistant: assistant, inbox: regular_inbox)
+        account.update!(settings: account.settings.merge('captain_disable_auto_resolve' => true))
       end
 
       it 'does not enqueue resolution jobs' do

--- a/spec/enterprise/lib/captain/tools/resolve_conversation_tool_spec.rb
+++ b/spec/enterprise/lib/captain/tools/resolve_conversation_tool_spec.rb
@@ -41,7 +41,18 @@ RSpec.describe Captain::Tools::ResolveConversationTool do
   end
 
   describe 'when auto-resolve is disabled for the account' do
-    before { account.update!(captain_disable_auto_resolve: true) }
+    before { account.update!(captain_auto_resolve_mode: 'disabled') }
+
+    it 'does not resolve and returns a disabled message' do
+      result = tool.perform(tool_context, reason: 'Possible spam')
+
+      expect(result).to eq('Auto-resolve is disabled for this account')
+      expect(conversation.reload).not_to be_resolved
+    end
+  end
+
+  describe 'when auto-resolve is disabled via legacy settings key' do
+    before { account.update!(settings: account.settings.merge('captain_disable_auto_resolve' => true)) }
 
     it 'does not resolve and returns a disabled message' do
       result = tool.perform(tool_context, reason: 'Possible spam')

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -218,13 +218,6 @@ RSpec.describe Account do
         expect(account).to be_captain_auto_resolve_disabled
       end
 
-      it 'falls back to legacy mode from legacy settings key' do
-        account.settings = { 'captain_force_legacy_auto_resolve' => true }
-
-        expect(account.captain_auto_resolve_mode).to eq('legacy')
-        expect(account).to be_captain_auto_resolve_legacy
-      end
-
       it 'handles nil values correctly' do
         account.auto_resolve_after = nil
         account.auto_resolve_message = nil

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -198,7 +198,16 @@ RSpec.describe Account do
         expect(account.settings['auto_resolve_message']).to eq(message)
       end
 
-      it 'defaults captain_auto_resolve_mode to evaluated' do
+      it 'defaults captain_auto_resolve_mode to legacy when captain_tasks is disabled' do
+        allow(account).to receive(:feature_enabled?).with('captain_tasks').and_return(false)
+
+        expect(account.captain_auto_resolve_mode).to eq('legacy')
+        expect(account).to be_captain_auto_resolve_legacy
+      end
+
+      it 'defaults captain_auto_resolve_mode to evaluated when captain_tasks is enabled' do
+        allow(account).to receive(:feature_enabled?).with('captain_tasks').and_return(true)
+
         expect(account.captain_auto_resolve_mode).to eq('evaluated')
         expect(account).to be_captain_auto_resolve_evaluated
       end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -220,6 +220,15 @@ RSpec.describe Account do
         expect(account).to be_captain_auto_resolve_legacy
       end
 
+      it 'allows clearing captain_auto_resolve_mode to fall back to feature defaults' do
+        allow(account).to receive(:feature_enabled?).with('captain_tasks').and_return(false)
+        account.captain_auto_resolve_mode = nil
+
+        expect(account).to be_valid
+        expect(account.captain_auto_resolve_mode).to eq('legacy')
+        expect(account.settings['captain_auto_resolve_mode']).to be_nil
+      end
+
       it 'falls back to disabled mode from legacy settings key' do
         account.settings = { 'captain_disable_auto_resolve' => true }
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -198,6 +198,33 @@ RSpec.describe Account do
         expect(account.settings['auto_resolve_message']).to eq(message)
       end
 
+      it 'defaults captain_auto_resolve_mode to evaluated' do
+        expect(account.captain_auto_resolve_mode).to eq('evaluated')
+        expect(account).to be_captain_auto_resolve_evaluated
+      end
+
+      it 'correctly gets and sets captain_auto_resolve_mode' do
+        account.captain_auto_resolve_mode = 'legacy'
+
+        expect(account.captain_auto_resolve_mode).to eq('legacy')
+        expect(account.settings['captain_auto_resolve_mode']).to eq('legacy')
+        expect(account).to be_captain_auto_resolve_legacy
+      end
+
+      it 'falls back to disabled mode from legacy settings key' do
+        account.settings = { 'captain_disable_auto_resolve' => true }
+
+        expect(account.captain_auto_resolve_mode).to eq('disabled')
+        expect(account).to be_captain_auto_resolve_disabled
+      end
+
+      it 'falls back to legacy mode from legacy settings key' do
+        account.settings = { 'captain_force_legacy_auto_resolve' => true }
+
+        expect(account.captain_auto_resolve_mode).to eq('legacy')
+        expect(account).to be_captain_auto_resolve_legacy
+      end
+
       it 'handles nil values correctly' do
         account.auto_resolve_after = nil
         account.auto_resolve_message = nil


### PR DESCRIPTION
# Pull Request Template

## Description

Add account setting and store_accessor for
`captain_force_legacy_auto_resolve`.
Enterprise job now skips LLM evaluation when this flag is true and falls back to legacy time-based resolution. Add spec to cover the fallback.


## Type of change

We recently rolled out Captain deciding if a conversation is resolved or not. While it is an improvement for majority of customers, some still prefer the old way of auto-resolving based on inactivity. This PR adds a check.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

legacy_auto_resolve = true

<img width="1282" height="848" alt="CleanShot 2026-03-13 at 19 55 55@2x" src="https://github.com/user-attachments/assets/dfdcc5d5-6d21-462b-87a6-a5e1b1290a8b" />


legacy_auto_resolve = false
<img width="1268" height="864" alt="CleanShot 2026-03-13 at 20 00 50@2x" src="https://github.com/user-attachments/assets/f4719ec6-922a-4c3b-bc45-7b29eaced565" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
