### PR TITLE
fix: show agent name in unread bubble for Captain replies

### DIFF
--- a/app/javascript/widget/components/UnreadMessage.vue
+++ b/app/javascript/widget/components/UnreadMessage.vue
@@ -60,8 +60,8 @@ export default {
     },
     agentName() {
       if (this.isSenderExist(this.sender)) {
-        const { available_name: availableName } = this.sender;
-        return availableName;
+        const { available_name: availableName, name } = this.sender;
+        return availableName || name || '';
       }
       if (this.useInboxAvatarForBot) {
         return this.channelConfig.websiteName;


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the missing name in the unread widget message bubble for Captain replies. It now falls back to `sender.name` when `available_name` is not present.


Fixes https://linear.app/chatwoot/issue/CW-6671/name-is-missing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="443" height="310" alt="image" src="https://github.com/user-attachments/assets/a5ad2535-91e5-4f6e-8050-b3ef12ca9130" />


**After**
<img width="443" height="310" alt="image" src="https://github.com/user-attachments/assets/c59d008e-2791-4f6a-a446-f060d38aadfb" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
