### PR TITLE
fix: [CW-6931] SafeFetch for Instagram and Messenger attachments

### DIFF
--- a/app/builders/messages/instagram/base_message_builder.rb
+++ b/app/builders/messages/instagram/base_message_builder.rb
@@ -1,4 +1,6 @@
 class Messages::Instagram::BaseMessageBuilder < Messages::Messenger::MessageBuilder
+  include ::Messages::Instagram::StoryReplyAttachmentHandling
+
   attr_reader :messaging
 
   def initialize(messaging, inbox, outgoing_echo: false)
@@ -113,24 +115,6 @@ class Messages::Instagram::BaseMessageBuilder < Messages::Messenger::MessageBuil
 
     @message.save_story_info(story_reply_attributes)
     create_story_reply_attachment(story_reply_attributes['url'])
-  end
-
-  def create_story_reply_attachment(story_url)
-    return if story_url.blank?
-
-    attachment = @message.attachments.new(
-      file_type: :ig_story,
-      account_id: @message.account_id,
-      external_url: story_url
-    )
-    attachment.save!
-    begin
-      attach_file(attachment, story_url)
-    rescue Down::Error, StandardError => e
-      Rails.logger.warn "Failed to download Instagram story attachment: #{e.message}"
-    end
-    @message.content_attributes[:image_type] = 'ig_story_reply'
-    @message.save!
   end
 
   def build_conversation

--- a/app/builders/messages/instagram/story_reply_attachment_handling.rb
+++ b/app/builders/messages/instagram/story_reply_attachment_handling.rb
@@ -1,0 +1,50 @@
+module Messages::Instagram::StoryReplyAttachmentHandling
+  private
+
+  def create_story_reply_attachment(story_url)
+    return if story_url.blank?
+
+    attach_story_reply_file(build_story_reply_attachment(story_url), story_url)
+    update_story_reply_message
+  end
+
+  def build_story_reply_attachment(story_url)
+    @message.attachments.new(
+      file_type: :ig_story,
+      account_id: @message.account_id,
+      external_url: story_url
+    )
+  end
+
+  def attach_story_reply_file(attachment, story_url)
+    SafeFetch.fetch(story_url, **remote_attachment_fetch_options) do |attachment_file|
+      persist_story_reply_attachment(attachment, attachment_file)
+    end
+  rescue SafeFetch::Error => e
+    Rails.logger.info "Error downloading Messenger attachment from #{story_url}: #{e.message}: Skipping"
+    discard_story_reply_attachment(attachment)
+  rescue StandardError => e
+    Rails.logger.warn "Failed to download Instagram story attachment: #{e.message}"
+    discard_story_reply_attachment(attachment)
+  end
+
+  def persist_story_reply_attachment(attachment, attachment_file)
+    attachment.file.attach(
+      io: attachment_file.tempfile,
+      filename: attachment_file.original_filename,
+      content_type: attachment_file.content_type
+    )
+    attachment.save!
+  end
+
+  def discard_story_reply_attachment(attachment)
+    return attachment.destroy if attachment.persisted?
+
+    @message.attachments.proxy_association.target.delete(attachment)
+  end
+
+  def update_story_reply_message
+    @message.content_attributes[:image_type] = 'ig_story_reply'
+    @message.save!
+  end
+end

--- a/app/builders/messages/messenger/message_builder.rb
+++ b/app/builders/messages/messenger/message_builder.rb
@@ -1,18 +1,14 @@
 class Messages::Messenger::MessageBuilder
   include ::FileTypeHelper
+  REMOTE_FILE_ALLOWED_CONTENT_TYPE_PREFIXES = %w[image/ video/ audio/].freeze
 
   def process_attachment(attachment)
     # This check handles very rare case if there are multiple files to attach with only one unsupported file
     return if unsupported_file_type?(attachment['type'])
 
-    params = attachment_params(attachment)
-    attachment_obj = @message.attachments.new(params.except(:remote_file_url))
-    attachment_obj.save!
-    if facebook_reel?(attachment)
-      update_facebook_reel_content(attachment)
-    elsif params[:remote_file_url]
-      attach_file(attachment_obj, params[:remote_file_url])
-    end
+    attachment_obj = persist_attachment(attachment)
+    return unless attachment_obj
+
     fetch_story_link(attachment_obj) if attachment_obj.file_type == 'story_mention'
     fetch_ig_story_link(attachment_obj) if attachment_obj.file_type == 'ig_story'
     fetch_ig_post_link(attachment_obj) if attachment_obj.file_type == 'ig_post'
@@ -20,14 +16,17 @@ class Messages::Messenger::MessageBuilder
   end
 
   def attach_file(attachment, file_url)
-    attachment_file = Down.download(
-      file_url
-    )
-    attachment.file.attach(
-      io: attachment_file,
-      filename: attachment_file.original_filename,
-      content_type: attachment_file.content_type
-    )
+    SafeFetch.fetch(file_url, **remote_attachment_fetch_options) do |attachment_file|
+      attachment.file.attach(
+        io: attachment_file.tempfile,
+        filename: attachment_file.original_filename,
+        content_type: attachment_file.content_type
+      )
+    end
+    true
+  rescue SafeFetch::Error => e
+    Rails.logger.info "Error downloading Messenger attachment from #{file_url}: #{e.message}: Skipping"
+    false
   end
 
   def attachment_params(attachment)
@@ -104,6 +103,37 @@ class Messages::Messenger::MessageBuilder
   end
 
   private
