### PR TITLE
fix: Send Microsoft email via Graph API instead of SMTP

### DIFF
--- a/app/controllers/concerns/microsoft_concern.rb
+++ b/app/controllers/concerns/microsoft_concern.rb
@@ -16,6 +16,12 @@ module MicrosoftConcern
   private
 
   def scope
-    'offline_access https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/SMTP.Send openid profile email'
+    [
+      'offline_access',
+      'https://outlook.office.com/IMAP.AccessAsUser.All',
+      'https://graph.microsoft.com/Mail.Send',
+      'https://graph.microsoft.com/Mail.ReadWrite',
+      'openid profile email'
+    ].join(' ')
   end
 end

--- a/app/services/email/send_on_email_service.rb
+++ b/app/services/email/send_on_email_service.rb
@@ -8,11 +8,94 @@ class Email::SendOnEmailService < Base::SendOnChannelService
   def perform_reply
     return unless message.email_notifiable_message?
 
-    reply_mail = ConversationReplyMailer.with(account: message.account).email_reply(message).deliver_now
-    Rails.logger.info("Email message #{message.id} sent with source_id: #{reply_mail.message_id}")
-    message.update(source_id: reply_mail.message_id)
+    if channel.microsoft?
+      send_via_microsoft_graph
+    else
+      send_via_smtp
+    end
   rescue StandardError => e
     ChatwootExceptionTracker.new(e, account: message.account).capture_exception
     Messages::StatusUpdateService.new(message, 'failed', e.message).perform
+  end
+
+  def send_via_microsoft_graph
+    result = Microsoft::SendMailService.new(
+      channel: channel,
+      message: message,
+      to_emails: to_emails,
+      cc_emails: cc_emails,
+      bcc_emails: bcc_emails,
+      subject: mail_subject,
+      html_body: html_body,
+      text_body: text_body,
+      in_reply_to: in_reply_to,
+      references: references_header
+    ).perform
+
+    Rails.logger.info("Email message #{message.id} sent via Microsoft Graph API with source_id: #{result.message_id}")
+    message.update(source_id: result.message_id)
+  end
+
+  def send_via_smtp
+    reply_mail = ConversationReplyMailer.with(account: message.account).email_reply(message).deliver_now
+    Rails.logger.info("Email message #{message.id} sent with source_id: #{reply_mail.message_id}")
+    message.update(source_id: reply_mail.message_id)
+  end
+
+  # Helper methods to build email components
+  def to_emails
+    content_attrs = message.content_attributes
+    to_list = content_attrs&.dig('to_emails') || content_attrs&.dig(:to_emails)
+    to_list.presence || [contact&.email].compact
+  end
+
+  def cc_emails
+    content_attrs = message.content_attributes
+    content_attrs&.dig('cc_emails') || content_attrs&.dig(:cc_emails) || []
+  end
+
+  def bcc_emails
+    content_attrs = message.content_attributes
+    content_attrs&.dig('bcc_emails') || content_attrs&.dig(:bcc_emails) || []
+  end
+
+  def mail_subject
+    subject = conversation.additional_attributes&.dig('mail_subject')
+    return "[##{conversation.display_id}] #{I18n.t('conversations.reply.email_subject')}" if subject.nil?
+
+    conversation.messages.chat.count > 1 ? "Re: #{subject}" : subject
+  end
+
+  def html_body
+    content_attrs = message.content_attributes
+    html_content = content_attrs&.dig('email', 'html_content', 'reply')
+
+    if html_content.present?
+      html_content
+    elsif message.content.present?
+      ChatwootMarkdownRenderer.new(message.outgoing_content).render_message
+    else
+      ''
+    end
+  end
+
+  def text_body
+    content_attrs = message.content_attributes
+    content_attrs&.dig('email', 'text_content', 'reply') || message.content || ''
+  end
+
+  def in_reply_to
+    incoming_message = conversation.messages.incoming.last
+    content_attrs = incoming_message&.content_attributes
+    message_id = content_attrs&.dig('email', 'message_id')
+    message_id.present? ? "<#{message_id}>" : nil
+  end
+
+  def references_header
+    in_reply_to || "<account/#{conversation.account_id}/conversation/#{conversation.uuid}@#{email_domain}>"
+  end
+
+  def email_domain
+    channel.email.split('@').last
   end
 end

--- a/app/services/microsoft/graph_token_service.rb
+++ b/app/services/microsoft/graph_token_service.rb
@@ -15,28 +15,31 @@ class Microsoft::GraphTokenService
   private
 
   def refresh_for_graph_api
-    uri = URI(TOKEN_URL)
+    response = Net::HTTP.post_form(URI(TOKEN_URL), token_params)
 
-    response = Net::HTTP.post_form(uri, {
+    raise_token_error(response) unless response.code.to_i == 200
+
+    JSON.parse(response.body)['access_token']
+  end
+
+  def token_params
+    {
       client_id: GlobalConfigService.load('AZURE_APP_ID', ''),
       client_secret: GlobalConfigService.load('AZURE_APP_SECRET', ''),
       refresh_token: provider_config['refresh_token'],
       grant_type: 'refresh_token',
       scope: GRAPH_SCOPE
-    })
+    }
+  end
 
-    if response.code.to_i == 200
-      token_data = JSON.parse(response.body)
-      token_data['access_token']
-    else
-      error_data = begin
-        JSON.parse(response.body)
-      rescue JSON::ParserError
-        { 'error_description' => response.body }
-      end
-      Rails.logger.error("Microsoft Graph token refresh failed: #{error_data['error_description']}")
-      raise StandardError, "Failed to get Graph API token: #{error_data['error_description']}"
+  def raise_token_error(response)
+    error_data = begin
+      JSON.parse(response.body)
+    rescue JSON::ParserError
+      { 'error_description' => response.body }
     end
+    Rails.logger.error("Microsoft Graph token refresh failed: #{error_data['error_description']}")
+    raise StandardError, "Failed to get Graph API token: #{error_data['error_description']}"
   end
 
   def provider_config

--- a/app/services/microsoft/graph_token_service.rb
+++ b/app/services/microsoft/graph_token_service.rb
@@ -1,0 +1,41 @@
+# Service to get an access token specifically for Microsoft Graph API
+# The regular OAuth token is for outlook.office.com (IMAP), but Graph API needs
+# a token with audience https://graph.microsoft.com
+class Microsoft::GraphTokenService
+  pattr_initialize [:channel!]
+
+  GRAPH_SCOPE = 'https://graph.microsoft.com/Mail.Send https://graph.microsoft.com/Mail.ReadWrite offline_access'.freeze
+  TOKEN_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'.freeze
+
+  def access_token
+    # Use the refresh token to get a new access token specifically for Graph API
+    refresh_for_graph_api
+  end
+
+  private
+
+  def refresh_for_graph_api
+    uri = URI(TOKEN_URL)
+
+    response = Net::HTTP.post_form(uri, {
+      client_id: GlobalConfigService.load('AZURE_APP_ID', ''),
+      client_secret: GlobalConfigService.load('AZURE_APP_SECRET', ''),
+      refresh_token: provider_config['refresh_token'],
+      grant_type: 'refresh_token',
+      scope: GRAPH_SCOPE
+    })
+
+    if response.code.to_i == 200
+      token_data = JSON.parse(response.body)
+      token_data['access_token']
+    else
+      error_data = JSON.parse(response.body) rescue { 'error_description' => response.body }
+      Rails.logger.error("Microsoft Graph token refresh failed: #{error_data['error_description']}")
+      raise StandardError, "Failed to get Graph API token: #{error_data['error_description']}"
+    end
+  end
+
+  def provider_config
+    @provider_config ||= channel.provider_config.with_indifferent_access
+  end
+end

--- a/app/services/microsoft/graph_token_service.rb
+++ b/app/services/microsoft/graph_token_service.rb
@@ -29,7 +29,11 @@ class Microsoft::GraphTokenService
       token_data = JSON.parse(response.body)
       token_data['access_token']
     else
-      error_data = JSON.parse(response.body) rescue { 'error_description' => response.body }
+      error_data = begin
+        JSON.parse(response.body)
+      rescue JSON::ParserError
+        { 'error_description' => response.body }
+      end
       Rails.logger.error("Microsoft Graph token refresh failed: #{error_data['error_description']}")
       raise StandardError, "Failed to get Graph API token: #{error_data['error_description']}"
     end

--- a/app/services/microsoft/send_mail_service.rb
+++ b/app/services/microsoft/send_mail_service.rb
@@ -42,25 +42,30 @@ class Microsoft::SendMailService
 
   def build_mime_message
     mail = Mail.new
+    set_mail_headers(mail)
+    set_mail_threading_headers(mail)
+    set_mail_body(mail)
+    mail.to_s
+  end
 
-    # Basic email headers
+  def set_mail_headers(mail)
     mail.to = Array(to_emails).compact
     mail.from = channel.email
     mail.subject = subject
     mail.message_id = generate_message_id
-
-    # CC and BCC
     mail.cc = Array(cc_emails).compact if cc_emails.present?
     mail.bcc = Array(bcc_emails).compact if bcc_emails.present?
+  end
 
-    # Threading headers - Graph API blocks these via internetMessageHeaders, but MIME allows them
-    if in_reply_to.present?
-      mail.in_reply_to = ensure_angle_brackets(in_reply_to)
-      mail.references = ensure_angle_brackets(references || in_reply_to)
-    end
+  # Graph API blocks In-Reply-To/References via internetMessageHeaders, but MIME allows them
+  def set_mail_threading_headers(mail)
+    return unless in_reply_to.present?
 
-    # Email body - HTML with text fallback
-    # Capture variables for block scope
+    mail.in_reply_to = ensure_angle_brackets(in_reply_to)
+    mail.references = ensure_angle_brackets(references || in_reply_to)
+  end
+
+  def set_mail_body(mail)
     html_content = html_body
     text_content = text_body
 
@@ -69,14 +74,12 @@ class Microsoft::SendMailService
       body html_content
     end
 
-    if text_content.present?
-      mail.text_part = Mail::Part.new do
-        content_type 'text/plain; charset=UTF-8'
-        body text_content
-      end
-    end
+    return unless text_content.present?
 
-    mail.to_s
+    mail.text_part = Mail::Part.new do
+      content_type 'text/plain; charset=UTF-8'
+      body text_content
+    end
   end
 
   def ensure_angle_brackets(value)
@@ -99,7 +102,11 @@ class Microsoft::SendMailService
     when 403
       raise_auth_error('Permission denied - Mail.Send scope may be missing')
     else
-      error_body = JSON.parse(response.body) rescue { 'error' => { 'message' => response.body } }
+      error_body = begin
+        JSON.parse(response.body)
+      rescue JSON::ParserError
+        { 'error' => { 'message' => response.body } }
+      end
       error_message = error_body.dig('error', 'message') || 'Unknown error'
       raise StandardError, "Microsoft Graph API error (#{response.code}): #{error_message}"
     end

