### PR TITLE
fix restrict agent issue

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
@@ -1,6 +1,8 @@
 class Api::V1::Accounts::Conversations::AssignmentsController < Api::V1::Accounts::Conversations::BaseController
   # assigns agent/team to a conversation
   def create
+    authorize @conversation, :update_assignee? unless self_assign_from_unassigned?
+
     if params.key?(:assignee_id) || agent_bot_assignment?
       set_agent
     elsif params.key?(:team_id)
@@ -41,5 +43,15 @@ class Api::V1::Accounts::Conversations::AssignmentsController < Api::V1::Account
 
   def agent_bot_assignment?
     params[:assignee_type].to_s == 'AgentBot'
+  end
+
+  # Agents picking up an unassigned conversation (self-assigning from the queue)
+  # are always permitted, regardless of the allow_agent_reassignment setting.
+  def self_assign_from_unassigned?
+    return false unless current_user.is_a?(User)
+    return false unless params.key?(:assignee_id)
+    return false unless @conversation.assignee_id.nil?
+
+    params[:assignee_id].to_i == current_user.id
   end
 end

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -117,7 +117,8 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def permitted_settings_attributes
-    [:auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting, :audio_transcriptions, :auto_resolve_label]
+    [:auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting, :audio_transcriptions, :auto_resolve_label,
+     :allow_agent_reassignment]
   end
 
   def check_signup_enabled

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -51,6 +51,7 @@ class Account < ApplicationRecord
   store_accessor :settings, :captain_models, :captain_features
   store_accessor :settings, :reporting_timezone
   store_accessor :settings, :keep_pending_on_bot_failure
+  store_accessor :settings, :allow_agent_reassignment
   store_accessor :settings, :captain_auto_resolve_mode
   include AccountCaptainAutoResolve
 

--- a/app/models/concerns/account_settings_schema.rb
+++ b/app/models/concerns/account_settings_schema.rb
@@ -11,6 +11,7 @@ module AccountSettingsSchema
         'audio_transcriptions': { 'type': %w[boolean null] },
         'auto_resolve_label': { 'type': %w[string null] },
         'keep_pending_on_bot_failure': { 'type': %w[boolean null] },
+        'allow_agent_reassignment': { 'type': %w[boolean null] },
         'captain_auto_resolve_mode': { 'type': %w[string null], 'enum': ['evaluated', 'legacy', 'disabled', nil] },
         'conversation_required_attributes': {
           'type': %w[array null],

--- a/app/policies/conversation_policy.rb
+++ b/app/policies/conversation_policy.rb
@@ -11,10 +11,20 @@ class ConversationPolicy < ApplicationPolicy
     administrator? || agent_bot? || agent_can_view_conversation?
   end
 
+  def update_assignee?
+    administrator? || agent_bot? || agent_can_reassign?
+  end
+
   private
 
   def agent_can_view_conversation?
     inbox_access? || team_access?
+  end
+
+  def agent_can_reassign?
+    # nil (not set) is treated as true for backwards compatibility;
+    # only an explicit false restricts agents.
+    account.allow_agent_reassignment != false
   end
 
   def administrator?

--- a/spec/controllers/api/v1/accounts/conversations/assignments_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/assignments_controller_spec.rb
@@ -180,5 +180,61 @@ RSpec.describe 'Conversation Assignment API', type: :request do
         expect(conversation.reload.team).to be_nil
       end
     end
+
+    context 'when allow_agent_reassignment is disabled' do
+      let(:agent) { create(:user, account: account, role: :agent) }
+      let(:other_agent) { create(:user, account: account, role: :agent) }
+      let(:administrator) { create(:user, account: account, role: :administrator) }
+
+      before do
+        account.update!(allow_agent_reassignment: false)
+        create(:inbox_member, inbox: conversation.inbox, user: agent)
+        create(:inbox_member, inbox: conversation.inbox, user: other_agent)
+        create(:inbox_member, inbox: conversation.inbox, user: administrator)
+      end
+
+      it 'prevents an agent from reassigning the conversation to another agent' do
+        post api_v1_account_conversation_assignments_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { assignee_id: other_agent.id },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(conversation.reload.assignee).not_to eq(other_agent)
+      end
+
+      it 'allows an administrator to reassign the conversation' do
+        post api_v1_account_conversation_assignments_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { assignee_id: other_agent.id },
+             headers: administrator.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.assignee).to eq(other_agent)
+      end
+
+      it 'allows an agent to self-assign an unassigned conversation' do
+        conversation.update!(assignee: nil)
+
+        post api_v1_account_conversation_assignments_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { assignee_id: agent.id },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.assignee).to eq(agent)
+      end
+
+      it 'prevents an agent from self-assigning when conversation already has an assignee' do
+        conversation.update!(assignee: other_agent)
+
+        post api_v1_account_conversation_assignments_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { assignee_id: agent.id },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
   end
 end

