### PR TITLE
fix: fall back to path-only attachment URL when FRONTEND_URL is blank (#14088)

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -51,7 +51,7 @@ class Attachment < ApplicationRecord
 
   # NOTE: the URl returned does a 301 redirect to the actual file
   def file_url
-    file.attached? ? url_for(file) : ''
+    file.attached? ? url_for_active_storage(file) : ''
   end
 
   # NOTE: for External services use this methods since redirect doesn't work effectively in a lot of cases
@@ -64,7 +64,7 @@ class Attachment < ApplicationRecord
     return '' unless file.attached? && image?
 
     begin
-      url_for(file.representation(resize_to_fill: [250, nil]))
+      url_for_active_storage(file.representation(resize_to_fill: [250, nil]))
     rescue ActiveStorage::UnrepresentableError => e
       Rails.logger.warn "Unrepresentable image attachment: #{id} (#{file.filename}) - #{e.message}"
       ''
@@ -76,6 +76,27 @@ class Attachment < ApplicationRecord
   end
 
   private
+
+  # Generates the URL for an ActiveStorage attachment or representation.
+  #
+  # Falls back to a path-only URL when FRONTEND_URL (and therefore
+  # `Rails.application.routes.default_url_options[:host]`) is blank.
+  # Without this fallback, `url_for` emits a malformed absolute URL like
+  # `http:///rails/active_storage/...` (empty host) which breaks image
+  # loading in the dashboard and in the live chat widget iframe when
+  # Chatwoot is deployed behind a reverse proxy without a configured
+  # FRONTEND_URL.
+  #
+  # Path-only URLs are resolved by the browser against the current
+  # document origin, which is the same origin as the Rails backend for
+  # both the dashboard and the widget iframe, so they load correctly.
+  def url_for_active_storage(resource)
+    url_for(resource, only_path: default_url_host.blank?)
+  end
+
+  def default_url_host
+    Rails.application.routes.default_url_options[:host]
+  end
 
   def metadata_for_file_type
     case file_type.to_sym

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -32,6 +32,56 @@ RSpec.describe Attachment do
     end
   end
 
+  describe 'file_url host handling' do
+    let(:attachment) do
+      message.attachments.create!(account_id: message.account_id, file_type: :image).tap do |a|
+        a.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
+      end
+    end
+
+    context 'when default_url_options[:host] is configured' do
+      before do
+        allow(Rails.application.routes).to receive(:default_url_options).and_return(host: 'chatwoot.example.com')
+      end
+
+      it 'returns an absolute file_url' do
+        expect(attachment.file_url).to start_with('http://chatwoot.example.com/rails/active_storage/')
+      end
+
+      it 'returns an absolute thumb_url' do
+        expect(attachment.thumb_url).to start_with('http://chatwoot.example.com/rails/active_storage/')
+      end
+
+      it 'exposes an absolute data_url via push_event_data' do
+        expect(attachment.push_event_data[:data_url]).to start_with('http://chatwoot.example.com/rails/active_storage/')
+      end
+    end
+
+    context 'when default_url_options[:host] is blank (e.g. FRONTEND_URL unset behind a reverse proxy)' do
+      before do
+        allow(Rails.application.routes).to receive(:default_url_options).and_return(host: nil)
+      end
+
+      it 'returns a path-only file_url without an empty scheme/host' do
+        url = attachment.file_url
+        expect(url).to start_with('/rails/active_storage/')
+        expect(url).not_to include('http:///')
+      end
+
+      it 'returns a path-only thumb_url without an empty scheme/host' do
+        url = attachment.thumb_url
+        expect(url).to start_with('/rails/active_storage/')
+        expect(url).not_to include('http:///')
+      end
+
+      it 'exposes a path-only data_url via push_event_data' do
+        url = attachment.push_event_data[:data_url]
+        expect(url).to start_with('/rails/active_storage/')
+        expect(url).not_to include('http:///')
+      end
+    end
+  end
+
   describe 'with_attached_file?' do
     it 'returns true if its an attachment with file' do
       attachment = message.attachments.new(account_id: message.account_id, file_type: :image)


### PR DESCRIPTION
## Summary
Fixes #14088. When Chatwoot is deployed behind a reverse proxy without \`FRONTEND_URL\` (and thus \`Rails.application.routes.default_url_options[:host]\`) configured, \`Attachment#file_url\` and \`Attachment#thumb_url\` call \`url_for(file)\` with \`host: nil\`. Rails emits \`http:///rails/active_storage/...\` (empty host), which the dashboard image loader and the live-chat widget cannot resolve.
## Fix
Route ActiveStorage URL generation in \`Attachment\` through a small private helper that returns a path-only URL when no host is configured. When \`FRONTEND_URL\` is set, behavior is unchanged. When it is blank, \`data_url\` becomes an origin-relative path (e.g. \`/rails/active_storage/disk/...\`), which the browser resolves against the current origin — correct for both the dashboard (same origin) and the widget iframe.
Fixes the reported problem in every consumer of \`dataUrl\` in one place: \`Image.vue\`, \`Video.vue\`, \`Audio.vue\`, \`File.vue\`, \`Embed.vue\`, \`GalleryView.vue\`, and the widget's \`AgentMessage.vue\` / \`UserMessage.vue\`, plus \`thumb_url\` which had the same bug.
Consumers that need absolute URLs (email mailers, Line sender, Captain OpenAI message builder) still require \`FRONTEND_URL\` — unchanged. \`ASSET_CDN_HOST\` is unaffected because it only applies to \`action_controller.asset_host\`, not ActiveStorage.
## Test plan
- [x] Added model specs covering configured and blank host cases for \`file_url\`, \`thumb_url\`, and \`push_event_data[:data_url]\`.
- [ ] Reproduce issue with \`FRONTEND_URL=""\`, confirm dashboard and widget image upload loads.
- [ ] Confirm with \`FRONTEND_URL=https://chatwoot.example.com\`, absolute URLs are still produced.
- [ ] Run \`bundle exec rspec spec/models/attachment_spec.rb\`.