### PR TITLE
fix(sidebar): prevent line wrap in availability selector

### DIFF
--- a/app/javascript/dashboard/components-next/sidebar/SidebarProfileMenuStatus.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarProfileMenuStatus.vue
@@ -82,18 +82,18 @@ function changeAvailabilityStatus(availability) {
         <div class="flex-grow flex items-center gap-1">
           {{ $t('SIDEBAR.SET_YOUR_AVAILABILITY') }}
         </div>
-        <DropdownContainer>
+        <DropdownContainer class="shrink-0">
           <template #trigger="{ toggle }">
             <Button
               size="sm"
               color="slate"
               variant="faded"
-              class="min-w-[96px]"
+              class="min-w-max"
               icon="i-lucide-chevron-down"
               trailing-icon
               @click="toggle"
             >
-              <div class="flex gap-1 items-center flex-grow text-sm">
+              <div class="flex gap-1 items-center whitespace-nowrap text-sm">
                 <div class="p-1 flex-shrink-0">
                   <div class="size-2 rounded-sm" :class="activeStatus.color" />
                 </div>


### PR DESCRIPTION
## Description

Prevents line wrapping in the availability selector in the sidebar profile menu.

On narrower layouts, the selector could shrink and wrap its content, making the row look broken or misaligned. This change keeps the trigger content on a single line and prevents the dropdown container from shrinking inside the flex layout.

### Changes
- add `shrink-0` to the `DropdownContainer`
- change the trigger button width from `min-w-[96px]` to `min-w-max`
- add `whitespace-nowrap` to the trigger content

### Before
The selector could break into two lines with longer labels, as tested in Català, Français, and Español, and it may also affect other locales with longer translations.
<img width="424" height="555" alt="image" src="https://github.com/user-attachments/assets/b08c4251-580c-4b3d-9898-da9ed3714b25" />

### After
<img width="407" height="595" alt="image" src="https://github.com/user-attachments/assets/10be1c63-6f68-48fc-b370-d082e66f9db0" />

## Type of change

- Bug fix (non-breaking change which fixes a UI issue)

## How Has This Been Tested?

- Open the sidebar profile menu
- Check the availability selector in narrower layouts
- Confirm the selector no longer wraps or breaks the row layout

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have tested the change locally