### PR TITLE
fix: Destroy orphaned articles and categories when a portal locale is removed

### DIFF
--- a/app/controllers/public/api/v1/portals/articles_controller.rb
+++ b/app/controllers/public/api/v1/portals/articles_controller.rb
@@ -8,14 +8,20 @@ class Public::Api::V1::Portals::ArticlesController < Public::Api::V1::Portals::B
 
   def index
     @search_query = list_params[:query]
-    @articles = @portal.articles.published.where(locale: @portal.allowed_locale_codes).includes(:category, :author)
 
-    @articles = @articles.where(locale: permitted_params[:locale]) if permitted_params[:locale].present?
+    base_scope = @portal.articles.published
+                        .where(locale: @portal.allowed_locale_codes)
+                        .includes(:category, :author)
 
-    @articles_count = @articles.count
+    base_scope = base_scope.where(locale: permitted_params[:locale]) if permitted_params[:locale].present?
+
+    @articles = base_scope
 
     search_articles
     order_by_sort_param
+
+    @articles_count = @articles.count
+
     limit_results
   end
 

--- a/app/controllers/public/api/v1/portals/articles_controller.rb
+++ b/app/controllers/public/api/v1/portals/articles_controller.rb
@@ -8,7 +8,7 @@ class Public::Api::V1::Portals::ArticlesController < Public::Api::V1::Portals::B
 
   def index
     @search_query = list_params[:query]
-    @articles = @portal.articles.published.includes(:category, :author)
+    @articles = @portal.articles.published.where(locale: @portal.allowed_locale_codes).includes(:category, :author)
 
     @articles = @articles.where(locale: permitted_params[:locale]) if permitted_params[:locale].present?
 
@@ -62,6 +62,8 @@ class Public::Api::V1::Portals::ArticlesController < Public::Api::V1::Portals::B
 
   def set_article
     @article = @portal.articles.find_by(slug: permitted_params[:article_slug])
+    render_404 and return if @article.blank? || @portal.allowed_locale_codes.exclude?(@article.locale)
+
     @parsed_content = render_article_content(@article.content.to_s)
   end
 

--- a/app/models/portal.rb
+++ b/app/models/portal.rb
@@ -38,6 +38,7 @@ class Portal < ApplicationRecord
   belongs_to :channel_web_widget, class_name: 'Channel::WebWidget', optional: true
 
   before_validation -> { normalize_empty_string_to_nil(%i[custom_domain homepage_link]) }
+  before_update :destroy_articles_and_categories_for_removed_locales
   validates :account_id, presence: true
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true
@@ -128,6 +129,17 @@ class Portal < ApplicationRecord
     return unless config.is_a?(Hash)
 
     config[key] || config[key.to_sym]
+  end
+
+  def destroy_articles_and_categories_for_removed_locales
+    previous_locales = normalize_locale_codes(persisted_config['allowed_locales'])
+    current_locales = allowed_locale_codes
+    removed_locales = previous_locales - current_locales
+
+    return if removed_locales.empty?
+
+    articles.where(locale: removed_locales).destroy_all
+    categories.where(locale: removed_locales).destroy_all
   end
 end
 

--- a/app/views/public/api/v1/portals/sitemap.xml.erb
+++ b/app/views/public/api/v1/portals/sitemap.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <% @portal.articles.where(status: :published).each do |article| %>
+  <% @portal.articles.where(status: :published, locale: @portal.allowed_locale_codes).each do |article| %>
     <url>
       <loc><%= @help_center_url %><%= generate_article_link(@portal.slug, article.slug, false, false) %></loc>
       <lastmod><%= article.updated_at.to_date.iso8601 %></lastmod>

--- a/spec/controllers/public/api/v1/portals/articles_controller_spec.rb
+++ b/spec/controllers/public/api/v1/portals/articles_controller_spec.rb
@@ -142,6 +142,45 @@ RSpec.describe 'Public Articles API', type: :request do
     end
   end
 
+  describe 'GET /public/api/v1/portals/:slug/articles (orphaned locale filtering)' do
+    it 'excludes articles from removed locales in index' do
+      orphaned_portal = create(:portal, slug: 'orphan-idx', custom_domain: 'www.orphan-idx.com',
+                                        config: { allowed_locales: %w[en fr] }, account_id: account.id)
+
+      en_cat = create(:category, portal: orphaned_portal, account_id: account.id, locale: 'en', slug: 'oidx-en')
+      fr_cat = create(:category, portal: orphaned_portal, account_id: account.id, locale: 'fr', slug: 'oidx-fr')
+
+      create(:article, category: en_cat, portal: orphaned_portal, account_id: account.id, author_id: agent.id)
+      create(:article, category: fr_cat, portal: orphaned_portal, account_id: account.id, author_id: agent.id)
+
+      # Verify both articles exist before locale removal
+      expect(orphaned_portal.articles.count).to eq(2)
+
+      # Remove fr locale — before_update callback destroys fr articles, controller also filters
+      orphaned_portal.update!(config: { allowed_locales: %w[en], default_locale: 'en' })
+
+      # Verify the callback destroyed the fr article
+      expect(orphaned_portal.articles.reload.count).to eq(1)
+      expect(orphaned_portal.articles.pluck(:locale)).to eq(['en'])
+    end
+
+    it 'returns 404 for direct access to an article with a removed locale' do
+      orphaned_portal = create(:portal, slug: 'orphan-show', custom_domain: 'www.orphan-show.com',
+                                        config: { allowed_locales: %w[en fr] }, account_id: account.id)
+
+      fr_cat = create(:category, portal: orphaned_portal, account_id: account.id, locale: 'fr', slug: 'oshow-fr')
+      orphaned_article = create(:article, portal: orphaned_portal, category: fr_cat, account_id: account.id, author_id: agent.id)
+      article_slug = orphaned_article.slug
+
+      # Remove fr locale — callback destroys the article, but controller also guards with 404
+      orphaned_portal.update!(config: { allowed_locales: %w[en], default_locale: 'en' })
+
+      get "/hc/#{orphaned_portal.slug}/articles/#{article_slug}"
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe 'GET /public/api/v1/portals/:slug/articles/:slug.png (tracking pixel)' do
     it 'serves a PNG image and increments view count for published article' do
       get "/hc/#{portal.slug}/articles/#{article.slug}.png"

--- a/spec/controllers/public/api/v1/portals_controller_spec.rb
+++ b/spec/controllers/public/api/v1/portals_controller_spec.rb
@@ -138,6 +138,64 @@ RSpec.describe Public::Api::V1::PortalsController, type: :request do
           match(%r{\Ahttps://www\.example\.com/hc/#{Regexp.escape(portal.slug)}/articles/\d+})
         )
       end
+
+      it 'excludes articles from removed locales in the sitemap' do
+        sitemap_portal = create(
+          :portal,
+          slug: 'sitemap-test',
+          config: { allowed_locales: %w[en fr] },
+          custom_domain: 'www.sitemap-test.com',
+          account_id: account.id
+        )
+
+        # Create categories
+        en_cat = create(
+          :category,
+          portal: sitemap_portal,
+          account_id: account.id,
+          locale: 'en',
+          slug: 'sitemap-en'
+        )
+
+        fr_cat = create(
+          :category,
+          portal: sitemap_portal,
+          account_id: account.id,
+          locale: 'fr',
+          slug: 'sitemap-fr'
+        )
+
+        # Create articles
+        en_article = create(
+          :article,
+          portal: sitemap_portal,
+          category: en_cat,
+          account_id: account.id,
+          author_id: agent.id
+        )
+
+        fr_article = create(
+          :article,
+          portal: sitemap_portal,
+          category: fr_cat,
+          account_id: account.id,
+          author_id: agent.id
+        )
+
+        # Simulate removing the 'fr' locale
+        sitemap_portal.update!(config: { allowed_locales: %w[en] })
+
+        # Call sitemap endpoint
+        get "/hc/#{sitemap_portal.slug}/sitemap.xml"
+        expect(response).to have_http_status(:success)
+
+        # Validate only allowed locale content is present
+        expect(response.body).to include(en_article.slug)
+        expect(response.body).not_to include(fr_article.slug)
+
+        # (Optional stronger assertion)
+        expect(response.body.scan('<url>').count).to eq(1)
+      end
     end
   end
 end

--- a/spec/models/portal_spec.rb
+++ b/spec/models/portal_spec.rb
@@ -62,4 +62,40 @@ RSpec.describe Portal do
       end
     end
   end
+
+  describe '#destroy_articles_and_categories_for_removed_locales' do
+    let!(:account) { create(:account) }
+    let!(:portal) { create(:portal, account_id: account.id, config: { allowed_locales: %w[en fr], default_locale: 'en' }) }
+    let(:agent) { create(:user, account: account, role: :agent) }
+    let!(:en_category) { create(:category, portal: portal, account_id: account.id, locale: 'en', slug: 'en-cat') }
+    let!(:fr_category) { create(:category, portal: portal, account_id: account.id, locale: 'fr', slug: 'fr-cat') }
+
+    before do
+      create(:article, portal: portal, category: en_category, account_id: account.id, author_id: agent.id)
+      create(:article, portal: portal, category: fr_category, account_id: account.id, author_id: agent.id)
+    end
+
+    it 'destroys articles and categories when a locale is removed' do
+      portal.update!(config: { allowed_locales: %w[en], default_locale: 'en' })
+
+      expect(portal.articles.where(locale: 'fr')).to be_empty
+      expect(portal.categories.where(locale: 'fr')).to be_empty
+      expect(portal.articles.where(locale: 'en').count).to eq(1)
+      expect(portal.categories.where(locale: 'en').count).to eq(1)
+    end
+
+    it 'does not destroy anything when locales are unchanged' do
+      portal.update!(config: { allowed_locales: %w[en fr], default_locale: 'en' })
+
+      expect(portal.articles.count).to eq(2)
+      expect(portal.categories.count).to eq(2)
+    end
+
+    it 'does not destroy anything when a new locale is added' do
+      portal.update!(config: { allowed_locales: %w[en fr es], default_locale: 'en' })
+
+      expect(portal.articles.count).to eq(2)
+      expect(portal.categories.count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Removing a locale from a portal's allowed_locales leaves behind orphaned articles and categories. These orphaned records continue to be served publicly via direct URL access and appear in sitemap.xml, even though the admin can no longer see or manage them.

Closes #13625

## Bug reproduction

**Setup:** A Help Center portal with two locales (`en` and `fr`), with articles created under the `fr` locale.

**Step 1 — Articles exist in the French locale:**

<!-- 📸 Screenshot: Help Center admin showing French articles -->
<img width="1124" height="381" alt="Screenshot 2026-04-24 at 22 27 52" src="https://github.com/user-attachments/assets/2857d487-da02-447e-98f3-4e4931339a63" />

**Step 2 — Remove the French locale from portal settings:**
<img width="1206" height="430" alt="Screenshot 2026-04-24 at 22 28 21" src="https://github.com/user-attachments/assets/59a734d3-84f1-4f81-801d-271b052d1279" />

<!-- 📸 Screenshot: Portal settings showing locale removal -->
<img width="1063" height="293" alt="Screenshot 2026-04-24 at 22 31 26" src="https://github.com/user-attachments/assets/07bced40-3006-44f9-9a7b-c051061b37ce" />

**Step 3 — Articles vanish from admin with no way to manage or delete them:**

<!-- 📸 Screenshot: Help Center admin with French articles no longer visible -->
<img width="1142" height="571" alt="Screenshot 2026-04-24 at 22 35 09" src="https://github.com/user-attachments/assets/ce2af97a-eb7c-41b5-8656-a5405b7d52c2" />


**Step 4 — Sitemap still exposes orphaned articles:**

<!-- 📸 Screenshot: sitemap.xml still listing the French article URLs -->
<img width="726" height="319" alt="Screenshot 2026-04-24 at 22 30 25" src="https://github.com/user-attachments/assets/8bc85230-5518-4a6b-97b4-2ee00b7e7e23" />


The orphaned `fr` articles remain in the database and continue to appear in `sitemap.xml` at `/hc/<slug>/sitemap.xml`, even though the locale has been removed.

**Step 5 — Direct URL access still serves the orphaned article:**

<!-- 📸 Screenshot: Browser showing orphaned French article still loads successfully -->
<img width="1021" height="605" alt="Screenshot 2026-04-24 at 22 30 41" src="https://github.com/user-attachments/assets/6a1c734d-aab2-4d52-8b98-37157513a5dc" />


Visiting the article URL directly still returns a 200 response with full content. The admin has no way to discover or clean up these orphaned records.

## After fix

After applying this change, removing a locale from a portal immediately cleans up all associated data and prevents any orphaned content from being exposed. Articles and categories belonging to removed locales are deleted during the update, ensuring the database remains consistent with the portal configuration. Additionally, sitemap generation and public API endpoints now strictly respect the portal’s active locales, and direct access to articles from removed locales correctly returns a 404. This guarantees that no stale or inaccessible content is left behind or publicly reachable.

<img width="648" height="204" alt="Screenshot 2026-04-25 at 03 58 49" src="https://github.com/user-attachments/assets/ab6d4033-8197-481e-ae7d-14a8e0eed8ab" />

<img width="2260" height="1456" alt="image" src="https://github.com/user-attachments/assets/8fc2c0db-f616-47c5-a644-cb7e0de487a6" />


## What changed

**`app/models/portal.rb`**
- Added `before_update :destroy_articles_and_categories_for_removed_locales` callback
- When `allowed_locales` changes, compares previous vs current locales and destroys all articles and categories belonging to removed locales

**`app/views/public/api/v1/portals/sitemap.xml.erb`**
- Added `locale: @portal.allowed_locale_codes` filter to the sitemap query so only articles with active locales are included

**`app/controllers/public/api/v1/portals/articles_controller.rb`**
- `index`: Added `where(locale: @portal.allowed_locale_codes)` filter so orphaned articles don't appear in listings
- `set_article`: Returns 404 if the article's locale is not in the portal's active locales, preventing direct URL access to orphaned articles

## How to test

1. Create a Help Center portal with two locales (e.g. `en` and `fr`)
2. Create a few articles under the `fr` locale and publish them
3. Verify they appear in `sitemap.xml` and are accessible via direct URL
4. Remove the `fr` locale from the portal settings and save
5. **Before fix:** Articles remain in sitemap, direct URLs still serve content, admin can't see or delete them
6. **After fix:** Articles and categories for `fr` are destroyed on save, sitemap only shows active locale articles, direct URLs return 404