### PR TITLE
fix(rack-attack): improve widget rate limiting and use real client IP behind proxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -231,6 +231,8 @@ ANDROID_SHA256_CERT_FINGERPRINT=AC:73:8E:DE:EB:56:EA:CC:10:87:02:A7:65:37:7B:38:
 # ENABLE_RACK_ATTACK_WIDGET_API=true
 # Comma-separated list of trusted IPs that bypass Rack Attack throttling rules
 # RACK_ATTACK_ALLOWED_IPS=127.0.0.1,::1,192.168.0.10
+# Proxy/LB CIDRs you operate (comma-separated; IPv4/IPv6, any order). Needed for real client IP behind proxies; too-wide = spoofing risk — use your provider ranges, not this doc-only example:
+# TRUSTED_PROXY_CIDRS=198.51.100.0/24,2001:db8:1::/48,203.0.113.0/24,2001:db8:2::/48
 
 ## Running chatwoot as an API only server
 ## setting this value to true will disable the frontend dashboard endpoints

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -19,10 +19,15 @@ class Rack::Attack
   Rack::Attack.cache.store = ActiveSupport::Cache::RedisCacheStore.new(redis: $velma, pool: false)
 
   class Request < ::Rack::Request
-    # You many need to specify a method to fetch the correct remote IP address
-    # if the web server is behind a load balancer.
+    # Prefer the client IP resolved by ActionDispatch::RemoteIp (uses X-Forwarded-For when
+    # trusted_proxies includes your load balancer). Falls back to Rack::Request#ip (REMOTE_ADDR).
+    # Configure extra proxy CIDRs via TRUSTED_PROXY_CIDRS — see config/initializers/trusted_proxies.rb.
+    def ip
+      (env['action_dispatch.remote_ip'] || super).to_s
+    end
+
     def remote_ip
-      @remote_ip ||= (env['action_dispatch.remote_ip'] || ip).to_s
+      @remote_ip ||= ip
     end
 
     def allowed_ip?

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -172,9 +172,22 @@ class Rack::Attack
       req.ip if req.path_without_extentions == '/api/v1/widget/contacts' && (req.patch? || req.put?)
     end
 
-    ## Prevent Conversation Bombing through multiple sessions
-    throttle('widget?website_token={website_token}&cw_conversation={x-auth-token}', limit: 5, period: 1.hour) do |req|
-      req.ip if req.path_without_extentions == '/widget' && ActionDispatch::Request.new(req.env).params['cw_conversation'].blank?
+    ## Aggregate per-IP cap on GET /widget (higher than per-token limit so shared egress /
+    ## NATEd clients with different website_token values are not all cut off at the stricter
+    ## per-(token, IP) ceiling; rotating tokens still cannot bypass this bucket).
+    throttle('widget:get:ip', limit: 180, period: 1.minute) do |req|
+      req.ip if req.path_without_extentions == '/widget' && req.get?
+    end
+
+    ## Per (website_token, IP): stricter than aggregate so one widget embed does not absorb
+    ## the full IP budget; multiple tokens from same IP can each use this headroom up to :ip.
+    throttle('widget:get', limit: 60, period: 1.minute) do |req|
+      next unless req.path_without_extentions == '/widget' && req.get?
+
+      token = ActionDispatch::Request.new(req.env).params['website_token'].presence
+      next if token.blank?
+
+      "#{token}:#{req.ip}"
     end
   end
 

--- a/config/initializers/trusted_proxies.rb
+++ b/config/initializers/trusted_proxies.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/trusted_proxy_cidrs')
+require 'action_dispatch/middleware/remote_ip'
+
+extra_proxies = TrustedProxyCidrs.build_from_env(ENV.fetch('TRUSTED_PROXY_CIDRS', ''))
+existing = Rails.application.config.action_dispatch.trusted_proxies
+base_proxies = existing.nil? ? ActionDispatch::RemoteIp::TRUSTED_PROXIES : existing
+
+Rails.application.config.action_dispatch.trusted_proxies = base_proxies + extra_proxies

