### PR TITLE
feat: add contact_deleted webhook event listener

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -56,6 +56,7 @@
             "WEBWIDGET_TRIGGERED": "Live chat widget opened by the user",
             "CONTACT_CREATED": "Contact created",
             "CONTACT_UPDATED": "Contact updated",
+            "CONTACT_DELETED": "Contact deleted",
             "CONVERSATION_TYPING_ON": "Conversation Typing On",
             "CONVERSATION_TYPING_OFF": "Conversation Typing Off"
           }

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
@@ -18,6 +18,7 @@ const SUPPORTED_WEBHOOK_EVENTS = [
   'webwidget_triggered',
   'contact_created',
   'contact_updated',
+  'contact_deleted',
   'conversation_typing_on',
   'conversation_typing_off',
 ];

--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -66,6 +66,15 @@ class WebhookListener < BaseListener
     deliver_account_webhooks(payload, account)
   end
 
+def contact_deleted(event)
+  contact_data = event.data[:contact_data]
+  account = Account.find_by(id: contact_data[:account_id])
+  return unless account
+
+  payload = contact_data.merge(event: __method__.to_s)
+  deliver_account_webhooks(payload, account)
+end
+
   def inbox_created(event)
     inbox, account = extract_inbox_and_account(event)
     inbox_webhook_data = Inbox::EventDataPresenter.new(inbox).push_data

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -30,9 +30,8 @@ class Webhook < ApplicationRecord
   enum webhook_type: { account_type: 0, inbox_type: 1 }
 
   ALLOWED_WEBHOOK_EVENTS = %w[conversation_status_changed conversation_updated conversation_created contact_created contact_updated
-                              message_created message_updated webwidget_triggered inbox_created inbox_updated
-                              conversation_typing_on conversation_typing_off].freeze
-
+                            contact_deleted message_created message_updated webwidget_triggered inbox_created inbox_updated
+                            conversation_typing_on conversation_typing_off].freeze
   private
 
   def validate_webhook_subscriptions

--- a/spec/listeners/webhook_listener_spec.rb
+++ b/spec/listeners/webhook_listener_spec.rb
@@ -236,7 +236,29 @@ describe WebhookListener do
       end
     end
   end
+describe '#contact_deleted' do
+  let(:event_name) { :'contact.deleted' }
+  let(:contact_data) { contact.webhook_data.merge(account_id: account.id) }
+  let!(:contact_deleted_event) { Events::Base.new(event_name, Time.zone.now, contact_data: contact_data) }
 
+  context 'when webhook is not configured' do
+    it 'does not trigger webhook' do
+      expect(WebhookJob).to receive(:perform_later).exactly(0).times
+      listener.contact_deleted(contact_deleted_event)
+    end
+  end
+
+  context 'when webhook is configured' do
+    it 'triggers webhook' do
+      webhook = create(:webhook, account: account)
+      expect(WebhookJob).to receive(:perform_later).with(
+        webhook.url, contact_data.merge(event: 'contact_deleted'), :account_webhook,
+        secret: webhook.secret, delivery_id: instance_of(String)
+      ).once
+      listener.contact_deleted(contact_deleted_event)
+    end
+  end
+end
   describe '#inbox_created' do
     let(:event_name) { :'inbox.created' }
     let!(:inbox_created_event) { Events::Base.new(event_name, Time.zone.now, inbox: inbox) }


### PR DESCRIPTION
## Summary
Closes #9552

When a contact is deleted, integrators using webhooks had no way to 
sync that deletion downstream. The event type `CONTACT_DELETED` was 
already registered in `lib/events/types.rb` and the Contact model was 
already dispatching the event via `dispatch_destroy_event` — but the 
WebhookListener had no handler for it.

## Changes
- Added `contact_deleted` method to `WebhookListener`
- Uses `contact_data` hash from the event (not the AR object) since 
  the contact is already deleted from the DB when the event fires
- Added test coverage for both configured and unconfigured webhook scenarios

## Testing
- Added specs to `spec/listeners/webhook_listener_spec.rb` mirroring 
  the existing `contact_created` test pattern