### PR TITLE
feat(whatsapp): use unified webhook URL for all WhatsApp Cloud numbers

### DIFF
--- a/app/controllers/webhooks/whatsapp_controller.rb
+++ b/app/controllers/webhooks/whatsapp_controller.rb
@@ -15,9 +15,21 @@ class Webhooks::WhatsappController < ActionController::API
   private
 
   def valid_token?(token)
-    channel = Channel::Whatsapp.find_by(phone_number: params[:phone_number])
-    whatsapp_webhook_verify_token = channel.provider_config['webhook_verify_token'] if channel.present?
-    token == whatsapp_webhook_verify_token if whatsapp_webhook_verify_token.present?
+    return false if token.blank?
+
+    if params[:phone_number].present?
+      channel = Channel::Whatsapp.find_by(phone_number: params[:phone_number])
+      if channel.present?
+        expected = channel.provider_config['webhook_verify_token']
+        return false if expected.blank?
+
+        return ActiveSupport::SecurityUtils.secure_compare(token.to_s, expected.to_s)
+      end
+    else
+      return Channel::Whatsapp.where(provider: 'whatsapp_cloud')
+                              .exists?(["provider_config->>'webhook_verify_token' = ?", token])
+    end
+    false
   end
 
   def inactive_whatsapp_number?

--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -9,6 +9,11 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
       return
     end
 
+    if inactive_whatsapp_number?(channel)
+      Rails.logger.warn("Rejected webhook for inactive WhatsApp number: #{channel.phone_number}")
+      return
+    end
+
     if message_echo_event?(params)
       handle_message_echo(channel, params)
     else
@@ -69,6 +74,15 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
 
   private
 
+  def inactive_whatsapp_number?(channel)
+    return false if channel.blank?
+
+    inactive_numbers = GlobalConfig.get_value('INACTIVE_WHATSAPP_NUMBERS').to_s
+    return false if inactive_numbers.blank?
+
+    inactive_numbers.split(',').map(&:strip).include?(channel.phone_number)
+  end
+
   def channel_is_inactive?(channel)
     return true if channel.blank?
     return true if channel.reauthorization_required?
@@ -93,10 +107,18 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
   end
 
   def get_channel_from_wb_payload(wb_params)
-    phone_number = "+#{wb_params[:entry].first[:changes].first.dig(:value, :metadata, :display_phone_number)}"
-    phone_number_id = wb_params[:entry].first[:changes].first.dig(:value, :metadata, :phone_number_id)
-    channel = Channel::Whatsapp.find_by(phone_number: phone_number)
-    # validate to ensure the phone number id matches the whatsapp channel
-    return channel if channel && channel.provider_config['phone_number_id'] == phone_number_id
+    phone_number_id = wb_params.dig(:entry, 0, :changes, 0, :value, :metadata, :phone_number_id)
+    display_phone_number = "+#{wb_params.dig(:entry, 0, :changes, 0, :value, :metadata, :display_phone_number)}"
+
+    # Primary: match directly by phone_number_id (most reliable, avoids display number formatting mismatches)
+    if phone_number_id.present?
+      channel = Channel::Whatsapp.where(provider: 'whatsapp_cloud')
+                                 .find_by("provider_config->>'phone_number_id' = ?", phone_number_id)
+    end
+    return channel if channel
+
+    # Fallback: match by display_phone_number with phone_number_id validation
+    channel = Channel::Whatsapp.find_by(phone_number: display_phone_number)
+    channel if channel && channel.provider_config['phone_number_id'] == phone_number_id
   end
 end

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -54,6 +54,22 @@ class Channel::Whatsapp < ApplicationRecord
     # rubocop:enable Rails/SkipsModelValidations
   end
 
+  def waba_siblings
+    return self.class.none unless provider == 'whatsapp_cloud'
+
+    waba_id = provider_config['business_account_id']
+    return self.class.none if waba_id.blank?
+
+    self.class
+        .where(provider: 'whatsapp_cloud')
+        .where("provider_config->>'business_account_id' = ?", waba_id)
+        .where.not(id: id)
+  end
+
+  def waba_sibling_exists?
+    waba_siblings.exists?
+  end
+
   delegate :send_message, to: :provider_service
   delegate :send_template, to: :provider_service
   delegate :sync_templates, to: :provider_service

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -191,7 +191,11 @@ class Inbox < ApplicationRecord
     when 'Channel::Line'
       "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/line/#{channel.line_channel_id}"
     when 'Channel::Whatsapp'
