### PR TITLE
docs(api): align application OpenAPI with runtime routes

### DIFF
--- a/swagger/definitions/request/conversation/create_message_payload.yml
+++ b/swagger/definitions/request/conversation/create_message_payload.yml
@@ -15,6 +15,18 @@ properties:
     type: boolean
     description: Flag to identify if it is a private note
     example: false
+  cc_emails:
+    type: string
+    description: Comma-separated email addresses to add to CC for outbound email replies
+    example: 'amy@example.com,ops@example.com'
+  bcc_emails:
+    type: string
+    description: Comma-separated email addresses to add to BCC for outbound email replies
+    example: 'audit@example.com'
+  to_emails:
+    type: string
+    description: Comma-separated email addresses to override the primary recipient list for outbound email replies
+    example: 'william@example.com'
   content_type:
     type: string
     enum: ['text', 'input_email', 'cards', 'input_select', 'form', 'article']

--- a/swagger/paths/application/conversation/update_last_seen.yml
+++ b/swagger/paths/application/conversation/update_last_seen.yml
@@ -1,29 +1,28 @@
-post:
-  tags:
-    - Conversations
-  operationId: conversationUpdateLastSeen
-  summary: Update Last Seen
-  security:
-    - userApiKey: []
-  description: Updates the last seen of the conversation so that conversations will have the bubbles in the agents screen
-  parameters:
-    - name: id
-      in: path
-      type: number
-      description: ID of the conversation
-      required: true
-  responses:
-    '200':
-      description: Success
-    '403':
-      description: Access denied
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/bad_request_error'
-    '404':
-      description: Contact not found
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/bad_request_error'
+tags:
+  - Conversations
+operationId: conversationUpdateLastSeen
+summary: Update last seen
+security:
+  - userApiKey: []
+description: Updates the last-seen timestamps for a conversation and clears unread notifications for the current agent when appropriate.
+responses:
+  '200':
+    description: Success
+  '401':
+    description: Unauthorized
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'
+  '403':
+    description: Access denied
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'
+  '404':
+    description: Conversation not found
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/index.yml
+++ b/swagger/paths/index.yml
@@ -478,6 +478,12 @@
     - $ref: '#/components/parameters/message_id'
   delete:
     $ref: ./application/conversation/messages/delete.yml
+/api/v1/accounts/{account_id}/conversations/{conversation_id}/update_last_seen:
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+    - $ref: '#/components/parameters/conversation_id'
+  post:
+    $ref: ./application/conversation/update_last_seen.yml
 
 # Integrations
 /api/v1/accounts/{account_id}/integrations/apps:
@@ -497,6 +503,24 @@
 # Profile
 /api/v1/profile:
   $ref: ./profile/index.yml
+/api/v1/profile/avatar:
+  delete:
+    $ref: ./profile/avatar.yml
+/api/v1/profile/availability:
+  post:
+    $ref: ./profile/availability.yml
+/api/v1/profile/auto_offline:
+  post:
+    $ref: ./profile/auto_offline.yml
+/api/v1/profile/set_active_account:
+  put:
+    $ref: ./profile/set_active_account.yml
+/api/v1/profile/resend_confirmation:
+  post:
+    $ref: ./profile/resend_confirmation.yml
+/api/v1/profile/reset_access_token:
+  post:
+    $ref: ./profile/reset_access_token.yml
 
 # Teams
 /api/v1/accounts/{account_id}/teams:

