### PR TITLE
fix: disable unchecked features in Super Admin account update

### DIFF
--- a/app/controllers/super_admin/accounts_controller.rb
+++ b/app/controllers/super_admin/accounts_controller.rb
@@ -36,10 +36,10 @@ class SuperAdmin::AccountsController < SuperAdmin::ApplicationController
   def resource_params
     permitted_params = super
     permitted_params[:limits] = permitted_params[:limits].to_h.compact
-    if action_name == 'update'
-      permitted_params[:selected_feature_flags] = params[:enabled_features].present? ? params[:enabled_features].keys.map(&:to_sym) : []
-    elsif params[:enabled_features].present?
+    if params[:enabled_features].present?
       permitted_params[:selected_feature_flags] = params[:enabled_features].keys.map(&:to_sym)
+    elsif action_name == 'update' && ChatwootApp.enterprise?
+      permitted_params[:selected_feature_flags] = []
     end
     permitted_params
   end

--- a/app/controllers/super_admin/accounts_controller.rb
+++ b/app/controllers/super_admin/accounts_controller.rb
@@ -36,7 +36,11 @@ class SuperAdmin::AccountsController < SuperAdmin::ApplicationController
   def resource_params
     permitted_params = super
     permitted_params[:limits] = permitted_params[:limits].to_h.compact
-    permitted_params[:selected_feature_flags] = params[:enabled_features].keys.map(&:to_sym) if params[:enabled_features].present?
+    if action_name == 'update'
+      permitted_params[:selected_feature_flags] = params[:enabled_features].present? ? params[:enabled_features].keys.map(&:to_sym) : []
+    elsif params[:enabled_features].present?
+      permitted_params[:selected_feature_flags] = params[:enabled_features].keys.map(&:to_sym)
+    end
     permitted_params
   end
 


### PR DESCRIPTION
## Summary

When editing account features in the Super Admin panel, unchecking a feature checkbox does not actually disable the feature. The previously enabled features remain active after saving.

Closes #14064

## Bug reproduction

**Setup:** An Enterprise Chatwoot instance with a Super Admin account.

**Step 1 — View current features:**

Navigate to Super Admin > Accounts > Edit on any account. Observe the feature checkboxes — some are checked (enabled).

**Step 2 — Uncheck features and save:**

Uncheck one or more feature checkboxes, then click Save.

**Step 3 — Features are still enabled:**

Go back to the edit page for the same account. The features you unchecked are still checked — the save did not actually disable them.

**Root cause:**

HTML checkboxes are only included in form submissions when checked. Unchecked boxes are absent from the payload entirely. The controller had this guard:

```ruby
permitted_params[:selected_feature_flags] = params[:enabled_features].keys.map(&:to_sym) if params[:enabled_features].present?
```

When nothing is checked, `params[:enabled_features]` is `nil`, so `present?` returns false and the setter is never called. Since FlagShihTzu's `selected_feature_flags=` calls `unselect_all_flags` before enabling the provided list, passing `[]` would correctly disable everything — but the guard prevents that call from happening.

## What changed

Modified `resource_params` in `SuperAdmin::AccountsController` to handle the absent-checkbox case:

- If features are submitted → set those features (existing behavior, works on both OSS and Enterprise)
- If nothing is submitted + update action + Enterprise → set empty array to disable all features (the form had checkboxes and the user unchecked them)
- If nothing is submitted + update action + OSS → do nothing (the form doesn't include feature checkboxes on OSS, so absence doesn't mean "uncheck all")
- On create → only set if explicitly submitted (preserves `before_create :enable_default_features` callback behavior)

## How to test

1. Go to Super Admin > Accounts > Edit an account
2. Note which features are enabled
3. Uncheck one or more features
4. Save
5. **Before fix:** unchecked features are still enabled
6. **After fix:** unchecked features are properly disabled