### PR TITLE
fix(widget): unread preview in real time and without-bubble offset

### DIFF
--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -189,7 +189,7 @@ export const SDK_CSS = `
 }
 
 .woot-widget--without-bubble {
-  bottom: 20px !important;
+  bottom: 62px !important;
 }
 .woot-widget-holder.woot--hide{
   transform: translateY(40px);

--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -189,7 +189,15 @@ export const SDK_CSS = `
 }
 
 .woot-widget--without-bubble {
-  bottom: 20px !important;
+  bottom: 62px !important;
+}
+
+@media only screen and (max-width: 767px) {
+  .woot-widget-holder.has-unread-view.woot-widget--without-bubble {
+    --woot-unread-bottom-offset: clamp(0px, calc(100vh - 464px), 76px);
+    bottom: var(--woot-unread-bottom-offset) !important;
+    max-height: calc(100vh - var(--woot-unread-bottom-offset)) !important;
+  }
 }
 .woot-widget-holder.woot--hide{
   transform: translateY(40px);

--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -135,11 +135,13 @@ export default {
     },
     setIframeHeight(isFixedHeight) {
       this.$nextTick(() => {
-        const extraHeight = getExtraSpaceToScroll();
-        IFrameHelper.sendMessage({
-          event: 'updateIframeHeight',
-          isFixedHeight,
-          extraHeight,
+        requestAnimationFrame(() => {
+          const extraHeight = getExtraSpaceToScroll();
+          IFrameHelper.sendMessage({
+            event: 'updateIframeHeight',
+            isFixedHeight,
+            extraHeight,
+          });
         });
       });
     },
@@ -219,12 +221,28 @@ export default {
       } else if (
         this.isIFrame &&
         unreadMessageCount > 0 &&
-        !this.isWidgetOpen
+        (!this.isWidgetOpen ||
+          ['unread-messages', 'campaigns'].includes(this.$route.name))
       ) {
-        this.router.replace({ name: 'unread-messages' }).then(() => {
-          this.setIframeHeight(true);
-          IFrameHelper.sendMessage({ event: 'setUnreadMode' });
-        });
+        const applyPreviewChrome = () => {
+          const skipSetUnreadMode =
+            this.$route.name === 'unread-messages' && this.isWidgetOpen;
+          if (!skipSetUnreadMode) {
+            IFrameHelper.sendMessage({ event: 'setUnreadMode' });
+          }
+          this.$nextTick(() => {
+            requestAnimationFrame(() => {
+              this.setIframeHeight(true);
+            });
+          });
+        };
+        if (this.$route.name === 'unread-messages') {
+          applyPreviewChrome();
+        } else {
+          this.router.replace({ name: 'unread-messages' }).then(() => {
+            applyPreviewChrome();
+          });
+        }
         this.handleUnreadNotificationDot();
       }
     },

--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -135,11 +135,13 @@ export default {
     },
     setIframeHeight(isFixedHeight) {
       this.$nextTick(() => {
-        const extraHeight = getExtraSpaceToScroll();
-        IFrameHelper.sendMessage({
-          event: 'updateIframeHeight',
-          isFixedHeight,
-          extraHeight,
+        requestAnimationFrame(() => {
+          const extraHeight = getExtraSpaceToScroll();
+          IFrameHelper.sendMessage({
+            event: 'updateIframeHeight',
+            isFixedHeight,
+            extraHeight,
+          });
         });
       });
     },
@@ -161,13 +163,27 @@ export default {
       }
     },
     registerUnreadEvents() {
-      emitter.on(ON_AGENT_MESSAGE_RECEIVED, () => {
-        const { name: routeName } = this.$route;
-        if ((this.isWidgetOpen || !this.isIFrame) && routeName === 'messages') {
-          this.$store.dispatch('conversation/setUserLastSeen');
+      emitter.on(
+        ON_AGENT_MESSAGE_RECEIVED,
+        ({ source } = { source: 'created' }) => {
+          const { name: routeName } = this.$route;
+
+          if (source === 'updated') {
+            if (routeName !== 'unread-messages') return;
+            this.setUnreadView();
+            return;
+          }
+
+          if (
+            (this.isWidgetOpen || !this.isIFrame) &&
+            routeName === 'messages'
+          ) {
+            this.$store.dispatch('conversation/setUserLastSeen');
+          }
+
+          this.setUnreadView();
         }
-        this.setUnreadView();
-      });
+      );
       emitter.on(ON_UNREAD_MESSAGE_CLICK, () => {
         this.router
           .replace({ name: 'messages' })
@@ -219,12 +235,24 @@ export default {
       } else if (
         this.isIFrame &&
         unreadMessageCount > 0 &&
-        !this.isWidgetOpen
+        (!this.isWidgetOpen ||
+          ['unread-messages', 'campaigns'].includes(this.$route.name))
       ) {
-        this.router.replace({ name: 'unread-messages' }).then(() => {
+        const applyPreviewChrome = () => {
+          const skipSetUnreadMode =
+            this.$route.name === 'unread-messages' && this.isWidgetOpen;
+          if (!skipSetUnreadMode) {
+            IFrameHelper.sendMessage({ event: 'setUnreadMode' });
+          }
           this.setIframeHeight(true);
-          IFrameHelper.sendMessage({ event: 'setUnreadMode' });
-        });
+        };
+        if (this.$route.name === 'unread-messages') {
+          applyPreviewChrome();
+        } else {
+          this.router.replace({ name: 'unread-messages' }).then(() => {
+            applyPreviewChrome();
+          });
+        }
         this.handleUnreadNotificationDot();
       }
     },
@@ -371,6 +399,7 @@ export default {
     class="flex flex-col justify-end h-full"
     :class="{
       'is-mobile': isMobile,
+      'is-unread-preview': $route.name === 'unread-messages',
       'is-widget-right': isRightAligned,
       'is-bubble-hidden': hideMessageBubble,
       'is-flat-design': isWidgetStyleFlat,

--- a/app/javascript/widget/assets/scss/views/_conversation.scss
+++ b/app/javascript/widget/assets/scss/views/_conversation.scss
@@ -123,10 +123,10 @@
 }
 
 .unread-messages {
-  @apply flex flex-col flex-nowrap mt-0 overflow-y-auto w-full pb-2;
+  @apply flex flex-col flex-nowrap mt-0 overflow-hidden w-full min-w-0 pb-2;
 
   .chat-bubble-wrap {
-    @apply mb-1;
+    @apply mb-1 min-w-0 max-w-full;
 
     &:first-child {
       margin-top: auto;

--- a/app/javascript/widget/assets/scss/views/_conversation.scss
+++ b/app/javascript/widget/assets/scss/views/_conversation.scss
@@ -123,10 +123,10 @@
 }
 
 .unread-messages {
-  @apply flex flex-col flex-nowrap mt-0 overflow-y-auto w-full pb-2;
+  @apply flex flex-col flex-nowrap mt-0 overflow-x-hidden overflow-y-auto w-full min-w-0 pb-2;
 
   .chat-bubble-wrap {
-    @apply mb-1;
+    @apply mb-1 min-w-0 max-w-full;
 
     &:first-child {
       margin-top: auto;

--- a/app/javascript/widget/assets/scss/woot.scss
+++ b/app/javascript/widget/assets/scss/woot.scss
@@ -13,6 +13,12 @@ body {
 .is-mobile {
   display: block;
 
+  &.is-unread-preview.is-bubble-hidden {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+  }
+
   .actions {
     .close-button {
       display: block !important;

--- a/app/javascript/widget/components/UnreadMessage.vue
+++ b/app/javascript/widget/components/UnreadMessage.vue
@@ -107,7 +107,7 @@ export default {
       </div>
       <div
         v-dompurify-html="formatMessage(message, false)"
-        class="message-content"
+        class="message-content line-clamp-3 break-words overflow-hidden"
       />
     </button>
   </div>

--- a/app/javascript/widget/components/UnreadMessageList.vue
+++ b/app/javascript/widget/components/UnreadMessageList.vue
@@ -26,9 +26,12 @@ export default {
       unreadMessageCount: 'conversation/getUnreadMessageCount',
       widgetColor: 'appConfig/getWidgetColor',
     }),
+    previewMessages() {
+      return this.messages.slice(-3);
+    },
     sender() {
-      const [firstMessage] = this.messages;
-      return firstMessage.sender || {};
+      const [firstMessage] = this.previewMessages;
+      return firstMessage?.sender || {};
     },
     isBackgroundLighter() {
       return isWidgetColorLighter(this.widgetColor);
@@ -51,6 +54,16 @@ export default {
 
       return '';
     },
+    unreadBubbleKey(message, index) {
+      const id = message.id ?? message.campaignId ?? `idx-${index}`;
+      const text = this.getMessageContent(message);
+      const mod = 1_000_000_007;
+      let h = 0;
+      for (let i = 0; i < Math.min(text.length, 256); i += 1) {
+        h = (h * 31 + text.charCodeAt(i)) % mod;
+      }
+      return `${id}-${text.length}-${h}`;
+    },
   },
 };
 </script>
@@ -67,8 +80,8 @@ export default {
     </div>
     <div class="unread-messages">
       <UnreadMessage
-        v-for="(message, index) in messages"
-        :key="message.id"
+        v-for="(message, index) in previewMessages"
+        :key="unreadBubbleKey(message, index)"
         :message-type="message.messageType"
         :message-id="message.id"
         :show-sender="!index"

--- a/app/javascript/widget/components/UnreadMessageList.vue
+++ b/app/javascript/widget/components/UnreadMessageList.vue
@@ -28,7 +28,7 @@ export default {
     }),
     sender() {
       const [firstMessage] = this.messages;
-      return firstMessage.sender || {};
+      return firstMessage?.sender || {};
     },
     isBackgroundLighter() {
       return isWidgetColorLighter(this.widgetColor);
@@ -68,7 +68,7 @@ export default {
     <div class="unread-messages">
       <UnreadMessage
         v-for="(message, index) in messages"
-        :key="message.id"
+        :key="message.id ?? message.campaignId ?? index"
         :message-type="message.messageType"
         :message-id="message.id"
         :show-sender="!index"

--- a/app/javascript/widget/helpers/actionCable.js
+++ b/app/javascript/widget/helpers/actionCable.js
@@ -85,7 +85,9 @@ class ActionCableConnector extends BaseActionCableConnector {
       });
     }
 
-    this.app.$store.dispatch('conversation/addOrUpdateMessage', data);
+    this.app.$store
+      .dispatch('conversation/addOrUpdateMessage', data)
+      .then(() => emitter.emit(ON_AGENT_MESSAGE_RECEIVED));
   };
 
   onConversationCreated = () => {

--- a/app/javascript/widget/helpers/actionCable.js
+++ b/app/javascript/widget/helpers/actionCable.js
@@ -63,7 +63,9 @@ class ActionCableConnector extends BaseActionCableConnector {
 
     this.app.$store
       .dispatch('conversation/addOrUpdateMessage', data)
-      .then(() => emitter.emit(ON_AGENT_MESSAGE_RECEIVED));
+      .then(() =>
+        emitter.emit(ON_AGENT_MESSAGE_RECEIVED, { source: 'created' })
+      );
 
     IFrameHelper.sendMessage({
       event: 'onEvent',
@@ -88,7 +90,11 @@ class ActionCableConnector extends BaseActionCableConnector {
       });
     }
 
-    this.app.$store.dispatch('conversation/addOrUpdateMessage', data);
+    this.app.$store
+      .dispatch('conversation/addOrUpdateMessage', data)
+      .then(() =>
+        emitter.emit(ON_AGENT_MESSAGE_RECEIVED, { source: 'updated' })
+      );
   };
 
   onConversationCreated = () => {


### PR DESCRIPTION
Fixes #12395

## Summary
This PR fixes the widget issue where the unread preview looked correct after refresh but broke during realtime updates.

It also fixes the positioning of the widget in without-bubble mode.

## Changes
- emit `ON_AGENT_MESSAGE_RECEIVED` after store updates on `message.updated`
- rework unread preview routing and iframe height recalculation
- keep only the last 3 unread preview messages with stable keys
- clamp preview message text to avoid layout breakage
- prevent overflow issues in the unread preview layout
- adjust `.woot-widget--without-bubble` bottom offset from `20px` to `62px`

## Testing
- verified unread preview after refresh
- verified unread preview during realtime updates
- verified without-bubble positioning


### Without bubble mode
<img width="364" height="493" alt="image" src="https://github.com/user-attachments/assets/a3636f0d-8197-4583-87b5-cf3687c5249d" />
<br />
<br />

### Bubble mode
<img width="364" height="514" alt="image" src="https://github.com/user-attachments/assets/c26968fb-9f7d-40bf-b0a2-e638b6f5c4e9" />
