### PR TITLE
fix(slack): preserve full formatted link URLs

### DIFF
--- a/lib/integrations/slack/slack_message_helper.rb
+++ b/lib/integrations/slack/slack_message_helper.rb
@@ -35,7 +35,7 @@ module Integrations::Slack::SlackMessageHelper
       message_type: :outgoing,
       account_id: conversation.account_id,
       inbox_id: conversation.inbox_id,
-      content: Slack::Messages::Formatting.unescape(params[:event][:text] || ''),
+      content: slack_message_content,
       external_source_id_slack: params[:event][:ts],
       private: private_note?,
       sender: resolved_sender,
@@ -47,6 +47,11 @@ module Integrations::Slack::SlackMessageHelper
 
   def attachments_present?
     params[:event][:files].present?
+  end
+
+  def slack_message_content
+    formatted_text = params[:event][:text].to_s.gsub(/<((?:https?|mailto):[^>|]+)\|[^>]*>/, '\1')
+    Slack::Messages::Formatting.unescape(formatted_text)
   end
 
   def process_attachments(attachments)


### PR DESCRIPTION
## Description

Slack can send links in formatted text as `<full-url|display-text>`. When Slack shortens a long URL for display, Chatwoot was storing the shortened display text instead of the real URL, which made the link invalid in the conversation.

This change normalizes Slack formatted links before unescaping the message text, so Chatwoot stores the full URL while preserving the existing Slack mention/link unescape behavior.

Fixes #8614

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Ran `bundle exec rspec spec/lib/integrations/slack/incoming_message_builder_spec.rb`
- Ran `bundle exec rubocop lib/integrations/slack/slack_message_helper.rb`
- Ran a focused Ruby check to confirm `<full-url|shortened-label>` Slack text resolves to the full URL before unescaping

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
