### PR TITLE
fix: conversation completion prompt to auto-resolve gibberish/no-intent messages after inactivity

### DIFF
--- a/enterprise/lib/captain/prompts/conversation_completion.liquid
+++ b/enterprise/lib/captain/prompts/conversation_completion.liquid
@@ -14,6 +14,8 @@ A conversation is COMPLETE only if ALL of these are true:
 - The assistant's answer fully addressed the customer's question or issue and is self-contained — it requires no further action from the customer
 - There are no unanswered questions, unmet requests, or outstanding follow-ups from either side
 - Note: customers often do not explicitly say thanks or confirm resolution. If the assistant gave a complete, self-contained answer and the customer had no follow-up, that is sufficient. Do not require explicit gratitude or confirmation.
+- If the customer sent only one or two short messages (single words, names, phone numbers, or gibberish) with no recognizable question or request across the entire conversation, and the
+  assistant has responded asking for clarification, the conversation is COMPLETE.
 
 Analyze the conversation and respond with ONLY a JSON object (no other text):
 {"complete": true, "reason": "brief explanation"}


### PR DESCRIPTION
# Pull Request Template

## Description

For our account, the conversation completion evaluator was proving to be too conservative. This resulted in queue noise. 
This PR adds a line to handle gibberish/single worded messages with no further context.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

<img width="3012" height="978" alt="CleanShot 2026-03-23 at 11 44 55@2x" src="https://github.com/user-attachments/assets/328195e8-6ea0-4c3a-9049-ee80196eecad" />

<img width="2202" height="866" alt="CleanShot 2026-03-23 at 11 47 15@2x" src="https://github.com/user-attachments/assets/8d51cff4-b18f-4582-9455-8119ec7eff3a" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
