### PR TITLE
fix(imap): fall back to LOGIN when server does not advertise AUTH=PLAIN

### DIFF
--- a/app/services/imap/base_fetch_email_service.rb
+++ b/app/services/imap/base_fetch_email_service.rb
@@ -107,9 +107,19 @@ class Imap::BaseFetchEmailService
 
   def build_imap_client
     imap = Net::IMAP.new(channel.imap_address, port: channel.imap_port, ssl: true)
-    imap.authenticate(authentication_type, channel.imap_login, imap_password)
+    imap_authenticate(imap)
     imap.select('INBOX')
     imap
+  end
+
+  # Use IMAP LOGIN when the server does not advertise AUTH=PLAIN (e.g. Alibaba Mail).
+  def imap_authenticate(imap)
+    if authentication_type == 'PLAIN' && imap.capability.exclude?('AUTH=PLAIN')
+      Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] AUTH=PLAIN not in CAPABILITY for #{channel.email}, using LOGIN"
+      imap.login(channel.imap_login, imap_password)
+    else
+      imap.authenticate(authentication_type, channel.imap_login, imap_password)
+    end
   end
 
   def terminate_imap_connection

--- a/spec/services/imap/fetch_email_service_spec.rb
+++ b/spec/services/imap/fetch_email_service_spec.rb
@@ -14,10 +14,50 @@ RSpec.describe Imap::FetchEmailService do
       allow(Net::IMAP).to receive(:new).with(
         imap_email_channel.imap_address, port: imap_email_channel.imap_port, ssl: true
       ).and_return(imap)
+      allow(imap).to receive(:capability).and_return(%w[IMAP4REV1 AUTH=PLAIN])
       allow(imap).to receive(:authenticate).with(
         'PLAIN', imap_email_channel.imap_login, imap_email_channel.imap_password
       )
       allow(imap).to receive(:select).with('INBOX')
+    end
+
+    context 'when server does not advertise AUTH=PLAIN in CAPABILITY' do
+      before do
+        allow(imap).to receive(:capability).and_return(%w[IMAP4REV1 AUTH=XOAUTH AUTH=XOAUTH2])
+        allow(imap).to receive(:login).with(imap_email_channel.imap_login, imap_email_channel.imap_password)
+      end
+
+      it 'uses IMAP LOGIN instead of SASL PLAIN' do
+        allow(imap).to receive(:search).and_return([])
+        allow(imap).to receive(:logout)
+
+        described_class.new(channel: imap_email_channel).perform
+
+        expect(imap).not_to have_received(:authenticate)
+        expect(imap).to have_received(:login).with(imap_email_channel.imap_login, imap_email_channel.imap_password)
+      end
+
+      it 'logs the LOGIN usage' do
+        allow(imap).to receive(:search).and_return([])
+        allow(imap).to receive(:logout)
+
+        described_class.new(channel: imap_email_channel).perform
+
+        expect(logger).to have_received(:info).with(/AUTH=PLAIN not in CAPABILITY.*using LOGIN/)
+      end
+    end
+
+    context 'when server advertises AUTH=PLAIN in CAPABILITY' do
+      it 'uses SASL PLAIN authentication' do
+        allow(imap).to receive(:login)
+        allow(imap).to receive(:search).and_return([])
+        allow(imap).to receive(:logout)
+
+        described_class.new(channel: imap_email_channel).perform
+
+        expect(imap).to have_received(:authenticate).with('PLAIN', imap_email_channel.imap_login, imap_email_channel.imap_password)
+        expect(imap).not_to have_received(:login)
+      end
     end
 
     context 'when new emails are available in the mailbox' do


### PR DESCRIPTION
IMAP email channels configured with PLAIN authentication fail to connect to servers that do not advertise `AUTH=PLAIN` in their CAPABILITY response (e.g. Alibaba Mail / AliMail). The `AUTHENTICATE PLAIN` command is rejected with an error, preventing email fetching.

This change checks the server's CAPABILITY list before choosing the authentication method. When `AUTH=PLAIN` is absent, it uses the standard IMAP `LOGIN` command instead of the SASL `AUTHENTICATE PLAIN` command. Servers that do advertise `AUTH=PLAIN` continue to use SASL as before.

## How to reproduce

1. Configure an email channel with IMAP using a provider that does not support SASL PLAIN (e.g. Alibaba Mail: `imap.qiye.aliyun.com`).
2. Observe that email syncing fails with an authentication error in Sidekiq logs.

## What changed

- Extracted `imap_authenticate` in `Imap::BaseFetchEmailService` to inspect `imap.capability` before authenticating.
- When `authentication_type` is `PLAIN` and the server CAPABILITY does not include `AUTH=PLAIN`, uses `imap.login` instead of `imap.authenticate`.
- Added unit tests covering both code paths (LOGIN fallback and SASL PLAIN).