### PR TITLE
docs(swagger): fix operationId typo `converation` -> `conversation`

### DIFF
--- a/swagger/paths/public/inboxes/messages/index.yml
+++ b/swagger/paths/public/inboxes/messages/index.yml
@@ -1,6 +1,6 @@
 tags:
   - Messages API
-operationId: list-all-converation-messages
+operationId: list-all-conversation-messages
 summary: List all messages
 description: List all messages in the conversation
 security: []

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1366,7 +1366,7 @@
         "tags": [
           "Messages API"
         ],
-        "operationId": "list-all-converation-messages",
+        "operationId": "list-all-conversation-messages",
         "summary": "List all messages",
         "description": "List all messages in the conversation",
         "security": [],

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -536,7 +536,7 @@
         "tags": [
           "Messages API"
         ],
-        "operationId": "list-all-converation-messages",
+        "operationId": "list-all-conversation-messages",
         "summary": "List all messages",
         "description": "List all messages in the conversation",
         "security": [],


### PR DESCRIPTION
issue: https://github.com/chatwoot/chatwoot/issues/13921

Fix a typo in the Messages API operationId where `converation` was used instead of `conversation`. This causes cspell errors when generating client code with tools like Orval.

## What changed

- `swagger/paths/public/inboxes/messages/index.yml`: fixed operationId from `list-all-converation-messages` to `list-all-conversation-messages`
- `swagger/swagger.json` and `swagger/tag_groups/client_swagger.json`: regenerated to reflect the fix


## Note

If you are using a code generator like Orval against this swagger spec, the generated function name will change from `listAllConverationMessages` to `listAllConversationMessages`.