### PR TITLE
fix(whatsapp): skip health check during reauthorization flow

### DIFF
--- a/app/services/whatsapp/embedded_signup_service.rb
+++ b/app/services/whatsapp/embedded_signup_service.rb
@@ -24,7 +24,7 @@ class Whatsapp::EmbeddedSignupService
     # Skip health check during reauthorization — phone numbers in pending provisioning state
     # (platform_type: NOT_APPLICABLE) would incorrectly trigger a disconnect email right after
     # a successful reauth. Only run health check for new channel creation.
-    check_channel_health_and_prompt_reauth(channel) unless @inbox_id.present?
+    check_channel_health_and_prompt_reauth(channel) if @inbox_id.blank?
     channel
 
   rescue StandardError => e

--- a/app/services/whatsapp/embedded_signup_service.rb
+++ b/app/services/whatsapp/embedded_signup_service.rb
@@ -21,7 +21,10 @@ class Whatsapp::EmbeddedSignupService
     # 2. We need to run check_channel_health_and_prompt_reauth after webhook setup completes
     # 3. The channel is marked with source: 'embedded_signup' to skip the after_commit callback
     channel.setup_webhooks
-    check_channel_health_and_prompt_reauth(channel)
+    # Skip health check during reauthorization — phone numbers in pending provisioning state
+    # (platform_type: NOT_APPLICABLE) would incorrectly trigger a disconnect email right after
+    # a successful reauth. Only run health check for new channel creation.
+    check_channel_health_and_prompt_reauth(channel) unless @inbox_id.present?
     channel
 
   rescue StandardError => e


### PR DESCRIPTION
After a successful WhatsApp OAuth reauthorization, the health check runs immediately and finds the phone number in a pending provisioning state (`platform_type: NOT_APPLICABLE`). This incorrectly triggers `prompt_reauthorization!`, re-setting the Redis disconnect flag and sending a disconnect email — even though the reauth just succeeded.

The fix skips the health check during reauthorization flows. It still runs for new channel creation.

Closes https://github.com/chatwoot/chatwoot/pull/12556

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How to reproduce

1. Have a WhatsApp channel with a phone number in pending provisioning state (display name not yet approved by Meta)
2. Complete the OAuth reauthorization flow
3. Observe that the user receives a "success" response but immediately gets a disconnect email

## What changed

- `Whatsapp::EmbeddedSignupService#perform` now skips `check_channel_health_and_prompt_reauth` when `inbox_id` is present (reauthorization flow)


🤖 Generated with [Claude Code](https://claude.com/claude-code)