### PR TITLE
feat(contacts): support contact IDs in merge search and multiple emails

### DIFF
--- a/app/actions/contact_merge_action.rb
+++ b/app/actions/contact_merge_action.rb
@@ -59,11 +59,12 @@ class ContactMergeAction
         next
       end
 
-      if contact_email.present?
-        contact_email.update!(contact: @base_contact, primary: false)
-      else
-        @base_contact.contact_emails.create!(account: @base_contact.account, email: email, primary: false)
-      end
+      contact_email ||= @mergee_contact.contact_emails.create!(
+        account: @mergee_contact.account,
+        email: email,
+        primary: false
+      )
+      contact_email.update!(contact: @base_contact, primary: false)
 
       base_contact_email_identities << email
     end

--- a/app/actions/contact_merge_action.rb
+++ b/app/actions/contact_merge_action.rb
@@ -48,8 +48,8 @@ class ContactMergeAction
   end
 
   def merge_contact_emails
-    base_contact_email_identities = @base_contact.all_emails
-    mergee_contact_emails = @mergee_contact.contact_emails.index_by(&:email)
+    base_contact_email_identities = @base_contact.all_emails.filter_map { |email| normalized_email(email) }
+    mergee_contact_emails = @mergee_contact.contact_emails.index_by { |contact_email| normalized_email(contact_email.email) }
 
     mergee_email_identities.each do |email|
       contact_email = mergee_contact_emails[email]
@@ -70,7 +70,12 @@ class ContactMergeAction
   end
 
   def mergee_email_identities
-    [@mergee_contact.email, *@mergee_contact.contact_emails.pluck(:email)].compact_blank.uniq
+    [@mergee_contact.email, *@mergee_contact.contact_emails.pluck(:email)].filter_map { |email| normalized_email(email) }.uniq
+  end
+
+  def normalized_email(email)
+    normalized_email = email.to_s.strip.downcase
+    normalized_email.presence
   end
 
   def merge_and_remove_mergee_contact

--- a/app/actions/contact_merge_action.rb
+++ b/app/actions/contact_merge_action.rb
@@ -49,16 +49,28 @@ class ContactMergeAction
 
   def merge_contact_emails
     base_contact_email_identities = @base_contact.all_emails
+    mergee_contact_emails = @mergee_contact.contact_emails.index_by(&:email)
 
-    mergee_contact.contact_emails.find_each do |contact_email|
-      if base_contact_email_identities.include?(contact_email.email)
-        contact_email.destroy!
+    mergee_email_identities.each do |email|
+      contact_email = mergee_contact_emails[email]
+
+      if base_contact_email_identities.include?(email)
+        contact_email&.destroy!
         next
       end
 
-      contact_email.update!(contact: @base_contact, primary: false)
-      base_contact_email_identities << contact_email.email
+      if contact_email.present?
+        contact_email.update!(contact: @base_contact, primary: false)
+      else
+        @base_contact.contact_emails.create!(account: @base_contact.account, email: email, primary: false)
+      end
+
+      base_contact_email_identities << email
     end
+  end
+
+  def mergee_email_identities
+    [@mergee_contact.email, *@mergee_contact.contact_emails.pluck(:email)].compact_blank.uniq
   end
 
   def merge_and_remove_mergee_contact

--- a/app/actions/contact_merge_action.rb
+++ b/app/actions/contact_merge_action.rb
@@ -13,6 +13,7 @@ class ContactMergeAction
       merge_messages
       merge_contact_inboxes
       merge_contact_notes
+      merge_contact_emails
       merge_and_remove_mergee_contact
     end
     @base_contact
@@ -44,6 +45,20 @@ class ContactMergeAction
 
   def merge_contact_inboxes
     ContactInbox.where(contact_id: @mergee_contact.id).update(contact_id: @base_contact.id)
+  end
+
+  def merge_contact_emails
+    base_contact_email_identities = @base_contact.all_emails
+
+    mergee_contact.contact_emails.find_each do |contact_email|
+      if base_contact_email_identities.include?(contact_email.email)
+        contact_email.destroy!
+        next
+      end
+
+      contact_email.update!(contact: @base_contact, primary: false)
+      base_contact_email_identities << contact_email.email
+    end
   end
 
   def merge_and_remove_mergee_contact

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
     search_query = params[:q].strip
     contacts = Current.account.contacts.left_outer_joins(:contact_emails)
     contacts = contacts.where(search_conditions, search: "%#{search_query}%", contact_id: search_query.to_i)
-    contacts = contacts.distinct
+    contacts = prioritize_exact_contact_id_match(contacts.distinct, search_query)
     @contacts = fetch_contacts_with_has_more(contacts)
   end
 
@@ -251,8 +251,25 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
       'contacts.identifier LIKE :search'
     ]
 
-    base_conditions << 'contacts.id = :contact_id' if params[:q].strip.match?(/\A\d+\z/)
+    base_conditions << 'contacts.id = :contact_id' if numeric_contact_query?(params[:q].to_s.strip)
     base_conditions.join(' OR ')
+  end
+
+  def prioritize_exact_contact_id_match(contacts, search_query)
+    return contacts unless numeric_contact_query?(search_query)
+
+    contact_id = search_query.to_i
+    priority_select = Contact.send(
+      :sanitize_sql_array,
+      ['contacts.*, CASE WHEN contacts.id = ? THEN 0 ELSE 1 END AS exact_match_priority', contact_id]
+    )
+
+    contacts.reselect(Arel.sql(priority_select))
+            .order(Arel.sql('exact_match_priority ASC, contacts.id DESC'))
+  end
+
+  def numeric_contact_query?(search_query)
+    search_query.match?(/\A\d+\z/)
   end
 
   def process_avatar_from_url

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -236,12 +236,13 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def replace_contact_emails
-    Contacts::ReplaceContactEmails.new(contact: @contact, emails: permitted_params[:emails], legacy_email: @contact.email).perform
+    Contacts::ReplaceContactEmails.new(contact: @contact, emails: permitted_params[:emails]).perform
   end
 
   def search_conditions
     base_conditions = [
       'contacts.name ILIKE :search',
+      'contacts.email ILIKE :search',
       'contact_emails.email ILIKE :search',
       'contacts.phone_number ILIKE :search',
       'contacts.identifier LIKE :search'

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -94,11 +94,13 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def update
-    @contact.assign_attributes(contact_update_params)
-    assign_primary_email_from_identities(@contact)
-    @contact.save!
-    replace_contact_emails if emails_param_provided?
-    process_avatar_from_url
+    ActiveRecord::Base.transaction do
+      @contact.assign_attributes(contact_update_params)
+      assign_primary_email_from_identities(@contact)
+      @contact.save!
+      replace_contact_emails if emails_param_provided?
+      process_avatar_from_url
+    end
   end
 
   def destroy

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -265,7 +265,7 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
     )
 
     contacts.reselect(Arel.sql(priority_select))
-            .order(Arel.sql('exact_match_priority ASC, contacts.id DESC'))
+            .order(Arel.sql('exact_match_priority ASC'))
   end
 
   def numeric_contact_query?(search_query)

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -26,9 +26,11 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
     render json: { error: 'Specify search string with parameter q' }, status: :unprocessable_entity if params[:q].blank? && return
 
     search_query = params[:q].strip
-    contacts = Current.account.contacts.left_outer_joins(:contact_emails)
-    contacts = contacts.where(search_conditions, search: "%#{search_query}%", contact_id: search_query.to_i)
-    contacts = prioritize_exact_contact_id_match(contacts.distinct, search_query)
+    matching_contacts = Current.account.contacts.left_outer_joins(:contact_emails)
+    matching_contacts = matching_contacts.where(search_conditions, search: "%#{search_query}%", contact_id: search_query.to_i)
+
+    contacts = Current.account.contacts.where(id: matching_contacts.select(:id))
+    contacts = prioritize_exact_contact_id_match(contacts, search_query)
     @contacts = fetch_contacts_with_has_more(contacts)
   end
 

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -24,10 +24,10 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   def search
     render json: { error: 'Specify search string with parameter q' }, status: :unprocessable_entity if params[:q].blank? && return
 
-    contacts = Current.account.contacts.where(
-      'name ILIKE :search OR email ILIKE :search OR phone_number ILIKE :search OR contacts.identifier LIKE :search',
-      search: "%#{params[:q].strip}%"
-    )
+    search_query = params[:q].strip
+    contacts = Current.account.contacts.left_outer_joins(:contact_emails)
+    contacts = contacts.where(search_conditions, search: "%#{search_query}%", contact_id: search_query.to_i)
+    contacts = contacts.distinct
     @contacts = fetch_contacts_with_has_more(contacts)
   end
 
@@ -84,8 +84,10 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
   def create
     ActiveRecord::Base.transaction do
-      @contact = Current.account.contacts.new(permitted_params.except(:avatar_url))
+      @contact = Current.account.contacts.new(contact_create_params)
+      assign_primary_email_from_identities(@contact)
       @contact.save!
+      replace_contact_emails if emails_param_provided?
       @contact_inbox = build_contact_inbox
       process_avatar_from_url
     end
@@ -93,7 +95,9 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
   def update
     @contact.assign_attributes(contact_update_params)
+    assign_primary_email_from_identities(@contact)
     @contact.save!
+    replace_contact_emails if emails_param_provided?
     process_avatar_from_url
   end
 
@@ -132,7 +136,7 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
   def fetch_contacts(contacts)
     # Build includes hash to avoid separate query when contact_inboxes are needed
-    includes_hash = { avatar_attachment: [:blob] }
+    includes_hash = { avatar_attachment: [:blob], contact_emails: [] }
     includes_hash[:contact_inboxes] = { inbox: :channel } if @include_contact_inboxes
 
     filtrate(contacts)
@@ -142,7 +146,7 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def fetch_contacts_with_has_more(contacts)
-    includes_hash = { avatar_attachment: [:blob] }
+    includes_hash = { avatar_attachment: [:blob], contact_emails: [] }
     includes_hash[:contact_inboxes] = { inbox: :channel } if @include_contact_inboxes
 
     # Calculate offset manually to fetch one extra record for has_more check
@@ -171,7 +175,14 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def permitted_params
-    params.permit(:name, :identifier, :email, :phone_number, :avatar, :blocked, :avatar_url, additional_attributes: {}, custom_attributes: {})
+    params.permit(
+      :name, :identifier, :email, :phone_number, :avatar, :blocked, :avatar_url,
+      emails: [], additional_attributes: {}, custom_attributes: {}
+    )
+  end
+
+  def contact_create_params
+    permitted_params.except(:avatar_url, :emails)
   end
 
   def contact_custom_attributes
@@ -187,7 +198,7 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def contact_update_params
-    permitted_params.except(:custom_attributes, :avatar_url)
+    permitted_params.except(:custom_attributes, :avatar_url, :emails)
                     .merge({ custom_attributes: contact_custom_attributes })
                     .merge({ additional_attributes: contact_additional_attributes })
   end
@@ -202,8 +213,42 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
   def fetch_contact
     contact_scope = Current.account.contacts
+    contact_scope = contact_scope.includes(:contact_emails)
     contact_scope = contact_scope.includes(contact_inboxes: [:inbox]) if @include_contact_inboxes
     @contact = contact_scope.find(params[:id])
+  end
+
+  def emails_param_provided?
+    permitted_params.key?(:emails)
+  end
+
+  def normalized_emails_param
+    @normalized_emails_param ||= Array(permitted_params[:emails]).filter_map do |email|
+      normalized_email = email.to_s.strip.downcase
+      normalized_email.presence
+    end.uniq
+  end
+
+  def assign_primary_email_from_identities(contact)
+    return unless emails_param_provided?
+
+    contact.email = normalized_emails_param.first
+  end
+
+  def replace_contact_emails
+    Contacts::ReplaceContactEmails.new(contact: @contact, emails: permitted_params[:emails], legacy_email: @contact.email).perform
+  end
+
+  def search_conditions
+    base_conditions = [
+      'contacts.name ILIKE :search',
+      'contact_emails.email ILIKE :search',
+      'contacts.phone_number ILIKE :search',
+      'contacts.identifier LIKE :search'
+    ]
+
+    base_conditions << 'contacts.id = :contact_id' if params[:q].strip.match?(/\A\d+\z/)
+    base_conditions.join(' OR ')
   end
 
   def process_avatar_from_url

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   include Sift
   sort_on :email, type: :string
@@ -262,3 +263,4 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
     render json: error, status: error_status
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -98,10 +98,12 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
   def update
     ActiveRecord::Base.transaction do
+      previous_emails = @contact.all_emails if emails_param_provided?
       @contact.assign_attributes(contact_update_params)
       assign_primary_email_from_identities(@contact)
       @contact.save!
       replace_contact_emails if emails_param_provided?
+      touch_contact_if_only_email_identities_changed(previous_emails)
       process_avatar_from_url
     end
   end
@@ -242,6 +244,14 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
   def replace_contact_emails
     Contacts::ReplaceContactEmails.new(contact: @contact, emails: permitted_params[:emails]).perform
+  end
+
+  def touch_contact_if_only_email_identities_changed(previous_emails)
+    return if previous_emails.blank?
+    return if @contact.previous_changes.present?
+    return if previous_emails == @contact.all_emails
+
+    @contact.update!(updated_at: Time.current)
   end
 
   def search_conditions

--- a/app/javascript/dashboard/api/specs/contacts.spec.js
+++ b/app/javascript/dashboard/api/specs/contacts.spec.js
@@ -84,6 +84,19 @@ describe('#ContactsAPI', () => {
       );
     });
 
+    it('#update', () => {
+      const formData = new FormData();
+      formData.append('email', 'primary@example.com');
+      formData.append('emails[]', 'primary@example.com');
+      formData.append('emails[]', 'alias@example.com');
+
+      contactAPI.update(1, formData);
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        '/api/v1/contacts/1?include_contact_inboxes=false',
+        formData
+      );
+    });
+
     it('#destroyCustomAttributes', () => {
       contactAPI.destroyCustomAttributes(1, ['cloudCustomer']);
       expect(axiosMock.post).toHaveBeenCalledWith(

--- a/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
@@ -15,6 +15,7 @@ const props = defineProps({
   id: { type: Number, required: true },
   name: { type: String, default: '' },
   email: { type: String, default: '' },
+  emails: { type: Array, default: () => [] },
   additionalAttributes: { type: Object, default: () => ({}) },
   phoneNumber: { type: String, default: '' },
   thumbnail: { type: String, default: '' },
@@ -41,6 +42,7 @@ const getInitialContactData = () => ({
   id: props.id,
   name: props.name,
   email: props.email,
+  emails: props.emails?.length ? props.emails : [props.email].filter(Boolean),
   phoneNumber: props.phoneNumber,
   additionalAttributes: props.additionalAttributes,
 });
@@ -81,6 +83,10 @@ const formattedLocation = computed(() => {
     .filter(Boolean)
     .join(' ');
 });
+
+const contactEmails = computed(() =>
+  (props.emails?.length ? props.emails : [props.email]).filter(Boolean)
+);
 
 const handleFormUpdate = updatedData => {
   Object.assign(contactData.value, updatedData);
@@ -164,12 +170,19 @@ const handleAvatarHover = isHovered => {
           <div
             class="flex flex-wrap items-center justify-start gap-x-3 gap-y-1"
           >
-            <div v-if="email" class="truncate max-w-72" :title="email">
+            <div
+              v-if="contactEmails.length"
+              class="truncate max-w-72"
+              :title="contactEmails.join(', ')"
+            >
               <span class="text-sm text-n-slate-11">
-                {{ email }}
+                {{ contactEmails.join(', ') }}
               </span>
             </div>
-            <div v-if="email" class="w-px h-3 truncate bg-n-slate-6" />
+            <div
+              v-if="contactEmails.length"
+              class="w-px h-3 truncate bg-n-slate-6"
+            />
             <span v-if="phoneNumber" class="text-sm truncate text-n-slate-11">
               {{ phoneNumber }}
             </span>

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactEmailsInput.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactEmailsInput.vue
@@ -52,11 +52,12 @@ const inputClass = computed(
 );
 
 const syncFieldsFromModel = emails => {
-  const normalizedModel = normalizeEmails(emails);
-  const normalizedFields = normalizeEmails(emailFields.value);
+  const modelFields = getEmailFields(emails);
+  const normalizedModel = JSON.stringify(modelFields);
+  const normalizedFields = JSON.stringify(emailFields.value);
 
-  if (JSON.stringify(normalizedModel) !== JSON.stringify(normalizedFields)) {
-    emailFields.value = getEmailFields(emails);
+  if (normalizedModel !== normalizedFields) {
+    emailFields.value = modelFields;
   }
 };
 

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactEmailsInput.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactEmailsInput.vue
@@ -110,6 +110,7 @@ watch(
       />
       <Button
         v-if="index > 0"
+        type="button"
         icon="i-lucide-trash-2"
         variant="ghost"
         color="slate"
@@ -119,6 +120,7 @@ watch(
       />
     </div>
     <Button
+      type="button"
       icon="i-lucide-plus"
       variant="link"
       color="slate"

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactEmailsInput.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactEmailsInput.vue
@@ -1,0 +1,132 @@
+<script setup>
+import { computed, ref, watch } from 'vue';
+
+import Button from 'dashboard/components-next/button/Button.vue';
+import Input from 'dashboard/components-next/input/Input.vue';
+
+const props = defineProps({
+  modelValue: {
+    type: Array,
+    default: () => [],
+  },
+  primaryPlaceholder: {
+    type: String,
+    default: '',
+  },
+  additionalPlaceholder: {
+    type: String,
+    default: '',
+  },
+  isDetailsView: {
+    type: Boolean,
+    default: false,
+  },
+  message: {
+    type: String,
+    default: '',
+  },
+  messageType: {
+    type: String,
+    default: 'info',
+  },
+});
+
+const emit = defineEmits(['update:modelValue', 'input', 'blur']);
+
+const normalizeEmails = emails => [
+  ...new Set(emails.map(email => email?.trim()).filter(Boolean)),
+];
+
+const getEmailFields = emails => {
+  const normalizedEmails = normalizeEmails(emails);
+  return normalizedEmails.length ? normalizedEmails : [''];
+};
+
+const emailFields = ref(getEmailFields(props.modelValue));
+
+const inputClass = computed(
+  () =>
+    `h-8 !pt-1 !pb-1 ${
+      !props.isDetailsView ? '[&:not(.error,.focus)]:!outline-transparent' : ''
+    }`
+);
+
+const syncFieldsFromModel = emails => {
+  const normalizedModel = normalizeEmails(emails);
+  const normalizedFields = normalizeEmails(emailFields.value);
+
+  if (JSON.stringify(normalizedModel) !== JSON.stringify(normalizedFields)) {
+    emailFields.value = getEmailFields(emails);
+  }
+};
+
+const emitUpdatedEmails = () => {
+  emit('update:modelValue', normalizeEmails(emailFields.value));
+};
+
+const updateEmail = (index, value) => {
+  emailFields.value[index] = value;
+  emitUpdatedEmails();
+
+  if (index === 0) {
+    emit('input');
+  }
+};
+
+const addEmailField = () => {
+  emailFields.value.push('');
+};
+
+const removeEmailField = index => {
+  emailFields.value.splice(index, 1);
+  emitUpdatedEmails();
+};
+
+watch(
+  () => props.modelValue,
+  emails => syncFieldsFromModel(emails),
+  { immediate: true }
+);
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <div
+      v-for="(email, index) in emailFields"
+      :key="index"
+      class="flex items-start gap-2"
+    >
+      <Input
+        :model-value="email"
+        type="email"
+        :placeholder="index === 0 ? primaryPlaceholder : additionalPlaceholder"
+        :message="index === 0 ? message : ''"
+        :message-type="messageType"
+        :custom-input-class="inputClass"
+        class="flex-1"
+        @update:model-value="value => updateEmail(index, value)"
+        @blur="index === 0 && emit('blur')"
+      />
+      <Button
+        v-if="index > 0"
+        icon="i-lucide-trash-2"
+        variant="ghost"
+        color="slate"
+        size="sm"
+        class="mt-1"
+        @click="removeEmailField(index)"
+      />
+    </div>
+    <Button
+      icon="i-lucide-plus"
+      variant="link"
+      color="slate"
+      size="sm"
+      class="self-start"
+      :label="
+        $t('CONTACTS_LAYOUT.CARD.EDIT_DETAILS_FORM.FORM.EMAIL_ADDRESS.ADD')
+      "
+      @click="addEmailField"
+    />
+  </div>
+</template>

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactMergeForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactMergeForm.vue
@@ -1,9 +1,10 @@
 <script setup>
+import { computed } from 'vue';
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
 import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
 import { useI18n } from 'vue-i18n';
 
-defineProps({
+const props = defineProps({
   selectedContact: {
     type: Object,
     required: true,
@@ -33,6 +34,13 @@ defineProps({
 const emit = defineEmits(['update:primaryContactId', 'search']);
 
 const { t } = useI18n();
+
+const selectedContactEmails = computed(() =>
+  (props.selectedContact.emails?.length
+    ? props.selectedContact.emails
+    : [props.selectedContact.email]
+  ).filter(Boolean)
+);
 </script>
 
 <template>
@@ -104,7 +112,7 @@ const { t } = useI18n();
             {{ selectedContact.name }}
           </span>
           <span class="text-sm leading-4 truncate text-n-slate-11">
-            {{ selectedContact.email }}
+            {{ selectedContactEmails.join(', ') }}
           </span>
         </div>
       </div>

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
@@ -9,6 +9,7 @@ import Input from 'dashboard/components-next/input/Input.vue';
 import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 import PhoneNumberInput from 'dashboard/components-next/phonenumberinput/PhoneNumberInput.vue';
+import ContactEmailsInput from './ContactEmailsInput.vue';
 
 const props = defineProps({
   contactData: {
@@ -54,6 +55,7 @@ const defaultState = {
   id: 0,
   name: '',
   email: '',
+  emails: [],
   firstName: '',
   lastName: '',
   phoneNumber: '',
@@ -86,6 +88,36 @@ const v$ = useVuelidate(validationRules, state);
 
 const isFormInvalid = computed(() => v$.value.$invalid);
 
+const normalizeEmails = emails => [
+  ...new Set(
+    emails
+      .map(emailAddress => emailAddress?.trim()?.toLowerCase())
+      .filter(Boolean)
+  ),
+];
+
+const getContactEmails = contactData => {
+  const sourceEmails = contactData?.emails?.length
+    ? contactData.emails
+    : [contactData?.email];
+
+  return normalizeEmails(sourceEmails);
+};
+
+const emitUpdatedState = () => {
+  const { firstName, lastName, ...stateWithoutNames } = state;
+
+  emit('update', {
+    ...stateWithoutNames,
+    email: state.emails[0] || '',
+    emails: [...state.emails],
+    additionalAttributes: {
+      ...state.additionalAttributes,
+      socialProfiles: { ...state.additionalAttributes.socialProfiles },
+    },
+  });
+};
+
 const prepareStateBasedOnProps = () => {
   if (props.isNewContact) {
     return; // Added to prevent state update for new contact form
@@ -95,6 +127,7 @@ const prepareStateBasedOnProps = () => {
     id,
     name = '',
     email: emailAddress,
+    emails = [],
     phoneNumber,
     additionalAttributes = {},
   } = props.contactData || {};
@@ -111,13 +144,18 @@ const prepareStateBasedOnProps = () => {
 
   const telegramUsername =
     socialProfiles?.telegram || socialTelegramUserName || '';
+  const normalizedEmails = getContactEmails({
+    email: emailAddress,
+    emails,
+  });
 
   Object.assign(state, {
     id,
     name,
     firstName,
     lastName,
-    email: emailAddress,
+    email: normalizedEmails[0] || '',
+    emails: normalizedEmails,
     phoneNumber,
     additionalAttributes: {
       description,
@@ -201,10 +239,7 @@ const getFormBinding = key => {
       }
 
       const isFormValid = await v$.value.$validate();
-      if (isFormValid) {
-        const { firstName, lastName, ...stateWithoutNames } = state;
-        emit('update', stateWithoutNames);
-      }
+      if (isFormValid) emitUpdatedState();
     },
   });
 };
@@ -218,7 +253,16 @@ const getMessageType = key => {
 const handleCountrySelection = value => {
   const selectedCountry = countries.find(option => option.id === value);
   state.additionalAttributes.country = selectedCountry?.name || '';
-  emit('update', state);
+  emitUpdatedState();
+};
+
+const handleEmailsUpdate = async emails => {
+  const normalizedEmails = normalizeEmails(emails);
+  state.emails = normalizedEmails;
+  state.email = normalizedEmails[0] || '';
+
+  const isFormValid = await v$.value.$validate();
+  if (isFormValid) emitUpdatedState();
 };
 
 const resetValidation = () => {
@@ -254,8 +298,24 @@ defineExpose({
       </span>
       <div class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
         <template v-for="item in editDetailsForm" :key="item.key">
+          <ContactEmailsInput
+            v-if="item.key === 'EMAIL_ADDRESS'"
+            v-model="state.emails"
+            :primary-placeholder="item.placeholder"
+            :additional-placeholder="
+              t(
+                'CONTACTS_LAYOUT.CARD.EDIT_DETAILS_FORM.FORM.EMAIL_ADDRESS.ADDITIONAL_PLACEHOLDER'
+              )
+            "
+            :is-details-view="isDetailsView"
+            :message-type="getMessageType(item.key)"
+            class="sm:col-span-2"
+            @update:model-value="handleEmailsUpdate"
+            @input="v$[getValidationKey(item.key)].$touch()"
+            @blur="v$[getValidationKey(item.key)].$touch()"
+          />
           <ComboBox
-            v-if="item.key === 'COUNTRY'"
+            v-else-if="item.key === 'COUNTRY'"
             v-model="state.additionalAttributes.countryCode"
             :options="countryOptions"
             :placeholder="item.placeholder"

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
@@ -79,9 +79,13 @@ const defaultState = {
 
 const state = reactive({ ...defaultState });
 
+const hasValidEmails = value =>
+  value.every(emailAddress => email.$validator(emailAddress));
+
 const validationRules = {
   firstName: { required },
   email: { email },
+  emails: { hasValidEmails },
 };
 
 const v$ = useVuelidate(validationRules, state);
@@ -245,9 +249,24 @@ const getFormBinding = key => {
 };
 
 const getMessageType = key => {
+  if (key === 'EMAIL_ADDRESS') {
+    return v$.value.email?.$error || v$.value.emails?.$error ? 'error' : 'info';
+  }
+
   return isValidationField(key) && v$.value[getValidationKey(key)]?.$error
     ? 'error'
     : 'info';
+};
+
+const getValidationMessage = key => {
+  if (
+    key === 'EMAIL_ADDRESS' &&
+    (v$.value.email?.$error || v$.value.emails?.$error)
+  ) {
+    return t('CONTACT_FORM.FORM.EMAIL_ADDRESS.ERROR');
+  }
+
+  return '';
 };
 
 const handleCountrySelection = value => {
@@ -260,6 +279,7 @@ const handleEmailsUpdate = async emails => {
   const normalizedEmails = normalizeEmails(emails);
   state.emails = normalizedEmails;
   state.email = normalizedEmails[0] || '';
+  v$.value.emails.$touch();
 
   const isFormValid = await v$.value.$validate();
   if (isFormValid) emitUpdatedState();
@@ -308,11 +328,18 @@ defineExpose({
               )
             "
             :is-details-view="isDetailsView"
+            :message="getValidationMessage(item.key)"
             :message-type="getMessageType(item.key)"
             class="sm:col-span-2"
             @update:model-value="handleEmailsUpdate"
-            @input="v$[getValidationKey(item.key)].$touch()"
-            @blur="v$[getValidationKey(item.key)].$touch()"
+            @input="
+              v$[getValidationKey(item.key)].$touch();
+              v$.emails.$touch();
+            "
+            @blur="
+              v$[getValidationKey(item.key)].$touch();
+              v$.emails.$touch();
+            "
           />
           <ComboBox
             v-else-if="item.key === 'COUNTRY'"

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/specs/ContactEmailsInput.spec.js
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/specs/ContactEmailsInput.spec.js
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import ContactEmailsInput from '../ContactEmailsInput.vue';
 
 const InputStub = {
@@ -24,7 +25,19 @@ const InputStub = {
 const ButtonStub = {
   name: 'Button',
   props: ['label', 'icon'],
-  template: `<button type="button" @click="$emit('click')">{{ label }}</button>`,
+  emits: ['click'],
+  methods: {
+    handleClick(event) {
+      this.$emit('click', event);
+
+      if (!this.$attrs.type || this.$attrs.type === 'submit') {
+        this.$el.form?.dispatchEvent(
+          new Event('submit', { bubbles: true, cancelable: true })
+        );
+      }
+    },
+  },
+  template: `<button v-bind="$attrs" @click="handleClick">{{ label }}</button>`,
 };
 
 describe('ContactEmailsInput', () => {
@@ -57,5 +70,42 @@ describe('ContactEmailsInput', () => {
     expect(updatedInputs).toHaveLength(1);
     expect(updatedInputs[0].element.value).toBe('alias@example.com');
     expect(updatedInputs[0].attributes('placeholder')).toBe('Primary email');
+  });
+
+  it('does not submit parent forms when adding or removing email fields', async () => {
+    const submitHandler = vi.fn(event => event.preventDefault());
+    const wrapper = mount(
+      {
+        components: { ContactEmailsInput },
+        data: () => ({
+          emails: ['primary@example.com', 'alias@example.com'],
+        }),
+        methods: { submitHandler },
+        template: `
+          <form @submit="submitHandler">
+            <ContactEmailsInput v-model="emails" />
+          </form>
+        `,
+      },
+      {
+        global: {
+          mocks: {
+            $t: key => key,
+          },
+          stubs: {
+            Input: InputStub,
+            Button: ButtonStub,
+          },
+        },
+      }
+    );
+
+    const buttons = wrapper.findAll('button');
+    buttons[0].element.click();
+    await nextTick();
+    buttons[1].element.click();
+    await nextTick();
+
+    expect(submitHandler).not.toHaveBeenCalled();
   });
 });

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/specs/ContactEmailsInput.spec.js
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/specs/ContactEmailsInput.spec.js
@@ -1,0 +1,61 @@
+import { mount } from '@vue/test-utils';
+import ContactEmailsInput from '../ContactEmailsInput.vue';
+
+const InputStub = {
+  name: 'Input',
+  props: [
+    'modelValue',
+    'placeholder',
+    'message',
+    'messageType',
+    'customInputClass',
+    'type',
+  ],
+  template: `
+    <input
+      :value="modelValue"
+      :placeholder="placeholder"
+      @input="$emit('update:modelValue', $event.target.value)"
+      @blur="$emit('blur')"
+    />
+  `,
+};
+
+const ButtonStub = {
+  name: 'Button',
+  props: ['label', 'icon'],
+  template: `<button type="button" @click="$emit('click')">{{ label }}</button>`,
+};
+
+describe('ContactEmailsInput', () => {
+  it('reflows remaining alias into the primary slot when the model collapses', async () => {
+    const wrapper = mount(ContactEmailsInput, {
+      props: {
+        modelValue: ['primary@example.com', 'alias@example.com'],
+        primaryPlaceholder: 'Primary email',
+        additionalPlaceholder: 'Additional email',
+      },
+      global: {
+        mocks: {
+          $t: key => key,
+        },
+        stubs: {
+          Input: InputStub,
+          Button: ButtonStub,
+        },
+      },
+    });
+
+    const inputs = wrapper.findAll('input');
+    await inputs[0].setValue('');
+
+    await wrapper.setProps({
+      modelValue: ['alias@example.com'],
+    });
+
+    const updatedInputs = wrapper.findAll('input');
+    expect(updatedInputs).toHaveLength(1);
+    expect(updatedInputs[0].element.value).toBe('alias@example.com');
+    expect(updatedInputs[0].attributes('placeholder')).toBe('Primary email');
+  });
+});

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/specs/ContactsForm.spec.js
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/specs/ContactsForm.spec.js
@@ -1,0 +1,43 @@
+import { mount } from '@vue/test-utils';
+import ContactsForm from '../ContactsForm.vue';
+
+const componentStubs = {
+  Input: { template: '<input />' },
+  ComboBox: { template: '<div />' },
+  Icon: { template: '<i />' },
+  PhoneNumberInput: { template: '<input />' },
+};
+
+describe('ContactsForm', () => {
+  it('marks the form invalid and blocks update emit when an alias email is invalid', async () => {
+    const wrapper = mount(ContactsForm, {
+      props: {
+        contactData: {
+          id: 1,
+          name: 'John Doe',
+          email: 'primary@example.com',
+          emails: ['primary@example.com'],
+          additionalAttributes: {
+            socialProfiles: {},
+          },
+        },
+      },
+      global: {
+        mocks: {
+          $t: key => key,
+        },
+        stubs: componentStubs,
+      },
+    });
+
+    const emailsInput = wrapper.findComponent({ name: 'ContactEmailsInput' });
+    await emailsInput.vm.$emit('update:modelValue', [
+      'primary@example.com',
+      'not-an-email',
+    ]);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.isFormInvalid).toBe(true);
+    expect(wrapper.emitted('update')).toBeFalsy();
+  });
+});

--- a/app/javascript/dashboard/components-next/Contacts/Pages/ContactsList.vue
+++ b/app/javascript/dashboard/components-next/Contacts/Pages/ContactsList.vue
@@ -92,6 +92,7 @@ const handleAvatarHover = (id, isHovered) => {
         :id="contact.id"
         :name="contact.name"
         :email="contact.email"
+        :emails="contact.emails"
         :thumbnail="contact.thumbnail"
         :phone-number="contact.phoneNumber"
         :additional-attributes="contact.additionalAttributes"

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -425,6 +425,8 @@
           },
           "EMAIL_ADDRESS": {
             "PLACEHOLDER": "Enter the email address",
+            "ADDITIONAL_PLACEHOLDER": "Enter an additional email address",
+            "ADD": "Add email",
             "DUPLICATE": "This email address is in use for another contact."
           },
           "PHONE_NUMBER": {
@@ -549,7 +551,7 @@
         "PARENT_HELP_LABEL": "To be deleted",
         "EMPTY_STATE": "No contacts found",
         "PLACEHOLDER": "Search for primary contact",
-        "SEARCH_PLACEHOLDER": "Search for a contact",
+        "SEARCH_PLACEHOLDER": "Search by name or contact ID",
         "SEARCH_ERROR_MESSAGE": "Could not search for contacts. Please try again later.",
         "SUCCESS_MESSAGE": "Contact merged successfully",
         "ERROR_MESSAGE": "Could not merge contacts, try again!",

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
@@ -12,12 +12,14 @@ import parsePhoneNumber from 'libphonenumber-js';
 import NextButton from 'dashboard/components-next/button/Button.vue';
 import Avatar from 'next/avatar/Avatar.vue';
 import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
+import ContactEmailsInput from 'dashboard/components-next/Contacts/ContactsForm/ContactEmailsInput.vue';
 
 export default {
   components: {
     NextButton,
     Avatar,
     ComboBox,
+    ContactEmailsInput,
   },
   props: {
     contact: {
@@ -43,6 +45,7 @@ export default {
       companyName: '',
       description: '',
       email: '',
+      emails: [],
       name: '',
       phoneNumber: '',
       activeDialCode: '',
@@ -126,6 +129,15 @@ export default {
     this.setDialCode();
   },
   methods: {
+    normalizeEmails(emails = []) {
+      return [
+        ...new Set(
+          emails
+            .map(emailAddress => emailAddress?.trim()?.toLowerCase())
+            .filter(Boolean)
+        ),
+      ];
+    },
     onCancel() {
       this.$emit('cancel');
     },
@@ -156,13 +168,18 @@ export default {
     setContactObject() {
       const {
         email: emailAddress,
+        emails = [],
         phone_number: phoneNumber,
         name,
       } = this.contact;
       const additionalAttributes = this.contact.additional_attributes || {};
+      const normalizedEmails = this.normalizeEmails(
+        emails.length ? emails : [emailAddress]
+      );
 
       this.name = name || '';
-      this.email = emailAddress || '';
+      this.email = normalizedEmails[0] || '';
+      this.emails = normalizedEmails;
       this.phoneNumber = phoneNumber || '';
       this.companyName = additionalAttributes.company_name || '';
       this.country = {
@@ -199,7 +216,8 @@ export default {
       const contactObject = {
         id: this.contact.id,
         name: this.name,
-        email: this.email,
+        email: this.emails[0] || '',
+        emails: this.emails,
         phone_number: this.setPhoneNumber,
         additional_attributes: {
           ...this.contact.additional_attributes,
@@ -220,6 +238,11 @@ export default {
         contactObject.isFormData = true;
       }
       return contactObject;
+    },
+    handleEmailsUpdate(emails) {
+      const normalizedEmails = this.normalizeEmails(emails);
+      this.emails = normalizedEmails;
+      this.email = normalizedEmails[0] || '';
     },
     setPhoneCode(code) {
       if (this.phoneNumber !== '' && this.parsePhoneNumber) {
@@ -318,15 +341,24 @@ export default {
 
         <label :class="{ error: v$.email.$error }">
           {{ $t('CONTACT_FORM.FORM.EMAIL_ADDRESS.LABEL') }}
-          <input
-            v-model="email"
-            type="text"
-            :placeholder="$t('CONTACT_FORM.FORM.EMAIL_ADDRESS.PLACEHOLDER')"
+          <ContactEmailsInput
+            v-model="emails"
+            :primary-placeholder="
+              $t('CONTACT_FORM.FORM.EMAIL_ADDRESS.PLACEHOLDER')
+            "
+            :additional-placeholder="
+              $t(
+                'CONTACTS_LAYOUT.CARD.EDIT_DETAILS_FORM.FORM.EMAIL_ADDRESS.ADDITIONAL_PLACEHOLDER'
+              )
+            "
+            :message="
+              v$.email.$error ? $t('CONTACT_FORM.FORM.EMAIL_ADDRESS.ERROR') : ''
+            "
+            :message-type="v$.email.$error ? 'error' : 'info'"
+            @update:model-value="handleEmailsUpdate"
             @input="v$.email.$touch"
+            @blur="v$.email.$touch"
           />
-          <span v-if="v$.email.$error" class="message">
-            {{ $t('CONTACT_FORM.FORM.EMAIL_ADDRESS.ERROR') }}
-          </span>
         </label>
       </div>
     </div>

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
@@ -74,6 +74,13 @@ export default {
     };
   },
   validations: {
+    emails: {
+      hasValidEmails(value) {
+        return (value || []).every(emailAddress =>
+          email.$validator(emailAddress)
+        );
+      },
+    },
     name: {
       required,
     },
@@ -243,6 +250,7 @@ export default {
       const normalizedEmails = this.normalizeEmails(emails);
       this.emails = normalizedEmails;
       this.email = normalizedEmails[0] || '';
+      this.v$.emails.$touch();
     },
     setPhoneCode(code) {
       if (this.phoneNumber !== '' && this.parsePhoneNumber) {
@@ -339,7 +347,7 @@ export default {
           />
         </label>
 
-        <label :class="{ error: v$.email.$error }">
+        <label :class="{ error: v$.email.$error || v$.emails.$error }">
           {{ $t('CONTACT_FORM.FORM.EMAIL_ADDRESS.LABEL') }}
           <ContactEmailsInput
             v-model="emails"
@@ -352,12 +360,22 @@ export default {
               )
             "
             :message="
-              v$.email.$error ? $t('CONTACT_FORM.FORM.EMAIL_ADDRESS.ERROR') : ''
+              v$.email.$error || v$.emails.$error
+                ? $t('CONTACT_FORM.FORM.EMAIL_ADDRESS.ERROR')
+                : ''
             "
-            :message-type="v$.email.$error ? 'error' : 'info'"
+            :message-type="
+              v$.email.$error || v$.emails.$error ? 'error' : 'info'
+            "
             @update:model-value="handleEmailsUpdate"
-            @input="v$.email.$touch"
-            @blur="v$.email.$touch"
+            @input="
+              v$.email.$touch();
+              v$.emails.$touch();
+            "
+            @blur="
+              v$.email.$touch();
+              v$.emails.$touch();
+            "
           />
         </label>
       </div>

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -92,6 +92,11 @@ export default {
         telegram,
       };
     },
+    contactEmails() {
+      return (
+        this.contact.emails?.length ? this.contact.emails : [this.contact.email]
+      ).filter(Boolean);
+    },
   },
   watch: {
     'contact.id': {
@@ -238,14 +243,22 @@ export default {
         </p>
         <div class="flex flex-col items-start w-full gap-2">
           <ContactInfoRow
-            :href="contact.email ? `mailto:${contact.email}` : ''"
-            :value="contact.email"
+            v-for="email in contactEmails"
+            :key="email"
+            :href="`mailto:${email}`"
+            :value="email"
             icon="mail"
             emoji="✉️"
             :title="$t('CONTACT_PANEL.EMAIL_ADDRESS')"
             show-copy
             editable
             @update="value => onFieldUpdate('email', value)"
+          />
+          <ContactInfoRow
+            v-if="!contactEmails.length"
+            icon="mail"
+            emoji="✉️"
+            :title="$t('CONTACT_PANEL.EMAIL_ADDRESS')"
           />
           <ContactInfoRow
             :href="contact.phone_number ? `tel:${contact.phone_number}` : ''"

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -144,6 +144,25 @@ export default {
     onFieldUpdate(field, value) {
       this.updateContactField({ [field]: value });
     },
+    normalizeEmails(emails = []) {
+      return [
+        ...new Set(
+          emails
+            .map(emailAddress => emailAddress?.trim()?.toLowerCase())
+            .filter(Boolean)
+        ),
+      ];
+    },
+    onEmailUpdate(index, value) {
+      const emails = [...this.contactEmails];
+      emails.splice(index, 1, value);
+      const normalizedEmails = this.normalizeEmails(emails);
+
+      this.updateContactField({
+        email: normalizedEmails[0] || '',
+        emails: normalizedEmails,
+      });
+    },
     async updateContactField(attrs) {
       const contactId = this.contact.id;
       try {
@@ -243,8 +262,8 @@ export default {
         </p>
         <div class="flex flex-col items-start w-full gap-2">
           <ContactInfoRow
-            v-for="email in contactEmails"
-            :key="email"
+            v-for="(email, index) in contactEmails"
+            :key="`${email}-${index}`"
             :href="`mailto:${email}`"
             :value="email"
             icon="mail"
@@ -252,7 +271,7 @@ export default {
             :title="$t('CONTACT_PANEL.EMAIL_ADDRESS')"
             show-copy
             editable
-            @update="value => onFieldUpdate('email', value)"
+            @update="value => onEmailUpdate(index, value)"
           />
           <ContactInfoRow
             v-if="!contactEmails.length"

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -278,6 +278,8 @@ export default {
             icon="mail"
             emoji="✉️"
             :title="$t('CONTACT_PANEL.EMAIL_ADDRESS')"
+            editable
+            @update="value => onEmailUpdate(0, value)"
           />
           <ContactInfoRow
             :href="contact.phone_number ? `tel:${contact.phone_number}` : ''"

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/specs/ContactForm.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/specs/ContactForm.spec.js
@@ -1,0 +1,46 @@
+import { mount } from '@vue/test-utils';
+import ContactForm from '../ContactForm.vue';
+
+const globalStubs = {
+  NextButton: { template: '<button />' },
+  Avatar: { template: '<div />' },
+  ComboBox: { template: '<div />' },
+  ContactEmailsInput: {
+    name: 'ContactEmailsInput',
+    template: '<div />',
+  },
+  'woot-phone-input': { template: '<input />' },
+  'woot-input': { template: '<input />' },
+};
+
+describe('Conversation ContactForm', () => {
+  it('blocks submit when any alias email is invalid', async () => {
+    const onSubmit = vi.fn();
+    const wrapper = mount(ContactForm, {
+      props: {
+        contact: {
+          id: 1,
+          name: 'John Doe',
+          email: 'primary@example.com',
+          emails: ['primary@example.com'],
+          additional_attributes: {},
+        },
+        onSubmit,
+      },
+      global: {
+        mocks: {
+          $t: key => key,
+          $store: {
+            dispatch: vi.fn(),
+          },
+        },
+        stubs: globalStubs,
+      },
+    });
+
+    wrapper.vm.handleEmailsUpdate(['primary@example.com', 'not-an-email']);
+    await wrapper.vm.handleSubmit();
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/specs/ContactInfo.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/specs/ContactInfo.spec.js
@@ -1,0 +1,65 @@
+import { shallowMount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import ContactInfo from '../ContactInfo.vue';
+
+const ContactInfoRowStub = {
+  name: 'ContactInfoRow',
+  props: {
+    icon: String,
+    editable: Boolean,
+  },
+  template: '<div />',
+};
+
+const componentStubs = {
+  ContactInfoRow: ContactInfoRowStub,
+  Avatar: { template: '<div />' },
+  SocialIcons: { template: '<div />' },
+  EditContact: { template: '<div />' },
+  ContactMergeModal: { template: '<div />' },
+  ContactDeleteModal: { template: '<div />' },
+  ComposeConversation: { template: '<div><slot name="trigger" /></div>' },
+  NextButton: { template: '<button />' },
+  VoiceCallButton: { template: '<button />' },
+  InlineInput: { template: '<input />' },
+};
+
+describe('ContactInfo', () => {
+  it('keeps the empty email row editable', () => {
+    const store = createStore({
+      getters: {
+        getCurrentRole: () => 'administrator',
+        'contacts/getUIFlags': () => ({}),
+      },
+      actions: {
+        'contacts/fetchContactableInbox': vi.fn(),
+      },
+    });
+
+    const wrapper = shallowMount(ContactInfo, {
+      props: {
+        contact: {
+          id: 1,
+          name: 'John Doe',
+          email: '',
+          emails: [],
+          additional_attributes: {},
+        },
+      },
+      global: {
+        mocks: {
+          $t: key => key,
+          $route: { params: { accountId: 1 } },
+        },
+        plugins: [store],
+        stubs: componentStubs,
+      },
+    });
+
+    const emailRow = wrapper
+      .findAllComponents(ContactInfoRowStub)
+      .find(row => row.props('icon') === 'mail');
+
+    expect(emailRow.props('editable')).toBe(true);
+  });
+});

--- a/app/javascript/dashboard/store/modules/contacts/actions.js
+++ b/app/javascript/dashboard/store/modules/contacts/actions.js
@@ -12,12 +12,26 @@ import { CONTACTS_EVENTS } from '../../../helper/AnalyticsHelper/events';
 const buildContactFormData = contactParams => {
   const formData = new FormData();
   const { additional_attributes = {}, ...contactProperties } = contactParams;
-  Object.keys(contactProperties).forEach(key => {
-    if (contactProperties[key]) {
-      formData.append(key, contactProperties[key]);
+
+  const appendFormDataValue = (key, value) => {
+    if (Array.isArray(value)) {
+      value.forEach(item => {
+        if (item) {
+          formData.append(`${key}[]`, item);
+        }
+      });
+      return;
     }
+
+    if (value !== undefined && value !== null && value !== '') {
+      formData.append(key, value);
+    }
+  };
+
+  Object.keys(contactProperties).forEach(key => {
+    appendFormDataValue(key, contactProperties[key]);
   });
-  const { social_profiles, ...additionalAttributesProperties } =
+  const { social_profiles = {}, ...additionalAttributesProperties } =
     additional_attributes;
   Object.keys(additionalAttributesProperties).forEach(key => {
     formData.append(

--- a/app/javascript/dashboard/store/modules/contacts/actions.js
+++ b/app/javascript/dashboard/store/modules/contacts/actions.js
@@ -15,8 +15,13 @@ const buildContactFormData = contactParams => {
 
   const appendFormDataValue = (key, value) => {
     if (Array.isArray(value)) {
+      if (value.length === 0 && key === 'emails') {
+        formData.append(`${key}[]`, '');
+        return;
+      }
+
       value.forEach(item => {
-        if (item) {
+        if (item || item === '') {
           formData.append(`${key}[]`, item);
         }
       });

--- a/app/javascript/dashboard/store/modules/specs/contacts/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/contacts/actions.spec.js
@@ -148,6 +148,30 @@ describe('#actions', () => {
       expect(formData.get('email')).toBe('primary@example.com');
     });
 
+    it('appends a blank emails[] value for explicit empty multipart emails', async () => {
+      axios.patch.mockResolvedValue({ data: { payload: contactList[0] } });
+
+      await actions.update(
+        { commit },
+        {
+          id: contactList[0].id,
+          isFormData: true,
+          name: 'Fayaz',
+          email: '',
+          emails: [],
+          additionalAttributes: {
+            socialProfiles: {},
+          },
+        }
+      );
+
+      const [, formData] = axios.patch.mock.calls[0];
+
+      expect(formData).toBeInstanceOf(FormData);
+      expect(formData.getAll('emails[]')).toEqual(['']);
+      expect(formData.get('email')).toBe(null);
+    });
+
     it('sends correct actions if duplicate contact is found', async () => {
       axios.patch.mockRejectedValue({
         response: {

--- a/app/javascript/dashboard/store/modules/specs/contacts/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/contacts/actions.spec.js
@@ -121,6 +121,33 @@ describe('#actions', () => {
       ]);
     });
 
+    it('appends every email as emails[] for form data updates', async () => {
+      axios.patch.mockResolvedValue({ data: { payload: contactList[0] } });
+
+      await actions.update(
+        { commit },
+        {
+          id: contactList[0].id,
+          isFormData: true,
+          name: 'Fayaz',
+          email: 'primary@example.com',
+          emails: ['primary@example.com', 'alias@example.com'],
+          additionalAttributes: {
+            socialProfiles: {},
+          },
+        }
+      );
+
+      const [, formData] = axios.patch.mock.calls[0];
+
+      expect(formData).toBeInstanceOf(FormData);
+      expect(formData.getAll('emails[]')).toEqual([
+        'primary@example.com',
+        'alias@example.com',
+      ]);
+      expect(formData.get('email')).toBe('primary@example.com');
+    });
+
     it('sends correct actions if duplicate contact is found', async () => {
       axios.patch.mockRejectedValue({
         response: {

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -2,17 +2,17 @@ class SendReplyJob < ApplicationJob
   queue_as :high
 
   CHANNEL_SERVICES = {
-    'Channel::TwitterProfile' => ::Twitter::SendOnTwitterService,
-    'Channel::TwilioSms' => ::Twilio::SendOnTwilioService,
-    'Channel::Line' => ::Line::SendOnLineService,
-    'Channel::Telegram' => ::Telegram::SendOnTelegramService,
-    'Channel::Whatsapp' => ::Whatsapp::SendOnWhatsappService,
-    'Channel::Sms' => ::Sms::SendOnSmsService,
-    'Channel::Instagram' => ::Instagram::SendOnInstagramService,
-    'Channel::Tiktok' => ::Tiktok::SendOnTiktokService,
-    'Channel::Email' => ::Email::SendOnEmailService,
-    'Channel::WebWidget' => ::Messages::SendEmailNotificationService,
-    'Channel::Api' => ::Messages::SendEmailNotificationService
+    'Channel::TwitterProfile' => 'Twitter::SendOnTwitterService',
+    'Channel::TwilioSms' => 'Twilio::SendOnTwilioService',
+    'Channel::Line' => 'Line::SendOnLineService',
+    'Channel::Telegram' => 'Telegram::SendOnTelegramService',
+    'Channel::Whatsapp' => 'Whatsapp::SendOnWhatsappService',
+    'Channel::Sms' => 'Sms::SendOnSmsService',
+    'Channel::Instagram' => 'Instagram::SendOnInstagramService',
+    'Channel::Tiktok' => 'Tiktok::SendOnTiktokService',
+    'Channel::Email' => 'Email::SendOnEmailService',
+    'Channel::WebWidget' => 'Messages::SendEmailNotificationService',
+    'Channel::Api' => 'Messages::SendEmailNotificationService'
   }.freeze
 
   def perform(message_id)
@@ -21,10 +21,10 @@ class SendReplyJob < ApplicationJob
 
     return send_on_facebook_page(message) if channel_name == 'Channel::FacebookPage'
 
-    service_class = CHANNEL_SERVICES[channel_name]
-    return unless service_class
+    service_class_name = CHANNEL_SERVICES[channel_name]
+    return unless service_class_name
 
-    service_class.new(message: message).perform
+    service_class_name.constantize.new(message: message).perform
   end
 
   private

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -191,7 +191,7 @@ class ConversationReplyMailer < ApplicationMailer
 
   def to_emails
     # if there is no to_emails from content_attributes, send it to @contact&.email
-    to_emails_from_content_attributes.presence || [@contact&.email]
+    to_emails_from_content_attributes.presence || [preferred_contact_reply_email || @contact&.email]
   end
 
   def inbound_email_enabled?
@@ -203,5 +203,11 @@ class ConversationReplyMailer < ApplicationMailer
     return false if action_name == 'reply_without_summary' || action_name == 'email_reply'
 
     'mailer/base'
+  end
+
+  def preferred_contact_reply_email
+    source_id = @conversation.contact_inbox&.source_id.to_s.downcase
+    return if source_id.blank?
+    return source_id if @contact.all_emails.include?(source_id)
   end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -56,17 +56,20 @@ class Contact < ApplicationRecord
             format: { with: /\+[1-9]\d{1,14}\z/, message: I18n.t('errors.contacts.phone_number.invalid') }
 
   belongs_to :account
+  has_many :contact_emails, dependent: :destroy_async
   has_many :conversations, dependent: :destroy_async
   has_many :contact_inboxes, dependent: :destroy_async
   has_many :csat_survey_responses, dependent: :destroy_async
   has_many :inboxes, through: :contact_inboxes
   has_many :messages, as: :sender, dependent: :destroy_async
   has_many :notes, dependent: :destroy_async
+  has_one :primary_contact_email, -> { primary }, class_name: 'ContactEmail'
   before_validation :prepare_contact_attributes
   after_create_commit :dispatch_create_event, :ip_lookup
   after_update_commit :dispatch_update_event
   after_destroy_commit :dispatch_destroy_event
   before_save :sync_contact_attributes
+  after_save :sync_primary_contact_email, if: :saved_change_to_email?
 
   enum contact_type: { visitor: 0, lead: 1, customer: 2 }
 
@@ -142,6 +145,14 @@ class Contact < ApplicationRecord
       .where('contacts.created_at < ?', time_period)
       .where.missing(:conversations)
   }
+  scope :matching_email, lambda { |email|
+    normalized_email = email.to_s.downcase
+    next none if normalized_email.blank?
+
+    left_outer_joins(:contact_emails)
+      .where('contacts.email = :email OR contact_emails.email = :email', email: normalized_email)
+      .distinct
+  }
 
   def get_source_id(inbox_id)
     contact_inboxes.find_by!(inbox_id: inbox_id).source_id
@@ -190,7 +201,14 @@ class Contact < ApplicationRecord
   end
 
   def self.from_email(email)
-    find_by(email: email&.downcase)
+    matching_email(email).first
+  end
+
+  def all_emails
+    emails = contact_emails.order(primary: :desc, id: :asc).pluck(:email)
+    return emails if primary_contact_email.present? || email.blank?
+
+    [email, *emails.reject { |contact_email| contact_email == email }]
   end
 
   private
@@ -230,6 +248,18 @@ class Contact < ApplicationRecord
 
   def sync_contact_attributes
     ::Contacts::SyncAttributes.new(self).perform
+  end
+
+  def sync_primary_contact_email
+    if email.present?
+      primary_email = contact_emails.find_or_initialize_by(email: email)
+      contact_emails.primary.where.not(id: primary_email.id).update_all(primary: false, updated_at: Time.current)
+      primary_email.account = account
+      primary_email.primary = true
+      primary_email.save! if primary_email.changed?
+    else
+      contact_emails.primary.destroy_all
+    end
   end
 
   def dispatch_create_event

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -170,6 +170,7 @@ class Contact < ApplicationRecord
       additional_attributes: additional_attributes,
       custom_attributes: custom_attributes,
       email: email,
+      emails: all_emails,
       id: id,
       identifier: identifier,
       name: name,

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -41,6 +41,7 @@
 
 # rubocop:enable Layout/LineLength
 
+# rubocop:disable Metrics/ClassLength
 class Contact < ApplicationRecord
   include Avatarable
   include AvailabilityStatusable
@@ -64,7 +65,12 @@ class Contact < ApplicationRecord
   has_many :inboxes, through: :contact_inboxes
   has_many :messages, as: :sender, dependent: :destroy_async
   has_many :notes, dependent: :destroy_async
-  has_one :primary_contact_email, -> { primary }, class_name: 'ContactEmail'
+  # This scoped alias points at the same rows as contact_emails, which already owns lifecycle cleanup.
+  # rubocop:disable Rails/HasManyOrHasOneDependent
+  has_one :primary_contact_email, -> { primary },
+          class_name: 'ContactEmail',
+          inverse_of: :contact
+  # rubocop:enable Rails/HasManyOrHasOneDependent
   before_validation :prepare_contact_attributes
   after_create_commit :dispatch_create_event, :ip_lookup
   after_update_commit :dispatch_update_event
@@ -282,4 +288,5 @@ class Contact < ApplicationRecord
     )
   end
 end
+# rubocop:enable Metrics/ClassLength
 Contact.include_mod_with('Concerns::Contact')

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -70,7 +70,7 @@ class Contact < ApplicationRecord
   after_update_commit :dispatch_update_event
   after_destroy_commit :dispatch_destroy_event
   before_save :sync_contact_attributes
-  after_save :sync_primary_contact_email, if: :saved_change_to_email?
+  after_commit :sync_primary_email_identity, if: :saved_change_to_email?
 
   enum contact_type: { visitor: 0, lead: 1, customer: 2 }
 
@@ -260,16 +260,8 @@ class Contact < ApplicationRecord
     errors.add(:email, :taken) if existing_contact_email
   end
 
-  def sync_primary_contact_email
-    if email.present?
-      primary_email = contact_emails.find_or_initialize_by(email: email)
-      contact_emails.primary.where.not(id: primary_email.id).update_all(primary: false, updated_at: Time.current)
-      primary_email.account = account
-      primary_email.primary = true
-      primary_email.save! if primary_email.changed?
-    else
-      contact_emails.primary.destroy_all
-    end
+  def sync_primary_email_identity
+    Contacts::SyncPrimaryEmailIdentity.new(contact: self).perform
   end
 
   def dispatch_create_event

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -212,13 +212,21 @@ class Contact < ApplicationRecord
   end
 
   def all_emails
-    emails = contact_emails.order(primary: :desc, id: :asc).pluck(:email)
-    return emails if primary_contact_email.present? || email.blank?
+    emails = ordered_contact_email_records.map(&:email)
+    return emails if emails.first == email || email.blank?
 
     [email, *emails.reject { |contact_email| contact_email == email }]
   end
 
   private
+
+  def ordered_contact_email_records
+    if association(:contact_emails).loaded?
+      contact_emails.sort_by { |contact_email| [contact_email.primary ? 0 : 1, contact_email.id] }
+    else
+      contact_emails.order(primary: :desc, id: :asc)
+    end
+  end
 
   def ip_lookup
     return unless account.feature_enabled?('ip_lookup')

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -70,7 +70,7 @@ class Contact < ApplicationRecord
   after_update_commit :dispatch_update_event
   after_destroy_commit :dispatch_destroy_event
   before_save :sync_contact_attributes
-  after_commit :sync_primary_email_identity, if: :saved_change_to_email?
+  after_save :sync_primary_email_identity, if: :saved_change_to_email?
 
   enum contact_type: { visitor: 0, lead: 1, customer: 2 }
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -54,6 +54,7 @@ class Contact < ApplicationRecord
   validates :phone_number,
             allow_blank: true, uniqueness: { scope: [:account_id] },
             format: { with: /\+[1-9]\d{1,14}\z/, message: I18n.t('errors.contacts.phone_number.invalid') }
+  validate :email_uniqueness_across_contact_emails
 
   belongs_to :account
   has_many :contact_emails, dependent: :destroy_async
@@ -248,6 +249,15 @@ class Contact < ApplicationRecord
 
   def sync_contact_attributes
     ::Contacts::SyncAttributes.new(self).perform
+  end
+
+  def email_uniqueness_across_contact_emails
+    return if email.blank? || account_id.blank?
+
+    existing_contact_email = ContactEmail.where(account_id: account_id, email: email)
+                                         .where.not(contact_id: id)
+                                         .exists?
+    errors.add(:email, :taken) if existing_contact_email
   end
 
   def sync_primary_contact_email

--- a/app/models/contact_email.rb
+++ b/app/models/contact_email.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: contact_emails
+#
+#  id         :bigint           not null, primary key
+#  email      :string           not null
+#  primary    :boolean          default(FALSE), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  account_id :bigint           not null
+#  contact_id :bigint           not null
+#
+# Indexes
+#
+#  index_contact_emails_on_account_id                 (account_id)
+#  index_contact_emails_on_contact_id                 (contact_id)
+#  index_contact_emails_on_contact_id_primary_unique  (contact_id) UNIQUE WHERE ("primary" = true)
+#  index_contact_emails_on_lower_email_account_id     (lower((email)::text), account_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (account_id => accounts.id) ON DELETE => cascade
+#  fk_rails_...  (contact_id => contacts.id) ON DELETE => cascade
+#
 class ContactEmail < ApplicationRecord
   belongs_to :account
   belongs_to :contact

--- a/app/models/contact_email.rb
+++ b/app/models/contact_email.rb
@@ -35,6 +35,7 @@ class ContactEmail < ApplicationRecord
                     format: { with: Devise.email_regexp, message: I18n.t('errors.contacts.email.invalid') }
   validates :primary, uniqueness: { scope: :contact_id }, if: :primary?
   validate :contact_belongs_to_account
+  validate :email_uniqueness_across_contacts
 
   private
 
@@ -47,5 +48,14 @@ class ContactEmail < ApplicationRecord
     return if contact.account_id == account_id
 
     errors.add(:contact, :invalid)
+  end
+
+  def email_uniqueness_across_contacts
+    return if email.blank? || account_id.blank?
+
+    existing_contact = Contact.where(account_id: account_id, email: email)
+                              .where.not(id: contact_id)
+                              .exists?
+    errors.add(:email, :taken) if existing_contact
   end
 end

--- a/app/models/contact_email.rb
+++ b/app/models/contact_email.rb
@@ -1,0 +1,27 @@
+class ContactEmail < ApplicationRecord
+  belongs_to :account
+  belongs_to :contact
+
+  scope :primary, -> { where(primary: true) }
+
+  before_validation :normalize_email
+
+  validates :email, presence: true,
+                    uniqueness: { scope: :account_id, case_sensitive: false },
+                    format: { with: Devise.email_regexp, message: I18n.t('errors.contacts.email.invalid') }
+  validates :primary, uniqueness: { scope: :contact_id }, if: :primary?
+  validate :contact_belongs_to_account
+
+  private
+
+  def normalize_email
+    self.email = email&.downcase
+  end
+
+  def contact_belongs_to_account
+    return if contact.blank? || account.blank?
+    return if contact.account_id == account_id
+
+    errors.add(:contact, :invalid)
+  end
+end

--- a/app/models/contact_email.rb
+++ b/app/models/contact_email.rb
@@ -54,8 +54,12 @@ class ContactEmail < ApplicationRecord
     return if email.blank? || account_id.blank?
 
     existing_contact = Contact.where(account_id: account_id, email: email)
-                              .where.not(id: contact_id)
+                              .where.not(id: conflicting_contact_ids_to_ignore)
                               .exists?
     errors.add(:email, :taken) if existing_contact
+  end
+
+  def conflicting_contact_ids_to_ignore
+    [contact_id, contact_id_in_database].compact.uniq
   end
 end

--- a/app/services/contacts/replace_contact_emails.rb
+++ b/app/services/contacts/replace_contact_emails.rb
@@ -28,10 +28,11 @@ class Contacts::ReplaceContactEmails
 
   def replace_with_emails(normalized_emails)
     primary_email = normalized_emails.first
-    current_time = Time.current
 
     contact.contact_emails.where.not(email: normalized_emails).destroy_all
-    contact.contact_emails.where.not(email: primary_email).update_all(primary: false, updated_at: current_time)
+    contact.contact_emails.primary.where.not(email: primary_email).find_each do |contact_email|
+      contact_email.update!(primary: false)
+    end
 
     normalized_emails.each do |email|
       contact_email = contact.contact_emails.find_or_initialize_by(email: email)
@@ -55,7 +56,8 @@ class Contacts::ReplaceContactEmails
   def mirror_legacy_email(email)
     return if contact.email == email
 
-    contact.update_columns(email: email, updated_at: Time.current)
+    # Avoid callback recursion while mirroring the already-validated primary identity.
+    contact.update_columns(email: email, updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
   end
 end
 

--- a/app/services/contacts/replace_contact_emails.rb
+++ b/app/services/contacts/replace_contact_emails.rb
@@ -1,0 +1,62 @@
+class Contacts::ReplaceContactEmails
+  attr_reader :contact, :emails, :legacy_email
+
+  def initialize(contact:, emails:, legacy_email: nil)
+    @contact = contact
+    @emails = emails
+    @legacy_email = legacy_email
+  end
+
+  def perform
+    normalized_emails = normalized_email_list
+
+    Contact.transaction do
+      if normalized_emails.empty?
+        replace_with_empty_list
+      else
+        replace_with_emails(normalized_emails)
+      end
+    end
+  end
+
+  private
+
+  def replace_with_empty_list
+    contact.contact_emails.destroy_all
+    mirror_legacy_email(nil)
+  end
+
+  def replace_with_emails(normalized_emails)
+    primary_email = normalized_emails.first
+    current_time = Time.current
+
+    contact.contact_emails.where.not(email: normalized_emails).destroy_all
+    contact.contact_emails.where.not(email: primary_email).update_all(primary: false, updated_at: current_time)
+
+    normalized_emails.each do |email|
+      contact_email = contact.contact_emails.find_or_initialize_by(email: email)
+      contact_email.account = contact.account
+      contact_email.primary = email == primary_email
+      contact_email.save! if contact_email.changed?
+    end
+
+    mirror_legacy_email(primary_email)
+  end
+
+  def normalized_email_list
+    source_emails = emails.presence || [legacy_email]
+
+    Array(source_emails).filter_map do |email|
+      normalized_email = email.to_s.strip.downcase
+      normalized_email.presence
+    end.uniq
+  end
+
+  def mirror_legacy_email(email)
+    return if contact.email == email
+
+    contact.update_columns(email: email, updated_at: Time.current)
+  end
+end
+
+Contacts::ReplaceContactEmails.prepend_mod_with('Contacts::ReplaceContactEmails')

--- a/app/services/contacts/replace_contact_emails.rb
+++ b/app/services/contacts/replace_contact_emails.rb
@@ -17,6 +17,8 @@ class Contacts::ReplaceContactEmails
         replace_with_emails(normalized_emails)
       end
     end
+
+    contact.association(:contact_emails).reset
   end
 
   private

--- a/app/services/contacts/sync_primary_email_identity.rb
+++ b/app/services/contacts/sync_primary_email_identity.rb
@@ -6,7 +6,7 @@ class Contacts::SyncPrimaryEmailIdentity
   end
 
   def perform
-    return clear_contact_emails if contact.email.blank?
+    return sync_blank_primary_email if contact.email.blank?
 
     primary_contact_email = contact.contact_emails.find_or_initialize_by(email: contact.email)
 
@@ -19,8 +19,31 @@ class Contacts::SyncPrimaryEmailIdentity
 
   private
 
-  def clear_contact_emails
-    contact.contact_emails.destroy_all
+  def sync_blank_primary_email
+    current_primary_email&.destroy!
+
+    fallback_contact_email = remaining_contact_emails.first
+
+    if fallback_contact_email.present?
+      fallback_contact_email.update!(primary: true) unless fallback_contact_email.primary?
+      mirror_legacy_email(fallback_contact_email.email)
+    else
+      mirror_legacy_email(nil)
+    end
+  end
+
+  def current_primary_email
+    contact.contact_emails.primary.first
+  end
+
+  def remaining_contact_emails
+    contact.contact_emails.order(:id)
+  end
+
+  def mirror_legacy_email(email)
+    return if contact.email == email
+
+    contact.update_columns(email: email, updated_at: Time.current)
   end
 end
 

--- a/app/services/contacts/sync_primary_email_identity.rb
+++ b/app/services/contacts/sync_primary_email_identity.rb
@@ -1,0 +1,27 @@
+class Contacts::SyncPrimaryEmailIdentity
+  attr_reader :contact
+
+  def initialize(contact:)
+    @contact = contact
+  end
+
+  def perform
+    return clear_contact_emails if contact.email.blank?
+
+    primary_contact_email = contact.contact_emails.find_or_initialize_by(email: contact.email)
+
+    contact.contact_emails.where.not(id: primary_contact_email.id).update_all(primary: false, updated_at: Time.current)
+
+    primary_contact_email.account = contact.account
+    primary_contact_email.primary = true
+    primary_contact_email.save! if primary_contact_email.changed?
+  end
+
+  private
+
+  def clear_contact_emails
+    contact.contact_emails.destroy_all
+  end
+end
+
+Contacts::SyncPrimaryEmailIdentity.prepend_mod_with('Contacts::SyncPrimaryEmailIdentity')

--- a/app/services/contacts/sync_primary_email_identity.rb
+++ b/app/services/contacts/sync_primary_email_identity.rb
@@ -10,7 +10,9 @@ class Contacts::SyncPrimaryEmailIdentity
 
     primary_contact_email = contact.contact_emails.find_or_initialize_by(email: contact.email)
 
-    contact.contact_emails.where.not(id: primary_contact_email.id).update_all(primary: false, updated_at: Time.current)
+    contact.contact_emails.primary.where.not(id: primary_contact_email.id).find_each do |contact_email|
+      contact_email.update!(primary: false)
+    end
 
     primary_contact_email.account = contact.account
     primary_contact_email.primary = true
@@ -43,7 +45,8 @@ class Contacts::SyncPrimaryEmailIdentity
   def mirror_legacy_email(email)
     return if contact.email == email
 
-    contact.update_columns(email: email, updated_at: Time.current)
+    # Avoid callback recursion while mirroring the selected primary identity.
+    contact.update_columns(email: email, updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
   end
 end
 

--- a/app/services/contacts/sync_primary_email_identity.rb
+++ b/app/services/contacts/sync_primary_email_identity.rb
@@ -6,8 +6,18 @@ class Contacts::SyncPrimaryEmailIdentity
   end
 
   def perform
-    return sync_blank_primary_email if contact.email.blank?
+    if contact.email.blank?
+      sync_blank_primary_email
+    else
+      sync_present_primary_email
+    end
 
+    contact.association(:contact_emails).reset
+  end
+
+  private
+
+  def sync_present_primary_email
     primary_contact_email = contact.contact_emails.find_or_initialize_by(email: contact.email)
 
     contact.contact_emails.primary.where.not(id: primary_contact_email.id).find_each do |contact_email|
@@ -18,8 +28,6 @@ class Contacts::SyncPrimaryEmailIdentity
     primary_contact_email.primary = true
     primary_contact_email.save! if primary_contact_email.changed?
   end
-
-  private
 
   def sync_blank_primary_email
     current_primary_email&.destroy!

--- a/app/views/api/v1/models/_contact.json.jbuilder
+++ b/app/views/api/v1/models/_contact.json.jbuilder
@@ -1,6 +1,7 @@
 json.additional_attributes resource.additional_attributes
 json.availability_status resource.availability_status
 json.email resource.email
+json.emails resource.all_emails
 json.id resource.id
 json.name resource.name
 json.phone_number resource.phone_number

--- a/db/migrate/20260412120000_create_contact_emails.rb
+++ b/db/migrate/20260412120000_create_contact_emails.rb
@@ -41,7 +41,11 @@ class CreateContactEmails < ActiveRecord::Migration[7.0]
              CURRENT_TIMESTAMP
       FROM contacts
       WHERE contacts.email IS NOT NULL AND contacts.email <> ''
-      ORDER BY contacts.account_id, LOWER(contacts.email), contacts.created_at ASC, contacts.id ASC
+      ORDER BY contacts.account_id,
+               LOWER(contacts.email),
+               contacts.email = LOWER(contacts.email) DESC,
+               contacts.created_at ASC,
+               contacts.id ASC
     SQL
   end
 end

--- a/db/migrate/20260412120000_create_contact_emails.rb
+++ b/db/migrate/20260412120000_create_contact_emails.rb
@@ -1,8 +1,8 @@
 class CreateContactEmails < ActiveRecord::Migration[7.0]
   def up
     create_table :contact_emails do |t|
-      t.references :account, null: false, foreign_key: true
-      t.references :contact, null: false, foreign_key: true
+      t.references :account, null: false, foreign_key: { on_delete: :cascade }
+      t.references :contact, null: false, foreign_key: { on_delete: :cascade }
       t.string :email, null: false
       t.boolean :primary, null: false, default: false
 
@@ -18,7 +18,7 @@ class CreateContactEmails < ActiveRecord::Migration[7.0]
               name: 'index_contact_emails_on_contact_id_primary_unique'
 
     execute <<~SQL.squish
-      INSERT INTO contact_emails (account_id, contact_id, email, primary, created_at, updated_at)
+      INSERT INTO contact_emails (account_id, contact_id, email, "primary", created_at, updated_at)
       SELECT contacts.account_id, contacts.id, LOWER(contacts.email), TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
       FROM contacts
       WHERE contacts.email IS NOT NULL AND contacts.email <> ''

--- a/db/migrate/20260412120000_create_contact_emails.rb
+++ b/db/migrate/20260412120000_create_contact_emails.rb
@@ -9,6 +9,17 @@ class CreateContactEmails < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
+    create_indexes
+    backfill_contact_emails
+  end
+
+  def down
+    drop_table :contact_emails
+  end
+
+  private
+
+  def create_indexes
     add_index :contact_emails, 'LOWER(email), account_id',
               unique: true,
               name: 'index_contact_emails_on_lower_email_account_id'
@@ -16,16 +27,14 @@ class CreateContactEmails < ActiveRecord::Migration[7.0]
               unique: true,
               where: '"primary" = TRUE',
               name: 'index_contact_emails_on_contact_id_primary_unique'
+  end
 
+  def backfill_contact_emails
     execute <<~SQL.squish
       INSERT INTO contact_emails (account_id, contact_id, email, "primary", created_at, updated_at)
       SELECT contacts.account_id, contacts.id, LOWER(contacts.email), TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
       FROM contacts
       WHERE contacts.email IS NOT NULL AND contacts.email <> ''
     SQL
-  end
-
-  def down
-    drop_table :contact_emails
   end
 end

--- a/db/migrate/20260412120000_create_contact_emails.rb
+++ b/db/migrate/20260412120000_create_contact_emails.rb
@@ -32,9 +32,16 @@ class CreateContactEmails < ActiveRecord::Migration[7.0]
   def backfill_contact_emails
     execute <<~SQL.squish
       INSERT INTO contact_emails (account_id, contact_id, email, "primary", created_at, updated_at)
-      SELECT contacts.account_id, contacts.id, LOWER(contacts.email), TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      SELECT DISTINCT ON (contacts.account_id, LOWER(contacts.email))
+             contacts.account_id,
+             contacts.id,
+             LOWER(contacts.email),
+             TRUE,
+             CURRENT_TIMESTAMP,
+             CURRENT_TIMESTAMP
       FROM contacts
       WHERE contacts.email IS NOT NULL AND contacts.email <> ''
+      ORDER BY contacts.account_id, LOWER(contacts.email), contacts.created_at ASC, contacts.id ASC
     SQL
   end
 end

--- a/db/migrate/20260412120000_create_contact_emails.rb
+++ b/db/migrate/20260412120000_create_contact_emails.rb
@@ -1,0 +1,31 @@
+class CreateContactEmails < ActiveRecord::Migration[7.0]
+  def up
+    create_table :contact_emails do |t|
+      t.references :account, null: false, foreign_key: true
+      t.references :contact, null: false, foreign_key: true
+      t.string :email, null: false
+      t.boolean :primary, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :contact_emails, 'LOWER(email), account_id',
+              unique: true,
+              name: 'index_contact_emails_on_lower_email_account_id'
+    add_index :contact_emails, :contact_id,
+              unique: true,
+              where: '"primary" = TRUE',
+              name: 'index_contact_emails_on_contact_id_primary_unique'
+
+    execute <<~SQL.squish
+      INSERT INTO contact_emails (account_id, contact_id, email, primary, created_at, updated_at)
+      SELECT contacts.account_id, contacts.id, LOWER(contacts.email), TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      FROM contacts
+      WHERE contacts.email IS NOT NULL AND contacts.email <> ''
+    SQL
+  end
+
+  def down
+    drop_table :contact_emails
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -617,6 +617,19 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_30_114500) do
     t.index ["name", "account_id"], name: "index_companies_on_name_and_account_id"
   end
 
+  create_table "contact_emails", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "contact_id", null: false
+    t.string "email", null: false
+    t.boolean "primary", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index "lower((email)::text), account_id", name: "index_contact_emails_on_lower_email_account_id", unique: true
+    t.index ["account_id"], name: "index_contact_emails_on_account_id"
+    t.index ["contact_id"], name: "index_contact_emails_on_contact_id"
+    t.index ["contact_id"], name: "index_contact_emails_on_contact_id_primary_unique", unique: true, where: "(\"primary\" = true)"
+  end
+
   create_table "contact_inboxes", force: :cascade do |t|
     t.bigint "contact_id"
     t.bigint "inbox_id"
@@ -1318,6 +1331,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_30_114500) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "contact_emails", "accounts", on_delete: :cascade
+  add_foreign_key "contact_emails", "contacts", on_delete: :cascade
   add_foreign_key "inboxes", "portals"
   create_trigger("accounts_after_insert_row_tr", :generated => true, :compatibility => 1).
       on("accounts").

--- a/docs/superpowers/specs/2026-04-12-contact-id-search-and-multi-email-design.md
+++ b/docs/superpowers/specs/2026-04-12-contact-id-search-and-multi-email-design.md
@@ -1,0 +1,324 @@
+# Contact ID Search And Multi-Email Design
+
+## Summary
+
+This change adds two related contact-management improvements to Chatwoot:
+
+1. Contact merge search should support exact contact ID lookup in addition to the existing text-based contact search fields.
+2. Contacts should support multiple email addresses while preserving Chatwoot's current contact and email-channel behavior.
+
+The recommended implementation keeps `contacts.email` as the primary cached email for compatibility, but introduces a new `contact_emails` table as the source of truth for contact email identities. This gives us account-scoped uniqueness, direct lookup for inbound email matching, safer merge behavior, and a path to evolve the UI and API without rewriting every `contact.email` callsite in one PR.
+
+Twenty's local implementation was reviewed for inspiration. Twenty models multiple emails as a composite field with `primaryEmail` plus `additionalEmails`. That data shape is useful conceptually, but Chatwoot has stronger identity and routing requirements than a CRM-only record store. Because Chatwoot must do account-scoped uniqueness, relational merge reassignment, and inbound email lookup under concurrency, a dedicated table is the better fit here than a JSON array on `contacts`.
+
+## Goals
+
+- Let agents find merge targets by typing an exact contact ID into the merge combobox.
+- Allow a single contact to own multiple email addresses.
+- Treat every stored contact email as a real identity for:
+  - inbound email matching
+  - contact search
+  - contact merge
+  - email continuity and reply addressing
+- Preserve backward compatibility for the majority of existing code that reads `contact.email`.
+
+## Non-Goals
+
+- Full replacement of every `contact.email` reference in the codebase.
+- A broad redesign of contact editing UI beyond what is needed to create, edit, and display multiple emails.
+- A generalized polymorphic identity system for phone numbers, social handles, or external IDs.
+- Bulk migration of all filters and integrations to expose new secondary-email semantics in one pass, unless required by the paths touched in this feature.
+
+## Current State
+
+### Merge Search
+
+The merge UI in `app/javascript/dashboard/components-next/Contacts/ContactsSidebar/ContactMerge.vue` uses `ContactAPI.search(query)`. The backend `GET /contacts/search` endpoint in `Api::V1::Accounts::ContactsController#search` currently matches:
+
+- `name ILIKE`
+- `email ILIKE`
+- `phone_number ILIKE`
+- `contacts.identifier LIKE`
+
+It does not match `contacts.id`, which is why numeric contact IDs such as `133741` are not discoverable from the merge picker today.
+
+### Email Identity
+
+Chatwoot currently stores one email directly on `contacts.email` and enforces account-scoped uniqueness there. Email-specific behavior is spread across:
+
+- `Contact.from_email`
+- `ContactInboxWithContactBuilder`
+- `Mailbox::ConversationFinderStrategies::NewConversationStrategy`
+- `Imap::ImapMailbox`
+- `DataImport::ContactManager`
+- `ContactMergeAction`
+- `ConversationReplyMailer`
+- dashboard contact CRUD/search UI
+- enterprise services that derive company or prompt data from `contact.email`
+
+This works for single-email contacts, but it prevents one contact from legitimately owning more than one email identity.
+
+## Proposed Design
+
+### 1. New `contact_emails` table
+
+Add a new model:
+
+- `ContactEmail`
+- columns:
+  - `id`
+  - `account_id`
+  - `contact_id`
+  - `email`
+  - `primary` boolean
+  - timestamps
+
+Constraints and indexes:
+
+- unique index on normalized email per account
+- unique partial index on one primary email per contact
+- foreign keys to `accounts` and `contacts`
+
+Rules:
+
+- all emails are normalized to lowercase before validation and persistence
+- each stored email must match `Devise.email_regexp`
+- each contact may have zero emails, or one or more emails with exactly one primary when any email rows exist
+- `contact_emails.account_id` must match `contact.account_id`
+
+### 2. Keep `contacts.email` as a compatibility mirror
+
+`contacts.email` remains in place for now, but it becomes a cached mirror of the primary contact email.
+
+Behavior:
+
+- when a contact has a primary `contact_email`, `contacts.email` must equal that primary email
+- when a contact has no email rows, `contacts.email` is `nil`
+- existing serializers and untouched code paths can continue reading `contact.email`
+
+This lets us ship the identity change without an all-at-once API break.
+
+### 3. Contact model helpers
+
+Extend `Contact` with helpers along these lines:
+
+- `has_many :contact_emails`
+- `has_one :primary_contact_email, -> { where(primary: true) }, class_name: 'ContactEmail'`
+- `primary_email`
+- `all_emails`
+- `email?`
+- updated `from_email`
+
+`Contact.from_email(email)` should resolve via `contact_emails` rather than the legacy column.
+
+For search and preload efficiency, this query should join or subquery against `contact_emails` instead of scanning JSON or Ruby-side collections.
+
+### 4. Migration strategy
+
+The migration should backfill one primary `contact_emails` row from each non-null `contacts.email`.
+
+Steps:
+
+1. Create `contact_emails`.
+2. Backfill one primary row per existing `contacts.email`.
+3. Add or update model callbacks/service sync so primary changes keep `contacts.email` mirrored.
+4. Move targeted lookup/search/merge flows to the new table.
+
+The existing unique constraint on `contacts.email` stays in place for this PR. Because `contacts.email` mirrors only the primary contact email, and primary emails remain unique per account through `contact_emails`, the legacy constraint remains compatible with the rollout.
+
+## Feature 1: Merge Search By Contact ID
+
+### Backend
+
+Update `Api::V1::Accounts::ContactsController#search` so a numeric query can match exact `contacts.id`.
+
+Recommended behavior:
+
+- preserve existing fuzzy text search behavior for name/email/phone/identifier
+- add exact `contacts.id = ?` matching when the trimmed query is fully numeric
+
+Why exact numeric match instead of `ILIKE` on casted ID:
+
+- avoids broad accidental matches on large result sets
+- aligns with how users think about contact numbers as an exact identifier
+- keeps query behavior predictable
+
+### Frontend
+
+Update merge picker UI copy so the user can discover the capability:
+
+- placeholder/search hint should explicitly say `Search by name or ID`
+- result labels can continue showing `(ID: <id>) <name>`
+
+No API shape change is required for feature 1.
+
+## Feature 2: Multi-Email Contact Identity
+
+### Contact create/update API
+
+Augment the contacts API to accept a multi-email payload while staying backward compatible.
+
+Recommended request contract:
+
+- continue accepting legacy `email`
+- add `emails`, shaped as an array of strings or an object with explicit primary and additional values
+
+For this PR, the safest server contract is:
+
+- `email`: optional string for legacy clients
+- `emails`: optional array of strings
+
+Server-side normalization:
+
+- deduplicate case-insensitively
+- preserve first email as primary unless the client explicitly indicates another primary in a future enhancement
+- if only `email` is provided, treat it as a single primary email
+- if `emails` is provided, derive `contacts.email` from the chosen primary
+
+This keeps the API simple while the dashboard is the only writer.
+
+### Dashboard contact UI
+
+Update the contact edit/create form to support multiple emails:
+
+- show one primary email input and an editable list of additional email inputs
+- keep the primary email visually distinct
+- normalize and dedupe client-side where convenient, but rely on server validation as the authority
+
+Display:
+
+- contact sidebar and contact profile should show the primary email prominently
+- secondary emails should also be visible where an agent expects to verify contact identity
+
+### Lookup and inbound email matching
+
+These flows must use `contact_emails` instead of only `contacts.email`:
+
+- `Contact.from_email`
+- `ContactInboxWithContactBuilder#find_contact_by_email`
+- `DataImport::ContactManager#find_contact_by_email`
+- `Mailbox::ConversationFinderStrategies::NewConversationStrategy#find_or_create_contact`
+- `Imap::ImapMailbox#find_or_create_contact`
+- `ContactIdentifyAction` email-based merge path
+
+Matching rule:
+
+- any normalized email owned by the contact should resolve the contact
+
+### Email continuity and reply addressing
+
+A contact may have multiple valid email identities. For outbound continuity, the reply should prefer the actual address tied to the current email conversation when available, not blindly the primary email.
+
+Recommended behavior:
+
+- if the current conversation is an email conversation and `conversation.contact_inbox.source_id` is one of the contact's emails, use that as the first `to` address
+- otherwise fall back to the contact's primary email
+- if explicit `to_emails` exist in message content attributes, they still take precedence
+
+This preserves continuity when the contact wrote from a secondary email address.
+
+### Merge behavior
+
+`ContactMergeAction` must merge email identities, not just scalar `contacts.email`.
+
+Rules:
+
+- reassign all `contact_emails` from mergee to base contact
+- if both contacts own overlapping normalized emails, collapse duplicates safely
+- preserve the base contact's primary email if present
+- if the base has no primary and mergee does, promote one merged email to primary
+- after merge, sync `contacts.email` from the resulting primary
+
+This is the core reason to prefer rows over JSON arrays: merge is a relational reassignment problem.
+
+### Search behavior
+
+Contact search should match:
+
+- contact name
+- any `contact_emails.email`
+- phone number
+- identifier
+- exact numeric `contacts.id` when query is numeric
+
+The response payload remains backward compatible by returning:
+
+- `email` as the primary email
+- `emails` as the full ordered list for the contact endpoints used by the dashboard
+
+For this PR, `show`, `index`, and `search` contact payloads include `emails`.
+
+## Enterprise Compatibility
+
+Enterprise code currently reads `contact.email` in several places, including company association and LLM prompt helpers. Because `contacts.email` remains mirrored from the primary email, those paths should continue to work without enterprise-specific overrides for the first PR.
+
+Still, touched areas should be reviewed for:
+
+- direct email lookup logic that should move to `Contact.from_email`
+- places where showing only the primary email would be misleading
+
+## Testing Strategy
+
+Follow TDD with focused request/model/service specs first.
+
+### Backend
+
+- `ContactsController` search spec:
+  - exact contact ID search returns the correct contact
+  - email search matches secondary emails
+- `ContactsController` create/update/show spec:
+  - accepts `emails`
+  - mirrors the primary email to `contacts.email`
+  - returns `emails` in payloads
+- `ContactEmail` model spec:
+  - normalization
+  - uniqueness per account
+  - one-primary rule
+  - account/contact consistency
+- `Contact` model or service spec:
+  - `from_email` resolves primary and secondary emails
+  - primary email mirrors to `contacts.email`
+- `ContactMergeAction` spec:
+  - merged contacts keep all unique emails
+  - primary precedence is correct
+  - duplicates collapse
+- mailbox/contact builder specs:
+  - inbound email from a secondary email resolves the correct existing contact
+- mailer/service spec:
+  - email replies prefer the current email conversation address before primary fallback
+
+### Frontend
+
+- contact API spec for `emails` request and response payloads
+- contact form/component tests for multi-email editing behavior
+- merge component test for copy/search intent if practical
+
+## Risks
+
+### Legacy uniqueness drift
+
+If `contacts.email` keeps a unique database index while secondary emails are added in `contact_emails`, the old constraint can become a rollout blocker or create redundant invariants. The migration and validation plan must explicitly reconcile this.
+
+### Conversation reply target ambiguity
+
+Once multiple emails exist, defaulting all outbound email continuity to `contact.email` can send replies to the wrong address. The conversation-specific email identity must be preferred when present.
+
+### Partial adoption bugs
+
+If some lookup paths are migrated and others still rely directly on `contacts.email`, behavior will feel inconsistent. The implementation plan should group all email-identity entry points into the first backend slice.
+
+## Recommended Implementation Slices
+
+1. Add `contact_emails`, backfill, model helpers, and primary mirroring.
+2. Add exact numeric contact ID search for merge and general contact search.
+3. Migrate backend identity lookups and merge logic to `contact_emails`.
+4. Add dashboard multi-email form support and payload updates.
+5. Update email reply continuity to prefer the conversation's actual email identity.
+6. Expand any remaining touched serializers/views with `emails` where required.
+
+## Open Decisions Resolved
+
+- Use exact numeric match for contact ID search.
+- Use a dedicated `contact_emails` table rather than JSON on `contacts`.
+- Keep `contacts.email` as a mirrored primary email for compatibility.
+- Treat all stored emails as first-class identities for inbound matching, search, merge, and email continuity.

--- a/spec/actions/contact_identify_action_spec.rb
+++ b/spec/actions/contact_identify_action_spec.rb
@@ -76,6 +76,18 @@ describe ContactIdentifyAction do
         expect(result.identifier).to eq params[:identifier]
         expect(result.email).to be_nil
       end
+
+      it 'merges the current contact to a contact matched by secondary email' do
+        existing_email_contact = create(:contact, account: account, email: 'primary@test.com', name: 'old name')
+        create(:contact_email, account: account, contact: existing_email_contact, email: 'secondary@test.com')
+
+        params = { name: 'new name', email: 'secondary@test.com' }
+        result = described_class.new(contact: contact, params: params).perform
+
+        expect(result.id).to eq existing_email_contact.id
+        expect(result.name).to eq 'new name'
+        expect { contact.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
 
     context 'when contact with same phone_number exists' do

--- a/spec/actions/contact_merge_action_spec.rb
+++ b/spec/actions/contact_merge_action_spec.rb
@@ -40,6 +40,32 @@ describe ContactMergeAction do
       expect(base_contact.custom_attributes['val_empty_new']).to eq('')
     end
 
+    it 'moves unique mergee email identities onto the base contact without changing the base primary email' do
+      create(:contact_email, account: account, contact: base_contact, email: 'shared@example.com')
+      create(:contact_email, account: account, contact: mergee_contact, email: 'alias@example.com')
+
+      contact_merge
+
+      base_contact.reload
+
+      expect(base_contact.email).to eq('old@old.com')
+      expect(base_contact.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq([
+                                                                                                                ['old@old.com', true],
+                                                                                                                ['alias@example.com', false],
+                                                                                                                ['new@new.com', false],
+                                                                                                                ['shared@example.com', false]
+                                                                                                              ])
+    end
+
+    it 'avoids duplicating identities the base contact already has' do
+      create(:contact_email, account: account, contact: base_contact, email: 'shared@example.com')
+      mergee_contact.update_column(:email, 'shared@example.com')
+
+      contact_merge
+
+      expect(base_contact.reload.contact_emails.where(email: 'shared@example.com').count).to eq(1)
+    end
+
     context 'when base contact and merge contact are same' do
       it 'does not delete contact' do
         mergee_contact = base_contact

--- a/spec/actions/contact_merge_action_spec.rb
+++ b/spec/actions/contact_merge_action_spec.rb
@@ -78,6 +78,14 @@ describe ContactMergeAction do
       expect(base_contact.reload.contact_emails.where(email: 'shared@example.com').count).to eq(1)
     end
 
+    it 'treats case-only legacy email drift as the same identity' do
+      create(:contact_email, account: account, contact: base_contact, email: 'alias@example.com')
+      mergee_contact.update_column(:email, 'Alias@Example.com')
+
+      expect { contact_merge }.not_to raise_error
+      expect(base_contact.reload.contact_emails.where(email: 'alias@example.com').count).to eq(1)
+    end
+
     context 'when base contact and merge contact are same' do
       it 'does not delete contact' do
         mergee_contact = base_contact

--- a/spec/actions/contact_merge_action_spec.rb
+++ b/spec/actions/contact_merge_action_spec.rb
@@ -57,20 +57,25 @@ describe ContactMergeAction do
                                                                                                               ])
     end
 
-    it 'avoids duplicating identities the base contact already has' do
-      connection = ActiveRecord::Base.connection
+    it 'moves a unique mergee legacy email drift onto the base contact as a non-primary identity' do
+      mergee_contact.update_column(:email, 'drift@example.com')
 
+      contact_merge
+
+      expect(base_contact.reload.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq([
+                                                                                                                      ['old@old.com', true],
+                                                                                                                      ['drift@example.com', false],
+                                                                                                                      ['new@new.com', false]
+                                                                                                                    ])
+    end
+
+    it 'avoids duplicating identities the base contact already has' do
       create(:contact_email, account: account, contact: base_contact, email: 'shared@example.com')
-      connection.execute('DROP INDEX IF EXISTS index_contact_emails_on_lower_email_account_id')
-      build(:contact_email, account: account, contact: mergee_contact, email: 'shared@example.com').save!(validate: false)
+      mergee_contact.update_column(:email, 'shared@example.com')
 
       contact_merge
 
       expect(base_contact.reload.contact_emails.where(email: 'shared@example.com').count).to eq(1)
-    ensure
-      duplicate_ids = ContactEmail.where(account_id: account.id, email: 'shared@example.com').order(:id).offset(1).pluck(:id)
-      ContactEmail.where(id: duplicate_ids).delete_all if duplicate_ids.any?
-      connection.execute('CREATE UNIQUE INDEX IF NOT EXISTS index_contact_emails_on_lower_email_account_id ON contact_emails (lower((email)::text), account_id)')
     end
 
     context 'when base contact and merge contact are same' do

--- a/spec/actions/contact_merge_action_spec.rb
+++ b/spec/actions/contact_merge_action_spec.rb
@@ -58,12 +58,19 @@ describe ContactMergeAction do
     end
 
     it 'avoids duplicating identities the base contact already has' do
+      connection = ActiveRecord::Base.connection
+
       create(:contact_email, account: account, contact: base_contact, email: 'shared@example.com')
-      mergee_contact.update_column(:email, 'shared@example.com')
+      connection.execute('DROP INDEX IF EXISTS index_contact_emails_on_lower_email_account_id')
+      build(:contact_email, account: account, contact: mergee_contact, email: 'shared@example.com').save!(validate: false)
 
       contact_merge
 
       expect(base_contact.reload.contact_emails.where(email: 'shared@example.com').count).to eq(1)
+    ensure
+      duplicate_ids = ContactEmail.where(account_id: account.id, email: 'shared@example.com').order(:id).offset(1).pluck(:id)
+      ContactEmail.where(id: duplicate_ids).delete_all if duplicate_ids.any?
+      connection.execute('CREATE UNIQUE INDEX IF NOT EXISTS index_contact_emails_on_lower_email_account_id ON contact_emails (lower((email)::text), account_id)')
     end
 
     context 'when base contact and merge contact are same' do

--- a/spec/actions/contact_merge_action_spec.rb
+++ b/spec/actions/contact_merge_action_spec.rb
@@ -49,29 +49,33 @@ describe ContactMergeAction do
       base_contact.reload
 
       expect(base_contact.email).to eq('old@old.com')
-      expect(base_contact.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq([
-                                                                                                                ['old@old.com', true],
-                                                                                                                ['alias@example.com', false],
-                                                                                                                ['new@new.com', false],
-                                                                                                                ['shared@example.com', false]
-                                                                                                              ])
+      expect(base_contact.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq(
+        [
+          ['old@old.com', true],
+          ['alias@example.com', false],
+          ['new@new.com', false],
+          ['shared@example.com', false]
+        ]
+      )
     end
 
     it 'moves a unique mergee legacy email drift onto the base contact as a non-primary identity' do
-      mergee_contact.update_column(:email, 'drift@example.com')
+      mergee_contact.update_column(:email, 'drift@example.com') # rubocop:disable Rails/SkipsModelValidations
 
       contact_merge
 
-      expect(base_contact.reload.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq([
-                                                                                                                      ['old@old.com', true],
-                                                                                                                      ['drift@example.com', false],
-                                                                                                                      ['new@new.com', false]
-                                                                                                                    ])
+      expect(base_contact.reload.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq(
+        [
+          ['old@old.com', true],
+          ['drift@example.com', false],
+          ['new@new.com', false]
+        ]
+      )
     end
 
     it 'avoids duplicating identities the base contact already has' do
       create(:contact_email, account: account, contact: base_contact, email: 'shared@example.com')
-      mergee_contact.update_column(:email, 'shared@example.com')
+      mergee_contact.update_column(:email, 'shared@example.com') # rubocop:disable Rails/SkipsModelValidations
 
       contact_merge
 
@@ -80,7 +84,7 @@ describe ContactMergeAction do
 
     it 'treats case-only legacy email drift as the same identity' do
       create(:contact_email, account: account, contact: base_contact, email: 'alias@example.com')
-      mergee_contact.update_column(:email, 'Alias@Example.com')
+      mergee_contact.update_column(:email, 'Alias@Example.com') # rubocop:disable Rails/SkipsModelValidations
 
       expect { contact_merge }.not_to raise_error
       expect(base_contact.reload.contact_emails.where(email: 'alias@example.com').count).to eq(1)

--- a/spec/builders/contact_inbox_with_contact_builder_spec.rb
+++ b/spec/builders/contact_inbox_with_contact_builder_spec.rb
@@ -82,6 +82,22 @@ describe ContactInboxWithContactBuilder do
       expect(contact_inbox.contact.id).to be(contact.id)
     end
 
+    it 'doesnot create contact if it already exist with a secondary email' do
+      create(:contact_email, account: account, contact: contact, email: 'secondary@example.com')
+
+      contact_inbox = described_class.new(
+        source_id: '123456',
+        inbox: inbox,
+        contact_attributes: {
+          name: 'Contact',
+          phone_number: '+1234567890',
+          email: 'secondary@example.com'
+        }
+      ).perform
+
+      expect(contact_inbox.contact.id).to be(contact.id)
+    end
+
     it 'doesnot create contact if it already exist with phone number' do
       contact_inbox = described_class.new(
         source_id: '123456',

--- a/spec/builders/v2/reports/label_summary_builder_spec.rb
+++ b/spec/builders/v2/reports/label_summary_builder_spec.rb
@@ -350,9 +350,16 @@ RSpec.describe V2::Reports::LabelSummaryBuilder do
             conversation.label_list
             conversation.save!
 
-            conversation.resolved!
-            conversation.open!
-            conversation.resolved!
+            2.times do
+              create(:reporting_event,
+                     account: account2,
+                     inbox: inbox,
+                     user: user,
+                     conversation: conversation,
+                     name: 'conversation_resolved',
+                     value: 3600,
+                     created_at: test_date.to_time + 1.hour)
+            end
           end
         end
       end

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -808,6 +808,26 @@ RSpec.describe 'Contacts API', type: :request do
         expect(payload['emails']).to eq(['new-primary@example.com', 'other@example.com'])
       end
 
+      it 'rolls back contact changes when email replacement fails' do
+        contact.update!(name: 'Original Name', email: 'primary@example.com')
+        create(:contact_email, account: account, contact: contact, email: 'secondary@example.com')
+        create(:contact, account: account, email: 'taken@example.com')
+
+        patch "/api/v1/accounts/#{account.id}/contacts/#{contact.id}",
+              params: { name: 'Changed Name', emails: ['new-primary@example.com', 'taken@example.com'] },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['message']).to be_present
+        expect(response.parsed_body['attributes']).to include(:email).or include('email')
+
+        contact.reload
+        expect(contact.name).to eq('Original Name')
+        expect(contact.email).to eq('primary@example.com')
+        expect(contact.all_emails).to eq(['primary@example.com', 'secondary@example.com'])
+      end
+
       it 'clears all contact emails when emails is explicitly empty' do
         contact.update!(email: 'primary@example.com')
         create(:contact_email, account: account, contact: contact, email: 'secondary@example.com')

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -402,6 +402,21 @@ RSpec.describe 'Contacts API', type: :request do
         expect(payload.first['emails']).to eq([contact2.email, 'secondary@example.com'])
       end
 
+      it 'matches the contact by the legacy contact email when identity rows are absent' do
+        legacy_contact = create(:contact, account: account)
+        legacy_contact.update_columns(email: 'legacy-only@example.com')
+
+        get "/api/v1/accounts/#{account.id}/contacts/search",
+            params: { q: 'legacy-only@example.com' },
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+
+        payload = response.parsed_body['payload']
+        expect(payload.pluck('id')).to include(legacy_contact.id)
+      end
+
       it 'matches the resolved contact respecting the identifier character casing' do
         contact_normal = create(:contact, name: 'testcontact', account: account, identifier: 'testidentifer')
         contact_special = create(:contact, name: 'testcontact', account: account, identifier: 'TestIdentifier')
@@ -791,6 +806,21 @@ RSpec.describe 'Contacts API', type: :request do
         expect(contact.all_emails).to eq(['new-primary@example.com', 'other@example.com'])
         expect(payload['email']).to eq('new-primary@example.com')
         expect(payload['emails']).to eq(['new-primary@example.com', 'other@example.com'])
+      end
+
+      it 'clears all contact emails when emails is explicitly empty' do
+        contact.update!(email: 'primary@example.com')
+        create(:contact_email, account: account, contact: contact, email: 'secondary@example.com')
+
+        patch "/api/v1/accounts/#{account.id}/contacts/#{contact.id}",
+              params: { emails: [] },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(contact.reload.email).to be_nil
+        expect(contact.contact_emails).to be_empty
+        expect(response.parsed_body['payload']['emails']).to eq([])
       end
 
       it 'allows unblocking of contact' do

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -68,6 +68,22 @@ RSpec.describe 'Contacts API', type: :request do
         expect(contact_inboxes).to eq([])
       end
 
+      it 'returns the full ordered email list for each contact' do
+        secondary_email = create(:contact_email, account: account, contact: contact, email: 'secondary@example.com')
+        tertiary_email = create(:contact_email, account: account, contact: contact, email: 'tertiary@example.com')
+
+        get "/api/v1/accounts/#{account.id}/contacts?include_contact_inboxes=false",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+
+        contact_payload = response.parsed_body['payload'].find { |payload| payload['id'] == contact.id }
+
+        expect(contact_payload['email']).to eq(contact.email)
+        expect(contact_payload['emails']).to eq([contact.email, secondary_email.email, tertiary_email.email])
+      end
+
       it 'returns limited information on inboxes' do
         get "/api/v1/accounts/#{account.id}/contacts?include_contact_inboxes=true",
             headers: admin.create_new_auth_token,
@@ -359,6 +375,33 @@ RSpec.describe 'Contacts API', type: :request do
         expect(response.body).not_to include(contact1.email)
       end
 
+      it 'matches the contact by an exact numeric id' do
+        get "/api/v1/accounts/#{account.id}/contacts/search",
+            params: { q: contact2.id.to_s },
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+
+        payload = response.parsed_body['payload']
+        expect(payload.pluck('id')).to eq([contact2.id])
+      end
+
+      it 'matches the contact by a secondary email' do
+        create(:contact_email, account: account, contact: contact2, email: 'secondary@example.com')
+
+        get "/api/v1/accounts/#{account.id}/contacts/search",
+            params: { q: 'secondary@example.com' },
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+
+        payload = response.parsed_body['payload']
+        expect(payload.pluck('id')).to eq([contact2.id])
+        expect(payload.first['emails']).to eq([contact2.email, 'secondary@example.com'])
+      end
+
       it 'matches the resolved contact respecting the identifier character casing' do
         contact_normal = create(:contact, name: 'testcontact', account: account, identifier: 'testidentifer')
         contact_special = create(:contact, name: 'testcontact', account: account, identifier: 'TestIdentifier')
@@ -503,6 +546,22 @@ RSpec.describe 'Contacts API', type: :request do
         expect(response).to conform_schema(200)
         expect(response.body).to include(contact.name)
       end
+
+      it 'returns the full ordered email list' do
+        contact.update!(email: 'primary@example.com')
+        create(:contact_email, account: account, contact: contact, email: 'secondary@example.com')
+        create(:contact_email, account: account, contact: contact, email: 'tertiary@example.com')
+
+        get "/api/v1/accounts/#{account.id}/contacts/#{contact.id}",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+
+        payload = response.parsed_body['payload']
+        expect(payload['email']).to eq('primary@example.com')
+        expect(payload['emails']).to eq(['primary@example.com', 'secondary@example.com', 'tertiary@example.com'])
+      end
     end
   end
 
@@ -593,6 +652,25 @@ RSpec.describe 'Contacts API', type: :request do
         end.to change(ContactInbox, :count).by(1)
 
         expect(response).to have_http_status(:success)
+      end
+
+      it 'creates a contact with primary and secondary emails and returns them' do
+        expect do
+          post "/api/v1/accounts/#{account.id}/contacts",
+               headers: admin.create_new_auth_token,
+               params: valid_params.merge({ emails: [' Primary@Example.com ', 'secondary@example.com'] }),
+               as: :json
+        end.to change(Contact, :count).by(1)
+
+        expect(response).to have_http_status(:success)
+
+        contact = account.contacts.order(:id).last
+        payload = response.parsed_body['payload']['contact']
+
+        expect(contact.reload.email).to eq('primary@example.com')
+        expect(contact.all_emails).to eq(['primary@example.com', 'secondary@example.com'])
+        expect(payload['email']).to eq('primary@example.com')
+        expect(payload['emails']).to eq(['primary@example.com', 'secondary@example.com'])
       end
     end
   end
@@ -696,6 +774,23 @@ RSpec.describe 'Contacts API', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(contact.reload.blocked).to be(true)
+      end
+
+      it 'replaces the contact email list' do
+        create(:contact_email, account: account, contact: contact, email: 'secondary@example.com')
+
+        patch "/api/v1/accounts/#{account.id}/contacts/#{contact.id}",
+              params: { emails: ['new-primary@example.com', 'other@example.com'] },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+
+        payload = response.parsed_body['payload']
+        expect(contact.reload.email).to eq('new-primary@example.com')
+        expect(contact.all_emails).to eq(['new-primary@example.com', 'other@example.com'])
+        expect(payload['email']).to eq('new-primary@example.com')
+        expect(payload['emails']).to eq(['new-primary@example.com', 'other@example.com'])
       end
 
       it 'allows unblocking of contact' do

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -420,6 +420,20 @@ RSpec.describe 'Contacts API', type: :request do
         expect(payload.first['emails']).to eq([contact2.email, 'secondary@example.com'])
       end
 
+      it 'supports name sorting when matching secondary emails' do
+        create(:contact_email, account: account, contact: contact2, email: 'sorted-secondary@example.com')
+
+        get "/api/v1/accounts/#{account.id}/contacts/search",
+            params: { q: 'sorted-secondary@example.com', sort: 'name' },
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+
+        payload = response.parsed_body['payload']
+        expect(payload.pluck('id')).to eq([contact2.id])
+      end
+
       it 'matches the contact by the legacy contact email when identity rows are absent' do
         legacy_contact = create(:contact, account: account)
         legacy_contact.update_columns(email: 'legacy-only@example.com') # rubocop:disable Rails/SkipsModelValidations

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -387,6 +387,24 @@ RSpec.describe 'Contacts API', type: :request do
         expect(payload.pluck('id')).to eq([contact2.id])
       end
 
+      it 'prioritizes an exact id match ahead of fuzzy numeric matches' do
+        target_contact = create(:contact, :with_email, account: account, name: 'target')
+        create_list(:contact, 20, account: account, email: nil, phone_number: nil) do |fuzzy_contact, index|
+          fuzzy_contact.update!(identifier: "lookup-#{target_contact.id}-#{index}")
+        end
+
+        get "/api/v1/accounts/#{account.id}/contacts/search",
+            params: { q: target_contact.id.to_s },
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+
+        payload = response.parsed_body['payload']
+        expect(payload.length).to eq(15)
+        expect(payload.first['id']).to eq(target_contact.id)
+      end
+
       it 'matches the contact by a secondary email' do
         create(:contact_email, account: account, contact: contact2, email: 'secondary@example.com')
 

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -840,6 +840,25 @@ RSpec.describe 'Contacts API', type: :request do
         expect(payload['emails']).to eq(['new-primary@example.com', 'other@example.com'])
       end
 
+      it 'publishes a contact update when only secondary emails change' do
+        contact.update!(email: 'primary@example.com')
+        create(:contact_email, account: account, contact: contact, email: 'secondary@example.com')
+        allow(Rails.configuration.dispatcher).to receive(:dispatch)
+
+        patch "/api/v1/accounts/#{account.id}/contacts/#{contact.id}",
+              params: { emails: ['primary@example.com', 'alias@example.com'] },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(Rails.configuration.dispatcher).to have_received(:dispatch).with(
+          'contact.updated',
+          anything,
+          contact: contact,
+          changed_attributes: include('updated_at')
+        )
+      end
+
       it 'rolls back contact changes when email replacement fails' do
         contact.update!(name: 'Original Name', email: 'primary@example.com')
         create(:contact_email, account: account, contact: contact, email: 'secondary@example.com')

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -404,7 +404,7 @@ RSpec.describe 'Contacts API', type: :request do
 
       it 'matches the contact by the legacy contact email when identity rows are absent' do
         legacy_contact = create(:contact, account: account)
-        legacy_contact.update_columns(email: 'legacy-only@example.com')
+        legacy_contact.update_columns(email: 'legacy-only@example.com') # rubocop:disable Rails/SkipsModelValidations
 
         get "/api/v1/accounts/#{account.id}/contacts/search",
             params: { q: 'legacy-only@example.com' },

--- a/spec/db/migrate/create_contact_emails_spec.rb
+++ b/spec/db/migrate/create_contact_emails_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260412120000_create_contact_emails')
+
+RSpec.describe CreateContactEmails do
+  describe '#backfill_contact_emails' do
+    it 'keeps a normalized legacy email with the contact that already owns it exactly' do
+      account = create(:account)
+      older_mixed_case_contact = create(:contact, account: account, email: nil, created_at: 2.days.ago)
+      lowercase_contact = create(:contact, account: account, email: nil, created_at: 1.day.ago)
+
+      # The migration must handle legacy rows created before current normalization.
+      # rubocop:disable Rails/SkipsModelValidations
+      older_mixed_case_contact.update_columns(email: 'User@example.com')
+      lowercase_contact.update_columns(email: 'user@example.com')
+      # rubocop:enable Rails/SkipsModelValidations
+
+      ContactEmail.where(account: account).delete_all
+
+      described_class.new.send(:backfill_contact_emails)
+
+      expect(ContactEmail.find_by!(account: account, email: 'user@example.com').contact).to eq(lowercase_contact)
+    end
+  end
+end

--- a/spec/factories/contact_emails.rb
+++ b/spec/factories/contact_emails.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :contact_email do
+    account
+    contact { association :contact, account: account }
+    sequence(:email) { |n| "contact-email-#{n}@example.com" }
+    primary { false }
+  end
+end

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe DataImportJob do
             phone_number: "+#{csv_data[0]['phone_number']}",
             name: csv_data[0]['name'].to_s
           )
-          expect(imported_contact.additional_attributes['company']).to eq(csv_data[0]['company'].to_s)
+          expect(imported_contact.additional_attributes['company_name']).to eq(csv_data[0]['company_name'].to_s)
         end
       end
 

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -148,9 +148,11 @@ RSpec.describe DataImportJob do
 
           imported_contact = Contact.from_email(csv_data[0]['email'])
           expect(imported_contact).to be_present
-          expect(imported_contact.id).to eq(contact.id)
-          expect(imported_contact.phone_number).to eq("+#{csv_data[0]['phone_number']}")
-          expect(imported_contact.name).to eq(csv_data[0]['name'].to_s)
+          expect(imported_contact).to have_attributes(
+            id: contact.id,
+            phone_number: "+#{csv_data[0]['phone_number']}",
+            name: csv_data[0]['name'].to_s
+          )
           expect(imported_contact.additional_attributes['company']).to eq(csv_data[0]['company'].to_s)
         end
       end

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -134,6 +134,25 @@ RSpec.describe DataImportJob do
           expect(contact.name).to eq((csv_data[0]['name']).to_s)
           expect(contact.additional_attributes['company_name']).to eq((csv_data[0]['company_name']).to_s)
         end
+
+        it 'updates the existing record when import email matches a secondary email' do
+          contact = Contact.create!(email: 'primary@example.com', account_id: existing_data_import.account_id)
+          create(:contact_email, account: existing_data_import.account, contact: contact, email: csv_data[0]['email'])
+          csv_length = csv_data.length
+
+          described_class.perform_now(existing_data_import)
+
+          expect(existing_data_import.account.contacts.count).to eq(csv_length)
+          expect(existing_data_import.reload.total_records).to eq(csv_length)
+          expect(existing_data_import.reload.processed_records).to eq(csv_length)
+
+          imported_contact = Contact.from_email(csv_data[0]['email'])
+          expect(imported_contact).to be_present
+          expect(imported_contact.id).to eq(contact.id)
+          expect(imported_contact.phone_number).to eq("+#{csv_data[0]['phone_number']}")
+          expect(imported_contact.name).to eq(csv_data[0]['name'].to_s)
+          expect(imported_contact.additional_attributes['company']).to eq(csv_data[0]['company'].to_s)
+        end
       end
 
       context 'when the existing record has a phone_number in import data' do

--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -14,17 +14,12 @@ RSpec.describe SendReplyJob do
   context 'when the job is triggered on a new message' do
     let(:process_service) { double }
 
-    before do
-      allow(process_service).to receive(:perform)
-    end
-
     it 'calls Facebook::SendOnFacebookService when its facebook message' do
       stub_request(:post, /graph.facebook.com/)
       facebook_channel = create(:channel_facebook_page)
       facebook_inbox = create(:inbox, channel: facebook_channel)
       message = create(:message, conversation: create(:conversation, inbox: facebook_inbox))
-      allow(Facebook::SendOnFacebookService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Facebook::SendOnFacebookService).to receive(:new).with(message: message)
+      expect(Facebook::SendOnFacebookService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end
@@ -33,8 +28,7 @@ RSpec.describe SendReplyJob do
       twitter_channel = create(:channel_twitter_profile)
       twitter_inbox = create(:inbox, channel: twitter_channel)
       message = create(:message, conversation: create(:conversation, inbox: twitter_inbox))
-      allow(Twitter::SendOnTwitterService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Twitter::SendOnTwitterService).to receive(:new).with(message: message)
+      expect(Twitter::SendOnTwitterService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end
@@ -42,8 +36,7 @@ RSpec.describe SendReplyJob do
     it 'calls ::Twilio::SendOnTwilioService when its twilio message' do
       twilio_channel = create(:channel_twilio_sms)
       message = create(:message, conversation: create(:conversation, inbox: twilio_channel.inbox))
-      allow(Twilio::SendOnTwilioService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Twilio::SendOnTwilioService).to receive(:new).with(message: message)
+      expect(Twilio::SendOnTwilioService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end
@@ -51,8 +44,7 @@ RSpec.describe SendReplyJob do
     it 'calls ::Telegram::SendOnTelegramService when its telegram message' do
       telegram_channel = create(:channel_telegram)
       message = create(:message, conversation: create(:conversation, inbox: telegram_channel.inbox))
-      allow(Telegram::SendOnTelegramService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Telegram::SendOnTelegramService).to receive(:new).with(message: message)
+      expect(Telegram::SendOnTelegramService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end
@@ -60,8 +52,7 @@ RSpec.describe SendReplyJob do
     it 'calls ::Line:SendOnLineService when its line message' do
       line_channel = create(:channel_line)
       message = create(:message, conversation: create(:conversation, inbox: line_channel.inbox))
-      allow(Line::SendOnLineService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Line::SendOnLineService).to receive(:new).with(message: message)
+      expect(Line::SendOnLineService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end
@@ -70,8 +61,7 @@ RSpec.describe SendReplyJob do
       stub_request(:post, 'https://waba.360dialog.io/v1/configs/webhook')
       whatsapp_channel = create(:channel_whatsapp, sync_templates: false)
       message = create(:message, conversation: create(:conversation, inbox: whatsapp_channel.inbox))
-      allow(Whatsapp::SendOnWhatsappService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Whatsapp::SendOnWhatsappService).to receive(:new).with(message: message)
+      expect(Whatsapp::SendOnWhatsappService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end
@@ -79,8 +69,7 @@ RSpec.describe SendReplyJob do
     it 'calls ::Sms::SendOnSmsService when its sms message' do
       sms_channel = create(:channel_sms)
       message = create(:message, conversation: create(:conversation, inbox: sms_channel.inbox))
-      allow(Sms::SendOnSmsService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Sms::SendOnSmsService).to receive(:new).with(message: message)
+      expect(Sms::SendOnSmsService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end
@@ -88,8 +77,7 @@ RSpec.describe SendReplyJob do
     it 'calls ::Instagram::Direct::SendOnInstagramService when its instagram message' do
       instagram_channel = create(:channel_instagram)
       message = create(:message, conversation: create(:conversation, inbox: instagram_channel.inbox))
-      allow(Instagram::SendOnInstagramService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Instagram::SendOnInstagramService).to receive(:new).with(message: message)
+      expect(Instagram::SendOnInstagramService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end
@@ -103,8 +91,7 @@ RSpec.describe SendReplyJob do
                             additional_attributes: { 'type' => 'instagram_direct_message' })
       message = create(:message, conversation: conversation)
 
-      allow(Instagram::Messenger::SendOnInstagramService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Instagram::Messenger::SendOnInstagramService).to receive(:new).with(message: message)
+      expect(Instagram::Messenger::SendOnInstagramService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end
@@ -112,8 +99,7 @@ RSpec.describe SendReplyJob do
     it 'calls ::Email::SendOnEmailService when its email message' do
       email_channel = create(:channel_email)
       message = create(:message, conversation: create(:conversation, inbox: email_channel.inbox))
-      allow(Email::SendOnEmailService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Email::SendOnEmailService).to receive(:new).with(message: message)
+      expect(Email::SendOnEmailService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end
@@ -121,8 +107,7 @@ RSpec.describe SendReplyJob do
     it 'calls ::Messages::SendEmailNotificationService when its webwidget message' do
       webwidget_channel = create(:channel_widget)
       message = create(:message, conversation: create(:conversation, inbox: webwidget_channel.inbox))
-      allow(Messages::SendEmailNotificationService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Messages::SendEmailNotificationService).to receive(:new).with(message: message)
+      expect(Messages::SendEmailNotificationService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end
@@ -130,8 +115,7 @@ RSpec.describe SendReplyJob do
     it 'calls ::Messages::SendEmailNotificationService when its api channel message' do
       api_channel = create(:channel_api)
       message = create(:message, conversation: create(:conversation, inbox: api_channel.inbox))
-      allow(Messages::SendEmailNotificationService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Messages::SendEmailNotificationService).to receive(:new).with(message: message)
+      expect(Messages::SendEmailNotificationService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end
@@ -139,8 +123,7 @@ RSpec.describe SendReplyJob do
     it 'calls ::Tiktok::SendOnTiktokService when its tiktok message' do
       tiktok_channel = create(:channel_tiktok)
       message = create(:message, conversation: create(:conversation, inbox: tiktok_channel.inbox))
-      allow(Tiktok::SendOnTiktokService).to receive(:new).with(message: message).and_return(process_service)
-      expect(Tiktok::SendOnTiktokService).to receive(:new).with(message: message)
+      expect(Tiktok::SendOnTiktokService).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
       described_class.perform_now(message.id)
     end

--- a/spec/mailboxes/imap/imap_mailbox_spec.rb
+++ b/spec/mailboxes/imap/imap_mailbox_spec.rb
@@ -99,6 +99,23 @@ RSpec.describe Imap::ImapMailbox do
       end
     end
 
+    context 'when a new email from a secondary contact email' do
+      let(:inbound_mail) { create_inbound_email_from_mail(from: 'secondary@gmail.com', to: 'imap@gmail.com', subject: 'Hello!') }
+
+      before do
+        create(:contact_email, account: account, contact: contact, email: 'secondary@gmail.com')
+      end
+
+      it 'reuses the existing contact' do
+        expect do
+          class_instance.process(inbound_mail.mail, channel)
+        end.to not_change(Contact, :count)
+          .and change(Conversation, :count).by(1)
+
+        expect(conversation.contact).to eq(contact)
+      end
+    end
+
     context 'when a new email with invalid from' do
       let(:inbound_mail) { create_inbound_email_from_mail(from: 'invalidemail', to: 'imap@gmail.com', subject: 'Hello!') }
 

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -247,6 +247,29 @@ RSpec.describe ConversationReplyMailer do
         expect(mail.message_id).to eq("conversation/#{conversation.uuid}/messages/#{message.id}@#{conversation.account.domain}")
       end
 
+      context 'when the conversation source_id matches one of the contact email identities' do
+        before do
+          create(:contact_email, account: conversation.account, contact: conversation.contact, email: 'secondary@example.com')
+          conversation.contact_inbox.update!(source_id: 'secondary@example.com')
+        end
+
+        it 'sends the reply to that address' do
+          expect(mail.to).to eq(['secondary@example.com'])
+        end
+      end
+
+      context 'when the conversation source_id is not one of the contact email identities' do
+        before do
+          create(:contact_email, account: conversation.account, contact: conversation.contact, email: 'secondary@example.com')
+          conversation.contact.update!(email: 'primary@example.com')
+          conversation.contact_inbox.update!(source_id: 'not-an-identity@example.com')
+        end
+
+        it 'falls back to the contact primary email' do
+          expect(mail.to).to eq(['primary@example.com'])
+        end
+      end
+
       context 'when message is a CSAT survey' do
         let(:csat_message) do
           create(:message, conversation: conversation, account: account, message_type: 'template',

--- a/spec/models/contact_email_spec.rb
+++ b/spec/models/contact_email_spec.rb
@@ -44,5 +44,17 @@ RSpec.describe ContactEmail do
       expect(conflicting_alias).not_to be_valid
       expect(conflicting_alias.errors[:email]).to include('has already been taken')
     end
+
+    it "allows moving an existing alias onto another contact when the only legacy conflict is the row's current owner" do
+      account = create(:account)
+      base_contact = create(:contact, account: account, email: 'base@example.com')
+      mergee_contact = create(:contact, account: account, email: 'mergee@example.com')
+      moved_alias = mergee_contact.primary_contact_email
+
+      moved_alias.contact = base_contact
+      moved_alias.primary = false
+
+      expect(moved_alias).to be_valid
+    end
   end
 end

--- a/spec/models/contact_email_spec.rb
+++ b/spec/models/contact_email_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ContactEmail do
+  describe 'validations' do
+    it 'normalizes email and enforces account-scoped uniqueness case insensitively' do
+      existing = create(:contact_email, email: 'Secondary@Example.com')
+      duplicate = build(:contact_email, account: existing.account, email: 'secondary@example.com')
+
+      expect(existing.email).to eq('secondary@example.com')
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:email]).to include('has already been taken')
+    end
+
+    it 'allows only one primary email per contact' do
+      contact = create(:contact, email: 'primary@example.com')
+
+      duplicate_primary = build(
+        :contact_email,
+        account: contact.account,
+        contact: contact,
+        email: 'secondary@example.com',
+        primary: true
+      )
+
+      expect(duplicate_primary).not_to be_valid
+      expect(duplicate_primary.errors[:primary]).to include('has already been taken')
+    end
+  end
+end

--- a/spec/models/contact_email_spec.rb
+++ b/spec/models/contact_email_spec.rb
@@ -27,5 +27,22 @@ RSpec.describe ContactEmail do
       expect(duplicate_primary).not_to be_valid
       expect(duplicate_primary.errors[:primary]).to include('has already been taken')
     end
+
+    it "does not allow claiming another contact's legacy email when no alias row exists yet" do
+      account = create(:account)
+      legacy_owner = create(:contact, account: account)
+      legacy_owner.update_columns(email: 'legacy-only@example.com', updated_at: Time.current)
+      claiming_contact = create(:contact, account: account, email: 'other@example.com')
+
+      conflicting_alias = build(
+        :contact_email,
+        account: account,
+        contact: claiming_contact,
+        email: 'legacy-only@example.com'
+      )
+
+      expect(conflicting_alias).not_to be_valid
+      expect(conflicting_alias.errors[:email]).to include('has already been taken')
+    end
   end
 end

--- a/spec/models/contact_email_spec.rb
+++ b/spec/models/contact_email_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ContactEmail do
     it "does not allow claiming another contact's legacy email when no alias row exists yet" do
       account = create(:account)
       legacy_owner = create(:contact, account: account)
-      legacy_owner.update_columns(email: 'legacy-only@example.com', updated_at: Time.current)
+      legacy_owner.update_columns(email: 'legacy-only@example.com', updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
       claiming_contact = create(:contact, account: account, email: 'other@example.com')
 
       conflicting_alias = build(

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Contact do
   context 'with associations' do
     it { is_expected.to belong_to(:account) }
     it { is_expected.to have_many(:conversations).dependent(:destroy_async) }
+    it { is_expected.to have_many(:contact_emails).dependent(:destroy_async) }
   end
 
   describe 'concerns' do
@@ -201,6 +202,28 @@ RSpec.describe Contact do
         expect(resolved_new).to include(lead_with_email, lead_without_email)
         expect(resolved_new).not_to include(visitor_contact, customer_contact)
       end
+    end
+  end
+
+  describe '.from_email' do
+    it 'finds a contact through a secondary email' do
+      account = create(:account)
+      contact = create(:contact, account: account, email: 'primary@example.com')
+      create(:contact_email, account: account, contact: contact, email: 'secondary@example.com')
+
+      expect(account.contacts.from_email('secondary@example.com')).to eq(contact)
+      expect(account.contacts.from_email('SECONDARY@EXAMPLE.COM')).to eq(contact)
+      expect(Contact.from_email('secondary@example.com')).to eq(contact)
+    end
+  end
+
+  describe '#all_emails' do
+    it 'returns primary email first and then secondary emails by id' do
+      contact = create(:contact, email: 'primary@example.com')
+      secondary_one = create(:contact_email, account: contact.account, contact: contact, email: 'second@example.com')
+      secondary_two = create(:contact_email, account: contact.account, contact: contact, email: 'third@example.com')
+
+      expect(contact.all_emails).to eq(['primary@example.com', secondary_one.email, secondary_two.email])
     end
   end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Contact do
 
       expect(account.contacts.from_email('secondary@example.com')).to eq(contact)
       expect(account.contacts.from_email('SECONDARY@EXAMPLE.COM')).to eq(contact)
-      expect(Contact.from_email('secondary@example.com')).to eq(contact)
+      expect(described_class.from_email('secondary@example.com')).to eq(contact)
     end
   end
 
@@ -237,10 +237,12 @@ RSpec.describe Contact do
       contact.reload
 
       expect(contact.email).to eq(secondary.email)
-      expect(contact.contact_emails.order(primary: :desc, id: :asc).pluck(:email, :primary)).to eq([
-                                                                                                      [secondary.email, true],
-                                                                                                      ['third@example.com', false]
-                                                                                                    ])
+      expect(contact.contact_emails.order(primary: :desc, id: :asc).pluck(:email, :primary)).to eq(
+        [
+          [secondary.email, true],
+          ['third@example.com', false]
+        ]
+      )
     end
   end
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -227,6 +227,23 @@ RSpec.describe Contact do
     end
   end
 
+  describe 'primary email identity sync' do
+    it 'promotes an existing alias when the legacy email field is cleared' do
+      contact = create(:contact, email: 'primary@example.com')
+      secondary = create(:contact_email, account: contact.account, contact: contact, email: 'secondary@example.com')
+      create(:contact_email, account: contact.account, contact: contact, email: 'third@example.com')
+
+      contact.update!(email: nil)
+      contact.reload
+
+      expect(contact.email).to eq(secondary.email)
+      expect(contact.contact_emails.order(primary: :desc, id: :asc).pluck(:email, :primary)).to eq([
+                                                                                                      [secondary.email, true],
+                                                                                                      ['third@example.com', false]
+                                                                                                    ])
+    end
+  end
+
   describe 'email uniqueness against contact_emails' do
     it 'fails validation cleanly when another contact uses a retained old email' do
       account = create(:account)

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -227,6 +227,18 @@ RSpec.describe Contact do
     end
   end
 
+  describe '#push_event_data' do
+    it 'includes all email identities for realtime updates' do
+      contact = create(:contact, email: 'primary@example.com')
+      create(:contact_email, account: contact.account, contact: contact, email: 'alias@example.com')
+
+      expect(contact.push_event_data).to include(
+        email: 'primary@example.com',
+        emails: ['primary@example.com', 'alias@example.com']
+      )
+    end
+  end
+
   describe 'primary email identity sync' do
     it 'promotes an existing alias when the legacy email field is cleared' do
       contact = create(:contact, email: 'primary@example.com')

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -226,4 +226,18 @@ RSpec.describe Contact do
       expect(contact.all_emails).to eq(['primary@example.com', secondary_one.email, secondary_two.email])
     end
   end
+
+  describe 'email uniqueness against contact_emails' do
+    it 'fails validation cleanly when another contact uses a retained old email' do
+      account = create(:account)
+      original_contact = create(:contact, account: account, email: 'old@example.com')
+      original_contact.update!(email: 'new@example.com')
+
+      conflicting_contact = build(:contact, account: account, email: 'old@example.com')
+
+      expect(conflicting_contact).not_to be_valid
+      expect(conflicting_contact.errors[:email]).to include('has already been taken')
+      expect { conflicting_contact.save! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
 end

--- a/spec/services/contacts/replace_contact_emails_spec.rb
+++ b/spec/services/contacts/replace_contact_emails_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Contacts::ReplaceContactEmails do
+  describe '#perform' do
+    it 'normalizes, dedupes, mirrors the first email, and preserves ordered emails' do
+      contact = create(:contact, email: 'old@example.com')
+      create(:contact_email, account: contact.account, contact: contact, email: 'stale@example.com')
+
+      described_class.new(
+        contact: contact,
+        emails: ['Primary@Example.com', 'secondary@example.com', 'secondary@example.com']
+      ).perform
+
+      expect(contact.reload.email).to eq('primary@example.com')
+      expect(contact.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq([
+                                                                                                         ['primary@example.com', true],
+                                                                                                         ['secondary@example.com', false]
+                                                                                                       ])
+      expect(contact.all_emails).to eq(['primary@example.com', 'secondary@example.com'])
+    end
+
+    it 'clears all identities and mirrors the legacy email to nil when the replacement list is empty' do
+      contact = create(:contact, email: 'primary@example.com')
+      create(:contact_email, account: contact.account, contact: contact, email: 'secondary@example.com')
+
+      described_class.new(contact: contact, emails: []).perform
+
+      expect(contact.reload.email).to be_nil
+      expect(contact.contact_emails).to be_empty
+    end
+
+    it 'promotes the new first email and demotes the old primary during rotation' do
+      contact = create(:contact, email: 'old-primary@example.com')
+      create(:contact_email, account: contact.account, contact: contact, email: 'secondary@example.com')
+
+      described_class.new(
+        contact: contact,
+        emails: ['secondary@example.com', 'old-primary@example.com']
+      ).perform
+
+      contact.reload
+
+      expect(contact.email).to eq('secondary@example.com')
+      expect(contact.contact_emails.find_by!(email: 'secondary@example.com')).to have_attributes(primary: true)
+      expect(contact.contact_emails.find_by!(email: 'old-primary@example.com')).to have_attributes(primary: false)
+    end
+
+    it 'falls back to the legacy email when the replacement list is blank' do
+      contact = create(:contact)
+
+      described_class.new(contact: contact, emails: nil, legacy_email: ' Legacy@Example.com ').perform
+
+      expect(contact.reload.email).to eq('legacy@example.com')
+      expect(contact.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq([
+                                                                                                         ['legacy@example.com', true]
+                                                                                                       ])
+    end
+  end
+end

--- a/spec/services/contacts/replace_contact_emails_spec.rb
+++ b/spec/services/contacts/replace_contact_emails_spec.rb
@@ -10,15 +10,16 @@ RSpec.describe Contacts::ReplaceContactEmails do
 
       described_class.new(
         contact: contact,
-        emails: ['Primary@Example.com', 'secondary@example.com', 'secondary@example.com']
+        emails: ['Primary@Example.com', 'zeta@example.com', 'alpha@example.com', 'zeta@example.com']
       ).perform
 
       expect(contact.reload.email).to eq('primary@example.com')
-      expect(contact.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq([
-                                                                                                         ['primary@example.com', true],
-                                                                                                         ['secondary@example.com', false]
-                                                                                                       ])
-      expect(contact.all_emails).to eq(['primary@example.com', 'secondary@example.com'])
+      expect(contact.contact_emails.order(primary: :desc, id: :asc).pluck(:email, :primary)).to eq([
+                                                                                                       ['primary@example.com', true],
+                                                                                                       ['zeta@example.com', false],
+                                                                                                       ['alpha@example.com', false]
+                                                                                                     ])
+      expect(contact.all_emails).to eq(['primary@example.com', 'zeta@example.com', 'alpha@example.com'])
     end
 
     it 'clears all identities and mirrors the legacy email to nil when the replacement list is empty' do

--- a/spec/services/contacts/replace_contact_emails_spec.rb
+++ b/spec/services/contacts/replace_contact_emails_spec.rb
@@ -14,11 +14,13 @@ RSpec.describe Contacts::ReplaceContactEmails do
       ).perform
 
       expect(contact.reload.email).to eq('primary@example.com')
-      expect(contact.contact_emails.order(primary: :desc, id: :asc).pluck(:email, :primary)).to eq([
-                                                                                                       ['primary@example.com', true],
-                                                                                                       ['zeta@example.com', false],
-                                                                                                       ['alpha@example.com', false]
-                                                                                                     ])
+      expect(contact.contact_emails.order(primary: :desc, id: :asc).pluck(:email, :primary)).to eq(
+        [
+          ['primary@example.com', true],
+          ['zeta@example.com', false],
+          ['alpha@example.com', false]
+        ]
+      )
       expect(contact.all_emails).to eq(['primary@example.com', 'zeta@example.com', 'alpha@example.com'])
     end
 
@@ -54,9 +56,11 @@ RSpec.describe Contacts::ReplaceContactEmails do
       described_class.new(contact: contact, emails: nil, legacy_email: ' Legacy@Example.com ').perform
 
       expect(contact.reload.email).to eq('legacy@example.com')
-      expect(contact.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq([
-                                                                                                         ['legacy@example.com', true]
-                                                                                                       ])
+      expect(contact.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq(
+        [
+          ['legacy@example.com', true]
+        ]
+      )
     end
   end
 end

--- a/spec/services/contacts/sync_primary_email_identity_spec.rb
+++ b/spec/services/contacts/sync_primary_email_identity_spec.rb
@@ -19,9 +19,25 @@ RSpec.describe Contacts::SyncPrimaryEmailIdentity do
                                                                                                                ])
     end
 
-    it 'removes all contact email identities when the legacy contact email field is blank' do
+    it 'preserves aliases by promoting an existing secondary when the legacy contact email field is blank' do
       contact = create(:contact, email: 'primary@example.com')
-      create(:contact_email, account: contact.account, contact: contact, email: 'secondary@example.com')
+      secondary = create(:contact_email, account: contact.account, contact: contact, email: 'secondary@example.com')
+      tertiary = create(:contact_email, account: contact.account, contact: contact, email: 'third@example.com')
+      contact.update_column(:email, nil)
+
+      described_class.new(contact: contact).perform
+
+      contact.reload
+
+      expect(contact.email).to eq(secondary.email)
+      expect(contact.contact_emails.order(primary: :desc, id: :asc).pluck(:email, :primary)).to eq([
+                                                                                                      [secondary.email, true],
+                                                                                                      [tertiary.email, false]
+                                                                                                    ])
+    end
+
+    it 'clears all identities only when no aliases remain after blanking the legacy email field' do
+      contact = create(:contact, email: 'primary@example.com')
       contact.update_column(:email, nil)
 
       described_class.new(contact: contact).perform

--- a/spec/services/contacts/sync_primary_email_identity_spec.rb
+++ b/spec/services/contacts/sync_primary_email_identity_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Contacts::SyncPrimaryEmailIdentity do
+  describe '#perform' do
+    it 'creates or updates the primary contact email from the legacy contact email field' do
+      contact = create(:contact)
+      create(:contact_email, account: contact.account, contact: contact, email: 'old-primary@example.com', primary: true)
+      create(:contact_email, account: contact.account, contact: contact, email: 'secondary@example.com')
+      contact.update_column(:email, 'legacy@example.com')
+
+      described_class.new(contact: contact).perform
+
+      expect(contact.reload.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq([
+                                                                                                                 ['legacy@example.com', true],
+                                                                                                                 ['old-primary@example.com', false],
+                                                                                                                 ['secondary@example.com', false]
+                                                                                                               ])
+    end
+
+    it 'removes all contact email identities when the legacy contact email field is blank' do
+      contact = create(:contact, email: 'primary@example.com')
+      create(:contact_email, account: contact.account, contact: contact, email: 'secondary@example.com')
+      contact.update_column(:email, nil)
+
+      described_class.new(contact: contact).perform
+
+      expect(contact.reload.email).to be_nil
+      expect(contact.contact_emails).to be_empty
+    end
+  end
+end

--- a/spec/services/contacts/sync_primary_email_identity_spec.rb
+++ b/spec/services/contacts/sync_primary_email_identity_spec.rb
@@ -8,37 +8,41 @@ RSpec.describe Contacts::SyncPrimaryEmailIdentity do
       contact = create(:contact)
       create(:contact_email, account: contact.account, contact: contact, email: 'old-primary@example.com', primary: true)
       create(:contact_email, account: contact.account, contact: contact, email: 'secondary@example.com')
-      contact.update_column(:email, 'legacy@example.com')
+      contact.update_column(:email, 'legacy@example.com') # rubocop:disable Rails/SkipsModelValidations
 
       described_class.new(contact: contact).perform
 
-      expect(contact.reload.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq([
-                                                                                                                 ['legacy@example.com', true],
-                                                                                                                 ['old-primary@example.com', false],
-                                                                                                                 ['secondary@example.com', false]
-                                                                                                               ])
+      expect(contact.reload.contact_emails.order(primary: :desc, email: :asc).pluck(:email, :primary)).to eq(
+        [
+          ['legacy@example.com', true],
+          ['old-primary@example.com', false],
+          ['secondary@example.com', false]
+        ]
+      )
     end
 
     it 'preserves aliases by promoting an existing secondary when the legacy contact email field is blank' do
       contact = create(:contact, email: 'primary@example.com')
       secondary = create(:contact_email, account: contact.account, contact: contact, email: 'secondary@example.com')
       tertiary = create(:contact_email, account: contact.account, contact: contact, email: 'third@example.com')
-      contact.update_column(:email, nil)
+      contact.update_column(:email, nil) # rubocop:disable Rails/SkipsModelValidations
 
       described_class.new(contact: contact).perform
 
       contact.reload
 
       expect(contact.email).to eq(secondary.email)
-      expect(contact.contact_emails.order(primary: :desc, id: :asc).pluck(:email, :primary)).to eq([
-                                                                                                      [secondary.email, true],
-                                                                                                      [tertiary.email, false]
-                                                                                                    ])
+      expect(contact.contact_emails.order(primary: :desc, id: :asc).pluck(:email, :primary)).to eq(
+        [
+          [secondary.email, true],
+          [tertiary.email, false]
+        ]
+      )
     end
 
     it 'clears all identities only when no aliases remain after blanking the legacy email field' do
       contact = create(:contact, email: 'primary@example.com')
-      contact.update_column(:email, nil)
+      contact.update_column(:email, nil) # rubocop:disable Rails/SkipsModelValidations
 
       described_class.new(contact: contact).perform
 

--- a/spec/services/mailbox/conversation_finder_strategies/new_conversation_strategy_spec.rb
+++ b/spec/services/mailbox/conversation_finder_strategies/new_conversation_strategy_spec.rb
@@ -66,6 +66,21 @@ RSpec.describe Mailbox::ConversationFinderStrategies::NewConversationStrategy do
             .and not_change(Contact, :count)
             .and not_change(ContactInbox, :count)
         end
+
+        it 'builds conversation with existing contact matched by a secondary email' do
+          create(:contact_email, account: account, contact: existing_contact, email: 'secondary@example.com')
+          mail.from = 'secondary@example.com'
+          strategy = described_class.new(mail)
+
+          expect do
+            conversation = strategy.find
+            expect(conversation).to be_a(Conversation)
+            expect(conversation.new_record?).to be(true)
+            expect(conversation.contact).to eq(existing_contact)
+          end.to not_change(Conversation, :count)
+            .and not_change(Contact, :count)
+            .and not_change(ContactInbox, :count)
+        end
       end
 
       context 'when mail has In-Reply-To header' do


### PR DESCRIPTION
This improves contact management so agents can find merge targets by numeric contact ID and keep multiple email addresses on a single contact without breaking inbound email matching, merges, search, or email reply continuity.

## Closes
Closes #14377

## How to test
- Go to a contact and open the merge flow. Search by another contact's numeric ID and confirm the target appears in the dropdown.
- Create or edit a contact and add multiple email addresses.
- Send an inbound email from one of the secondary addresses and confirm the conversation resolves to the same contact.
- Reply on an email conversation tied to a secondary address and confirm the outbound reply uses the matched contact email identity.
- Merge two contacts that each have email identities and confirm non-conflicting emails remain attached to the surviving contact.

## What changed
- Added contact email identities and kept them synchronized with the legacy primary email field.
- Updated contact create and edit payloads plus dashboard forms to support multiple emails.
- Extended inbound email matching, merge behavior, search behavior, and reply routing to preserve email-channel continuity.
- Extended the merge target search to match contact IDs in addition to contact names.
- Fixed inline contact panel email edits so updating a secondary email row changes that alias instead of overwriting the primary email.