### PR TITLE
fix(telegram): ignore edited message events to preserve history

### DIFF
--- a/app/jobs/webhooks/telegram_events_job.rb
+++ b/app/jobs/webhooks/telegram_events_job.rb
@@ -35,9 +35,7 @@ class Webhooks::TelegramEventsJob < ApplicationJob
   def process_event_params(channel, params)
     return unless params[:telegram]
 
-    if params.dig(:telegram, :edited_message).present? || params.dig(:telegram, :edited_business_message).present?
-      return
-    end
+    return if params.dig(:telegram, :edited_message).present? || params.dig(:telegram, :edited_business_message).present?
 
     Telegram::IncomingMessageService.new(inbox: channel.inbox, params: params['telegram'].with_indifferent_access).perform
   end

--- a/app/jobs/webhooks/telegram_events_job.rb
+++ b/app/jobs/webhooks/telegram_events_job.rb
@@ -36,9 +36,9 @@ class Webhooks::TelegramEventsJob < ApplicationJob
     return unless params[:telegram]
 
     if params.dig(:telegram, :edited_message).present? || params.dig(:telegram, :edited_business_message).present?
-      Telegram::UpdateMessageService.new(inbox: channel.inbox, params: params['telegram'].with_indifferent_access).perform
-    else
-      Telegram::IncomingMessageService.new(inbox: channel.inbox, params: params['telegram'].with_indifferent_access).perform
+      return
     end
+
+    Telegram::IncomingMessageService.new(inbox: channel.inbox, params: params['telegram'].with_indifferent_access).perform
   end
 end

--- a/spec/jobs/webhooks/telegram_events_job_spec.rb
+++ b/spec/jobs/webhooks/telegram_events_job_spec.rb
@@ -48,16 +48,22 @@ RSpec.describe Webhooks::TelegramEventsJob do
     end
   end
 
-  context 'when update message params' do
+  context 'when edited_message params' do
     let!(:params) { { :bot_token => telegram_channel.bot_token, 'telegram' => { edited_message: 'test' } } }
 
-    it 'calls Telegram::UpdateMessageService' do
-      process_service = double
-      allow(Telegram::UpdateMessageService).to receive(:new).and_return(process_service)
-      allow(process_service).to receive(:perform)
-      expect(Telegram::UpdateMessageService).to receive(:new).with(inbox: telegram_channel.inbox,
-                                                                   params: params['telegram'].with_indifferent_access)
-      expect(process_service).to receive(:perform)
+    it 'does not call Telegram services' do
+      expect(Telegram::IncomingMessageService).not_to receive(:new)
+      expect(Telegram::UpdateMessageService).not_to receive(:new)
+      described_class.perform_now(params.with_indifferent_access)
+    end
+  end
+
+  context 'when edited_business_message params' do
+    let!(:params) { { :bot_token => telegram_channel.bot_token, 'telegram' => { edited_business_message: 'test' } } }
+
+    it 'does not call Telegram services' do
+      expect(Telegram::IncomingMessageService).not_to receive(:new)
+      expect(Telegram::UpdateMessageService).not_to receive(:new)
       described_class.perform_now(params.with_indifferent_access)
     end
   end


### PR DESCRIPTION
## Description

This change prevents Telegram `edited_message` and `edited_business_message` events from mutating existing message content in Chatwoot.

Currently, when a Telegram user edits a message, Chatwoot overwrites the original content in the conversation history via `Telegram::UpdateMessageService`. This allows external contacts to silently alter past messages after agents have already read or responded, which undermines audit integrity and can lead to confusion or misuse.

In addition, this issue also affects already resolved conversations. A contact can edit a previously sent message after an agent has taken action or marked the conversation as resolved. This can lead to inconsistencies between what was originally communicated and what is later displayed, potentially causing internal confusion, incorrect assumptions, or operational issues when reviewing past interactions.

This change is intentionally minimal and does not affect the handling of regular Telegram messages or other channels.

This PR introduces an early return in `Webhooks::TelegramEventsJob`, ignoring edit events entirely and preserving the original message content.

Preserving the original message content ensures a consistent and reliable conversation history, which is critical for auditability and agent decision-making.

Fixes: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The following scenarios were tested:

1. **Edited message events**
   - Simulated payloads containing `edited_message` and `edited_business_message` were processed
   - Verified that the job returns early
   - Confirmed that `Telegram::UpdateMessageService` is NOT invoked

2. **Normal message events**
   - Regular Telegram messages continue to be processed normally
   - Verified no regression in message creation flow

3. **Automated tests**
   - Updated specs to remove expectations for edit handling
   - Added tests ensuring early return behavior for edited events
   - Verified existing tests continue to pass

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules