### PR TITLE
fix: use last_activity_at for orphan conversation cleanup timeframe

### DIFF
--- a/app/services/internal/remove_orphan_conversations_service.rb
+++ b/app/services/internal/remove_orphan_conversations_service.rb
@@ -25,7 +25,7 @@ class Internal::RemoveOrphanConversationsService
 
   def build_orphan_conversations_query
     base = @account ? @account.conversations : Conversation.all
-    base = base.where('conversations.created_at > ?', @days.days.ago)
+    base = base.where('conversations.last_activity_at > ?', @days.days.ago)
     base = base.left_outer_joins(:contact, :inbox)
 
     # Find conversations whose associated contact or inbox record is missing

--- a/lib/tasks/ops/cleanup_orphan_conversations.rake
+++ b/lib/tasks/ops/cleanup_orphan_conversations.rake
@@ -20,7 +20,7 @@ namespace :chatwoot do
       # Preview count using the same query logic
       base = account
              .conversations
-             .where('conversations.created_at > ?', days.days.ago)
+             .where('conversations.last_activity_at > ?', days.days.ago)
              .left_outer_joins(:contact, :inbox)
       conversations = base.where(contacts: { id: nil }).or(base.where(inboxes: { id: nil }))
 


### PR DESCRIPTION
## Description

The RemoveOrphanConversationsService filters orphan conversations by a time window before deleting them. Previously it used created_at, which could miss old conversations that still had recent activity.
Switching to last_activity_at ensures the cleanup window reflects actual conversation activity rather than creation time.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- By running Rake task 
- Run the job from console 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
