### PR TITLE
fix: use correct company_name key in contact CSV import

### DIFF
--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -61,7 +61,7 @@ class DataImport::ContactManager
   def update_contact_attributes(params, contact)
     contact.name = params[:name] if params[:name].present?
     contact.additional_attributes ||= {}
-    contact.additional_attributes[:company] = params[:company] if params[:company].present?
+    contact.additional_attributes[:company_name] = params[:company] if params[:company].present?
     contact.additional_attributes[:city] = params[:city] if params[:city].present?
     contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number)))
   end

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DataImportJob do
         expect(data_import.reload.processed_records).to eq(csv_length)
         contact = Contact.find_by(phone_number: '+918080808080')
         expect(contact).to be_truthy
-        expect(contact['additional_attributes']['company']).to eq('My Company Name')
+        expect(contact['additional_attributes']['company_name']).to eq('My Company Name')
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe DataImportJob do
           expect(contact).to be_present
           expect(contact.phone_number).to eq("+#{csv_data[0]['phone_number']}")
           expect(contact.name).to eq((csv_data[0]['name']).to_s)
-          expect(contact.additional_attributes['company']).to eq((csv_data[0]['company']).to_s)
+          expect(contact.additional_attributes['company_name']).to eq((csv_data[0]['company']).to_s)
         end
       end
 
@@ -149,7 +149,7 @@ RSpec.describe DataImportJob do
           expect(contact).to be_present
           expect(contact.email).to eq(csv_data[0]['email'])
           expect(contact.name).to eq((csv_data[0]['name']).to_s)
-          expect(contact.additional_attributes['company']).to eq((csv_data[0]['company']).to_s)
+          expect(contact.additional_attributes['company_name']).to eq((csv_data[0]['company']).to_s)
         end
       end
 


### PR DESCRIPTION
Contact CSV import stores company data under `additional_attributes[:company]`, but the entire codebase (Contact model scopes, Vue frontend components, Enterprise services, Slack integration) uses `additional_attributes[:company_name]`. This means imported company data never appears in the UI.

**What changed:** Changed the key from `:company` to `:company_name` in `DataImport::ContactManager#update_contact_attributes`. The CSV column header remains `company` (the read is correct), only the storage key is fixed.

**How to reproduce:** Import a contacts CSV with a `company` column. View the imported contact — the company field will be empty in the UI. Check `additional_attributes` in the DB and you'll see `company` instead of `company_name`.

Closes #14096