-      "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/whatsapp/#{channel.phone_number}"
+      if channel.provider == 'whatsapp_cloud'
+        "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/whatsapp"
+      else
+        "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/whatsapp/#{channel.phone_number}"
+      end
     end
   end
 

--- a/app/services/whatsapp/health_service.rb
+++ b/app/services/whatsapp/health_service.rb
@@ -90,6 +90,6 @@ class Whatsapp::HealthService
     frontend_url = ENV.fetch('FRONTEND_URL', nil)
     return nil if frontend_url.blank?
 
-    "#{frontend_url}/webhooks/whatsapp/#{@channel.phone_number}"
+    "#{frontend_url}/webhooks/whatsapp"
   end
 end

--- a/app/services/whatsapp/webhook_setup_service.rb
+++ b/app/services/whatsapp/webhook_setup_service.rb
@@ -57,10 +57,9 @@ class Whatsapp::WebhookSetupService
 
   def setup_webhook
     callback_url = build_callback_url
-    verify_token = @channel.provider_config['webhook_verify_token']
+    verify_token = resolve_verify_token
 
     @api_client.subscribe_waba_webhook(@waba_id, callback_url, verify_token)
-
   rescue StandardError => e
     Rails.logger.error("[WHATSAPP] Webhook setup failed: #{e.message}")
     raise "Webhook setup failed: #{e.message}"
@@ -68,9 +67,30 @@ class Whatsapp::WebhookSetupService
 
   def build_callback_url
     frontend_url = ENV.fetch('FRONTEND_URL', nil)
-    phone_number = @channel.phone_number
 
-    "#{frontend_url}/webhooks/whatsapp/#{phone_number}"
+    "#{frontend_url}/webhooks/whatsapp"
+  end
+
+  def resolve_verify_token
+    sibling = find_waba_sibling
+    return @channel.provider_config['webhook_verify_token'] unless sibling
+
+    sibling_token = sibling.provider_config['webhook_verify_token']
+    return @channel.provider_config['webhook_verify_token'] if sibling_token.blank?
+
+    persist_verify_token(sibling_token)
+    sibling_token
+  end
+
+  def persist_verify_token(token)
+    return if @channel.provider_config['webhook_verify_token'] == token
+
+    @channel.provider_config['webhook_verify_token'] = token
+    @channel.save!(validate: false)
+  end
+
+  def find_waba_sibling
+    @channel.waba_siblings.order(:id).first
   end
 
   def phone_number_verified?

--- a/app/services/whatsapp/webhook_teardown_service.rb
+++ b/app/services/whatsapp/webhook_teardown_service.rb
@@ -14,7 +14,7 @@ class Whatsapp::WebhookTeardownService
   private
 
   def should_teardown_webhook?
-    whatsapp_cloud_provider? && embedded_signup_source? && webhook_config_present?
+    whatsapp_cloud_provider? && embedded_signup_source? && webhook_config_present? && !@channel.waba_sibling_exists?
   end
 
   def whatsapp_cloud_provider?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -569,6 +569,8 @@ Rails.application.routes.draw do
   post 'webhooks/line/:line_channel_id', to: 'webhooks/line#process_payload'
   post 'webhooks/telegram/:bot_token', to: 'webhooks/telegram#process_payload'
   post 'webhooks/sms/:phone_number', to: 'webhooks/sms#process_payload'
+  get 'webhooks/whatsapp', to: 'webhooks/whatsapp#verify'
+  post 'webhooks/whatsapp', to: 'webhooks/whatsapp#process_payload'
   get 'webhooks/whatsapp/:phone_number', to: 'webhooks/whatsapp#verify'
   post 'webhooks/whatsapp/:phone_number', to: 'webhooks/whatsapp#process_payload'
   get 'webhooks/instagram', to: 'webhooks/instagram#verify'

--- a/spec/controllers/webhooks/whatsapp_controller_spec.rb
+++ b/spec/controllers/webhooks/whatsapp_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Webhooks::WhatsappController', type: :request do
   let(:channel) { create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false) }
 
-  describe 'GET /webhooks/verify' do
+  describe 'GET /webhooks/whatsapp/:phone_number (legacy)' do
     it 'returns 401 when valid params are not present' do
       get "/webhooks/whatsapp/#{channel.phone_number}"
       expect(response).to have_http_status(:unauthorized)
@@ -22,7 +22,34 @@ RSpec.describe 'Webhooks::WhatsappController', type: :request do
     end
   end
 
