### PR TITLE
fix(agent-bot): Update listener spec to match signed webhook arguments

### DIFF
--- a/spec/listeners/agent_bot_listener_spec.rb
+++ b/spec/listeners/agent_bot_listener_spec.rb
@@ -82,7 +82,9 @@ describe AgentBotListener do
         create(:agent_bot_inbox, inbox: inbox, agent_bot: agent_bot)
         expect(AgentBots::WebhookJob).to receive(:perform_later).with(
           agent_bot.outgoing_url,
-          hash_including(event: 'conversation_status_changed', changed_attributes: anything)
+          hash_including(event: 'conversation_status_changed', changed_attributes: anything),
+          :agent_bot_webhook,
+          hash_including(secret: agent_bot.secret)
         ).once
         listener.conversation_status_changed(event)
       end
@@ -96,7 +98,9 @@ describe AgentBotListener do
       it 'sends webhook to the assigned agent bot' do
         expect(AgentBots::WebhookJob).to receive(:perform_later).with(
           agent_bot.outgoing_url,
-          hash_including(event: 'conversation_status_changed', changed_attributes: anything)
+          hash_including(event: 'conversation_status_changed', changed_attributes: anything),
+          :agent_bot_webhook,
+          hash_including(secret: agent_bot.secret)
         ).once
         listener.conversation_status_changed(event)
       end


### PR DESCRIPTION
Fixes failing `agent_bot_listener_spec.rb` tests for `conversation_status_changed` events. After #13892 added webhook signing, `process_webhook_bot_event` passes `:agent_bot_webhook` and `secret:`/`delivery_id:` kwargs to `AgentBots::WebhookJob.perform_later`, but two spec expectations were not updated to match the new call signature.

## What changed
- Updated `perform_later` expectations in `conversation_status_changed` specs to include the `:agent_bot_webhook` type and `secret` keyword arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)