### PR TITLE
ci: add API schema drift check for swagger definitions

### DIFF
--- a/.github/workflows/api_schema_check.yml
+++ b/.github/workflows/api_schema_check.yml
@@ -1,0 +1,22 @@
+name: API Schema Check
+
+on:
+  pull_request:
+    paths:
+      - 'swagger/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  schema-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: delimit-ai/delimit-action@v1
+        with:
+          spec: swagger/swagger.json

--- a/.github/workflows/api_schema_check.yml
+++ b/.github/workflows/api_schema_check.yml
@@ -2,9 +2,16 @@
 # that touches swagger definitions. Posts an advisory comment — does not block merges.
 # ref: https://github.com/chatwoot/chatwoot/issues/13871
 #
-# Note: This diffs the source-of-truth files under swagger/ directly.
-# If swagger/swagger.json is generated from the fragments in definitions/
-# and paths/, consider adding a build step to regenerate it before the diff.
+# Build process: Chatwoot compiles swagger/swagger.json from YAML fragments
+# (swagger/index.yml, swagger/paths/, swagger/definitions/) using the json_refs
+# gem: `bundle exec rake swagger:build`. Contributors must run this locally
+# before committing so that swagger.json stays in sync with the fragments.
+#
+# This workflow diffs swagger.json between the base and PR branches, so it will
+# catch breaking changes whenever contributors follow the existing convention of
+# regenerating swagger.json before pushing. If the team wants to enforce
+# regeneration in CI, add a Ruby + bundle install + rake swagger:build step
+# before the delimit-action step below.
 
 name: API Schema Check
 

--- a/.github/workflows/api_schema_check.yml
+++ b/.github/workflows/api_schema_check.yml
@@ -1,3 +1,11 @@
+# Checks for breaking changes in the OpenAPI/Swagger schema on every PR
+# that touches swagger definitions. Posts an advisory comment — does not block merges.
+# ref: https://github.com/chatwoot/chatwoot/issues/13871
+#
+# Note: This diffs the source-of-truth files under swagger/ directly.
+# If swagger/swagger.json is generated from the fragments in definitions/
+# and paths/, consider adding a build step to regenerate it before the diff.
+
 name: API Schema Check
 
 on:


### PR DESCRIPTION
## Description
Adds a CI workflow that checks for breaking API changes whenever a PR touches `swagger/**`. It diffs the base branch schema against the PR and posts an advisory comment identifying:

- Breaking vs non-breaking changes (field removals, type mismatches, required param additions, enum changes)
- Semver impact classification
- Migration guidance for breaking changes

Advisory mode only — posts a comment but **never blocks merges**. No API keys or configuration needed.

### How it works
The workflow uses [delimit-action](https://github.com/delimit-ai/delimit-action) to diff `swagger/swagger.json` against the base branch version. Example output: [demo PR comment](https://github.com/delimit-ai/delimit-action-demo/pull/1).

### Context
Issue #13693 caught a mismatch between the swagger definitions and actual jbuilder responses. This workflow would catch that class of drift automatically on future PRs.

Closes #13871

## Type
- [x] Chore