### PR TITLE
fix: include private messages in webhook conversation payload

### DIFF
--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -33,7 +33,7 @@ class Conversations::EventDataPresenter < SimpleDelegator
   end
 
   def webhook_push_messages
-    [messages.where(account_id: account_id).chat.last&.webhook_push_event_data].compact
+    [messages.where(account_id: account_id).where.not(message_type: :activity).last&.webhook_push_event_data].compact
   end
 
   def push_meta

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -68,5 +68,39 @@ RSpec.describe Conversations::EventDataPresenter do
     it 'returns empty messages when conversation has no chat messages' do
       expect(presenter.webhook_data[:messages]).to eq([])
     end
+
+    it 'includes private messages in webhook conversation context' do
+      create(:message, conversation: conversation, account: conversation.account,
+                       message_type: :outgoing, content: 'public reply')
+      private_note = create(:message, conversation: conversation, account: conversation.account,
+                                      message_type: :outgoing, content: 'internal note for team', private: true)
+      data = presenter.webhook_data
+      webhook_message = data[:messages].first
+
+      expect(webhook_message).to be_present
+      expect(webhook_message[:id]).to eq(private_note.id)
+      expect(webhook_message[:content]).to eq('internal note for team')
+    end
+
+    it 'excludes activity messages from webhook conversation context' do
+      create(:message, conversation: conversation, account: conversation.account,
+                       message_type: :outgoing, content: 'a normal message')
+      create(:message, conversation: conversation, account: conversation.account,
+                       message_type: :activity, content: 'conversation was resolved')
+      data = presenter.webhook_data
+      webhook_message = data[:messages].first
+
+      expect(webhook_message[:content]).to eq('a normal message')
+    end
+
+    it 'returns the last message regardless of private flag' do
+      create(:message, conversation: conversation, account: conversation.account,
+                       message_type: :incoming, content: 'customer message', private: false)
+      last_msg = create(:message, conversation: conversation, account: conversation.account,
+                                  message_type: :outgoing, content: 'latest private note', private: true)
+      webhook_message = presenter.webhook_data[:messages].first
+
+      expect(webhook_message[:id]).to eq(last_msg.id)
+    end
   end
 end


### PR DESCRIPTION
## Summary

When a private/internal note is created, the `message_created` webhook payload's conversation messages array contains the last public message instead of the actual private message that triggered the event. This means webhook consumers get the wrong message content for private notes.

Closes #14023

## Bug reproduction

**Setup:** A conversation exists with at least one public message from a customer.

**Step 1 — Agent adds a private note:**

In the conversation view, an agent adds a private/internal note (e.g. "Needs escalation to billing team").

**Step 2 — Webhook payload shows wrong message:**

The `message_created` webhook fires, but the `conversation.messages` array in the payload contains the last *public* message instead of the private note:

```json
{
  "event": "message_created",
  "content": "Needs escalation to billing team",
  "private": true,
  "conversation": {
    "messages": [
      {
        "content": "Hello, I need help with my order"  // <-- wrong! should be the private note
      }
    ]
  }
}
```

The top-level `content` field correctly shows the private note, but the nested `conversation.messages` shows stale content because the `.chat` scope applies `where(private: false)`.

<img width="3122" height="5447" alt="Screenshot_24-4-2026_16450_webhook site" src="https://github.com/user-attachments/assets/65da88d0-1078-43f5-9dc9-59b50dea716f" />


**Root cause trace:**

1. `WebhookListener` picks up the event → calls `message.webhook_data`
2. `message.webhook_data` embeds `conversation.webhook_data` for context
3. `EventDataPresenter#webhook_push_messages` uses the `.chat` scope
4. `.chat` scope = `where.not(message_type: :activity).where(private: false)` — the `where(private: false)` excludes the triggering message

## After fix

After applying this change, the `message_created` webhook payload correctly includes the actual message that triggered the event within the `conversation.messages` array, regardless of whether it is public or private. When a private/internal note is created, both the top-level `content` field and the nested `conversation.messages` now reflect the same private message. This ensures webhook consumers receive consistent and accurate message data, eliminating the mismatch caused by the previous `.chat` scope filtering out private messages.

<img width="3122" height="5240" alt="image" src="https://github.com/user-attachments/assets/1513166b-d6bf-4d34-8b74-a2c6bf7bba70" />

## What changed

Changed `webhook_push_messages` in `Conversations::EventDataPresenter` to use `.where.not(message_type: :activity)` instead of the `.chat` scope.

The `.chat` scope applies `where(private: false)` which explicitly excludes private messages. When a private message triggers the webhook, `.chat.last` skips it and returns the last public message instead. The fix keeps the activity message exclusion (system messages like "conversation resolved" aren't useful in webhook payloads) but drops the private message filter.

The actual message that triggered the event is already included at the top level of the webhook payload via `message.webhook_data` — this fix is specifically about the `conversation.messages` array embedded within that payload, which was showing stale/wrong content.

## How to test

1. Create a conversation with a public message (message A)
2. Add a private/internal note (message B)
3. Check the `message_created` webhook payload
4. **Before fix:** `payload.conversation.messages[0].content` contains message A's content
5. **After fix:** `payload.conversation.messages[0].content` contains message B's content