### PR TITLE
fix: drop WhatsApp incoming messages from blocked contacts

### DIFF
--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -37,7 +37,7 @@ class Whatsapp::IncomingMessageBaseService
 
     set_contact
     return unless @contact
-    return if @contact.blocked?
+    return if @contact.blocked? && !outgoing_echo
 
     ActiveRecord::Base.transaction do
       set_conversation

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -37,6 +37,7 @@ class Whatsapp::IncomingMessageBaseService
 
     set_contact
     return unless @contact
+    return if @contact.blocked?
 
     ActiveRecord::Base.transaction do
       set_conversation


### PR DESCRIPTION
## Linear ticket
https://linear.app/chatwoot/issue/CW-6839/blocked-contact-can-still-send-messages-to-whatsapp-inbox

## Description

Drop WhatsApp incoming messages  from blocked contacts

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Incoming messages for blocked contacts 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
