### PR TITLE
fix: bind form select value

### DIFF
--- a/app/javascript/v3/components/Form/Select.spec.js
+++ b/app/javascript/v3/components/Form/Select.spec.js
@@ -1,0 +1,47 @@
+import { mount } from '@vue/test-utils';
+import FormSelect from './Select.vue';
+
+const options = [
+  { label: 'Small', value: 'small' },
+  { label: 'Large', value: 'large' },
+];
+
+const buildWrapper = props =>
+  mount(FormSelect, {
+    global: {
+      stubs: {
+        'fluent-icon': true,
+      },
+    },
+    props: {
+      label: 'Font size',
+      name: 'fontSize',
+      options,
+      ...props,
+    },
+  });
+
+describe('FormSelect', () => {
+  it('sets the initial selected option from modelValue', () => {
+    const wrapper = buildWrapper({ modelValue: 'large' });
+
+    expect(wrapper.find('select').element.value).toBe('large');
+  });
+
+  it('shows the placeholder when modelValue is empty', () => {
+    const wrapper = buildWrapper({
+      modelValue: '',
+      placeholder: 'Select a size',
+    });
+
+    expect(wrapper.find('select').element.value).toBe('');
+  });
+
+  it('emits model updates when the selection changes', async () => {
+    const wrapper = buildWrapper({ modelValue: 'small' });
+
+    await wrapper.find('select').setValue('large');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['large']]);
+  });
+});

--- a/app/javascript/v3/components/Form/Select.vue
+++ b/app/javascript/v3/components/Form/Select.vue
@@ -61,7 +61,7 @@ export default {
   >
     <select
       :id="id"
-      :selected="modelValue"
+      :value="modelValue"
       :name="name"
       :class="{
         'text-n-slate-9': !modelValue,
@@ -71,7 +71,7 @@ export default {
       class="block w-full px-3 py-2 pr-6 mb-0 border-0 shadow-sm appearance-none rounded-xl select-caret leading-6"
       @input="onInput"
     >
-      <option value="" disabled selected class="hidden">
+      <option value="" disabled class="hidden">
         {{ placeholder }}
       </option>
       <slot>


### PR DESCRIPTION
## Summary

This fixes the `FormSelect` component so the initial selected option is correctly bound from `modelValue`.

Before this change, the component used `selected` attributes on options instead of binding the `<select>` value directly. That could cause the wrong initial option to appear selected and made the component behavior inconsistent with Vue's standard controlled select pattern.

## What changed

- bind the `<select>` with `:value="modelValue"`
- remove static `selected` handling from the placeholder option
- keep emitting `update:modelValue` on change

## Why this approach

This keeps the component aligned with normal Vue form control behavior and makes the initial rendered state reflect the actual `modelValue` prop with a minimal change.

## Tests

Added frontend tests covering:

- rendering the option selected from `modelValue`
- rendering the placeholder when the value is empty
- emitting `update:modelValue` when the user changes the selection

## Issue

Closes #12534