-  describe 'POST /webhooks/whatsapp/{:phone_number}' do
+  describe 'GET /webhooks/whatsapp (default without phone_number)' do
+    it 'returns 401 when valid params are not present' do
+      get '/webhooks/whatsapp'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 401 when verify token does not match any channel' do
+      get '/webhooks/whatsapp',
+          params: { 'hub.challenge' => '123456', 'hub.mode' => 'subscribe', 'hub.verify_token' => 'nonexistent_token' }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns challenge when verify token matches a whatsapp_cloud channel' do
+      get '/webhooks/whatsapp',
+          params: { 'hub.challenge' => '123456', 'hub.mode' => 'subscribe', 'hub.verify_token' => channel.provider_config['webhook_verify_token'] }
+      expect(response.body).to include '123456'
+    end
+
+    it 'does not match non-cloud provider channels' do
+      non_cloud_channel = create(:channel_whatsapp, provider: 'default', sync_templates: false, validate_provider_config: false)
+      get '/webhooks/whatsapp',
+          params: { 'hub.challenge' => '123456', 'hub.mode' => 'subscribe',
+                    'hub.verify_token' => non_cloud_channel.provider_config['webhook_verify_token'] }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'POST /webhooks/whatsapp/{:phone_number} (legacy)' do
     it 'call the whatsapp events job with the params' do
       allow(Webhooks::WhatsappEventsJob).to receive(:perform_later)
       expect(Webhooks::WhatsappEventsJob).to receive(:perform_later)
@@ -57,6 +84,23 @@ RSpec.describe 'Webhooks::WhatsappController', type: :request do
         post '/webhooks/whatsapp/+1234567890', params: { content: 'hello' }
         expect(response).to have_http_status(:success)
       end
+    end
+  end
+
+  describe 'POST /webhooks/whatsapp (default without phone_number)' do
+    it 'enqueues the whatsapp events job' do
+      allow(Webhooks::WhatsappEventsJob).to receive(:perform_later)
+      expect(Webhooks::WhatsappEventsJob).to receive(:perform_later)
+      post '/webhooks/whatsapp', params: { content: 'hello' }
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'delegates inactive number check to job when phone_number is absent' do
+      allow(GlobalConfig).to receive(:get_value).with('INACTIVE_WHATSAPP_NUMBERS').and_return('+1234567890')
+      allow(Webhooks::WhatsappEventsJob).to receive(:perform_later)
+
+      post '/webhooks/whatsapp', params: { content: 'hello' }
+      expect(response).to have_http_status(:success)
     end
   end
 end

--- a/spec/jobs/webhooks/whatsapp_events_job_spec.rb
+++ b/spec/jobs/webhooks/whatsapp_events_job_spec.rb
@@ -97,6 +97,21 @@ RSpec.describe Webhooks::WhatsappEventsJob do
       expect(Rails.logger).to receive(:warn).with("Inactive WhatsApp channel: unknown - #{unknown_phone}")
       job.perform_now(phone_number: unknown_phone)
     end
+
+    context 'when channel phone number is in INACTIVE_WHATSAPP_NUMBERS' do
+      before do
+        allow(GlobalConfig).to receive(:get_value).with('INACTIVE_WHATSAPP_NUMBERS').and_return(channel.phone_number)
+      end
+
+      it 'rejects the webhook and does not process messages' do
+        allow(Whatsapp::IncomingMessageWhatsappCloudService).to receive(:new).and_return(process_service)
+        allow(Rails.logger).to receive(:warn)
+
+        expect(Whatsapp::IncomingMessageWhatsappCloudService).not_to receive(:new)
+        expect(Rails.logger).to receive(:warn).with("Rejected webhook for inactive WhatsApp number: #{channel.phone_number}")
+        job.perform_now(params)
+      end
+    end
   end
 
   context 'when default provider' do
@@ -215,6 +230,32 @@ RSpec.describe Webhooks::WhatsappEventsJob do
       expect do
         Whatsapp::IncomingMessageWhatsappCloudService.new(inbox: other_channel.inbox, params: wb_params).perform
       end.not_to change(Conversation, :count)
