### PR TITLE
fix: validate labels exist before assigning via API

### DIFF
--- a/app/controllers/concerns/label_concern.rb
+++ b/app/controllers/concerns/label_concern.rb
@@ -1,6 +1,15 @@
 module LabelConcern
   def create
-    model.update_labels(permitted_params[:labels])
+    requested_labels = permitted_params[:labels]
+    if requested_labels.present?
+      existing_label_titles = model.account.labels.where(title: requested_labels.map(&:downcase)).pluck(:title)
+      invalid_labels = requested_labels.reject { |label| existing_label_titles.include?(label.downcase) }
+      if invalid_labels.present?
+        render_could_not_create_error("Labels do not exist: #{invalid_labels.join(', ')}")
+        return
+      end
+    end
+    model.update_labels(requested_labels)
     @labels = model.label_list
   end
 

--- a/app/controllers/concerns/label_concern.rb
+++ b/app/controllers/concerns/label_concern.rb
@@ -2,8 +2,9 @@ module LabelConcern
   def create
     requested_labels = permitted_params[:labels]
     if requested_labels.present?
-      existing_label_titles = model.account.labels.where(title: requested_labels.map(&:downcase)).pluck(:title)
-      invalid_labels = requested_labels.reject { |label| existing_label_titles.include?(label.downcase) }
+      valid_labels = requested_labels.select { |label| label.is_a?(String) && label.present? }
+      existing_label_titles = model.account.labels.where(title: valid_labels.map(&:downcase)).pluck(:title)
+      invalid_labels = valid_labels.reject { |label| existing_label_titles.include?(label.downcase) }
       if invalid_labels.present?
         render_could_not_create_error("Labels do not exist: #{invalid_labels.join(', ')}")
         return

--- a/spec/controllers/api/v1/accounts/contacts/labels_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/labels_controller_spec.rb
@@ -52,7 +52,10 @@ RSpec.describe 'Contact Label API', type: :request do
     context 'when it is an authenticated user' do
       let(:agent) { create(:user, account: account, role: :agent) }
 
-      it 'creates labels for the contact' do
+      it 'creates labels for the contact when labels exist' do
+        create(:label, title: 'label3', account: account)
+        create(:label, title: 'label4', account: account)
+
         post api_v1_account_contact_labels_url(account_id: account.id, contact_id: contact.id),
              params: { labels: %w[label3 label4] },
              headers: agent.create_new_auth_token,
@@ -61,6 +64,16 @@ RSpec.describe 'Contact Label API', type: :request do
         expect(response).to have_http_status(:success)
         expect(response.body).to include('label3')
         expect(response.body).to include('label4')
+      end
+
+      it 'returns error when assigning non-existent labels' do
+        post api_v1_account_contact_labels_url(account_id: account.id, contact_id: contact.id),
+             params: { labels: %w[nonexistent_label] },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include('Labels do not exist')
       end
     end
   end

--- a/spec/controllers/api/v1/accounts/conversations/labels_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/labels_controller_spec.rb
@@ -61,7 +61,10 @@ RSpec.describe 'Conversation Label API', type: :request do
         create(:inbox_member, inbox: conversation.inbox, user: agent)
       end
 
-      it 'creates labels for the conversation' do
+      it 'creates labels for the conversation when labels exist' do
+        create(:label, title: 'label3', account: account)
+        create(:label, title: 'label4', account: account)
+
         post api_v1_account_conversation_labels_url(account_id: account.id, conversation_id: conversation.display_id),
              params: { labels: %w[label3 label4] },
              headers: agent.create_new_auth_token,
@@ -70,6 +73,29 @@ RSpec.describe 'Conversation Label API', type: :request do
         expect(response).to have_http_status(:success)
         expect(response.body).to include('label3')
         expect(response.body).to include('label4')
+      end
+
+      it 'returns error when assigning non-existent labels' do
+        post api_v1_account_conversation_labels_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { labels: %w[nonexistent_label] },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include('Labels do not exist')
+        expect(response.body).to include('nonexistent_label')
+      end
+
+      it 'returns error when some labels do not exist' do
+        create(:label, title: 'existing_label', account: account)
+
+        post api_v1_account_conversation_labels_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { labels: %w[existing_label nonexistent_label] },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include('nonexistent_label')
       end
     end
   end


### PR DESCRIPTION
The labels API endpoint (`POST /api/v1/accounts/{id}/conversations/{id}/labels`) accepts arbitrary label strings without checking if they exist in the account's labels table. The `acts_as_taggable_on` gem auto-creates tags for any string, so invalid labels silently persist as data integrity bugs.

**What changed:** Added validation in `LabelConcern#create` that checks each requested label against the account's `Label` records (case-insensitive). Returns 422 with `"Labels do not exist: <list>"` when invalid labels are provided. Follows the same pattern already used in the widget messages controller.

**How to reproduce:** Create a conversation, then POST labels `["nonexistent-label"]` to the labels endpoint. Before this fix, the label gets created silently. After, you get a 422 error.

Closes #13918