### PR TITLE
fix: include private messages in conversation event webhook payload

### DIFF
--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -33,7 +33,9 @@ class Conversations::EventDataPresenter < SimpleDelegator
   end
 
   def webhook_push_messages
-    [messages.where(account_id: account_id).chat.last&.webhook_push_event_data].compact
+    # `.chat` hides private messages, but webhooks must include them (see Message#webhook_sendable?).
+    last_message = messages.where(account_id: account_id).where.not(message_type: :activity).last
+    [last_message&.webhook_push_event_data].compact
   end
 
   def push_meta

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -68,5 +68,27 @@ RSpec.describe Conversations::EventDataPresenter do
     it 'returns empty messages when conversation has no chat messages' do
       expect(presenter.webhook_data[:messages]).to eq([])
     end
+
+    it 'includes the private message when it is the latest in the conversation' do
+      create(:message, conversation: conversation, account: conversation.account,
+                       message_type: :outgoing, content: 'public reply')
+      private_message = create(:message, conversation: conversation, account: conversation.account,
+                                         message_type: :outgoing, content: 'private note', private: true)
+
+      webhook_messages = presenter.webhook_data[:messages]
+
+      expect(webhook_messages.length).to eq(1)
+      expect(webhook_messages.first[:id]).to eq(private_message.id)
+      expect(webhook_messages.first[:private]).to be true
+    end
+
+    it 'skips activity messages when picking the latest' do
+      outgoing = create(:message, conversation: conversation, account: conversation.account,
+                                  message_type: :outgoing, content: 'reply')
+      create(:message, conversation: conversation, account: conversation.account,
+                       message_type: :activity, content: 'Conversation was marked resolved')
+
+      expect(presenter.webhook_data[:messages].first[:id]).to eq(outgoing.id)
+    end
   end
 end


### PR DESCRIPTION
## Description

When an agent adds a private note to a conversation, the `message_created` webhook fires correctly (because `Message#webhook_sendable?` permits private messages), but the attached `conversation.messages` array silently substitutes the previous *public* message. Consumers listening for private-note events therefore act on the wrong content — a pain point for routing, audit logging, and summarization pipelines.

The root cause is the `Message.chat` scope (`where.not(message_type: :activity).where(private: false)`) applied in `Conversations::EventDataPresenter#webhook_push_messages`. The private filter is appropriate for in-app chat rendering but wrong for outbound webhook payloads.

This PR drops only the private filter from the webhook presenter, keeping the activity filter so system messages continue to be skipped. The sibling `push_messages` path (ActionCable) is intentionally unchanged — it broadcasts to both agent and contact tokens, and widening it could leak private content to contact sockets. The scope of the fix is limited to the one webhook call site.

Fixes #14023

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

**Automated.** Added two RSpec cases to the existing `#webhook_data` describe block: one asserting that the latest private message is returned in the payload with `private: true`; another regression-guarding that activity messages are still excluded. Pre-existing webhook specs continue to pass.

**Manual.** Reproduced on `develop` by configuring an outbound webhook, sending a public reply, then adding a private note. Before the fix the webhook payload's `conversation.messages[0].content` is the earlier public reply; after the fix it is the private note, with `private: true`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