+
+  def persist_attachment(attachment)
+    params = attachment_params(attachment)
+    attachment_obj = @message.attachments.new(params.except(:remote_file_url))
+
+    return save_facebook_reel_attachment(attachment, attachment_obj) if facebook_reel?(attachment)
+    return save_remote_file_attachment(attachment_obj, params[:remote_file_url]) if params[:remote_file_url].present?
+
+    attachment_obj.save!
+    attachment_obj
+  end
+
+  def save_facebook_reel_attachment(attachment, attachment_obj)
+    attachment_obj.save!
+    update_facebook_reel_content(attachment)
+    attachment_obj
+  end
+
+  def save_remote_file_attachment(attachment_obj, remote_file_url)
+    return unless attach_file(attachment_obj, remote_file_url)
+
+    attachment_obj.save!
+    attachment_obj
+  end
+
+  def remote_attachment_fetch_options
+    {
+      allowed_content_type_prefixes: REMOTE_FILE_ALLOWED_CONTENT_TYPE_PREFIXES,
+      allowed_content_types: Attachment::ACCEPTABLE_FILE_TYPES
+    }
+  end
 
   # Facebook may send attachment types that don't directly match our file_type enum.
   # Map known aliases to their canonical enum values.

--- a/app/jobs/avatar/avatar_from_url_job.rb
+++ b/app/jobs/avatar/avatar_from_url_job.rb
@@ -9,7 +9,7 @@ class Avatar::AvatarFromUrlJob < ApplicationJob
   include UrlHelper
   queue_as :purgable
 
-  ALLOWED_CONTENT_TYPES = %w[image/jpeg image/png image/gif image/webp].freeze
+  ALLOWED_CONTENT_TYPES = Avatarable::ALLOWED_AVATAR_CONTENT_TYPES
   MAX_DOWNLOAD_SIZE = 15.megabytes
   RATE_LIMIT_WINDOW = 1.minute
 

--- a/app/jobs/avatar/avatar_from_url_job.rb
+++ b/app/jobs/avatar/avatar_from_url_job.rb
@@ -9,33 +9,58 @@ class Avatar::AvatarFromUrlJob < ApplicationJob
   include UrlHelper
   queue_as :purgable
 
-  MAX_DOWNLOAD_SIZE = 15 * 1024 * 1024
+  ALLOWED_CONTENT_TYPES = %w[image/jpeg image/png image/gif image/webp].freeze
+  MAX_DOWNLOAD_SIZE = 15.megabytes
   RATE_LIMIT_WINDOW = 1.minute
 
   def perform(avatarable, avatar_url)
-    return unless avatarable.respond_to?(:avatar)
-    return unless url_valid?(avatar_url)
+    return unless syncable_avatar?(avatarable, avatar_url)
 
-    return unless should_sync_avatar?(avatarable, avatar_url)
-
-    avatar_file = Down.download(avatar_url, max_size: MAX_DOWNLOAD_SIZE)
-    raise Down::Error, 'Invalid file' unless valid_file?(avatar_file)
-
-    avatarable.avatar.attach(
-      io: avatar_file,
-      filename: avatar_file.original_filename,
-      content_type: avatar_file.content_type
-    )
-
-  rescue Down::NotFound
-    Rails.logger.info "AvatarFromUrlJob: avatar not found at #{avatar_url}"
-  rescue Down::Error => e
+    fetch_and_attach_avatar(avatarable, avatar_url)
+  rescue SafeFetch::HttpError => e
+    log_http_error(avatar_url, e)
+  rescue SafeFetch::Error => e
     Rails.logger.error "AvatarFromUrlJob error for #{avatar_url}: #{e.class} - #{e.message}"
   ensure
     update_avatar_sync_attributes(avatarable, avatar_url)
   end
 
   private
+
+  def syncable_avatar?(avatarable, avatar_url)
+    avatarable.respond_to?(:avatar) &&
+      url_valid?(avatar_url) &&
+      should_sync_avatar?(avatarable, avatar_url)
+  end
+
+  def fetch_and_attach_avatar(avatarable, avatar_url)
+    SafeFetch.fetch(
+      avatar_url,
+      max_bytes: MAX_DOWNLOAD_SIZE,
+      allowed_content_type_prefixes: [],
+      allowed_content_types: ALLOWED_CONTENT_TYPES
+    ) do |avatar_file|
+      attach_avatar(avatarable, avatar_file)
+    end
+  end
+
+  def attach_avatar(avatarable, avatar_file)
+    raise SafeFetch::FetchError, 'Invalid file' unless valid_file?(avatar_file)
+
+    avatarable.avatar.attach(
+      io: avatar_file.tempfile,
+      filename: avatar_file.original_filename,
+      content_type: avatar_file.content_type
+    )
+  end
+
+  def log_http_error(avatar_url, error)
+    if error.message.start_with?('404')
+      Rails.logger.info "AvatarFromUrlJob: avatar not found at #{avatar_url}"
+    else
+      Rails.logger.error "AvatarFromUrlJob error for #{avatar_url}: #{error.class} - #{error.message}"
+    end
+  end
 
   def should_sync_avatar?(avatarable, avatar_url)
     # Only Contacts are rate-limited and hash-gated.

--- a/app/models/concerns/avatarable.rb
+++ b/app/models/concerns/avatarable.rb
@@ -4,6 +4,8 @@ module Avatarable
   extend ActiveSupport::Concern
   include Rails.application.routes.url_helpers
 
+  ALLOWED_AVATAR_CONTENT_TYPES = %w[image/jpeg image/png image/gif image/webp].freeze
+
   included do
     has_one_attached :avatar
     validate :acceptable_avatar, if: -> { avatar.changed? }
@@ -30,7 +32,6 @@ module Avatarable
 
     errors.add(:avatar, 'is too big') if avatar.byte_size > 15.megabytes
 