--- a/swagger/paths/profile/auto_offline.yml
+++ b/swagger/paths/profile/auto_offline.yml
@@ -1,0 +1,47 @@
+tags:
+  - Profile
+operationId: updateProfileAutoOffline
+summary: Update profile auto offline
+description: Update whether the current user should automatically go offline for an account.
+security:
+  - userApiKey: []
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+          - profile
+        properties:
+          profile:
+            type: object
+            required:
+              - account_id
+              - auto_offline
+            properties:
+              account_id:
+                type: integer
+                description: The numeric ID of the account.
+              auto_offline:
+                type: boolean
+                description: Whether the current user should automatically switch offline when away.
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/user'
+  '401':
+    description: Unauthorized
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'
+  '404':
+    description: Account membership not found
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/profile/availability.yml
+++ b/swagger/paths/profile/availability.yml
@@ -1,0 +1,48 @@
+tags:
+  - Profile
+operationId: updateProfileAvailability
+summary: Update profile availability
+description: Update the current user's availability for an account.
+security:
+  - userApiKey: []
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+          - profile
+        properties:
+          profile:
+            type: object
+            required:
+              - account_id
+              - availability
+            properties:
+              account_id:
+                type: integer
+                description: The numeric ID of the account.
+              availability:
+                type: string
+                enum: ['online', 'busy', 'offline']
+                description: The availability value to store for the current user in the account.
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/user'
+  '401':
+    description: Unauthorized
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'
+  '404':
+    description: Account membership not found
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/profile/avatar.yml
+++ b/swagger/paths/profile/avatar.yml
@@ -1,0 +1,20 @@
+tags:
+  - Profile
+operationId: deleteProfileAvatar
+summary: Delete profile avatar
+description: Delete the current user's avatar image.
+security:
+  - userApiKey: []
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/user'
+  '401':
+    description: Unauthorized
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/profile/resend_confirmation.yml
+++ b/swagger/paths/profile/resend_confirmation.yml
@@ -1,0 +1,16 @@
+tags:
+  - Profile
+operationId: resendProfileConfirmation
+summary: Resend profile confirmation
+description: Resend email confirmation instructions for the current user when the account is unconfirmed.
+security:
+  - userApiKey: []
+responses:
+  '200':
+    description: Success
+  '401':
+    description: Unauthorized
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/profile/reset_access_token.yml
+++ b/swagger/paths/profile/reset_access_token.yml
@@ -1,0 +1,20 @@
+tags:
+  - Profile
+operationId: resetProfileAccessToken
+summary: Reset profile access token
+description: Regenerate the current user's access token.
+security:
+  - userApiKey: []
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/user'
+  '401':
+    description: Unauthorized
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/profile/set_active_account.yml
+++ b/swagger/paths/profile/set_active_account.yml
@@ -1,0 +1,33 @@
+tags:
+  - Profile
+operationId: setActiveProfileAccount
+summary: Set active account
+description: Mark one of the current user's accounts as the active account.
+security:
+  - userApiKey: []
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+          - profile
+        properties:
+          profile:
+            type: object
+            required:
+              - account_id
+            properties:
+              account_id:
+                type: integer
+                description: The numeric ID of the account to activate.
+responses:
+  '200':
+    description: Success
+  '401':
+    description: Unauthorized
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -6573,6 +6573,64 @@
         }
       }
     },