--- a/app/services/microsoft/send_mail_service.rb
+++ b/app/services/microsoft/send_mail_service.rb
@@ -1,0 +1,122 @@
+# Service to send emails via Microsoft Graph API using MIME format
+# This bypasses SMTP AUTH requirements and works with Security Defaults enabled
+# Using MIME format allows setting In-Reply-To and References headers for proper threading
+# Ref: https://learn.microsoft.com/en-us/graph/api/user-sendmail
+class Microsoft::SendMailService
+  pattr_initialize [:channel!, :message!, :to_emails!, :cc_emails, :bcc_emails, :subject!, :html_body!, :text_body, :in_reply_to, :references]
+
+  GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0'.freeze
+
+  def perform
+    response = send_mail_via_graph_api
+    handle_response(response)
+  end
+
+  private
+
+  def send_mail_via_graph_api
+    uri = URI("#{GRAPH_API_BASE}/me/sendMail")
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.open_timeout = 15
+    http.read_timeout = 30
+
+    request = Net::HTTP::Post.new(uri)
+    request['Authorization'] = "Bearer #{access_token}"
+    request['Content-Type'] = 'text/plain'  # MIME format requires text/plain
+    request.body = Base64.strict_encode64(build_mime_message)
+
+    http.request(request)
+  end
+
+  def access_token
+    # Get a token specifically for Microsoft Graph API
+    # The stored token is for outlook.office.com (IMAP), we need one for graph.microsoft.com
+    graph_token_service.access_token
+  end
+
+  def graph_token_service
+    @graph_token_service ||= Microsoft::GraphTokenService.new(channel: channel)
+  end
+
+  def build_mime_message
+    mail = Mail.new
+
+    # Basic email headers
+    mail.to = Array(to_emails).compact
+    mail.from = channel.email
+    mail.subject = subject
+    mail.message_id = generate_message_id
+
+    # CC and BCC
+    mail.cc = Array(cc_emails).compact if cc_emails.present?
+    mail.bcc = Array(bcc_emails).compact if bcc_emails.present?
+
+    # Threading headers - Graph API blocks these via internetMessageHeaders, but MIME allows them
+    if in_reply_to.present?
+      mail.in_reply_to = ensure_angle_brackets(in_reply_to)
+      mail.references = ensure_angle_brackets(references || in_reply_to)
+    end
+
+    # Email body - HTML with text fallback
+    # Capture variables for block scope
+    html_content = html_body
+    text_content = text_body
+
+    mail.html_part = Mail::Part.new do
+      content_type 'text/html; charset=UTF-8'
+      body html_content
+    end
+
+    if text_content.present?
+      mail.text_part = Mail::Part.new do
+        content_type 'text/plain; charset=UTF-8'
+        body text_content
+      end
+    end
+
+    mail.to_s
+  end
+
+  def ensure_angle_brackets(value)
+    return nil if value.blank?
+
+    value = value.to_s.strip
+    return value if value.start_with?('<') && value.end_with?('>')
+
+    "<#{value.gsub(/^<|>$/, '')}>"
+  end
+
+  def handle_response(response)
+    case response.code.to_i
+    when 202
+      # Success - Microsoft returns 202 Accepted for sendMail
+      Rails.logger.info("Microsoft Graph API: Email sent successfully via MIME for message #{message.id}")
+      OpenStruct.new(success: true, message_id: generate_message_id)
+    when 401
+      raise_auth_error('Authentication failed - token may be expired or invalid')
+    when 403
+      raise_auth_error('Permission denied - Mail.Send scope may be missing')
+    else
+      error_body = JSON.parse(response.body) rescue { 'error' => { 'message' => response.body } }
+      error_message = error_body.dig('error', 'message') || 'Unknown error'
+      raise StandardError, "Microsoft Graph API error (#{response.code}): #{error_message}"
+    end
+  end
+
+  def raise_auth_error(msg)
+    Rails.logger.error("Microsoft Graph API: #{msg}")
+    raise StandardError, msg
+  end
+
+  # Generate a unique message ID that Chatwoot can recognize for threading
+  def generate_message_id
+    conversation = message.conversation
+    "<conversation/#{conversation.uuid}/messages/#{message.id}@#{email_domain}>"
+  end
+
+  def email_domain
+    channel.email.split('@').last
+  end
+end

--- a/app/services/microsoft/send_mail_service.rb
+++ b/app/services/microsoft/send_mail_service.rb
@@ -42,13 +42,13 @@ class Microsoft::SendMailService
 
   def build_mime_message
     mail = Mail.new
-    set_mail_headers(mail)
-    set_mail_threading_headers(mail)
-    set_mail_body(mail)
+    apply_mail_headers(mail)
+    apply_threading_headers(mail)
+    apply_mail_body(mail)
     mail.to_s
   end
 
-  def set_mail_headers(mail)
+  def apply_mail_headers(mail)
     mail.to = Array(to_emails).compact
     mail.from = channel.email
     mail.subject = subject
@@ -58,14 +58,14 @@ class Microsoft::SendMailService
   end
 
   # Graph API blocks In-Reply-To/References via internetMessageHeaders, but MIME allows them
-  def set_mail_threading_headers(mail)
-    return unless in_reply_to.present?
+  def apply_threading_headers(mail)
+    return if in_reply_to.blank?
 
     mail.in_reply_to = ensure_angle_brackets(in_reply_to)
     mail.references = ensure_angle_brackets(references || in_reply_to)
   end
 
-  def set_mail_body(mail)
+  def apply_mail_body(mail)
     html_content = html_body
     text_content = text_body
 
@@ -74,7 +74,7 @@ class Microsoft::SendMailService
       body html_content
     end
 
-    return unless text_content.present?
+    return if text_content.blank?
 
     mail.text_part = Mail::Part.new do
       content_type 'text/plain; charset=UTF-8'

--- a/app/services/microsoft/send_mail_service.rb
+++ b/app/services/microsoft/send_mail_service.rb
@@ -40,11 +40,14 @@ class Microsoft::SendMailService
     @graph_token_service ||= Microsoft::GraphTokenService.new(channel: channel)
   end
 
+  MAX_ATTACHMENT_SIZE = 20.megabytes
+
   def build_mime_message
     mail = Mail.new
     apply_mail_headers(mail)
     apply_threading_headers(mail)
     apply_mail_body(mail)
