### PR TITLE
fix: reverse order of api_key for bg task

### DIFF
--- a/enterprise/app/services/captain/llm/translate_query_service.rb
+++ b/enterprise/app/services/captain/llm/translate_query_service.rb
@@ -26,6 +26,12 @@ class Captain::Llm::TranslateQueryService < Captain::BaseTaskService
     'translate_query'
   end
 
+  # Translation is an internal operation, not customer-initiated.
+  # Prefer the system key; fall back to the account's hook key for self-hosted setups without one.
+  def api_key
+    @api_key ||= system_api_key.presence || openai_hook&.settings&.dig('api_key')
+  end
+
   def query_in_target_language?(query)
     detector = CLD3::NNetLanguageIdentifier.new(0, 1000)
     result = detector.find_language(query)


### PR DESCRIPTION
# Pull Request Template

## Description

we were getting 403, 401 errors on `translate_query` on langfuse and sentry
This happened because, we use the customer's openai key if they have BYOK
But translation is something they never opt in so we should not use their quota for it. 
This PR addresses the issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
