### PR TITLE
feat(conversation): truncate long text messages with show more toggle (closes #1632)

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/Text/Index.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Text/Index.vue
@@ -8,6 +8,11 @@ import { MESSAGE_TYPES } from '../../constants';
 import { useMessageContext } from '../../provider.js';
 import { useTranslations } from 'dashboard/composables/useTranslations';
 
+// Truncate plain-text messages longer than this many characters and reveal
+// the rest behind a "Show more" toggle. Keeps long API / paste content from
+// monopolising the agent view.
+const LONG_MESSAGE_CHAR_LIMIT = 800;
+
 const { content, attachments, contentAttributes, messageType } =
   useMessageContext();
 
@@ -15,6 +20,7 @@ const { hasTranslations, translationContent } =
   useTranslations(contentAttributes);
 
 const renderOriginal = ref(false);
+const isExpanded = ref(false);
 
 const renderContent = computed(() => {
   if (renderOriginal.value) {
@@ -36,8 +42,26 @@ const isEmpty = computed(() => {
   return !content.value && !attachments.value?.length;
 });
 
+const isTruncatable = computed(() => {
+  return (
+    typeof renderContent.value === 'string' &&
+    renderContent.value.length > LONG_MESSAGE_CHAR_LIMIT
+  );
+});
+
+const displayedContent = computed(() => {
+  if (!isTruncatable.value || isExpanded.value) {
+    return renderContent.value;
+  }
+  return `${renderContent.value.slice(0, LONG_MESSAGE_CHAR_LIMIT)}…`;
+});
+
 const handleSeeOriginal = () => {
   renderOriginal.value = !renderOriginal.value;
+};
+
+const toggleExpanded = () => {
+  isExpanded.value = !isExpanded.value;
 };
 </script>
 
@@ -47,7 +71,19 @@ const handleSeeOriginal = () => {
       <span v-if="isEmpty" class="text-n-slate-11">
         {{ $t('CONVERSATION.NO_CONTENT') }}
       </span>
-      <FormattedContent v-if="renderContent" :content="renderContent" />
+      <FormattedContent v-if="displayedContent" :content="displayedContent" />
+      <button
+        v-if="isTruncatable"
+        type="button"
+        class="text-start text-xs font-medium text-n-slate-11 cursor-pointer hover:text-n-brand hover:underline select-none"
+        @click="toggleExpanded"
+      >
+        {{
+          isExpanded
+            ? $t('CONVERSATION.SHOW_LESS')
+            : $t('CONVERSATION.SHOW_MORE')
+        }}
+      </button>
       <TranslationToggle
         v-if="hasTranslations"
         class="-mt-3"

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -50,6 +50,8 @@
     "UNKNOWN_FILE_TYPE": "Unknown File",
     "SAVE_CONTACT": "Save Contact",
     "NO_CONTENT": "No content to display",
+    "SHOW_MORE": "Show more",
+    "SHOW_LESS": "Show less",
     "SHARED_ATTACHMENT": {
       "CONTACT": "{sender} has shared a contact",
       "LOCATION": "{sender} has shared a location",


### PR DESCRIPTION
## Context

Closes #1632. Long text bubbles (e.g. API responses, big pastes) currently occupy the entire message list in the agent view and push earlier context off screen. Screenshot in the issue shows the problem on a >3000-char incoming message.

## Change

Messages in the Text bubble (`components-next/message/bubbles/Text/Index.vue`) are now truncated to the first 800 characters with a **Show more** / **Show less** toggle. Per-bubble expanded state, no persistence, no reflow on incoming new messages.

- Added `LONG_MESSAGE_CHAR_LIMIT = 800` at module scope — matches the ≈800 suggestion from the issue author.
- Truncates **after** the translation / original-message branch, so the toggle works consistently regardless of which copy is being displayed.
- `FormattedContent` still runs through `MessageFormatter` + `v-dompurify-html`, so markdown / links are preserved on the truncated slice.
- Only truncates when `renderContent` is a string (guards against unexpected types).

### i18n

- Added `CONVERSATION.SHOW_MORE` → "Show more"
- Added `CONVERSATION.SHOW_LESS` → "Show less"

Both in `app/javascript/dashboard/i18n/locale/en/conversation.json`. Other locales will fall back to English until translators add the keys — this matches the existing convention for newly introduced strings in this repo.

### Styling

Re-uses existing utility classes (`text-xs text-n-slate-11 hover:text-n-brand hover:underline`) consistent with `TranslationToggle.vue` so the toggle visually matches the rest of the bubble chrome. No new Tailwind tokens introduced.

## Test plan

- [ ] Send a short message (<800 chars) — no toggle appears, render is unchanged.
- [ ] Send a long message (>800 chars) — bubble shows the first 800 chars + ellipsis and a **Show more** button; clicking expands to full content and toggle becomes **Show less**; clicking again collapses.
- [ ] Send a translated long message — toggle works on the translated copy; switching via TranslationToggle to original also preserves the truncation toggle.
- [ ] Markdown/formatting in the first 800 chars still renders correctly (bold, links, quotes).
- [ ] Multiple long messages in the same conversation each have independent expanded state.
- [ ] Template messages (Twilio etc.) with `contentAttributes.submittedEmail` still render the submitted email block unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)