### PR TITLE
fix: prevent Country from being set to Zimbabwe in the contacts list

### DIFF
--- a/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
@@ -51,7 +51,6 @@ const isFormInvalid = computed(() => contactsFormRef.value?.isFormInvalid);
 
 const countriesMap = computed(() => {
   return countries.reduce((acc, country) => {
-    acc[country.code] = country;
     acc[country.id] = country;
     return acc;
   }, {});


### PR DESCRIPTION
## Description

This PR resolves an issue that was causing Zimbabwe country being selected in the Contacts list.
The root cause is objects in `countries.json` file are missing the `code` property which was causing the countries map to always have the last country in the list also map to an `undefined` key. In turn, this was causing an error when contact's `country` was undefined.

Additional thing to keep in mind: I am not sure if there is a case when contact's `country` property is used or if it can be removed as well, but in my Chatwoot installation contacts only have a `countryCode` property, and there is no way to set `country` from the widget sdk.

Fixes #7822

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Simply running the vue application locally targeting my live chatwoot API.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
