### PR TITLE
feat(whatsapp): support local upload for template header media

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -69,7 +69,7 @@ class Messages::MessageBuilder
   def process_template_media_attachment
     Messages::TemplateMediaAttachmentService.new(message: @message, attachments: @attachments, template_params: @params[:template_params]).perform
   rescue ArgumentError => e
-    raise StandardError, e.message
+    raise CustomExceptions::Message::InvalidTemplateMedia, e.message
   end
 
   def process_emails

--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -48,9 +48,12 @@ class Messages::MessageBuilder
   end
 
   def process_attachments
-    return if @attachments.blank?
+    process_uploaded_attachments
+    process_template_media_attachment
+  end
 
-    @attachments.each do |uploaded_attachment|
+  def process_uploaded_attachments
+    Array(@attachments).each do |uploaded_attachment|
       attachment = @message.attachments.build(
         account_id: @message.account_id,
         file: uploaded_attachment
@@ -64,6 +67,11 @@ class Messages::MessageBuilder
                                file_type(uploaded_attachment&.content_type)
                              end
     end
+  end
+
+  def process_template_media_attachment
+    Messages::TemplateMediaAttachmentService.new(message: @message, attachments: @attachments,
+                                                 template_params: @params[:template_params]).perform
   end
 
   def process_emails

--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -128,7 +128,10 @@ class Messages::MessageBuilder
   end
 
   def template_params
-    @params[:template_params].present? ? { additional_attributes: { template_params: JSON.parse(@params[:template_params].to_json) } } : {}
+    normalized = Messages::TemplateParamsFromRequest.call(@params[:template_params])
+    return {} if normalized.blank?
+
+    { additional_attributes: { template_params: normalized } }
   end
 
   def message_sender
@@ -226,9 +229,7 @@ class Messages::MessageBuilder
   end
 
   def drops_with_sender
-    message_drops(@conversation).merge({
-                                         'agent' => UserDrop.new(sender)
-                                       })
+    message_drops(@conversation).merge('agent' => UserDrop.new(sender))
   end
 end
 

--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -33,10 +33,7 @@ class Messages::MessageBuilder
 
   private
 
-  # Extracts content attributes from the given params.
-  # - Converts ActionController::Parameters to a regular hash if needed.
-  # - Attempts to parse a JSON string if content is a string.
-  # - Returns an empty hash if content is not present, if there's a parsing error, or if it's an unexpected type.
+  # Parses content_attributes from params (hash, JSON string, or empty).
   def content_attributes
     params = convert_to_hash(@params)
     content_attributes = params.fetch(:content_attributes, {})
@@ -70,8 +67,9 @@ class Messages::MessageBuilder
   end
 
   def process_template_media_attachment
-    Messages::TemplateMediaAttachmentService.new(message: @message, attachments: @attachments,
-                                                 template_params: @params[:template_params]).perform
+    Messages::TemplateMediaAttachmentService.new(message: @message, attachments: @attachments, template_params: @params[:template_params]).perform
+  rescue ArgumentError => e
+    raise StandardError, e.message
   end
 
   def process_emails
@@ -129,9 +127,7 @@ class Messages::MessageBuilder
 
   def template_params
     normalized = Messages::TemplateParamsFromRequest.call(@params[:template_params])
-    return {} if normalized.blank?
-
-    { additional_attributes: { template_params: normalized } }
+    normalized.blank? ? {} : { additional_attributes: { template_params: normalized } }
   end
 
   def message_sender
@@ -211,7 +207,6 @@ class Messages::MessageBuilder
     html_content
   end
 
-  # Liquid processing methods for email content
   def process_liquid_in_email_body(content)
     return content if content.blank?
     return content unless should_process_liquid?

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -37,10 +37,12 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   def show; end
 
   def create
-    ActiveRecord::Base.transaction do
-      @conversation = ConversationBuilder.new(params: params, contact_inbox: @contact_inbox).perform
-      Messages::MessageBuilder.new(Current.user, @conversation, params[:message]).perform if params[:message].present?
-    end
+    @conversation, initial_message_error = Conversations::CreateWithInitialMessage.new(
+      user: Current.user,
+      contact_inbox: @contact_inbox,
+      params: params
+    ).perform
+    return render_could_not_create_error(initial_message_error) if initial_message_error.present?
   end
 
   def update

--- a/app/javascript/dashboard/api/inbox/message.js
+++ b/app/javascript/dashboard/api/inbox/message.js
@@ -17,8 +17,8 @@ export const buildCreatePayload = ({
     if (value === null || value === undefined) return;
 
     if (Array.isArray(value)) {
-      value.forEach((item, index) => {
-        appendNestedFormData(formData, `${prefix}[${index}]`, item);
+      value.forEach(item => {
+        appendNestedFormData(formData, `${prefix}[]`, item);
       });
       return;
     }

--- a/app/javascript/dashboard/api/inbox/message.js
+++ b/app/javascript/dashboard/api/inbox/message.js
@@ -33,6 +33,9 @@ export const buildCreatePayload = ({
     if (contentAttributes) {
       payload.append('content_attributes', JSON.stringify(contentAttributes));
     }
+    if (templateParams) {
+      payload.append('template_params', JSON.stringify(templateParams));
+    }
   } else {
     payload = {
       content: message,

--- a/app/javascript/dashboard/api/inbox/message.js
+++ b/app/javascript/dashboard/api/inbox/message.js
@@ -17,9 +17,15 @@ export const buildCreatePayload = ({
     if (value === null || value === undefined) return;
 
     if (Array.isArray(value)) {
-      value.forEach(item => {
-        appendNestedFormData(formData, `${prefix}[]`, item);
-      });
+      for (let index = 0; index < value.length; index += 1) {
+        const currentValue = value[index];
+        if (!(index in value) || currentValue === undefined) {
+          // Preserve sparse array positions so backend with_index stays aligned.
+          formData.append(`${prefix}[]`, '');
+        } else {
+          appendNestedFormData(formData, `${prefix}[]`, currentValue);
+        }
+      }
       return;
     }
 

--- a/app/javascript/dashboard/api/inbox/message.js
+++ b/app/javascript/dashboard/api/inbox/message.js
@@ -2,6 +2,40 @@
 /* global axios */
 import ApiClient from '../ApiClient';
 
+/** Placeholder for empty button slots (multipart JSON); skipped by TemplateProcessorService. */
+const TEMPLATE_BUTTON_PADDING = { type: 'static' };
+
+/**
+ * Multipart FormData cannot represent sparse arrays reliably. Serialize template_params as JSON
+ * (like content_attributes) and densify processed_params.buttons so indices align without '' slots.
+ */
+export const serializeTemplateParamsForMultipart = templateParams => {
+  if (!templateParams || typeof templateParams !== 'object') {
+    return templateParams;
+  }
+
+  const processed = templateParams.processed_params;
+  if (!processed || !Array.isArray(processed.buttons)) {
+    return templateParams;
+  }
+
+  const { buttons } = processed;
+  const denseButtons = Array.from({ length: buttons.length }, (_, index) => {
+    if (index in buttons && buttons[index] != null) {
+      return buttons[index];
+    }
+    return TEMPLATE_BUTTON_PADDING;
+  });
+
+  return {
+    ...templateParams,
+    processed_params: {
+      ...processed,
+      buttons: denseButtons,
+    },
+  };
+};
+
 export const buildCreatePayload = ({
   message,
   isPrivate,
@@ -13,32 +47,6 @@ export const buildCreatePayload = ({
   toEmails = '',
   templateParams,
 }) => {
-  const appendNestedFormData = (formData, prefix, value) => {
-    if (value === null || value === undefined) return;
-
-    if (Array.isArray(value)) {
-      for (let index = 0; index < value.length; index += 1) {
-        const currentValue = value[index];
-        if (!(index in value) || currentValue === undefined) {
-          // Preserve sparse array positions so backend with_index stays aligned.
-          formData.append(`${prefix}[]`, '');
-        } else {
-          appendNestedFormData(formData, `${prefix}[]`, currentValue);
-        }
-      }
-      return;
-    }
-
-    if (typeof value === 'object') {
-      Object.entries(value).forEach(([key, nestedValue]) => {
-        appendNestedFormData(formData, `${prefix}[${key}]`, nestedValue);
-      });
-      return;
-    }
-
-    formData.append(prefix, value);
-  };
-
   let payload;
   if (files && files.length !== 0) {
     payload = new FormData();
@@ -60,7 +68,10 @@ export const buildCreatePayload = ({
       payload.append('content_attributes', JSON.stringify(contentAttributes));
     }
     if (templateParams) {
-      appendNestedFormData(payload, 'template_params', templateParams);
+      payload.append(
+        'template_params',
+        JSON.stringify(serializeTemplateParamsForMultipart(templateParams))
+      );
     }
   } else {
     payload = {

--- a/app/javascript/dashboard/api/inbox/message.js
+++ b/app/javascript/dashboard/api/inbox/message.js
@@ -13,6 +13,26 @@ export const buildCreatePayload = ({
   toEmails = '',
   templateParams,
 }) => {
+  const appendNestedFormData = (formData, prefix, value) => {
+    if (value === null || value === undefined) return;
+
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => {
+        appendNestedFormData(formData, `${prefix}[${index}]`, item);
+      });
+      return;
+    }
+
+    if (typeof value === 'object') {
+      Object.entries(value).forEach(([key, nestedValue]) => {
+        appendNestedFormData(formData, `${prefix}[${key}]`, nestedValue);
+      });
+      return;
+    }
+
+    formData.append(prefix, value);
+  };
+
   let payload;
   if (files && files.length !== 0) {
     payload = new FormData();
@@ -34,7 +54,7 @@ export const buildCreatePayload = ({
       payload.append('content_attributes', JSON.stringify(contentAttributes));
     }
     if (templateParams) {
-      payload.append('template_params', JSON.stringify(templateParams));
+      appendNestedFormData(payload, 'template_params', templateParams);
     }
   } else {
     payload = {

--- a/app/javascript/dashboard/api/specs/inbox/message.spec.js
+++ b/app/javascript/dashboard/api/specs/inbox/message.spec.js
@@ -48,7 +48,10 @@ describe('#ConversationAPI', () => {
     it('builds form payload if file is available', () => {
       const templateParams = {
         name: 'ticket_status_updated',
-        processed_params: { body: { name: 'John' } },
+        processed_params: {
+          body: { name: 'John' },
+          buttons: [{ type: 'url', parameter: 'track-123' }],
+        },
       };
       const formPayload = buildCreatePayload({
         message: 'test content',
@@ -74,6 +77,17 @@ describe('#ConversationAPI', () => {
       expect(
         formPayload.get('template_params[processed_params][body][name]')
       ).toEqual('John');
+      expect(
+        formPayload.get('template_params[processed_params][buttons][][type]')
+      ).toEqual('url');
+      expect(
+        formPayload.get(
+          'template_params[processed_params][buttons][][parameter]'
+        )
+      ).toEqual('track-123');
+      expect(
+        Array.from(formPayload.keys()).some(key => key.includes('[buttons][0]'))
+      ).toBe(false);
     });
 
     it('builds object payload if file is not available', () => {

--- a/app/javascript/dashboard/api/specs/inbox/message.spec.js
+++ b/app/javascript/dashboard/api/specs/inbox/message.spec.js
@@ -46,12 +46,17 @@ describe('#ConversationAPI', () => {
   });
   describe('#buildCreatePayload', () => {
     it('builds form payload if file is available', () => {
+      const templateParams = {
+        name: 'ticket_status_updated',
+        processed_params: { body: { name: 'John' } },
+      };
       const formPayload = buildCreatePayload({
         message: 'test content',
         echoId: 12,
         isPrivate: true,
         contentAttributes: { in_reply_to: 12 },
         files: [new Blob(['test-content'], { type: 'application/pdf' })],
+        templateParams,
       });
       expect(formPayload).toBeInstanceOf(FormData);
       expect(formPayload.get('content')).toEqual('test content');
@@ -61,6 +66,9 @@ describe('#ConversationAPI', () => {
       expect(formPayload.get('bcc_emails')).toEqual('');
       expect(formPayload.get('content_attributes')).toEqual(
         '{"in_reply_to":12}'
+      );
+      expect(formPayload.get('template_params')).toEqual(
+        JSON.stringify(templateParams)
       );
     });
 

--- a/app/javascript/dashboard/api/specs/inbox/message.spec.js
+++ b/app/javascript/dashboard/api/specs/inbox/message.spec.js
@@ -109,5 +109,34 @@ describe('#ConversationAPI', () => {
         template_params: undefined,
       });
     });
+
+    it('preserves sparse button indices in multipart template params', () => {
+      const buttons = [];
+      buttons[1] = { type: 'url', parameter: 'track-123' };
+
+      const formPayload = buildCreatePayload({
+        message: 'test content',
+        echoId: 12,
+        isPrivate: true,
+        files: [new Blob(['test-content'], { type: 'application/pdf' })],
+        templateParams: {
+          name: 'ticket_status_updated',
+          processed_params: { buttons },
+        },
+      });
+
+      expect(formPayload).toBeInstanceOf(FormData);
+      expect(
+        formPayload.getAll('template_params[processed_params][buttons][]')
+      ).toEqual(['']);
+      expect(
+        formPayload.getAll('template_params[processed_params][buttons][][type]')
+      ).toEqual(['url']);
+      expect(
+        formPayload.getAll(
+          'template_params[processed_params][buttons][][parameter]'
+        )
+      ).toEqual(['track-123']);
+    });
   });
 });

--- a/app/javascript/dashboard/api/specs/inbox/message.spec.js
+++ b/app/javascript/dashboard/api/specs/inbox/message.spec.js
@@ -1,4 +1,7 @@
-import messageAPI, { buildCreatePayload } from '../../inbox/message';
+import messageAPI, {
+  buildCreatePayload,
+  serializeTemplateParamsForMultipart,
+} from '../../inbox/message';
 import ApiClient from '../../ApiClient';
 
 describe('#ConversationAPI', () => {
@@ -70,23 +73,17 @@ describe('#ConversationAPI', () => {
       expect(formPayload.get('content_attributes')).toEqual(
         '{"in_reply_to":12}'
       );
-      expect(formPayload.get('template_params')).toEqual(null);
-      expect(formPayload.get('template_params[name]')).toEqual(
-        'ticket_status_updated'
-      );
+      const rawTemplate = formPayload.get('template_params');
+      expect(typeof rawTemplate).toEqual('string');
+      const parsed = JSON.parse(rawTemplate);
+      expect(parsed.name).toEqual('ticket_status_updated');
+      expect(parsed.processed_params.body.name).toEqual('John');
+      expect(parsed.processed_params.buttons[0].type).toEqual('url');
+      expect(parsed.processed_params.buttons[0].parameter).toEqual('track-123');
       expect(
-        formPayload.get('template_params[processed_params][body][name]')
-      ).toEqual('John');
-      expect(
-        formPayload.get('template_params[processed_params][buttons][][type]')
-      ).toEqual('url');
-      expect(
-        formPayload.get(
-          'template_params[processed_params][buttons][][parameter]'
+        Array.from(formPayload.keys()).some(key =>
+          key.startsWith('template_params[')
         )
-      ).toEqual('track-123');
-      expect(
-        Array.from(formPayload.keys()).some(key => key.includes('[buttons][0]'))
       ).toBe(false);
     });
 
@@ -110,7 +107,7 @@ describe('#ConversationAPI', () => {
       });
     });
 
-    it('preserves sparse button indices in multipart template params', () => {
+    it('multipart template_params uses JSON with dense padded buttons for sparse indices', () => {
       const buttons = [];
       buttons[1] = { type: 'url', parameter: 'track-123' };
 
@@ -126,17 +123,20 @@ describe('#ConversationAPI', () => {
       });
 
       expect(formPayload).toBeInstanceOf(FormData);
-      expect(
-        formPayload.getAll('template_params[processed_params][buttons][]')
-      ).toEqual(['']);
-      expect(
-        formPayload.getAll('template_params[processed_params][buttons][][type]')
-      ).toEqual(['url']);
-      expect(
-        formPayload.getAll(
-          'template_params[processed_params][buttons][][parameter]'
-        )
-      ).toEqual(['track-123']);
+      const parsed = JSON.parse(formPayload.get('template_params'));
+      expect(parsed.processed_params.buttons).toHaveLength(2);
+      expect(parsed.processed_params.buttons[0]).toEqual({ type: 'static' });
+      expect(parsed.processed_params.buttons[1]).toEqual({
+        type: 'url',
+        parameter: 'track-123',
+      });
+    });
+  });
+
+  describe('#serializeTemplateParamsForMultipart', () => {
+    it('returns same object when buttons are absent', () => {
+      const input = { name: 'x', processed_params: { body: { a: '1' } } };
+      expect(serializeTemplateParamsForMultipart(input)).toBe(input);
     });
   });
 });

--- a/app/javascript/dashboard/api/specs/inbox/message.spec.js
+++ b/app/javascript/dashboard/api/specs/inbox/message.spec.js
@@ -67,9 +67,13 @@ describe('#ConversationAPI', () => {
       expect(formPayload.get('content_attributes')).toEqual(
         '{"in_reply_to":12}'
       );
-      expect(formPayload.get('template_params')).toEqual(
-        JSON.stringify(templateParams)
+      expect(formPayload.get('template_params')).toEqual(null);
+      expect(formPayload.get('template_params[name]')).toEqual(
+        'ticket_status_updated'
       );
+      expect(
+        formPayload.get('template_params[processed_params][body][name]')
+      ).toEqual('John');
     });
 
     it('builds object payload if file is not available', () => {

--- a/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
+++ b/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
@@ -94,6 +94,10 @@ const renderedTemplate = computed(() => {
 const isFormInvalid = computed(() => {
   if (!hasVariables.value && !hasMediaHeader.value) return false;
 
+  if (hasMediaHeader.value && isUploadingMedia.value) {
+    return true;
+  }
+
   const hasMediaReference =
     processedParams.value.header?.media_url ||
     processedParams.value.header?.media_blob_id;
@@ -218,7 +222,11 @@ const processUploadedFile = async file => {
     return;
   }
 
+  // Drop previous media immediately so send cannot use stale blob/URL while the new upload resolves.
+  processedParams.value.header.media_blob_id = '';
+  processedParams.value.header.media_url = '';
   isUploadingMedia.value = true;
+  updateMediaPreview(file);
   try {
     const { blobId } = await uploadFile(file);
     processedParams.value.header.media_blob_id = blobId;
@@ -226,7 +234,6 @@ const processUploadedFile = async file => {
     if (isDocumentTemplate.value && !processedParams.value.header.media_name) {
       processedParams.value.header.media_name = file.name;
     }
-    updateMediaPreview(file);
   } catch (error) {
     mediaUploadError.value =
       error?.response?.data?.error ||
@@ -270,6 +277,7 @@ const mediaPreviewSize = computed(() => {
 });
 
 const sendMessage = () => {
+  if (isUploadingMedia.value) return;
   v$.value.$touch();
   if (v$.value.$invalid) return;
 

--- a/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
+++ b/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
@@ -45,6 +45,8 @@ const { t } = useI18n();
 
 const processedParams = ref({});
 const isUploadingMedia = ref(false);
+/** Bumped on template change or when a new upload starts; completions must match or be discarded. */
+const mediaUploadGeneration = ref(0);
 const mediaUploadError = ref('');
 const mediaPreview = ref(null);
 const mediaInputRef = ref(null);
@@ -140,6 +142,11 @@ const initializeTemplateParameters = () => {
   );
 };
 
+const invalidateInFlightMediaUpload = () => {
+  mediaUploadGeneration.value += 1;
+  isUploadingMedia.value = false;
+};
+
 function clearMediaPreview() {
   if (mediaPreview.value?.url) {
     URL.revokeObjectURL(mediaPreview.value.url);
@@ -222,6 +229,9 @@ const processUploadedFile = async file => {
     return;
   }
 
+  mediaUploadGeneration.value += 1;
+  const uploadId = mediaUploadGeneration.value;
+
   // Drop previous media immediately so send cannot use stale blob/URL while the new upload resolves.
   processedParams.value.header.media_blob_id = '';
   processedParams.value.header.media_url = '';
@@ -229,17 +239,25 @@ const processUploadedFile = async file => {
   updateMediaPreview(file);
   try {
     const { blobId } = await uploadFile(file);
+    if (uploadId !== mediaUploadGeneration.value) {
+      return;
+    }
     processedParams.value.header.media_blob_id = blobId;
     processedParams.value.header.media_url = '';
     if (isDocumentTemplate.value && !processedParams.value.header.media_name) {
       processedParams.value.header.media_name = file.name;
     }
   } catch (error) {
+    if (uploadId !== mediaUploadGeneration.value) {
+      return;
+    }
     mediaUploadError.value =
       error?.response?.data?.error ||
       t('WHATSAPP_TEMPLATES.PARSER.MEDIA_UPLOAD_FAILED');
   } finally {
-    isUploadingMedia.value = false;
+    if (uploadId === mediaUploadGeneration.value) {
+      isUploadingMedia.value = false;
+    }
   }
 };
 
@@ -309,6 +327,7 @@ onMounted(initializeTemplateParameters);
 watch(
   () => props.template,
   () => {
+    invalidateInFlightMediaUpload();
     initializeTemplateParameters();
     clearMediaPreview();
     mediaUploadError.value = '';

--- a/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
+++ b/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
@@ -223,6 +223,9 @@ const processUploadedFile = async file => {
     const { blobId } = await uploadFile(file);
     processedParams.value.header.media_blob_id = blobId;
     processedParams.value.header.media_url = '';
+    if (isDocumentTemplate.value && !processedParams.value.header.media_name) {
+      processedParams.value.header.media_name = file.name;
+    }
     updateMediaPreview(file);
   } catch (error) {
     mediaUploadError.value =

--- a/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
+++ b/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
@@ -247,7 +247,7 @@ const processUploadedFile = async file => {
     }
     processedParams.value.header.media_blob_id = blobId;
     processedParams.value.header.media_url = '';
-    if (isDocumentTemplate.value && !processedParams.value.header.media_name) {
+    if (isDocumentTemplate.value) {
       processedParams.value.header.media_name = file.name;
     }
   } catch (error) {

--- a/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
+++ b/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
@@ -227,6 +227,7 @@ const processUploadedFile = async file => {
   mediaUploadError.value = '';
 
   if (!isAllowedFileType(file)) {
+    clearUploadedMedia();
     mediaUploadError.value = t('WHATSAPP_TEMPLATES.PARSER.INVALID_MEDIA_TYPE');
     return;
   }

--- a/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
+++ b/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
@@ -45,7 +45,7 @@ const { t } = useI18n();
 
 const processedParams = ref({});
 const isUploadingMedia = ref(false);
-/** Bumped on template change or when a new upload starts; completions must match or be discarded. */
+/** Bumped on template change, new upload, or header URL input; stale completions must not apply. */
 const mediaUploadGeneration = ref(0);
 const mediaUploadError = ref('');
 const mediaPreview = ref(null);
@@ -158,6 +158,7 @@ const updateMediaUrl = value => {
   processedParams.value.header ??= {};
   processedParams.value.header.media_url = value;
   if (value) {
+    invalidateInFlightMediaUpload();
     processedParams.value.header.media_blob_id = '';
     mediaUploadError.value = '';
     clearMediaPreview();

--- a/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
+++ b/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
@@ -396,6 +396,7 @@ defineExpose({
               faded
               slate
               size="sm"
+              type="button"
               class="shrink-0 !w-8"
               :disabled="isUploadingMedia"
               :title="$t('WHATSAPP_TEMPLATES.PARSER.UPLOAD_LOCAL_FILE')"
@@ -407,6 +408,7 @@ defineExpose({
               color="slate"
               icon="i-lucide-trash-2"
               size="xs"
+              type="button"
               :title="$t('WHATSAPP_TEMPLATES.PARSER.REMOVE_UPLOADED_FILE')"
               @click="clearUploadedMedia"
             />

--- a/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
+++ b/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
@@ -14,6 +14,8 @@ import { requiredIf } from '@vuelidate/validators';
 import { useI18n } from 'vue-i18n';
 
 import Input from 'dashboard/components-next/input/Input.vue';
+import Button from 'dashboard/components-next/button/Button.vue';
+import { uploadFile } from 'dashboard/helper/uploadHelper';
 import {
   buildTemplateParameters,
   allKeysRequired,
@@ -42,6 +44,11 @@ const emit = defineEmits(['sendMessage', 'resetTemplate', 'back']);
 const { t } = useI18n();
 
 const processedParams = ref({});
+const isUploadingMedia = ref(false);
+const mediaUploadError = ref('');
+const mediaPreview = ref(null);
+const mediaInputRef = ref(null);
+const isDragOverMediaZone = ref(false);
 
 const languageLabel = computed(() => {
   return `${t('WHATSAPP_TEMPLATES.PARSER.LANGUAGE')}: ${props.template.language || DEFAULT_LANGUAGE}`;
@@ -87,7 +94,11 @@ const renderedTemplate = computed(() => {
 const isFormInvalid = computed(() => {
   if (!hasVariables.value && !hasMediaHeader.value) return false;
 
-  if (hasMediaHeader.value && !processedParams.value.header?.media_url) {
+  const hasMediaReference =
+    processedParams.value.header?.media_url ||
+    processedParams.value.header?.media_blob_id;
+
+  if (hasMediaHeader.value && !hasMediaReference) {
     return true;
   }
 
@@ -125,15 +136,135 @@ const initializeTemplateParameters = () => {
   );
 };
 
+function clearMediaPreview() {
+  if (mediaPreview.value?.url) {
+    URL.revokeObjectURL(mediaPreview.value.url);
+  }
+  mediaPreview.value = null;
+}
+
 const updateMediaUrl = value => {
   processedParams.value.header ??= {};
   processedParams.value.header.media_url = value;
+  if (value) {
+    processedParams.value.header.media_blob_id = '';
+    mediaUploadError.value = '';
+    clearMediaPreview();
+  }
 };
 
 const updateMediaName = value => {
   processedParams.value.header ??= {};
   processedParams.value.header.media_name = value;
 };
+
+const allowedMimeTypes = computed(() => {
+  const mediaType = headerComponent.value?.format?.toLowerCase();
+  if (mediaType === 'image') return ['image/*'];
+  if (mediaType === 'video') return ['video/*'];
+  if (mediaType === 'document') {
+    return [
+      'application/pdf',
+      'application/msword',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/vnd.ms-excel',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'text/plain',
+    ];
+  }
+  return ['*/*'];
+});
+
+const localFileAccept = computed(() => allowedMimeTypes.value.join(','));
+
+const isAllowedFileType = file => {
+  const mediaType = headerComponent.value?.format?.toLowerCase();
+  if (mediaType === 'image') return file.type.startsWith('image/');
+  if (mediaType === 'video') return file.type.startsWith('video/');
+  if (mediaType === 'document')
+    return allowedMimeTypes.value.includes(file.type);
+  return false;
+};
+
+const updateMediaPreview = file => {
+  clearMediaPreview();
+
+  const isImage = file.type.startsWith('image/');
+  mediaPreview.value = {
+    name: file.name,
+    size: file.size,
+    type: file.type,
+    url: isImage ? URL.createObjectURL(file) : '',
+    isImage,
+  };
+};
+
+const clearUploadedMedia = () => {
+  processedParams.value.header ??= {};
+  processedParams.value.header.media_blob_id = '';
+  processedParams.value.header.media_url = '';
+  mediaUploadError.value = '';
+  clearMediaPreview();
+};
+
+const processUploadedFile = async file => {
+  if (!file) return;
+
+  processedParams.value.header ??= {};
+  mediaUploadError.value = '';
+
+  if (!isAllowedFileType(file)) {
+    mediaUploadError.value = t('WHATSAPP_TEMPLATES.PARSER.INVALID_MEDIA_TYPE');
+    return;
+  }
+
+  isUploadingMedia.value = true;
+  try {
+    const { blobId } = await uploadFile(file);
+    processedParams.value.header.media_blob_id = blobId;
+    processedParams.value.header.media_url = '';
+    updateMediaPreview(file);
+  } catch (error) {
+    mediaUploadError.value =
+      error?.response?.data?.error ||
+      t('WHATSAPP_TEMPLATES.PARSER.MEDIA_UPLOAD_FAILED');
+  } finally {
+    isUploadingMedia.value = false;
+  }
+};
+
+const handleMediaUpload = async event => {
+  const file = event?.target?.files?.[0];
+  await processUploadedFile(file);
+  event.target.value = '';
+};
+
+const openFilePicker = () => {
+  mediaInputRef.value?.click();
+};
+
+const onMediaDragOver = event => {
+  event.preventDefault();
+  if (isUploadingMedia.value) return;
+  isDragOverMediaZone.value = true;
+};
+
+const onMediaDragLeave = () => {
+  isDragOverMediaZone.value = false;
+};
+
+const onMediaDrop = async event => {
+  event.preventDefault();
+  if (isUploadingMedia.value) return;
+  isDragOverMediaZone.value = false;
+  const file = event?.dataTransfer?.files?.[0];
+  await processUploadedFile(file);
+};
+
+const mediaPreviewSize = computed(() => {
+  if (!mediaPreview.value?.size) return '';
+  return `${Math.ceil(mediaPreview.value.size / 1024)} KB`;
+});
 
 const sendMessage = () => {
   v$.value.$touch();
@@ -168,9 +299,20 @@ watch(
   () => props.template,
   () => {
     initializeTemplateParameters();
+    clearMediaPreview();
+    mediaUploadError.value = '';
     v$.value.$reset();
   },
   { deep: true }
+);
+
+watch(
+  () => processedParams.value.header?.media_url,
+  value => {
+    if (value) {
+      clearMediaPreview();
+    }
+  }
 );
 
 defineExpose({
@@ -223,19 +365,86 @@ defineExpose({
             }) || `${formatType} Header`
           }}
         </p>
-        <div class="flex items-center mb-2.5">
-          <Input
-            :model-value="processedParams.header?.media_url || ''"
-            type="url"
-            class="flex-1"
-            :placeholder="
-              t('WHATSAPP_TEMPLATES.PARSER.MEDIA_URL_LABEL', {
-                type: formatType,
-              })
-            "
-            @update:model-value="updateMediaUrl"
+        <div
+          class="p-2 mb-2.5 rounded-lg border transition-colors"
+          :class="
+            isDragOverMediaZone
+              ? 'border-n-brand bg-n-alpha-1'
+              : 'border-n-strong bg-transparent'
+          "
+          @dragover="onMediaDragOver"
+          @dragleave="onMediaDragLeave"
+          @drop="onMediaDrop"
+        >
+          <div class="flex items-center gap-2">
+            <Input
+              :model-value="processedParams.header?.media_url || ''"
+              type="url"
+              class="flex-1"
+              :placeholder="
+                t('WHATSAPP_TEMPLATES.PARSER.MEDIA_URL_LABEL', {
+                  type: formatType,
+                })
+              "
+              @update:model-value="updateMediaUrl"
+            />
+            <Button
+              icon="i-lucide-upload"
+              faded
+              slate
+              size="sm"
+              class="shrink-0 !w-8"
+              :disabled="isUploadingMedia"
+              :title="$t('WHATSAPP_TEMPLATES.PARSER.UPLOAD_LOCAL_FILE')"
+              @click="openFilePicker"
+            />
+            <Button
+              v-if="processedParams.header?.media_blob_id"
+              variant="ghost"
+              color="slate"
+              icon="i-lucide-trash-2"
+              size="xs"
+              :title="$t('WHATSAPP_TEMPLATES.PARSER.REMOVE_UPLOADED_FILE')"
+              @click="clearUploadedMedia"
+            />
+          </div>
+          <input
+            ref="mediaInputRef"
+            type="file"
+            class="hidden"
+            :accept="localFileAccept"
+            :disabled="isUploadingMedia"
+            @change="handleMediaUpload"
           />
+          <p class="mt-1 text-xs text-n-slate-11">
+            {{ $t('WHATSAPP_TEMPLATES.PARSER.DRAG_AND_DROP_HINT') }}
+          </p>
         </div>
+        <div v-if="isUploadingMedia" class="mb-2.5 text-xs text-n-slate-11">
+          {{ $t('WHATSAPP_TEMPLATES.PARSER.UPLOADING_MEDIA') }}
+        </div>
+        <div
+          v-if="mediaPreview"
+          class="flex items-center gap-2 p-2 mb-2.5 rounded-md border border-n-strong bg-n-alpha-black2"
+        >
+          <img
+            v-if="mediaPreview.isImage"
+            :src="mediaPreview.url"
+            :alt="mediaPreview.name"
+            class="object-cover w-10 h-10 rounded"
+          />
+          <div class="flex flex-col min-w-0">
+            <span class="text-xs font-medium truncate text-n-slate-12">
+              {{ mediaPreview.name }}
+            </span>
+            <span class="text-xs text-n-slate-11">
+              {{ mediaPreviewSize }}
+            </span>
+          </div>
+        </div>
+        <p v-if="mediaUploadError" class="mb-2.5 text-xs text-n-ruby-9">
+          {{ mediaUploadError }}
+        </p>
         <div v-if="isDocumentTemplate" class="flex items-center mb-2.5">
           <Input
             :model-value="processedParams.header?.media_name || ''"

--- a/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
+++ b/app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue
@@ -215,6 +215,7 @@ const clearUploadedMedia = () => {
   processedParams.value.header ??= {};
   processedParams.value.header.media_blob_id = '';
   processedParams.value.header.media_url = '';
+  processedParams.value.header.media_name = '';
   mediaUploadError.value = '';
   clearMediaPreview();
 };

--- a/app/javascript/dashboard/helper/specs/templateHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/templateHelper.spec.js
@@ -131,6 +131,17 @@ describe('templateHelper', () => {
       });
     });
 
+    it('does not throw when hasMediaHeader is true but template has no header component', () => {
+      const bodyOnly = {
+        components: [{ type: 'BODY', text: 'Hello {{name}}' }],
+      };
+
+      expect(() => buildTemplateParameters(bodyOnly, true)).not.toThrow();
+      const result = buildTemplateParameters(bodyOnly, true);
+      expect(result.header).toBeUndefined();
+      expect(result.body).toEqual({ name: '' });
+    });
+
     it('should handle template with no variables', () => {
       const templateWithoutVars = templates.find(
         t => t.name === 'no_variable_template'

--- a/app/javascript/dashboard/helper/specs/templateHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/templateHelper.spec.js
@@ -97,6 +97,7 @@ describe('templateHelper', () => {
 
       expect(result.header).toEqual({
         media_url: '',
+        media_blob_id: '',
         media_type: 'image',
       });
     });
@@ -181,6 +182,7 @@ describe('templateHelper', () => {
 
       expect(result.header).toEqual({
         media_url: '',
+        media_blob_id: '',
         media_type: 'image',
       });
       expect(result.body).toEqual({ 1: '', 2: '' });
@@ -217,6 +219,7 @@ describe('templateHelper', () => {
 
       expect(result.header).toEqual({
         media_url: '',
+        media_blob_id: '',
         media_type: 'document',
         media_name: '',
       });
@@ -233,6 +236,7 @@ describe('templateHelper', () => {
 
       expect(result.header).toEqual({
         media_url: '',
+        media_blob_id: '',
         media_type: 'video',
       });
       expect(result.body).toEqual({
@@ -327,6 +331,7 @@ describe('templateHelper', () => {
 
       expect(result.header).toEqual({
         media_url: '',
+        media_blob_id: '',
         media_type: 'video',
       });
       expect(result.body).toEqual({

--- a/app/javascript/dashboard/helper/specs/templateHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/templateHelper.spec.js
@@ -116,6 +116,21 @@ describe('templateHelper', () => {
       expect(result).toEqual({});
     });
 
+    it('should build media header params even when body component is missing', () => {
+      const templateWithoutBody = {
+        components: [{ type: 'HEADER', format: 'IMAGE' }],
+      };
+
+      const result = buildTemplateParameters(templateWithoutBody, true);
+      expect(result).toEqual({
+        header: {
+          media_url: '',
+          media_blob_id: '',
+          media_type: 'image',
+        },
+      });
+    });
+
     it('should handle template with no variables', () => {
       const templateWithoutVars = templates.find(
         t => t.name === 'no_variable_template'

--- a/app/javascript/dashboard/helper/templateHelper.js
+++ b/app/javascript/dashboard/helper/templateHelper.js
@@ -50,6 +50,7 @@ export const buildTemplateParameters = (template, hasMediaHeaderValue) => {
   if (hasMediaHeaderValue) {
     if (!allVariables.header) allVariables.header = {};
     allVariables.header.media_url = '';
+    allVariables.header.media_blob_id = '';
     allVariables.header.media_type = headerComponent.format.toLowerCase();
 
     // For document templates, include media_name field for filename support

--- a/app/javascript/dashboard/helper/templateHelper.js
+++ b/app/javascript/dashboard/helper/templateHelper.js
@@ -32,10 +32,7 @@ export const buildTemplateParameters = (template, hasMediaHeaderValue) => {
 
   const bodyComponent = findComponentByType(template, COMPONENT_TYPES.BODY);
   const headerComponent = findComponentByType(template, COMPONENT_TYPES.HEADER);
-
-  if (!bodyComponent) return allVariables;
-
-  const templateString = bodyComponent.text;
+  const templateString = bodyComponent?.text || '';
 
   // Process body variables
   const matchedVariables = templateString.match(/{{([^}]+)}}/g);

--- a/app/javascript/dashboard/helper/templateHelper.js
+++ b/app/javascript/dashboard/helper/templateHelper.js
@@ -44,20 +44,21 @@ export const buildTemplateParameters = (template, hasMediaHeaderValue) => {
     });
   }
 
-  if (hasMediaHeaderValue) {
+  if (hasMediaHeaderValue && headerComponent?.format) {
     if (!allVariables.header) allVariables.header = {};
     allVariables.header.media_url = '';
     allVariables.header.media_blob_id = '';
-    allVariables.header.media_type = headerComponent.format.toLowerCase();
+    const formatLower = headerComponent.format.toLowerCase();
+    allVariables.header.media_type = formatLower;
 
     // For document templates, include media_name field for filename support
-    if (headerComponent.format.toLowerCase() === 'document') {
+    if (formatLower === 'document') {
       allVariables.header.media_name = '';
     }
   }
 
   // Process button variables
-  const buttonComponents = template.components.filter(
+  const buttonComponents = (template.components || []).filter(
     component => component.type === COMPONENT_TYPES.BUTTONS
   );
 

--- a/app/javascript/dashboard/i18n/locale/en/whatsappTemplates.json
+++ b/app/javascript/dashboard/i18n/locale/en/whatsappTemplates.json
@@ -40,6 +40,12 @@
       "BUTTON_LABEL": "Button {index}",
       "COUPON_CODE": "Enter coupon code (max 15 chars)",
       "MEDIA_URL_LABEL": "Enter {type} URL",
+      "UPLOAD_LOCAL_FILE": "Upload local file",
+      "REMOVE_UPLOADED_FILE": "Remove uploaded file",
+      "DRAG_AND_DROP_HINT": "or drag and drop a file here",
+      "UPLOADING_MEDIA": "Uploading...",
+      "INVALID_MEDIA_TYPE": "The selected file type is not supported for this template header.",
+      "MEDIA_UPLOAD_FAILED": "Unable to upload file. Please try again.",
       "DOCUMENT_NAME_PLACEHOLDER": "Enter document filename (e.g., Invoice_2025.pdf)",
       "BUTTON_PARAMETER": "Enter button parameter"
     }

--- a/app/services/conversations/create_with_initial_message.rb
+++ b/app/services/conversations/create_with_initial_message.rb
@@ -1,0 +1,25 @@
+class Conversations::CreateWithInitialMessage
+  def initialize(user:, contact_inbox:, params:)
+    @user = user
+    @contact_inbox = contact_inbox
+    @params = params
+  end
+
+  # Returns [conversation, nil] on success, or [conversation_or_nil, error_message] when the initial message fails.
+  def perform
+    initial_message_error = nil
+    conversation = nil
+    ActiveRecord::Base.transaction do
+      conversation = ConversationBuilder.new(params: @params, contact_inbox: @contact_inbox).perform
+      if @params[:message].present?
+        begin
+          Messages::MessageBuilder.new(@user, conversation, @params[:message]).perform
+        rescue StandardError => e
+          initial_message_error = e.message
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+    [conversation, initial_message_error]
+  end
+end

--- a/app/services/conversations/create_with_initial_message.rb
+++ b/app/services/conversations/create_with_initial_message.rb
@@ -14,7 +14,7 @@ class Conversations::CreateWithInitialMessage
       if @params[:message].present?
         begin
           Messages::MessageBuilder.new(@user, conversation, @params[:message]).perform
-        rescue StandardError => e
+        rescue CustomExceptions::Message::InvalidTemplateMedia => e
           initial_message_error = e.message
           raise ActiveRecord::Rollback
         end

--- a/app/services/messages/template_media_attachment_service.rb
+++ b/app/services/messages/template_media_attachment_service.rb
@@ -1,0 +1,34 @@
+class Messages::TemplateMediaAttachmentService
+  include FileTypeHelper
+
+  pattr_initialize [:message!, :attachments, :template_params]
+
+  def perform
+    media_blob_id = parsed_template_params.dig('processed_params', 'header', 'media_blob_id')
+    return if media_blob_id.blank? || attachments&.include?(media_blob_id)
+
+    attachment = message.attachments.build(
+      account_id: message.account_id,
+      file: media_blob_id
+    )
+    attachment.file_type = file_type_by_signed_id(media_blob_id)
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
+    raise ArgumentError, 'Invalid media upload. Please upload the media again.'
+  end
+
+  private
+
+  def parsed_template_params
+    params_hash = template_params.is_a?(String) ? safe_parse_json(template_params) : template_params
+    params_hash = params_hash.to_unsafe_h if params_hash.respond_to?(:to_unsafe_h)
+    return {} unless params_hash.is_a?(Hash)
+
+    params_hash.deep_stringify_keys
+  end
+
+  def safe_parse_json(value)
+    JSON.parse(value)
+  rescue JSON::ParserError
+    {}
+  end
+end

--- a/app/services/messages/template_media_attachment_service.rb
+++ b/app/services/messages/template_media_attachment_service.rb
@@ -5,7 +5,8 @@ class Messages::TemplateMediaAttachmentService
 
   def perform
     media_blob_id = parsed_template_params.dig('processed_params', 'header', 'media_blob_id')
-    return if media_blob_id.blank? || Array(attachments).include?(media_blob_id)
+    return if media_blob_id.blank?
+    return if template_media_signed_id_already_in_attachments?(media_blob_id)
 
     attachment = message.attachments.build(
       account_id: message.account_id,
@@ -17,6 +18,11 @@ class Messages::TemplateMediaAttachmentService
   end
 
   private
+
+  # Dedupe when the same signed id is already in attachments[]; use include? (==) instead of any?(pattern).
+  def template_media_signed_id_already_in_attachments?(media_blob_id)
+    Array(attachments).include?(media_blob_id)
+  end
 
   def parsed_template_params
     params_hash = template_params.is_a?(String) ? safe_parse_json(template_params) : template_params

--- a/app/services/messages/template_media_attachment_service.rb
+++ b/app/services/messages/template_media_attachment_service.rb
@@ -5,7 +5,7 @@ class Messages::TemplateMediaAttachmentService
 
   def perform
     media_blob_id = parsed_template_params.dig('processed_params', 'header', 'media_blob_id')
-    return if media_blob_id.blank? || attachments&.include?(media_blob_id)
+    return if media_blob_id.blank? || Array(attachments).include?(media_blob_id)
 
     attachment = message.attachments.build(
       account_id: message.account_id,

--- a/app/services/messages/template_params_from_request.rb
+++ b/app/services/messages/template_params_from_request.rb
@@ -1,0 +1,17 @@
+class Messages::TemplateParamsFromRequest
+  # Normalizes template_params from either nested multipart params or a single JSON field.
+  def self.call(raw)
+    return if raw.blank?
+
+    normalized = if raw.is_a?(String)
+                   JSON.parse(raw)
+                 else
+                   JSON.parse(raw.to_json)
+                 end
+    return normalized if normalized.is_a?(Hash) && normalized.present?
+
+    nil
+  rescue JSON::ParserError
+    nil
+  end
+end

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -35,6 +35,8 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
                                          parameters: processed_parameters
                                        }, message)
     message.update!(source_id: message_id) if message_id.present?
+  rescue ArgumentError => e
+    message.update!(status: :failed, external_error: e.message)
   end
 
   def send_session_message

--- a/app/services/whatsapp/template_media_resolver_service.rb
+++ b/app/services/whatsapp/template_media_resolver_service.rb
@@ -1,0 +1,31 @@
+class Whatsapp::TemplateMediaResolverService
+  pattr_initialize [:header_data!, :message]
+
+  def call
+    return header_data if media_blob_id.blank?
+    raise ArgumentError, 'Provide either media URL or uploaded file, not both.' if header_data['media_url'].present?
+
+    blob = ActiveStorage::Blob.find_signed!(media_blob_id)
+    resolved_header_data.merge('media_url' => resolved_media_url(blob))
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
+    raise ArgumentError, 'Invalid media upload. Please upload the media again.'
+  end
+
+  private
+
+  def media_blob_id
+    header_data['media_blob_id']
+  end
+
+  def resolved_header_data
+    header_data.except('media_blob_id')
+  end
+
+  def resolved_media_url(blob)
+    attachment = message&.attachments&.find { |item| item.file&.blob_id == blob.id }
+    return attachment.download_url if attachment.present?
+
+    ActiveStorage::Current.url_options = Rails.application.routes.default_url_options if ActiveStorage::Current.url_options.blank?
+    blob.url
+  end
+end

--- a/app/services/whatsapp/template_processor_service.rb
+++ b/app/services/whatsapp/template_processor_service.rb
@@ -52,28 +52,40 @@ class Whatsapp::TemplateProcessorService
   def process_header_components(processed_params)
     return [] if processed_params['header'].blank?
 
-    header_params = build_header_params(processed_params['header'])
+    header_params = build_header_params(resolve_header_media(processed_params['header']))
     header_params.present? ? [{ type: 'header', parameters: header_params }] : []
   end
 
-  def build_header_params(header_data)
-    header_params = []
-    header_data.each do |key, value|
-      next if value.blank?
-
-      if media_url_with_type?(key, header_data)
-        media_name = header_data['media_name']
-        media_param = parameter_builder.build_media_parameter(value, header_data['media_type'], media_name)
-        header_params << media_param if media_param
-      elsif key != 'media_type' && key != 'media_name'
-        header_params << parameter_builder.build_parameter(value)
-      end
-    end
-    header_params
+  def resolve_header_media(header_data)
+    Whatsapp::TemplateMediaResolverService.new(
+      header_data: header_data,
+      message: message
+    ).call
   end
 
-  def media_url_with_type?(key, header_data)
-    key == 'media_url' && header_data['media_type'].present?
+  def build_header_params(header_data)
+    media_param = build_header_media_parameter(header_data)
+    text_params = build_header_text_parameters(header_data)
+    [media_param, *text_params].compact
+  end
+
+  def build_header_media_parameter(header_data)
+    return unless header_data['media_url'].present? && header_data['media_type'].present?
+
+    parameter_builder.build_media_parameter(
+      header_data['media_url'],
+      header_data['media_type'],
+      header_data['media_name']
+    )
+  end
+
+  def build_header_text_parameters(header_data)
+    ignored_keys = %w[media_url media_type media_name media_blob_id]
+    header_data.filter_map do |key, value|
+      next if ignored_keys.include?(key) || value.blank?
+
+      parameter_builder.build_parameter(value)
+    end
   end
 
   def process_body_components(processed_params, template)

--- a/lib/custom_exceptions/message/invalid_template_media.rb
+++ b/lib/custom_exceptions/message/invalid_template_media.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Raised when WhatsApp template header media references an invalid or expired blob.
+# Caught by Conversations::CreateWithInitialMessage to rollback without masking RecordInvalid.
+class CustomExceptions::Message::InvalidTemplateMedia < StandardError; end

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -199,6 +199,26 @@ describe Messages::MessageBuilder do
           expect(message.attachments.size).to eq(1)
           expect(message.attachments.first.file_type).to eq('image')
         end
+
+        it 'raises StandardError when template media_blob_id is invalid' do
+          params = ActionController::Parameters.new({
+                                                      content: 'test',
+                                                      template_params: {
+                                                        name: 'sample',
+                                                        language: 'en_US',
+                                                        processed_params: {
+                                                          header: {
+                                                            media_type: 'image',
+                                                            media_blob_id: 'invalid-signed-id'
+                                                          }
+                                                        }
+                                                      }
+                                                    })
+
+          expect do
+            described_class.new(user, conversation, params).perform
+          end.to raise_error(StandardError, /Invalid media upload/)
+        end
       end
     end
 

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -200,7 +200,7 @@ describe Messages::MessageBuilder do
           expect(message.attachments.first.file_type).to eq('image')
         end
 
-        it 'raises StandardError when template media_blob_id is invalid' do
+        it 'raises InvalidTemplateMedia when template media_blob_id is invalid' do
           params = ActionController::Parameters.new({
                                                       content: 'test',
                                                       template_params: {
@@ -217,7 +217,7 @@ describe Messages::MessageBuilder do
 
           expect do
             described_class.new(user, conversation, params).perform
-          end.to raise_error(StandardError, /Invalid media upload/)
+          end.to raise_error(CustomExceptions::Message::InvalidTemplateMedia, /Invalid media upload/)
         end
       end
     end

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -20,6 +20,29 @@ describe Messages::MessageBuilder do
       message = message_builder
       expect(message.content).to eq params[:content]
     end
+
+    context 'when template_params is a JSON string' do
+      let(:template_hash) do
+        {
+          'name' => 'hello_template',
+          'language' => 'en_US',
+          'processed_params' => { 'body' => { '1' => 'x' } }
+        }
+      end
+      let(:params) do
+        ActionController::Parameters.new({
+                                           content: 'test',
+                                           template_params: template_hash.to_json
+                                         })
+      end
+
+      it 'stores parsed template_params on additional_attributes' do
+        message = message_builder
+        stored = message.additional_attributes['template_params']
+        expect(stored['name']).to eq('hello_template')
+        expect(stored.dig('processed_params', 'body', '1')).to eq('x')
+      end
+    end
   end
 
   describe '#content_attributes' do

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -147,6 +147,36 @@ describe Messages::MessageBuilder do
           expect(message.attachments.first.file_type).to eq 'image'
         end
       end
+
+      context 'when whatsapp template has uploaded media blob' do
+        let(:inbox) do
+          create(:inbox,
+                 channel: create(:channel_whatsapp, account: account, validate_provider_config: false, sync_templates: false),
+                 account: account)
+        end
+        let(:blob) { get_blob_for('spec/assets/avatar.png', 'image/png') }
+        let(:params) do
+          ActionController::Parameters.new({
+                                             content: 'test',
+                                             template_params: {
+                                               name: 'sample',
+                                               language: 'en_US',
+                                               processed_params: {
+                                                 header: {
+                                                   media_type: 'image',
+                                                   media_blob_id: blob.signed_id
+                                                 }
+                                               }
+                                             }
+                                           })
+        end
+
+        it 'creates message attachment from media blob id for conversation preview' do
+          message = message_builder
+          expect(message.attachments.size).to eq(1)
+          expect(message.attachments.first.file_type).to eq('image')
+        end
+      end
     end
 
     context 'when email channel messages' do

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -414,6 +414,23 @@ RSpec.describe 'Conversations API', type: :request do
           expect(account.conversations.where(contact_inbox_id: whatsapp_contact_inbox.id).count).to eq(0)
         end
 
+        it 'returns structured validation error when initial message fails model validation' do
+          allow(Rails.configuration.dispatcher).to receive(:dispatch)
+          post "/api/v1/accounts/#{account.id}/conversations",
+               headers: agent.create_new_auth_token,
+               params: {
+                 source_id: contact_inbox.source_id,
+                 message: { content: 'x' * 150_001 }
+               },
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          body = response.parsed_body
+          expect(body['message']).to be_present
+          expect(body['attributes']).to be_present
+          expect(account.conversations.where(contact_inbox_id: contact_inbox.id).count).to eq(0)
+        end
+
         it 'calls contact inbox builder if contact_id and inbox_id is present' do
           builder = double
           allow(Rails.configuration.dispatcher).to receive(:dispatch)

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -386,6 +386,34 @@ RSpec.describe 'Conversations API', type: :request do
           expect(account.conversations.find_by(display_id: response_data[:id]).messages.outgoing.first.content).to eq 'hi'
         end
 
+        it 'returns unprocessable entity when initial message has invalid template media_blob_id' do
+          whatsapp_inbox = create(:inbox,
+                                  channel: create(:channel_whatsapp, account: account, validate_provider_config: false, sync_templates: false),
+                                  account: account)
+          create(:inbox_member, user: agent, inbox: whatsapp_inbox)
+          whatsapp_contact_inbox = create(:contact_inbox, contact: contact, inbox: whatsapp_inbox)
+
+          post "/api/v1/accounts/#{account.id}/conversations",
+               headers: agent.create_new_auth_token,
+               params: {
+                 source_id: whatsapp_contact_inbox.source_id,
+                 message: {
+                   content: 'hi',
+                   template_params: {
+                     name: 'sample',
+                     processed_params: {
+                       header: { media_type: 'image', media_blob_id: 'invalid-signed-id' }
+                     }
+                   }
+                 }
+               },
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body['error']).to match(/Invalid media upload/)
+          expect(account.conversations.where(contact_inbox_id: whatsapp_contact_inbox.id).count).to eq(0)
+        end
+
         it 'calls contact inbox builder if contact_id and inbox_id is present' do
           builder = double
           allow(Rails.configuration.dispatcher).to receive(:dispatch)

--- a/spec/services/messages/template_media_attachment_service_spec.rb
+++ b/spec/services/messages/template_media_attachment_service_spec.rb
@@ -27,5 +27,28 @@ describe Messages::TemplateMediaAttachmentService do
         described_class.new(message: message, attachments: single_attachment, template_params: template_params).perform
       end.not_to raise_error
     end
+
+    it 'does not add a template attachment when the same signed id is already listed in attachments' do
+      described_class.new(
+        message: message,
+        attachments: [blob.signed_id],
+        template_params: template_params
+      ).perform
+
+      expect(message.attachments.size).to eq(0)
+    end
+
+    it 'adds a template attachment when attachments are raw files (no signed id overlap)' do
+      file = Rack::Test::UploadedFile.new('spec/assets/avatar.png', 'image/png')
+
+      described_class.new(
+        message: message,
+        attachments: [file],
+        template_params: template_params
+      ).perform
+
+      expect(message.attachments.size).to eq(1)
+      expect(message.attachments.first.file_type).to eq('image')
+    end
   end
 end

--- a/spec/services/messages/template_media_attachment_service_spec.rb
+++ b/spec/services/messages/template_media_attachment_service_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe Messages::TemplateMediaAttachmentService do
+  describe '#perform' do
+    let(:account) { create(:account) }
+    let(:inbox) do
+      create(:inbox, channel: create(:channel_whatsapp, account: account, validate_provider_config: false, sync_templates: false), account: account)
+    end
+    let(:conversation) { create(:conversation, inbox: inbox, account: account) }
+    let(:message) { create(:message, account: account, inbox: inbox, conversation: conversation, message_type: :outgoing) }
+    let(:blob) { get_blob_for('spec/assets/avatar.png', 'image/png') }
+    let(:template_params) do
+      {
+        'processed_params' => {
+          'header' => {
+            'media_blob_id' => blob.signed_id,
+            'media_type' => 'image'
+          }
+        }
+      }
+    end
+
+    it 'handles non-array attachments without raising error' do
+      single_attachment = Rack::Test::UploadedFile.new('spec/assets/avatar.png', 'image/png')
+
+      expect do
+        described_class.new(message: message, attachments: single_attachment, template_params: template_params).perform
+      end.not_to raise_error
+    end
+  end
+end

--- a/spec/services/whatsapp/template_media_resolver_service_spec.rb
+++ b/spec/services/whatsapp/template_media_resolver_service_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe Whatsapp::TemplateMediaResolverService do
+  describe '#call' do
+    let(:blob) { get_blob_for('spec/assets/avatar.png', 'image/png') }
+
+    it 'resolves media_blob_id to media_url' do
+      header_data = {
+        'media_type' => 'image',
+        'media_blob_id' => blob.signed_id
+      }
+
+      result = described_class.new(header_data: header_data).call
+
+      expect(result['media_blob_id']).to be_nil
+      expect(result['media_url']).to be_present
+      expect(result['media_type']).to eq('image')
+    end
+
+    it 'raises error when media_url and media_blob_id are both provided' do
+      header_data = {
+        'media_type' => 'image',
+        'media_blob_id' => blob.signed_id,
+        'media_url' => 'https://example.com/image.png'
+      }
+
+      expect { described_class.new(header_data: header_data).call }
+        .to raise_error(ArgumentError, 'Provide either media URL or uploaded file, not both.')
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds native local file upload support for WhatsApp template header media in the dashboard compose flows (including new conversation), while preserving backward compatibility with existing `media_url` payloads.

It also improves UX by introducing a cleaner upload interaction with a slate-styled icon button and drag-and-drop support in the template parser.

Backend now resolves `media_blob_id` references into provider-usable media links and persists uploaded template media as message attachments so the file is visible in conversation previews/timeline.

Fixes #12684

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `pnpm run ruby:prettier` (passes, no offenses).
- Ran `pnpm eslint app/javascript/dashboard/components-next/whatsapp/WhatsAppTemplateParser.vue` (passes).
- Ran focused Ruby specs:
  - `bundle exec rspec spec/services/whatsapp/template_media_resolver_service_spec.rb spec/builders/messages/message_builder_spec.rb`
  - Result: 24 examples, 0 failures.
- Attempted JS unit test:
  - `pnpm test app/javascript/dashboard/helper/specs/templateHelper.spec.js`
  - Blocked by local environment incompatibility (Node 20 + jsdom/parse5 ESM issue), unrelated to feature logic.

Manual verification:
1. Open WhatsApp template composer with media header.
2. Upload local file using upload icon button or drag-and-drop.
3. Confirm file preview appears in parser.
4. Send template.
5. Confirm attachment appears in conversation timeline.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules