### PR TITLE
fix: add Estonian to settings language options

### DIFF
--- a/config/initializers/languages.rb
+++ b/config/initializers/languages.rb
@@ -43,7 +43,7 @@ LANGUAGES_CONFIG = {
   38 => { name: 'lietuvių (lt)', iso_639_3_code: 'lit', iso_639_1_code: 'lt', enabled: true },
   39 => { name: 'Српски (sr)', iso_639_3_code: 'srp', iso_639_1_code: 'sr', enabled: true },
   40 => { name: 'български (bg)', iso_639_3_code: 'bul', iso_639_1_code: 'bg', enabled: true },
-  41 => { name: 'Eesti (et)', iso_639_3_code: 'est', iso_639_1_code: 'et', enabled: true }
+  41 => { name: 'Eesti keel (et)', iso_639_3_code: 'est', iso_639_1_code: 'et', enabled: true }
 }.filter { |_key, val| val[:enabled] }.freeze
 
 Rails.configuration.i18n.available_locales = LANGUAGES_CONFIG.map { |_index, lang| lang[:iso_639_1_code].to_sym }

--- a/config/initializers/languages.rb
+++ b/config/initializers/languages.rb
@@ -42,7 +42,8 @@ LANGUAGES_CONFIG = {
   37 => { name: 'עִברִית (he)', iso_639_3_code: 'heb', iso_639_1_code: 'he', enabled: true },
   38 => { name: 'lietuvių (lt)', iso_639_3_code: 'lit', iso_639_1_code: 'lt', enabled: true },
   39 => { name: 'Српски (sr)', iso_639_3_code: 'srp', iso_639_1_code: 'sr', enabled: true },
-  40 => { name: 'български (bg)', iso_639_3_code: 'bul', iso_639_1_code: 'bg', enabled: true }
+  40 => { name: 'български (bg)', iso_639_3_code: 'bul', iso_639_1_code: 'bg', enabled: true },
+  41 => { name: 'Eesti (et)', iso_639_3_code: 'est', iso_639_1_code: 'et', enabled: true }
 }.filter { |_key, val| val[:enabled] }.freeze
 
 Rails.configuration.i18n.available_locales = LANGUAGES_CONFIG.map { |_index, lang| lang[:iso_639_1_code].to_sym }


### PR DESCRIPTION
Adds Estonian to the settings language dropdown so accounts can select the existing `et` translation from the UI.

Fixes: N/A
Closes: N/A

## Why
Estonian translation files already exist in the repo and in Crowdin, but the settings dropdown is driven by `LANGUAGES_CONFIG`, where `et` was missing.

## What this change does
- Adds `et` / `Eesti (et)` to `LANGUAGES_CONFIG`
- Makes Estonian available in the settings language selectors backed by `enabledLanguages`

## Validation
- `ruby -c config/initializers/languages.rb`
- Opened the local UI at `/app/accounts/1/settings/general` and verified `Eesti (et)` appears in the `Site language` dropdown
