### PR TITLE
feat(twilio): capture Meta Click-to-WhatsApp referral attributes on incoming messages

### DIFF
--- a/app/controllers/twilio/callback_controller.rb
+++ b/app/controllers/twilio/callback_controller.rb
@@ -35,7 +35,17 @@ class Twilio::CallbackController < ApplicationController
       :ExternalUserId,
       :ParentExternalUserId,
       :ProfileUsername,
-      :Username
+      :Username,
+      :ReferralBody,
+      :ReferralHeadline,
+      :ReferralSourceId,
+      :ReferralSourceType,
+      :ReferralSourceUrl,
+      :ReferralMediaId,
+      :ReferralMediaContentType,
+      :ReferralMediaUrl,
+      :ReferralNumMedia,
+      :ReferralCtwaClid
     )
   end
 end

--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -1,4 +1,4 @@
-class Twilio::IncomingMessageService
+class Twilio::IncomingMessageService # rubocop:disable Metrics/ClassLength
   include ::FileTypeHelper
   include ::Twilio::WhatsappIdentifierHelper
 

--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -15,7 +15,8 @@ class Twilio::IncomingMessageService
       inbox_id: @inbox.id,
       message_type: :incoming,
       sender: @contact,
-      source_id: params[:SmsSid]
+      source_id: params[:SmsSid],
+      content_attributes: referral_attributes
     )
     attach_files
     attach_location if location_message?
@@ -135,6 +136,23 @@ class Twilio::IncomingMessageService
     else
       {}
     end
+  end
+
+  def referral_attributes
+    return {} if params[:ReferralSourceId].blank?
+
+    {
+      referral_source_id: params[:ReferralSourceId],
+      referral_source_type: params[:ReferralSourceType],
+      referral_source_url: params[:ReferralSourceUrl],
+      referral_headline: params[:ReferralHeadline],
+      referral_body: params[:ReferralBody],
+      referral_media_id: params[:ReferralMediaId],
+      referral_media_content_type: params[:ReferralMediaContentType],
+      referral_media_url: params[:ReferralMediaUrl],
+      referral_num_media: params[:ReferralNumMedia],
+      referral_ctwa_clid: params[:ReferralCtwaClid]
+    }
   end
 
   def attach_files

--- a/spec/services/twilio/incoming_message_service_spec.rb
+++ b/spec/services/twilio/incoming_message_service_spec.rb
@@ -261,6 +261,59 @@ describe Twilio::IncomingMessageService do
       end
     end
 
+    context 'when a Click-to-WhatsApp referral message is received' do
+      let(:referral_params) do
+        {
+          SmsSid: 'SMxx',
+          From: '+12345',
+          AccountSid: 'ACxxx',
+          MessagingServiceSid: twilio_channel.messaging_service_sid,
+          Body: 'Hello from ad',
+          ReferralSourceId: 'ad_123',
+          ReferralSourceType: 'UNKNOWN',
+          ReferralSourceUrl: 'https://fb.com/ad/123',
+          ReferralHeadline: 'Special offer',
+          ReferralBody: 'Click to get 20% off',
+          ReferralMediaId: 'media_456',
+          ReferralMediaContentType: 'image/jpeg',
+          ReferralMediaUrl: 'https://fb.com/media/456.jpg',
+          ReferralNumMedia: '1',
+          ReferralCtwaClid: 'ctwa_clid_abc123'
+        }
+      end
+
+      it 'stores referral attributes in message content_attributes' do
+        described_class.new(params: referral_params).perform
+
+        message = conversation.reload.messages.last
+        expect(message.content_attributes['referral_source_id']).to eq('ad_123')
+        expect(message.content_attributes['referral_source_type']).to eq('UNKNOWN')
+        expect(message.content_attributes['referral_source_url']).to eq('https://fb.com/ad/123')
+        expect(message.content_attributes['referral_headline']).to eq('Special offer')
+        expect(message.content_attributes['referral_body']).to eq('Click to get 20% off')
+        expect(message.content_attributes['referral_media_id']).to eq('media_456')
+        expect(message.content_attributes['referral_media_content_type']).to eq('image/jpeg')
+        expect(message.content_attributes['referral_media_url']).to eq('https://fb.com/media/456.jpg')
+        expect(message.content_attributes['referral_num_media']).to eq('1')
+        expect(message.content_attributes['referral_ctwa_clid']).to eq('ctwa_clid_abc123')
+      end
+
+      it 'does not store referral attributes when ReferralSourceId is absent' do
+        params = {
+          SmsSid: 'SMxx',
+          From: '+12345',
+          AccountSid: 'ACxxx',
+          MessagingServiceSid: twilio_channel.messaging_service_sid,
+          Body: 'Regular message'
+        }
+
+        described_class.new(params: params).perform
+
+        message = conversation.reload.messages.last
+        expect(message.content_attributes).not_to have_key('referral_source_id')
+      end
+    end
+
     context 'when a location message is received' do
       let(:params_with_location) do
         {

--- a/spec/services/twilio/incoming_message_service_spec.rb
+++ b/spec/services/twilio/incoming_message_service_spec.rb
@@ -282,20 +282,32 @@ describe Twilio::IncomingMessageService do
         }
       end
 
