### PR TITLE
fix: validate that labels exist in account before applying to conversation

### DIFF
--- a/app/controllers/concerns/label_concern.rb
+++ b/app/controllers/concerns/label_concern.rb
@@ -1,6 +1,18 @@
 module LabelConcern
   def create
-    model.update_labels(permitted_params[:labels])
+    labels = Array(permitted_params[:labels]).map { |l| l.to_s.downcase }.uniq
+
+    if labels.any?
+      valid_titles = Current.account.labels.where(title: labels).pluck(:title)
+      invalid_labels = labels - valid_titles
+
+      if invalid_labels.any?
+        render_could_not_create_error("Invalid labels: #{invalid_labels.join(', ')}. Labels must exist in the account.")
+        return
+      end
+    end
+
+    model.update_labels(labels)
     @labels = model.label_list
   end
 

--- a/spec/controllers/api/v1/accounts/conversations/labels_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/labels_controller_spec.rb
@@ -57,6 +57,8 @@ RSpec.describe 'Conversation Label API', type: :request do
       let(:agent) { create(:user, account: account, role: :agent) }
 
       before do
+        create(:label, account: account, title: 'label3')
+        create(:label, account: account, title: 'label4')
         conversation.update_labels('label1, label2')
         create(:inbox_member, inbox: conversation.inbox, user: agent)
       end
@@ -70,6 +72,16 @@ RSpec.describe 'Conversation Label API', type: :request do
         expect(response).to have_http_status(:success)
         expect(response.body).to include('label3')
         expect(response.body).to include('label4')
+      end
+
+      it 'returns unprocessable entity when non-existent labels are provided' do
+        post api_v1_account_conversation_labels_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { labels: %w[nonexistent_label] },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include('nonexistent_label')
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes #13918

The `POST /api/v1/accounts/:account_id/conversations/:conversation_id/labels` endpoint accepted arbitrary label strings and applied them to the conversation without verifying that those labels actually exist in the account. This allowed callers to silently attach invented label names, resulting in label_list values that have no corresponding `Label` record in the database.

## Root Cause

```ruby
# app/controllers/concerns/label_concern.rb (before)
module LabelConcern
  def create
    model.update_labels(permitted_params[:labels])  # no validation!
    @labels = model.label_list
  end
end
```

`update_labels` delegates directly to the `acts-as-taggable-on` gem which accepts any string. There was no guard ensuring the provided labels map to real `Label` records for the account.

## Fix

Validate the requested labels against the account's label titles before applying them. Any label not found in `Current.account.labels` is rejected with a `422 Unprocessable Entity` response that names the offending value(s):

```ruby
module LabelConcern
  def create
    labels = permitted_params[:labels].to_a.map { |l| l.to_s.downcase }

    if labels.any?
      valid_titles = Current.account.labels.where(title: labels).pluck(:title)
      invalid_labels = labels - valid_titles

      if invalid_labels.any?
        render_could_not_create_error("Invalid labels: #{invalid_labels.join(', ')}. Labels must exist in the account.")
        return
      end
    end

    model.update_labels(labels)
    @labels = model.label_list
  end
end
```

The incoming labels are also normalised to lower-case to match the `Label` model's `before_validation` downcasing callback, ensuring consistent comparison.

## Testing

- Updated the existing "creates labels for the conversation" spec to first create matching `Label` records (`label3`, `label4`) in the account before posting them.
- Added a new spec: **"returns unprocessable entity when non-existent labels are provided"** — posts `nonexistent_label` and expects a `422` response that includes the offending label name in the error body.

## Before / After

| Request | Before | After |
|---|---|---|
| POST with valid account labels | 200 ✅ | 200 ✅ |
| POST with non-existent labels | 200 (silent data corruption) ❌ | 422 with error message ✅ |
| POST with empty labels array | 200 (clears labels) ✅ | 200 (clears labels) ✅ |
