### PR TITLE
chore(i18n): add missing pt_BR locale imports for companies, mfa, snooze, webhooks and more

### DIFF
--- a/app/javascript/dashboard/i18n/locale/pt_BR/index.js
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/index.js
@@ -8,9 +8,11 @@ import bulkActions from './bulkActions.json';
 import campaign from './campaign.json';
 import cannedMgmt from './cannedMgmt.json';
 import chatlist from './chatlist.json';
+import companies from './companies.json';
 import components from './components.json';
 import contact from './contact.json';
 import contactFilters from './contactFilters.json';
+import contentTemplates from './contentTemplates.json';
 import conversation from './conversation.json';
 import csatMgmt from './csatMgmt.json';
 import customRole from './customRole.json';
@@ -26,6 +28,7 @@ import integrations from './integrations.json';
 import labelsMgmt from './labelsMgmt.json';
 import login from './login.json';
 import macros from './macros.json';
+import mfa from './mfa.json';
 import report from './report.json';
 import resetPassword from './resetPassword.json';
 import search from './search.json';
@@ -33,8 +36,11 @@ import setNewPassword from './setNewPassword.json';
 import settings from './settings.json';
 import signup from './signup.json';
 import sla from './sla.json';
+import snooze from './snooze.json';
 import teamsSettings from './teamsSettings.json';
+import webhooks from './webhooks.json';
 import whatsappTemplates from './whatsappTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -47,9 +53,11 @@ export default {
   ...campaign,
   ...cannedMgmt,
   ...chatlist,
+  ...companies,
   ...components,
   ...contact,
   ...contactFilters,
+  ...contentTemplates,
   ...conversation,
   ...csatMgmt,
   ...customRole,
@@ -65,6 +73,7 @@ export default {
   ...labelsMgmt,
   ...login,
   ...macros,
+  ...mfa,
   ...report,
   ...resetPassword,
   ...search,
@@ -72,6 +81,9 @@ export default {
   ...settings,
   ...signup,
   ...sla,
+  ...snooze,
   ...teamsSettings,
+  ...webhooks,
   ...whatsappTemplates,
+  ...yearInReview,
 };


### PR DESCRIPTION
## Description

Add missing JSON imports and spread exports for `companies`, `contentTemplates`, `mfa`, `snooze`, `webhooks`, and `yearInReview` so these translations are properly loaded in the pt_BR locale. Without these imports, those sections of the UI were falling back to English for Brazilian Portuguese users.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings