### PR TITLE
fix: exclude MutexApplicationJob::LockAcquisitionError from Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,7 +7,7 @@ if ENV['SENTRY_DSN'].present?
     # We recommend adjusting the value in production:
     config.traces_sample_rate = 0.1 if ENV['ENABLE_SENTRY_TRANSACTIONS']
 
-    config.excluded_exceptions += ['Rack::Timeout::RequestTimeoutException']
+    config.excluded_exceptions += ['Rack::Timeout::RequestTimeoutException', 'MutexApplicationJob::LockAcquisitionError']
 
     # to track post data in sentry
     config.send_default_pii = true unless ENV['DISABLE_SENTRY_PII']


### PR DESCRIPTION
## Summary
- Add `MutexApplicationJob::LockAcquisitionError` to Sentry's `excluded_exceptions`
- This error is expected control flow (mutex lock contention during webhook processing), not a bug
- Generated ~131K Sentry events in March 2026, 100% from `InstagramEventsJob`

Fixes https://linear.app/chatwoot/issue/INF-58