### PR TITLE
fix(sentry): syntaxError: No error message

### DIFF
--- a/app/javascript/dashboard/App.vue
+++ b/app/javascript/dashboard/App.vue
@@ -98,7 +98,7 @@ export default {
       mql.onchange = e => setColorTheme(e.matches);
     },
     setLocale(locale) {
-      this.$root.$i18n.locale = locale;
+      this.$root.$i18n.locale = locale || 'en';
     },
     async initializeAccount() {
       await this.$store.dispatch('accounts/get');

--- a/app/javascript/dashboard/App.vue
+++ b/app/javascript/dashboard/App.vue
@@ -98,7 +98,9 @@ export default {
       mql.onchange = e => setColorTheme(e.matches);
     },
     setLocale(locale) {
-      this.$root.$i18n.locale = locale || 'en';
+      if (locale) {
+        this.$root.$i18n.locale = locale;
+      }
     },
     async initializeAccount() {
       await this.$store.dispatch('accounts/get');

--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -103,7 +103,10 @@ export default {
         const { name, locale, id, domain, support_email, features } =
           this.getAccount(this.accountId);
 
-        this.$root.$i18n.locale = this.uiSettings?.locale || locale || 'en';
+        const effectiveLocale = this.uiSettings?.locale || locale;
+        if (effectiveLocale) {
+          this.$root.$i18n.locale = effectiveLocale;
+        }
         this.name = name;
         this.locale = locale;
         this.id = id;
@@ -129,11 +132,9 @@ export default {
           support_email: this.supportEmail,
         });
         // If user locale is set, update the locale with user locale
-        if (this.uiSettings?.locale) {
-          this.$root.$i18n.locale = this.uiSettings?.locale || 'en';
-        } else {
-          // If user locale is not set, update the locale with account locale
-          this.$root.$i18n.locale = this.locale || 'en';
+        const updatedLocale = this.uiSettings?.locale || this.locale;
+        if (updatedLocale) {
+          this.$root.$i18n.locale = updatedLocale;
         }
         this.getAccount(this.id).locale = this.locale;
         useAlert(this.$t('GENERAL_SETTINGS.UPDATE.SUCCESS'));

--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -103,7 +103,7 @@ export default {
         const { name, locale, id, domain, support_email, features } =
           this.getAccount(this.accountId);
 
-        this.$root.$i18n.locale = this.uiSettings?.locale || locale;
+        this.$root.$i18n.locale = this.uiSettings?.locale || locale || 'en';
         this.name = name;
         this.locale = locale;
         this.id = id;
@@ -130,10 +130,10 @@ export default {
         });
         // If user locale is set, update the locale with user locale
         if (this.uiSettings?.locale) {
-          this.$root.$i18n.locale = this.uiSettings?.locale;
+          this.$root.$i18n.locale = this.uiSettings?.locale || 'en';
         } else {
           // If user locale is not set, update the locale with account locale
-          this.$root.$i18n.locale = this.locale;
+          this.$root.$i18n.locale = this.locale || 'en';
         }
         this.getAccount(this.id).locale = this.locale;
         useAlert(this.$t('GENERAL_SETTINGS.UPDATE.SUCCESS'));

--- a/app/javascript/v3/App.vue
+++ b/app/javascript/v3/App.vue
@@ -35,7 +35,9 @@ export default {
       };
     },
     setLocale(locale) {
-      this.$root.$i18n.locale = locale || 'en';
+      if (locale) {
+        this.$root.$i18n.locale = locale;
+      }
     },
   },
 };

--- a/app/javascript/v3/App.vue
+++ b/app/javascript/v3/App.vue
@@ -35,7 +35,7 @@ export default {
       };
     },
     setLocale(locale) {
-      this.$root.$i18n.locale = locale;
+      this.$root.$i18n.locale = locale || 'en';
     },
   },
 };


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes a `SyntaxError: No error message` reported in Sentry.

**Root cause**
When a user logs in, the app fetches account data and sets the i18n locale from it. If the account API call fails (e.g., network issues or timeouts), the error is silently ignored and execution continues. As a result, the locale becomes `undefined`, which causes `vue-i18n` to throw a `NOT_SUPPORT_LOCALE_TYPE` error in any component using translations.

**When this can happen**

* Intermittent network issues during login
* Slow or failed responses from the account API
* Any scenario where account data is unavailable when `initializeAccount` completes

**What changed**
Locale updates now guard against falsy values. `setLocale` only updates `i18n.locale` when the incoming value is valid. If the account API fails and returns `undefined`, the update is skipped, preserving the existing locale set during initialization (default, or the `'en'` fallback from `createI18n`). This ensures the app never enters an invalid locale state.


**Reproduction steps**

1. Log in to the dashboard
2. Open DevTools → Network tab
3. Block requests matching `/api/v1/accounts`
4. Refresh the page
5. Observe the `SyntaxError: cannot support locale type` in the console, triggered by components using `t()`

**Screenshot**
<img width="507" height="411" alt="image" src="https://github.com/user-attachments/assets/48d174ee-923a-4095-a148-3cbb672b6fbd" />



Fixes https://linear.app/chatwoot/issue/CW-4128/syntaxerror-no-error-message

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Log in to the dashboard
2. Open DevTools → Network tab
3. Block requests matching `/api/v1/accounts`.
4. Refresh the page
5. Observe any `SyntaxError: cannot support locale type` error in the console.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
