### PR TITLE
feat: add GuideJar embed support in HC

### DIFF
--- a/config/markdown_embeds.yml
+++ b/config/markdown_embeds.yml
@@ -134,6 +134,18 @@ codepen:
       </iframe>
     </div>
 
+guidejar:
+  regex: 'https?://(?:www\.)?guidejar\.com/(?:embed|guides)/(?<guide_id>[^&/?]+)'
+  template: |
+    <div style="position: relative; padding-bottom: 62.5%; height: 0;">
+      <iframe
+        src="https://www.guidejar.com/embed/%{guide_id}?type=1&controls=on"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+    </div>
+
 github_gist:
   regex: 'https?://gist\.github\.com/(?<username>[^/]+)/(?<gist_id>[a-f0-9]+)'
   template: |

--- a/spec/config/markdown_embeds_spec.rb
+++ b/spec/config/markdown_embeds_spec.rb
@@ -21,7 +21,7 @@ describe 'Markdown Embeds Configuration' do
     end
 
     it 'contains expected embed types' do
-      expected_types = %w[youtube loom vimeo mp4 arcade_tab arcade wistia bunny codepen github_gist]
+      expected_types = %w[youtube loom vimeo mp4 arcade_tab arcade wistia bunny codepen guidejar github_gist]
       expect(config.keys).to match_array(expected_types)
     end
   end
@@ -72,6 +72,12 @@ describe 'Markdown Embeds Configuration' do
         'codepen' => [
           { url: 'https://codepen.io/username/pen/abcdef', expected: { 'user' => 'username', 'pen_id' => 'abcdef' } },
           { url: 'https://www.codepen.io/testuser/pen/xyz123', expected: { 'user' => 'testuser', 'pen_id' => 'xyz123' } }
+        ],
+        'guidejar' => [
+          { url: 'https://www.guidejar.com/embed/i2qMQRp26rtRxpZczmaA', expected: { 'guide_id' => 'i2qMQRp26rtRxpZczmaA' } },
+          { url: 'https://guidejar.com/guides/i2qMQRp26rtRxpZczmaA', expected: { 'guide_id' => 'i2qMQRp26rtRxpZczmaA' } },
+          { url: 'https://guidejar.com/guides/d6a6fdc2-4812-4777-897e-ec1b0c64238f',
+            expected: { 'guide_id' => 'd6a6fdc2-4812-4777-897e-ec1b0c64238f' } }
         ],
         'github_gist' => [
           { url: 'https://gist.github.com/username/1234567890abcdef1234567890abcdef',

--- a/spec/lib/custom_markdown_renderer_spec.rb
+++ b/spec/lib/custom_markdown_renderer_spec.rb
@@ -184,6 +184,32 @@ describe CustomMarkdownRenderer do
       end
     end
 
+    context 'when link is a GuideJar embed URL' do
+      let(:guidejar_url) { 'https://www.guidejar.com/embed/i2qMQRp26rtRxpZczmaA' }
+
+      it 'renders an iframe with GuideJar embed code' do
+        output = render_markdown_link(guidejar_url)
+        expect(output).to include('src="https://www.guidejar.com/embed/i2qMQRp26rtRxpZczmaA?type=1&controls=on"')
+        expect(output).to include('allowfullscreen')
+      end
+    end
+
+    context 'when link is a GuideJar guides URL' do
+      let(:guidejar_url) { 'https://guidejar.com/guides/d6a6fdc2-4812-4777-897e-ec1b0c64238f' }
+
+      it 'renders an iframe with GuideJar embed code' do
+        output = render_markdown_link(guidejar_url)
+        expect(output).to include('src="https://www.guidejar.com/embed/d6a6fdc2-4812-4777-897e-ec1b0c64238f?type=1&controls=on"')
+        expect(output).to include('allowfullscreen')
+      end
+
+      it 'wraps iframe in responsive container' do
+        output = render_markdown_link(guidejar_url)
+        expect(output).to include('position: relative; padding-bottom: 62.5%; height: 0;')
+        expect(output).to include('position: absolute; top: 0; left: 0; width: 100%; height: 100%;')
+      end
+    end
+
     context 'when link is a Bunny.net iframe URL' do
       let(:bunny_url) { 'https://iframe.mediadelivery.net/play/431789/1f105841-cad9-46fe-a70e-b7623c60797c' }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR introduces a new embed type for the Help Center, enabling users to embed GuideJar guides.


Fixes https://linear.app/chatwoot/issue/CW-6705/guidejar-embed-support-in-hc

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Loom video
https://www.loom.com/share/1475c23e351c492aa1101844d47f3433


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