--- a/lib/trusted_proxy_cidrs.rb
+++ b/lib/trusted_proxy_cidrs.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'ipaddr'
+
+# Parses TRUSTED_PROXY_CIDRS-style CSV into IPAddr instances for ActionDispatch::RemoteIp.
+module TrustedProxyCidrs
+  module_function
+
+  def build_from_env(value)
+    cidr_strings = value.to_s.split(',').map(&:strip).reject(&:empty?)
+    return [] if cidr_strings.empty?
+
+    cidr_strings.map do |cidr|
+      IPAddr.new(cidr)
+    rescue IPAddr::InvalidAddressError => e
+      raise ArgumentError,
+            "TRUSTED_PROXY_CIDRS contains invalid CIDR #{cidr.inspect}: #{e.message}"
+    end
+  end
+end

--- a/spec/lib/trusted_proxy_cidrs_spec.rb
+++ b/spec/lib/trusted_proxy_cidrs_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TrustedProxyCidrs do
+  describe '.build_from_env' do
+    it 'returns empty array for blank string' do
+      expect(described_class.build_from_env('')).to eq([])
+    end
+
+    it 'returns empty array for whitespace-only entries' do
+      expect(described_class.build_from_env(' ,  , ')).to eq([])
+    end
+
+    it 'parses comma-separated CIDRs' do
+      result = described_class.build_from_env('10.0.0.0/8, 2001:db8::/32')
+      expect(result).to all(be_a(IPAddr))
+      expect(result.length).to eq(2)
+    end
+
+    it 'raises ArgumentError with a clear message for invalid CIDR' do
+      expect do
+        described_class.build_from_env('192.168.1.0/24,not-a-cidr')
+      end.to raise_error(
+        ArgumentError,
+        /TRUSTED_PROXY_CIDRS contains invalid CIDR.*not-a-cidr/
+      )
+    end
+  end
+end

--- a/spec/rack/attack/request_spec.rb
+++ b/spec/rack/attack/request_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Rack::Attack::Request do
+  describe '#ip' do
+    let(:remote_ip_value) { instance_double(Object, to_s: '198.51.100.2') }
+
+    context 'when action_dispatch.remote_ip is set' do
+      let(:env) do
+        {
+          'REMOTE_ADDR' => '10.0.0.1',
+          'action_dispatch.remote_ip' => remote_ip_value
+        }
+      end
+
+      it 'returns the Rails-resolved client IP string' do
+        request = described_class.new(env)
+        expect(request.ip).to eq('198.51.100.2')
+      end
+
+      it 'matches #remote_ip' do
+        request = described_class.new(env)
+        expect(request.remote_ip).to eq(request.ip)
+      end
+    end
+
+    context 'when action_dispatch.remote_ip is absent' do
+      let(:env) { { 'REMOTE_ADDR' => '192.0.2.1' } }
+
+      it 'falls back to Rack::Request#ip' do
+        request = described_class.new(env)
+        expect(request.ip).to eq('192.0.2.1')
+      end
+    end
+  end
+end

