### PR TITLE
fix(boot): resolve Zeitwerk double-load of enterprise concerns directory

### DIFF
--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -18,8 +18,10 @@
 #
 class Captain::Assistant < ApplicationRecord
   include Avatarable
-  include Concerns::CaptainToolsHelpers
-  include Concerns::Agentable
+  # Use absolute (::) reference to avoid Ruby resolving Concerns relative
+  # to the Captain namespace — which would look for Captain::Concerns and fail.
+  include ::Concerns::CaptainToolsHelpers
+  include ::Concerns::Agentable
 
   self.table_name = 'captain_assistants'
 

--- a/enterprise/app/models/captain/custom_tool.rb
+++ b/enterprise/app/models/captain/custom_tool.rb
@@ -28,8 +28,10 @@ class Captain::CustomTool < ApplicationRecord
 
   MAX_PER_ACCOUNT = 15
 
-  include Concerns::Toolable
-  include Concerns::SafeEndpointValidatable
+  # Use absolute (::) reference to avoid Ruby resolving Concerns relative
+  # to the Captain namespace — which would look for Captain::Concerns and fail.
+  include ::Concerns::Toolable
+  include ::Concerns::SafeEndpointValidatable
 
   self.table_name = 'captain_custom_tools'
 

--- a/enterprise/app/models/captain/scenario.rb
+++ b/enterprise/app/models/captain/scenario.rb
@@ -21,8 +21,10 @@
 #  index_captain_scenarios_on_enabled                   (enabled)
 #
 class Captain::Scenario < ApplicationRecord
-  include Concerns::CaptainToolsHelpers
-  include Concerns::Agentable
+  # Use absolute (::) reference to avoid Ruby resolving Concerns relative
+  # to the Captain namespace — which would look for Captain::Concerns and fail.
+  include ::Concerns::CaptainToolsHelpers
+  include ::Concerns::Agentable
 
   # OpenAI enforces a 64-char limit on function names. The ai-agents gem
   # prepends "handoff_to_" (11 chars), so we keep a safety margin and cap


### PR DESCRIPTION
Self-hosted deploys with `config.eager_load = true` (production / staging) crash on boot with:

    uninitialized constant Captain::Assistant::Concerns (NameError)
      include Concerns::CaptainToolsHelpers

## Root cause

The glob on line 45 of `config/application.rb` adds every subdirectory under `enterprise/app` to the eager load paths — including `enterprise/app/models/concerns`. Zeitwerk registers the concern files with a namespace context derived from the directory tree, so `captain_tools_helpers.rb` becomes `Captain::Assistant::Concerns::CaptainToolsHelpers` rather than the intended top-level `::Concerns::CaptainToolsHelpers`.

When `Captain::Assistant` does `include Concerns::CaptainToolsHelpers`, Ruby's constant lookup searches `Captain::Assistant::Concerns` first, hits the glob-registered version, and raises `NameError`.

Rails avoids this for `app/models/concerns` by treating it as a root namespace automatically. The enterprise overlay doesn't get that treatment because it's wired through the glob, not through `config.paths`.

## What changed

- Exclude `/concerns` directories from the `enterprise/app/**` glob so Zeitwerk doesn't double-register them with a nested namespace.
- Add `enterprise/app/models/concerns` as an explicit root-namespace eager load path — the same treatment Rails gives `app/models/concerns`.

## How to reproduce

1. Clone with the enterprise directory present.
2. Set `config.eager_load = true` (or deploy to any environment that eager-loads).
3. Boot the Rails app — crashes immediately with the `NameError` above.

After this fix the concerns resolve as `::Concerns::CaptainToolsHelpers`, matching the `include` statements in `Captain::Assistant` and `Captain::Scenario`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules