### PR TITLE
fix(dropdown): apply pointer cursor only on interactive items

### DIFF
--- a/app/javascript/dashboard/components-next/dropdown-menu/base/DropdownItem.vue
+++ b/app/javascript/dashboard/components-next/dropdown-menu/base/DropdownItem.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, useAttrs } from 'vue';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 import { useDropdownContext } from './provider.js';
 
@@ -17,6 +17,7 @@ defineOptions({
 });
 
 const { closeMenu } = useDropdownContext();
+const attrs = useAttrs();
 
 const componentIs = computed(() => {
   if (props.link) {
@@ -30,6 +31,18 @@ const componentIs = computed(() => {
 
   return 'div';
 });
+
+const hasForwardedClick = computed(() => {
+  const listener = attrs.onClick;
+  if (typeof listener === 'function') return true;
+  return Array.isArray(listener) && listener.some(l => typeof l === 'function');
+});
+
+const isInteractive = computed(
+  () =>
+    ['button', 'a', 'router-link'].includes(componentIs.value) ||
+    hasForwardedClick.value
+);
 
 const triggerClick = () => {
   if (props.click) {
@@ -47,6 +60,7 @@ const triggerClick = () => {
       class="flex text-left rtl:text-right items-center p-2 reset-base text-sm text-n-slate-12 w-full border-0"
       :class="{
         'hover:bg-n-alpha-2 rounded-lg w-full gap-3': !$slots.default,
+        'cursor-pointer': isInteractive,
       }"
       :href="componentIs === 'a' ? props.link : null"
       :to="componentIs === 'router-link' ? props.link : null"


### PR DESCRIPTION
## Description

Applies the pointer cursor only to interactive items in the dropdown component.

Some dropdown items can render as non-interactive elements, such as `div`, when they do not have a click handler or navigation target. In those cases, showing `cursor: pointer` can be misleading.

This change adds an `isInteractive` computed based on the rendered root element and applies `cursor-pointer` only when the item renders as:
- `button`
- `a`
- `router-link`

In the profile menu dropdown, this was visible because **Profile settings** was the only non-interactive item and still showed the pointer cursor, while the other items were actually interactive.

## Type of change

- Bug fix (non-breaking change which fixes a UI/UX issue)

## How Has This Been Tested?

- Verified the behavior in the profile menu dropdown
- Confirmed **Profile settings** no longer shows the pointer cursor
- Verified interactive items still show the pointer cursor
- Confirmed no changes to slots, props, or event handling

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have tested the change locally

## Screenshot
Profile menu dropdown examples.

### Before:
<img width="343" height="435" alt="image" src="https://github.com/user-attachments/assets/a5a011fe-945c-45b2-80be-d7c5a72ec4b9" />

### After:
<img width="341" height="432" alt="image" src="https://github.com/user-attachments/assets/5b3692b6-354b-4637-9a72-16441bfa6306" />