+    apply_attachments(mail)
     mail.to_s
   end
 
@@ -79,6 +82,22 @@ class Microsoft::SendMailService
     mail.text_part = Mail::Part.new do
       content_type 'text/plain; charset=UTF-8'
       body text_content
+    end
+  end
+
+  def apply_attachments(mail)
+    return if message.attachments.blank?
+
+    total_size = 0
+    message.attachments.each do |attachment|
+      blob = attachment.file.blob
+      next if blob.blank?
+      next if (total_size + blob.byte_size) > MAX_ATTACHMENT_SIZE
+
+      total_size += blob.byte_size
+      blob.open do |file|
+        mail.add_file filename: attachment.file.filename.to_s, content: file.read
+      end
     end
   end
 

--- a/lib/microsoft_graph_auth.rb
+++ b/lib/microsoft_graph_auth.rb
@@ -11,7 +11,12 @@ require 'omniauth-oauth2'
 class MicrosoftGraphAuth < OmniAuth::Strategies::OAuth2
   option :name, :microsoft_graph_auth
 
-  DEFAULT_SCOPE = 'offline_access https://outlook.office.com/IMAP.AccessAsUser.All https://graph.microsoft.com/Mail.Send https://graph.microsoft.com/Mail.ReadWrite'
+  DEFAULT_SCOPE = [
+    'offline_access',
+    'https://outlook.office.com/IMAP.AccessAsUser.All',
+    'https://graph.microsoft.com/Mail.Send',
+    'https://graph.microsoft.com/Mail.ReadWrite'
+  ].join(' ')
 
   # Configure the Microsoft identity platform endpoints
   option :client_options,

--- a/lib/microsoft_graph_auth.rb
+++ b/lib/microsoft_graph_auth.rb
@@ -11,7 +11,7 @@ require 'omniauth-oauth2'
 class MicrosoftGraphAuth < OmniAuth::Strategies::OAuth2
   option :name, :microsoft_graph_auth
 
-  DEFAULT_SCOPE = 'offline_access https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/SMTP.Send'
+  DEFAULT_SCOPE = 'offline_access https://outlook.office.com/IMAP.AccessAsUser.All https://graph.microsoft.com/Mail.Send https://graph.microsoft.com/Mail.ReadWrite'
 
   # Configure the Microsoft identity platform endpoints
   option :client_options,

--- a/spec/services/email/send_on_email_service_spec.rb
+++ b/spec/services/email/send_on_email_service_spec.rb
@@ -42,6 +42,49 @@ describe Email::SendOnEmailService do
       end
     end
 
+    context 'when channel is microsoft' do
+      let(:email_channel) { create(:channel_email, :microsoft_email, account: account) }
+      let(:graph_service) { instance_double(Microsoft::SendMailService) }
+      let(:graph_result) { OpenStruct.new(success: true, message_id: '<test-message-id@example.com>') }
+
+      before do
+        allow(Microsoft::SendMailService).to receive(:new).and_return(graph_service)
+        allow(graph_service).to receive(:perform).and_return(graph_result)
+      end
+
+      it 'sends email via Microsoft Graph API instead of SMTP' do
+        service.perform
+
+        expect(Microsoft::SendMailService).to have_received(:new)
+        expect(graph_service).to have_received(:perform)
+        expect(ConversationReplyMailer).not_to have_received(:with)
+      end
+
+      it 'updates message source id from Graph API result' do
+        service.perform
+
+        expect(message.reload.source_id).to eq('<test-message-id@example.com>')
+      end
+
+      context 'when Graph API fails' do
+        let(:error) { StandardError.new('Microsoft Graph API error (403): Permission denied') }
+
+        before do
+          allow(graph_service).to receive(:perform).and_raise(error)
+          allow(ChatwootExceptionTracker).to receive(:new).and_return(
+            instance_double(ChatwootExceptionTracker, capture_exception: true)
+          )
+        end
+
+        it 'captures the exception and marks message as failed' do
+          service.perform
+
+          expect(message.reload.status).to eq('failed')
+          expect(message.reload.external_error).to eq('Microsoft Graph API error (403): Permission denied')
+        end
+      end
+    end
+
     context 'when message is not email notifiable' do
       let(:message) { create(:message, conversation: conversation, message_type: 'incoming') }
 

