### PR TITLE
fix(widget/campaign): fire campaigns when widget was opened programmatically (closes #14022)

### DIFF
--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -244,8 +244,8 @@ export const IFrameHelper = {
       removeUnreadClass();
     },
 
-    onBubbleToggle: isOpen => {
-      IFrameHelper.sendMessage('toggle-open', { isOpen });
+    onBubbleToggle: (isOpen, isUserInitiated = false) => {
+      IFrameHelper.sendMessage('toggle-open', { isOpen, isUserInitiated });
       if (isOpen) {
         IFrameHelper.pushEvent('webwidget.triggered');
       }

--- a/app/javascript/sdk/bubbleHelpers.js
+++ b/app/javascript/sdk/bubbleHelpers.js
@@ -71,8 +71,8 @@ export const createBubbleHolder = hideMessageBubble => {
   body.appendChild(bubbleHolder);
 };
 
-const handleBubbleToggle = newIsOpen => {
-  IFrameHelper.events.onBubbleToggle(newIsOpen);
+const handleBubbleToggle = (newIsOpen, isUserInitiated) => {
+  IFrameHelper.events.onBubbleToggle(newIsOpen, isUserInitiated);
 
   if (newIsOpen) {
     dispatchWindowEvent({ eventName: CHATWOOT_OPENED });
@@ -87,6 +87,11 @@ export const onBubbleClick = (props = {}) => {
   const { isOpen } = window.$chatwoot;
   if (isOpen === toggleValue) return;
 
+  // When `toggleValue` is undefined, this invocation came from the DOM
+  // click listener on the bubble (real user click). When it's an explicit
+  // boolean, the call originated from the SDK (e.g. window.$chatwoot.toggle).
+  const isUserInitiated = toggleValue === undefined;
+
   const newIsOpen = toggleValue === undefined ? !isOpen : toggleValue;
   window.$chatwoot.isOpen = newIsOpen;
 
@@ -94,7 +99,7 @@ export const onBubbleClick = (props = {}) => {
   toggleClass(closeBubble, 'woot--hide');
   toggleClass(widgetHolder, 'woot--hide');
 
-  handleBubbleToggle(newIsOpen);
+  handleBubbleToggle(newIsOpen, isUserInitiated);
 };
 
 export const onClickChatBubble = () => {

--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -317,7 +317,10 @@ export default {
         } else if (message.event === 'set-color-scheme') {
           this.setColorScheme(message.darkMode);
         } else if (message.event === 'toggle-open') {
-          this.$store.dispatch('appConfig/toggleWidgetOpen', message.isOpen);
+          this.$store.dispatch('appConfig/toggleWidgetOpen', {
+            isWidgetOpen: message.isOpen,
+            isUserInitiated: Boolean(message.isUserInitiated),
+          });
 
           const shouldShowMessageView =
             ['home'].includes(this.$route.name) &&

--- a/app/javascript/widget/store/modules/appConfig.js
+++ b/app/javascript/widget/store/modules/appConfig.js
@@ -149,8 +149,7 @@ export const mutations = {
       // Any close event clears the "opened by user" flag so the next
       // open is evaluated fresh.
       $state.isWidgetOpenedByUser = false;
-    }
-    else if (isUserInitiated) {
+    } else if (isUserInitiated) {
       $state.isWidgetOpenedByUser = true;
     }
   },

--- a/app/javascript/widget/store/modules/appConfig.js
+++ b/app/javascript/widget/store/modules/appConfig.js
@@ -97,12 +97,14 @@ export const actions = {
   // differentiate "user is actively using the widget" from "widget was
   // pre-opened by an integrator script" (see #14022).
   toggleWidgetOpen({ commit }, payload) {
-    const isWidgetOpen = typeof payload === 'object' && payload !== null
-      ? payload.isWidgetOpen
-      : payload;
-    const isUserInitiated = typeof payload === 'object' && payload !== null
-      ? Boolean(payload.isUserInitiated)
-      : false;
+    const isWidgetOpen =
+      typeof payload === 'object' && payload !== null
+        ? payload.isWidgetOpen
+        : payload;
+    const isUserInitiated =
+      typeof payload === 'object' && payload !== null
+        ? Boolean(payload.isUserInitiated)
+        : false;
     commit(TOGGLE_WIDGET_OPEN, { isWidgetOpen, isUserInitiated });
   },
   setWidgetColor({ commit }, widgetColor) {

--- a/app/javascript/widget/store/modules/appConfig.js
+++ b/app/javascript/widget/store/modules/appConfig.js
@@ -14,6 +14,10 @@ const state = {
   showUnreadMessagesDialog: true,
   isWebWidgetTriggered: false,
   isWidgetOpen: false,
+  // Distinct from `isWidgetOpen` — true only when the widget was opened by
+  // a real user click on the bubble (not by `window.$chatwoot.toggle('open')`).
+  // Resets to false when the widget is closed.
+  isWidgetOpenedByUser: false,
   position: 'right',
   referrerHost: '',
   showPopoutButton: false,
@@ -35,6 +39,7 @@ export const getters = {
   isRightAligned: $state => $state.position === 'right',
   getHideMessageBubble: $state => $state.hideMessageBubble,
   getIsWidgetOpen: $state => $state.isWidgetOpen,
+  getIsWidgetOpenedByUser: $state => $state.isWidgetOpenedByUser,
   getWidgetColor: $state => $state.widgetColor,
   getReferrerHost: $state => $state.referrerHost,
   isWidgetStyleFlat: $state => $state.widgetStyle === 'flat',
@@ -85,8 +90,20 @@ export const actions = {
       enableEndConversation,
     });
   },
-  toggleWidgetOpen({ commit }, isWidgetOpen) {
-    commit(TOGGLE_WIDGET_OPEN, isWidgetOpen);
+  // Accepts either the legacy boolean form (`isWidgetOpen`) or an object
+  // `{ isWidgetOpen, isUserInitiated }`. When the widget is being opened
+  // programmatically via `window.$chatwoot.toggle('open')` (no user click),
+  // we track that separately so features like campaign triggering can
+  // differentiate "user is actively using the widget" from "widget was
+  // pre-opened by an integrator script" (see #14022).
+  toggleWidgetOpen({ commit }, payload) {
+    const isWidgetOpen = typeof payload === 'object' && payload !== null
+      ? payload.isWidgetOpen
+      : payload;
+    const isUserInitiated = typeof payload === 'object' && payload !== null
+      ? Boolean(payload.isUserInitiated)
+      : false;
+    commit(TOGGLE_WIDGET_OPEN, { isWidgetOpen, isUserInitiated });
   },
   setWidgetColor({ commit }, widgetColor) {
     commit(SET_WIDGET_COLOR, widgetColor);
@@ -126,8 +143,16 @@ export const mutations = {
     $state.enableEmojiPicker = data.enableEmojiPicker;
     $state.enableEndConversation = data.enableEndConversation;
   },
-  [TOGGLE_WIDGET_OPEN]($state, isWidgetOpen) {
+  [TOGGLE_WIDGET_OPEN]($state, { isWidgetOpen, isUserInitiated }) {
     $state.isWidgetOpen = isWidgetOpen;
+    if (!isWidgetOpen) {
+      // Any close event clears the "opened by user" flag so the next
+      // open is evaluated fresh.
+      $state.isWidgetOpenedByUser = false;
+    }
+    else if (isUserInitiated) {
+      $state.isWidgetOpenedByUser = true;
+    }
   },
   [SET_WIDGET_COLOR]($state, widgetColor) {
     $state.widgetColor = widgetColor;

--- a/app/javascript/widget/store/modules/campaign.js
+++ b/app/javascript/widget/store/modules/campaign.js
@@ -106,13 +106,17 @@ export const actions = {
     {
       commit,
       rootState: {
-        appConfig: { isWidgetOpen },
+        appConfig: { isWidgetOpenedByUser },
       },
     },
     { websiteToken, campaignId }
   ) => {
-    // Disable campaign execution if widget is opened
-    if (!isWidgetOpen) {
+    // Suppress campaign execution only when the visitor has actively opened
+    // the widget themselves. If the widget was pre-opened programmatically
+    // via `window.$chatwoot.toggle('open')` (e.g. inside a `chatwoot:ready`
+    // listener), the visitor hasn't engaged yet and the campaign should
+    // still fire. See #14022.
+    if (!isWidgetOpenedByUser) {
       const { data: campaigns } = await getCampaigns(websiteToken);
       // Check campaign is disabled or not
       const campaign = campaigns.find(item => item.id === campaignId);

--- a/app/javascript/widget/store/modules/specs/campaign/actions.spec.js
+++ b/app/javascript/widget/store/modules/specs/campaign/actions.spec.js
@@ -182,7 +182,7 @@ describe('#actions', () => {
           getters: { getCampaigns: campaigns },
           commit,
           rootState: {
-            appConfig: { isWidgetOpen: true },
+            appConfig: { isWidgetOpenedByUser: true },
           },
         },
         { campaignId: 32 }
@@ -196,7 +196,24 @@ describe('#actions', () => {
           getters: { getCampaigns: campaigns },
           commit,
           rootState: {
-            appConfig: { isWidgetOpen: false },
+            appConfig: { isWidgetOpenedByUser: false },
+          },
+        },
+        { campaignId: 1 }
+      );
+      expect(commit.mock.calls).toEqual([['setActiveCampaign', campaigns[0]]]);
+    });
+    it('still fires campaign when widget was opened programmatically, not by user', async () => {
+      // Reproduces #14022: `window.$chatwoot.toggle('open')` inside
+      // `chatwoot:ready` → isWidgetOpen=true but isWidgetOpenedByUser=false.
+      API.get.mockResolvedValue({ data: campaigns });
+      await actions.startCampaign(
+        {
+          dispatch,
+          getters: { getCampaigns: campaigns },
+          commit,
+          rootState: {
+            appConfig: { isWidgetOpen: true, isWidgetOpenedByUser: false },
           },
         },
         { campaignId: 1 }


### PR DESCRIPTION
## Context

Closes #14022.

When an integrator calls \`window.\$chatwoot.toggle('open')\` inside their \`chatwoot:ready\` handler to pre-open the widget for the visitor, any campaign configured for that page never fires. The visitor lands, the widget is already open, the campaign timer eventually elapses, and \`startCampaign\` silently skips with:

\`\`\`js
// app/javascript/widget/store/modules/campaign.js
if (!isWidgetOpen) {          // ← true, because toggle('open') already flipped it
  ...
}
\`\`\`

But the visitor hasn't actually clicked the widget — the integrator's script did.

## Root cause

The flag \`isWidgetOpen\` conflates two fundamentally different states:

| Scenario | \`isWidgetOpen\` | Should campaign fire? |
|---|---|---|
| Visitor has ignored the widget | \`false\` | Yes |
| Visitor clicked the bubble, is actively chatting | \`true\` | No — would be annoying |
| Integrator pre-opened via SDK \`toggle('open')\` | \`true\` | **Yes** — visitor hasn't engaged yet |

The current guard treats case 2 and case 3 identically.

## Change

Differentiate user-initiated opens from SDK-initiated opens end-to-end and guard campaigns on the finer signal.

1. **\`app/javascript/sdk/bubbleHelpers.js\`**
   - \`onBubbleClick(props)\` — when invoked with no \`toggleValue\` it's the bubble DOM click listener (real user click); when invoked with an explicit boolean it comes from \`IFrameHelper.events.toggleBubble\` (SDK \`toggle()\`). Derives \`isUserInitiated = toggleValue === undefined\` and propagates it through \`handleBubbleToggle\`.

2. **\`app/javascript/sdk/IFrameHelper.js\`**
   - \`events.onBubbleToggle(isOpen, isUserInitiated = false)\` forwards the flag in the \`toggle-open\` \`postMessage\`.

3. **\`app/javascript/widget/App.vue\`**
   - \`toggle-open\` handler dispatches \`appConfig/toggleWidgetOpen\` with \`{ isWidgetOpen, isUserInitiated }\` instead of the bare boolean.

4. **\`app/javascript/widget/store/modules/appConfig.js\`**
   - New state \`isWidgetOpenedByUser\` (default \`false\`).
   - New getter \`getIsWidgetOpenedByUser\`.
   - \`toggleWidgetOpen\` action now accepts either the legacy boolean **or** \`{ isWidgetOpen, isUserInitiated }\` (backward-compat is preserved for any external caller I may have missed).
   - \`TOGGLE_WIDGET_OPEN\` mutation: sets \`isWidgetOpenedByUser = true\` only on user-initiated opens, clears it on every close.

5. **\`app/javascript/widget/store/modules/campaign.js\`**
   - \`startCampaign\` guard switches from \`isWidgetOpen\` to \`isWidgetOpenedByUser\`. Campaigns now fire when the widget was only pre-opened programmatically.

## Tests

\`app/javascript/widget/store/modules/specs/campaign/actions.spec.js\`:

- Migrated the two existing specs to the renamed flag.
- Added a regression spec that reproduces the issue — \`isWidgetOpen: true\`, \`isWidgetOpenedByUser: false\` — and asserts \`setActiveCampaign\` is committed.

## Test plan

- [ ] \`pnpm test app/javascript/widget/store/modules/specs/campaign\` green, including the new regression spec.
- [ ] Manually reproduce the issue steps:
  \`\`\`html
  <script>
    window.addEventListener('chatwoot:ready', () => {
      window.$chatwoot.toggle('open');
    });
  </script>
  \`\`\`
  With an active campaign configured for the page, confirm the campaign appears after its delay.
- [ ] Manually verify the original suppression still works: visitor clicks the bubble to open → wait past a campaign's delay → campaign should **not** fire.
- [ ] Close the widget and re-open via user click → \`isWidgetOpenedByUser\` goes back to \`true\`; no regression.
- [ ] Close the widget and re-open via \`toggle('open')\` → \`isWidgetOpenedByUser\` stays \`false\`; campaign would fire if delay hadn't been consumed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)