### PR TITLE
fix: align message trimming with configured maxLength

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -545,7 +545,10 @@ export default {
     },
     setCopilotAcceptedMessage(message, replyType = this.replyType) {
       const key = this.getDraftKey(this.conversationIdByRoute, replyType);
-      this.copilotAcceptedMessages[key] = trimContent(message || '');
+      this.copilotAcceptedMessages[key] = trimContent(
+        message || '',
+        this.maxLength
+      );
     },
     clearCopilotAcceptedMessage(replyType = this.replyType) {
       const key = this.getDraftKey(this.conversationIdByRoute, replyType);
@@ -603,7 +606,7 @@ export default {
     saveDraft(conversationId, replyType) {
       if (this.message || this.message === '') {
         const key = this.getDraftKey(conversationId, replyType);
-        const draftToSave = trimContent(this.message || '');
+        const draftToSave = trimContent(this.message || '', this.maxLength);
 
         this.$store.dispatch('draftMessages/set', {
           key,

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -244,7 +244,40 @@ export default {
       return type || '';
     },
     maxLength() {
-      return this.maxLengthForReplyType(this.replyType);
+      if (this.isPrivate) {
+        return MESSAGE_MAX_LENGTH.GENERAL;
+      }
+      if (this.isAFacebookInbox) {
+        return MESSAGE_MAX_LENGTH.FACEBOOK;
+      }
+      if (this.isAnInstagramChannel) {
+        return MESSAGE_MAX_LENGTH.INSTAGRAM;
+      }
+      if (this.isATelegramChannel) {
+        return MESSAGE_MAX_LENGTH.TELEGRAM;
+      }
+      if (this.isATiktokChannel) {
+        return MESSAGE_MAX_LENGTH.TIKTOK;
+      }
+      if (this.isATwilioWhatsAppChannel) {
+        return MESSAGE_MAX_LENGTH.TWILIO_WHATSAPP;
+      }
+      if (this.isAWhatsAppCloudChannel) {
+        return MESSAGE_MAX_LENGTH.WHATSAPP_CLOUD;
+      }
+      if (this.isASmsInbox) {
+        return MESSAGE_MAX_LENGTH.TWILIO_SMS;
+      }
+      if (this.isAnEmailChannel) {
+        return MESSAGE_MAX_LENGTH.EMAIL;
+      }
+      if (this.isATwilioSMSChannel) {
+        return MESSAGE_MAX_LENGTH.TWILIO_SMS;
+      }
+      if (this.isAWhatsAppChannel) {
+        return MESSAGE_MAX_LENGTH.WHATSAPP_CLOUD;
+      }
+      return MESSAGE_MAX_LENGTH.GENERAL;
     },
     showFileUpload() {
       return (
@@ -503,23 +536,6 @@ export default {
     emitter.off(CMD_AI_ASSIST, this.executeCopilotAction);
   },
   methods: {
-    maxLengthForReplyType(replyType) {
-      const isPrivateNote = replyType === REPLY_EDITOR_MODES.NOTE;
-      if (isPrivateNote) return MESSAGE_MAX_LENGTH.GENERAL;
-      if (this.isAFacebookInbox) return MESSAGE_MAX_LENGTH.FACEBOOK;
-      if (this.isAnInstagramChannel) return MESSAGE_MAX_LENGTH.INSTAGRAM;
-      if (this.isATelegramChannel) return MESSAGE_MAX_LENGTH.TELEGRAM;
-      if (this.isATiktokChannel) return MESSAGE_MAX_LENGTH.TIKTOK;
-      if (this.isATwilioWhatsAppChannel)
-        return MESSAGE_MAX_LENGTH.TWILIO_WHATSAPP;
-      if (this.isAWhatsAppCloudChannel)
-        return MESSAGE_MAX_LENGTH.WHATSAPP_CLOUD;
-      if (this.isASmsInbox) return MESSAGE_MAX_LENGTH.TWILIO_SMS;
-      if (this.isAnEmailChannel) return MESSAGE_MAX_LENGTH.EMAIL;
-      if (this.isATwilioSMSChannel) return MESSAGE_MAX_LENGTH.TWILIO_SMS;
-      if (this.isAWhatsAppChannel) return MESSAGE_MAX_LENGTH.WHATSAPP_CLOUD;
-      return MESSAGE_MAX_LENGTH.GENERAL;
-    },
     getDraftKey(
       conversationId = this.conversationIdByRoute,
       replyType = this.replyType
@@ -534,7 +550,7 @@ export default {
       const key = this.getDraftKey(this.conversationIdByRoute, replyType);
       this.copilotAcceptedMessages[key] = trimContent(
         message || '',
-        this.maxLengthForReplyType(replyType)
+        this.maxLength
       );
     },
     clearCopilotAcceptedMessage(replyType = this.replyType) {
@@ -593,10 +609,7 @@ export default {
     saveDraft(conversationId, replyType) {
       if (this.message || this.message === '') {
         const key = this.getDraftKey(conversationId, replyType);
-        const draftToSave = trimContent(
-          this.message || '',
-          this.maxLengthForReplyType(replyType)
-        );
+        const draftToSave = trimContent(this.message || '', this.maxLength);
 
         this.$store.dispatch('draftMessages/set', {
           key,

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -244,37 +244,7 @@ export default {
       return type || '';
     },
     maxLength() {
-      if (this.isPrivate) {
-        return MESSAGE_MAX_LENGTH.GENERAL;
-      }
-      if (this.isAFacebookInbox) {
-        return MESSAGE_MAX_LENGTH.FACEBOOK;
-      }
-      if (this.isAnInstagramChannel) {
-        return MESSAGE_MAX_LENGTH.INSTAGRAM;
-      }
-      if (this.isATiktokChannel) {
-        return MESSAGE_MAX_LENGTH.TIKTOK;
-      }
-      if (this.isATwilioWhatsAppChannel) {
-        return MESSAGE_MAX_LENGTH.TWILIO_WHATSAPP;
-      }
-      if (this.isAWhatsAppCloudChannel) {
-        return MESSAGE_MAX_LENGTH.WHATSAPP_CLOUD;
-      }
-      if (this.isASmsInbox) {
-        return MESSAGE_MAX_LENGTH.TWILIO_SMS;
-      }
-      if (this.isAnEmailChannel) {
-        return MESSAGE_MAX_LENGTH.EMAIL;
-      }
-      if (this.isATwilioSMSChannel) {
-        return MESSAGE_MAX_LENGTH.TWILIO_SMS;
-      }
-      if (this.isAWhatsAppChannel) {
-        return MESSAGE_MAX_LENGTH.WHATSAPP_CLOUD;
-      }
-      return MESSAGE_MAX_LENGTH.GENERAL;
+      return this.maxLengthForReplyType(this.replyType);
     },
     showFileUpload() {
       return (
@@ -533,6 +503,23 @@ export default {
     emitter.off(CMD_AI_ASSIST, this.executeCopilotAction);
   },
   methods: {
+    maxLengthForReplyType(replyType) {
+      const isPrivateNote = replyType === REPLY_EDITOR_MODES.NOTE;
+      if (isPrivateNote) return MESSAGE_MAX_LENGTH.GENERAL;
+      if (this.isAFacebookInbox) return MESSAGE_MAX_LENGTH.FACEBOOK;
+      if (this.isAnInstagramChannel) return MESSAGE_MAX_LENGTH.INSTAGRAM;
+      if (this.isATelegramChannel) return MESSAGE_MAX_LENGTH.TELEGRAM;
+      if (this.isATiktokChannel) return MESSAGE_MAX_LENGTH.TIKTOK;
+      if (this.isATwilioWhatsAppChannel)
+        return MESSAGE_MAX_LENGTH.TWILIO_WHATSAPP;
+      if (this.isAWhatsAppCloudChannel)
+        return MESSAGE_MAX_LENGTH.WHATSAPP_CLOUD;
+      if (this.isASmsInbox) return MESSAGE_MAX_LENGTH.TWILIO_SMS;
+      if (this.isAnEmailChannel) return MESSAGE_MAX_LENGTH.EMAIL;
+      if (this.isATwilioSMSChannel) return MESSAGE_MAX_LENGTH.TWILIO_SMS;
+      if (this.isAWhatsAppChannel) return MESSAGE_MAX_LENGTH.WHATSAPP_CLOUD;
+      return MESSAGE_MAX_LENGTH.GENERAL;
+    },
     getDraftKey(
       conversationId = this.conversationIdByRoute,
       replyType = this.replyType
@@ -547,7 +534,7 @@ export default {
       const key = this.getDraftKey(this.conversationIdByRoute, replyType);
       this.copilotAcceptedMessages[key] = trimContent(
         message || '',
-        this.maxLength
+        this.maxLengthForReplyType(replyType)
       );
     },
     clearCopilotAcceptedMessage(replyType = this.replyType) {
@@ -606,7 +593,10 @@ export default {
     saveDraft(conversationId, replyType) {
       if (this.message || this.message === '') {
         const key = this.getDraftKey(conversationId, replyType);
-        const draftToSave = trimContent(this.message || '', this.maxLength);
+        const draftToSave = trimContent(
+          this.message || '',
+          this.maxLengthForReplyType(replyType)
+        );
 
         this.$store.dispatch('draftMessages/set', {
           key,


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes 
1. Messages being trimmed to the default 1024 limit in `trimContent` method, instead of channel-specific limits for drafts and AI tasks.
2. Telegram messages are allowed up to 10,000 characters in config, but the API supports only 4096, causing failures for oversized messages.

Fixes https://linear.app/chatwoot/issue/CW-6694/captain-ai-rewrite-tasks-truncate-draft-to-1024-chars-trimcontent
https://github.com/chatwoot/chatwoot/issues/13919

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Loom video

**Before**
https://www.loom.com/share/00e9d6b4d19247febf35dffa99da3805

**After**
https://www.loom.com/share/c4900e9effc345c79bcd8a5aa1ee277b


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
