### PR TITLE
fix: return correct outgoing_url in Platform agent bot API responses

### DIFF
--- a/app/views/platform/api/v1/models/_agent_bot.json.jbuilder
+++ b/app/views/platform/api/v1/models/_agent_bot.json.jbuilder
@@ -1,6 +1,6 @@
 json.id resource.id
 json.name resource.name
 json.description resource.description
-json.outgoing_url resource.name
+json.outgoing_url resource.outgoing_url
 json.account_id resource.account_id
 json.access_token resource.access_token.token

--- a/spec/controllers/platform/api/v1/agent_bots_controller_spec.rb
+++ b/spec/controllers/platform/api/v1/agent_bots_controller_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe 'Platform Agent Bot API', type: :request do
         expect(response).to have_http_status(:success)
         data = response.parsed_body
         expect(data.length).to eq(1)
+        expect(data.first['outgoing_url']).to eq(agent_bot.outgoing_url)
       end
     end
   end
@@ -73,6 +74,7 @@ RSpec.describe 'Platform Agent Bot API', type: :request do
         expect(response).to have_http_status(:success)
         data = response.parsed_body
         expect(data['name']).to eq(agent_bot.name)
+        expect(data['outgoing_url']).to eq(agent_bot.outgoing_url)
       end
     end
   end


### PR DESCRIPTION
The Platform API was returning the bot's `name` value for the `outgoing_url` field across all agent bot endpoints (index, show, create, update). A typo in the `_agent_bot.json.jbuilder` partial used `resource.name` instead of `resource.outgoing_url`.

Closes #13787

## What changed

- `app/views/platform/api/v1/models/_agent_bot.json.jbuilder`: corrected `resource.name` → `resource.outgoing_url` on the `outgoing_url` field.

## How to reproduce

1. Create an agent bot via `POST /platform/api/v1/agent_bots` with a distinct `outgoing_url`.
2. Call `GET /platform/api/v1/agent_bots/:id`.
3. Before this fix the `outgoing_url` in the response equals the bot's `name`; after the fix it equals the value set at creation.

## Tests

Added `outgoing_url` assertions to the existing GET index and GET show request specs so the regression is covered.