### PR TITLE
fix: clean up conversation list rendering

### DIFF
--- a/app/javascript/dashboard/components-next/Conversation/ConversationCard/ConversationCardExpanded.vue
+++ b/app/javascript/dashboard/components-next/Conversation/ConversationCard/ConversationCardExpanded.vue
@@ -112,11 +112,14 @@ const selectedModel = computed({
 
       <div class="w-px h-3 bg-n-slate-6 flex-shrink-0" />
 
-      <div v-if="!isInboxView" class="w-20 flex-shrink-0">
+      <div v-if="!isInboxView && showInboxName" class="w-20 flex-shrink-0">
         <InboxName v-if="showInboxName" :inbox="inbox" class="min-w-0" />
       </div>
 
-      <div v-if="!isInboxView" class="w-px h-3 bg-n-slate-6 flex-shrink-0" />
+      <div
+        v-if="!isInboxView && showInboxName"
+        class="w-px h-3 bg-n-slate-6 flex-shrink-0"
+      />
 
       <div
         v-tooltip.top="{

--- a/app/javascript/dashboard/components/ConversationList.vue
+++ b/app/javascript/dashboard/components/ConversationList.vue
@@ -65,12 +65,11 @@ defineExpose({ conversationListRef });
   >
     <Virtualizer
       ref="virtualListRef"
-      v-slot="{ item, index }"
+      v-slot="{ item }"
       :data="conversationList"
       class="[&>div:has(+_div_.active)>*]:!border-n-surface-1 [&>div:has(+_div_.selected)>*]:!border-n-surface-1"
     >
       <ConversationItem
-        :key="index"
         :source="item"
         :label="label"
         :team-id="teamId"


### PR DESCRIPTION
# Pull Request Template

## Description

* Removed unused `index` key from `ConversationItem` in `ConversationList.vue` (which was removed by this [PR](https://github.com/chatwoot/chatwoot/pull/13648/changes#diff-b5614c5cdc9eeb65a0625d2beb23bff694ad04410a416352ce3c3c3ea2972af4L961) )
* Fixed conditional rendering in `ConversationCardExpanded` to show inbox name only when applicable, avoiding empty whitespace in single-inbox accounts


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Screenshots**

**Before**
<img width="763" height="389" alt="image" src="https://github.com/user-attachments/assets/1d8a34cf-ac46-45a9-a9ca-a9a4c7bdd859" />


**After**
<img width="763" height="389" alt="image" src="https://github.com/user-attachments/assets/c74e65d7-1887-4d5b-943d-b58bd8e0cc87" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
