### PR TITLE
fix: strip manually_managed_features from params in super admin account create

### DIFF
--- a/enterprise/app/controllers/enterprise/super_admin/accounts_controller.rb
+++ b/enterprise/app/controllers/enterprise/super_admin/accounts_controller.rb
@@ -1,4 +1,15 @@
 module Enterprise::SuperAdmin::AccountsController
+  def create
+    manually_managed = params[:account]&.delete(:manually_managed_features)
+
+    super do |resource|
+      if manually_managed.present?
+        service = ::Internal::Accounts::InternalAttributesService.new(resource)
+        service.manually_managed_features = manually_managed
+      end
+    end
+  end
+
   def update
     # Handle manually managed features from form submission
     if params[:account] && params[:account][:manually_managed_features].present?


### PR DESCRIPTION
## Summary

When a Super Admin creates a new account via the Administrate dashboard, the `manually_managed_features` field (a virtual attribute stored in `internal_attributes` JSON) is passed to `Account.new(...)`, raising `ActiveModel::UnknownAttributeError`. The existing `update` action already strips this param — this fix adds the same handling to `create`.

Closes -> https://linear.app/chatwoot/issue/INF-66
Related Sentry -> https://chatwoot-p3.sentry.io/issues/7168237533/?project=6382945&referrer=Linear

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How to reproduce

1. Log in as Super Admin
2. Navigate to Accounts → New
3. Fill in the form (with or without manually managed features selected)
4. Submit → `ActiveModel::UnknownAttributeError: unknown attribute 'manually_managed_features' for Account`

## What changed

- Added a `create` override in `Enterprise::SuperAdmin::AccountsController` that strips `manually_managed_features` from params before calling `super`, then persists them via `InternalAttributesService` after the account is saved.