### PR TITLE
fix: normalize "in less than a minute" to "now" in chat list timestamp

### DIFF
--- a/app/javascript/shared/helpers/specs/timeHelper.spec.js
+++ b/app/javascript/shared/helpers/specs/timeHelper.spec.js
@@ -54,6 +54,7 @@ describe('#dateFormat', () => {
 describe('#shortTimestamp', () => {
   // Test cases when withAgo is false or not provided
   it('returns correct value without ago', () => {
+    expect(shortTimestamp('in less than a minute')).toEqual('now');
     expect(shortTimestamp('less than a minute ago')).toEqual('now');
     expect(shortTimestamp('1 minute ago')).toEqual('1m');
     expect(shortTimestamp('12 minutes ago')).toEqual('12m');

--- a/app/javascript/shared/helpers/timeHelper.js
+++ b/app/javascript/shared/helpers/timeHelper.js
@@ -68,6 +68,7 @@ export const shortTimestamp = (time, withAgo = false) => {
   const suffix = withAgo ? ' ago' : '';
   const timeMappings = {
     'less than a minute ago': 'now',
+    'in less than a minute': 'now',
     'a minute ago': `1m${suffix}`,
     'an hour ago': `1h${suffix}`,
     'a day ago': `1d${suffix}`,


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the conversation list showing raw "**in less than a minute**" text instead of "**now**" for very recent conversations.

Fixes https://linear.app/chatwoot/issue/CW-6666/issue-with-timestamps

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
