### PR TITLE
fix: show all statuses in the All assignee tab

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -264,10 +264,13 @@ const conversationListPagination = computed(() => {
 });
 
 const conversationFilters = computed(() => {
+  // All tab always shows every status so resolved conversations don't disappear.
+  // Mine/Unassigned keep the user-controlled status filter (defaults to 'open').
+  const isAllTab = activeAssigneeTab.value === wootConstants.ASSIGNEE_TYPE.ALL;
   return {
     inboxId: props.conversationInbox ? props.conversationInbox : undefined,
     assigneeType: activeAssigneeTab.value,
-    status: activeStatus.value,
+    status: isAllTab ? wootConstants.STATUS_TYPE.ALL : activeStatus.value,
     sortBy: activeSortBy.value,
     page: conversationListPagination.value,
     labels: props.label ? [props.label] : undefined,
@@ -275,6 +278,12 @@ const conversationFilters = computed(() => {
     conversationType: props.conversationType || undefined,
   };
 });
+
+const effectiveStatus = computed(() =>
+  activeAssigneeTab.value === wootConstants.ASSIGNEE_TYPE.ALL
+    ? wootConstants.STATUS_TYPE.ALL
+    : activeStatus.value
+);
 
 const activeTeam = computed(() => {
   if (props.teamId) {
@@ -886,7 +895,7 @@ watch(conversationFilters, (newVal, oldVal) => {
       :page-title="pageTitle"
       :has-applied-filters="hasAppliedFilters"
       :has-active-folders="hasActiveFolders"
-      :active-status="activeStatus"
+      :active-status="effectiveStatus"
       :is-on-expanded-layout="isOnExpandedLayout"
       :conversation-stats="conversationStats"
       :is-list-loading="chatListLoading && !conversationList.length"

--- a/app/javascript/dashboard/store/modules/conversations/helpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers.js
@@ -7,8 +7,12 @@ export const findPendingMessageIndex = (chat, message) => {
   );
 };
 
-export const filterByStatus = (chatStatus, filterStatus) =>
-  filterStatus === 'all' ? true : chatStatus === filterStatus;
+export const filterByStatus = (chatStatus, filterStatus) => {
+  if (filterStatus === 'all') return true;
+  if (Array.isArray(filterStatus))
+    return filterStatus.includes('all') || filterStatus.includes(chatStatus);
+  return chatStatus === filterStatus;
+};
 
 export const filterByInbox = (shouldFilter, inboxId, chatInboxId) => {
   const isOnInbox = Number(inboxId) === chatInboxId;


### PR DESCRIPTION
## Description

The "All" assignee tab only shows open conversations because `conversationFilters` always passes `activeStatus` (defaults to `'open'`) as the status filter. Resolved conversations silently disappear from the list.

This changes the All tab to always fetch with `status: 'all'` so resolved, pending, and open conversations all appear. Mine/Unassigned tabs continue using the user-controlled status filter.

Also fixes `filterByStatus` in the conversations store to handle array values correctly.

Fixes #13865

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Running in production (v4.11.1, Docker on AWS) for our healthcare support team. Verified:
- All tab shows open, resolved, and pending conversations
- Mine and Unassigned tabs still default to open-only
- Status badge counts reflect the effective filter

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules