### PR TITLE
chore: Add validations for Dialogflow credentials (#2383)

### DIFF
--- a/app/models/integrations/hook.rb
+++ b/app/models/integrations/hook.rb
@@ -29,6 +29,7 @@ class Integrations::Hook < ApplicationRecord
   validates :inbox_id, presence: true, if: -> { hook_type == 'inbox' }
   validate :validate_settings_json_schema
   validate :ensure_feature_enabled
+  validate :validate_dialogflow_credentials, if: :dialogflow?
   validates :app_id, uniqueness: { scope: [:account_id], unless: -> { app.present? && app.params[:allow_multiple_hooks].present? } }
 
   # TODO: This seems to be only used for slack at the moment
@@ -93,6 +94,35 @@ class Integrations::Hook < ApplicationRecord
     return if app.blank? || app.params[:settings_json_schema].blank?
 
     errors.add(:settings, ': Invalid settings data') unless JSONSchemer.schema(app.params[:settings_json_schema]).valid?(settings)
+  end
+
+  def validate_dialogflow_credentials
+    return if settings.blank?
+
+    credentials = settings['credentials']
+    project_id = settings['project_id']
+
+    errors.add(:settings, ': project_id is required') if project_id.blank?
+
+    if credentials.blank? || !credentials.is_a?(Hash)
+      errors.add(:settings, ': credentials are required')
+      return
+    end
+
+    validate_service_account_credentials(credentials)
+  end
+
+  def validate_service_account_credentials(credentials)
+    required_keys = %w[type project_id private_key client_email]
+    missing_keys = required_keys.reject { |key| credentials[key].present? || credentials[key.to_sym].present? }
+
+    if missing_keys.any?
+      errors.add(:settings, ": credentials missing required fields: #{missing_keys.join(', ')}")
+      return
+    end
+
+    type = credentials['type'] || credentials[:type]
+    errors.add(:settings, ': credentials type must be "service_account"') if type != 'service_account'
   end
 
   def trigger_setup_if_crm

--- a/spec/models/integrations/hook_spec.rb
+++ b/spec/models/integrations/hook_spec.rb
@@ -41,8 +41,13 @@ RSpec.describe Integrations::Hook do
              app_id: 'dialogflow',
              inbox: inbox,
              settings: {
-               project_id: 'test-project',
-               credentials: { type: 'service_account' }
+               'project_id' => 'test-project',
+               'credentials' => {
+                 'type' => 'service_account',
+                 'project_id' => 'test-project',
+                 'private_key' => 'fake-key',
+                 'client_email' => 'test@test-project.iam.gserviceaccount.com'
+               }
              })
     end
 
@@ -108,6 +113,94 @@ RSpec.describe Integrations::Hook do
       it 'does not enqueue setup job' do
         create(:integrations_hook, account: account, app_id: 'slack')
         expect(Crm::SetupJob).not_to have_received(:perform_later)
+      end
+    end
+  end
+
+  describe 'Dialogflow credentials validation' do
+    let(:account) { create(:account) }
+    let(:inbox) { create(:inbox, account: account) }
+    let(:valid_credentials) do
+      {
+        'type' => 'service_account',
+        'project_id' => 'test-project',
+        'private_key' => '-----BEGIN PRIVATE KEY-----
+fake
+-----END PRIVATE KEY-----',
+        'client_email' => 'test@test-project.iam.gserviceaccount.com'
+      }
+    end
+
+    context 'when credentials are valid' do
+      it 'is valid with a complete service account key' do
+        hook = build(:integrations_hook,
+                     account: account,
+                     inbox: inbox,
+                     app_id: 'dialogflow',
+                     settings: { 'project_id' => 'test-project', 'credentials' => valid_credentials })
+        expect(hook).to be_valid
+      end
+    end
+
+    context 'when project_id is missing' do
+      it 'is invalid' do
+        hook = build(:integrations_hook,
+                     account: account,
+                     inbox: inbox,
+                     app_id: 'dialogflow',
+                     settings: { 'credentials' => valid_credentials })
+        expect(hook).not_to be_valid
+        expect(hook.errors[:settings].join).to include('project_id is required')
+      end
+    end
+
+    context 'when credentials are missing' do
+      it 'is invalid' do
+        hook = build(:integrations_hook,
+                     account: account,
+                     inbox: inbox,
+                     app_id: 'dialogflow',
+                     settings: { 'project_id' => 'test-project' })
+        expect(hook).not_to be_valid
+        expect(hook.errors[:settings].join).to include('credentials are required')
+      end
+    end
+
+    context 'when credentials hash is missing required fields' do
+      it 'is invalid and lists missing fields' do
+        hook = build(:integrations_hook,
+                     account: account,
+                     inbox: inbox,
+                     app_id: 'dialogflow',
+                     settings: {
+                       'project_id' => 'test-project',
+                       'credentials' => { 'type' => 'service_account' }
+                     })
+        expect(hook).not_to be_valid
+        expect(hook.errors[:settings].join).to include('missing required fields')
+      end
+    end
+
+    context 'when credentials type is not service_account' do
+      it 'is invalid' do
+        bad_credentials = valid_credentials.merge('type' => 'user_account')
+        hook = build(:integrations_hook,
+                     account: account,
+                     inbox: inbox,
+                     app_id: 'dialogflow',
+                     settings: { 'project_id' => 'test-project', 'credentials' => bad_credentials })
+        expect(hook).not_to be_valid
+        expect(hook.errors[:settings].join).to include('type must be "service_account"')
+      end
+    end
+
+    context 'when app is not dialogflow' do
+      it 'does not run dialogflow validation' do
+        hook = build(:integrations_hook,
+                     account: account,
+                     app_id: 'slack',
+                     settings: { 'test' => 'test' })
+        expect(hook).to be_valid
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes #2383

This PR adds save-time validation for Dialogflow integration credentials on the `Integrations::Hook` model. Previously, invalid or malformed Google service account credentials could be saved silently and only surface as runtime errors when the bot tried to respond to a message.

## Investigation

Before writing the fix, I traced through the Dialogflow integration to understand the failure surface:

- `app/models/integrations/hook.rb` stored `settings['credentials']` (a JSON service-account key) and `settings['project_id']` with no structural validation beyond the generic `validate_settings_json_schema` callback.
- `lib/integrations/dialogflow/processor_service.rb` already handles runtime auth failures gracefully — it rescues `Google::Cloud::PermissionDeniedError`, calls `hook.prompt_reauthorization!`, and disables the hook. That side of the issue is already solved.
- What was missing is the **save-time** validation the issue title asks for: rejecting malformed credentials before they enter the database.

I deliberately kept the PR scope to this single concern rather than also touching the runtime path.

## Changes

**`app/models/integrations/hook.rb`**
- Add a conditional validator `validate_dialogflow_credentials, if: :dialogflow?` so the validation runs only for Dialogflow hooks and never affects other integrations (Slack, Leadsquared, etc.)
- New private method `validate_dialogflow_credentials` checks:
  - `settings['project_id']` is present
  - `settings['credentials']` is a non-empty Hash
- New private method `validate_service_account_credentials` checks:
  - Required Google service account fields are present: `type`, `project_id`, `private_key`, `client_email`
  - `credentials['type']` equals `'service_account'`
- Validator accepts both string and symbol keys in the credentials hash, matching how `jsonb` settings can be set in tests and runtime.

**`spec/models/integrations/hook_spec.rb`**
- Add a new `describe 'Dialogflow credentials validation'` block with 6 cases:
  - Valid complete service account key → passes
  - Missing `project_id` → invalid
  - Missing `credentials` → invalid
  - Credentials hash missing required fields → invalid, with error listing which fields
  - Credentials `type` is not `service_account` → invalid
  - Non-Dialogflow apps (e.g. Slack) are unaffected by the new validation
- Updated the existing `scopes` test setup to use a valid credentials payload so it passes the new validator (previously passed a minimal `{ type: 'service_account' }` hash).

## Testing