+    "/api/v1/accounts/{account_id}/conversations/{conversation_id}/update_last_seen": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "$ref": "#/components/parameters/conversation_id"
+        }
+      ],
+      "post": {
+        "tags": [
+          "Conversations"
+        ],
+        "operationId": "conversationUpdateLastSeen",
+        "summary": "Update last seen",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Updates the last-seen timestamps for a conversation and clears unread notifications for the current agent when appropriate.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Conversation not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/accounts/{account_id}/integrations/apps": {
       "parameters": [
         {
@@ -6941,6 +6999,330 @@
           },
           "401": {
             "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/profile/avatar": {
+      "delete": {
+        "tags": [
+          "Profile"
+        ],
+        "operationId": "deleteProfileAvatar",
+        "summary": "Delete profile avatar",
+        "description": "Delete the current user's avatar image.",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/profile/availability": {
+      "post": {
+        "tags": [
+          "Profile"
+        ],
+        "operationId": "updateProfileAvailability",
+        "summary": "Update profile availability",
+        "description": "Update the current user's availability for an account.",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "profile"
+                ],
+                "properties": {
+                  "profile": {
+                    "type": "object",
+                    "required": [
+                      "account_id",
+                      "availability"
+                    ],
+                    "properties": {
+                      "account_id": {
+                        "type": "integer",
+                        "description": "The numeric ID of the account."
+                      },
+                      "availability": {
+                        "type": "string",
+                        "enum": [
+                          "online",
+                          "busy",
+                          "offline"
+                        ],
+                        "description": "The availability value to store for the current user in the account."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account membership not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/profile/auto_offline": {
+      "post": {
+        "tags": [
+          "Profile"
+        ],
+        "operationId": "updateProfileAutoOffline",
+        "summary": "Update profile auto offline",
+        "description": "Update whether the current user should automatically go offline for an account.",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "profile"
+                ],
+                "properties": {
+                  "profile": {
+                    "type": "object",
+                    "required": [
+                      "account_id",
+                      "auto_offline"
+                    ],
+                    "properties": {
+                      "account_id": {
+                        "type": "integer",
+                        "description": "The numeric ID of the account."
+                      },
+                      "auto_offline": {
+                        "type": "boolean",
+                        "description": "Whether the current user should automatically switch offline when away."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account membership not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/profile/set_active_account": {
+      "put": {
+        "tags": [
+          "Profile"
+        ],
+        "operationId": "setActiveProfileAccount",
+        "summary": "Set active account",
+        "description": "Mark one of the current user's accounts as the active account.",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "profile"
+                ],
+                "properties": {
+                  "profile": {
+                    "type": "object",
+                    "required": [
+                      "account_id"
+                    ],
+                    "properties": {
+                      "account_id": {
+                        "type": "integer",
+                        "description": "The numeric ID of the account to activate."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/profile/resend_confirmation": {
+      "post": {
+        "tags": [
+          "Profile"
+        ],
+        "operationId": "resendProfileConfirmation",
+        "summary": "Resend profile confirmation",
+        "description": "Resend email confirmation instructions for the current user when the account is unconfirmed.",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/profile/reset_access_token": {
+      "post": {
+        "tags": [
+          "Profile"
+        ],
+        "operationId": "resetProfileAccessToken",
+        "summary": "Reset profile access token",
+        "description": "Regenerate the current user's access token.",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
           }
         }
       }
@@ -11891,6 +12273,21 @@
             "type": "boolean",
             "description": "Flag to identify if it is a private note",
             "example": false
+          },
+          "cc_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to add to CC for outbound email replies",
+            "example": "amy@example.com,ops@example.com"
+          },
+          "bcc_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to add to BCC for outbound email replies",
+            "example": "audit@example.com"
+          },
+          "to_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to override the primary recipient list for outbound email replies",
+            "example": "william@example.com"
           },
           "content_type": {
             "type": "string",

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -5116,6 +5116,64 @@
         }
       }
     },
+    "/api/v1/accounts/{account_id}/conversations/{conversation_id}/update_last_seen": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "$ref": "#/components/parameters/conversation_id"
+        }
+      ],
+      "post": {
+        "tags": [
+          "Conversations"
+        ],
+        "operationId": "conversationUpdateLastSeen",
+        "summary": "Update last seen",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Updates the last-seen timestamps for a conversation and clears unread notifications for the current agent when appropriate.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Conversation not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/accounts/{account_id}/integrations/apps": {
       "parameters": [
         {
@@ -5484,6 +5542,330 @@
           },
           "401": {
             "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/profile/avatar": {
+      "delete": {
+        "tags": [
+          "Profile"
+        ],
+        "operationId": "deleteProfileAvatar",
+        "summary": "Delete profile avatar",
+        "description": "Delete the current user's avatar image.",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/profile/availability": {
+      "post": {
+        "tags": [
+          "Profile"
+        ],
+        "operationId": "updateProfileAvailability",
+        "summary": "Update profile availability",
+        "description": "Update the current user's availability for an account.",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "profile"
+                ],
+                "properties": {
+                  "profile": {
+                    "type": "object",
+                    "required": [
+                      "account_id",
+                      "availability"
+                    ],
+                    "properties": {
+                      "account_id": {
+                        "type": "integer",
+                        "description": "The numeric ID of the account."
+                      },
+                      "availability": {
+                        "type": "string",
+                        "enum": [
+                          "online",
+                          "busy",
+                          "offline"
+                        ],
+                        "description": "The availability value to store for the current user in the account."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account membership not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/profile/auto_offline": {
+      "post": {
+        "tags": [
+          "Profile"
+        ],
+        "operationId": "updateProfileAutoOffline",
+        "summary": "Update profile auto offline",
+        "description": "Update whether the current user should automatically go offline for an account.",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "profile"
+                ],
+                "properties": {
+                  "profile": {
+                    "type": "object",
+                    "required": [
+                      "account_id",
+                      "auto_offline"
+                    ],
+                    "properties": {
+                      "account_id": {
+                        "type": "integer",
+                        "description": "The numeric ID of the account."
+                      },
+                      "auto_offline": {
+                        "type": "boolean",
+                        "description": "Whether the current user should automatically switch offline when away."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account membership not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/profile/set_active_account": {
+      "put": {
+        "tags": [
+          "Profile"
+        ],
+        "operationId": "setActiveProfileAccount",
+        "summary": "Set active account",
+        "description": "Mark one of the current user's accounts as the active account.",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "profile"
+                ],
+                "properties": {
+                  "profile": {
+                    "type": "object",
+                    "required": [
+                      "account_id"
+                    ],
+                    "properties": {
+                      "account_id": {
+                        "type": "integer",
+                        "description": "The numeric ID of the account to activate."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/profile/resend_confirmation": {
+      "post": {
+        "tags": [
+          "Profile"
+        ],
+        "operationId": "resendProfileConfirmation",
+        "summary": "Resend profile confirmation",
+        "description": "Resend email confirmation instructions for the current user when the account is unconfirmed.",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/profile/reset_access_token": {
+      "post": {
+        "tags": [
+          "Profile"
+        ],
+        "operationId": "resetProfileAccessToken",
+        "summary": "Reset profile access token",
+        "description": "Regenerate the current user's access token.",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
           }
         }
       }
@@ -10398,6 +10780,21 @@
             "type": "boolean",
             "description": "Flag to identify if it is a private note",
             "example": false
+          },
+          "cc_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to add to CC for outbound email replies",
+            "example": "amy@example.com,ops@example.com"
+          },
+          "bcc_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to add to BCC for outbound email replies",
+            "example": "audit@example.com"
+          },
+          "to_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to override the primary recipient list for outbound email replies",
+            "example": "william@example.com"
           },
           "content_type": {
             "type": "string",

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -3664,6 +3664,21 @@
             "description": "Flag to identify if it is a private note",
             "example": false
           },
+          "cc_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to add to CC for outbound email replies",
+            "example": "amy@example.com,ops@example.com"
+          },
+          "bcc_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to add to BCC for outbound email replies",
+            "example": "audit@example.com"
+          },
+          "to_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to override the primary recipient list for outbound email replies",
+            "example": "william@example.com"
+          },
           "content_type": {
             "type": "string",
             "enum": [

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -3079,6 +3079,21 @@
             "description": "Flag to identify if it is a private note",
             "example": false
           },
+          "cc_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to add to CC for outbound email replies",
+            "example": "amy@example.com,ops@example.com"
+          },
+          "bcc_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to add to BCC for outbound email replies",
+            "example": "audit@example.com"
+          },
+          "to_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to override the primary recipient list for outbound email replies",
+            "example": "william@example.com"
+          },
           "content_type": {
             "type": "string",
             "enum": [

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -3840,6 +3840,21 @@
             "description": "Flag to identify if it is a private note",
             "example": false
           },
+          "cc_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to add to CC for outbound email replies",
+            "example": "amy@example.com,ops@example.com"
+          },
+          "bcc_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to add to BCC for outbound email replies",
+            "example": "audit@example.com"
+          },
+          "to_emails": {
+            "type": "string",
+            "description": "Comma-separated email addresses to override the primary recipient list for outbound email replies",
+            "example": "william@example.com"
+          },
           "content_type": {
             "type": "string",
             "enum": [


### PR DESCRIPTION
Align the application OpenAPI docs with message recipient fields and existing profile/conversation routes that Chatwoot already supports at runtime.

## Summary

This updates the application swagger/OpenAPI source and generated artifacts so the published API reference matches existing runtime behavior.

What changed:
- expose `cc_emails`, `bcc_emails`, and `to_emails` on the create-message request schema
- document the account conversation `update_last_seen` endpoint in the generated application paths
- document existing profile mutation endpoints for avatar delete, availability, auto-offline, active-account switch, confirmation resend, and access-token reset

Runtime support for these surfaces already exists in Chatwoot:
- the dashboard message API sends `cc_emails`, `bcc_emails`, and `to_emails`
- the message builder persists those recipient fields and the mailer uses them for outbound email replies
- the Rails routes/controllers and controller specs already cover the profile mutation endpoints and account conversation `update_last_seen`

This PR only updates swagger/OpenAPI source files and the checked-in generated artifacts. It does not change runtime behavior.

## How to test

1. `eval "$(rbenv init -)"`
2. `bundle exec rake swagger:build`
3. `bundle exec rspec spec/swagger/openapi_spec.rb`
4. Confirm the following now appear in the generated OpenAPI output:
   - `cc_emails`, `bcc_emails`, and `to_emails` in `swagger/definitions/request/conversation/create_message_payload.yml`
   - `/api/v1/accounts/{account_id}/conversations/{conversation_id}/update_last_seen`
   - `/api/v1/profile/avatar`
   - `/api/v1/profile/availability`
   - `/api/v1/profile/auto_offline`
   - `/api/v1/profile/set_active_account`
   - `/api/v1/profile/resend_confirmation`
   - `/api/v1/profile/reset_access_token`
