### PR TITLE
fix(captain): reset conversation context after resolution to prevent …

### DIFF
--- a/enterprise/app/jobs/captain/conversation/response_builder_job.rb
+++ b/enterprise/app/jobs/captain/conversation/response_builder_job.rb
@@ -80,11 +80,19 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
   end
 
   def collect_previous_messages
-    @conversation
-      .messages
-      .where(message_type: [:incoming, :outgoing])
-      .where(private: false)
-      .map do |message|
+    last_resolution_at = account.reporting_events
+                                .where(conversation_id: @conversation.id, name: 'conversation_resolved')
+                                .order(event_end_time: :desc)
+                                .pick(:event_end_time)
+
+    scope = @conversation
+            .messages
+            .where(message_type: [:incoming, :outgoing])
+            .where(private: false)
+
+    scope = scope.where('created_at > ?', last_resolution_at) if last_resolution_at
+
+    scope.map do |message|
       message_hash = {
         content: prepare_multimodal_message_content(message),
         role: determine_role(message)

--- a/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
+++ b/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
@@ -191,6 +191,71 @@ RSpec.describe Captain::Conversation::ResponseBuilderJob, type: :job do
         described_class.perform_now(conversation, assistant)
       end
 
+      it 'collects only messages after a single resolution event using event_end_time' do
+        conversation.messages.destroy_all
+
+        # Message before resolution
+        create(:message, conversation: conversation, content: 'Old message', message_type: :incoming, created_at: 2.hours.ago)
+        create(:message, conversation: conversation, content: 'Handoff message', message_type: :outgoing, created_at: 1.5.hours.ago)
+
+        # Resolution event — event_end_time is the canonical resolution timestamp
+        create(:reporting_event, name: 'conversation_resolved', conversation_id: conversation.id,
+                                 account_id: account.id, event_end_time: 1.hour.ago)
+
+        # Message after resolution
+        create(:message, conversation: conversation, content: 'New message', message_type: :incoming, created_at: 30.minutes.ago)
+
+        expected_messages = [
+          { content: 'New message', role: 'user' }
+        ]
+
+        expect(mock_agent_runner_service).to receive(:generate_response).with(
+          message_history: expected_messages
+        )
+
+        described_class.perform_now(conversation, assistant)
+      end
+
+      it 'collects only messages after the most recent event_end_time across multiple resolutions' do
+        conversation.messages.destroy_all
+        create(:message, conversation: conversation, content: 'Oldest message', message_type: :incoming, created_at: 3.hours.ago)
+        create(:reporting_event, name: 'conversation_resolved', conversation_id: conversation.id,
+                                 account_id: account.id, event_end_time: 2.5.hours.ago)
+
+        create(:message, conversation: conversation, content: 'Old message', message_type: :incoming, created_at: 2.hours.ago)
+        create(:reporting_event, name: 'conversation_resolved', conversation_id: conversation.id,
+                                 account_id: account.id, event_end_time: 1.hour.ago)
+
+        create(:message, conversation: conversation, content: 'New message', message_type: :incoming, created_at: 30.minutes.ago)
+
+        expected_messages = [
+          { content: 'New message', role: 'user' }
+        ]
+
+        expect(mock_agent_runner_service).to receive(:generate_response).with(
+          message_history: expected_messages
+        )
+
+        described_class.perform_now(conversation, assistant)
+      end
+
+      it 'collects all messages when no resolution event exists' do
+        conversation.messages.destroy_all
+        create(:message, conversation: conversation, content: 'Old message', message_type: :incoming, created_at: 2.hours.ago)
+        create(:message, conversation: conversation, content: 'New message', message_type: :incoming, created_at: 30.minutes.ago)
+
+        expected_messages = [
+          { content: 'Old message', role: 'user' },
+          { content: 'New message', role: 'user' }
+        ]
+
+        expect(mock_agent_runner_service).to receive(:generate_response).with(
+          message_history: expected_messages
+        )
+
+        described_class.perform_now(conversation, assistant)
+      end
+
       it 'generates and processes response' do
         described_class.perform_now(conversation, assistant)
         expect(conversation.messages.count).to eq(2)


### PR DESCRIPTION
…handoff loops

# Pull Request Template

## Description

Fixed a bug where Captain AI would reuse the entire conversation history after a conversation was resolved, leading to redundant handoffs and infinite loops.<br>Fixes chatwoot/chatwoot#13880

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added rspec tests to spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb verifying that history is correctly partitioned at the resolution point.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules