### PR TITLE
fix: TypeError cannot read properties of null (reading 'name')

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/ConversationAction.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ConversationAction.vue
@@ -125,7 +125,7 @@ export default {
       set(priorityItem) {
         const conversationId = this.currentChat.id;
         const oldValue = this.currentChat?.priority;
-        const priority = priorityItem ? priorityItem.id : null;
+        const priority = priorityItem.id;
 
         this.$store.dispatch('setCurrentChatPriority', {
           priority,
@@ -203,7 +203,9 @@ export default {
         this.assignedPriority &&
         this.assignedPriority.id === selectedPriorityItem.id;
 
-      this.assignedPriority = isSamePriority ? null : selectedPriorityItem;
+      this.assignedPriority = isSamePriority
+        ? this.priorityOptions[0]
+        : selectedPriorityItem;
     },
   },
 };


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes a Sentry issue where clearing an already-selected priority caused a runtime error: `TypeError: Cannot read properties of null (reading 'name')`.

When the same priority was clicked again, it toggled off correctly, but the success callback still tried to access `priorityItem.name`, which becomes `null`. This now safely handles the null case and shows a proper “changed to None” confirmation instead of crashing.

Fixes https://linear.app/chatwoot/issue/CW-6891/typeerror-cannot-read-properties-of-null-reading-name

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Steps**
1. Open a conversation and set a priority (e.g. High)
2. Click the same priority again to clear it.
3. Now you can check the console.

**Screencast**

**Before**

https://github.com/user-attachments/assets/603e982d-c9d4-435c-8952-be8f128ef362

**After**

https://github.com/user-attachments/assets/728e3984-0311-40fb-941c-67aff45d0b15




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
