### PR TITLE
fix: Skip email rate limiting for self-hosted instances

### DIFF
--- a/app/models/concerns/account_email_rate_limitable.rb
+++ b/app/models/concerns/account_email_rate_limitable.rb
@@ -17,6 +17,7 @@ module AccountEmailRateLimitable
   end
 
   def within_email_rate_limit?
+    return true unless ChatwootApp.chatwoot_cloud?
     return true if emails_sent_today < email_rate_limit
 
     Rails.logger.warn("Account #{id} reached daily email rate limit of #{email_rate_limit}. Sent: #{emails_sent_today}")

--- a/spec/models/concerns/account_email_rate_limitable_spec.rb
+++ b/spec/models/concerns/account_email_rate_limitable_spec.rb
@@ -34,6 +34,28 @@ RSpec.describe AccountEmailRateLimitable do
       2.times { account.increment_email_sent_count }
       expect(account).not_to be_within_email_rate_limit
     end
+
+    context 'when self-hosted' do
+      before do
+        allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(false)
+        2.times { account.increment_email_sent_count }
+      end
+
+      it 'always returns true regardless of limit' do
+        expect(account).to be_within_email_rate_limit
+      end
+    end
+
+    context 'when chatwoot cloud' do
+      before do
+        allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
+        2.times { account.increment_email_sent_count }
+      end
+
+      it 'returns false when at limit' do
+        expect(account).not_to be_within_email_rate_limit
+      end
+    end
   end
 
   describe '#increment_email_sent_count' do

--- a/spec/models/concerns/account_email_rate_limitable_spec.rb
+++ b/spec/models/concerns/account_email_rate_limitable_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe AccountEmailRateLimitable do
 
   describe '#within_email_rate_limit?' do
     before do
+      allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
       account.update!(limits: { 'emails' => 2 })
     end
 


### PR DESCRIPTION
Self-hosted installations were incorrectly hitting the daily email rate limit of 100, seeded from `installation_config`. Since self-hosted users control their own infrastructure, email rate limiting should only apply to Chatwoot Cloud.

Closes #13913