-    acceptable_types = ['image/jpeg', 'image/png', 'image/gif'].freeze
-    errors.add(:avatar, 'filetype not supported') unless acceptable_types.include?(avatar.content_type)
+    errors.add(:avatar, 'filetype not supported') unless ALLOWED_AVATAR_CONTENT_TYPES.include?(avatar.content_type)
   end
 end

--- a/lib/safe_fetch.rb
+++ b/lib/safe_fetch.rb
@@ -6,7 +6,11 @@ module SafeFetch
   DEFAULT_READ_TIMEOUT = 20
   DEFAULT_MAX_BYTES_FALLBACK_MB = 40
 
-  Result = Data.define(:tempfile, :filename, :content_type)
+  Result = Data.define(:tempfile, :filename, :content_type) do
+    def original_filename
+      filename
+    end
+  end
 
   class Error < StandardError; end
   class InvalidUrlError < Error; end
@@ -18,19 +22,15 @@ module SafeFetch
 
   def self.fetch(url,
                  max_bytes: nil,
-                 allowed_content_type_prefixes: DEFAULT_ALLOWED_CONTENT_TYPE_PREFIXES)
+                 allowed_content_type_prefixes: DEFAULT_ALLOWED_CONTENT_TYPE_PREFIXES,
+                 allowed_content_types: [])
     raise ArgumentError, 'block required' unless block_given?
 
     effective_max_bytes = max_bytes || default_max_bytes
-    uri = parse_and_validate_url!(url)
-    filename = filename_for(uri)
+    filename = filename_for(parse_and_validate_url!(url))
     tempfile = Tempfile.new('chatwoot-safe-fetch', binmode: true)
-
-    response = stream_to_tempfile(url, tempfile, effective_max_bytes, allowed_content_type_prefixes)
-    raise HttpError, "#{response.code} #{response.message}" unless response.is_a?(Net::HTTPSuccess)
-
-    tempfile.rewind
-    yield Result.new(tempfile: tempfile, filename: filename, content_type: response['content-type'])
+    response = fetch_response(url, tempfile, effective_max_bytes, allowed_content_type_prefixes, allowed_content_types)
+    yield build_result(tempfile, filename, response)
   rescue SsrfFilter::InvalidUriScheme, URI::InvalidURIError => e
     raise InvalidUrlError, e.message
   rescue SsrfFilter::Error, Resolv::ResolvError => e
@@ -44,7 +44,11 @@ module SafeFetch
   class << self
     private
 
-    def stream_to_tempfile(url, tempfile, max_bytes, allowed_content_type_prefixes)
+    def fetch_response(url, tempfile, max_bytes, allowed_content_type_prefixes, allowed_content_types)
+      stream_to_tempfile(url, tempfile, max_bytes, allowed_content_type_prefixes, allowed_content_types)
+    end
+
+    def stream_to_tempfile(url, tempfile, max_bytes, allowed_content_type_prefixes, allowed_content_types)
       response = nil
       bytes_written = 0
 
@@ -55,7 +59,7 @@ module SafeFetch
         response = res
         next unless res.is_a?(Net::HTTPSuccess)
 
-        unless allowed_content_type?(res['content-type'], allowed_content_type_prefixes)
+        unless allowed_content_type?(res['content-type'], allowed_content_type_prefixes, allowed_content_types)
           raise UnsupportedContentTypeError, "content-type not allowed: #{res['content-type']}"
         end
 
@@ -74,6 +78,13 @@ module SafeFetch
       File.basename(uri.path).presence || "download-#{Time.current.to_i}-#{SecureRandom.hex(4)}"
     end
 
+    def build_result(tempfile, filename, response)
+      raise HttpError, "#{response.code} #{response.message}" unless response.is_a?(Net::HTTPSuccess)
+
+      tempfile.rewind
+      Result.new(tempfile: tempfile, filename: filename, content_type: response['content-type'])
+    end
+
     def default_max_bytes
       limit_mb = GlobalConfigService.load('MAXIMUM_FILE_UPLOAD_SIZE', DEFAULT_MAX_BYTES_FALLBACK_MB).to_i
       limit_mb = DEFAULT_MAX_BYTES_FALLBACK_MB if limit_mb <= 0
@@ -88,11 +99,11 @@ module SafeFetch
       uri
     end
 
-    def allowed_content_type?(value, prefixes)
+    def allowed_content_type?(value, prefixes, content_types)
       mime = value.to_s.split(';').first&.strip&.downcase
       return false if mime.blank?
 
-      prefixes.any? { |prefix| mime.start_with?(prefix) }
+      prefixes.any? { |prefix| mime.start_with?(prefix) } || content_types.include?(mime)
     end
   end
 end

--- a/lib/safe_fetch.rb
+++ b/lib/safe_fetch.rb
@@ -82,7 +82,8 @@ module SafeFetch
       raise HttpError, "#{response.code} #{response.message}" unless response.is_a?(Net::HTTPSuccess)
 
       tempfile.rewind
-      Result.new(tempfile: tempfile, filename: filename, content_type: response['content-type'])
+      content_type = normalized_content_type(response['content-type'])
+      Result.new(tempfile: tempfile, filename: filename, content_type: content_type)
     end
 
     def default_max_bytes
@@ -100,10 +101,14 @@ module SafeFetch
     end
 
     def allowed_content_type?(value, prefixes, content_types)
-      mime = value.to_s.split(';').first&.strip&.downcase
+      mime = normalized_content_type(value)
       return false if mime.blank?
 
       prefixes.any? { |prefix| mime.start_with?(prefix) } || content_types.include?(mime)
+    end
+
+    def normalized_content_type(value)
+      value.to_s.split(';').first&.strip&.downcase
     end
   end
 end

--- a/spec/builders/messages/facebook/message_builder_spec.rb
+++ b/spec/builders/messages/facebook/message_builder_spec.rb
@@ -4,7 +4,12 @@ describe Messages::Facebook::MessageBuilder do
   subject(:message_builder) { described_class.new(incoming_fb_text_message, facebook_channel.inbox).perform }
 
   before do
+    allow(Resolv).to receive(:getaddresses).and_call_original
+    allow(Resolv).to receive(:getaddresses).with('www.example.com').and_return(['93.184.216.34'])
+    allow(Resolv).to receive(:getaddresses).with('chatwoot-assets.local').and_return(['93.184.216.35'])
     stub_request(:post, /graph.facebook.com/)
+    stub_request(:get, 'https://www.example.com/test.jpeg')
+      .to_return(status: 200, body: 'image-data', headers: { 'Content-Type' => 'image/jpeg' })
   end
 
   let!(:facebook_channel) { create(:channel_facebook_page) }
@@ -137,6 +142,62 @@ describe Messages::Facebook::MessageBuilder do
 
         message = facebook_channel.inbox.messages.find_by(source_id: 'm_reel_test')
         expect(message.content).to eq('https://www.facebook.com/reel/123456')
+      end
+    end
+
+    context 'when message contains a downloadable attachment' do
+      let(:attachment_message_object) do
+        {
+          messaging: {
+            sender: { id: '3383290475046708' },
+            recipient: { id: facebook_channel.page_id },
+            timestamp: 1_772_452_164_516,
+            message: {
+              mid: 'm_attachment_test',
+              attachments: [
+                {
+                  type: 'share',
+                  payload: {
+                    url: attachment_url
+                  }
+                }
+              ]
+            }
+          }
+        }.to_json
+      end
+      let(:attachment_message) { Integrations::Facebook::MessageParser.new(attachment_message_object) }
+      let(:attachment_url) { 'https://www.example.com/test.jpeg' }
+
+      before do
+        allow(Koala::Facebook::API).to receive(:new).and_return(fb_object)
+        allow(fb_object).to receive(:get_object).and_return(
+          { first_name: 'Jane', last_name: 'Dae', profile_pic: 'https://chatwoot-assets.local/sample.png' }.with_indifferent_access
+        )
+      end
+
+      it 'downloads and attaches files for safe public URLs' do
+        described_class.new(attachment_message, facebook_channel.inbox).perform
+
+        message = facebook_channel.inbox.messages.find_by(source_id: 'm_attachment_test')
+        expect(message).to be_present
+        expect(message.attachments.first.file_type).to eq('image')
+        expect(message.attachments.first.external_url).to eq(attachment_url)
+        expect(message.attachments.first.file).to be_attached
+      end
+
+      it 'skips blocked attachment URLs' do
+        blocked_message = Integrations::Facebook::MessageParser.new(
+          attachment_message_object.gsub(attachment_url, 'http://127.0.0.1/blocked.jpeg')
+        )
+
+        expect do
+          described_class.new(blocked_message, facebook_channel.inbox).perform
+        end.not_to raise_error
+
+        message = facebook_channel.inbox.messages.find_by(source_id: 'm_attachment_test')
+        expect(message).to be_present
+        expect(message.attachments).to be_empty
       end
     end
 

--- a/spec/builders/messages/instagram/message_builder_spec.rb
+++ b/spec/builders/messages/instagram/message_builder_spec.rb
@@ -4,15 +4,19 @@ describe Messages::Instagram::MessageBuilder do
   subject(:instagram_direct_message_builder) { described_class }
 
   before do
+    allow(Resolv).to receive(:getaddresses).and_call_original
+    allow(Resolv).to receive(:getaddresses).with('www.example.com').and_return(['93.184.216.34'])
+    allow(Resolv).to receive(:getaddresses).with('chatwoot-assets.local').and_return(['93.184.216.35'])
     stub_request(:post, /graph\.instagram\.com/)
     stub_request(:get, 'https://www.example.com/test.jpeg')
-      .to_return(status: 200, body: '', headers: {})
+      .to_return(status: 200, body: 'image-data', headers: { 'Content-Type' => 'image/jpeg' })
   end
 
   let!(:account) { create(:account) }
   let!(:instagram_channel) { create(:channel_instagram, account: account, instagram_id: 'chatwoot-app-user-id-1') }
   let!(:instagram_inbox) { create(:inbox, channel: instagram_channel, account: account, greeting_enabled: false) }
   let!(:dm_params) { build(:instagram_message_create_event).with_indifferent_access }
+  let!(:attachment_params) { build(:instagram_message_attachment_event).with_indifferent_access }
   let!(:story_mention_params) { build(:instagram_story_mention_event).with_indifferent_access }
   let!(:shared_reel_params) { build(:instagram_shared_reel_event).with_indifferent_access }
   let!(:instagram_story_reply_event) { build(:instagram_story_reply_event).with_indifferent_access }
@@ -100,6 +104,32 @@ describe Messages::Instagram::MessageBuilder do
       )
     end
 
+    it 'creates message with a downloadable attachment' do
+      messaging = attachment_params[:entry][0]['messaging'][0]
+      create_instagram_contact_for_sender(messaging['sender']['id'], instagram_inbox)
+
+      described_class.new(messaging, instagram_inbox).perform
+
+      message = instagram_inbox.messages.first
+      expect(message.attachments.first.file_type).to eq('image')
+      expect(message.attachments.first.external_url).to eq('https://www.example.com/test.jpeg')
+      expect(message.attachments.first.file).to be_attached
+    end
+
+    it 'skips blocked attachment URLs' do
+      messaging = attachment_params[:entry][0]['messaging'][0]
+      messaging['message']['attachments'][0]['payload']['url'] = 'http://127.0.0.1/blocked.jpeg'
+      create_instagram_contact_for_sender(messaging['sender']['id'], instagram_inbox)
+
+      expect do
+        described_class.new(messaging, instagram_inbox).perform
+      end.not_to raise_error
+
+      message = instagram_inbox.messages.first
+      expect(message).to be_present
+      expect(message.attachments).to be_empty
+    end
+
     it 'creates message with story id' do
       messaging = instagram_story_reply_event[:entry][0]['messaging'][0]
       create_instagram_contact_for_sender(messaging['sender']['id'], instagram_inbox)
@@ -118,6 +148,20 @@ describe Messages::Instagram::MessageBuilder do
       expect(message.content_attributes[:image_type]).to eq('ig_story_reply')
       expect(message.attachments.first.file_type).to eq('ig_story')
       expect(message.attachments.first.external_url).to eq(story_url)
+    end
+
+    it 'skips story reply attachments for blocked URLs' do
+      messaging = instagram_story_reply_event[:entry][0]['messaging'][0]
+      messaging['message']['reply_to']['story']['url'] = 'http://127.0.0.1/blocked.png'
+      create_instagram_contact_for_sender(messaging['sender']['id'], instagram_inbox)
+
+      expect do
+        described_class.new(messaging, instagram_inbox).perform
+      end.not_to raise_error
+
+      message = instagram_inbox.messages.first
+      expect(message.content).to eq('This is the story reply')
+      expect(message.attachments).to be_empty
     end
 
     it 'creates message with reply to mid' do

--- a/spec/builders/messages/instagram/messenger/message_builder_spec.rb
+++ b/spec/builders/messages/instagram/messenger/message_builder_spec.rb
@@ -4,14 +4,19 @@ describe Messages::Instagram::Messenger::MessageBuilder do
   subject(:instagram_message_builder) { described_class }
 
   before do
+    allow(Resolv).to receive(:getaddresses).and_call_original
+    allow(Resolv).to receive(:getaddresses).with('www.example.com').and_return(['93.184.216.34'])
+    allow(Resolv).to receive(:getaddresses).with('chatwoot-assets.local').and_return(['93.184.216.35'])
     stub_request(:post, /graph\.facebook\.com/)
     stub_request(:get, 'https://www.example.com/test.jpeg')
+      .to_return(status: 200, body: 'image-data', headers: { 'Content-Type' => 'image/jpeg' })
   end
 
   let!(:account) { create(:account) }
   let!(:instagram_messenger_channel) { create(:channel_instagram_fb_page, account: account, instagram_id: 'chatwoot-app-user-id-1') }
   let!(:instagram_messenger_inbox) { create(:inbox, channel: instagram_messenger_channel, account: account, greeting_enabled: false) }
   let!(:dm_params) { build(:instagram_message_create_event).with_indifferent_access }
+  let!(:attachment_params) { build(:instagram_message_attachment_event).with_indifferent_access }
   let!(:story_mention_params) { build(:instagram_story_mention_event).with_indifferent_access }
   let!(:shared_reel_params) { build(:instagram_shared_reel_event).with_indifferent_access }
   let!(:instagram_story_reply_event) { build(:instagram_story_reply_event).with_indifferent_access }
@@ -101,6 +106,55 @@ describe Messages::Instagram::Messenger::MessageBuilder do
       )
     end
 
+    it 'creates message with a downloadable attachment' do
+      messaging = attachment_params[:entry][0]['messaging'][0]
+      sender_id = messaging['sender']['id']
+
+      allow(Koala::Facebook::API).to receive(:new).and_return(fb_object)
+      allow(fb_object).to receive(:get_object).and_return(
+        {
+          name: 'Jane',
+          id: sender_id,
+          account_id: instagram_messenger_inbox.account_id,
+          profile_pic: 'https://chatwoot-assets.local/sample.png'
+        }.with_indifferent_access
+      )
+
+      create_instagram_contact_for_sender(sender_id, instagram_messenger_inbox)
+      described_class.new(messaging, instagram_messenger_inbox).perform
+
+      message = instagram_messenger_channel.inbox.messages.first
+      expect(message.attachments.first.file_type).to eq('image')
+      expect(message.attachments.first.external_url).to eq('https://www.example.com/test.jpeg')
+      expect(message.attachments.first.file).to be_attached
+    end
+
+    it 'skips blocked attachment URLs' do
+      messaging = attachment_params[:entry][0]['messaging'][0]
+      sender_id = messaging['sender']['id']
+      messaging['message']['attachments'][0]['payload']['url'] = 'http://127.0.0.1/blocked.jpeg'
+
+      allow(Koala::Facebook::API).to receive(:new).and_return(fb_object)
+      allow(fb_object).to receive(:get_object).and_return(
+        {
+          name: 'Jane',
+          id: sender_id,
+          account_id: instagram_messenger_inbox.account_id,
+          profile_pic: 'https://chatwoot-assets.local/sample.png'
+        }.with_indifferent_access
+      )
+
+      create_instagram_contact_for_sender(sender_id, instagram_messenger_inbox)
+
+      expect do
+        described_class.new(messaging, instagram_messenger_inbox).perform
+      end.not_to raise_error
+
+      message = instagram_messenger_channel.inbox.messages.first
+      expect(message).to be_present
+      expect(message.attachments).to be_empty
+    end
+
     it 'creates message with for reply with story id' do
       messaging = instagram_story_reply_event[:entry][0]['messaging'][0]
       sender_id = messaging['sender']['id']
@@ -130,6 +184,32 @@ describe Messages::Instagram::Messenger::MessageBuilder do
       expect(message.content_attributes[:image_type]).to eq('ig_story_reply')
       expect(message.attachments.first.file_type).to eq('ig_story')
       expect(message.attachments.first.external_url).to eq(story_url)
+    end
+
+    it 'skips story reply attachments for blocked URLs' do
+      messaging = instagram_story_reply_event[:entry][0]['messaging'][0]
+      sender_id = messaging['sender']['id']
+      messaging['message']['reply_to']['story']['url'] = 'http://127.0.0.1/blocked.png'
+
+      allow(Koala::Facebook::API).to receive(:new).and_return(fb_object)
+      allow(fb_object).to receive(:get_object).and_return(
+        {
+          name: 'Jane',
+          id: sender_id,
+          account_id: instagram_messenger_inbox.account_id,
+          profile_pic: 'https://chatwoot-assets.local/sample.png'
+        }.with_indifferent_access
+      )
+
+      create_instagram_contact_for_sender(sender_id, instagram_messenger_inbox)
+
+      expect do
+        described_class.new(messaging, instagram_messenger_inbox).perform
+      end.not_to raise_error
+
+      message = instagram_messenger_channel.inbox.messages.first
+      expect(message.content).to eq('This is the story reply')
+      expect(message.attachments).to be_empty
     end
 
     it 'creates message with for reply with mid' do

--- a/spec/jobs/avatar/avatar_from_url_job_spec.rb
+++ b/spec/jobs/avatar/avatar_from_url_job_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Avatar::AvatarFromUrlJob do
         valid_url,
         max_bytes: Avatar::AvatarFromUrlJob::MAX_DOWNLOAD_SIZE,
         allowed_content_type_prefixes: [],
-        allowed_content_types: %w[image/jpeg image/png image/gif]
+        allowed_content_types: Avatar::AvatarFromUrlJob::ALLOWED_CONTENT_TYPES
       ).and_yield(
         SafeFetch::Result.new(
           tempfile: invalid_file,

--- a/spec/jobs/avatar/avatar_from_url_job_spec.rb
+++ b/spec/jobs/avatar/avatar_from_url_job_spec.rb
@@ -32,6 +32,24 @@ RSpec.describe Avatar::AvatarFromUrlJob do
       expect(avatarable.additional_attributes['last_avatar_sync_at']).to be_present
     end
 
+    it 'attaches webp avatars and updates sync attributes' do
+      webp_url = 'https://example.com/avatar.webp'
+
+      stub_request(:get, webp_url)
+        .to_return(
+          status: 200,
+          body: File.read(Rails.root.join('spec/assets/avatar.png')),
+          headers: { 'Content-Type' => 'image/webp' }
+        )
+
+      described_class.perform_now(avatarable, webp_url)
+      avatarable.reload
+
+      expect(avatarable.avatar).to be_attached
+      expect(avatarable.additional_attributes['avatar_url_hash']).to eq(Digest::SHA256.hexdigest(webp_url))
+      expect(avatarable.additional_attributes['last_avatar_sync_at']).to be_present
+    end
+
     it 'returns early when rate limited' do
       ts = 30.seconds.ago.iso8601
       avatarable.update(additional_attributes: { 'last_avatar_sync_at' => ts })

--- a/spec/jobs/avatar/avatar_from_url_job_spec.rb
+++ b/spec/jobs/avatar/avatar_from_url_job_spec.rb
@@ -1,8 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Avatar::AvatarFromUrlJob do
-  let(:file) { fixture_file_upload(Rails.root.join('spec/assets/avatar.png'), 'image/png') }
   let(:valid_url) { 'https://example.com/avatar.png' }
+
+  before do
+    allow(Resolv).to receive(:getaddresses).and_call_original
+    allow(Resolv).to receive(:getaddresses).with('example.com').and_return(['93.184.216.34'])
+  end
 
   it 'enqueues the job' do
     contact = create(:contact)
@@ -14,7 +18,13 @@ RSpec.describe Avatar::AvatarFromUrlJob do
     let(:avatarable) { create(:contact) }
 
     it 'attaches and updates sync attributes' do
-      expect(Down).to receive(:download).with(valid_url, max_size: Avatar::AvatarFromUrlJob::MAX_DOWNLOAD_SIZE).and_return(file)
+      stub_request(:get, valid_url)
+        .to_return(
+          status: 200,
+          body: File.read(Rails.root.join('spec/assets/avatar.png')),
+          headers: { 'Content-Type' => 'image/png' }
+        )
+
       described_class.perform_now(avatarable, valid_url)
       avatarable.reload
       expect(avatarable.avatar).to be_attached
@@ -25,7 +35,14 @@ RSpec.describe Avatar::AvatarFromUrlJob do
     it 'returns early when rate limited' do
       ts = 30.seconds.ago.iso8601
       avatarable.update(additional_attributes: { 'last_avatar_sync_at' => ts })
-      expect(Down).not_to receive(:download)
+
+      stub_request(:get, valid_url)
+        .to_return(
+          status: 200,
+          body: File.read(Rails.root.join('spec/assets/avatar.png')),
+          headers: { 'Content-Type' => 'image/png' }
+        )
+
       described_class.perform_now(avatarable, valid_url)
       avatarable.reload
       expect(avatarable.avatar).not_to be_attached
@@ -33,21 +50,29 @@ RSpec.describe Avatar::AvatarFromUrlJob do
       expect(Time.zone.parse(avatarable.additional_attributes['last_avatar_sync_at']))
         .to be > Time.zone.parse(ts)
       expect(avatarable.additional_attributes['avatar_url_hash']).to eq(Digest::SHA256.hexdigest(valid_url))
+      expect(WebMock).not_to have_requested(:get, valid_url)
     end
 
     it 'returns early when hash unchanged' do
       avatarable.update(additional_attributes: { 'avatar_url_hash' => Digest::SHA256.hexdigest(valid_url) })
-      expect(Down).not_to receive(:download)
+
+      stub_request(:get, valid_url)
+        .to_return(
+          status: 200,
+          body: File.read(Rails.root.join('spec/assets/avatar.png')),
+          headers: { 'Content-Type' => 'image/png' }
+        )
+
       described_class.perform_now(avatarable, valid_url)
       expect(avatarable.avatar).not_to be_attached
       avatarable.reload
       expect(avatarable.additional_attributes['last_avatar_sync_at']).to be_present
       expect(avatarable.additional_attributes['avatar_url_hash']).to eq(Digest::SHA256.hexdigest(valid_url))
+      expect(WebMock).not_to have_requested(:get, valid_url)
     end
 
     it 'updates sync attributes even when URL is invalid' do
       invalid_url = 'invalid_url'
-      expect(Down).not_to receive(:download)
       described_class.perform_now(avatarable, invalid_url)
       avatarable.reload
       expect(avatarable.avatar).not_to be_attached
@@ -56,17 +81,12 @@ RSpec.describe Avatar::AvatarFromUrlJob do
     end
 
     it 'updates sync attributes when file download is valid but content type is unsupported' do
-      temp_file = Tempfile.new(['invalid', '.xml'])
-      temp_file.write('<invalid>content</invalid>')
-      temp_file.rewind
-
-      uploaded = ActionDispatch::Http::UploadedFile.new(
-        tempfile: temp_file,
-        filename: 'invalid.xml',
-        type: 'application/xml'
-      )
-
-      expect(Down).to receive(:download).with(valid_url, max_size: Avatar::AvatarFromUrlJob::MAX_DOWNLOAD_SIZE).and_return(uploaded)
+      stub_request(:get, valid_url)
+        .to_return(
+          status: 200,
+          body: '<invalid>content</invalid>',
+          headers: { 'Content-Type' => 'application/xml' }
+        )
 
       described_class.perform_now(avatarable, valid_url)
       avatarable.reload
@@ -74,9 +94,19 @@ RSpec.describe Avatar::AvatarFromUrlJob do
       expect(avatarable.avatar).not_to be_attached
       expect(avatarable.additional_attributes['last_avatar_sync_at']).to be_present
       expect(avatarable.additional_attributes['avatar_url_hash']).to eq(Digest::SHA256.hexdigest(valid_url))
+    end
 
-      temp_file.close
-      temp_file.unlink
+    it 'updates sync attributes when the avatar URL is blocked by SSRF protection' do
+      blocked_url = 'http://127.0.0.1/avatar.png'
+
+      expect do
+        described_class.perform_now(avatarable, blocked_url)
+      end.not_to raise_error
+
+      avatarable.reload
+      expect(avatarable.avatar).not_to be_attached
+      expect(avatarable.additional_attributes['last_avatar_sync_at']).to be_present
+      expect(avatarable.additional_attributes['avatar_url_hash']).to eq(Digest::SHA256.hexdigest(blocked_url))
     end
   end
 
@@ -84,7 +114,13 @@ RSpec.describe Avatar::AvatarFromUrlJob do
     let(:avatarable) { create(:agent_bot) }
 
     it 'downloads and attaches avatar' do
-      expect(Down).to receive(:download).with(valid_url, max_size: Avatar::AvatarFromUrlJob::MAX_DOWNLOAD_SIZE).and_return(file)
+      stub_request(:get, valid_url)
+        .to_return(
+          status: 200,
+          body: File.read(Rails.root.join('spec/assets/avatar.png')),
+          headers: { 'Content-Type' => 'image/png' }
+        )
+
       described_class.perform_now(avatarable, valid_url)
       expect(avatarable.avatar).to be_attached
     end
@@ -93,22 +129,30 @@ RSpec.describe Avatar::AvatarFromUrlJob do
   # ref: https://github.com/chatwoot/chatwoot/issues/10449
   it 'does not raise error when downloaded file has no filename (invalid content)' do
     contact = create(:contact)
-    temp_file = Tempfile.new(['invalid', '.xml'])
-    temp_file.write('<invalid>content</invalid>')
-    temp_file.rewind
+    invalid_file = Tempfile.new('avatar-without-name')
 
-    expect(Down).to receive(:download).with(valid_url, max_size: Avatar::AvatarFromUrlJob::MAX_DOWNLOAD_SIZE)
-                                      .and_return(ActionDispatch::Http::UploadedFile.new(tempfile: temp_file, type: 'application/xml'))
+    allow(SafeFetch).to receive(:fetch)
+      .with(
+        valid_url,
+        max_bytes: Avatar::AvatarFromUrlJob::MAX_DOWNLOAD_SIZE,
+        allowed_content_type_prefixes: [],
+        allowed_content_types: %w[image/jpeg image/png image/gif]
+      ).and_yield(
+        SafeFetch::Result.new(
+          tempfile: invalid_file,
+          filename: nil,
+          content_type: 'image/png'
+        )
+      )
 
     expect { described_class.perform_now(contact, valid_url) }.not_to raise_error
-
-    temp_file.close
-    temp_file.unlink
+    expect(contact.reload.avatar).not_to be_attached
+  ensure
+    invalid_file.close!
   end
 
   it 'skips sync attribute updates when URL is nil' do
     contact = create(:contact)
-    expect(Down).not_to receive(:download)
 
     expect { described_class.perform_now(contact, nil) }.not_to raise_error
 

--- a/spec/jobs/avatar/avatar_from_url_job_spec.rb
+++ b/spec/jobs/avatar/avatar_from_url_job_spec.rb
@@ -50,6 +50,24 @@ RSpec.describe Avatar::AvatarFromUrlJob do
       expect(avatarable.additional_attributes['last_avatar_sync_at']).to be_present
     end
 
+    it 'attaches avatars with parameterized content type headers' do
+      parameterized_url = 'https://example.com/avatar-parameterized.png'
+
+      stub_request(:get, parameterized_url)
+        .to_return(
+          status: 200,
+          body: File.read(Rails.root.join('spec/assets/avatar.png')),
+          headers: { 'Content-Type' => 'IMAGE/PNG; charset=binary' }
+        )
+
+      described_class.perform_now(avatarable, parameterized_url)
+      avatarable.reload
+
+      expect(avatarable.avatar).to be_attached
+      expect(avatarable.avatar.blob.content_type).to eq('image/png')
+      expect(avatarable.additional_attributes['avatar_url_hash']).to eq(Digest::SHA256.hexdigest(parameterized_url))
+    end
+
     it 'returns early when rate limited' do
       ts = 30.seconds.ago.iso8601
       avatarable.update(additional_attributes: { 'last_avatar_sync_at' => ts })

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -4,13 +4,17 @@ describe Webhooks::InstagramEventsJob do
   subject(:instagram_webhook) { described_class }
 
   before do
+    allow(Resolv).to receive(:getaddresses).and_call_original
+    allow(Resolv).to receive(:getaddresses).with('www.example.com').and_return(['93.184.216.34'])
+    allow(Resolv).to receive(:getaddresses).with('lookaside.fbsbx.com').and_return(['157.240.22.35'])
+
     stub_request(:post, /graph\.facebook\.com/)
     stub_request(:get, 'https://www.example.com/test.jpeg')
-      .to_return(status: 200, body: '', headers: {})
+      .to_return(status: 200, body: 'image-data', headers: { 'Content-Type' => 'image/jpeg' })
     stub_request(:get, 'https://lookaside.fbsbx.com/ig_messaging_cdn/?asset_id=17949487764033669&signature=test')
-      .to_return(status: 200, body: '', headers: {})
+      .to_return(status: 200, body: 'image-data', headers: { 'Content-Type' => 'image/jpeg' })
     stub_request(:get, 'https://lookaside.fbsbx.com/ig_messaging_cdn/?asset_id=18091626484740369&signature=test')
-      .to_return(status: 200, body: '', headers: {})
+      .to_return(status: 200, body: 'image-data', headers: { 'Content-Type' => 'image/jpeg' })
   end
 
   let!(:account) { create(:account) }

--- a/spec/lib/safe_fetch_spec.rb
+++ b/spec/lib/safe_fetch_spec.rb
@@ -153,14 +153,16 @@ RSpec.describe SafeFetch do
         expect { described_class.fetch(url) { nil } }.not_to raise_error
       end
 
-      it 'strips charset/boundary parameters before comparing' do
+      it 'normalizes parameters and casing before yielding content_type' do
         stub_request(:get, url).to_return(
           status: 200,
           body: 'x',
-          headers: { 'Content-Type' => 'image/png; charset=binary' }
+          headers: { 'Content-Type' => 'IMAGE/PNG; charset=binary' }
         )
 
-        expect { described_class.fetch(url) { nil } }.not_to raise_error
+        described_class.fetch(url) do |result|
+          expect(result.content_type).to eq('image/png')
+        end
       end
 
       it 'allows exact content-type matches when prefixes are empty' do

--- a/spec/lib/safe_fetch_spec.rb
+++ b/spec/lib/safe_fetch_spec.rb
@@ -163,6 +163,39 @@ RSpec.describe SafeFetch do
         expect { described_class.fetch(url) { nil } }.not_to raise_error
       end
 
+      it 'allows exact content-type matches when prefixes are empty' do
+        pdf_url = 'http://example.com/file.pdf'
+        stub_request(:get, pdf_url).to_return(
+          status: 200,
+          body: 'pdf-data',
+          headers: { 'Content-Type' => 'application/pdf' }
+        )
+
+        expect do
+          described_class.fetch(
+            pdf_url,
+            allowed_content_type_prefixes: [],
+            allowed_content_types: ['application/pdf']
+          ) { nil }
+        end.not_to raise_error
+      end
+
+      it 'rejects exact content-type mismatches when prefixes are empty' do
+        stub_request(:get, url).to_return(
+          status: 200,
+          body: 'x',
+          headers: { 'Content-Type' => 'image/webp' }
+        )
+
+        expect do
+          described_class.fetch(
+            url,
+            allowed_content_type_prefixes: [],
+            allowed_content_types: ['image/png']
+          ) { nil }
+        end.to raise_error(described_class::UnsupportedContentTypeError)
+      end
+
       it 'rejects when the content-type header is missing' do
         stub_request(:get, url).to_return(status: 200, body: 'x', headers: {})
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe Contact do
 
   describe 'concerns' do
     it_behaves_like 'avatarable'
+
+    it 'accepts webp avatars' do
+      contact = build(:contact, account: create(:account))
+      contact.avatar.attach(get_blob_for(Rails.root.join('spec/assets/avatar.png'), 'image/webp'))
+
+      expect(contact).to be_valid
+    end
   end
 
   context 'when prepare contact attributes before validation' do


### PR DESCRIPTION
# Pull Request Template

## Description

This routes external downloads used by instagram and messenger attachment fetch through SafeFetch. It closes the SSRF exposure from raw Down.download paths, preserves provider-specific auth and header flows, and adds regression coverage for blocked internal URLs plus authenticated downloads.

Fixes # (issue): [CW-6931](https://linear.app/chatwoot/issue/CW-6931/avatarwidget-url-ssrf-downdownload-unprotected-unauth)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Updated and ran the changed spec bundle covering:
* spec/builders/messages/facebook/message_builder_spec.rb
* spec/builders/messages/instagram/message_builder_spec.rb
* spec/builders/messages/instagram/messenger/message_builder_spec.rb



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