--- a/spec/policies/conversation_policy_spec.rb
+++ b/spec/policies/conversation_policy_spec.rb
@@ -70,4 +70,38 @@ RSpec.describe ConversationPolicy, type: :policy do
       end
     end
   end
+
+  permissions :update_assignee? do
+    context 'when user is an administrator' do
+      it 'allows reassignment' do
+        expect(subject).to permit(administrator_context, conversation)
+      end
+    end
+
+    context 'when allow_agent_reassignment is not set (default)' do
+      it 'allows agents to reassign' do
+        expect(subject).to permit(agent_context, conversation)
+      end
+    end
+
+    context 'when allow_agent_reassignment is true' do
+      before { account.update!(allow_agent_reassignment: true) }
+
+      it 'allows agents to reassign' do
+        expect(subject).to permit(agent_context, conversation)
+      end
+    end
+
+    context 'when allow_agent_reassignment is false' do
+      before { account.update!(allow_agent_reassignment: false) }
+
+      it 'denies agents from reassigning' do
+        expect(subject).not_to permit(agent_context, conversation)
+      end
+
+      it 'still allows administrators to reassign' do
+        expect(subject).to permit(administrator_context, conversation)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Is your feature request related to a problem? Please describe.
On self-hosted Community Edition, the only roles are agent and administrator. Any agent can change the assignee of a conversation — assigning it to another agent, or unassigning themselves — and admins have no way to prevent it.

For teams with accountability requirements (SLA ownership, escalation flows, audit trails), this is a real gap. Agents can silently dump tickets on each other or on managers, and there's no policy lever to stop it.

Custom Roles (https://github.com/chatwoot/chatwoot/issues/4216) is the long-term home for granular permissions, but it's Enterprise-only — the CE community has no path to solve this today.

Describe the solution you'd like
An account-level setting: "Allow agents to reassign conversations" (default on, for backwards compatibility).

When off:

Agents cannot change the assignee of a conversation they don't own, or unassign themselves
The "Assignee" dropdown in the conversation header is read-only for agents
POST /api/v1/accounts/:id/conversations/:id/assignments rejects agent requests with 403
Admins retain full reassignment capability
Agents can still self-assign from the unassigned queue (picking up work is different from reassigning)
Describe alternatives you've considered
Automation rules to revert assignee changes — noisy, racy, and visible as activity-log flicker.
Upgrading to Enterprise for Custom Roles — not viable for all self-hosted deployments.
Additional context
Version: self-hosted Community Edition, v4.11.0.

Implementation hint — the pieces are already isolated:

app/policies/conversation_policy.rb — currently has no update? or update_assignee? predicate. A new one gated by role + account setting would be the natural place.
app/controllers/api/v1/accounts/conversations/assignments_controller.rb#create — the endpoint to authorize. Today it relies on inherited base-controller access checks only.
Agent self-assign from unassigned queue would need a special-case bypass (allow when conversation.assignee_id.nil? and target is current_user).