### PR TITLE
fix: handle renamed ActsAsTaggableOn Cache constant in migration

### DIFF
--- a/db/migrate/20231211010807_add_cached_labels_list.rb
+++ b/db/migrate/20231211010807_add_cached_labels_list.rb
@@ -2,6 +2,14 @@ class AddCachedLabelsList < ActiveRecord::Migration[7.0]
   def change
     add_column :conversations, :cached_label_list, :string
     Conversation.reset_column_information
-    ActsAsTaggableOn::Taggable::Cache.included(Conversation)
+    begin
+      ActsAsTaggableOn::Taggable::Cache.included(Conversation)
+    rescue NameError
+      begin
+        ActsAsTaggableOn::Taggable::CacheKeys.included(Conversation)
+      rescue NameError
+        # Neither constant exists — column added successfully, skip cache backfill
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

The `AddCachedLabelsList` migration references `ActsAsTaggableOn::Taggable::Cache`, which was renamed to `CacheKeys` in newer versions of `acts-as-taggable-on`. This crashes `db:migrate` on fresh database setup with a `NameError`.

This adds a fallback chain: try `Cache` first, then `CacheKeys`, and gracefully skip if neither exists. The column is added successfully regardless — only the cache backfill (which is a no-op on empty databases) is affected.

Previously reported in #11853 (locked). PRs #11615 and #11858 were closed without merge.

Fixes #13775

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified on fresh database setup (v4.11.1, Docker on AWS, PostgreSQL 16). Migration completes successfully where it previously crashed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules