### PR TITLE
fix: Ignore RoutingError in New Relic error reporting

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -18,6 +18,9 @@ common: &default_settings
   distributed_tracing:
     enabled: true
 
+  error_collector:
+    ignore_errors: 'ActionController::RoutingError'
+
   # To disable the agent regardless of other settings, uncomment the following:
   agent_enabled: <%= ENV['NEW_RELIC_LICENSE_KEY'].present? && ENV.fetch('NEW_RELIC_AGENT_ENABLED', true)  %>
 


### PR DESCRIPTION
Routing errors (404s) are expected in production and don't represent actionable issues. Reporting them to New Relic creates noise and makes it harder to spot real errors. Adds ActionController::RoutingError to the New Relic error_collector.ignore_errors list so these are no longer tracked as exceptions.