-      it 'stores referral attributes in message content_attributes' do
+      it 'stores referral source attributes in message content_attributes' do
         described_class.new(params: referral_params).perform
 
         message = conversation.reload.messages.last
         expect(message.content_attributes['referral_source_id']).to eq('ad_123')
         expect(message.content_attributes['referral_source_type']).to eq('UNKNOWN')
         expect(message.content_attributes['referral_source_url']).to eq('https://fb.com/ad/123')
+      end
+
+      it 'stores referral content attributes in message content_attributes' do
+        described_class.new(params: referral_params).perform
+
+        message = conversation.reload.messages.last
         expect(message.content_attributes['referral_headline']).to eq('Special offer')
         expect(message.content_attributes['referral_body']).to eq('Click to get 20% off')
+        expect(message.content_attributes['referral_ctwa_clid']).to eq('ctwa_clid_abc123')
+      end
+
+      it 'stores referral media attributes in message content_attributes' do
+        described_class.new(params: referral_params).perform
+
+        message = conversation.reload.messages.last
         expect(message.content_attributes['referral_media_id']).to eq('media_456')
         expect(message.content_attributes['referral_media_content_type']).to eq('image/jpeg')
         expect(message.content_attributes['referral_media_url']).to eq('https://fb.com/media/456.jpg')
         expect(message.content_attributes['referral_num_media']).to eq('1')
-        expect(message.content_attributes['referral_ctwa_clid']).to eq('ctwa_clid_abc123')
       end
 
       it 'does not store referral attributes when ReferralSourceId is absent' do


### PR DESCRIPTION
## Description

When customers initiate a WhatsApp conversation by clicking a Meta ad (Click-to-WhatsApp campaign), Twilio forwards referral attributes in the webhook payload that identify the specific ad and capture the customer's context at the point of contact. Currently, Chatwoot discards these attributes because they are not in the permitted parameters list, making it impossible to attribute conversations to campaigns or measure ad performance.

This PR permits all Twilio Click-to-WhatsApp referral parameters in the callback controller and stores them in `content_attributes` of the incoming message.

Fixes #14047

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests were added to `spec/services/twilio/incoming_message_service_spec.rb` covering:

- A message with `ReferralSourceId` present stores all 10 referral attributes in `message.content_attributes` with the `referral_*` prefix.
- A regular message without `ReferralSourceId` produces no referral keys in `content_attributes`.

To reproduce manually:
1. Configure a Twilio WhatsApp inbox in Chatwoot.
2. Send a POST request to `/twilio/callback` with referral params (e.g. `ReferralSourceId`, `ReferralCtwaClid`, etc.) simulating a Click-to-WhatsApp webhook.
3. Verify the created message has the referral data in `content_attributes`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules