### PR TITLE
fix: Markdown tables don't render properly in help centre

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@amplitude/analytics-browser": "^2.11.10",
     "@breezystack/lamejs": "^1.2.7",
     "@chatwoot/ninja-keys": "1.2.3",
-    "@chatwoot/prosemirror-schema": "1.3.8",
+    "@chatwoot/prosemirror-schema": "1.3.9",
     "@chatwoot/utils": "^0.0.52",
     "@formkit/core": "^1.7.2",
     "@formkit/vue": "^1.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: 1.2.3
         version: 1.2.3
       '@chatwoot/prosemirror-schema':
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.9
+        version: 1.3.9
       '@chatwoot/utils':
         specifier: ^0.0.52
         version: 0.0.52
@@ -454,8 +454,8 @@ packages:
   '@chatwoot/ninja-keys@1.2.3':
     resolution: {integrity: sha512-xM8d9P5ikDMZm2WbaCTk/TW5HFauylrU3cJ75fq5je6ixKwyhl/0kZbVN/vbbZN4+AUX/OaSIn6IJbtCgIF67g==}
 
-  '@chatwoot/prosemirror-schema@1.3.8':
-    resolution: {integrity: sha512-Vr8eUdydmVr7iRnNky4jXKX3XD4z5HAS4bV7zJXxA4av4ig5qjTldDOg7c/C8rqYNKGR5UEOEu9CQfGcjfKVXg==}
+  '@chatwoot/prosemirror-schema@1.3.9':
+    resolution: {integrity: sha512-nbzvW4Rfe7EC+tHF/wWJK5pIxRzfQj/DDAtZI7pwM9uJfv9yQz6bAUCA7kz7Vq1NF29XOisZaT5W0005ygk1pg==}
 
   '@chatwoot/utils@0.0.52':
     resolution: {integrity: sha512-e57uVqyVW4tj1gql4YJPNMykqMJPkETn5Y9AmHdhc6Y7oxDXfRXBq27fZrrDadLkZdn5RYVCZjfIhXOumyYv2Q==}
@@ -4966,7 +4966,7 @@ snapshots:
       hotkeys-js: 3.8.7
       lit: 2.2.6
 
-  '@chatwoot/prosemirror-schema@1.3.8':
+  '@chatwoot/prosemirror-schema@1.3.9':
     dependencies:
       markdown-it-sup: 2.0.0
       prosemirror-commands: 1.6.0


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where markdown tables were not rendering correctly in the Help Center.

The issue was caused by a backslash `(\)` being appended after table row separators `(|)`, which breaks the markdown table parsing.

The issue was introduced after recent editor changes made to preserve new lines, which unintentionally affected how table markdown is parsed and displayed.

### https://github.com/chatwoot/prosemirror-schema/pull/44

Fixes https://linear.app/chatwoot/issue/CW-6714/markdown-tables-dont-render-properly-in-help-centre-preview

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Before**
```
| Type         | What you provide              |\
|--------------|-------------------------------|\
| None         | No authentication             |\
| Bearer Token | A token string                |\
| Basic Auth   | Username and password         |\
| API Key      | A custom header name and value|
```

**After**
```
| Type         | What you provide              | 
|--------------|-------------------------------| 
| None         | No authentication             | 
| Bearer Token | A token string                | 
| Basic Auth   | Username and password         | 
| API Key      | A custom header name and value|
```




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
