### PR TITLE
feat: allow admins to disable message deletion per inbox

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -19,6 +19,8 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
   end
 
   def destroy
+    return render_message_deletion_disabled unless @conversation.inbox.allow_message_deletion
+
     ActiveRecord::Base.transaction do
       message.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: { deleted: true })
       message.attachments.destroy_all
@@ -76,5 +78,9 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
   def ensure_api_inbox
     # Only API inboxes can update messages
     render json: { error: 'Message status update is only allowed for API inboxes' }, status: :forbidden unless @conversation.inbox.api?
+  end
+
+  def render_message_deletion_disabled
+    render json: { error: I18n.t('conversations.messages.deletion_disabled') }, status: :forbidden
   end
 end

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -157,7 +157,7 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   def inbox_attributes
     [:name, :avatar, :greeting_enabled, :greeting_message, :enable_email_collect, :csat_survey_enabled,
      :enable_auto_assignment, :working_hours_enabled, :out_of_office_message, :timezone, :allow_messages_after_resolved,
-     :lock_to_single_conversation, :portal_id, :sender_name_type, :business_name,
+     :allow_message_deletion, :lock_to_single_conversation, :portal_id, :sender_name_type, :business_name,
      { csat_config: [:display_type, :message, :button_text, :language,
                      { survey_rules: [:operator, { values: [] }],
                        template: [:name, :template_id, :friendly_name, :content_sid, :approval_sid, :created_at, :language, :status] }] }]

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -372,10 +372,14 @@ const contextMenuEnabledOptions = computed(() => {
   const isFailedOrProcessing =
     props.status === MESSAGE_STATUS.FAILED ||
     props.status === MESSAGE_STATUS.PROGRESS;
+  // Fall through to allowed when the flag is undefined so a cold inbox cache does not
+  // hide the action; the server still enforces the ban if the admin has disabled it.
+  const deletionAllowed = inbox.value?.allow_message_deletion !== false;
 
   return {
     copy: hasText,
     delete:
+      deletionAllowed &&
       (hasText || hasAttachments) &&
       !isFailedOrProcessing &&
       !isMessageDeleted.value,

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -763,6 +763,8 @@
       "FORWARD_EMAIL_NOT_CONFIGURED": "Forwarding emails to your inbox is currently disabled on this installation. To use this feature, it must be enabled by your administrator. Please get in touch with them to proceed.",
       "ALLOW_MESSAGES_AFTER_RESOLVED": "Allow messages after conversation resolved",
       "ALLOW_MESSAGES_AFTER_RESOLVED_SUB_TEXT": "Allow the end-users to send messages even after the conversation is resolved.",
+      "ALLOW_MESSAGE_DELETION": "Allow agents to delete messages",
+      "ALLOW_MESSAGE_DELETION_SUB_TEXT": "When enabled, agents can delete their outgoing messages in this inbox. Turning this off hides the delete action in the dashboard and rejects deletions through the API.",
       "WHATSAPP_SECTION_SUBHEADER": "This API Key is used for the integration with the WhatsApp APIs.",
       "WHATSAPP_SECTION_UPDATE_SUBHEADER": "Enter the new API key to be used for the integration with the WhatsApp APIs.",
       "WHATSAPP_SECTION_TITLE": "API Key",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -88,6 +88,7 @@ export default {
       businessName: '',
       locktoSingleConversation: false,
       allowMessagesAfterResolved: true,
+      allowMessageDeletion: true,
       continuityViaEmail: true,
       selectedInboxName: '',
       channelWebsiteUrl: '',
@@ -435,6 +436,7 @@ export default {
       this.businessName = this.inbox.business_name;
       this.allowMessagesAfterResolved =
         this.inbox.allow_messages_after_resolved;
+      this.allowMessageDeletion = this.inbox.allow_message_deletion !== false;
       this.continuityViaEmail = this.inbox.continuity_via_email;
       this.channelWebsiteUrl = this.inbox.website_url;
       this.channelWelcomeTitle = this.inbox.welcome_title;
@@ -548,6 +550,7 @@ export default {
           name: this.selectedInboxName?.trim(),
           enable_email_collect: this.emailCollectEnabled,
           allow_messages_after_resolved: this.allowMessagesAfterResolved,
+          allow_message_deletion: this.allowMessageDeletion,
           greeting_enabled: this.greetingEnabled,
           greeting_message: this.greetingMessage || '',
           portal_id: this.selectedPortalSlug
@@ -1168,6 +1171,16 @@ export default {
                 :description="
                   $t(
                     'INBOX_MGMT.SETTINGS_POPUP.ALLOW_MESSAGES_AFTER_RESOLVED_SUB_TEXT'
+                  )
+                "
+              />
+
+              <SettingsToggleSection
+                v-model="allowMessageDeletion"
+                :header="$t('INBOX_MGMT.SETTINGS_POPUP.ALLOW_MESSAGE_DELETION')"
+                :description="
+                  $t(
+                    'INBOX_MGMT.SETTINGS_POPUP.ALLOW_MESSAGE_DELETION_SUB_TEXT'
                   )
                 "
               />

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -5,6 +5,7 @@
 # Table name: inboxes
 #
 #  id                            :integer          not null, primary key
+#  allow_message_deletion        :boolean          default(TRUE), not null
 #  allow_messages_after_resolved :boolean          default(TRUE)
 #  auto_assignment_config        :jsonb
 #  business_name                 :string

--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -16,6 +16,7 @@ json.working_hours resource.weekly_schedule
 json.timezone resource.timezone
 json.callback_webhook_url resource.callback_webhook_url
 json.allow_messages_after_resolved resource.allow_messages_after_resolved
+json.allow_message_deletion resource.allow_message_deletion
 json.lock_to_single_conversation resource.lock_to_single_conversation
 json.sender_name_type resource.sender_name_type
 json.business_name resource.business_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -241,6 +241,7 @@ en:
       instagram_shared_story_content: 'Shared story'
       instagram_shared_post_content: 'Shared post'
       deleted: This message was deleted
+      deletion_disabled: Message deletion is disabled for this inbox.
       whatsapp:
         list_button_label: 'Choose an item'
       delivery_status:

--- a/db/migrate/20260425000000_add_allow_message_deletion_to_inboxes.rb
+++ b/db/migrate/20260425000000_add_allow_message_deletion_to_inboxes.rb
@@ -1,0 +1,5 @@
+class AddAllowMessageDeletionToInboxes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :inboxes, :allow_message_deletion, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_10_092753) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_25_000000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -381,11 +381,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_10_092753) do
     t.integer "sync_status"
     t.datetime "last_synced_at"
     t.datetime "last_sync_attempted_at"
+    t.index ["account_id", "sync_status"], name: "index_captain_documents_on_account_id_and_sync_status"
     t.index ["account_id"], name: "index_captain_documents_on_account_id"
     t.index ["assistant_id", "external_link"], name: "index_captain_documents_on_assistant_id_and_external_link", unique: true
     t.index ["assistant_id"], name: "index_captain_documents_on_assistant_id"
     t.index ["status"], name: "index_captain_documents_on_status"
-    t.index ["account_id", "sync_status"], name: "index_captain_documents_on_account_id_and_sync_status"
   end
 
   create_table "captain_inboxes", force: :cascade do |t|
@@ -908,6 +908,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_10_092753) do
     t.integer "sender_name_type", default: 0, null: false
     t.string "business_name"
     t.jsonb "csat_config", default: {}, null: false
+    t.boolean "allow_message_deletion", default: true, null: false
     t.index ["account_id"], name: "index_inboxes_on_account_id"
     t.index ["channel_id", "channel_type"], name: "index_inboxes_on_channel_id_and_channel_type"
     t.index ["portal_id"], name: "index_inboxes_on_portal_id"

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -234,6 +234,25 @@ RSpec.describe 'Conversation Messages API', type: :request do
       end
     end
 
+    context 'when the inbox disallows message deletion' do
+      let(:agent) { create(:user, account: account, role: :agent) }
+
+      before do
+        create(:inbox_member, inbox: conversation.inbox, user: agent)
+        conversation.inbox.update!(allow_message_deletion: false)
+      end
+
+      it 'rejects deletion with a forbidden status and leaves the message unchanged' do
+        delete "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/messages/#{message.id}",
+               headers: agent.create_new_auth_token,
+               as: :json
+
+        expect(response).to have_http_status(:forbidden)
+        expect(message.reload.content).not_to eq 'This message was deleted'
+        expect(message.reload.content_attributes['deleted']).to be_falsey
+      end
+    end
+
     context 'when the message id is invalid' do
       let(:agent) { create(:user, account: account, role: :agent) }
 


### PR DESCRIPTION
## Description

Administrators can now toggle "Allow agents to delete messages" on each inbox. When the toggle is off, the delete action is hidden from the message context menu in the dashboard and the `DELETE /conversations/:id/messages/:id` endpoint rejects the request with a 403. The flag defaults to `true`, so every existing inbox keeps today's behavior — admins opt in to the restriction.

This closes a longstanding ask from compliance/audit-sensitive deployments where agents
being able to silently delete messages is not acceptable. The implementation mirrors the existing `allow_messages_after_resolved` inbox setting end-to-end (migration, serializer, permitted params, settings toggle), so there is no new pattern to maintain.

**What's in scope**

- `inboxes.allow_message_deletion` boolean column (default `true`, `null: false`)
- `Api::V1::Accounts::Conversations::MessagesController#destroy` returns `403` with a translated error when the inbox disallows deletion
- `_inbox.json.jbuilder` exposes the field so the Vuex store receives it on inbox load
- `Message.vue` context menu hides the delete action when the inbox disallows it (falls through to "allowed" if the flag is `undefined`, so a cold cache never silently hides the action — the server is still the source of truth)
- Inbox settings adds a `SettingsToggleSection` below "Reopen existing conversation"
- i18n keys for the toggle copy (`en.json`) and the API error (`en.yml`)
- Spec for the 403 path

**Out of scope, flagged for follow-up if maintainers want them**

- Admin-bypass (admins still blocked when the toggle is off — simplest to reason about)
- Pundit policy refactor (controller uses inline guards like `ensure_api_inbox`; matched that idiom)
- Audit logging of deletion attempts

Fixes #5950

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

**Automated.** Added an RSpec case to `spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb` asserting that `DELETE` returns `403` and leaves the message unchanged when the inbox has `allow_message_deletion: false`. Existing destroy and permitted-params specs continue to pass.

**Manual.** With an inbox flipped via the new setting, confirmed (1) the delete action disappears from the outgoing-message context menu in the dashboard, (2) a direct `curl -X DELETE` to the endpoint returns `403` with `{"error":"Message deletion is disabled for this inbox."}`, and (3) toggling the setting back on restores both paths.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
