### PR TITLE
fix(microsoft): prevent OAuth admin consent loop

### DIFF
--- a/app/controllers/api/v1/accounts/microsoft/authorizations_controller.rb
+++ b/app/controllers/api/v1/accounts/microsoft/authorizations_controller.rb
@@ -6,8 +6,7 @@ class Api::V1::Accounts::Microsoft::AuthorizationsController < Api::V1::Accounts
       {
         redirect_uri: "#{base_url}/microsoft/callback",
         scope: scope,
-        state: state,
-        prompt: 'consent'
+        state: state
       }
     )
     if redirect_url

--- a/spec/controllers/api/v1/accounts/microsoft/authorization_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/microsoft/authorization_controller_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe 'Microsoft Authorization API', type: :request do
         ]
         expect(params['scope']).to eq(expected_scope)
         expect(params['redirect_uri']).to eq(["#{ENV.fetch('FRONTEND_URL', 'http://localhost:3000')}/microsoft/callback"])
+        expect(url).not_to match(/(?:\?|&)prompt=/)
 
         # Validate state parameter exists and can be decoded back to the account
         expect(params['state']).to be_present


### PR DESCRIPTION
Fixes #9775

## Description

This fixes a repeated admin consent loop in the Microsoft OAuth flow when connecting a Microsoft email inbox.

Chatwoot was always sending `prompt=consent` in the Microsoft authorization URL. In the current code path, this parameter is only used when building the authorization URL and is not required by the callback, token exchange, token persistence, or refresh flow.

By removing the forced consent prompt, the OAuth flow can proceed normally without repeatedly sending users back through the admin consent screen.

## What changed

- removed `prompt: 'consent'` from the Microsoft authorization URL
- added a regression assertion to ensure `prompt` is not included in the generated URL

## Why this is safe

- `redirect_uri`, `scope`, and `state` remain unchanged
- callback and token exchange flow remain unchanged
- refresh token flow remains unchanged
- no other part of the current Microsoft inbox flow depends on forcing a consent screen

## Testing

- updated controller spec to assert that the generated authorization URL does not include `prompt`