--- a/spec/services/microsoft/graph_token_service_spec.rb
+++ b/spec/services/microsoft/graph_token_service_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe Microsoft::GraphTokenService do
+  let(:account) { create(:account) }
+  let(:channel) { create(:channel_email, :microsoft_email, account: account) }
+  let(:service) { described_class.new(channel: channel) }
+
+  describe '#access_token' do
+    let(:token_response_body) { { 'access_token' => 'graph-api-token-123' }.to_json }
+
+    before do
+      allow(GlobalConfigService).to receive(:load).with('AZURE_APP_ID', '').and_return('test-app-id')
+      allow(GlobalConfigService).to receive(:load).with('AZURE_APP_SECRET', '').and_return('test-app-secret')
+    end
+
+    context 'when token refresh succeeds' do
+      before do
+        stub_request(:post, 'https://login.microsoftonline.com/common/oauth2/v2.0/token')
+          .to_return(status: 200, body: token_response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns the access token from Microsoft' do
+        expect(service.access_token).to eq('graph-api-token-123')
+      end
+
+      it 'sends the correct parameters' do
+        service.access_token
+
+        expect(WebMock).to have_requested(:post, 'https://login.microsoftonline.com/common/oauth2/v2.0/token')
+          .with(body: hash_including(
+            'client_id' => 'test-app-id',
+            'client_secret' => 'test-app-secret',
+            'grant_type' => 'refresh_token',
+            'scope' => 'https://graph.microsoft.com/Mail.Send https://graph.microsoft.com/Mail.ReadWrite offline_access'
+          ))
+      end
+    end
+
+    context 'when token refresh fails' do
+      before do
+        stub_request(:post, 'https://login.microsoftonline.com/common/oauth2/v2.0/token')
+          .to_return(
+            status: 400,
+            body: { 'error' => 'invalid_grant', 'error_description' => 'Token has expired' }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+      end
+
+      it 'raises an error with the failure message' do
+        expect { service.access_token }.to raise_error(StandardError, /Token has expired/)
+      end
+    end
+  end
+end

--- a/spec/services/microsoft/send_mail_service_spec.rb
+++ b/spec/services/microsoft/send_mail_service_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+describe Microsoft::SendMailService do
+  let(:account) { create(:account) }
+  let(:channel) { create(:channel_email, :microsoft_email, account: account, email: 'test@example.com') }
+  let(:inbox) { channel.inbox }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox) }
+  let(:message) { create(:message, conversation: conversation, message_type: 'outgoing', content: 'Test reply') }
+
+  let(:service) do
+    described_class.new(
+      channel: channel,
+      message: message,
+      to_emails: ['recipient@example.com'],
+      cc_emails: [],
+      bcc_emails: [],
+      subject: 'Re: Test Subject',
+      html_body: '<p>Test reply</p>',
+      text_body: 'Test reply',
+      in_reply_to: '<original-id@example.com>',
+      references: '<original-id@example.com>'
+    )
+  end
+
+  let(:graph_token_service) { instance_double(Microsoft::GraphTokenService, access_token: 'test-graph-token') }
+
+  before do
+    allow(Microsoft::GraphTokenService).to receive(:new).and_return(graph_token_service)
+  end
+
+  describe '#perform' do
+    context 'when Graph API returns 202 (success)' do
+      before do
+        stub_request(:post, 'https://graph.microsoft.com/v1.0/me/sendMail')
+          .to_return(status: 202, body: '', headers: {})
+      end
+
+      it 'sends the email via Graph API' do
+        service.perform
+
+        expect(WebMock).to have_requested(:post, 'https://graph.microsoft.com/v1.0/me/sendMail')
+          .with(headers: { 'Authorization' => 'Bearer test-graph-token', 'Content-Type' => 'text/plain' })
+      end
+
+      it 'returns a result with a message_id' do
+        result = service.perform
+
+        expect(result.success).to be true
+        expect(result.message_id).to include(conversation.uuid)
+        expect(result.message_id).to include(message.id.to_s)
+      end
+    end
+
+    context 'when Graph API returns 401' do
+      before do
+        stub_request(:post, 'https://graph.microsoft.com/v1.0/me/sendMail')
+          .to_return(status: 401, body: '', headers: {})
+      end
+
+      it 'raises an authentication error' do
+        expect { service.perform }.to raise_error(StandardError, /Authentication failed/)
+      end
+    end
+
+    context 'when Graph API returns 403' do
+      before do
+        stub_request(:post, 'https://graph.microsoft.com/v1.0/me/sendMail')
+          .to_return(status: 403, body: '', headers: {})
+      end
+
+      it 'raises a permission error' do
+        expect { service.perform }.to raise_error(StandardError, /Mail.Send scope may be missing/)
+      end
+    end
+
+    context 'when Graph API returns an unexpected error' do
+      before do
+        stub_request(:post, 'https://graph.microsoft.com/v1.0/me/sendMail')
+          .to_return(
+            status: 500,
+            body: { 'error' => { 'message' => 'Internal server error' } }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+      end
+
+      it 'raises an error with the API error message' do
+        expect { service.perform }.to raise_error(StandardError, /Internal server error/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Fixes #13021

Microsoft 365 tenants with **Security Defaults** enabled disable SMTP AUTH tenant-wide with no per-user override. This breaks Chatwoot's email sending for Microsoft OAuth channels, which currently uses SMTP with `xoauth2` authentication, even though the OAuth connection and IMAP email fetching work correctly.

Since Security Defaults is enabled by default on new Microsoft 365 tenants, this affects a growing number of users.

Additionally, Microsoft is [retiring Basic Auth for SMTP AUTH entirely](https://techcommunity.microsoft.com/blog/exchange/exchange-online-to-retire-basic-auth-for-client-submission-smtp-auth/4114750), with gradual rejections starting March 1, 2026 and full deprecation by April 30, 2026. After that date, the current SMTP-based sending will stop working for all Microsoft 365 tenants, not just those with Security Defaults. Moving to the Graph API is the recommended path forward.

**Root cause**

`Email::SendOnEmailService#perform_reply` sends all emails via `:smtp` with `authentication: 'xoauth2'`. This still requires SMTP AUTH to be enabled on the tenant, which Security Defaults disables.

**What changed**

Routes Microsoft email channels through the [Microsoft Graph API `/me/sendMail` endpoint](https://learn.microsoft.com/en-us/graph/api/user-sendmail) instead of SMTP. The Graph API uses the `Mail.Send` permission, which is **not** affected by the SMTP AUTH policy.

MIME format is used (instead of JSON) because Graph API's `internetMessageHeaders` blocks `In-Reply-To` and `References` headers, but MIME allows them, preserving proper email threading.

| File | Change |
|------|--------|
| `app/services/email/send_on_email_service.rb` | Detect Microsoft channels via `channel.microsoft?` and route to `Microsoft::SendMailService` instead of SMTP |
| `app/services/microsoft/send_mail_service.rb` | **New**. Sends email via Graph API `/me/sendMail` using base64-encoded MIME |
| `app/services/microsoft/graph_token_service.rb` | **New**. Exchanges the IMAP-scoped refresh token for a Graph API-scoped access token (different audience: `graph.microsoft.com` vs `outlook.office.com`) |
| `lib/microsoft_graph_auth.rb` | Updated OAuth scopes: replaced `https://outlook.office.com/SMTP.Send` with `https://graph.microsoft.com/Mail.Send` and `https://graph.microsoft.com/Mail.ReadWrite` |

**Backward compatibility**

- **Non-Microsoft channels**: Completely unaffected, they continue using the existing SMTP path
- **Existing Microsoft channels**: Users will need to re-authenticate to grant the new Graph API scopes (`Mail.Send` + `Mail.ReadWrite` replace `SMTP.Send`)
- **Tenants without Security Defaults**: Will also work via Graph API, no longer depends on SMTP AUTH being enabled

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

We have been running this patch in production on our self-hosted Chatwoot instance for ~4 months (since December 2025), processing thousands of Outlook threads through this channel. It has been working reliably. Replies sent from Chatwoot via Graph API sync back into the Outlook conversation thread correctly, preserving proper threading via `In-Reply-To` and `References` headers.

**Manual testing:**
1. Connected a Microsoft 365 email channel on a tenant with Security Defaults enabled (SMTP AUTH disabled)
2. Before fix: sending a reply from Chatwoot fails with SMTP authentication error in Sidekiq
3. After fix: reply sends successfully via Graph API, email threads correctly in Outlook

**Automated:**
- Added specs for the Microsoft Graph send path in `SendOnEmailService`
- Added specs for `Microsoft::GraphTokenService` (token refresh success/failure)
- Added specs for `Microsoft::SendMailService` (202 success, 401/403/500 error handling)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules