### PR TITLE
fix: use committed model registry for RubyLLM

### DIFF
--- a/config/llm_models.json
+++ b/config/llm_models.json
@@ -1,0 +1,24264 @@
+[
+  {
+    "id": "claude-3-5-haiku-20241022",
+    "name": "Claude Haiku 3.5",
+    "provider": "anthropic",
+    "family": "claude-haiku",
+    "created_at": "2024-10-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": "2024-07-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.8,
+          "output_per_million": 4,
+          "cached_input_per_million": 0.08
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-10-22",
+      "cost": {
+        "input": 0.8,
+        "output": 4,
+        "cache_read": 0.08,
+        "cache_write": 1
+      },
+      "limit": {
+        "context": 200000,
+        "output": 8192
+      },
+      "knowledge": "2024-07-31"
+    }
+  },
+  {
+    "id": "claude-3-5-haiku-latest",
+    "name": "Claude Haiku 3.5 (latest)",
+    "provider": "anthropic",
+    "family": "claude-haiku",
+    "created_at": "2024-10-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": "2024-07-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.8,
+          "output_per_million": 4,
+          "cached_input_per_million": 0.08
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-10-22",
+      "cost": {
+        "input": 0.8,
+        "output": 4,
+        "cache_read": 0.08,
+        "cache_write": 1
+      },
+      "limit": {
+        "context": 200000,
+        "output": 8192
+      },
+      "knowledge": "2024-07-31"
+    }
+  },
+  {
+    "id": "claude-3-5-sonnet-20240620",
+    "name": "Claude Sonnet 3.5",
+    "provider": "anthropic",
+    "family": "claude-sonnet",
+    "created_at": "2024-06-20 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": "2024-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-06-20",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 8192
+      },
+      "knowledge": "2024-04-30"
+    }
+  },
+  {
+    "id": "claude-3-5-sonnet-20241022",
+    "name": "Claude Sonnet 3.5 v2",
+    "provider": "anthropic",
+    "family": "claude-sonnet",
+    "created_at": "2024-10-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": "2024-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-10-22",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 8192
+      },
+      "knowledge": "2024-04-30"
+    }
+  },
+  {
+    "id": "claude-3-7-sonnet-20250219",
+    "name": "Claude Sonnet 3.7",
+    "provider": "anthropic",
+    "family": "claude-sonnet",
+    "created_at": "2025-02-19 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2024-10-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-02-19",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2024-10-31"
+    }
+  },
+  {
+    "id": "claude-3-haiku-20240307",
+    "name": "Claude Haiku 3",
+    "provider": "anthropic",
+    "family": "claude-haiku",
+    "created_at": "2024-03-13 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": "2023-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.25,
+          "output_per_million": 1.25,
+          "cached_input_per_million": 0.03
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-03-13",
+      "cost": {
+        "input": 0.25,
+        "output": 1.25,
+        "cache_read": 0.03,
+        "cache_write": 0.3
+      },
+      "limit": {
+        "context": 200000,
+        "output": 4096
+      },
+      "knowledge": "2023-08-31"
+    }
+  },
+  {
+    "id": "claude-3-opus-20240229",
+    "name": "Claude Opus 3",
+    "provider": "anthropic",
+    "family": "claude-opus",
+    "created_at": "2024-02-29 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": "2023-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 75,
+          "cached_input_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-02-29",
+      "cost": {
+        "input": 15,
+        "output": 75,
+        "cache_read": 1.5,
+        "cache_write": 18.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 4096
+      },
+      "knowledge": "2023-08-31"
+    }
+  },
+  {
+    "id": "claude-3-sonnet-20240229",
+    "name": "Claude Sonnet 3",
+    "provider": "anthropic",
+    "family": "claude-sonnet",
+    "created_at": "2024-03-04 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": "2023-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-03-04",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 0.3
+      },
+      "limit": {
+        "context": 200000,
+        "output": 4096
+      },
+      "knowledge": "2023-08-31"
+    }
+  },
+  {
+    "id": "claude-haiku-4-5",
+    "name": "Claude Haiku 4.5 (latest)",
+    "provider": "anthropic",
+    "family": "claude-haiku",
+    "created_at": "2025-10-15 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-02-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 5,
+          "cached_input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-10-15",
+      "cost": {
+        "input": 1,
+        "output": 5,
+        "cache_read": 0.1,
+        "cache_write": 1.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-02-28"
+    }
+  },
+  {
+    "id": "claude-haiku-4-5-20251001",
+    "name": "Claude Haiku 4.5",
+    "provider": "anthropic",
+    "family": "claude-haiku",
+    "created_at": "2025-10-15 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-02-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 5,
+          "cached_input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-10-15",
+      "cost": {
+        "input": 1,
+        "output": 5,
+        "cache_read": 0.1,
+        "cache_write": 1.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-02-28"
+    }
+  },
+  {
+    "id": "claude-opus-4-0",
+    "name": "Claude Opus 4 (latest)",
+    "provider": "anthropic",
+    "family": "claude-opus",
+    "created_at": "2025-05-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 75,
+          "cached_input_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-22",
+      "cost": {
+        "input": 15,
+        "output": 75,
+        "cache_read": 1.5,
+        "cache_write": 18.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 32000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "claude-opus-4-1",
+    "name": "Claude Opus 4.1 (latest)",
+    "provider": "anthropic",
+    "family": "claude-opus",
+    "created_at": "2025-08-05 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 75,
+          "cached_input_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-05",
+      "cost": {
+        "input": 15,
+        "output": 75,
+        "cache_read": 1.5,
+        "cache_write": 18.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 32000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "claude-opus-4-1-20250805",
+    "name": "Claude Opus 4.1",
+    "provider": "anthropic",
+    "family": "claude-opus",
+    "created_at": "2025-08-05 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 75,
+          "cached_input_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-05",
+      "cost": {
+        "input": 15,
+        "output": 75,
+        "cache_read": 1.5,
+        "cache_write": 18.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 32000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "claude-opus-4-20250514",
+    "name": "Claude Opus 4",
+    "provider": "anthropic",
+    "family": "claude-opus",
+    "created_at": "2025-05-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 75,
+          "cached_input_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-22",
+      "cost": {
+        "input": 15,
+        "output": 75,
+        "cache_read": 1.5,
+        "cache_write": 18.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 32000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "claude-opus-4-5",
+    "name": "Claude Opus 4.5 (latest)",
+    "provider": "anthropic",
+    "family": "claude-opus",
+    "created_at": "2025-11-24 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-11-24",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "claude-opus-4-5-20251101",
+    "name": "Claude Opus 4.5",
+    "provider": "anthropic",
+    "family": "claude-opus",
+    "created_at": "2025-11-01 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-11-01",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "claude-opus-4-6",
+    "name": "Claude Opus 4.6",
+    "provider": "anthropic",
+    "family": "claude-opus",
+    "created_at": "2026-02-05 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-13",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 128000
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "claude-sonnet-4-0",
+    "name": "Claude Sonnet 4 (latest)",
+    "provider": "anthropic",
+    "family": "claude-sonnet",
+    "created_at": "2025-05-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-22",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "claude-sonnet-4-20250514",
+    "name": "Claude Sonnet 4",
+    "provider": "anthropic",
+    "family": "claude-sonnet",
+    "created_at": "2025-05-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-22",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "claude-sonnet-4-5",
+    "name": "Claude Sonnet 4.5 (latest)",
+    "provider": "anthropic",
+    "family": "claude-sonnet",
+    "created_at": "2025-09-29 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-07-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-29",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-07-31"
+    }
+  },
+  {
+    "id": "claude-sonnet-4-5-20250929",
+    "name": "Claude Sonnet 4.5",
+    "provider": "anthropic",
+    "family": "claude-sonnet",
+    "created_at": "2025-09-29 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-07-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-29",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-07-31"
+    }
+  },
+  {
+    "id": "claude-sonnet-4-6",
+    "name": "Claude Sonnet 4.6",
+    "provider": "anthropic",
+    "family": "claude-sonnet",
+    "created_at": "2026-02-17 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "anthropic",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-13",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 64000
+      },
+      "knowledge": "2025-08"
+    }
+  },
+  {
+    "id": "amazon.nova-2-lite-v1:0",
+    "name": "Nova 2 Lite",
+    "provider": "bedrock",
+    "family": "nova",
+    "created_at": "2024-12-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.33,
+          "output_per_million": 2.75
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-01",
+      "cost": {
+        "input": 0.33,
+        "output": 2.75
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      }
+    }
+  },
+  {
+    "id": "amazon.nova-lite-v1:0",
+    "name": "Nova Lite",
+    "provider": "bedrock",
+    "family": "nova-lite",
+    "created_at": "2024-12-03 00:00:00 +0530",
+    "context_window": 300000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.06,
+          "output_per_million": 0.24,
+          "cached_input_per_million": 0.015
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-12-03",
+      "cost": {
+        "input": 0.06,
+        "output": 0.24,
+        "cache_read": 0.015
+      },
+      "limit": {
+        "context": 300000,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "amazon.nova-micro-v1:0",
+    "name": "Nova Micro",
+    "provider": "bedrock",
+    "family": "nova-micro",
+    "created_at": "2024-12-03 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.035,
+          "output_per_million": 0.14,
+          "cached_input_per_million": 0.00875
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-03",
+      "cost": {
+        "input": 0.035,
+        "output": 0.14,
+        "cache_read": 0.00875
+      },
+      "limit": {
+        "context": 128000,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "amazon.nova-premier-v1:0",
+    "name": "Nova Premier",
+    "provider": "bedrock",
+    "family": "nova",
+    "created_at": "2024-12-03 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 12.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-12-03",
+      "cost": {
+        "input": 2.5,
+        "output": 12.5
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 16384
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "amazon.nova-pro-v1:0",
+    "name": "Nova Pro",
+    "provider": "bedrock",
+    "family": "nova-pro",
+    "created_at": "2024-12-03 00:00:00 +0530",
+    "context_window": 300000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.8,
+          "output_per_million": 3.2,
+          "cached_input_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-12-03",
+      "cost": {
+        "input": 0.8,
+        "output": 3.2,
+        "cache_read": 0.2
+      },
+      "limit": {
+        "context": 300000,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "anthropic.claude-3-5-haiku-20241022-v1:0",
+    "name": "Claude Haiku 3.5",
+    "provider": "bedrock",
+    "family": "claude-haiku",
+    "created_at": "2024-10-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.8,
+          "output_per_million": 4,
+          "cached_input_per_million": 0.08
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-10-22",
+      "cost": {
+        "input": 0.8,
+        "output": 4,
+        "cache_read": 0.08,
+        "cache_write": 1
+      },
+      "limit": {
+        "context": 200000,
+        "output": 8192
+      },
+      "knowledge": "2024-07"
+    }
+  },
+  {
+    "id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "name": "Claude Sonnet 3.5",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2024-06-20 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-06-20",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 8192
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "name": "Claude Sonnet 3.5 v2",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2024-10-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-10-22",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 8192
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "name": "Claude Sonnet 3.7",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2025-02-19 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-02-19",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 8192
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "anthropic.claude-3-haiku-20240307-v1:0",
+    "name": "Claude Haiku 3",
+    "provider": "bedrock",
+    "family": "claude-haiku",
+    "created_at": "2024-03-13 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.25,
+          "output_per_million": 1.25
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-03-13",
+      "cost": {
+        "input": 0.25,
+        "output": 1.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 4096
+      },
+      "knowledge": "2024-02"
+    }
+  },
+  {
+    "id": "anthropic.claude-haiku-4-5-20251001-v1:0",
+    "name": "Claude Haiku 4.5",
+    "provider": "bedrock",
+    "family": "claude-haiku",
+    "created_at": "2025-10-15 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-02-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 5,
+          "cached_input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-10-15",
+      "cost": {
+        "input": 1,
+        "output": 5,
+        "cache_read": 0.1,
+        "cache_write": 1.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-02-28"
+    }
+  },
+  {
+    "id": "anthropic.claude-opus-4-1-20250805-v1:0",
+    "name": "Claude Opus 4.1",
+    "provider": "bedrock",
+    "family": "claude-opus",
+    "created_at": "2025-08-05 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 75,
+          "cached_input_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-05",
+      "cost": {
+        "input": 15,
+        "output": 75,
+        "cache_read": 1.5,
+        "cache_write": 18.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 32000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "anthropic.claude-opus-4-20250514-v1:0",
+    "name": "Claude Opus 4",
+    "provider": "bedrock",
+    "family": "claude-opus",
+    "created_at": "2025-05-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 75,
+          "cached_input_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-22",
+      "cost": {
+        "input": 15,
+        "output": 75,
+        "cache_read": 1.5,
+        "cache_write": 18.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 32000
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "anthropic.claude-opus-4-5-20251101-v1:0",
+    "name": "Claude Opus 4.5",
+    "provider": "bedrock",
+    "family": "claude-opus",
+    "created_at": "2025-11-24 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-01",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "anthropic.claude-opus-4-6-v1",
+    "name": "Claude Opus 4.6",
+    "provider": "bedrock",
+    "family": "claude-opus",
+    "created_at": "2026-02-05 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 128000
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "anthropic.claude-sonnet-4-20250514-v1:0",
+    "name": "Claude Sonnet 4",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2025-05-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-22",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "name": "Claude Sonnet 4.5",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2025-09-29 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-07-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-29",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-07-31"
+    }
+  },
+  {
+    "id": "anthropic.claude-sonnet-4-6",
+    "name": "Claude Sonnet 4.6",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2026-02-17 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 64000
+      },
+      "knowledge": "2025-08"
+    }
+  },
+  {
+    "id": "deepseek.r1-v1:0",
+    "name": "DeepSeek-R1",
+    "provider": "bedrock",
+    "family": "deepseek-thinking",
+    "created_at": "2025-01-20 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.35,
+          "output_per_million": 5.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-05-29",
+      "cost": {
+        "input": 1.35,
+        "output": 5.4
+      },
+      "limit": {
+        "context": 128000,
+        "output": 32768
+      },
+      "knowledge": "2024-07"
+    }
+  },
+  {
+    "id": "deepseek.v3-v1:0",
+    "name": "DeepSeek-V3.1",
+    "provider": "bedrock",
+    "family": "deepseek",
+    "created_at": "2025-09-18 00:00:00 +0530",
+    "context_window": 163840,
+    "max_output_tokens": 81920,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.58,
+          "output_per_million": 1.68
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-18",
+      "cost": {
+        "input": 0.58,
+        "output": 1.68
+      },
+      "limit": {
+        "context": 163840,
+        "output": 81920
+      },
+      "knowledge": "2024-07"
+    }
+  },
+  {
+    "id": "deepseek.v3.2",
+    "name": "DeepSeek-V3.2",
+    "provider": "bedrock",
+    "family": "deepseek",
+    "created_at": "2026-02-06 00:00:00 +0530",
+    "context_window": 163840,
+    "max_output_tokens": 81920,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.62,
+          "output_per_million": 1.85
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-02-06",
+      "cost": {
+        "input": 0.62,
+        "output": 1.85
+      },
+      "limit": {
+        "context": 163840,
+        "output": 81920
+      },
+      "knowledge": "2024-07"
+    }
+  },
+  {
+    "id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "name": "Claude Haiku 4.5 (EU)",
+    "provider": "bedrock",
+    "family": "claude-haiku",
+    "created_at": "2025-10-15 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-02-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 5,
+          "cached_input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-10-15",
+      "cost": {
+        "input": 1,
+        "output": 5,
+        "cache_read": 0.1,
+        "cache_write": 1.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-02-28"
+    }
+  },
+  {
+    "id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
+    "name": "Claude Opus 4.5 (EU)",
+    "provider": "bedrock",
+    "family": "claude-opus",
+    "created_at": "2025-11-24 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-01",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "eu.anthropic.claude-opus-4-6-v1",
+    "name": "Claude Opus 4.6 (EU)",
+    "provider": "bedrock",
+    "family": "claude-opus",
+    "created_at": "2026-02-05 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 128000
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
+    "name": "Claude Sonnet 4 (EU)",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2025-05-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-22",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "name": "Claude Sonnet 4.5 (EU)",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2025-09-29 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-07-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-29",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-07-31"
+    }
+  },
+  {
+    "id": "eu.anthropic.claude-sonnet-4-6",
+    "name": "Claude Sonnet 4.6 (EU)",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2026-02-17 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 64000
+      },
+      "knowledge": "2025-08"
+    }
+  },
+  {
+    "id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "name": "Claude Haiku 4.5 (Global)",
+    "provider": "bedrock",
+    "family": "claude-haiku",
+    "created_at": "2025-10-15 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-02-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 5,
+          "cached_input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-10-15",
+      "cost": {
+        "input": 1,
+        "output": 5,
+        "cache_read": 0.1,
+        "cache_write": 1.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-02-28"
+    }
+  },
+  {
+    "id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+    "name": "Claude Opus 4.5 (Global)",
+    "provider": "bedrock",
+    "family": "claude-opus",
+    "created_at": "2025-11-24 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-01",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "global.anthropic.claude-opus-4-6-v1",
+    "name": "Claude Opus 4.6 (Global)",
+    "provider": "bedrock",
+    "family": "claude-opus",
+    "created_at": "2026-02-05 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 128000
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "global.anthropic.claude-sonnet-4-20250514-v1:0",
+    "name": "Claude Sonnet 4 (Global)",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2025-05-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-22",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "name": "Claude Sonnet 4.5 (Global)",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2025-09-29 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-07-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-29",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-07-31"
+    }
+  },
+  {
+    "id": "global.anthropic.claude-sonnet-4-6",
+    "name": "Claude Sonnet 4.6 (Global)",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2026-02-17 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 64000
+      },
+      "knowledge": "2025-08"
+    }
+  },
+  {
+    "id": "google.gemma-3-12b-it",
+    "name": "Google Gemma 3 12B",
+    "provider": "bedrock",
+    "family": "gemma",
+    "created_at": "2024-12-01 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.049999999999999996,
+          "output_per_million": 0.09999999999999999
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-01",
+      "cost": {
+        "input": 0.049999999999999996,
+        "output": 0.09999999999999999
+      },
+      "limit": {
+        "context": 131072,
+        "output": 8192
+      },
+      "knowledge": "2024-12"
+    }
+  },
+  {
+    "id": "google.gemma-3-27b-it",
+    "name": "Google Gemma 3 27B Instruct",
+    "provider": "bedrock",
+    "family": "gemma",
+    "created_at": "2025-07-27 00:00:00 +0530",
+    "context_window": 202752,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.12,
+          "output_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-07-27",
+      "cost": {
+        "input": 0.12,
+        "output": 0.2
+      },
+      "limit": {
+        "context": 202752,
+        "output": 8192
+      },
+      "knowledge": "2025-07"
+    }
+  },
+  {
+    "id": "google.gemma-3-4b-it",
+    "name": "Gemma 3 4B IT",
+    "provider": "bedrock",
+    "family": "gemma",
+    "created_at": "2024-12-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.04,
+          "output_per_million": 0.08
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-01",
+      "cost": {
+        "input": 0.04,
+        "output": 0.08
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      }
+    }
+  },
+  {
+    "id": "meta.llama3-1-405b-instruct-v1:0",
+    "name": "Llama 3.1 405B Instruct",
+    "provider": "bedrock",
+    "family": "llama",
+    "created_at": "2024-07-23 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.4,
+          "output_per_million": 2.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-07-23",
+      "cost": {
+        "input": 2.4,
+        "output": 2.4
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "meta.llama3-1-70b-instruct-v1:0",
+    "name": "Llama 3.1 70B Instruct",
+    "provider": "bedrock",
+    "family": "llama",
+    "created_at": "2024-07-23 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.72,
+          "output_per_million": 0.72
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-07-23",
+      "cost": {
+        "input": 0.72,
+        "output": 0.72
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "meta.llama3-1-8b-instruct-v1:0",
+    "name": "Llama 3.1 8B Instruct",
+    "provider": "bedrock",
+    "family": "llama",
+    "created_at": "2024-07-23 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.22,
+          "output_per_million": 0.22
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-07-23",
+      "cost": {
+        "input": 0.22,
+        "output": 0.22
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "meta.llama3-2-11b-instruct-v1:0",
+    "name": "Llama 3.2 11B Instruct",
+    "provider": "bedrock",
+    "family": "llama",
+    "created_at": "2024-09-25 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.16,
+          "output_per_million": 0.16
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-09-25",
+      "cost": {
+        "input": 0.16,
+        "output": 0.16
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "meta.llama3-2-1b-instruct-v1:0",
+    "name": "Llama 3.2 1B Instruct",
+    "provider": "bedrock",
+    "family": "llama",
+    "created_at": "2024-09-25 00:00:00 +0530",
+    "context_window": 131000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-09-25",
+      "cost": {
+        "input": 0.1,
+        "output": 0.1
+      },
+      "limit": {
+        "context": 131000,
+        "output": 4096
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "meta.llama3-2-3b-instruct-v1:0",
+    "name": "Llama 3.2 3B Instruct",
+    "provider": "bedrock",
+    "family": "llama",
+    "created_at": "2024-09-25 00:00:00 +0530",
+    "context_window": 131000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.15
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-09-25",
+      "cost": {
+        "input": 0.15,
+        "output": 0.15
+      },
+      "limit": {
+        "context": 131000,
+        "output": 4096
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "meta.llama3-2-90b-instruct-v1:0",
+    "name": "Llama 3.2 90B Instruct",
+    "provider": "bedrock",
+    "family": "llama",
+    "created_at": "2024-09-25 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.72,
+          "output_per_million": 0.72
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-09-25",
+      "cost": {
+        "input": 0.72,
+        "output": 0.72
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "meta.llama3-3-70b-instruct-v1:0",
+    "name": "Llama 3.3 70B Instruct",
+    "provider": "bedrock",
+    "family": "llama",
+    "created_at": "2024-12-06 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.72,
+          "output_per_million": 0.72
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-06",
+      "cost": {
+        "input": 0.72,
+        "output": 0.72
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "meta.llama4-maverick-17b-instruct-v1:0",
+    "name": "Llama 4 Maverick 17B Instruct",
+    "provider": "bedrock",
+    "family": "llama",
+    "created_at": "2025-04-05 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.24,
+          "output_per_million": 0.97
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-04-05",
+      "cost": {
+        "input": 0.24,
+        "output": 0.97
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 16384
+      },
+      "knowledge": "2024-08"
+    }
+  },
+  {
+    "id": "meta.llama4-scout-17b-instruct-v1:0",
+    "name": "Llama 4 Scout 17B Instruct",
+    "provider": "bedrock",
+    "family": "llama",
+    "created_at": "2025-04-05 00:00:00 +0530",
+    "context_window": 3500000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.17,
+          "output_per_million": 0.66
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-04-05",
+      "cost": {
+        "input": 0.17,
+        "output": 0.66
+      },
+      "limit": {
+        "context": 3500000,
+        "output": 16384
+      },
+      "knowledge": "2024-08"
+    }
+  },
+  {
+    "id": "minimax.minimax-m2",
+    "name": "MiniMax M2",
+    "provider": "bedrock",
+    "family": "minimax",
+    "created_at": "2025-10-27 00:00:00 +0530",
+    "context_window": 204608,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 1.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-10-27",
+      "cost": {
+        "input": 0.3,
+        "output": 1.2
+      },
+      "limit": {
+        "context": 204608,
+        "output": 128000
+      }
+    }
+  },
+  {
+    "id": "minimax.minimax-m2.1",
+    "name": "MiniMax M2.1",
+    "provider": "bedrock",
+    "family": "minimax",
+    "created_at": "2025-12-23 00:00:00 +0530",
+    "context_window": 204800,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 1.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-23",
+      "cost": {
+        "input": 0.3,
+        "output": 1.2
+      },
+      "limit": {
+        "context": 204800,
+        "output": 131072
+      }
+    }
+  },
+  {
+    "id": "minimax.minimax-m2.5",
+    "name": "MiniMax M2.5",
+    "provider": "bedrock",
+    "family": "minimax",
+    "created_at": "2026-03-18 00:00:00 +0530",
+    "context_window": 196608,
+    "max_output_tokens": 98304,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 1.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "cost": {
+        "input": 0.3,
+        "output": 1.2
+      },
+      "limit": {
+        "context": 196608,
+        "output": 98304
+      }
+    }
+  },
+  {
+    "id": "mistral.devstral-2-123b",
+    "name": "Devstral 2 123B",
+    "provider": "bedrock",
+    "family": "devstral",
+    "created_at": "2026-02-17 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-02-17",
+      "cost": {
+        "input": 0.4,
+        "output": 2
+      },
+      "limit": {
+        "context": 256000,
+        "output": 8192
+      }
+    }
+  },
+  {
+    "id": "mistral.magistral-small-2509",
+    "name": "Magistral Small 1.2",
+    "provider": "bedrock",
+    "family": "magistral",
+    "created_at": "2025-12-02 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 40000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-02",
+      "cost": {
+        "input": 0.5,
+        "output": 1.5
+      },
+      "limit": {
+        "context": 128000,
+        "output": 40000
+      }
+    }
+  },
+  {
+    "id": "mistral.ministral-3-14b-instruct",
+    "name": "Ministral 14B 3.0",
+    "provider": "bedrock",
+    "family": "ministral",
+    "created_at": "2024-12-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.2,
+          "output_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-01",
+      "cost": {
+        "input": 0.2,
+        "output": 0.2
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      }
+    }
+  },
+  {
+    "id": "mistral.ministral-3-3b-instruct",
+    "name": "Ministral 3 3B",
+    "provider": "bedrock",
+    "family": "ministral",
+    "created_at": "2025-12-02 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-02",
+      "cost": {
+        "input": 0.1,
+        "output": 0.1
+      },
+      "limit": {
+        "context": 256000,
+        "output": 8192
+      }
+    }
+  },
+  {
+    "id": "mistral.ministral-3-8b-instruct",
+    "name": "Ministral 3 8B",
+    "provider": "bedrock",
+    "family": "ministral",
+    "created_at": "2024-12-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.15
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-01",
+      "cost": {
+        "input": 0.15,
+        "output": 0.15
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      }
+    }
+  },
+  {
+    "id": "mistral.mistral-large-3-675b-instruct",
+    "name": "Mistral Large 3",
+    "provider": "bedrock",
+    "family": "mistral",
+    "created_at": "2025-12-02 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-02",
+      "cost": {
+        "input": 0.5,
+        "output": 1.5
+      },
+      "limit": {
+        "context": 256000,
+        "output": 8192
+      }
+    }
+  },
+  {
+    "id": "mistral.pixtral-large-2502-v1:0",
+    "name": "Pixtral Large (25.02)",
+    "provider": "bedrock",
+    "family": "mistral",
+    "created_at": "2025-04-08 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-04-08",
+      "cost": {
+        "input": 2,
+        "output": 6
+      },
+      "limit": {
+        "context": 128000,
+        "output": 8192
+      }
+    }
+  },
+  {
+    "id": "mistral.voxtral-mini-3b-2507",
+    "name": "Voxtral Mini 3B 2507",
+    "provider": "bedrock",
+    "family": "mistral",
+    "created_at": "2024-12-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "audio",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.04,
+          "output_per_million": 0.04
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-01",
+      "cost": {
+        "input": 0.04,
+        "output": 0.04
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      }
+    }
+  },
+  {
+    "id": "mistral.voxtral-small-24b-2507",
+    "name": "Voxtral Small 24B 2507",
+    "provider": "bedrock",
+    "family": "mistral",
+    "created_at": "2025-07-01 00:00:00 +0530",
+    "context_window": 32000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.35
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-07-01",
+      "cost": {
+        "input": 0.15,
+        "output": 0.35
+      },
+      "limit": {
+        "context": 32000,
+        "output": 8192
+      }
+    }
+  },
+  {
+    "id": "moonshot.kimi-k2-thinking",
+    "name": "Kimi K2 Thinking",
+    "provider": "bedrock",
+    "family": "kimi-thinking",
+    "created_at": "2025-12-02 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 256000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-02",
+      "interleaved": true,
+      "cost": {
+        "input": 0.6,
+        "output": 2.5
+      },
+      "limit": {
+        "context": 256000,
+        "output": 256000
+      }
+    }
+  },
+  {
+    "id": "moonshotai.kimi-k2.5",
+    "name": "Kimi K2.5",
+    "provider": "bedrock",
+    "family": "kimi",
+    "created_at": "2026-02-06 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 256000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-02-06",
+      "interleaved": true,
+      "cost": {
+        "input": 0.6,
+        "output": 3
+      },
+      "limit": {
+        "context": 256000,
+        "output": 256000
+      }
+    }
+  },
+  {
+    "id": "nvidia.nemotron-nano-12b-v2",
+    "name": "NVIDIA Nemotron Nano 12B v2 VL BF16",
+    "provider": "bedrock",
+    "family": "nemotron",
+    "created_at": "2024-12-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.2,
+          "output_per_million": 0.6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-01",
+      "cost": {
+        "input": 0.2,
+        "output": 0.6
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      }
+    }
+  },
+  {
+    "id": "nvidia.nemotron-nano-3-30b",
+    "name": "NVIDIA Nemotron Nano 3 30B",
+    "provider": "bedrock",
+    "family": "nemotron",
+    "created_at": "2025-12-23 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.06,
+          "output_per_million": 0.24
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-23",
+      "cost": {
+        "input": 0.06,
+        "output": 0.24
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      }
+    }
+  },
+  {
+    "id": "nvidia.nemotron-nano-9b-v2",
+    "name": "NVIDIA Nemotron Nano 9B v2",
+    "provider": "bedrock",
+    "family": "nemotron",
+    "created_at": "2024-12-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.06,
+          "output_per_million": 0.23
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-01",
+      "cost": {
+        "input": 0.06,
+        "output": 0.23
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      }
+    }
+  },
+  {
+    "id": "nvidia.nemotron-super-3-120b",
+    "name": "NVIDIA Nemotron 3 Super 120B A12B",
+    "provider": "bedrock",
+    "family": "nemotron",
+    "created_at": "2026-03-11 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.65
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-03-11",
+      "cost": {
+        "input": 0.15,
+        "output": 0.65
+      },
+      "limit": {
+        "context": 262144,
+        "output": 131072
+      }
+    }
+  },
+  {
+    "id": "openai.gpt-oss-120b-1:0",
+    "name": "gpt-oss-120b",
+    "provider": "bedrock",
+    "family": "gpt-oss",
+    "created_at": "2024-12-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-01",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      }
+    }
+  },
+  {
+    "id": "openai.gpt-oss-20b-1:0",
+    "name": "gpt-oss-20b",
+    "provider": "bedrock",
+    "family": "gpt-oss",
+    "created_at": "2024-12-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.07,
+          "output_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-01",
+      "cost": {
+        "input": 0.07,
+        "output": 0.3
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      }
+    }
+  },
+  {
+    "id": "openai.gpt-oss-safeguard-120b",
+    "name": "GPT OSS Safeguard 120B",
+    "provider": "bedrock",
+    "family": "gpt-oss",
+    "created_at": "2024-12-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-01",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      }
+    }
+  },
+  {
+    "id": "openai.gpt-oss-safeguard-20b",
+    "name": "GPT OSS Safeguard 20B",
+    "provider": "bedrock",
+    "family": "gpt-oss",
+    "created_at": "2024-12-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.07,
+          "output_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-01",
+      "cost": {
+        "input": 0.07,
+        "output": 0.2
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      }
+    }
+  },
+  {
+    "id": "qwen.qwen3-235b-a22b-2507-v1:0",
+    "name": "Qwen3 235B A22B 2507",
+    "provider": "bedrock",
+    "family": "qwen",
+    "created_at": "2025-09-18 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.22,
+          "output_per_million": 0.88
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-18",
+      "cost": {
+        "input": 0.22,
+        "output": 0.88
+      },
+      "limit": {
+        "context": 262144,
+        "output": 131072
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "qwen.qwen3-32b-v1:0",
+    "name": "Qwen3 32B (dense)",
+    "provider": "bedrock",
+    "family": "qwen",
+    "created_at": "2025-09-18 00:00:00 +0530",
+    "context_window": 16384,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-18",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6
+      },
+      "limit": {
+        "context": 16384,
+        "output": 16384
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "qwen.qwen3-coder-30b-a3b-v1:0",
+    "name": "Qwen3 Coder 30B A3B Instruct",
+    "provider": "bedrock",
+    "family": "qwen",
+    "created_at": "2025-09-18 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-18",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6
+      },
+      "limit": {
+        "context": 262144,
+        "output": 131072
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "qwen.qwen3-coder-480b-a35b-v1:0",
+    "name": "Qwen3 Coder 480B A35B Instruct",
+    "provider": "bedrock",
+    "family": "qwen",
+    "created_at": "2025-09-18 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.22,
+          "output_per_million": 1.8
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-18",
+      "cost": {
+        "input": 0.22,
+        "output": 1.8
+      },
+      "limit": {
+        "context": 131072,
+        "output": 65536
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "qwen.qwen3-coder-next",
+    "name": "Qwen3 Coder Next",
+    "provider": "bedrock",
+    "family": "qwen",
+    "created_at": "2026-02-06 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.22,
+          "output_per_million": 1.8
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-02-06",
+      "cost": {
+        "input": 0.22,
+        "output": 1.8
+      },
+      "limit": {
+        "context": 131072,
+        "output": 65536
+      }
+    }
+  },
+  {
+    "id": "qwen.qwen3-next-80b-a3b",
+    "name": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+    "provider": "bedrock",
+    "family": "qwen",
+    "created_at": "2025-09-18 00:00:00 +0530",
+    "context_window": 262000,
+    "max_output_tokens": 262000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.14,
+          "output_per_million": 1.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-11-25",
+      "cost": {
+        "input": 0.14,
+        "output": 1.4
+      },
+      "limit": {
+        "context": 262000,
+        "output": 262000
+      }
+    }
+  },
+  {
+    "id": "qwen.qwen3-vl-235b-a22b",
+    "name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+    "provider": "bedrock",
+    "family": "qwen",
+    "created_at": "2025-10-04 00:00:00 +0530",
+    "context_window": 262000,
+    "max_output_tokens": 262000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-11-25",
+      "cost": {
+        "input": 0.3,
+        "output": 1.5
+      },
+      "limit": {
+        "context": 262000,
+        "output": 262000
+      }
+    }
+  },
+  {
+    "id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "name": "Claude Haiku 4.5 (US)",
+    "provider": "bedrock",
+    "family": "claude-haiku",
+    "created_at": "2025-10-15 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-02-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 5,
+          "cached_input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-10-15",
+      "cost": {
+        "input": 1,
+        "output": 5,
+        "cache_read": 0.1,
+        "cache_write": 1.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-02-28"
+    }
+  },
+  {
+    "id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
+    "name": "Claude Opus 4.1 (US)",
+    "provider": "bedrock",
+    "family": "claude-opus",
+    "created_at": "2025-08-05 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 75,
+          "cached_input_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-05",
+      "cost": {
+        "input": 15,
+        "output": 75,
+        "cache_read": 1.5,
+        "cache_write": 18.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 32000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "us.anthropic.claude-opus-4-20250514-v1:0",
+    "name": "Claude Opus 4 (US)",
+    "provider": "bedrock",
+    "family": "claude-opus",
+    "created_at": "2025-05-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 75,
+          "cached_input_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-22",
+      "cost": {
+        "input": 15,
+        "output": 75,
+        "cache_read": 1.5,
+        "cache_write": 18.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 32000
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
+    "name": "Claude Opus 4.5 (US)",
+    "provider": "bedrock",
+    "family": "claude-opus",
+    "created_at": "2025-11-24 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-01",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "us.anthropic.claude-opus-4-6-v1",
+    "name": "Claude Opus 4.6 (US)",
+    "provider": "bedrock",
+    "family": "claude-opus",
+    "created_at": "2026-02-05 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 128000
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+    "name": "Claude Sonnet 4 (US)",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2025-05-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-22",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "name": "Claude Sonnet 4.5 (US)",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2025-09-29 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-07-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-29",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-07-31"
+    }
+  },
+  {
+    "id": "us.anthropic.claude-sonnet-4-6",
+    "name": "Claude Sonnet 4.6 (US)",
+    "provider": "bedrock",
+    "family": "claude-sonnet",
+    "created_at": "2026-02-17 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 64000
+      },
+      "knowledge": "2025-08"
+    }
+  },
+  {
+    "id": "writer.palmyra-x4-v1:0",
+    "name": "Palmyra X4",
+    "provider": "bedrock",
+    "family": "palmyra",
+    "created_at": "2025-04-28 00:00:00 +0530",
+    "context_window": 122880,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 10
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-04-28",
+      "cost": {
+        "input": 2.5,
+        "output": 10
+      },
+      "limit": {
+        "context": 122880,
+        "output": 8192
+      }
+    }
+  },
+  {
+    "id": "writer.palmyra-x5-v1:0",
+    "name": "Palmyra X5",
+    "provider": "bedrock",
+    "family": "palmyra",
+    "created_at": "2025-04-28 00:00:00 +0530",
+    "context_window": 1040000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-04-28",
+      "cost": {
+        "input": 0.6,
+        "output": 6
+      },
+      "limit": {
+        "context": 1040000,
+        "output": 8192
+      }
+    }
+  },
+  {
+    "id": "zai.glm-4.7",
+    "name": "GLM-4.7",
+    "provider": "bedrock",
+    "family": "glm",
+    "created_at": "2025-12-22 00:00:00 +0530",
+    "context_window": 204800,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-22",
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "cost": {
+        "input": 0.6,
+        "output": 2.2
+      },
+      "limit": {
+        "context": 204800,
+        "output": 131072
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "zai.glm-4.7-flash",
+    "name": "GLM-4.7-Flash",
+    "provider": "bedrock",
+    "family": "glm-flash",
+    "created_at": "2026-01-19 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.07,
+          "output_per_million": 0.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-19",
+      "cost": {
+        "input": 0.07,
+        "output": 0.4
+      },
+      "limit": {
+        "context": 200000,
+        "output": 131072
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "zai.glm-5",
+    "name": "GLM-5",
+    "provider": "bedrock",
+    "family": "glm",
+    "created_at": "2026-03-18 00:00:00 +0530",
+    "context_window": 202752,
+    "max_output_tokens": 101376,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 3.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "amazon-bedrock",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "cost": {
+        "input": 1,
+        "output": 3.2
+      },
+      "limit": {
+        "context": 202752,
+        "output": 101376
+      }
+    }
+  },
+  {
+    "id": "deepseek-chat",
+    "name": "DeepSeek Chat",
+    "provider": "deepseek",
+    "family": "deepseek",
+    "created_at": "2025-12-01 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.28,
+          "output_per_million": 0.42,
+          "cached_input_per_million": 0.028
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "deepseek",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-28",
+      "cost": {
+        "input": 0.28,
+        "output": 0.42,
+        "cache_read": 0.028
+      },
+      "limit": {
+        "context": 131072,
+        "output": 8192
+      },
+      "knowledge": "2025-09"
+    }
+  },
+  {
+    "id": "deepseek-reasoner",
+    "name": "DeepSeek Reasoner",
+    "provider": "deepseek",
+    "family": "deepseek-thinking",
+    "created_at": "2025-12-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.28,
+          "output_per_million": 0.42,
+          "cached_input_per_million": 0.028
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "deepseek",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-28",
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "cost": {
+        "input": 0.28,
+        "output": 0.42,
+        "cache_read": 0.028
+      },
+      "limit": {
+        "context": 128000,
+        "output": 64000
+      },
+      "knowledge": "2025-09"
+    }
+  },
+  {
+    "id": "gemini-1.5-flash",
+    "name": "Gemini 1.5 Flash",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2024-05-14 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.075,
+          "output_per_million": 0.3,
+          "cached_input_per_million": 0.01875
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-05-14",
+      "cost": {
+        "input": 0.075,
+        "output": 0.3,
+        "cache_read": 0.01875
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 8192
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "gemini-1.5-flash-8b",
+    "name": "Gemini 1.5 Flash-8B",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2024-10-03 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.0375,
+          "output_per_million": 0.15,
+          "cached_input_per_million": 0.01
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-10-03",
+      "cost": {
+        "input": 0.0375,
+        "output": 0.15,
+        "cache_read": 0.01
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 8192
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "gemini-1.5-pro",
+    "name": "Gemini 1.5 Pro",
+    "provider": "gemini",
+    "family": "gemini-pro",
+    "created_at": "2024-02-15 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 5,
+          "cached_input_per_million": 0.3125
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-02-15",
+      "cost": {
+        "input": 1.25,
+        "output": 5,
+        "cache_read": 0.3125
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 8192
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "gemini-2.0-flash",
+    "name": "Gemini 2.0 Flash",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2024-12-11 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-12-11",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 8192
+      },
+      "knowledge": "2024-06"
+    }
+  },
+  {
+    "id": "gemini-2.0-flash-lite",
+    "name": "Gemini 2.0 Flash Lite",
+    "provider": "gemini",
+    "family": "gemini-flash-lite",
+    "created_at": "2024-12-11 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.075,
+          "output_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-12-11",
+      "cost": {
+        "input": 0.075,
+        "output": 0.3
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 8192
+      },
+      "knowledge": "2024-06"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash",
+    "name": "Gemini 2.5 Flash",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2025-03-20 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 2.5,
+          "cached_input_per_million": 0.075
+        }
+      },
+      "audio_tokens": {
+        "standard": {
+          "input_per_million": 1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-05",
+      "cost": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_read": 0.075,
+        "input_audio": 1
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-image",
+    "name": "Gemini 2.5 Flash Image",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2025-08-26 00:00:00 +0530",
+    "context_window": 32768,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "capabilities": [
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 30,
+          "cached_input_per_million": 0.075
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-26",
+      "cost": {
+        "input": 0.3,
+        "output": 30,
+        "cache_read": 0.075
+      },
+      "limit": {
+        "context": 32768,
+        "output": 32768
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-image-preview",
+    "name": "Gemini 2.5 Flash Image (Preview)",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2025-08-26 00:00:00 +0530",
+    "context_window": 32768,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "capabilities": [
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 30,
+          "cached_input_per_million": 0.075
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-26",
+      "cost": {
+        "input": 0.3,
+        "output": 30,
+        "cache_read": 0.075
+      },
+      "limit": {
+        "context": 32768,
+        "output": 32768
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-lite",
+    "name": "Gemini 2.5 Flash Lite",
+    "provider": "gemini",
+    "family": "gemini-flash-lite",
+    "created_at": "2025-06-17 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-17",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-lite-preview-06-17",
+    "name": "Gemini 2.5 Flash Lite Preview 06-17",
+    "provider": "gemini",
+    "family": "gemini-flash-lite",
+    "created_at": "2025-06-17 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.025
+        }
+      },
+      "audio_tokens": {
+        "standard": {
+          "input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-17",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.025,
+        "input_audio": 0.3
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-lite-preview-09-2025",
+    "name": "Gemini 2.5 Flash Lite Preview 09-25",
+    "provider": "gemini",
+    "family": "gemini-flash-lite",
+    "created_at": "2025-09-25 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-25",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-preview-04-17",
+    "name": "Gemini 2.5 Flash Preview 04-17",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2025-04-17 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6,
+          "cached_input_per_million": 0.0375
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-04-17",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_read": 0.0375
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-preview-05-20",
+    "name": "Gemini 2.5 Flash Preview 05-20",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2025-05-20 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6,
+          "cached_input_per_million": 0.0375
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-20",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_read": 0.0375
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-preview-09-2025",
+    "name": "Gemini 2.5 Flash Preview 09-25",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2025-09-25 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 2.5,
+          "cached_input_per_million": 0.075
+        }
+      },
+      "audio_tokens": {
+        "standard": {
+          "input_per_million": 1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-25",
+      "cost": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_read": 0.075,
+        "input_audio": 1
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-preview-tts",
+    "name": "Gemini 2.5 Flash Preview TTS",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2025-05-01 00:00:00 +0530",
+    "context_window": 8000,
+    "max_output_tokens": 16000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "audio"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 10
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2025-05-01",
+      "cost": {
+        "input": 0.5,
+        "output": 10
+      },
+      "limit": {
+        "context": 8000,
+        "output": 16000
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-pro",
+    "name": "Gemini 2.5 Pro",
+    "provider": "gemini",
+    "family": "gemini-pro",
+    "created_at": "2025-03-20 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.31
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-05",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.31
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-pro-preview-05-06",
+    "name": "Gemini 2.5 Pro Preview 05-06",
+    "provider": "gemini",
+    "family": "gemini-pro",
+    "created_at": "2025-05-06 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.31
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-06",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.31
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-pro-preview-06-05",
+    "name": "Gemini 2.5 Pro Preview 06-05",
+    "provider": "gemini",
+    "family": "gemini-pro",
+    "created_at": "2025-06-05 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.31
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-05",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.31
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-pro-preview-tts",
+    "name": "Gemini 2.5 Pro Preview TTS",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2025-05-01 00:00:00 +0530",
+    "context_window": 8000,
+    "max_output_tokens": 16000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "audio"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 20
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2025-05-01",
+      "cost": {
+        "input": 1,
+        "output": 20
+      },
+      "limit": {
+        "context": 8000,
+        "output": 16000
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-3-flash-preview",
+    "name": "Gemini 3 Flash Preview",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2025-12-17 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 3,
+          "cached_input_per_million": 0.05
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-12-17",
+      "cost": {
+        "input": 0.5,
+        "output": 3,
+        "cache_read": 0.05,
+        "context_over_200k": {
+          "input": 0.5,
+          "output": 3,
+          "cache_read": 0.05
+        }
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-3-pro-preview",
+    "name": "Gemini 3 Pro Preview",
+    "provider": "gemini",
+    "family": "gemini-pro",
+    "created_at": "2025-11-18 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 12,
+          "cached_input_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-11-18",
+      "cost": {
+        "input": 2,
+        "output": 12,
+        "cache_read": 0.2,
+        "context_over_200k": {
+          "input": 4,
+          "output": 18,
+          "cache_read": 0.4
+        }
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 64000
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-3.1-flash-image-preview",
+    "name": "Gemini 3.1 Flash Image (Preview)",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2026-02-26 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "capabilities": [
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.25,
+          "output_per_million": 60
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-26",
+      "cost": {
+        "input": 0.25,
+        "output": 60
+      },
+      "limit": {
+        "context": 131072,
+        "output": 32768
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-3.1-flash-lite-preview",
+    "name": "Gemini 3.1 Flash Lite Preview",
+    "provider": "gemini",
+    "family": "gemini-flash-lite",
+    "created_at": "2026-03-03 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.25,
+          "output_per_million": 1.5,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-03",
+      "cost": {
+        "input": 0.25,
+        "output": 1.5,
+        "cache_read": 0.025,
+        "cache_write": 1
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-3.1-pro-preview",
+    "name": "Gemini 3.1 Pro Preview",
+    "provider": "gemini",
+    "family": "gemini-pro",
+    "created_at": "2026-02-19 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 12,
+          "cached_input_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-19",
+      "cost": {
+        "input": 2,
+        "output": 12,
+        "cache_read": 0.2,
+        "context_over_200k": {
+          "input": 4,
+          "output": 18,
+          "cache_read": 0.4
+        }
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-3.1-pro-preview-customtools",
+    "name": "Gemini 3.1 Pro Preview Custom Tools",
+    "provider": "gemini",
+    "family": "gemini-pro",
+    "created_at": "2026-02-19 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 12,
+          "cached_input_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-19",
+      "cost": {
+        "input": 2,
+        "output": 12,
+        "cache_read": 0.2,
+        "context_over_200k": {
+          "input": 4,
+          "output": 18,
+          "cache_read": 0.4
+        }
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-embedding-001",
+    "name": "Gemini Embedding 001",
+    "provider": "gemini",
+    "family": "gemini",
+    "created_at": "2025-05-20 00:00:00 +0530",
+    "context_window": 2048,
+    "max_output_tokens": 3072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2025-05-20",
+      "cost": {
+        "input": 0.15,
+        "output": 0
+      },
+      "limit": {
+        "context": 2048,
+        "output": 3072
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "gemini-flash-latest",
+    "name": "Gemini Flash Latest",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2025-09-25 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 2.5,
+          "cached_input_per_million": 0.075
+        }
+      },
+      "audio_tokens": {
+        "standard": {
+          "input_per_million": 1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-25",
+      "cost": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_read": 0.075,
+        "input_audio": 1
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-flash-lite-latest",
+    "name": "Gemini Flash-Lite Latest",
+    "provider": "gemini",
+    "family": "gemini-flash-lite",
+    "created_at": "2025-09-25 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-25",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-live-2.5-flash",
+    "name": "Gemini Live 2.5 Flash",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2025-09-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 8000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 2
+        }
+      },
+      "audio_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 12
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-01",
+      "cost": {
+        "input": 0.5,
+        "output": 2,
+        "input_audio": 3,
+        "output_audio": 12
+      },
+      "limit": {
+        "context": 128000,
+        "output": 8000
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-live-2.5-flash-preview-native-audio",
+    "name": "Gemini Live 2.5 Flash Preview Native Audio",
+    "provider": "gemini",
+    "family": "gemini-flash",
+    "created_at": "2025-06-17 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 2
+        }
+      },
+      "audio_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 12
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2025-09-18",
+      "cost": {
+        "input": 0.5,
+        "output": 2,
+        "input_audio": 3,
+        "output_audio": 12
+      },
+      "limit": {
+        "context": 131072,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemma-3-12b-it",
+    "name": "Gemma 3 12B",
+    "provider": "gemini",
+    "family": "gemma",
+    "created_at": "2025-03-13 00:00:00 +0530",
+    "context_window": 32768,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-03-13",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 32768,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "gemma-3-27b-it",
+    "name": "Gemma 3 27B",
+    "provider": "gemini",
+    "family": "gemma",
+    "created_at": "2025-03-12 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-03-12",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 131072,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "gemma-3-4b-it",
+    "name": "Gemma 3 4B",
+    "provider": "gemini",
+    "family": "gemma",
+    "created_at": "2025-03-13 00:00:00 +0530",
+    "context_window": 32768,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-03-13",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 32768,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "gemma-3n-e2b-it",
+    "name": "Gemma 3n 2B",
+    "provider": "gemini",
+    "family": "gemma",
+    "created_at": "2025-07-09 00:00:00 +0530",
+    "context_window": 8192,
+    "max_output_tokens": 2000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-07-09",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 8192,
+        "output": 2000
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "gemma-3n-e4b-it",
+    "name": "Gemma 3n 4B",
+    "provider": "gemini",
+    "family": "gemma",
+    "created_at": "2025-05-20 00:00:00 +0530",
+    "context_window": 8192,
+    "max_output_tokens": 2000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-20",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 8192,
+        "output": 2000
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "gemma-4-26b-it",
+    "name": "Gemma 4 26B",
+    "provider": "gemini",
+    "family": "gemma",
+    "created_at": "2026-04-02 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-04-02",
+      "limit": {
+        "context": 256000,
+        "output": 8192
+      }
+    }
+  },
+  {
+    "id": "gemma-4-31b-it",
+    "name": "Gemma 4 31B",
+    "provider": "gemini",
+    "family": "gemma",
+    "created_at": "2026-04-02 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-04-02",
+      "limit": {
+        "context": 256000,
+        "output": 8192
+      }
+    }
+  },
+  {
+    "id": "codestral-latest",
+    "name": "Codestral (latest)",
+    "provider": "mistral",
+    "family": "codestral",
+    "created_at": "2024-05-29 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 0.9
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-01-04",
+      "cost": {
+        "input": 0.3,
+        "output": 0.9
+      },
+      "limit": {
+        "context": 256000,
+        "output": 4096
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "devstral-2512",
+    "name": "Devstral 2",
+    "provider": "mistral",
+    "family": "devstral",
+    "created_at": "2025-12-09 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-09",
+      "cost": {
+        "input": 0.4,
+        "output": 2
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2025-12"
+    }
+  },
+  {
+    "id": "devstral-medium-2507",
+    "name": "Devstral Medium",
+    "provider": "mistral",
+    "family": "devstral",
+    "created_at": "2025-07-10 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-10",
+      "cost": {
+        "input": 0.4,
+        "output": 2
+      },
+      "limit": {
+        "context": 128000,
+        "output": 128000
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "devstral-medium-latest",
+    "name": "Devstral 2 (latest)",
+    "provider": "mistral",
+    "family": "devstral",
+    "created_at": "2025-12-02 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-02",
+      "cost": {
+        "input": 0.4,
+        "output": 2
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2025-12"
+    }
+  },
+  {
+    "id": "devstral-small-2505",
+    "name": "Devstral Small 2505",
+    "provider": "mistral",
+    "family": "devstral",
+    "created_at": "2025-05-07 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-05-07",
+      "cost": {
+        "input": 0.1,
+        "output": 0.3
+      },
+      "limit": {
+        "context": 128000,
+        "output": 128000
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "devstral-small-2507",
+    "name": "Devstral Small",
+    "provider": "mistral",
+    "family": "devstral",
+    "created_at": "2025-07-10 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-10",
+      "cost": {
+        "input": 0.1,
+        "output": 0.3
+      },
+      "limit": {
+        "context": 128000,
+        "output": 128000
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "labs-devstral-small-2512",
+    "name": "Devstral Small 2",
+    "provider": "mistral",
+    "family": "devstral",
+    "created_at": "2025-12-09 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 256000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-09",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 256000,
+        "output": 256000
+      },
+      "knowledge": "2025-12"
+    }
+  },
+  {
+    "id": "magistral-medium-latest",
+    "name": "Magistral Medium (latest)",
+    "provider": "mistral",
+    "family": "magistral-medium",
+    "created_at": "2025-03-17 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-03-20",
+      "cost": {
+        "input": 2,
+        "output": 5
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "magistral-small",
+    "name": "Magistral Small",
+    "provider": "mistral",
+    "family": "magistral-small",
+    "created_at": "2025-03-17 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-03-17",
+      "cost": {
+        "input": 0.5,
+        "output": 1.5
+      },
+      "limit": {
+        "context": 128000,
+        "output": 128000
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "ministral-3b-latest",
+    "name": "Ministral 3B (latest)",
+    "provider": "mistral",
+    "family": "ministral",
+    "created_at": "2024-10-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.04,
+          "output_per_million": 0.04
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-10-04",
+      "cost": {
+        "input": 0.04,
+        "output": 0.04
+      },
+      "limit": {
+        "context": 128000,
+        "output": 128000
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "ministral-8b-latest",
+    "name": "Ministral 8B (latest)",
+    "provider": "mistral",
+    "family": "ministral",
+    "created_at": "2024-10-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-10-04",
+      "cost": {
+        "input": 0.1,
+        "output": 0.1
+      },
+      "limit": {
+        "context": 128000,
+        "output": 128000
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "mistral-embed",
+    "name": "Mistral Embed",
+    "provider": "mistral",
+    "family": "mistral-embed",
+    "created_at": "2023-12-11 00:00:00 +0530",
+    "context_window": 8000,
+    "max_output_tokens": 3072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2023-12-11",
+      "cost": {
+        "input": 0.1,
+        "output": 0
+      },
+      "limit": {
+        "context": 8000,
+        "output": 3072
+      }
+    }
+  },
+  {
+    "id": "mistral-large-2411",
+    "name": "Mistral Large 2.1",
+    "provider": "mistral",
+    "family": "mistral-large",
+    "created_at": "2024-11-01 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-11-04",
+      "cost": {
+        "input": 2,
+        "output": 6
+      },
+      "limit": {
+        "context": 131072,
+        "output": 16384
+      },
+      "knowledge": "2024-11"
+    }
+  },
+  {
+    "id": "mistral-large-2512",
+    "name": "Mistral Large 3",
+    "provider": "mistral",
+    "family": "mistral-large",
+    "created_at": "2024-11-01 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-12-02",
+      "cost": {
+        "input": 0.5,
+        "output": 1.5
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2024-11"
+    }
+  },
+  {
+    "id": "mistral-large-latest",
+    "name": "Mistral Large (latest)",
+    "provider": "mistral",
+    "family": "mistral-large",
+    "created_at": "2024-11-01 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-12-02",
+      "cost": {
+        "input": 0.5,
+        "output": 1.5
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2024-11"
+    }
+  },
+  {
+    "id": "mistral-medium-2505",
+    "name": "Mistral Medium 3",
+    "provider": "mistral",
+    "family": "mistral-medium",
+    "created_at": "2025-05-07 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-07",
+      "cost": {
+        "input": 0.4,
+        "output": 2
+      },
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "mistral-medium-2508",
+    "name": "Mistral Medium 3.1",
+    "provider": "mistral",
+    "family": "mistral-medium",
+    "created_at": "2025-08-12 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-12",
+      "cost": {
+        "input": 0.4,
+        "output": 2
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "mistral-medium-latest",
+    "name": "Mistral Medium (latest)",
+    "provider": "mistral",
+    "family": "mistral-medium",
+    "created_at": "2025-05-07 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-05-10",
+      "cost": {
+        "input": 0.4,
+        "output": 2
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "mistral-nemo",
+    "name": "Mistral Nemo",
+    "provider": "mistral",
+    "family": "mistral-nemo",
+    "created_at": "2024-07-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.15
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-07-01",
+      "cost": {
+        "input": 0.15,
+        "output": 0.15
+      },
+      "limit": {
+        "context": 128000,
+        "output": 128000
+      },
+      "knowledge": "2024-07"
+    }
+  },
+  {
+    "id": "mistral-small-2506",
+    "name": "Mistral Small 3.2",
+    "provider": "mistral",
+    "family": "mistral-small",
+    "created_at": "2025-06-20 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-06-20",
+      "cost": {
+        "input": 0.1,
+        "output": 0.3
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2025-03"
+    }
+  },
+  {
+    "id": "mistral-small-2603",
+    "name": "Mistral Small 4",
+    "provider": "mistral",
+    "family": "mistral-small",
+    "created_at": "2026-03-16 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 256000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-16",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6
+      },
+      "limit": {
+        "context": 256000,
+        "output": 256000
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "mistral-small-latest",
+    "name": "Mistral Small (latest)",
+    "provider": "mistral",
+    "family": "mistral-small",
+    "created_at": "2026-03-16 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 256000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-16",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6
+      },
+      "limit": {
+        "context": 256000,
+        "output": 256000
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "open-mistral-7b",
+    "name": "Mistral 7B",
+    "provider": "mistral",
+    "family": "mistral",
+    "created_at": "2023-09-27 00:00:00 +0530",
+    "context_window": 8000,
+    "max_output_tokens": 8000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.25,
+          "output_per_million": 0.25
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2023-09-27",
+      "cost": {
+        "input": 0.25,
+        "output": 0.25
+      },
+      "limit": {
+        "context": 8000,
+        "output": 8000
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "open-mixtral-8x22b",
+    "name": "Mixtral 8x22B",
+    "provider": "mistral",
+    "family": "mixtral",
+    "created_at": "2024-04-17 00:00:00 +0530",
+    "context_window": 64000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-04-17",
+      "cost": {
+        "input": 2,
+        "output": 6
+      },
+      "limit": {
+        "context": 64000,
+        "output": 64000
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "open-mixtral-8x7b",
+    "name": "Mixtral 8x7B",
+    "provider": "mistral",
+    "family": "mixtral",
+    "created_at": "2023-12-11 00:00:00 +0530",
+    "context_window": 32000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.7,
+          "output_per_million": 0.7
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2023-12-11",
+      "cost": {
+        "input": 0.7,
+        "output": 0.7
+      },
+      "limit": {
+        "context": 32000,
+        "output": 32000
+      },
+      "knowledge": "2024-01"
+    }
+  },
+  {
+    "id": "pixtral-12b",
+    "name": "Pixtral 12B",
+    "provider": "mistral",
+    "family": "pixtral",
+    "created_at": "2024-09-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.15
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-09-01",
+      "cost": {
+        "input": 0.15,
+        "output": 0.15
+      },
+      "limit": {
+        "context": 128000,
+        "output": 128000
+      },
+      "knowledge": "2024-09"
+    }
+  },
+  {
+    "id": "pixtral-large-latest",
+    "name": "Pixtral Large (latest)",
+    "provider": "mistral",
+    "family": "pixtral",
+    "created_at": "2024-11-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "mistral",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-11-04",
+      "cost": {
+        "input": 2,
+        "output": 6
+      },
+      "limit": {
+        "context": 128000,
+        "output": 128000
+      },
+      "knowledge": "2024-11"
+    }
+  },
+  {
+    "id": "babbage-002",
+    "name": "Babbage 002",
+    "provider": "openai",
+    "family": "babbage",
+    "created_at": "2023-08-21 21:46:55 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 0.4
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "chatgpt-image-latest",
+    "name": "chatgpt-image-latest",
+    "provider": "openai",
+    "family": "gpt-image",
+    "created_at": "2025-12-16 00:00:00 +0530",
+    "context_window": 0,
+    "max_output_tokens": 0,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "capabilities": [
+      "vision",
+      "streaming"
+    ],
+    "pricing": {},
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-12-16",
+      "limit": {
+        "context": 0,
+        "input": 0,
+        "output": 0
+      }
+    }
+  },
+  {
+    "id": "codex-mini-latest",
+    "name": "Codex Mini",
+    "provider": "openai",
+    "family": "gpt-codex-mini",
+    "created_at": "2025-05-16 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.5,
+          "output_per_million": 6,
+          "cached_input_per_million": 0.375
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-05-16",
+      "cost": {
+        "input": 1.5,
+        "output": 6,
+        "cache_read": 0.375
+      },
+      "limit": {
+        "context": 200000,
+        "output": 100000
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "computer-use-preview",
+    "name": "Computer Use Preview",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2024-12-20 06:17:57 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "computer-use-preview-2025-03-11",
+    "name": "Computer Use Preview 20250311",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-03-08 01:20:21 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "dall-e-2",
+    "name": "DALL-E-2",
+    "provider": "openai",
+    "family": "dall_e",
+    "created_at": "2023-11-01 05:52:57 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "dall-e-3",
+    "name": "DALL-E-3",
+    "provider": "openai",
+    "family": "dall_e",
+    "created_at": "2023-11-01 02:16:29 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "davinci-002",
+    "name": "Davinci 002",
+    "provider": "openai",
+    "family": "davinci",
+    "created_at": "2023-08-21 21:41:41 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.0,
+          "output_per_million": 2.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-3.5-turbo",
+    "name": "GPT-3.5-turbo",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2023-03-01 00:00:00 +0530",
+    "context_window": 16385,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": "2021-09-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5,
+          "cached_input_per_million": 1.25
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "openai",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2023-11-06",
+      "cost": {
+        "input": 0.5,
+        "output": 1.5,
+        "cache_read": 1.25
+      },
+      "limit": {
+        "context": 16385,
+        "output": 4096
+      },
+      "knowledge": "2021-09-01"
+    }
+  },
+  {
+    "id": "gpt-3.5-turbo-0125",
+    "name": "GPT-3.5 Turbo 0125",
+    "provider": "openai",
+    "family": "gpt35_turbo",
+    "created_at": "2024-01-24 03:49:18 +0530",
+    "context_window": 16385,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-3.5-turbo-1106",
+    "name": "GPT-3.5 Turbo 1106",
+    "provider": "openai",
+    "family": "gpt35_turbo",
+    "created_at": "2023-11-03 02:45:48 +0530",
+    "context_window": 16385,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-3.5-turbo-16k",
+    "name": "GPT-3.5 Turbo 16k",
+    "provider": "openai",
+    "family": "gpt35_turbo",
+    "created_at": "2023-05-11 04:05:02 +0530",
+    "context_window": 16385,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "openai-internal"
+    }
+  },
+  {
+    "id": "gpt-3.5-turbo-instruct",
+    "name": "GPT-3.5 Turbo Instruct",
+    "provider": "openai",
+    "family": "gpt35_turbo",
+    "created_at": "2023-08-24 23:53:47 +0530",
+    "context_window": 16385,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-3.5-turbo-instruct-0914",
+    "name": "GPT-3.5 Turbo Instruct 0914",
+    "provider": "openai",
+    "family": "gpt35_turbo",
+    "created_at": "2023-09-08 03:04:32 +0530",
+    "context_window": 16385,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4",
+    "name": "GPT-4",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2023-11-06 00:00:00 +0530",
+    "context_window": 8192,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 30,
+          "output_per_million": 60
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "openai",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-04-09",
+      "cost": {
+        "input": 30,
+        "output": 60
+      },
+      "limit": {
+        "context": 8192,
+        "output": 8192
+      },
+      "knowledge": "2023-11"
+    }
+  },
+  {
+    "id": "gpt-4-0613",
+    "name": "GPT-4 0613",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2023-06-12 22:24:56 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "openai"
+    }
+  },
+  {
+    "id": "gpt-4-turbo",
+    "name": "GPT-4 Turbo",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2023-11-06 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 10,
+          "output_per_million": 30
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-04-09",
+      "cost": {
+        "input": 10,
+        "output": 30
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "gpt-4-turbo-2024-04-09",
+    "name": "GPT-4 Turbo 20240409",
+    "provider": "openai",
+    "family": "gpt4_turbo",
+    "created_at": "2024-04-09 00:11:17 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 10.0,
+          "output_per_million": 30.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4.1",
+    "name": "GPT-4.1",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2025-04-14 00:00:00 +0530",
+    "context_window": 1047576,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 8,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-04-14",
+      "cost": {
+        "input": 2,
+        "output": 8,
+        "cache_read": 0.5
+      },
+      "limit": {
+        "context": 1047576,
+        "output": 32768
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "gpt-4.1-2025-04-14",
+    "name": "GPT-4.1 20250414",
+    "provider": "openai",
+    "family": "gpt41",
+    "created_at": "2025-04-11 01:39:06 +0530",
+    "context_window": 1047576,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.0,
+          "output_per_million": 8.0,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4.1-mini",
+    "name": "GPT-4.1 mini",
+    "provider": "openai",
+    "family": "gpt-mini",
+    "created_at": "2025-04-14 00:00:00 +0530",
+    "context_window": 1047576,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 1.6,
+          "cached_input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-04-14",
+      "cost": {
+        "input": 0.4,
+        "output": 1.6,
+        "cache_read": 0.1
+      },
+      "limit": {
+        "context": 1047576,
+        "output": 32768
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "gpt-4.1-mini-2025-04-14",
+    "name": "GPT-4.1 Mini 20250414",
+    "provider": "openai",
+    "family": "gpt41_mini",
+    "created_at": "2025-04-11 02:09:07 +0530",
+    "context_window": 1047576,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 1.6,
+          "cached_input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4.1-nano",
+    "name": "GPT-4.1 nano",
+    "provider": "openai",
+    "family": "gpt-nano",
+    "created_at": "2025-04-14 00:00:00 +0530",
+    "context_window": 1047576,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.03
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-04-14",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.03
+      },
+      "limit": {
+        "context": 1047576,
+        "output": 32768
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "gpt-4.1-nano-2025-04-14",
+    "name": "GPT-4.1 Nano 20250414",
+    "provider": "openai",
+    "family": "gpt41_nano",
+    "created_at": "2025-04-11 03:07:05 +0530",
+    "context_window": 1047576,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o",
+    "name": "GPT-4o",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2024-05-13 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 10,
+          "cached_input_per_million": 1.25
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-08-06",
+      "cost": {
+        "input": 2.5,
+        "output": 10,
+        "cache_read": 1.25
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2023-09"
+    }
+  },
+  {
+    "id": "gpt-4o-2024-05-13",
+    "name": "GPT-4o (2024-05-13)",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2024-05-13 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 15
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-05-13",
+      "cost": {
+        "input": 5,
+        "output": 15
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "knowledge": "2023-09"
+    }
+  },
+  {
+    "id": "gpt-4o-2024-08-06",
+    "name": "GPT-4o (2024-08-06)",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2024-08-06 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 10,
+          "cached_input_per_million": 1.25
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-08-06",
+      "cost": {
+        "input": 2.5,
+        "output": 10,
+        "cache_read": 1.25
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2023-09"
+    }
+  },
+  {
+    "id": "gpt-4o-2024-11-20",
+    "name": "GPT-4o (2024-11-20)",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2024-11-20 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 10,
+          "cached_input_per_million": 1.25
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-11-20",
+      "cost": {
+        "input": 2.5,
+        "output": 10,
+        "cache_read": 1.25
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2023-09"
+    }
+  },
+  {
+    "id": "gpt-4o-audio-preview",
+    "name": "GPT-4o-Audio Preview",
+    "provider": "openai",
+    "family": "gpt4o_audio",
+    "created_at": "2024-09-27 23:37:23 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "speech_generation",
+      "transcription"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 10.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-audio-preview-2024-12-17",
+    "name": "GPT-4o-Audio Preview 20241217",
+    "provider": "openai",
+    "family": "gpt4o_audio",
+    "created_at": "2024-12-13 01:40:39 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "speech_generation",
+      "transcription"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 10.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-audio-preview-2025-06-03",
+    "name": "GPT-4o-Audio Preview 20250603",
+    "provider": "openai",
+    "family": "gpt4o_audio",
+    "created_at": "2025-06-03 05:24:58 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "speech_generation",
+      "transcription"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 10.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini",
+    "name": "GPT-4o mini",
+    "provider": "openai",
+    "family": "gpt-mini",
+    "created_at": "2024-07-18 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6,
+          "cached_input_per_million": 0.08
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-07-18",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_read": 0.08
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2023-09"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-2024-07-18",
+    "name": "GPT-4o-Mini 20240718",
+    "provider": "openai",
+    "family": "gpt4o_mini",
+    "created_at": "2024-07-17 05:01:57 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-audio-preview",
+    "name": "GPT-4o-Mini Audio Preview",
+    "provider": "openai",
+    "family": "gpt4o_mini_audio",
+    "created_at": "2024-12-17 03:47:04 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "speech_generation",
+      "transcription"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-audio-preview-2024-12-17",
+    "name": "GPT-4o-Mini Audio Preview 20241217",
+    "provider": "openai",
+    "family": "gpt4o_mini_audio",
+    "created_at": "2024-12-14 00:22:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "speech_generation",
+      "transcription"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-realtime-preview",
+    "name": "GPT-4o-Mini Realtime Preview",
+    "provider": "openai",
+    "family": "gpt4o_mini_realtime",
+    "created_at": "2024-12-17 03:46:20 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.4
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-realtime-preview-2024-12-17",
+    "name": "GPT-4o-Mini Realtime Preview 20241217",
+    "provider": "openai",
+    "family": "gpt4o_mini_realtime",
+    "created_at": "2024-12-13 23:26:41 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.4
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-search-preview",
+    "name": "GPT-4o-Mini Search Preview",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-03-08 05:16:01 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-search-preview-2025-03-11",
+    "name": "GPT-4o-Mini Search Preview 20250311",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-03-08 05:10:58 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-transcribe",
+    "name": "GPT-4o-Mini Transcribe",
+    "provider": "openai",
+    "family": "gpt4o_mini_transcribe",
+    "created_at": "2025-03-16 01:26:36 +0530",
+    "context_window": 16000,
+    "max_output_tokens": 2000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 5.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-transcribe-2025-03-20",
+    "name": "GPT-4o-Mini Transcribe 20250320",
+    "provider": "openai",
+    "family": "gpt4o_mini_transcribe",
+    "created_at": "2025-12-13 12:52:25 +0530",
+    "context_window": 16000,
+    "max_output_tokens": 2000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 5.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-transcribe-2025-12-15",
+    "name": "GPT-4o-Mini Transcribe 20251215",
+    "provider": "openai",
+    "family": "gpt4o_mini_transcribe",
+    "created_at": "2025-12-13 12:50:07 +0530",
+    "context_window": 16000,
+    "max_output_tokens": 2000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 5.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-tts",
+    "name": "GPT-4o-Mini Tts",
+    "provider": "openai",
+    "family": "gpt4o_mini_tts",
+    "created_at": "2025-03-19 22:35:59 +0530",
+    "context_window": null,
+    "max_output_tokens": null,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 12.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-tts-2025-03-20",
+    "name": "GPT-4o-Mini Tts 20250320",
+    "provider": "openai",
+    "family": "gpt4o_mini_tts",
+    "created_at": "2025-12-13 12:55:31 +0530",
+    "context_window": null,
+    "max_output_tokens": null,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 12.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-mini-tts-2025-12-15",
+    "name": "GPT-4o-Mini Tts 20251215",
+    "provider": "openai",
+    "family": "gpt4o_mini_tts",
+    "created_at": "2025-12-13 12:57:17 +0530",
+    "context_window": null,
+    "max_output_tokens": null,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 12.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-realtime-preview",
+    "name": "GPT-4o-Realtime Preview",
+    "provider": "openai",
+    "family": "gpt4o_realtime",
+    "created_at": "2024-09-30 07:03:18 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5.0,
+          "output_per_million": 20.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-realtime-preview-2024-12-17",
+    "name": "GPT-4o-Realtime Preview 20241217",
+    "provider": "openai",
+    "family": "gpt4o_realtime",
+    "created_at": "2024-12-12 01:00:30 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5.0,
+          "output_per_million": 20.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-realtime-preview-2025-06-03",
+    "name": "GPT-4o-Realtime Preview 20250603",
+    "provider": "openai",
+    "family": "gpt4o_realtime",
+    "created_at": "2025-06-03 05:13:58 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5.0,
+          "output_per_million": 20.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-search-preview",
+    "name": "GPT-4o Search Preview",
+    "provider": "openai",
+    "family": "gpt4o_search",
+    "created_at": "2026-02-24 09:28:54 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 10.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-search-preview-2025-03-11",
+    "name": "GPT-4o Search Preview 20250311",
+    "provider": "openai",
+    "family": "gpt4o_search",
+    "created_at": "2026-02-24 09:30:21 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 10.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-transcribe",
+    "name": "GPT-4o-Transcribe",
+    "provider": "openai",
+    "family": "gpt4o_transcribe",
+    "created_at": "2025-03-16 01:24:23 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 10.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-4o-transcribe-diarize",
+    "name": "GPT-4o-Transcribe Diarize",
+    "provider": "openai",
+    "family": "gpt4o_transcribe",
+    "created_at": "2025-06-25 02:31:27 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 10.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5",
+    "name": "GPT-5",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2025-08-07 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-08-07",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.125
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "gpt-5-2025-08-07",
+    "name": "GPT-5 20250807",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2025-08-02 00:39:20 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5-chat-latest",
+    "name": "GPT-5 Chat (latest)",
+    "provider": "openai",
+    "family": "gpt-codex",
+    "created_at": "2025-08-07 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming",
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-07",
+      "cost": {
+        "input": 1.25,
+        "output": 10
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "gpt-5-codex",
+    "name": "GPT-5-Codex",
+    "provider": "openai",
+    "family": "gpt-codex",
+    "created_at": "2025-09-15 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2025-09-15",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.125
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "gpt-5-mini",
+    "name": "GPT-5 Mini",
+    "provider": "openai",
+    "family": "gpt-mini",
+    "created_at": "2025-08-07 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-05-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.25,
+          "output_per_million": 2,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-08-07",
+      "cost": {
+        "input": 0.25,
+        "output": 2,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2024-05-30"
+    }
+  },
+  {
+    "id": "gpt-5-mini-2025-08-07",
+    "name": "GPT-5 Mini 20250807",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2025-08-06 02:01:07 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5-nano",
+    "name": "GPT-5 Nano",
+    "provider": "openai",
+    "family": "gpt-nano",
+    "created_at": "2025-08-07 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-05-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.05,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.005
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-08-07",
+      "cost": {
+        "input": 0.05,
+        "output": 0.4,
+        "cache_read": 0.005
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2024-05-30"
+    }
+  },
+  {
+    "id": "gpt-5-nano-2025-08-07",
+    "name": "GPT-5 Nano 20250807",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2025-08-06 02:08:23 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5-pro",
+    "name": "GPT-5 Pro",
+    "provider": "openai",
+    "family": "gpt-pro",
+    "created_at": "2025-10-06 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 272000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 120
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-10-06",
+      "cost": {
+        "input": 15,
+        "output": 120
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 272000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "gpt-5-pro-2025-10-06",
+    "name": "GPT-5 Pro 20251006",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2025-10-03 11:05:07 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5-search-api",
+    "name": "GPT-5 Search Api",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2025-10-03 23:33:49 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5-search-api-2025-10-14",
+    "name": "GPT-5 Search Api 20251014",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2025-10-10 02:36:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5.1",
+    "name": "GPT-5.1",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2025-11-13 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.13
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-11-13",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.13
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "gpt-5.1-2025-11-13",
+    "name": "GPT-5.1 20251113",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2025-11-11 00:15:53 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5.1-chat-latest",
+    "name": "GPT-5.1 Chat",
+    "provider": "openai",
+    "family": "gpt-codex",
+    "created_at": "2025-11-13 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-11-13",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.125
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "gpt-5.1-codex",
+    "name": "GPT-5.1 Codex",
+    "provider": "openai",
+    "family": "gpt-codex",
+    "created_at": "2025-11-13 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-11-13",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.125
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "gpt-5.1-codex-max",
+    "name": "GPT-5.1 Codex Max",
+    "provider": "openai",
+    "family": "gpt-codex",
+    "created_at": "2025-11-13 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-11-13",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.125
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "gpt-5.1-codex-mini",
+    "name": "GPT-5.1 Codex mini",
+    "provider": "openai",
+    "family": "gpt-codex",
+    "created_at": "2025-11-13 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.25,
+          "output_per_million": 2,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-11-13",
+      "cost": {
+        "input": 0.25,
+        "output": 2,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "gpt-5.2",
+    "name": "GPT-5.2",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2025-12-11 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.75,
+          "output_per_million": 14,
+          "cached_input_per_million": 0.175
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-12-11",
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cache_read": 0.175
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "gpt-5.2-2025-12-11",
+    "name": "GPT-5.2 20251211",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2025-12-10 02:13:48 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5.2-chat-latest",
+    "name": "GPT-5.2 Chat",
+    "provider": "openai",
+    "family": "gpt-codex",
+    "created_at": "2025-12-11 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.75,
+          "output_per_million": 14,
+          "cached_input_per_million": 0.175
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-12-11",
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cache_read": 0.175
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "gpt-5.2-codex",
+    "name": "GPT-5.2 Codex",
+    "provider": "openai",
+    "family": "gpt-codex",
+    "created_at": "2025-12-11 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.75,
+          "output_per_million": 14,
+          "cached_input_per_million": 0.175
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-12-11",
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cache_read": 0.175
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "gpt-5.2-pro",
+    "name": "GPT-5.2 Pro",
+    "provider": "openai",
+    "family": "gpt-pro",
+    "created_at": "2025-12-11 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision",
+      "streaming",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 21,
+          "output_per_million": 168
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-12-11",
+      "cost": {
+        "input": 21,
+        "output": 168
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "gpt-5.2-pro-2025-12-11",
+    "name": "GPT-5.2 Pro 20251211",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2025-12-10 10:49:19 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5.3-chat-latest",
+    "name": "GPT-5.3 Chat (latest)",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2026-03-03 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision",
+      "streaming",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.75,
+          "output_per_million": 14,
+          "cached_input_per_million": 0.175
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-03",
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cache_read": 0.175
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "gpt-5.3-codex",
+    "name": "GPT-5.3 Codex",
+    "provider": "openai",
+    "family": "gpt-codex",
+    "created_at": "2026-02-05 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.75,
+          "output_per_million": 14,
+          "cached_input_per_million": 0.175
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2026-02-05",
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cache_read": 0.175
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "gpt-5.3-codex-spark",
+    "name": "GPT-5.3 Codex Spark",
+    "provider": "openai",
+    "family": "gpt-codex-spark",
+    "created_at": "2026-02-05 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.75,
+          "output_per_million": 14,
+          "cached_input_per_million": 0.175
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2026-02-05",
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cache_read": 0.175
+      },
+      "limit": {
+        "context": 128000,
+        "input": 100000,
+        "output": 32000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "gpt-5.4",
+    "name": "GPT-5.4",
+    "provider": "openai",
+    "family": "gpt",
+    "created_at": "2026-03-05 00:00:00 +0530",
+    "context_window": 1050000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.25
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2026-03-05",
+      "cost": {
+        "input": 2.5,
+        "output": 15,
+        "cache_read": 0.25,
+        "context_over_200k": {
+          "input": 5,
+          "output": 22.5,
+          "cache_read": 0.5
+        }
+      },
+      "limit": {
+        "context": 1050000,
+        "input": 922000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "gpt-5.4-2026-03-05",
+    "name": "GPT-5.4 20260305",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2026-03-05 01:24:22 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5.4-mini",
+    "name": "GPT-5.4 mini",
+    "provider": "openai",
+    "family": "gpt-mini",
+    "created_at": "2026-03-17 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.75,
+          "output_per_million": 4.5,
+          "cached_input_per_million": 0.075
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2026-03-17",
+      "cost": {
+        "input": 0.75,
+        "output": 4.5,
+        "cache_read": 0.075
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "gpt-5.4-mini-2026-03-17",
+    "name": "GPT-5.4 Mini 20260317",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2026-03-14 06:47:56 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5.4-nano",
+    "name": "GPT-5.4 nano",
+    "provider": "openai",
+    "family": "gpt-nano",
+    "created_at": "2026-03-17 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.2,
+          "output_per_million": 1.25,
+          "cached_input_per_million": 0.02
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2026-03-17",
+      "cost": {
+        "input": 0.2,
+        "output": 1.25,
+        "cache_read": 0.02
+      },
+      "limit": {
+        "context": 400000,
+        "input": 272000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "gpt-5.4-nano-2026-03-17",
+    "name": "GPT-5.4 Nano 20260317",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2026-03-14 06:43:57 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-5.4-pro",
+    "name": "GPT-5.4 Pro",
+    "provider": "openai",
+    "family": "gpt-pro",
+    "created_at": "2026-03-05 00:00:00 +0530",
+    "context_window": 1050000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision",
+      "streaming",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 30,
+          "output_per_million": 180
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2026-03-05",
+      "cost": {
+        "input": 30,
+        "output": 180,
+        "context_over_200k": {
+          "input": 60,
+          "output": 270
+        }
+      },
+      "limit": {
+        "context": 1050000,
+        "input": 922000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "gpt-5.4-pro-2026-03-05",
+    "name": "GPT-5.4 Pro 20260305",
+    "provider": "openai",
+    "family": "gpt5",
+    "created_at": "2026-03-05 02:57:37 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 400000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10.0,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-audio",
+    "name": "GPT-Audio",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-08-28 05:30:49 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-audio-1.5",
+    "name": "GPT-Audio 1.5",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2026-02-20 06:58:05 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-audio-2025-08-28",
+    "name": "GPT-Audio 20250828",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-08-27 06:25:46 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-audio-mini",
+    "name": "GPT-Audio Mini",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-10-03 22:50:27 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-audio-mini-2025-10-06",
+    "name": "GPT-Audio Mini 20251006",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-10-03 22:52:17 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-audio-mini-2025-12-15",
+    "name": "GPT-Audio Mini 20251215",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-12-15 06:23:28 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-image-1",
+    "name": "gpt-image-1",
+    "provider": "openai",
+    "family": "gpt-image",
+    "created_at": "2025-04-24 00:00:00 +0530",
+    "context_window": 0,
+    "max_output_tokens": 0,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "capabilities": [
+      "vision",
+      "streaming"
+    ],
+    "pricing": {},
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-04-24",
+      "limit": {
+        "context": 0,
+        "input": 0,
+        "output": 0
+      }
+    }
+  },
+  {
+    "id": "gpt-image-1-mini",
+    "name": "gpt-image-1-mini",
+    "provider": "openai",
+    "family": "gpt-image",
+    "created_at": "2025-09-26 00:00:00 +0530",
+    "context_window": 0,
+    "max_output_tokens": 0,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "capabilities": [
+      "vision",
+      "streaming"
+    ],
+    "pricing": {},
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-09-26",
+      "limit": {
+        "context": 0,
+        "input": 0,
+        "output": 0
+      }
+    }
+  },
+  {
+    "id": "gpt-image-1.5",
+    "name": "gpt-image-1.5",
+    "provider": "openai",
+    "family": "gpt-image",
+    "created_at": "2025-11-25 00:00:00 +0530",
+    "context_window": 0,
+    "max_output_tokens": 0,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "capabilities": [
+      "vision",
+      "streaming"
+    ],
+    "pricing": {},
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-11-25",
+      "limit": {
+        "context": 0,
+        "input": 0,
+        "output": 0
+      }
+    }
+  },
+  {
+    "id": "gpt-realtime",
+    "name": "GPT-Realtime",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-08-27 10:45:01 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-realtime-1.5",
+    "name": "GPT-Realtime 1.5",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2026-02-19 06:07:49 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-realtime-2025-08-28",
+    "name": "GPT-Realtime 20250828",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-08-27 10:46:13 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-realtime-mini",
+    "name": "GPT-Realtime Mini",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-10-04 00:15:33 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-realtime-mini-2025-10-06",
+    "name": "GPT-Realtime Mini 20251006",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-10-04 00:16:15 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "gpt-realtime-mini-2025-12-15",
+    "name": "GPT-Realtime Mini 20251215",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-12-13 13:16:47 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "o1",
+    "name": "o1",
+    "provider": "openai",
+    "family": "o",
+    "created_at": "2024-12-05 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 60,
+          "cached_input_per_million": 7.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2024-12-05",
+      "cost": {
+        "input": 15,
+        "output": 60,
+        "cache_read": 7.5
+      },
+      "limit": {
+        "context": 200000,
+        "output": 100000
+      },
+      "knowledge": "2023-09"
+    }
+  },
+  {
+    "id": "o1-2024-12-17",
+    "name": "O1-20241217",
+    "provider": "openai",
+    "family": "o1",
+    "created_at": "2024-12-16 10:59:36 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15.0,
+          "output_per_million": 60.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "o1-mini",
+    "name": "o1-mini",
+    "provider": "openai",
+    "family": "o-mini",
+    "created_at": "2024-09-12 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.1,
+          "output_per_million": 4.4,
+          "cached_input_per_million": 0.55
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2024-09-12",
+      "cost": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_read": 0.55
+      },
+      "limit": {
+        "context": 128000,
+        "output": 65536
+      },
+      "knowledge": "2023-09"
+    }
+  },
+  {
+    "id": "o1-preview",
+    "name": "o1-preview",
+    "provider": "openai",
+    "family": "o",
+    "created_at": "2024-09-12 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 60,
+          "cached_input_per_million": 7.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-09-12",
+      "cost": {
+        "input": 15,
+        "output": 60,
+        "cache_read": 7.5
+      },
+      "limit": {
+        "context": 128000,
+        "output": 32768
+      },
+      "knowledge": "2023-09"
+    }
+  },
+  {
+    "id": "o1-pro",
+    "name": "o1-pro",
+    "provider": "openai",
+    "family": "o-pro",
+    "created_at": "2025-03-19 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 150,
+          "output_per_million": 600
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-03-19",
+      "cost": {
+        "input": 150,
+        "output": 600
+      },
+      "limit": {
+        "context": 200000,
+        "output": 100000
+      },
+      "knowledge": "2023-09"
+    }
+  },
+  {
+    "id": "o1-pro-2025-03-19",
+    "name": "O1-Pro 20250319",
+    "provider": "openai",
+    "family": "o1_pro",
+    "created_at": "2025-03-18 04:15:04 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 150.0,
+          "output_per_million": 600.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "o3",
+    "name": "o3",
+    "provider": "openai",
+    "family": "o",
+    "created_at": "2025-04-16 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 8,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-04-16",
+      "cost": {
+        "input": 2,
+        "output": 8,
+        "cache_read": 0.5
+      },
+      "limit": {
+        "context": 200000,
+        "output": 100000
+      },
+      "knowledge": "2024-05"
+    }
+  },
+  {
+    "id": "o3-2025-04-16",
+    "name": "O3-20250416",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-04-08 22:58:21 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "o3-deep-research",
+    "name": "o3-deep-research",
+    "provider": "openai",
+    "family": "o",
+    "created_at": "2024-06-26 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 10,
+          "output_per_million": 40,
+          "cached_input_per_million": 2.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2024-06-26",
+      "cost": {
+        "input": 10,
+        "output": 40,
+        "cache_read": 2.5
+      },
+      "limit": {
+        "context": 200000,
+        "output": 100000
+      },
+      "knowledge": "2024-05"
+    }
+  },
+  {
+    "id": "o3-deep-research-2025-06-26",
+    "name": "O3-Deep Research 20250626",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-06-25 20:56:59 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "o3-mini",
+    "name": "o3-mini",
+    "provider": "openai",
+    "family": "o-mini",
+    "created_at": "2024-12-20 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.1,
+          "output_per_million": 4.4,
+          "cached_input_per_million": 0.55
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2025-01-29",
+      "cost": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_read": 0.55
+      },
+      "limit": {
+        "context": 200000,
+        "output": 100000
+      },
+      "knowledge": "2024-05"
+    }
+  },
+  {
+    "id": "o3-mini-2025-01-31",
+    "name": "O3-Mini 20250131",
+    "provider": "openai",
+    "family": "o3_mini",
+    "created_at": "2025-01-28 02:06:40 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.1,
+          "output_per_million": 4.4
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "o3-pro",
+    "name": "o3-pro",
+    "provider": "openai",
+    "family": "o-pro",
+    "created_at": "2025-06-10 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 20,
+          "output_per_million": 80
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-06-10",
+      "cost": {
+        "input": 20,
+        "output": 80
+      },
+      "limit": {
+        "context": 200000,
+        "output": 100000
+      },
+      "knowledge": "2024-05"
+    }
+  },
+  {
+    "id": "o3-pro-2025-06-10",
+    "name": "O3-Pro 20250610",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-06-06 05:09:21 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "o4-mini",
+    "name": "o4-mini",
+    "provider": "openai",
+    "family": "o-mini",
+    "created_at": "2025-04-16 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.1,
+          "output_per_million": 4.4,
+          "cached_input_per_million": 0.28
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-04-16",
+      "cost": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_read": 0.28
+      },
+      "limit": {
+        "context": 200000,
+        "output": 100000
+      },
+      "knowledge": "2024-05"
+    }
+  },
+  {
+    "id": "o4-mini-2025-04-16",
+    "name": "O4 Mini 20250416",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-04-08 23:01:46 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "o4-mini-deep-research",
+    "name": "o4-mini-deep-research",
+    "provider": "openai",
+    "family": "o-mini",
+    "created_at": "2024-06-26 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision",
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 8,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2024-06-26",
+      "cost": {
+        "input": 2,
+        "output": 8,
+        "cache_read": 0.5
+      },
+      "limit": {
+        "context": 200000,
+        "output": 100000
+      },
+      "knowledge": "2024-05"
+    }
+  },
+  {
+    "id": "o4-mini-deep-research-2025-06-26",
+    "name": "O4 Mini Deep Research 20250626",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-06-25 21:12:01 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "omni-moderation-2024-09-26",
+    "name": "Omni Moderation 20240926",
+    "provider": "openai",
+    "family": "moderation",
+    "created_at": "2024-11-28 00:37:46 +0530",
+    "context_window": null,
+    "max_output_tokens": null,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text",
+        "moderation"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {},
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "omni-moderation-latest",
+    "name": "Omni Moderation Latest",
+    "provider": "openai",
+    "family": "moderation",
+    "created_at": "2024-11-15 22:17:45 +0530",
+    "context_window": null,
+    "max_output_tokens": null,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text",
+        "moderation"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {},
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "sora-2",
+    "name": "Sora 2",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-10-06 05:26:55 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "sora-2-pro",
+    "name": "Sora 2 Pro",
+    "provider": "openai",
+    "family": "other",
+    "created_at": "2025-10-06 05:27:43 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "text-embedding-3-large",
+    "name": "text-embedding-3-large",
+    "provider": "openai",
+    "family": "text-embedding",
+    "created_at": "2024-01-25 00:00:00 +0530",
+    "context_window": 8191,
+    "max_output_tokens": 3072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "batch"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.13
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2024-01-25",
+      "cost": {
+        "input": 0.13,
+        "output": 0
+      },
+      "limit": {
+        "context": 8191,
+        "output": 3072
+      },
+      "knowledge": "2024-01"
+    }
+  },
+  {
+    "id": "text-embedding-3-small",
+    "name": "text-embedding-3-small",
+    "provider": "openai",
+    "family": "text-embedding",
+    "created_at": "2024-01-25 00:00:00 +0530",
+    "context_window": 8191,
+    "max_output_tokens": 1536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "batch"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.02
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2024-01-25",
+      "cost": {
+        "input": 0.02,
+        "output": 0
+      },
+      "limit": {
+        "context": 8191,
+        "output": 1536
+      },
+      "knowledge": "2024-01"
+    }
+  },
+  {
+    "id": "text-embedding-ada-002",
+    "name": "text-embedding-ada-002",
+    "provider": "openai",
+    "family": "text-embedding",
+    "created_at": "2022-12-15 00:00:00 +0530",
+    "context_window": 8192,
+    "max_output_tokens": 1536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "batch"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "openai-internal",
+      "source": "models.dev",
+      "provider_id": "openai",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2022-12-15",
+      "cost": {
+        "input": 0.1,
+        "output": 0
+      },
+      "limit": {
+        "context": 8192,
+        "output": 1536
+      },
+      "knowledge": "2022-12"
+    }
+  },
+  {
+    "id": "tts-1",
+    "name": "TTS-1",
+    "provider": "openai",
+    "family": "tts1",
+    "created_at": "2023-04-20 03:19:11 +0530",
+    "context_window": null,
+    "max_output_tokens": null,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15.0,
+          "output_per_million": 15.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "openai-internal"
+    }
+  },
+  {
+    "id": "tts-1-1106",
+    "name": "TTS-1 1106",
+    "provider": "openai",
+    "family": "tts1",
+    "created_at": "2023-11-04 04:44:01 +0530",
+    "context_window": null,
+    "max_output_tokens": null,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15.0,
+          "output_per_million": 15.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "tts-1-hd",
+    "name": "TTS-1 HD",
+    "provider": "openai",
+    "family": "tts1_hd",
+    "created_at": "2023-11-04 02:43:35 +0530",
+    "context_window": null,
+    "max_output_tokens": null,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 30.0,
+          "output_per_million": 30.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "tts-1-hd-1106",
+    "name": "TTS-1 HD 1106",
+    "provider": "openai",
+    "family": "tts1_hd",
+    "created_at": "2023-11-04 04:48:53 +0530",
+    "context_window": null,
+    "max_output_tokens": null,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 30.0,
+          "output_per_million": 30.0
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "system"
+    }
+  },
+  {
+    "id": "whisper-1",
+    "name": "Whisper 1",
+    "provider": "openai",
+    "family": "whisper",
+    "created_at": "2023-02-28 02:43:04 +0530",
+    "context_window": null,
+    "max_output_tokens": null,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "streaming"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.006,
+          "output_per_million": 0.006
+        }
+      }
+    },
+    "metadata": {
+      "object": "model",
+      "owned_by": "openai-internal"
+    }
+  },
+  {
+    "id": "anthropic/claude-3.5-haiku",
+    "name": "Claude Haiku 3.5",
+    "provider": "openrouter",
+    "family": "claude-haiku",
+    "created_at": "2024-10-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": "2024-07-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.8,
+          "output_per_million": 4,
+          "cached_input_per_million": 0.08
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-10-22",
+      "cost": {
+        "input": 0.8,
+        "output": 4,
+        "cache_read": 0.08,
+        "cache_write": 1
+      },
+      "limit": {
+        "context": 200000,
+        "output": 8192
+      },
+      "knowledge": "2024-07-31"
+    }
+  },
+  {
+    "id": "anthropic/claude-3.7-sonnet",
+    "name": "Claude Sonnet 3.7",
+    "provider": "openrouter",
+    "family": "claude-sonnet",
+    "created_at": "2025-02-19 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 75,
+          "cached_input_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-02-19",
+      "cost": {
+        "input": 15,
+        "output": 75,
+        "cache_read": 1.5,
+        "cache_write": 18.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 128000
+      },
+      "knowledge": "2024-01"
+    }
+  },
+  {
+    "id": "anthropic/claude-haiku-4.5",
+    "name": "Claude Haiku 4.5",
+    "provider": "openrouter",
+    "family": "claude-haiku",
+    "created_at": "2025-10-15 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-02-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 5,
+          "cached_input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-10-15",
+      "cost": {
+        "input": 1,
+        "output": 5,
+        "cache_read": 0.1,
+        "cache_write": 1.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-02-28"
+    }
+  },
+  {
+    "id": "anthropic/claude-opus-4",
+    "name": "Claude Opus 4",
+    "provider": "openrouter",
+    "family": "claude-opus",
+    "created_at": "2025-05-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 75,
+          "cached_input_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-22",
+      "cost": {
+        "input": 15,
+        "output": 75,
+        "cache_read": 1.5,
+        "cache_write": 18.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 32000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "anthropic/claude-opus-4.1",
+    "name": "Claude Opus 4.1",
+    "provider": "openrouter",
+    "family": "claude-opus",
+    "created_at": "2025-08-05 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 75,
+          "cached_input_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-05",
+      "cost": {
+        "input": 15,
+        "output": 75,
+        "cache_read": 1.5,
+        "cache_write": 18.75
+      },
+      "limit": {
+        "context": 200000,
+        "output": 32000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "anthropic/claude-opus-4.5",
+    "name": "Claude Opus 4.5",
+    "provider": "openrouter",
+    "family": "claude-opus",
+    "created_at": "2025-11-24 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 32000,
+    "knowledge_cutoff": "2025-05-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-11-24",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25
+      },
+      "limit": {
+        "context": 200000,
+        "output": 32000
+      },
+      "knowledge": "2025-05-30"
+    }
+  },
+  {
+    "id": "anthropic/claude-opus-4.6",
+    "name": "Claude Opus 4.6",
+    "provider": "openrouter",
+    "family": "claude-opus",
+    "created_at": "2026-02-05 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-05-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 25,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-05",
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cache_read": 0.5,
+        "cache_write": 6.25,
+        "context_over_200k": {
+          "input": 10,
+          "output": 37.5,
+          "cache_read": 1,
+          "cache_write": 12.5
+        }
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 128000
+      },
+      "knowledge": "2025-05-30"
+    }
+  },
+  {
+    "id": "anthropic/claude-sonnet-4",
+    "name": "Claude Sonnet 4",
+    "provider": "openrouter",
+    "family": "claude-sonnet",
+    "created_at": "2025-05-22 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-22",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75,
+        "context_over_200k": {
+          "input": 6,
+          "output": 22.5,
+          "cache_read": 0.6,
+          "cache_write": 7.5
+        }
+      },
+      "limit": {
+        "context": 200000,
+        "output": 64000
+      },
+      "knowledge": "2025-03-31"
+    }
+  },
+  {
+    "id": "anthropic/claude-sonnet-4.5",
+    "name": "Claude Sonnet 4.5",
+    "provider": "openrouter",
+    "family": "claude-sonnet",
+    "created_at": "2025-09-29 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": "2025-07-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-29",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75,
+        "context_over_200k": {
+          "input": 6,
+          "output": 22.5,
+          "cache_read": 0.6,
+          "cache_write": 7.5
+        }
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 64000
+      },
+      "knowledge": "2025-07-31"
+    }
+  },
+  {
+    "id": "anthropic/claude-sonnet-4.6",
+    "name": "Claude Sonnet 4.6",
+    "provider": "openrouter",
+    "family": "claude-sonnet",
+    "created_at": "2026-02-17 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-17",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3,
+        "cache_write": 3.75,
+        "context_over_200k": {
+          "input": 6,
+          "output": 22.5,
+          "cache_read": 0.6,
+          "cache_write": 7.5
+        }
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 128000
+      }
+    }
+  },
+  {
+    "id": "arcee-ai/trinity-large-preview:free",
+    "name": "Trinity Large Preview",
+    "provider": "openrouter",
+    "family": "trinity",
+    "created_at": "2026-01-28 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-28",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "arcee-ai/trinity-large-thinking",
+    "name": "Trinity Large Thinking",
+    "provider": "openrouter",
+    "family": "trinity",
+    "created_at": "2026-04-01 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 80000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.22,
+          "output_per_million": 0.85
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-04-03",
+      "cost": {
+        "input": 0.22,
+        "output": 0.85
+      },
+      "limit": {
+        "context": 262144,
+        "output": 80000
+      }
+    }
+  },
+  {
+    "id": "black-forest-labs/flux.2-flex",
+    "name": "FLUX.2 Flex",
+    "provider": "openrouter",
+    "family": "flux",
+    "created_at": "2025-11-25 00:00:00 +0530",
+    "context_window": 67344,
+    "max_output_tokens": 67344,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-31",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 67344,
+        "output": 67344
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "black-forest-labs/flux.2-klein-4b",
+    "name": "FLUX.2 Klein 4B",
+    "provider": "openrouter",
+    "family": "flux",
+    "created_at": "2026-01-14 00:00:00 +0530",
+    "context_window": 40960,
+    "max_output_tokens": 40960,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-31",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 40960,
+        "output": 40960
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "black-forest-labs/flux.2-max",
+    "name": "FLUX.2 Max",
+    "provider": "openrouter",
+    "family": "flux",
+    "created_at": "2025-12-16 00:00:00 +0530",
+    "context_window": 46864,
+    "max_output_tokens": 46864,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-31",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 46864,
+        "output": 46864
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "black-forest-labs/flux.2-pro",
+    "name": "FLUX.2 Pro",
+    "provider": "openrouter",
+    "family": "flux",
+    "created_at": "2025-11-25 00:00:00 +0530",
+    "context_window": 46864,
+    "max_output_tokens": 46864,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-31",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 46864,
+        "output": 46864
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "bytedance-seed/seedream-4.5",
+    "name": "Seedream 4.5",
+    "provider": "openrouter",
+    "family": "seed",
+    "created_at": "2025-12-23 00:00:00 +0530",
+    "context_window": 4096,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-31",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 4096,
+        "output": 4096
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
+    "name": "Uncensored (free)",
+    "provider": "openrouter",
+    "family": "mistral",
+    "created_at": "2025-07-09 00:00:00 +0530",
+    "context_window": 32768,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "structured_output"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-31",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 32768,
+        "output": 32768
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "deepseek/deepseek-chat-v3-0324",
+    "name": "DeepSeek V3 0324",
+    "provider": "openrouter",
+    "family": "deepseek",
+    "created_at": "2025-03-24 00:00:00 +0530",
+    "context_window": 16384,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "structured_output"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-03-24",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 16384,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "deepseek/deepseek-chat-v3.1",
+    "name": "DeepSeek-V3.1",
+    "provider": "openrouter",
+    "family": "deepseek",
+    "created_at": "2025-08-21 00:00:00 +0530",
+    "context_window": 163840,
+    "max_output_tokens": 163840,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.2,
+          "output_per_million": 0.8
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-21",
+      "cost": {
+        "input": 0.2,
+        "output": 0.8
+      },
+      "limit": {
+        "context": 163840,
+        "output": 163840
+      },
+      "knowledge": "2025-07"
+    }
+  },
+  {
+    "id": "deepseek/deepseek-r1",
+    "name": "DeepSeek: R1",
+    "provider": "openrouter",
+    "family": "deepseek-thinking",
+    "created_at": "2025-01-20 00:00:00 +0530",
+    "context_window": 64000,
+    "max_output_tokens": 16000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.7,
+          "output_per_million": 2.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-01-20",
+      "cost": {
+        "input": 0.7,
+        "output": 2.5
+      },
+      "limit": {
+        "context": 64000,
+        "output": 16000
+      },
+      "knowledge": "2024-07"
+    }
+  },
+  {
+    "id": "deepseek/deepseek-r1-distill-llama-70b",
+    "name": "DeepSeek R1 Distill Llama 70B",
+    "provider": "openrouter",
+    "family": "deepseek-thinking",
+    "created_at": "2025-01-23 00:00:00 +0530",
+    "context_window": 8192,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-01-23",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 8192,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "deepseek/deepseek-v3.1-terminus",
+    "name": "DeepSeek V3.1 Terminus",
+    "provider": "openrouter",
+    "family": "deepseek",
+    "created_at": "2025-09-22 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.27,
+          "output_per_million": 1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-22",
+      "cost": {
+        "input": 0.27,
+        "output": 1
+      },
+      "limit": {
+        "context": 131072,
+        "output": 65536
+      },
+      "knowledge": "2025-07"
+    }
+  },
+  {
+    "id": "deepseek/deepseek-v3.1-terminus:exacto",
+    "name": "DeepSeek V3.1 Terminus (exacto)",
+    "provider": "openrouter",
+    "family": "deepseek",
+    "created_at": "2025-09-22 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.27,
+          "output_per_million": 1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-22",
+      "cost": {
+        "input": 0.27,
+        "output": 1
+      },
+      "limit": {
+        "context": 131072,
+        "output": 65536
+      },
+      "knowledge": "2025-07"
+    }
+  },
+  {
+    "id": "deepseek/deepseek-v3.2",
+    "name": "DeepSeek V3.2",
+    "provider": "openrouter",
+    "family": "deepseek",
+    "created_at": "2025-12-01 00:00:00 +0530",
+    "context_window": 163840,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.28,
+          "output_per_million": 0.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-01",
+      "cost": {
+        "input": 0.28,
+        "output": 0.4
+      },
+      "limit": {
+        "context": 163840,
+        "output": 65536
+      },
+      "knowledge": "2024-07"
+    }
+  },
+  {
+    "id": "deepseek/deepseek-v3.2-speciale",
+    "name": "DeepSeek V3.2 Speciale",
+    "provider": "openrouter",
+    "family": "deepseek",
+    "created_at": "2025-12-01 00:00:00 +0530",
+    "context_window": 163840,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.27,
+          "output_per_million": 0.41
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-01",
+      "cost": {
+        "input": 0.27,
+        "output": 0.41
+      },
+      "limit": {
+        "context": 163840,
+        "output": 65536
+      },
+      "knowledge": "2024-07"
+    }
+  },
+  {
+    "id": "google/gemini-2.0-flash-001",
+    "name": "Gemini 2.0 Flash",
+    "provider": "openrouter",
+    "family": "gemini-flash",
+    "created_at": "2024-12-11 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-12-11",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 8192
+      },
+      "knowledge": "2024-06"
+    }
+  },
+  {
+    "id": "google/gemini-2.5-flash",
+    "name": "Gemini 2.5 Flash",
+    "provider": "openrouter",
+    "family": "gemini-flash",
+    "created_at": "2025-07-17 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 2.5,
+          "cached_input_per_million": 0.0375
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-07-17",
+      "cost": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_read": 0.0375
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemini-2.5-flash-lite",
+    "name": "Gemini 2.5 Flash Lite",
+    "provider": "openrouter",
+    "family": "gemini-flash-lite",
+    "created_at": "2025-06-17 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-17",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemini-2.5-flash-lite-preview-09-2025",
+    "name": "Gemini 2.5 Flash Lite Preview 09-25",
+    "provider": "openrouter",
+    "family": "gemini-flash-lite",
+    "created_at": "2025-09-25 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-25",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemini-2.5-flash-preview-09-2025",
+    "name": "Gemini 2.5 Flash Preview 09-25",
+    "provider": "openrouter",
+    "family": "gemini-flash",
+    "created_at": "2025-09-25 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 2.5,
+          "cached_input_per_million": 0.031
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-25",
+      "cost": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_read": 0.031
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemini-2.5-pro",
+    "name": "Gemini 2.5 Pro",
+    "provider": "openrouter",
+    "family": "gemini-pro",
+    "created_at": "2025-03-20 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.31
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-05",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.31
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemini-2.5-pro-preview-05-06",
+    "name": "Gemini 2.5 Pro Preview 05-06",
+    "provider": "openrouter",
+    "family": "gemini-pro",
+    "created_at": "2025-05-06 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.31
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-06",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.31
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemini-2.5-pro-preview-06-05",
+    "name": "Gemini 2.5 Pro Preview 06-05",
+    "provider": "openrouter",
+    "family": "gemini-pro",
+    "created_at": "2025-06-05 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.31
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-05",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.31
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemini-3-flash-preview",
+    "name": "Gemini 3 Flash Preview",
+    "provider": "openrouter",
+    "family": "gemini-flash",
+    "created_at": "2025-12-17 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 3,
+          "cached_input_per_million": 0.05
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-12-17",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 0.5,
+        "output": 3,
+        "cache_read": 0.05
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemini-3-pro-preview",
+    "name": "Gemini 3 Pro Preview",
+    "provider": "openrouter",
+    "family": "gemini-pro",
+    "created_at": "2025-11-18 00:00:00 +0530",
+    "context_window": 1050000,
+    "max_output_tokens": 66000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 12
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-11",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 2,
+        "output": 12
+      },
+      "limit": {
+        "context": 1050000,
+        "output": 66000
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemini-3.1-flash-lite-preview",
+    "name": "Gemini 3.1 Flash Lite Preview",
+    "provider": "openrouter",
+    "family": "gemini-flash-lite",
+    "created_at": "2026-03-03 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.25,
+          "output_per_million": 1.5,
+          "cached_input_per_million": 0.025,
+          "reasoning_output_per_million": 1.5
+        }
+      },
+      "audio_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-03",
+      "cost": {
+        "input": 0.25,
+        "output": 1.5,
+        "reasoning": 1.5,
+        "cache_read": 0.025,
+        "cache_write": 0.083,
+        "input_audio": 0.5,
+        "output_audio": 0.5
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      }
+    }
+  },
+  {
+    "id": "google/gemini-3.1-pro-preview",
+    "name": "Gemini 3.1 Pro Preview",
+    "provider": "openrouter",
+    "family": "gemini-pro",
+    "created_at": "2026-02-19 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 12,
+          "reasoning_output_per_million": 12
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-19",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 2,
+        "output": 12,
+        "reasoning": 12,
+        "context_over_200k": {
+          "input": 4,
+          "output": 18,
+          "cache_read": 0.4
+        }
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemini-3.1-pro-preview-customtools",
+    "name": "Gemini 3.1 Pro Preview Custom Tools",
+    "provider": "openrouter",
+    "family": "gemini-pro",
+    "created_at": "2026-02-19 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 12,
+          "reasoning_output_per_million": 12
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-19",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 2,
+        "output": 12,
+        "reasoning": 12,
+        "context_over_200k": {
+          "input": 4,
+          "output": 18,
+          "cache_read": 0.4
+        }
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemma-2-9b-it",
+    "name": "Gemma 2 9B",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2024-06-28 00:00:00 +0530",
+    "context_window": 8192,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.03,
+          "output_per_million": 0.09
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-06-28",
+      "cost": {
+        "input": 0.03,
+        "output": 0.09
+      },
+      "limit": {
+        "context": 8192,
+        "output": 8192
+      },
+      "knowledge": "2024-06"
+    }
+  },
+  {
+    "id": "google/gemma-3-12b-it",
+    "name": "Gemma 3 12B",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2025-03-13 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.03,
+          "output_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-03-13",
+      "cost": {
+        "input": 0.03,
+        "output": 0.1
+      },
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "google/gemma-3-12b-it:free",
+    "name": "Gemma 3 12B (free)",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2025-03-13 00:00:00 +0530",
+    "context_window": 32768,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-03-13",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 32768,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "google/gemma-3-27b-it",
+    "name": "Gemma 3 27B",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2025-03-12 00:00:00 +0530",
+    "context_window": 96000,
+    "max_output_tokens": 96000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.04,
+          "output_per_million": 0.15
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-03-12",
+      "cost": {
+        "input": 0.04,
+        "output": 0.15
+      },
+      "limit": {
+        "context": 96000,
+        "output": 96000
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "google/gemma-3-27b-it:free",
+    "name": "Gemma 3 27B (free)",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2025-03-12 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-03-12",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 131072,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "google/gemma-3-4b-it",
+    "name": "Gemma 3 4B",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2025-03-13 00:00:00 +0530",
+    "context_window": 96000,
+    "max_output_tokens": 96000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.01703,
+          "output_per_million": 0.06815
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-03-13",
+      "cost": {
+        "input": 0.01703,
+        "output": 0.06815
+      },
+      "limit": {
+        "context": 96000,
+        "output": 96000
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "google/gemma-3-4b-it:free",
+    "name": "Gemma 3 4B (free)",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2025-03-13 00:00:00 +0530",
+    "context_window": 32768,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-03-13",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 32768,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "google/gemma-3n-e2b-it:free",
+    "name": "Gemma 3n 2B (free)",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2025-07-09 00:00:00 +0530",
+    "context_window": 8192,
+    "max_output_tokens": 2000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-07-09",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 8192,
+        "output": 2000
+      },
+      "knowledge": "2024-06"
+    }
+  },
+  {
+    "id": "google/gemma-3n-e4b-it",
+    "name": "Gemma 3n 4B",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2025-05-20 00:00:00 +0530",
+    "context_window": 32768,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.02,
+          "output_per_million": 0.04
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-20",
+      "cost": {
+        "input": 0.02,
+        "output": 0.04
+      },
+      "limit": {
+        "context": 32768,
+        "output": 32768
+      },
+      "knowledge": "2024-06"
+    }
+  },
+  {
+    "id": "google/gemma-3n-e4b-it:free",
+    "name": "Gemma 3n 4B (free)",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2025-05-20 00:00:00 +0530",
+    "context_window": 8192,
+    "max_output_tokens": 2000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-20",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 8192,
+        "output": 2000
+      },
+      "knowledge": "2024-06"
+    }
+  },
+  {
+    "id": "google/gemma-4-26b-a4b-it",
+    "name": "Gemma 4 26B A4B",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2026-04-03 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.13,
+          "output_per_million": 0.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-04-03",
+      "cost": {
+        "input": 0.13,
+        "output": 0.4
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemma-4-26b-a4b-it:free",
+    "name": "Gemma 4 26B A4B (free)",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2026-04-03 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-04-03",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 262144,
+        "output": 32768
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemma-4-31b-it",
+    "name": "Gemma 4 31B",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2026-04-02 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.14,
+          "output_per_million": 0.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-04-02",
+      "cost": {
+        "input": 0.14,
+        "output": 0.4
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "google/gemma-4-31b-it:free",
+    "name": "Gemma 4 31B (free)",
+    "provider": "openrouter",
+    "family": "gemma",
+    "created_at": "2026-04-02 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-04-02",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 262144,
+        "output": 32768
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "inception/mercury-2",
+    "name": "Mercury 2",
+    "provider": "openrouter",
+    "family": "mercury",
+    "created_at": "2026-03-04 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 50000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.25,
+          "output_per_million": 0.75,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-03-04",
+      "cost": {
+        "input": 0.25,
+        "output": 0.75,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 128000,
+        "output": 50000
+      }
+    }
+  },
+  {
+    "id": "inception/mercury-edit-2",
+    "name": "Mercury Edit 2",
+    "provider": "openrouter",
+    "family": null,
+    "created_at": "2026-03-30 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.25,
+          "output_per_million": 0.75,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-03-30",
+      "cost": {
+        "input": 0.25,
+        "output": 0.75,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 128000,
+        "output": 8192
+      }
+    }
+  },
+  {
+    "id": "liquid/lfm-2.5-1.2b-instruct:free",
+    "name": "LFM2.5-1.2B-Instruct (free)",
+    "provider": "openrouter",
+    "family": "liquid",
+    "created_at": "2026-01-20 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-28",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 131072,
+        "output": 32768
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "liquid/lfm-2.5-1.2b-thinking:free",
+    "name": "LFM2.5-1.2B-Thinking (free)",
+    "provider": "openrouter",
+    "family": "liquid",
+    "created_at": "2026-01-20 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "reasoning"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-28",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 131072,
+        "output": 32768
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "meta-llama/llama-3.2-11b-vision-instruct",
+    "name": "Llama 3.2 11B Vision Instruct",
+    "provider": "openrouter",
+    "family": "llama",
+    "created_at": "2024-09-25 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-09-25",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 131072,
+        "output": 8192
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "meta-llama/llama-3.2-3b-instruct:free",
+    "name": "Llama 3.2 3B Instruct (free)",
+    "provider": "openrouter",
+    "family": "llama",
+    "created_at": "2024-09-25 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-09-25",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "meta-llama/llama-3.3-70b-instruct:free",
+    "name": "Llama 3.3 70B Instruct (free)",
+    "provider": "openrouter",
+    "family": "llama",
+    "created_at": "2024-12-06 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-12-06",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "knowledge": "2024-12"
+    }
+  },
+  {
+    "id": "minimax/minimax-01",
+    "name": "MiniMax-01",
+    "provider": "openrouter",
+    "family": "minimax",
+    "created_at": "2025-01-15 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 1000000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.2,
+          "output_per_million": 1.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-01-15",
+      "cost": {
+        "input": 0.2,
+        "output": 1.1
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 1000000
+      }
+    }
+  },
+  {
+    "id": "minimax/minimax-m1",
+    "name": "MiniMax M1",
+    "provider": "openrouter",
+    "family": "minimax",
+    "created_at": "2025-06-17 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 40000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-06-17",
+      "cost": {
+        "input": 0.4,
+        "output": 2.2
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 40000
+      }
+    }
+  },
+  {
+    "id": "minimax/minimax-m2",
+    "name": "MiniMax M2",
+    "provider": "openrouter",
+    "family": "minimax",
+    "created_at": "2025-10-23 00:00:00 +0530",
+    "context_window": 196600,
+    "max_output_tokens": 118000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.28,
+          "output_per_million": 1.15,
+          "cached_input_per_million": 0.28
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-10-23",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 0.28,
+        "output": 1.15,
+        "cache_read": 0.28,
+        "cache_write": 1.15
+      },
+      "limit": {
+        "context": 196600,
+        "output": 118000
+      }
+    }
+  },
+  {
+    "id": "minimax/minimax-m2.1",
+    "name": "MiniMax M2.1",
+    "provider": "openrouter",
+    "family": "minimax",
+    "created_at": "2025-12-23 00:00:00 +0530",
+    "context_window": 204800,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 1.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-23",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 0.3,
+        "output": 1.2
+      },
+      "limit": {
+        "context": 204800,
+        "output": 131072
+      }
+    }
+  },
+  {
+    "id": "minimax/minimax-m2.5",
+    "name": "MiniMax M2.5",
+    "provider": "openrouter",
+    "family": "minimax",
+    "created_at": "2026-02-12 00:00:00 +0530",
+    "context_window": 204800,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 1.2,
+          "cached_input_per_million": 0.03
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-02-12",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_read": 0.03
+      },
+      "limit": {
+        "context": 204800,
+        "output": 131072
+      }
+    }
+  },
+  {
+    "id": "minimax/minimax-m2.5:free",
+    "name": "MiniMax M2.5 (free)",
+    "provider": "openrouter",
+    "family": "minimax",
+    "created_at": "2026-02-12 00:00:00 +0530",
+    "context_window": 204800,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-02-12",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 204800,
+        "output": 131072
+      }
+    }
+  },
+  {
+    "id": "minimax/minimax-m2.7",
+    "name": "MiniMax M2.7",
+    "provider": "openrouter",
+    "family": "minimax",
+    "created_at": "2026-03-18 00:00:00 +0530",
+    "context_window": 204800,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 1.2,
+          "cached_input_per_million": 0.06
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "cost": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_read": 0.06,
+        "cache_write": 0.375
+      },
+      "limit": {
+        "context": 204800,
+        "output": 131072
+      }
+    }
+  },
+  {
+    "id": "mistralai/codestral-2508",
+    "name": "Codestral 2508",
+    "provider": "openrouter",
+    "family": "codestral",
+    "created_at": "2025-08-01 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 256000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 0.9
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-01",
+      "cost": {
+        "input": 0.3,
+        "output": 0.9
+      },
+      "limit": {
+        "context": 256000,
+        "output": 256000
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "mistralai/devstral-2512",
+    "name": "Devstral 2 2512",
+    "provider": "openrouter",
+    "family": "devstral",
+    "created_at": "2025-09-12 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-12",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2025-12"
+    }
+  },
+  {
+    "id": "mistralai/devstral-medium-2507",
+    "name": "Devstral Medium",
+    "provider": "openrouter",
+    "family": "devstral",
+    "created_at": "2025-07-10 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-10",
+      "cost": {
+        "input": 0.4,
+        "output": 2
+      },
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "mistralai/devstral-small-2505",
+    "name": "Devstral Small",
+    "provider": "openrouter",
+    "family": "devstral",
+    "created_at": "2025-05-07 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.06,
+          "output_per_million": 0.12
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-05-07",
+      "cost": {
+        "input": 0.06,
+        "output": 0.12
+      },
+      "limit": {
+        "context": 128000,
+        "output": 128000
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "mistralai/devstral-small-2507",
+    "name": "Devstral Small 1.1",
+    "provider": "openrouter",
+    "family": "devstral",
+    "created_at": "2025-07-10 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-10",
+      "cost": {
+        "input": 0.1,
+        "output": 0.3
+      },
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "mistralai/mistral-medium-3",
+    "name": "Mistral Medium 3",
+    "provider": "openrouter",
+    "family": "mistral-medium",
+    "created_at": "2025-05-07 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-07",
+      "cost": {
+        "input": 0.4,
+        "output": 2
+      },
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "mistralai/mistral-medium-3.1",
+    "name": "Mistral Medium 3.1",
+    "provider": "openrouter",
+    "family": "mistral-medium",
+    "created_at": "2025-08-12 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-12",
+      "cost": {
+        "input": 0.4,
+        "output": 2
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "mistralai/mistral-small-2603",
+    "name": "Mistral Small 4",
+    "provider": "openrouter",
+    "family": "mistral-small",
+    "created_at": "2026-03-16 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-16",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "mistralai/mistral-small-3.1-24b-instruct",
+    "name": "Mistral Small 3.1 24B Instruct",
+    "provider": "openrouter",
+    "family": "mistral-small",
+    "created_at": "2025-03-17 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-03-17",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 128000,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "mistralai/mistral-small-3.2-24b-instruct",
+    "name": "Mistral Small 3.2 24B Instruct",
+    "provider": "openrouter",
+    "family": "mistral-small",
+    "created_at": "2025-06-20 00:00:00 +0530",
+    "context_window": 96000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-20",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 96000,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "moonshotai/kimi-k2",
+    "name": "Kimi K2",
+    "provider": "openrouter",
+    "family": "kimi",
+    "created_at": "2025-07-11 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.55,
+          "output_per_million": 2.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-11",
+      "cost": {
+        "input": 0.55,
+        "output": 2.2
+      },
+      "limit": {
+        "context": 131072,
+        "output": 32768
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "moonshotai/kimi-k2-0905",
+    "name": "Kimi K2 Instruct 0905",
+    "provider": "openrouter",
+    "family": "kimi",
+    "created_at": "2025-09-05 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-05",
+      "cost": {
+        "input": 0.6,
+        "output": 2.5
+      },
+      "limit": {
+        "context": 262144,
+        "output": 16384
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "moonshotai/kimi-k2-0905:exacto",
+    "name": "Kimi K2 Instruct 0905 (exacto)",
+    "provider": "openrouter",
+    "family": "kimi",
+    "created_at": "2025-09-05 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-05",
+      "cost": {
+        "input": 0.6,
+        "output": 2.5
+      },
+      "limit": {
+        "context": 262144,
+        "output": 16384
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "moonshotai/kimi-k2-thinking",
+    "name": "Kimi K2 Thinking",
+    "provider": "openrouter",
+    "family": "kimi-thinking",
+    "created_at": "2025-11-06 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.5,
+          "cached_input_per_million": 0.15
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-11-06",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 0.6,
+        "output": 2.5,
+        "cache_read": 0.15
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2024-08"
+    }
+  },
+  {
+    "id": "moonshotai/kimi-k2.5",
+    "name": "Kimi K2.5",
+    "provider": "openrouter",
+    "family": "kimi",
+    "created_at": "2026-01-27 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 3,
+          "cached_input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-01-27",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 0.6,
+        "output": 3,
+        "cache_read": 0.1
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "nousresearch/hermes-3-llama-3.1-405b:free",
+    "name": "Hermes 3 405B Instruct (free)",
+    "provider": "openrouter",
+    "family": "hermes",
+    "created_at": "2024-08-16 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "reasoning"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-08-16",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "nousresearch/hermes-4-405b",
+    "name": "Hermes 4 405B",
+    "provider": "openrouter",
+    "family": "hermes",
+    "created_at": "2025-08-25 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-25",
+      "cost": {
+        "input": 1,
+        "output": 3
+      },
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "nousresearch/hermes-4-70b",
+    "name": "Hermes 4 70B",
+    "provider": "openrouter",
+    "family": "hermes",
+    "created_at": "2025-08-25 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.13,
+          "output_per_million": 0.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-25",
+      "cost": {
+        "input": 0.13,
+        "output": 0.4
+      },
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "nvidia/nemotron-3-nano-30b-a3b:free",
+    "name": "Nemotron 3 Nano 30B A3B (free)",
+    "provider": "openrouter",
+    "family": "nemotron",
+    "created_at": "2025-12-14 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 256000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-31",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 256000,
+        "output": 256000
+      },
+      "knowledge": "2025-11"
+    }
+  },
+  {
+    "id": "nvidia/nemotron-3-super-120b-a12b",
+    "name": "Nemotron 3 Super",
+    "provider": "openrouter",
+    "family": "nemotron",
+    "created_at": "2026-03-11 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-03-11",
+      "cost": {
+        "input": 0.1,
+        "output": 0.5
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "nvidia/nemotron-3-super-120b-a12b:free",
+    "name": "Nemotron 3 Super (free)",
+    "provider": "openrouter",
+    "family": "nemotron",
+    "created_at": "2026-03-11 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-03-11",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "nvidia/nemotron-nano-12b-v2-vl:free",
+    "name": "Nemotron Nano 12B 2 VL (free)",
+    "provider": "openrouter",
+    "family": "nemotron",
+    "created_at": "2025-10-28 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-31",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 128000,
+        "output": 128000
+      },
+      "knowledge": "2025-11"
+    }
+  },
+  {
+    "id": "nvidia/nemotron-nano-9b-v2",
+    "name": "nvidia-nemotron-nano-9b-v2",
+    "provider": "openrouter",
+    "family": "nemotron",
+    "created_at": "2025-08-18 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.04,
+          "output_per_million": 0.16
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-18",
+      "cost": {
+        "input": 0.04,
+        "output": 0.16
+      },
+      "limit": {
+        "context": 131072,
+        "output": 131072
+      },
+      "knowledge": "2024-09"
+    }
+  },
+  {
+    "id": "nvidia/nemotron-nano-9b-v2:free",
+    "name": "Nemotron Nano 9B V2 (free)",
+    "provider": "openrouter",
+    "family": "nemotron",
+    "created_at": "2025-09-05 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-18",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 128000,
+        "output": 128000
+      },
+      "knowledge": "2024-09"
+    }
+  },
+  {
+    "id": "openai/gpt-4.1",
+    "name": "GPT-4.1",
+    "provider": "openrouter",
+    "family": "gpt",
+    "created_at": "2025-04-14 00:00:00 +0530",
+    "context_window": 1047576,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 8,
+          "cached_input_per_million": 0.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-04-14",
+      "cost": {
+        "input": 2,
+        "output": 8,
+        "cache_read": 0.5
+      },
+      "limit": {
+        "context": 1047576,
+        "output": 32768
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "openai/gpt-4.1-mini",
+    "name": "GPT-4.1 Mini",
+    "provider": "openrouter",
+    "family": "gpt-mini",
+    "created_at": "2025-04-14 00:00:00 +0530",
+    "context_window": 1047576,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 1.6,
+          "cached_input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-04-14",
+      "cost": {
+        "input": 0.4,
+        "output": 1.6,
+        "cache_read": 0.1
+      },
+      "limit": {
+        "context": 1047576,
+        "output": 32768
+      },
+      "knowledge": "2024-04"
+    }
+  },
+  {
+    "id": "openai/gpt-4o-mini",
+    "name": "GPT-4o-mini",
+    "provider": "openrouter",
+    "family": "gpt-mini",
+    "created_at": "2024-07-18 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6,
+          "cached_input_per_million": 0.08
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-07-18",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_read": 0.08
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "openai/gpt-5",
+    "name": "GPT-5",
+    "provider": "openrouter",
+    "family": "gpt",
+    "created_at": "2025-08-07 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-10-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-07",
+      "cost": {
+        "input": 1.25,
+        "output": 10
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2024-10-01"
+    }
+  },
+  {
+    "id": "openai/gpt-5-chat",
+    "name": "GPT-5 Chat (latest)",
+    "provider": "openrouter",
+    "family": "gpt-codex",
+    "created_at": "2025-08-07 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-07",
+      "cost": {
+        "input": 1.25,
+        "output": 10
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "openai/gpt-5-codex",
+    "name": "GPT-5 Codex",
+    "provider": "openrouter",
+    "family": "gpt-codex",
+    "created_at": "2025-09-15 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-10-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-15",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.125
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2024-10-01"
+    }
+  },
+  {
+    "id": "openai/gpt-5-image",
+    "name": "GPT-5 Image",
+    "provider": "openrouter",
+    "family": "gpt",
+    "created_at": "2025-10-14 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-10-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 5,
+          "output_per_million": 10,
+          "cached_input_per_million": 1.25
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-10-14",
+      "cost": {
+        "input": 5,
+        "output": 10,
+        "cache_read": 1.25
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2024-10-01"
+    }
+  },
+  {
+    "id": "openai/gpt-5-mini",
+    "name": "GPT-5 Mini",
+    "provider": "openrouter",
+    "family": "gpt-mini",
+    "created_at": "2025-08-07 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-10-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.25,
+          "output_per_million": 2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-07",
+      "cost": {
+        "input": 0.25,
+        "output": 2
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2024-10-01"
+    }
+  },
+  {
+    "id": "openai/gpt-5-nano",
+    "name": "GPT-5 Nano",
+    "provider": "openrouter",
+    "family": "gpt-nano",
+    "created_at": "2025-08-07 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-10-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.05,
+          "output_per_million": 0.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-07",
+      "cost": {
+        "input": 0.05,
+        "output": 0.4
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2024-10-01"
+    }
+  },
+  {
+    "id": "openai/gpt-5-pro",
+    "name": "GPT-5 Pro",
+    "provider": "openrouter",
+    "family": "gpt-pro",
+    "created_at": "2025-10-06 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 272000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 15,
+          "output_per_million": 120
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-10-06",
+      "cost": {
+        "input": 15,
+        "output": 120
+      },
+      "limit": {
+        "context": 400000,
+        "output": 272000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "openai/gpt-5.1",
+    "name": "GPT-5.1",
+    "provider": "openrouter",
+    "family": "gpt",
+    "created_at": "2025-11-13 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-11-13",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.125
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "openai/gpt-5.1-chat",
+    "name": "GPT-5.1 Chat",
+    "provider": "openrouter",
+    "family": "gpt-codex",
+    "created_at": "2025-11-13 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-11-13",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.125
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "openai/gpt-5.1-codex",
+    "name": "GPT-5.1-Codex",
+    "provider": "openrouter",
+    "family": "gpt-codex",
+    "created_at": "2025-11-13 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.125
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-11-13",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.125
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "openai/gpt-5.1-codex-max",
+    "name": "GPT-5.1-Codex-Max",
+    "provider": "openrouter",
+    "family": "gpt-codex",
+    "created_at": "2025-11-13 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.1,
+          "output_per_million": 9,
+          "cached_input_per_million": 0.11
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-11-13",
+      "cost": {
+        "input": 1.1,
+        "output": 9,
+        "cache_read": 0.11
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "openai/gpt-5.1-codex-mini",
+    "name": "GPT-5.1-Codex-Mini",
+    "provider": "openrouter",
+    "family": "gpt-codex",
+    "created_at": "2025-11-13 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": "2024-09-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.25,
+          "output_per_million": 2,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-11-13",
+      "cost": {
+        "input": 0.25,
+        "output": 2,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 400000,
+        "output": 100000
+      },
+      "knowledge": "2024-09-30"
+    }
+  },
+  {
+    "id": "openai/gpt-5.2",
+    "name": "GPT-5.2",
+    "provider": "openrouter",
+    "family": "gpt",
+    "created_at": "2025-12-11 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.75,
+          "output_per_million": 14,
+          "cached_input_per_million": 0.175
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-12-11",
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cache_read": 0.175
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "openai/gpt-5.2-chat",
+    "name": "GPT-5.2 Chat",
+    "provider": "openrouter",
+    "family": "gpt-codex",
+    "created_at": "2025-12-11 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.75,
+          "output_per_million": 14,
+          "cached_input_per_million": 0.175
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-12-11",
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cache_read": 0.175
+      },
+      "limit": {
+        "context": 128000,
+        "output": 16384
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "openai/gpt-5.2-codex",
+    "name": "GPT-5.2-Codex",
+    "provider": "openrouter",
+    "family": "gpt-codex",
+    "created_at": "2026-01-14 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.75,
+          "output_per_million": 14,
+          "cached_input_per_million": 0.175
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-01-14",
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cache_read": 0.175
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "openai/gpt-5.2-pro",
+    "name": "GPT-5.2 Pro",
+    "provider": "openrouter",
+    "family": "gpt-pro",
+    "created_at": "2025-12-11 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 21,
+          "output_per_million": 168
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2025-12-11",
+      "cost": {
+        "input": 21,
+        "output": 168
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "openai/gpt-5.3-codex",
+    "name": "GPT-5.3-Codex",
+    "provider": "openrouter",
+    "family": "gpt-codex",
+    "created_at": "2026-02-24 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.75,
+          "output_per_million": 14,
+          "cached_input_per_million": 0.175
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2026-02-24",
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cache_read": 0.175
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "openai/gpt-5.4",
+    "name": "GPT-5.4",
+    "provider": "openrouter",
+    "family": "gpt",
+    "created_at": "2026-03-05 00:00:00 +0530",
+    "context_window": 1050000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2.5,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.25
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2026-03-05",
+      "cost": {
+        "input": 2.5,
+        "output": 15,
+        "cache_read": 0.25,
+        "context_over_200k": {
+          "input": 5,
+          "output": 22.5,
+          "cache_read": 0.5
+        }
+      },
+      "limit": {
+        "context": 1050000,
+        "input": 922000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "openai/gpt-5.4-mini",
+    "name": "GPT-5.4 Mini",
+    "provider": "openrouter",
+    "family": "gpt-mini",
+    "created_at": "2026-03-17 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.00000075,
+          "output_per_million": 0.0000045,
+          "cached_input_per_million": 0.000000075
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-17",
+      "cost": {
+        "input": 0.00000075,
+        "output": 0.0000045,
+        "cache_read": 0.000000075
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "openai/gpt-5.4-nano",
+    "name": "GPT-5.4 Nano",
+    "provider": "openrouter",
+    "family": "gpt-nano",
+    "created_at": "2026-03-17 00:00:00 +0530",
+    "context_window": 400000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.0000002,
+          "output_per_million": 0.00000125,
+          "cached_input_per_million": 0.00000002
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-17",
+      "cost": {
+        "input": 0.0000002,
+        "output": 0.00000125,
+        "cache_read": 0.00000002
+      },
+      "limit": {
+        "context": 400000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "openai/gpt-5.4-pro",
+    "name": "GPT-5.4 Pro",
+    "provider": "openrouter",
+    "family": "gpt-pro",
+    "created_at": "2026-03-05 00:00:00 +0530",
+    "context_window": 1050000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": "2025-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 30,
+          "output_per_million": 180,
+          "cached_input_per_million": 30
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": false,
+      "last_updated": "2026-03-05",
+      "cost": {
+        "input": 30,
+        "output": 180,
+        "cache_read": 30
+      },
+      "limit": {
+        "context": 1050000,
+        "input": 922000,
+        "output": 128000
+      },
+      "knowledge": "2025-08-31"
+    }
+  },
+  {
+    "id": "openai/gpt-oss-120b",
+    "name": "GPT OSS 120B",
+    "provider": "openrouter",
+    "family": "gpt-oss",
+    "created_at": "2025-08-05 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.072,
+          "output_per_million": 0.28
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-05",
+      "cost": {
+        "input": 0.072,
+        "output": 0.28
+      },
+      "limit": {
+        "context": 131072,
+        "output": 32768
+      }
+    }
+  },
+  {
+    "id": "openai/gpt-oss-120b:exacto",
+    "name": "GPT OSS 120B (exacto)",
+    "provider": "openrouter",
+    "family": "gpt-oss",
+    "created_at": "2025-08-05 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.05,
+          "output_per_million": 0.24
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-05",
+      "cost": {
+        "input": 0.05,
+        "output": 0.24
+      },
+      "limit": {
+        "context": 131072,
+        "output": 32768
+      }
+    }
+  },
+  {
+    "id": "openai/gpt-oss-120b:free",
+    "name": "gpt-oss-120b (free)",
+    "provider": "openrouter",
+    "family": "gpt-oss",
+    "created_at": "2025-08-05 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-05",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 131072,
+        "output": 32768
+      }
+    }
+  },
+  {
+    "id": "openai/gpt-oss-20b",
+    "name": "GPT OSS 20B",
+    "provider": "openrouter",
+    "family": "gpt-oss",
+    "created_at": "2025-08-05 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.05,
+          "output_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-05",
+      "cost": {
+        "input": 0.05,
+        "output": 0.2
+      },
+      "limit": {
+        "context": 131072,
+        "output": 32768
+      }
+    }
+  },
+  {
+    "id": "openai/gpt-oss-20b:free",
+    "name": "gpt-oss-20b (free)",
+    "provider": "openrouter",
+    "family": "gpt-oss",
+    "created_at": "2025-08-05 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-31",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 131072,
+        "output": 32768
+      }
+    }
+  },
+  {
+    "id": "openai/gpt-oss-safeguard-20b",
+    "name": "GPT OSS Safeguard 20B",
+    "provider": "openrouter",
+    "family": "gpt-oss",
+    "created_at": "2025-10-29 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.075,
+          "output_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-10-29",
+      "cost": {
+        "input": 0.075,
+        "output": 0.3
+      },
+      "limit": {
+        "context": 131072,
+        "output": 65536
+      }
+    }
+  },
+  {
+    "id": "openai/o4-mini",
+    "name": "o4 Mini",
+    "provider": "openrouter",
+    "family": "o-mini",
+    "created_at": "2025-04-16 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 100000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.1,
+          "output_per_million": 4.4,
+          "cached_input_per_million": 0.28
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-04-16",
+      "cost": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_read": 0.28
+      },
+      "limit": {
+        "context": 200000,
+        "output": 100000
+      },
+      "knowledge": "2024-06"
+    }
+  },
+  {
+    "id": "openrouter/elephant-alpha",
+    "name": "Elephant (free)",
+    "provider": "openrouter",
+    "family": "elephant",
+    "created_at": "2026-04-13 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-04-13",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 262144,
+        "output": 32768
+      }
+    }
+  },
+  {
+    "id": "openrouter/free",
+    "name": "Free Models Router",
+    "provider": "openrouter",
+    "family": null,
+    "created_at": "2026-02-01 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 8000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-01",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 200000,
+        "input": 200000,
+        "output": 8000
+      }
+    }
+  },
+  {
+    "id": "prime-intellect/intellect-3",
+    "name": "Intellect 3",
+    "provider": "openrouter",
+    "family": "glm",
+    "created_at": "2025-01-15 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.2,
+          "output_per_million": 1.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-01-15",
+      "cost": {
+        "input": 0.2,
+        "output": 1.1
+      },
+      "limit": {
+        "context": 131072,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "qwen/qwen-2.5-coder-32b-instruct",
+    "name": "Qwen2.5 Coder 32B Instruct",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2024-11-11 00:00:00 +0530",
+    "context_window": 32768,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "structured_output"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2024-11-11",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 32768,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "qwen/qwen2.5-vl-72b-instruct",
+    "name": "Qwen2.5 VL 72B Instruct",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2025-02-01 00:00:00 +0530",
+    "context_window": 32768,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-02-01",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 32768,
+        "output": 8192
+      },
+      "knowledge": "2024-10"
+    }
+  },
+  {
+    "id": "qwen/qwen3-235b-a22b-07-25",
+    "name": "Qwen3 235B A22B Instruct 2507",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2025-04-28 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.85
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-21",
+      "cost": {
+        "input": 0.15,
+        "output": 0.85
+      },
+      "limit": {
+        "context": 262144,
+        "output": 131072
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "qwen/qwen3-235b-a22b-thinking-2507",
+    "name": "Qwen3 235B A22B Thinking 2507",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2025-07-25 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 81920,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.078,
+          "output_per_million": 0.312
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-25",
+      "cost": {
+        "input": 0.078,
+        "output": 0.312
+      },
+      "limit": {
+        "context": 262144,
+        "output": 81920
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "qwen/qwen3-30b-a3b-instruct-2507",
+    "name": "Qwen3 30B A3B Instruct 2507",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2025-07-29 00:00:00 +0530",
+    "context_window": 262000,
+    "max_output_tokens": 262000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.2,
+          "output_per_million": 0.8
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-29",
+      "cost": {
+        "input": 0.2,
+        "output": 0.8
+      },
+      "limit": {
+        "context": 262000,
+        "output": 262000
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "qwen/qwen3-30b-a3b-thinking-2507",
+    "name": "Qwen3 30B A3B Thinking 2507",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2025-07-29 00:00:00 +0530",
+    "context_window": 262000,
+    "max_output_tokens": 262000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.2,
+          "output_per_million": 0.8
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-29",
+      "cost": {
+        "input": 0.2,
+        "output": 0.8
+      },
+      "limit": {
+        "context": 262000,
+        "output": 262000
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "qwen/qwen3-coder",
+    "name": "Qwen3 Coder",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2025-07-23 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 66536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 1.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-23",
+      "cost": {
+        "input": 0.3,
+        "output": 1.2
+      },
+      "limit": {
+        "context": 262144,
+        "output": 66536
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "qwen/qwen3-coder-30b-a3b-instruct",
+    "name": "Qwen3 Coder 30B A3B Instruct",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2025-07-31 00:00:00 +0530",
+    "context_window": 160000,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.07,
+          "output_per_million": 0.27
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-31",
+      "cost": {
+        "input": 0.07,
+        "output": 0.27
+      },
+      "limit": {
+        "context": 160000,
+        "output": 65536
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "qwen/qwen3-coder-flash",
+    "name": "Qwen3 Coder Flash",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2025-07-23 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 66536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 1.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-23",
+      "cost": {
+        "input": 0.3,
+        "output": 1.5
+      },
+      "limit": {
+        "context": 128000,
+        "output": 66536
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "qwen/qwen3-coder:exacto",
+    "name": "Qwen3 Coder (exacto)",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2025-07-23 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.38,
+          "output_per_million": 1.53
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-23",
+      "cost": {
+        "input": 0.38,
+        "output": 1.53
+      },
+      "limit": {
+        "context": 131072,
+        "output": 32768
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "qwen/qwen3-max",
+    "name": "Qwen3 Max",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2025-09-05 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.2,
+          "output_per_million": 6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-05",
+      "cost": {
+        "input": 1.2,
+        "output": 6
+      },
+      "limit": {
+        "context": 262144,
+        "output": 32768
+      }
+    }
+  },
+  {
+    "id": "qwen/qwen3-next-80b-a3b-instruct",
+    "name": "Qwen3 Next 80B A3B Instruct",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2025-09-11 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.14,
+          "output_per_million": 1.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-11",
+      "cost": {
+        "input": 0.14,
+        "output": 1.4
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "qwen/qwen3-next-80b-a3b-thinking",
+    "name": "Qwen3 Next 80B A3B Thinking",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2025-09-11 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.14,
+          "output_per_million": 1.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-11",
+      "cost": {
+        "input": 0.14,
+        "output": 1.4
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "qwen/qwen3.5-397b-a17b",
+    "name": "Qwen3.5 397B A17B",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2026-02-16 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 3.6
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-16",
+      "cost": {
+        "input": 0.6,
+        "output": 3.6
+      },
+      "limit": {
+        "context": 262144,
+        "output": 65536
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "qwen/qwen3.5-flash-02-23",
+    "name": "Qwen: Qwen3.5-Flash",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2026-02-25 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.065,
+          "output_per_million": 0.26
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-25",
+      "cost": {
+        "input": 0.065,
+        "output": 0.26
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 65536
+      }
+    }
+  },
+  {
+    "id": "qwen/qwen3.5-plus-02-15",
+    "name": "Qwen3.5 Plus 2026-02-15",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2026-02-16 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-16",
+      "cost": {
+        "input": 0.4,
+        "output": 2.4
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 65536
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "qwen/qwen3.6-plus",
+    "name": "Qwen3.6 Plus",
+    "provider": "openrouter",
+    "family": "qwen",
+    "created_at": "2026-04-02 00:00:00 +0530",
+    "context_window": 1000000,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.325,
+          "output_per_million": 1.95
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-04-02",
+      "cost": {
+        "input": 0.325,
+        "output": 1.95
+      },
+      "limit": {
+        "context": 1000000,
+        "output": 65536
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "sourceful/riverflow-v2-fast-preview",
+    "name": "Riverflow V2 Fast Preview",
+    "provider": "openrouter",
+    "family": "sourceful",
+    "created_at": "2025-12-08 00:00:00 +0530",
+    "context_window": 8192,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-28",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 8192,
+        "output": 8192
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "sourceful/riverflow-v2-max-preview",
+    "name": "Riverflow V2 Max Preview",
+    "provider": "openrouter",
+    "family": "sourceful",
+    "created_at": "2025-12-08 00:00:00 +0530",
+    "context_window": 8192,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-28",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 8192,
+        "output": 8192
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "sourceful/riverflow-v2-standard-preview",
+    "name": "Riverflow V2 Standard Preview",
+    "provider": "openrouter",
+    "family": "sourceful",
+    "created_at": "2025-12-08 00:00:00 +0530",
+    "context_window": 8192,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-28",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 8192,
+        "output": 8192
+      },
+      "knowledge": "2025-06"
+    }
+  },
+  {
+    "id": "stepfun/step-3.5-flash",
+    "name": "Step 3.5 Flash",
+    "provider": "openrouter",
+    "family": "step",
+    "created_at": "2026-01-29 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 256000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.3,
+          "cached_input_per_million": 0.02
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-29",
+      "cost": {
+        "input": 0.1,
+        "output": 0.3,
+        "cache_read": 0.02
+      },
+      "limit": {
+        "context": 256000,
+        "output": 256000
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "x-ai/grok-3",
+    "name": "Grok 3",
+    "provider": "openrouter",
+    "family": "grok",
+    "created_at": "2025-02-17 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.75
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-02-17",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.75,
+        "cache_write": 15
+      },
+      "limit": {
+        "context": 131072,
+        "output": 8192
+      },
+      "knowledge": "2024-11"
+    }
+  },
+  {
+    "id": "x-ai/grok-3-beta",
+    "name": "Grok 3 Beta",
+    "provider": "openrouter",
+    "family": "grok",
+    "created_at": "2025-02-17 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.75
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-02-17",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.75,
+        "cache_write": 15
+      },
+      "limit": {
+        "context": 131072,
+        "output": 8192
+      },
+      "knowledge": "2024-11"
+    }
+  },
+  {
+    "id": "x-ai/grok-3-mini",
+    "name": "Grok 3 Mini",
+    "provider": "openrouter",
+    "family": "grok",
+    "created_at": "2025-02-17 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 0.5,
+          "cached_input_per_million": 0.075
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-02-17",
+      "cost": {
+        "input": 0.3,
+        "output": 0.5,
+        "cache_read": 0.075,
+        "cache_write": 0.5
+      },
+      "limit": {
+        "context": 131072,
+        "output": 8192
+      },
+      "knowledge": "2024-11"
+    }
+  },
+  {
+    "id": "x-ai/grok-3-mini-beta",
+    "name": "Grok 3 Mini Beta",
+    "provider": "openrouter",
+    "family": "grok",
+    "created_at": "2025-02-17 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 0.5,
+          "cached_input_per_million": 0.075
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-02-17",
+      "cost": {
+        "input": 0.3,
+        "output": 0.5,
+        "cache_read": 0.075,
+        "cache_write": 0.5
+      },
+      "limit": {
+        "context": 131072,
+        "output": 8192
+      },
+      "knowledge": "2024-11"
+    }
+  },
+  {
+    "id": "x-ai/grok-4",
+    "name": "Grok 4",
+    "provider": "openrouter",
+    "family": "grok",
+    "created_at": "2025-07-09 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 64000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15,
+          "cached_input_per_million": 0.75
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-09",
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.75,
+        "cache_write": 15
+      },
+      "limit": {
+        "context": 256000,
+        "output": 64000
+      },
+      "knowledge": "2025-07"
+    }
+  },
+  {
+    "id": "x-ai/grok-4-fast",
+    "name": "Grok 4 Fast",
+    "provider": "openrouter",
+    "family": "grok",
+    "created_at": "2025-08-19 00:00:00 +0530",
+    "context_window": 2000000,
+    "max_output_tokens": 30000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.2,
+          "output_per_million": 0.5,
+          "cached_input_per_million": 0.05
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-19",
+      "cost": {
+        "input": 0.2,
+        "output": 0.5,
+        "cache_read": 0.05,
+        "cache_write": 0.05
+      },
+      "limit": {
+        "context": 2000000,
+        "output": 30000
+      },
+      "knowledge": "2024-11"
+    }
+  },
+  {
+    "id": "x-ai/grok-4.1-fast",
+    "name": "Grok 4.1 Fast",
+    "provider": "openrouter",
+    "family": "grok",
+    "created_at": "2025-11-19 00:00:00 +0530",
+    "context_window": 2000000,
+    "max_output_tokens": 30000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.2,
+          "output_per_million": 0.5,
+          "cached_input_per_million": 0.05
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-11-19",
+      "cost": {
+        "input": 0.2,
+        "output": 0.5,
+        "cache_read": 0.05,
+        "cache_write": 0.05
+      },
+      "limit": {
+        "context": 2000000,
+        "output": 30000
+      },
+      "knowledge": "2024-11"
+    }
+  },
+  {
+    "id": "x-ai/grok-4.20-beta",
+    "name": "Grok 4.20 Beta",
+    "provider": "openrouter",
+    "family": "grok",
+    "created_at": "2026-03-12 00:00:00 +0530",
+    "context_window": 2000000,
+    "max_output_tokens": 30000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 6,
+          "cached_input_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-12",
+      "status": "beta",
+      "cost": {
+        "input": 2,
+        "output": 6,
+        "cache_read": 0.2,
+        "context_over_200k": {
+          "input": 4,
+          "output": 12
+        }
+      },
+      "limit": {
+        "context": 2000000,
+        "output": 30000
+      }
+    }
+  },
+  {
+    "id": "x-ai/grok-4.20-multi-agent-beta",
+    "name": "Grok 4.20 Multi - Agent Beta",
+    "provider": "openrouter",
+    "family": "grok",
+    "created_at": "2026-03-12 00:00:00 +0530",
+    "context_window": 2000000,
+    "max_output_tokens": 30000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 6,
+          "cached_input_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-12",
+      "status": "beta",
+      "cost": {
+        "input": 2,
+        "output": 6,
+        "cache_read": 0.2,
+        "context_over_200k": {
+          "input": 4,
+          "output": 12
+        }
+      },
+      "limit": {
+        "context": 2000000,
+        "output": 30000
+      }
+    }
+  },
+  {
+    "id": "x-ai/grok-code-fast-1",
+    "name": "Grok Code Fast 1",
+    "provider": "openrouter",
+    "family": "grok",
+    "created_at": "2025-08-26 00:00:00 +0530",
+    "context_window": 256000,
+    "max_output_tokens": 10000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.2,
+          "output_per_million": 1.5,
+          "cached_input_per_million": 0.02
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-26",
+      "cost": {
+        "input": 0.2,
+        "output": 1.5,
+        "cache_read": 0.02
+      },
+      "limit": {
+        "context": 256000,
+        "output": 10000
+      },
+      "knowledge": "2025-08"
+    }
+  },
+  {
+    "id": "xiaomi/mimo-v2-flash",
+    "name": "MiMo-V2-Flash",
+    "provider": "openrouter",
+    "family": "mimo",
+    "created_at": "2025-12-14 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.3,
+          "cached_input_per_million": 0.01
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-14",
+      "cost": {
+        "input": 0.1,
+        "output": 0.3,
+        "cache_read": 0.01
+      },
+      "limit": {
+        "context": 262144,
+        "output": 65536
+      },
+      "knowledge": "2024-12"
+    }
+  },
+  {
+    "id": "xiaomi/mimo-v2-omni",
+    "name": "MiMo-V2-Omni",
+    "provider": "openrouter",
+    "family": "mimo",
+    "created_at": "2026-03-18 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.4,
+          "output_per_million": 2,
+          "cached_input_per_million": 0.08
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 0.4,
+        "output": 2,
+        "cache_read": 0.08
+      },
+      "limit": {
+        "context": 262144,
+        "output": 65536
+      }
+    }
+  },
+  {
+    "id": "xiaomi/mimo-v2-pro",
+    "name": "MiMo-V2-Pro",
+    "provider": "openrouter",
+    "family": "mimo",
+    "created_at": "2026-03-18 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 3,
+          "cached_input_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-03-18",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 1,
+        "output": 3,
+        "cache_read": 0.2
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      }
+    }
+  },
+  {
+    "id": "z-ai/glm-4.5",
+    "name": "GLM 4.5",
+    "provider": "openrouter",
+    "family": "glm",
+    "created_at": "2025-07-28 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 96000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-28",
+      "cost": {
+        "input": 0.6,
+        "output": 2.2
+      },
+      "limit": {
+        "context": 128000,
+        "output": 96000
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "z-ai/glm-4.5-air",
+    "name": "GLM 4.5 Air",
+    "provider": "openrouter",
+    "family": "glm-air",
+    "created_at": "2025-07-28 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 96000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.2,
+          "output_per_million": 1.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-28",
+      "cost": {
+        "input": 0.2,
+        "output": 1.1
+      },
+      "limit": {
+        "context": 128000,
+        "output": 96000
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "z-ai/glm-4.5-air:free",
+    "name": "GLM 4.5 Air (free)",
+    "provider": "openrouter",
+    "family": "glm-air",
+    "created_at": "2025-07-28 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 96000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "reasoning"
+    ],
+    "pricing": {},
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-07-28",
+      "cost": {
+        "input": 0,
+        "output": 0
+      },
+      "limit": {
+        "context": 128000,
+        "output": 96000
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "z-ai/glm-4.5v",
+    "name": "GLM 4.5V",
+    "provider": "openrouter",
+    "family": "glm",
+    "created_at": "2025-08-11 00:00:00 +0530",
+    "context_window": 64000,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 1.8
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-08-11",
+      "cost": {
+        "input": 0.6,
+        "output": 1.8
+      },
+      "limit": {
+        "context": 64000,
+        "output": 16384
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "z-ai/glm-4.6",
+    "name": "GLM 4.6",
+    "provider": "openrouter",
+    "family": "glm",
+    "created_at": "2025-09-30 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.2,
+          "cached_input_per_million": 0.11
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-30",
+      "cost": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_read": 0.11
+      },
+      "limit": {
+        "context": 200000,
+        "output": 128000
+      },
+      "knowledge": "2025-09"
+    }
+  },
+  {
+    "id": "z-ai/glm-4.6:exacto",
+    "name": "GLM 4.6 (exacto)",
+    "provider": "openrouter",
+    "family": "glm",
+    "created_at": "2025-09-30 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 1.9,
+          "cached_input_per_million": 0.11
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-30",
+      "cost": {
+        "input": 0.6,
+        "output": 1.9,
+        "cache_read": 0.11
+      },
+      "limit": {
+        "context": 200000,
+        "output": 128000
+      },
+      "knowledge": "2025-09"
+    }
+  },
+  {
+    "id": "z-ai/glm-4.7",
+    "name": "GLM-4.7",
+    "provider": "openrouter",
+    "family": "glm",
+    "created_at": "2025-12-22 00:00:00 +0530",
+    "context_window": 204800,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.2,
+          "cached_input_per_million": 0.11
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-12-22",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_read": 0.11
+      },
+      "limit": {
+        "context": 204800,
+        "output": 131072
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "z-ai/glm-4.7-flash",
+    "name": "GLM-4.7-Flash",
+    "provider": "openrouter",
+    "family": "glm",
+    "created_at": "2026-01-19 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 65535,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.07,
+          "output_per_million": 0.4
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-19",
+      "interleaved": {
+        "field": "reasoning_details"
+      },
+      "cost": {
+        "input": 0.07,
+        "output": 0.4
+      },
+      "limit": {
+        "context": 200000,
+        "output": 65535
+      }
+    }
+  },
+  {
+    "id": "z-ai/glm-5",
+    "name": "GLM-5",
+    "provider": "openrouter",
+    "family": "glm",
+    "created_at": "2026-02-12 00:00:00 +0530",
+    "context_window": 202752,
+    "max_output_tokens": 131000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 3.2,
+          "cached_input_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-02-12",
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "cost": {
+        "input": 1,
+        "output": 3.2,
+        "cache_read": 0.2
+      },
+      "limit": {
+        "context": 202752,
+        "output": 131000
+      }
+    }
+  },
+  {
+    "id": "z-ai/glm-5-turbo",
+    "name": "GLM-5-Turbo",
+    "provider": "openrouter",
+    "family": "glm",
+    "created_at": "2026-03-16 00:00:00 +0530",
+    "context_window": 202752,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.96,
+          "output_per_million": 3.2,
+          "cached_input_per_million": 0.192
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-03-16",
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "cost": {
+        "input": 0.96,
+        "output": 3.2,
+        "cache_read": 0.192,
+        "cache_write": 0
+      },
+      "limit": {
+        "context": 202752,
+        "output": 131072
+      }
+    }
+  },
+  {
+    "id": "z-ai/glm-5.1",
+    "name": "GLM-5.1",
+    "provider": "openrouter",
+    "family": "glm",
+    "created_at": "2026-04-07 00:00:00 +0530",
+    "context_window": 202752,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.4,
+          "output_per_million": 4.4,
+          "cached_input_per_million": 0.26
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "openrouter",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-04-07",
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "cost": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_read": 0.26
+      },
+      "limit": {
+        "context": 202752,
+        "output": 131072
+      }
+    }
+  },
+  {
+    "id": "sonar",
+    "name": "Sonar",
+    "provider": "perplexity",
+    "family": "sonar",
+    "created_at": "2024-01-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": "2025-09-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "perplexity",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-09-01",
+      "cost": {
+        "input": 1,
+        "output": 1
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "knowledge": "2025-09-01"
+    }
+  },
+  {
+    "id": "sonar-deep-research",
+    "name": "Perplexity Sonar Deep Research",
+    "provider": "perplexity",
+    "family": null,
+    "created_at": "2025-02-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 8,
+          "reasoning_output_per_million": 3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "perplexity",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2025-09-01",
+      "cost": {
+        "input": 2,
+        "output": 8,
+        "reasoning": 3
+      },
+      "limit": {
+        "context": 128000,
+        "output": 32768
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "sonar-pro",
+    "name": "Sonar Pro",
+    "provider": "perplexity",
+    "family": "sonar-pro",
+    "created_at": "2024-01-01 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": "2025-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 3,
+          "output_per_million": 15
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "perplexity",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-01",
+      "cost": {
+        "input": 3,
+        "output": 15
+      },
+      "limit": {
+        "context": 200000,
+        "output": 8192
+      },
+      "knowledge": "2025-09-01"
+    }
+  },
+  {
+    "id": "sonar-reasoning-pro",
+    "name": "Sonar Reasoning Pro",
+    "provider": "perplexity",
+    "family": "sonar-reasoning",
+    "created_at": "2024-01-01 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 4096,
+    "knowledge_cutoff": "2025-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 8
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "perplexity",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-01",
+      "cost": {
+        "input": 2,
+        "output": 8
+      },
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "knowledge": "2025-09-01"
+    }
+  },
+  {
+    "id": "deepseek-ai/deepseek-v3.1-maas",
+    "name": "DeepSeek V3.1",
+    "provider": "vertexai",
+    "family": "deepseek",
+    "created_at": "2025-08-28 00:00:00 +0530",
+    "context_window": 163840,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 1.7
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-28",
+      "cost": {
+        "input": 0.6,
+        "output": 1.7
+      },
+      "limit": {
+        "context": 163840,
+        "output": 32768
+      }
+    }
+  },
+  {
+    "id": "deepseek-ai/deepseek-v3.2-maas",
+    "name": "DeepSeek V3.2",
+    "provider": "vertexai",
+    "family": "deepseek",
+    "created_at": "2025-12-17 00:00:00 +0530",
+    "context_window": 163840,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.56,
+          "output_per_million": 1.68,
+          "cached_input_per_million": 0.056
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-04-04",
+      "cost": {
+        "input": 0.56,
+        "output": 1.68,
+        "cache_read": 0.056
+      },
+      "limit": {
+        "context": 163840,
+        "output": 65536
+      }
+    }
+  },
+  {
+    "id": "gemini-2.0-flash",
+    "name": "Gemini 2.0 Flash",
+    "provider": "vertexai",
+    "family": "gemini-flash",
+    "created_at": "2024-12-11 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-12-11",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 8192
+      },
+      "knowledge": "2024-06"
+    }
+  },
+  {
+    "id": "gemini-2.0-flash-lite",
+    "name": "Gemini 2.0 Flash Lite",
+    "provider": "vertexai",
+    "family": "gemini-flash-lite",
+    "created_at": "2024-12-11 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.075,
+          "output_per_million": 0.3
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2024-12-11",
+      "cost": {
+        "input": 0.075,
+        "output": 0.3
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 8192
+      },
+      "knowledge": "2024-06"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash",
+    "name": "Gemini 2.5 Flash",
+    "provider": "vertexai",
+    "family": "gemini-flash",
+    "created_at": "2025-06-17 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 2.5,
+          "cached_input_per_million": 0.075
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-17",
+      "cost": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_read": 0.075,
+        "cache_write": 0.383
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-lite",
+    "name": "Gemini 2.5 Flash Lite",
+    "provider": "vertexai",
+    "family": "gemini-flash-lite",
+    "created_at": "2025-06-17 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-17",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-lite-preview-06-17",
+    "name": "Gemini 2.5 Flash Lite Preview 06-17",
+    "provider": "vertexai",
+    "family": "gemini-flash-lite",
+    "created_at": "2025-06-17 00:00:00 +0530",
+    "context_window": 65536,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-17",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 65536,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-lite-preview-09-2025",
+    "name": "Gemini 2.5 Flash Lite Preview 09-25",
+    "provider": "vertexai",
+    "family": "gemini-flash-lite",
+    "created_at": "2025-09-25 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-25",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-preview-04-17",
+    "name": "Gemini 2.5 Flash Preview 04-17",
+    "provider": "vertexai",
+    "family": "gemini-flash",
+    "created_at": "2025-04-17 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6,
+          "cached_input_per_million": 0.0375
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-04-17",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_read": 0.0375
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-preview-05-20",
+    "name": "Gemini 2.5 Flash Preview 05-20",
+    "provider": "vertexai",
+    "family": "gemini-flash",
+    "created_at": "2025-05-20 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15,
+          "output_per_million": 0.6,
+          "cached_input_per_million": 0.0375
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-20",
+      "cost": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_read": 0.0375
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-flash-preview-09-2025",
+    "name": "Gemini 2.5 Flash Preview 09-25",
+    "provider": "vertexai",
+    "family": "gemini-flash",
+    "created_at": "2025-09-25 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 2.5,
+          "cached_input_per_million": 0.075
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-25",
+      "cost": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_read": 0.075,
+        "cache_write": 0.383
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-pro",
+    "name": "Gemini 2.5 Pro",
+    "provider": "vertexai",
+    "family": "gemini-pro",
+    "created_at": "2025-03-20 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.31
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-05",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.31
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-pro-preview-05-06",
+    "name": "Gemini 2.5 Pro Preview 05-06",
+    "provider": "vertexai",
+    "family": "gemini-pro",
+    "created_at": "2025-05-06 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.31
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-05-06",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.31
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-2.5-pro-preview-06-05",
+    "name": "Gemini 2.5 Pro Preview 06-05",
+    "provider": "vertexai",
+    "family": "gemini-pro",
+    "created_at": "2025-06-05 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1.25,
+          "output_per_million": 10,
+          "cached_input_per_million": 0.31
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-06-05",
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cache_read": 0.31
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-3-flash-preview",
+    "name": "Gemini 3 Flash Preview",
+    "provider": "vertexai",
+    "family": "gemini-flash",
+    "created_at": "2025-12-17 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.5,
+          "output_per_million": 3,
+          "cached_input_per_million": 0.05
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-12-17",
+      "cost": {
+        "input": 0.5,
+        "output": 3,
+        "cache_read": 0.05,
+        "context_over_200k": {
+          "input": 0.5,
+          "output": 3,
+          "cache_read": 0.05
+        }
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-3-pro-preview",
+    "name": "Gemini 3 Pro Preview",
+    "provider": "vertexai",
+    "family": "gemini-pro",
+    "created_at": "2025-11-18 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 12,
+          "cached_input_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-11-18",
+      "cost": {
+        "input": 2,
+        "output": 12,
+        "cache_read": 0.2,
+        "context_over_200k": {
+          "input": 4,
+          "output": 18,
+          "cache_read": 0.4
+        }
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-3.1-pro-preview",
+    "name": "Gemini 3.1 Pro Preview",
+    "provider": "vertexai",
+    "family": "gemini-pro",
+    "created_at": "2026-02-19 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 12,
+          "cached_input_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-19",
+      "cost": {
+        "input": 2,
+        "output": 12,
+        "cache_read": 0.2,
+        "context_over_200k": {
+          "input": 4,
+          "output": 18,
+          "cache_read": 0.4
+        }
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-3.1-pro-preview-customtools",
+    "name": "Gemini 3.1 Pro Preview Custom Tools",
+    "provider": "vertexai",
+    "family": "gemini-pro",
+    "created_at": "2026-02-19 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 2,
+          "output_per_million": 12,
+          "cached_input_per_million": 0.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2026-02-19",
+      "cost": {
+        "input": 2,
+        "output": 12,
+        "cache_read": 0.2,
+        "context_over_200k": {
+          "input": 4,
+          "output": 18,
+          "cache_read": 0.4
+        }
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-embedding-001",
+    "name": "Gemini Embedding 001",
+    "provider": "vertexai",
+    "family": "gemini",
+    "created_at": "2025-05-20 00:00:00 +0530",
+    "context_window": 2048,
+    "max_output_tokens": 3072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.15
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": false,
+      "temperature": false,
+      "last_updated": "2025-05-20",
+      "cost": {
+        "input": 0.15,
+        "output": 0
+      },
+      "limit": {
+        "context": 2048,
+        "output": 3072
+      },
+      "knowledge": "2025-05"
+    }
+  },
+  {
+    "id": "gemini-flash-latest",
+    "name": "Gemini Flash Latest",
+    "provider": "vertexai",
+    "family": "gemini-flash",
+    "created_at": "2025-09-25 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.3,
+          "output_per_million": 2.5,
+          "cached_input_per_million": 0.075
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-25",
+      "cost": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_read": 0.075,
+        "cache_write": 0.383
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "gemini-flash-lite-latest",
+    "name": "Gemini Flash-Lite Latest",
+    "provider": "vertexai",
+    "family": "gemini-flash-lite",
+    "created_at": "2025-09-25 00:00:00 +0530",
+    "context_window": 1048576,
+    "max_output_tokens": 65536,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.1,
+          "output_per_million": 0.4,
+          "cached_input_per_million": 0.025
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": false,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-09-25",
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_read": 0.025
+      },
+      "limit": {
+        "context": 1048576,
+        "output": 65536
+      },
+      "knowledge": "2025-01"
+    }
+  },
+  {
+    "id": "meta/llama-3.3-70b-instruct-maas",
+    "name": "Llama 3.3 70B Instruct",
+    "provider": "vertexai",
+    "family": "llama",
+    "created_at": "2025-04-29 00:00:00 +0530",
+    "context_window": 128000,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.72,
+          "output_per_million": 0.72
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-04-29",
+      "cost": {
+        "input": 0.72,
+        "output": 0.72
+      },
+      "limit": {
+        "context": 128000,
+        "output": 8192
+      },
+      "knowledge": "2023-12"
+    }
+  },
+  {
+    "id": "meta/llama-4-maverick-17b-128e-instruct-maas",
+    "name": "Llama 4 Maverick 17B 128E Instruct",
+    "provider": "vertexai",
+    "family": "llama",
+    "created_at": "2025-04-29 00:00:00 +0530",
+    "context_window": 524288,
+    "max_output_tokens": 8192,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.35,
+          "output_per_million": 1.15
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": true,
+      "attachment": true,
+      "temperature": true,
+      "last_updated": "2025-04-29",
+      "cost": {
+        "input": 0.35,
+        "output": 1.15
+      },
+      "limit": {
+        "context": 524288,
+        "output": 8192
+      },
+      "knowledge": "2024-08"
+    }
+  },
+  {
+    "id": "moonshotai/kimi-k2-thinking-maas",
+    "name": "Kimi K2 Thinking",
+    "provider": "vertexai",
+    "family": "kimi-thinking",
+    "created_at": "2025-11-13 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 262144,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.5
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-11-13",
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "cost": {
+        "input": 0.6,
+        "output": 2.5
+      },
+      "limit": {
+        "context": 262144,
+        "output": 262144
+      },
+      "knowledge": "2024-08"
+    }
+  },
+  {
+    "id": "openai/gpt-oss-120b-maas",
+    "name": "GPT OSS 120B",
+    "provider": "vertexai",
+    "family": "gpt-oss",
+    "created_at": "2025-08-05 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.09,
+          "output_per_million": 0.36
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-05",
+      "cost": {
+        "input": 0.09,
+        "output": 0.36
+      },
+      "limit": {
+        "context": 131072,
+        "output": 32768
+      }
+    }
+  },
+  {
+    "id": "openai/gpt-oss-20b-maas",
+    "name": "GPT OSS 20B",
+    "provider": "vertexai",
+    "family": "gpt-oss",
+    "created_at": "2025-08-05 00:00:00 +0530",
+    "context_window": 131072,
+    "max_output_tokens": 32768,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.07,
+          "output_per_million": 0.25
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-05",
+      "cost": {
+        "input": 0.07,
+        "output": 0.25
+      },
+      "limit": {
+        "context": 131072,
+        "output": 32768
+      }
+    }
+  },
+  {
+    "id": "qwen/qwen3-235b-a22b-instruct-2507-maas",
+    "name": "Qwen3 235B A22B Instruct",
+    "provider": "vertexai",
+    "family": "qwen",
+    "created_at": "2025-08-13 00:00:00 +0530",
+    "context_window": 262144,
+    "max_output_tokens": 16384,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.22,
+          "output_per_million": 0.88
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2025-08-13",
+      "cost": {
+        "input": 0.22,
+        "output": 0.88
+      },
+      "limit": {
+        "context": 262144,
+        "output": 16384
+      }
+    }
+  },
+  {
+    "id": "zai-org/glm-4.7-maas",
+    "name": "GLM-4.7",
+    "provider": "vertexai",
+    "family": "glm",
+    "created_at": "2026-01-06 00:00:00 +0530",
+    "context_window": 200000,
+    "max_output_tokens": 128000,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "structured_output",
+      "reasoning",
+      "vision"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 0.6,
+          "output_per_million": 2.2
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-01-06",
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "cost": {
+        "input": 0.6,
+        "output": 2.2
+      },
+      "limit": {
+        "context": 200000,
+        "output": 128000
+      },
+      "knowledge": "2025-04"
+    }
+  },
+  {
+    "id": "zai-org/glm-5-maas",
+    "name": "GLM-5",
+    "provider": "vertexai",
+    "family": "glm",
+    "created_at": "2026-02-11 00:00:00 +0530",
+    "context_window": 202752,
+    "max_output_tokens": 131072,
+    "knowledge_cutoff": null,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "capabilities": [
+      "function_calling",
+      "reasoning"
+    ],
+    "pricing": {
+      "text_tokens": {
+        "standard": {
+          "input_per_million": 1,
+          "output_per_million": 3.2,
+          "cached_input_per_million": 0.1
+        }
+      }
+    },
+    "metadata": {
+      "source": "models.dev",
+      "provider_id": "google-vertex",
+      "open_weights": true,
+      "attachment": false,
+      "temperature": true,
+      "last_updated": "2026-02-11",
+      "interleaved": {
+        "field": "reasoning_content"
+      },
+      "cost": {
+        "input": 1,
+        "output": 3.2,
+        "cache_read": 0.1
+      },
+      "limit": {
+        "context": 202752,
+        "output": 131072
+      }
+    }
+  }
+]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,6 +80,10 @@ COPY . /app
 # https://github.com/chatwoot/chatwoot/issues/701
 RUN mkdir -p /app/log
 
+# Refresh RubyLLM model registry so new models are available without gem upgrades
+RUN SECRET_KEY_BASE=precompile_placeholder bundle exec rake ruby_llm:refresh_models \
+  || echo 'RubyLLM model registry refresh skipped'
+
 # generate production assets if production environment
 RUN if [ "$RAILS_ENV" = "production" ]; then \
   SECRET_KEY_BASE=precompile_placeholder RAILS_LOG_TO_STDOUT=enabled bundle exec rake assets:precompile \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,10 +80,6 @@ COPY . /app
 # https://github.com/chatwoot/chatwoot/issues/701
 RUN mkdir -p /app/log
 
-# Refresh RubyLLM model registry so new models are available without gem upgrades
-RUN SECRET_KEY_BASE=precompile_placeholder bundle exec rake ruby_llm:refresh_models \
-  || echo 'RubyLLM model registry refresh skipped'
-
 # generate production assets if production environment
 RUN if [ "$RAILS_ENV" = "production" ]; then \
   SECRET_KEY_BASE=precompile_placeholder RAILS_LOG_TO_STDOUT=enabled bundle exec rake assets:precompile \

--- a/lib/llm/config.rb
+++ b/lib/llm/config.rb
@@ -34,6 +34,7 @@ module Llm::Config
       RubyLLM.configure do |config|
         config.openai_api_key = system_api_key if system_api_key.present?
         config.openai_api_base = openai_endpoint.chomp('/') if openai_endpoint.present?
+        config.model_registry_file = Rails.root.join('config/llm_models.json').to_s
         config.logger = Rails.logger
       end
     end

--- a/lib/llm/config.rb
+++ b/lib/llm/config.rb
@@ -20,6 +20,7 @@ module Llm::Config
     end
 
     def with_api_key(api_key, api_base: nil)
+      initialize!
       context = RubyLLM.context do |config|
         config.openai_api_key = api_key
         config.openai_api_base = api_base

--- a/lib/tasks/ruby_llm.rake
+++ b/lib/tasks/ruby_llm.rake
@@ -1,16 +1,17 @@
 # Refresh the RubyLLM model registry from models.dev and configured providers.
-# Updates the gem's bundled models.json so new models are available without a gem upgrade.
+# Updates config/llm_models.json so new models are available without a gem upgrade.
 #
 # Usage:
 #   bundle exec rake ruby_llm:refresh_models
 #
-# Called during Docker image build and can be run manually in dev.
+# Run this when new models are released, commit the updated config/llm_models.json.
 namespace :ruby_llm do
   desc 'Refresh RubyLLM model registry from models.dev'
   task refresh_models: :environment do
+    registry_path = Rails.root.join('config/llm_models.json').to_s
     puts 'Refreshing RubyLLM model registry...'
     RubyLLM.models.refresh!
-    RubyLLM.models.save_to_json
-    puts "RubyLLM model registry updated with #{RubyLLM.models.all.size} models"
+    RubyLLM.models.save_to_json(registry_path)
+    puts "RubyLLM model registry updated with #{RubyLLM.models.all.size} models at #{registry_path}"
   end
 end

--- a/lib/tasks/ruby_llm.rake
+++ b/lib/tasks/ruby_llm.rake
@@ -1,0 +1,16 @@
+# Refresh the RubyLLM model registry from models.dev and configured providers.
+# Updates the gem's bundled models.json so new models are available without a gem upgrade.
+#
+# Usage:
+#   bundle exec rake ruby_llm:refresh_models
+#
+# Called during Docker image build and can be run manually in dev.
+namespace :ruby_llm do
+  desc 'Refresh RubyLLM model registry from models.dev'
+  task refresh_models: :environment do
+    puts 'Refreshing RubyLLM model registry...'
+    RubyLLM.models.refresh!
+    RubyLLM.models.save_to_json
+    puts "RubyLLM model registry updated with #{RubyLLM.models.all.size} models"
+  end
+end


### PR DESCRIPTION
RubyLLM bundles a static models.json that doesn't know about models released after the gem was published. Self-hosted users configuring newer models hit ModelNotFoundError.

Added a rake task that refreshes the registry from models.dev and saves to disk. ~~Called during Docker image build so every deploy gets fresh model data. Falls back silently to the bundled registry if models.dev is unreachable.~~

Commit the models.json file to code so it is available across deployments.

