### PR TITLE
fix: create article on title blur instead of debounce

### DIFF
--- a/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { debounce } from '@chatwoot/utils';
 import { useI18n } from 'vue-i18n';
 import { ARTICLE_EDITOR_MENU_OPTIONS } from 'dashboard/constants/editor';
@@ -77,9 +77,12 @@ const articleTitle = computed({
   },
 });
 
+const localContent = ref(props.article.content || '');
+
 const articleContent = computed({
   get: () => props.article.content,
   set: content => {
+    localContent.value = content;
     handleSave({ content });
   },
 });
@@ -103,7 +106,7 @@ const previewArticle = () => {
 const handleBlur = event => {
   const title = event?.target?.value || '';
   if (title.trim()) {
-    emit('titleBlur', { title });
+    emit('titleBlur', { title, content: localContent.value });
   }
 };
 </script>

--- a/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
@@ -32,6 +32,7 @@ const emit = defineEmits([
   'setAuthor',
   'setCategory',
   'previewArticle',
+  'titleBlur',
 ]);
 
 const { t } = useI18n();
@@ -98,6 +99,10 @@ const setCategoryId = categoryId => {
 const previewArticle = () => {
   emit('previewArticle');
 };
+
+const handleBlur = () => {
+  emit('titleBlur', { title: articleTitle.value, content: '' });
+};
 </script>
 
 <template>
@@ -122,6 +127,7 @@ const previewArticle = () => {
           custom-text-area-wrapper-class="border-0 !bg-transparent dark:!bg-transparent !py-0 !px-0"
           placeholder="Title"
           autofocus
+          @blur="handleBlur"
         />
         <ArticleEditorControls
           :article="article"

--- a/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
@@ -100,8 +100,11 @@ const previewArticle = () => {
   emit('previewArticle');
 };
 
-const handleBlur = () => {
-  emit('titleBlur', { title: articleTitle.value, content: '' });
+const handleBlur = event => {
+  const title = event?.target?.value || '';
+  if (title.trim()) {
+    emit('titleBlur', { title });
+  }
 };
 </script>
 

--- a/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
@@ -32,7 +32,7 @@ const emit = defineEmits([
   'setAuthor',
   'setCategory',
   'previewArticle',
-  'titleBlur',
+  'createArticle',
 ]);
 
 const { t } = useI18n();
@@ -97,11 +97,11 @@ const previewArticle = () => {
   emit('previewArticle');
 };
 
-const handleBlur = event => {
+const handleCreateArticle = event => {
   if (!isNewArticle.value) return;
   const title = event?.target?.value || '';
   if (title.trim()) {
-    emit('titleBlur', { title, content: localContent.value });
+    emit('createArticle', { title, content: localContent.value });
   }
 };
 </script>
@@ -128,7 +128,7 @@ const handleBlur = event => {
           custom-text-area-wrapper-class="border-0 !bg-transparent dark:!bg-transparent !py-0 !px-0"
           placeholder="Title"
           autofocus
-          @blur="handleBlur"
+          @blur="handleCreateArticle"
         />
         <ArticleEditorControls
           :article="article"

--- a/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
@@ -58,16 +58,10 @@ const quickSave = debounce(
 // Only use to save for existing articles
 const saveAndSyncDebounced = debounce(saveAndSync, 2500, false);
 
-// Debounced save for new articles
-const quickSaveNewArticle = debounce(saveAndSync, 400, false);
-
 const handleSave = value => {
-  if (isNewArticle.value) {
-    quickSaveNewArticle(value);
-  } else {
-    quickSave(value);
-    saveAndSyncDebounced(value);
-  }
+  if (isNewArticle.value) return;
+  quickSave(value);
+  saveAndSyncDebounced(value);
 };
 
 const articleTitle = computed({
@@ -104,6 +98,7 @@ const previewArticle = () => {
 };
 
 const handleBlur = event => {
+  if (!isNewArticle.value) return;
   const title = event?.target?.value || '';
   if (title.trim()) {
     emit('titleBlur', { title, content: localContent.value });

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesNewPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesNewPage.vue
@@ -39,7 +39,7 @@ const createNewArticle = async ({ title, content }) => {
   if (title) article.value.title = title;
   if (content) article.value.content = content;
 
-  if (!article.value.title) return;
+  if (!article.value.title || isUpdating.value) return;
 
   isUpdating.value = true;
   try {

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesNewPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesNewPage.vue
@@ -86,7 +86,7 @@ const goBackToArticles = () => {
     :article="article"
     :is-updating="isUpdating"
     :is-saved="isSaved"
-    @save-article="createNewArticle"
+    @title-blur="createNewArticle"
     @go-back="goBackToArticles"
     @set-author="setAuthorId"
     @set-category="setCategoryId"

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesNewPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesNewPage.vue
@@ -86,7 +86,7 @@ const goBackToArticles = () => {
     :article="article"
     :is-updating="isUpdating"
     :is-saved="isSaved"
-    @title-blur="createNewArticle"
+    @create-article="createNewArticle"
     @go-back="goBackToArticles"
     @set-author="setAuthorId"
     @set-category="setCategoryId"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR updates article creation to trigger only when the title input loses focus, instead of using a debounce.

Previously, article creation was debounced at 400ms. Before PR https://github.com/chatwoot/chatwoot/pull/14007, this wasn’t an issue because content was required to create an article, so the title was usually complete by the time creation happened.

After PR https://github.com/chatwoot/chatwoot/pull/14007 removed the content requirement, articles began getting created as soon as a title was entered. With debounce still in place, this could result in articles being created with partially typed titles, leading to incomplete slugs.

With this change, we wait for the title field to emit a blur event before creating the article. This ensures the user has finished typing, resulting in more accurate and complete slugs.

**What changed**

* `ArticleEditor.vue`: emit current title on `blur`
* `PortalsArticlesNewPage.vue`: listen to `@blur` instead of `@save-article`, so the article is created only after the user finishes typing and moves focus away


Fixes https://linear.app/chatwoot/issue/CW-6837/bug-slug-generation-when-article-is-creating

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Go to Help Center → Create a new article
2. Type a title — no API call while typing
3. Blur the title (click editor or tab out) — article is created
4. Existing articles still auto-save title via debounce



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