--- a/spec/rack/attack/widget_get_throttle_spec.rb
+++ b/spec/rack/attack/widget_get_throttle_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Exercises the real GET /widget throttle blocks in config/initializers/rack_attack.rb
+# via Rack::Attack::Throttle#block (public attribute on rack-attack 6.x).
+# rubocop:disable RSpec/DescribeClass -- throttles are defined in an initializer, not a constant
+RSpec.describe 'GET /widget Rack::Attack throttle keys' do
+  def widget_get_env(remote_ip:, path: '/widget')
+    Rack::MockRequest.env_for(path, 'REMOTE_ADDR' => remote_ip)
+  end
+
+  def call_throttle_block(name, env)
+    Rack::Attack.configuration.throttles.fetch(name).block.call(Rack::Attack::Request.new(env))
+  end
+
+  let(:token) { 'website-token-abc' }
+
+  describe "throttle 'widget:get' (token + IP when token present)" do
+    it 'uses distinct keys for the same website_token and different client IPs' do
+      path = "/widget?website_token=#{token}"
+      key_a = call_throttle_block('widget:get', widget_get_env(remote_ip: '198.51.100.1', path: path))
+      key_b = call_throttle_block('widget:get', widget_get_env(remote_ip: '198.51.100.2', path: path))
+      expect(key_a).not_to eq(key_b)
+    end
+
+    it 'does not apply (nil discriminator) when website_token is absent' do
+      ip = '203.0.113.7'
+      expect(call_throttle_block('widget:get', widget_get_env(remote_ip: ip))).to be_nil
+    end
+
+    it 'uses distinct keys for the same client IP and different website_tokens' do
+      ip = '192.0.2.50'
+      key_one = call_throttle_block('widget:get', widget_get_env(remote_ip: ip, path: '/widget?website_token=token-one'))
+      key_two = call_throttle_block('widget:get', widget_get_env(remote_ip: ip, path: '/widget?website_token=token-two'))
+      expect(key_one).not_to eq(key_two)
+    end
+  end
+
+  describe "throttle 'widget:get:ip' (per client IP)" do
+    it 'uses the client IP so the cap cannot be reset by rotating website_token' do
+      ip = '198.51.100.9'
+      env_one = widget_get_env(remote_ip: ip, path: '/widget?website_token=token-a')
+      env_two = widget_get_env(remote_ip: ip, path: '/widget?website_token=token-b')
+      expect(call_throttle_block('widget:get:ip', env_one)).to eq(ip)
+      expect(call_throttle_block('widget:get:ip', env_two)).to eq(ip)
+    end
+
+    it 'falls back to client IP when website_token is absent' do
+      ip = '203.0.113.7'
+      expect(call_throttle_block('widget:get:ip', widget_get_env(remote_ip: ip))).to eq(ip)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
Fixes #8923

This is also related to #4740, since incorrect/shared throttling on widget traffic can surface as 429 responses in the widget experience.

## Summary

This PR includes two related Rack::Attack improvements:

1. Improve `GET /widget` throttling by splitting it into:
   - per-IP limit
   - per-website-token + IP limit

2. Use the Rails-resolved client IP behind proxies/load balancers by:
   - aligning Rack::Attack request IP resolution with `action_dispatch.remote_ip`
   - adding configurable trusted proxy CIDRs through `TRUSTED_PROXY_CIDRS`

## Why

In proxy / load balancer setups, Rack::Attack may otherwise throttle requests using the proxy IP instead of the real client IP. This can cause incorrect shared throttling, especially for widget traffic behind services like Cloudflare or other reverse proxies.

While the most visible symptom here is widget traffic, the `Rack::Attack::Request#ip` change also makes other IP-based Rack::Attack rules use the Rails-resolved client IP.

## Changes

- replace the old `GET /widget` throttle with:
  - `widget:per_ip`
  - `widget:per_token_ip`
- override `Rack::Attack::Request#ip` to prefer `action_dispatch.remote_ip`
- add `TRUSTED_PROXY_CIDRS` support
- preserve any existing `config.action_dispatch.trusted_proxies` configuration and append `TRUSTED_PROXY_CIDRS` on top of it
- fall back to `ActionDispatch::RemoteIp::TRUSTED_PROXIES` only when no trusted proxy configuration is already present
- add minimal specs for:
  - trusted proxy CIDR parsing
  - Rack::Attack request IP resolution

## Notes

- This PR does not change ActionCable / WebSocket IP handling.
- `TRUSTED_PROXY_CIDRS` should only include CIDRs for proxies/load balancers controlled by the operator.
- Invalid CIDRs raise a clear boot-time error.
- Existing Rails trusted proxy configuration is preserved rather than replaced.

## Validation

Tested in a real Cloudflare-backed environment:
- widget HTTP requests resolved to the real client IP
- widget traffic no longer showed the previous shared-proxy behavior
- login throttling also used the real client IP
- normal widget flows continued to work as expected

ActionCable/WebSocket upgrade logs may still show the proxy IP, which is outside the scope of this PR.