### PR TITLE
feat: Auto-migrate captain v1 instructions

### DIFF
--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -36,11 +36,13 @@ class Captain::Assistant < ApplicationRecord
   has_many :copilot_threads, dependent: :destroy_async
   has_many :scenarios, class_name: 'Captain::Scenario', dependent: :destroy_async
 
-  store_accessor :config, :temperature, :feature_faq, :feature_memory, :product_name
+  store_accessor :config, :temperature, :feature_faq, :feature_memory, :product_name, :v2_migrated
 
   validates :name, presence: true
   validates :description, presence: true
   validates :account_id, presence: true
+
+  before_save :mark_v2_migrated_on_v2_description_change
 
   scope :ordered, -> { order(created_at: :desc) }
 
@@ -85,7 +87,22 @@ class Captain::Assistant < ApplicationRecord
     }
   end
 
+  def migrate_v1_instructions_if_needed!
+    return if v2_migrated
+    return if config['instructions'].blank?
+
+    update!(description: config['instructions'], v2_migrated: true)
+  end
+
   private
+
+  def mark_v2_migrated_on_v2_description_change
+    return unless persisted?
+    return unless will_save_change_to_description?
+    return unless account&.feature_enabled?('captain_integration_v2')
+
+    self.v2_migrated = true
+  end
 
   def agent_name
     name.parameterize(separator: '_')

--- a/enterprise/app/services/captain/assistant/agent_runner_service.rb
+++ b/enterprise/app/services/captain/assistant/agent_runner_service.rb
@@ -27,6 +27,7 @@ class Captain::Assistant::AgentRunnerService
   end
 
   def generate_response(message_history: [])
+    @assistant.migrate_v1_instructions_if_needed!
     message_to_process, context = run_payload(message_history)
     result = runner.run(message_to_process, context: context, max_turns: 100)
 


### PR DESCRIPTION
Migrate legacy config['instructions'] into description on first use and set the v2_migrated flag. Also mark assistants as v2_migrated when the description is changed while the v2 feature flag is enabled.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