+    end
+
+    it 'resolves channel by phone_number_id even when display_phone_number does not match' do
+      other_channel = create(:channel_whatsapp, phone_number: '+1987654', provider: 'whatsapp_cloud', sync_templates: false,
+                                                validate_provider_config: false)
+      wb_params = {
+        phone_number: channel.phone_number,
+        object: 'whatsapp_business_account',
+        entry: [
+          {
+            changes: [
+              {
+                value: {
+                  metadata: {
+                    phone_number_id: other_channel.provider_config['phone_number_id'],
+                    display_phone_number: '0000000000'
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+      allow(Whatsapp::IncomingMessageWhatsappCloudService).to receive(:new).and_return(process_service)
+      expect(Whatsapp::IncomingMessageWhatsappCloudService).to receive(:new).with(inbox: other_channel.inbox, params: wb_params)
+      job.perform_now(wb_params)
     end
 
     it 'will not enque Whatsapp::IncomingMessageWhatsappCloudService when invalid phone number id' do

--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -209,4 +209,50 @@ RSpec.describe Channel::Whatsapp do
       end
     end
   end
+
+  describe '#waba_sibling_exists?' do
+    let(:channel) do
+      create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false).tap do |ch|
+        allow(ch).to receive(:setup_webhooks).and_return(true)
+        ch.update!(provider_config: ch.provider_config.merge('business_account_id' => 'waba_123'))
+      end
+    end
+
+    context 'when sibling exists with same business_account_id' do
+      before do
+        sibling = create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false)
+        allow(sibling).to receive(:setup_webhooks).and_return(true)
+        sibling.update!(provider_config: sibling.provider_config.merge('business_account_id' => 'waba_123'))
+      end
+
+      it 'returns true' do
+        expect(channel.waba_sibling_exists?).to be true
+      end
+    end
+
+    context 'when no sibling exists' do
+      it 'returns false' do
+        expect(channel.waba_sibling_exists?).to be false
+      end
+    end
+
+    context 'when provider is not whatsapp_cloud' do
+      before { channel.update!(provider: 'default') }
+
+      it 'returns false' do
+        expect(channel.waba_sibling_exists?).to be false
+      end
+    end
+
+    context 'when business_account_id is blank' do
+      before do
+        allow(channel).to receive(:setup_webhooks).and_return(true)
+        channel.update!(provider_config: channel.provider_config.merge('business_account_id' => ''))
+      end
+
+      it 'returns false' do
+        expect(channel.waba_sibling_exists?).to be false
+      end
+    end
+  end
 end

--- a/spec/services/whatsapp/webhook_setup_service_spec.rb
+++ b/spec/services/whatsapp/webhook_setup_service_spec.rb
@@ -18,17 +18,14 @@ describe Whatsapp::WebhookSetupService do
   let(:service) { described_class.new(channel, waba_id, access_token) }
   let(:api_client) { instance_double(Whatsapp::FacebookApiClient) }
   let(:health_service) { instance_double(Whatsapp::HealthService) }
+  let(:base_url) { 'https://app.chatwoot.com' }
+  let(:expected_webhook_url) { "#{base_url}/webhooks/whatsapp" }
 
   before do
-    # Stub webhook teardown to prevent HTTP calls during cleanup
     stub_request(:delete, /graph.facebook.com/).to_return(status: 200, body: '{}', headers: {})
-
-    # Clean up any existing channels to avoid phone number conflicts
     Channel::Whatsapp.destroy_all
     allow(Whatsapp::FacebookApiClient).to receive(:new).and_return(api_client)
     allow(Whatsapp::HealthService).to receive(:new).and_return(health_service)
-
-    # Default stubs for phone_number_verified? and health service
     allow(api_client).to receive(:phone_number_verified?).and_return(false)
     allow(health_service).to receive(:fetch_health_status).and_return({
                                                                         platform_type: 'APPLICABLE',
@@ -36,7 +33,7 @@ describe Whatsapp::WebhookSetupService do
                                                                       })
   end
 
-  describe '#perform' do
+  shared_examples 'webhook setup with correct URL' do |url_description|
     context 'when phone number is NOT verified (should register)' do
       before do
         allow(api_client).to receive(:phone_number_verified?).with('123456789').and_return(false)
@@ -47,11 +44,11 @@ describe Whatsapp::WebhookSetupService do
         allow(channel).to receive(:save!)
       end
 
-      it 'registers the phone number and sets up webhook' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+      it "registers the phone number and sets up webhook (#{url_description})" do
+        with_modified_env FRONTEND_URL: base_url do
           expect(api_client).to receive(:register_phone_number).with('123456789', 223_456)
           expect(api_client).to receive(:subscribe_waba_webhook)
-            .with(waba_id, 'https://app.chatwoot.com/webhooks/whatsapp/+1234567890', 'test_verify_token')
+            .with(waba_id, expected_webhook_url, 'test_verify_token')
           service.perform
         end
       end
@@ -68,11 +65,11 @@ describe Whatsapp::WebhookSetupService do
           .with(waba_id, anything, 'test_verify_token').and_return({ 'success' => true })
       end
 
-      it 'does NOT register phone, but sets up webhook' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+      it "does NOT register phone, but sets up webhook (#{url_description})" do
+        with_modified_env FRONTEND_URL: base_url do
           expect(api_client).not_to receive(:register_phone_number)
           expect(api_client).to receive(:subscribe_waba_webhook)
-            .with(waba_id, 'https://app.chatwoot.com/webhooks/whatsapp/+1234567890', 'test_verify_token')
+            .with(waba_id, expected_webhook_url, 'test_verify_token')
           service.perform
         end
       end
@@ -92,11 +89,11 @@ describe Whatsapp::WebhookSetupService do
         allow(channel).to receive(:save!)
       end
 
-      it 'registers the phone number due to pending provisioning state' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+      it "registers the phone number due to pending provisioning state (#{url_description})" do
+        with_modified_env FRONTEND_URL: base_url do
           expect(api_client).to receive(:register_phone_number).with('123456789', 223_456)
           expect(api_client).to receive(:subscribe_waba_webhook)
-            .with(waba_id, 'https://app.chatwoot.com/webhooks/whatsapp/+1234567890', 'test_verify_token')
+            .with(waba_id, expected_webhook_url, 'test_verify_token')
           service.perform
         end
       end
@@ -116,14 +113,104 @@ describe Whatsapp::WebhookSetupService do
         allow(channel).to receive(:save!)
       end
 
-      it 'registers the phone number due to throughput not applicable' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+      it "registers the phone number due to throughput not applicable (#{url_description})" do
+        with_modified_env FRONTEND_URL: base_url do
           expect(api_client).to receive(:register_phone_number).with('123456789', 223_456)
           expect(api_client).to receive(:subscribe_waba_webhook)
-            .with(waba_id, 'https://app.chatwoot.com/webhooks/whatsapp/+1234567890', 'test_verify_token')
+            .with(waba_id, expected_webhook_url, 'test_verify_token')
           service.perform
         end
       end
+    end
+
+    context 'when used during reauthorization flow' do
+      let(:existing_channel) do
+        create(:channel_whatsapp,
+               phone_number: '+5555555555',
+               provider_config: {
+                 'phone_number_id' => '123456789',
+                 'webhook_verify_token' => 'existing_verify_token',
+                 'business_id' => 'existing_business_id',
+                 'waba_id' => 'existing_waba_id',
+                 'source' => 'embedded_signup'
+               },
+               provider: 'whatsapp_cloud',
+               sync_templates: false,
+               validate_provider_config: false)
+      end
+      let(:new_access_token) { 'new_access_token' }
+      let(:service_reauth) { described_class.new(existing_channel, waba_id, new_access_token) }
+
+      before do
+        allow(api_client).to receive(:phone_number_verified?).with('123456789').and_return(true)
+        allow(health_service).to receive(:fetch_health_status).and_return({
+                                                                            platform_type: 'APPLICABLE',
+                                                                            throughput: { level: 'APPLICABLE' }
+                                                                          })
+        allow(api_client).to receive(:subscribe_waba_webhook)
+          .with(waba_id, anything, 'existing_verify_token').and_return({ 'success' => true })
+      end
+
+      it "uses the correct webhook URL during reauthorization (#{url_description})" do
+        with_modified_env FRONTEND_URL: base_url do
+          expect(api_client).not_to receive(:register_phone_number)
+          expect(api_client).to receive(:subscribe_waba_webhook)
+            .with(waba_id, expected_webhook_url, 'existing_verify_token')
+          service_reauth.perform
+        end
+      end
+
+      it 'uses the existing webhook verify token during reauthorization' do
+        with_modified_env FRONTEND_URL: base_url do
+          expect(api_client).to receive(:subscribe_waba_webhook)
+            .with(waba_id, anything, 'existing_verify_token')
+          service_reauth.perform
+        end
+      end
+    end
+
+    context 'when webhook setup is successful in creation flow' do
+      before do
+        allow(api_client).to receive(:phone_number_verified?).with('123456789').and_return(true)
+        allow(health_service).to receive(:fetch_health_status).and_return({
+                                                                            platform_type: 'APPLICABLE',
+                                                                            throughput: { level: 'APPLICABLE' }
+                                                                          })
+        allow(api_client).to receive(:subscribe_waba_webhook)
+          .with(waba_id, anything, 'test_verify_token').and_return({ 'success' => true })
+      end
+
+      it "uses the correct webhook URL (#{url_description})" do
+        with_modified_env FRONTEND_URL: base_url do
+          expect(api_client).to receive(:subscribe_waba_webhook)
+            .with(waba_id, expected_webhook_url, 'test_verify_token')
+          service.perform
+        end
+      end
+
+      it 'does not log any errors' do
+        with_modified_env FRONTEND_URL: base_url do
+          expect(Rails.logger).not_to receive(:error)
+          service.perform
+        end
+      end
+    end
+  end
+
+  describe '#perform' do
+    context 'with default webhook URL (without phone number)' do
+      it_behaves_like 'webhook setup with correct URL', 'default URL'
+    end
+
+    context 'with legacy webhook URL (with phone number)' do
+      let(:legacy_url) { "#{base_url}/webhooks/whatsapp/+1234567890" }
+      let(:expected_webhook_url) { legacy_url }
+
+      before do
+        allow_any_instance_of(described_class).to receive(:build_callback_url).and_return(legacy_url) # rubocop:disable RSpec/AnyInstance
+      end
+
+      it_behaves_like 'webhook setup with correct URL', 'legacy URL'
     end
 
     context 'when phone_number_verified? raises error' do
@@ -140,7 +227,7 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'tries to register phone (due to verification error) and proceeds with webhook setup' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env FRONTEND_URL: base_url do
           expect(api_client).to receive(:register_phone_number)
           expect(api_client).to receive(:subscribe_waba_webhook)
           expect { service.perform }.not_to raise_error
@@ -156,7 +243,7 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'does not register phone (conservative approach) and proceeds with webhook setup' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env FRONTEND_URL: base_url do
           expect(api_client).not_to receive(:register_phone_number)
           expect(api_client).to receive(:subscribe_waba_webhook)
           expect { service.perform }.not_to raise_error
@@ -174,7 +261,7 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'continues with webhook setup even if registration fails' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env FRONTEND_URL: base_url do
           expect(api_client).to receive(:register_phone_number)
           expect(api_client).to receive(:subscribe_waba_webhook)
           expect { service.perform }.not_to raise_error
@@ -191,7 +278,7 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'raises an error' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env FRONTEND_URL: base_url do
           expect(api_client).to receive(:register_phone_number)
           expect(api_client).to receive(:subscribe_waba_webhook)
           expect { service.perform }.to raise_error(/Webhook setup failed/)
@@ -226,7 +313,7 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'reuses existing PIN' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env FRONTEND_URL: base_url do
           expect(api_client).to receive(:register_phone_number).with('123456789', 123_456)
           expect(SecureRandom).not_to receive(:random_number)
           service.perform
@@ -241,85 +328,92 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'raises error with webhook setup failure message' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env FRONTEND_URL: base_url do
           expect { service.perform }.to raise_error(/Webhook setup failed: Invalid access token/)
         end
       end
 
       it 'logs the webhook setup failure' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env FRONTEND_URL: base_url do
           expect(Rails.logger).to receive(:error).with('[WHATSAPP] Webhook setup failed: Invalid access token')
           expect { service.perform }.to raise_error(/Webhook setup failed/)
         end
       end
     end
 
-    context 'when used during reauthorization flow' do
-      let(:existing_channel) do
-        create(:channel_whatsapp,
-               phone_number: '+1234567890',
-               provider_config: {
-                 'phone_number_id' => '123456789',
-                 'webhook_verify_token' => 'existing_verify_token',
-                 'business_id' => 'existing_business_id',
-                 'waba_id' => 'existing_waba_id',
-                 'source' => 'embedded_signup'
-               },
-               provider: 'whatsapp_cloud',
-               sync_templates: false,
-               validate_provider_config: false)
+    context 'when sibling channel exists with same WABA' do
+      let(:sibling_channel) do
+        instance_double(Channel::Whatsapp, provider_config: { 'webhook_verify_token' => 'sibling_verify_token' })
       end
-      let(:new_access_token) { 'new_access_token' }
-      let(:service_reauth) { described_class.new(existing_channel, waba_id, new_access_token) }
 
       before do
         allow(api_client).to receive(:phone_number_verified?).with('123456789').and_return(true)
-        allow(health_service).to receive(:fetch_health_status).and_return({
-                                                                            platform_type: 'APPLICABLE',
-                                                                            throughput: { level: 'APPLICABLE' }
-                                                                          })
-        allow(api_client).to receive(:subscribe_waba_webhook)
-          .with(waba_id, anything, 'existing_verify_token').and_return({ 'success' => true })
+        allow(api_client).to receive(:subscribe_waba_webhook).and_return({ 'success' => true })
+        allow(service).to receive(:find_waba_sibling).and_return(sibling_channel)
+        allow(channel).to receive(:save!)
       end
 
-      it 'successfully reauthorizes with new access token' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
-          expect(api_client).not_to receive(:register_phone_number)
+      it 'uses the sibling verify token for webhook setup' do
+        with_modified_env FRONTEND_URL: base_url do
           expect(api_client).to receive(:subscribe_waba_webhook)
-            .with(waba_id, 'https://app.chatwoot.com/webhooks/whatsapp/+1234567890', 'existing_verify_token')
-          service_reauth.perform
+            .with(waba_id, expected_webhook_url, 'sibling_verify_token')
+          service.perform
         end
       end
 
-      it 'uses the existing webhook verify token during reauthorization' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
-          expect(api_client).to receive(:subscribe_waba_webhook)
-            .with(waba_id, anything, 'existing_verify_token')
-          service_reauth.perform
+      it 'persists the sibling verify token on the current channel' do
+        with_modified_env FRONTEND_URL: base_url do
+          service.perform
+          expect(channel.provider_config['webhook_verify_token']).to eq('sibling_verify_token')
         end
       end
     end
 
-    context 'when webhook setup is successful in creation flow' do
-      before do
-        allow(api_client).to receive(:phone_number_verified?).with('123456789').and_return(true)
-        allow(health_service).to receive(:fetch_health_status).and_return({
-                                                                            platform_type: 'APPLICABLE',
-                                                                            throughput: { level: 'APPLICABLE' }
-                                                                          })
-        allow(api_client).to receive(:subscribe_waba_webhook)
-          .with(waba_id, anything, 'test_verify_token').and_return({ 'success' => true })
+    context 'when sibling channel exists but has blank verify token' do
+      let(:sibling_channel) do
+        instance_double(Channel::Whatsapp, provider_config: { 'webhook_verify_token' => '' })
       end
 
-      it 'completes successfully without errors' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
-          expect { service.perform }.not_to raise_error
+      before do
+        allow(api_client).to receive(:phone_number_verified?).with('123456789').and_return(true)
+        allow(api_client).to receive(:subscribe_waba_webhook).and_return({ 'success' => true })
+        allow(service).to receive(:find_waba_sibling).and_return(sibling_channel)
+      end
+
+      it 'keeps the current channel verify token instead of blank sibling token' do
+        with_modified_env FRONTEND_URL: base_url do
+          original_token = channel.provider_config['webhook_verify_token']
+          expect(api_client).to receive(:subscribe_waba_webhook)
+            .with(waba_id, expected_webhook_url, original_token)
+          service.perform
         end
       end
 
-      it 'does not log any errors' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
-          expect(Rails.logger).not_to receive(:error)
+      it 'does not persist the blank sibling token' do
+        with_modified_env FRONTEND_URL: base_url do
+          original_token = channel.provider_config['webhook_verify_token']
+          service.perform
+          expect(channel.provider_config['webhook_verify_token']).to eq(original_token)
+        end
+      end
+    end
+
+    context 'when sibling channel exists but has nil verify token' do
+      let(:sibling_channel) do
+        instance_double(Channel::Whatsapp, provider_config: {})
+      end
+
+      before do
+        allow(api_client).to receive(:phone_number_verified?).with('123456789').and_return(true)
+        allow(api_client).to receive(:subscribe_waba_webhook).and_return({ 'success' => true })
+        allow(service).to receive(:find_waba_sibling).and_return(sibling_channel)
+      end
+
+      it 'keeps the current channel verify token instead of nil sibling token' do
+        with_modified_env FRONTEND_URL: base_url do
+          original_token = channel.provider_config['webhook_verify_token']
+          expect(api_client).to receive(:subscribe_waba_webhook)
+            .with(waba_id, expected_webhook_url, original_token)
           service.perform
         end
       end

--- a/spec/services/whatsapp/webhook_teardown_service_spec.rb
+++ b/spec/services/whatsapp/webhook_teardown_service_spec.rb
@@ -66,6 +66,61 @@ RSpec.describe Whatsapp::WebhookTeardownService do
       end
     end
 
+    context 'when WABA sibling exists' do
+      before do
+        sibling = create(:channel_whatsapp, validate_provider_config: false, sync_templates: false)
+        allow(sibling).to receive(:setup_webhooks).and_return(true)
+        sibling.update!(
+          provider: 'whatsapp_cloud',
+          provider_config: {
+            'source' => 'embedded_signup',
+            'business_account_id' => 'shared_waba_id',
+            'api_key' => 'sibling_api_key'
+          }
+        )
+
+        allow(channel).to receive(:setup_webhooks).and_return(true)
+        channel.update!(
+          provider: 'whatsapp_cloud',
+          provider_config: {
+            'source' => 'embedded_signup',
+            'business_account_id' => 'shared_waba_id',
+            'api_key' => 'test_api_key'
+          }
+        )
+      end
+
+      it 'does not unsubscribe webhook when sibling channel exists' do
+        expect(Whatsapp::FacebookApiClient).not_to receive(:new)
+
+        service.perform
+      end
+    end
+
+    context 'when last channel for WABA (no siblings)' do
+      before do
+        allow(channel).to receive(:setup_webhooks).and_return(true)
+        channel.update!(
+          provider: 'whatsapp_cloud',
+          provider_config: {
+            'source' => 'embedded_signup',
+            'business_account_id' => 'unique_waba_id',
+            'api_key' => 'test_api_key'
+          }
+        )
+      end
+
+      it 'unsubscribes webhook when no sibling channels exist' do
+        api_client = instance_double(Whatsapp::FacebookApiClient)
+        allow(Whatsapp::FacebookApiClient).to receive(:new).with('test_api_key').and_return(api_client)
+        allow(api_client).to receive(:unsubscribe_waba_webhook).with('unique_waba_id')
+
+        service.perform
+
+        expect(api_client).to have_received(:unsubscribe_waba_webhook).with('unique_waba_id')
+      end
+    end
+
     context 'when required config is missing' do
       before do
         channel.update!(


### PR DESCRIPTION
## Description

Use a single `/webhooks/whatsapp` endpoint as the default callback URL for all WhatsApp Cloud API channels, instead of per-number URLs. This simplifies multi-number WABA setups by sharing one webhook across all phone numbers under the same Business Account.

The legacy `/webhooks/whatsapp/:phone_number` route remains functional for backward compatibility with existing configurations and non-cloud providers (e.g., 360dialog).

### What changed

- **`config/routes.rb`**: Added generic `/webhooks/whatsapp` routes (GET + POST) without `:phone_number` param.
- **`whatsapp_controller.rb`**: `valid_token?` now supports both modes — lookup by `phone_number` param (legacy) or by matching `webhook_verify_token` across all `whatsapp_cloud` channels (default).
- **`webhook_setup_service.rb`**: `build_callback_url` always returns `/webhooks/whatsapp` (no phone number). `resolve_verify_token` reuses the verify token from an existing sibling channel on the same WABA.
- **`inbox.rb`** / **`health_service.rb`**: Webhook URL always uses the generic endpoint.
- **`webhook_teardown_service.rb`**: Skips teardown if sibling channels still exist on the same WABA.
- **`channel/whatsapp.rb`**: Added `waba_sibling_exists?` to detect other channels sharing the same `business_account_id`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- **Controller spec** (`spec/controllers/webhooks/whatsapp_controller_spec.rb` — 12 tests):
  - Legacy route (`/webhooks/whatsapp/:phone_number`): verify with valid/invalid tokens, POST dispatching, inactive number filtering.
  - Default route (`/webhooks/whatsapp`): verify by token match across cloud channels, POST dispatching, ensures non-cloud providers are excluded, inactive number check is skipped when no phone_number param.

- **Setup service spec** (`spec/services/whatsapp/webhook_setup_service_spec.rb` — 27 tests):
  - Shared examples run all webhook URL scenarios for both default and legacy URLs.
  - Covers: phone registration, reauthorization flow, PIN reuse, sibling verify token reuse, error handling (API down, health service failure, registration failure), parameter validation.

- **Manual testing**: Received a live WhatsApp message via the generic `/webhooks/whatsapp` endpoint — contact created, conversation opened, message processed, notifications dispatched successfully.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes