### PR TITLE
fix: disable unchecked feature flags on super admin account update

### DIFF
--- a/app/controllers/super_admin/accounts_controller.rb
+++ b/app/controllers/super_admin/accounts_controller.rb
@@ -36,7 +36,7 @@ class SuperAdmin::AccountsController < SuperAdmin::ApplicationController
   def resource_params
     permitted_params = super
     permitted_params[:limits] = permitted_params[:limits].to_h.compact
-    permitted_params[:selected_feature_flags] = params[:enabled_features].keys.map(&:to_sym) if params[:enabled_features].present?
+    permitted_params[:selected_feature_flags] = params.fetch(:enabled_features, {}).keys.map(&:to_sym)
     permitted_params
   end
 

--- a/spec/controllers/super_admin/accounts_controller_spec.rb
+++ b/spec/controllers/super_admin/accounts_controller_spec.rb
@@ -55,6 +55,44 @@ RSpec.describe 'Super Admin accounts API', type: :request do
     end
   end
 
+  describe 'PATCH /super_admin/accounts/{account_id}' do
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized' do
+        patch "/super_admin/accounts/#{account.id}", params: { account: { name: 'New Name' } }
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context 'when it is an authenticated user' do
+      before { sign_in(super_admin, scope: :super_admin) }
+
+      it 'enables only the submitted feature flags and disables the rest' do
+        account.enable_features!('inbound_emails', 'channel_email')
+
+        patch "/super_admin/accounts/#{account.id}", params: {
+          account: { name: account.name },
+          enabled_features: { 'feature_inbound_emails' => 'true' }
+        }
+
+        account.reload
+        expect(account.feature_enabled?('inbound_emails')).to be(true)
+        expect(account.feature_enabled?('channel_email')).to be(false)
+      end
+
+      it 'disables all features when no enabled_features param is submitted' do
+        account.enable_features!('inbound_emails', 'channel_email')
+
+        patch "/super_admin/accounts/#{account.id}", params: {
+          account: { name: account.name }
+        }
+
+        account.reload
+        expect(account.feature_enabled?('inbound_emails')).to be(false)
+        expect(account.feature_enabled?('channel_email')).to be(false)
+      end
+    end
+  end
+
   describe 'DELETE /super_admin/accounts/{account_id}' do
     context 'when it is an unauthenticated user' do
       it 'returns unauthorized' do


### PR DESCRIPTION
# Pull Request Template

## Description

When a super admin edits account features, unchecked checkboxes send no value in the form submission — only checked boxes are included in the request. The previous code only updated selected_feature_flags when enabled_features was present, meaning unchecked features were never disabled, and previously-enabled features would persist indefinitely.

The fix replaces the conditional guard with params.fetch(:enabled_features, {}) so the setter is always called. When nothing is checked, it receives an empty array, which causes FlagShihTzu to unselect all flags before re-enabling only the submitted ones.

Fixes #14064


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

**Manual testing:**
1. Log in to /super_admin and open any account
2. Enable a few feature flags and save — confirm they are on
3. Uncheck all features and save again — confirm they are now off
4. Enable some features, uncheck only a subset, save — confirm only the unchecked ones are disabled

**Automated testing:**
- Added two RSpec request specs to `spec/controllers/super_admin/accounts_controller_spec.rb`
    - Verifies that submitting a subset of features disables the ones not included
    - Verifies that submitting no features at all disables all previously-enabled features

Run with:
bundle exec rspec spec/controllers/super_admin/accounts_controller_spec.rb

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
