### PR TITLE
fix: reuse open conversation when creating from contacts view

### DIFF
--- a/app/builders/conversation_builder.rb
+++ b/app/builders/conversation_builder.rb
@@ -8,9 +8,13 @@ class ConversationBuilder
   private
 
   def look_up_exising_conversation
-    return unless @contact_inbox.inbox.lock_to_single_conversation?
+    return @contact_inbox.conversations.last if @contact_inbox.inbox.lock_to_single_conversation?
+    return unless @contact_inbox.inbox.allow_messages_after_resolved
 
-    @contact_inbox.conversations.last
+    # Mirrors incoming message services (e.g. Whatsapp::IncomingMessageBaseService#set_conversation):
+    # when the inbox reopens existing conversations, agent-initiated messages should land in the
+    # contact's last non-resolved conversation instead of spawning a duplicate.
+    @contact_inbox.conversations.where.not(status: :resolved).last
   end
 
   def create_new_conversation

--- a/spec/builders/conversation_builder_spec.rb
+++ b/spec/builders/conversation_builder_spec.rb
@@ -80,5 +80,37 @@ describe ConversationBuilder do
         expect(conversation.id).to eq(existing_conversation.id)
       end
     end
+
+    context 'when allow_messages_after_resolved is enabled and lock_to_single_conversation is disabled' do
+      it 'reuses the last non-resolved conversation for the contact inbox' do
+        create(:conversation, contact_inbox: contact_sms_inbox, status: :resolved)
+        open_conversation = create(:conversation, contact_inbox: contact_sms_inbox, status: :open)
+
+        conversation = described_class.new(contact_inbox: contact_sms_inbox, params: {}).perform
+
+        expect(conversation.id).to eq(open_conversation.id)
+      end
+
+      it 'creates a new conversation when every existing conversation is resolved' do
+        create(:conversation, contact_inbox: contact_sms_inbox, status: :resolved)
+
+        conversation = described_class.new(contact_inbox: contact_sms_inbox, params: {}).perform
+
+        expect(conversation.status).to eq('open')
+        expect(conversation.contact_inbox_id).to eq(contact_sms_inbox.id)
+      end
+    end
+
+    context 'when allow_messages_after_resolved is disabled' do
+      before { sms_inbox.update!(allow_messages_after_resolved: false) }
+
+      it 'creates a new conversation even when a non-resolved conversation exists' do
+        existing = create(:conversation, contact_inbox: contact_sms_inbox, status: :open)
+
+        conversation = described_class.new(contact_inbox: contact_sms_inbox, params: {}).perform
+
+        expect(conversation.id).not_to eq(existing.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

Creating a conversation from the Contacts view (e.g. sending a WhatsApp template to a contact who already has an open conversation) currently always spawns a new conversation unless the inbox has `lock_to_single_conversation` enabled. The `allow_messages_after_resolved` setting — the "Reopen existing conversation" toggle — is ignored on the agent-initiated path. As a result, agents end up with duplicate conversation threads for the same contact within the 24-hour WhatsApp session window, losing context and confusing the end customer.

The incoming-message side already does the right thing: `Whatsapp::IncomingMessageBaseService#set_conversation` reuses the last non-resolved conversation when `lock_to_single_conversation` is off. 

This PR brings `ConversationBuilder#look_up_exising_conversation` in line with that behavior so agent-initiated and contact-initiated messages land in the same thread.

Returning only a non-resolved conversation keeps the builder free of state mutation — the existing `Message#reopen_conversation` callback still handles `snoozed → open` transitions on outgoing message creation. `allow_messages_after_resolved` defaults to `true`, so admins who explicitly want strict "new conversation per message" behavior can still disable the flag.

Fixes #14086


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

**Automated.** Added three RSpec cases to `spec/builders/conversation_builder_spec.rb` covering: (1) reuse of the last non-resolved conversation when a prior resolved one also exists, (2) creation of a fresh conversation when every prior conversation is resolved, (3) strict new-conversation creation when `allow_messages_after_resolved` is disabled. Existing `lock_to_single_conversation` specs continue to pass.

**Manual.** On a WhatsApp inbox with `allow_messages_after_resolved` on, created an open conversation with a contact, then used the Contacts view to send a template to the same contact. Before the fix a second conversation was created; after the fix the existing one is reused.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
