### PR TITLE
fix: use created_at cursor in messages_before pagination

### DIFF
--- a/app/finders/message_finder.rb
+++ b/app/finders/message_finder.rb
@@ -37,7 +37,16 @@ class MessageFinder
   end
 
   def messages_before(before_id)
-    messages.reorder('created_at desc').where('id < ?', before_id).limit(20).reverse
+    ref = @conversation.messages.find_by(id: before_id)
+    return messages_latest unless ref
+
+    # Use created_at for comparison so backdated messages (with high IDs) are included correctly.
+    # Primary sort by created_at, with id as tiebreaker.
+    messages
+      .reorder('created_at desc, id desc')
+      .where('created_at < ? OR (created_at = ? AND id < ?)', ref.created_at, ref.created_at, ref.id)
+      .limit(20)
+      .reverse
   end
 
   def messages_between(after_id, before_id)


### PR DESCRIPTION
## Description

`MessageFinder#messages_before` uses `WHERE id < ?` for cursor pagination but orders by `created_at desc`. When messages have timestamps that differ from insertion order (imported messages, channel-synced messages with earlier timestamps), the ID-based cursor skips them — users see gaps when scrolling up in a conversation.

This switches to a `created_at`-based comparison with `id` as a tiebreaker, so backdated messages appear correctly in scroll order.

Fixes #13866

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Running in production (v4.11.1, Docker on AWS) with WhatsApp Cloud API channels where message timestamps occasionally diverge from insertion order. Verified that previously-skipped messages now appear when scrolling up.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules