### PR TITLE
chore: remove unused session key from cookie store

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_chatwoot_session', same_site: :lax
+Rails.application.config.session_store :cookie_store, same_site: :lax


### PR DESCRIPTION
## Summary

Removes the explicit `_chatwoot_session` key from the session store configuration, as it is no longer required.

## Changes Made

- Removed custom session cookie key
- Preserved existing `same_site: :lax` configuration

## Notes

This is a small cleanup change related to issue #2683.