### PR TITLE
feat: 14045 24h time format

### DIFF
--- a/app/javascript/dashboard/components-next/message/MessageMeta.vue
+++ b/app/javascript/dashboard/components-next/message/MessageMeta.vue
@@ -5,6 +5,7 @@ import { messageTimestamp } from 'shared/helpers/timeHelper';
 import MessageStatus from './MessageStatus.vue';
 import Icon from 'next/icon/Icon.vue';
 import { useInbox } from 'dashboard/composables/useInbox';
+import { useTimeFormat } from 'dashboard/composables/useTimeFormat';
 import { useMessageContext } from './provider.js';
 
 import { MESSAGE_STATUS, MESSAGE_TYPES } from './constants';
@@ -32,8 +33,10 @@ const {
   contentAttributes,
 } = useMessageContext();
 
+const { fullTimestampFormat } = useTimeFormat();
+
 const readableTime = computed(() =>
-  messageTimestamp(createdAt.value, 'LLL d, h:mm a')
+  messageTimestamp(createdAt.value, fullTimestampFormat.value)
 );
 
 const showStatusIndicator = computed(() => {

--- a/app/javascript/dashboard/components-next/message/bubbles/Activity.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Activity.vue
@@ -2,12 +2,15 @@
 import { computed } from 'vue';
 import { messageTimestamp } from 'shared/helpers/timeHelper';
 import BaseBubble from './Base.vue';
+import { useTimeFormat } from 'dashboard/composables/useTimeFormat';
 import { useMessageContext } from '../provider.js';
 
 const { content, createdAt } = useMessageContext();
 
+const { fullTimestampFormat } = useTimeFormat();
+
 const readableTime = computed(() =>
-  messageTimestamp(createdAt.value, 'LLL d, h:mm a')
+  messageTimestamp(createdAt.value, fullTimestampFormat.value)
 );
 </script>
 

--- a/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
@@ -7,6 +7,7 @@ import { useStoreGetters } from 'dashboard/composables/store';
 import { useKeyboardEvents } from 'dashboard/composables/useKeyboardEvents';
 import { useImageZoom } from 'dashboard/composables/useImageZoom';
 import { messageTimestamp } from 'shared/helpers/timeHelper';
+import { useTimeFormat } from 'dashboard/composables/useTimeFormat';
 import { downloadFile } from '@chatwoot/utils';
 
 import NextButton from 'dashboard/components-next/button/Button.vue';
@@ -61,6 +62,8 @@ const {
   resetZoomAndRotation,
 } = useImageZoom(imageRef);
 
+const { fullTimestampFormat } = useTimeFormat();
+
 const currentUser = computed(() => getters.getCurrentUser.value);
 const hasMoreThanOneAttachment = computed(
   () => props.allAttachments.length > 1
@@ -69,7 +72,7 @@ const hasMoreThanOneAttachment = computed(
 const readableTime = computed(() => {
   const { created_at: createdAt } = activeAttachment.value;
   if (!createdAt) return '';
-  return messageTimestamp(createdAt, 'LLL d yyyy, h:mm a') || '';
+  return messageTimestamp(createdAt, fullTimestampFormat.value) || '';
 });
 
 const isImage = computed(

--- a/app/javascript/dashboard/composables/spec/useTimeFormat.spec.js
+++ b/app/javascript/dashboard/composables/spec/useTimeFormat.spec.js
@@ -1,0 +1,183 @@
+import { ref } from 'vue';
+import { useTimeFormat } from '../useTimeFormat';
+import { useUISettings } from 'dashboard/composables/useUISettings';
+import { useAlert } from 'dashboard/composables';
+import { useI18n } from 'vue-i18n';
+
+vi.mock('dashboard/composables/useUISettings');
+vi.mock('dashboard/composables', () => ({
+  useAlert: vi.fn(message => message),
+}));
+vi.mock('vue-i18n');
+
+describe('useTimeFormat', () => {
+  const mockUISettings = ref({ time_format: '12h' });
+  const mockUpdateUISettings = vi.fn().mockResolvedValue(undefined);
+  const mockTranslate = vi.fn(key => key);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useUISettings.mockReturnValue({
+      uiSettings: mockUISettings,
+      updateUISettings: mockUpdateUISettings,
+    });
+
+    useI18n.mockReturnValue({ t: mockTranslate });
+
+    mockUISettings.value = { time_format: '12h' };
+  });
+
+  describe('timeFormatOptions', () => {
+    it('returns two options with correct values', () => {
+      const { timeFormatOptions } = useTimeFormat();
+      expect(timeFormatOptions.value).toHaveLength(2);
+      expect(timeFormatOptions.value.map(o => o.value)).toEqual(['12h', '24h']);
+    });
+
+    it('each option has a value and label', () => {
+      const { timeFormatOptions } = useTimeFormat();
+      timeFormatOptions.value.forEach(option => {
+        expect(option).toHaveProperty('value');
+        expect(option).toHaveProperty('label');
+      });
+    });
+
+    it('uses translated labels', () => {
+      mockTranslate.mockImplementation(key => {
+        const map = {
+          'PROFILE_SETTINGS.FORM.INTERFACE_SECTION.TIME_FORMAT.OPTIONS.TWELVE_HOUR':
+            '12-hour (1:30 PM)',
+          'PROFILE_SETTINGS.FORM.INTERFACE_SECTION.TIME_FORMAT.OPTIONS.TWENTY_FOUR_HOUR':
+            '24-hour (13:30)',
+        };
+        return map[key] || key;
+      });
+
+      const { timeFormatOptions } = useTimeFormat();
+      expect(timeFormatOptions.value[0].label).toBe('12-hour (1:30 PM)');
+      expect(timeFormatOptions.value[1].label).toBe('24-hour (13:30)');
+    });
+  });
+
+  describe('currentTimeFormat', () => {
+    it('returns the value from ui settings', () => {
+      const { currentTimeFormat } = useTimeFormat();
+      expect(currentTimeFormat.value).toBe('12h');
+    });
+
+    it('defaults to 12h when not set', () => {
+      mockUISettings.value = {};
+      const { currentTimeFormat } = useTimeFormat();
+      expect(currentTimeFormat.value).toBe('12h');
+    });
+
+    it('reflects 24h when set', () => {
+      mockUISettings.value = { time_format: '24h' };
+      const { currentTimeFormat } = useTimeFormat();
+      expect(currentTimeFormat.value).toBe('24h');
+    });
+
+    it('is reactive to ui settings changes', () => {
+      const { currentTimeFormat } = useTimeFormat();
+      expect(currentTimeFormat.value).toBe('12h');
+
+      mockUISettings.value = { time_format: '24h' };
+      expect(currentTimeFormat.value).toBe('24h');
+    });
+  });
+
+  describe('is24HourFormat', () => {
+    it('is false when format is 12h', () => {
+      const { is24HourFormat } = useTimeFormat();
+      expect(is24HourFormat.value).toBe(false);
+    });
+
+    it('is true when format is 24h', () => {
+      mockUISettings.value = { time_format: '24h' };
+      const { is24HourFormat } = useTimeFormat();
+      expect(is24HourFormat.value).toBe(true);
+    });
+
+    it('is false when no format is saved', () => {
+      mockUISettings.value = {};
+      const { is24HourFormat } = useTimeFormat();
+      expect(is24HourFormat.value).toBe(false);
+    });
+  });
+
+  describe('shortTimeFormat', () => {
+    it('returns h:mm a for 12h', () => {
+      const { shortTimeFormat } = useTimeFormat();
+      expect(shortTimeFormat.value).toBe('h:mm a');
+    });
+
+    it('returns HH:mm for 24h', () => {
+      mockUISettings.value = { time_format: '24h' };
+      const { shortTimeFormat } = useTimeFormat();
+      expect(shortTimeFormat.value).toBe('HH:mm');
+    });
+  });
+
+  describe('fullTimestampFormat', () => {
+    it('returns LLL d, h:mm a for 12h', () => {
+      const { fullTimestampFormat } = useTimeFormat();
+      expect(fullTimestampFormat.value).toBe('LLL d, h:mm a');
+    });
+
+    it('returns LLL d, HH:mm for 24h', () => {
+      mockUISettings.value = { time_format: '24h' };
+      const { fullTimestampFormat } = useTimeFormat();
+      expect(fullTimestampFormat.value).toBe('LLL d, HH:mm');
+    });
+
+    it('is reactive to format changes', () => {
+      const { fullTimestampFormat } = useTimeFormat();
+      expect(fullTimestampFormat.value).toBe('LLL d, h:mm a');
+
+      mockUISettings.value = { time_format: '24h' };
+      expect(fullTimestampFormat.value).toBe('LLL d, HH:mm');
+    });
+  });
+
+  describe('updateTimeFormat', () => {
+    it('calls updateUISettings with the new format', async () => {
+      const { updateTimeFormat } = useTimeFormat();
+      await updateTimeFormat('24h');
+      expect(mockUpdateUISettings).toHaveBeenCalledWith({ time_format: '24h' });
+    });
+
+    it('shows a success alert on update', async () => {
+      const { updateTimeFormat } = useTimeFormat();
+      await updateTimeFormat('24h');
+      expect(useAlert).toHaveBeenCalledWith(
+        'PROFILE_SETTINGS.FORM.INTERFACE_SECTION.TIME_FORMAT.UPDATE_SUCCESS'
+      );
+    });
+
+    it('shows an error alert when update fails', async () => {
+      mockUpdateUISettings.mockRejectedValueOnce(new Error('Network error'));
+      const { updateTimeFormat } = useTimeFormat();
+      await updateTimeFormat('24h');
+      expect(useAlert).toHaveBeenCalledWith(
+        'PROFILE_SETTINGS.FORM.INTERFACE_SECTION.TIME_FORMAT.UPDATE_ERROR'
+      );
+    });
+
+    it('does not show success alert when update fails', async () => {
+      mockUpdateUISettings.mockRejectedValueOnce(new Error('Network error'));
+      const { updateTimeFormat } = useTimeFormat();
+      await updateTimeFormat('24h');
+      expect(useAlert).not.toHaveBeenCalledWith(
+        'PROFILE_SETTINGS.FORM.INTERFACE_SECTION.TIME_FORMAT.UPDATE_SUCCESS'
+      );
+    });
+
+    it('works when switching back to 12h', async () => {
+      mockUISettings.value = { time_format: '24h' };
+      const { updateTimeFormat } = useTimeFormat();
+      await updateTimeFormat('12h');
+      expect(mockUpdateUISettings).toHaveBeenCalledWith({ time_format: '12h' });
+    });
+  });
+});

--- a/app/javascript/dashboard/composables/useTimeFormat.js
+++ b/app/javascript/dashboard/composables/useTimeFormat.js
@@ -1,0 +1,69 @@
+import { computed } from 'vue';
+import { useUISettings } from 'dashboard/composables/useUISettings';
+import { useAlert } from 'dashboard/composables';
+import { useI18n } from 'vue-i18n';
+
+const TIME_FORMAT_12H = '12h';
+const TIME_FORMAT_24H = '24h';
+
+export const useTimeFormat = () => {
+  const { uiSettings, updateUISettings } = useUISettings();
+  const { t } = useI18n();
+
+  const timeFormatOptions = computed(() => [
+    {
+      value: TIME_FORMAT_12H,
+      label: t(
+        'PROFILE_SETTINGS.FORM.INTERFACE_SECTION.TIME_FORMAT.OPTIONS.TWELVE_HOUR'
+      ),
+    },
+    {
+      value: TIME_FORMAT_24H,
+      label: t(
+        'PROFILE_SETTINGS.FORM.INTERFACE_SECTION.TIME_FORMAT.OPTIONS.TWENTY_FOUR_HOUR'
+      ),
+    },
+  ]);
+
+  const currentTimeFormat = computed(
+    () => uiSettings.value.time_format || TIME_FORMAT_12H
+  );
+
+  const is24HourFormat = computed(
+    () => currentTimeFormat.value === TIME_FORMAT_24H
+  );
+
+  // Short time-only format used in message stamps
+  const shortTimeFormat = computed(() =>
+    is24HourFormat.value ? 'HH:mm' : 'h:mm a'
+  );
+
+  // Full date+time format used in tooltips and timestamps
+  const fullTimestampFormat = computed(() =>
+    is24HourFormat.value ? 'LLL d, HH:mm' : 'LLL d, h:mm a'
+  );
+
+  const updateTimeFormat = async format => {
+    try {
+      await updateUISettings({ time_format: format });
+      useAlert(
+        t('PROFILE_SETTINGS.FORM.INTERFACE_SECTION.TIME_FORMAT.UPDATE_SUCCESS')
+      );
+    } catch {
+      useAlert(
+        t('PROFILE_SETTINGS.FORM.INTERFACE_SECTION.TIME_FORMAT.UPDATE_ERROR')
+      );
+    }
+  };
+
+  return {
+    timeFormatOptions,
+    currentTimeFormat,
+    is24HourFormat,
+    shortTimeFormat,
+    fullTimestampFormat,
+    updateTimeFormat,
+  };
+};
+
+export default useTimeFormat;

--- a/app/javascript/dashboard/composables/useUISettings.js
+++ b/app/javascript/dashboard/composables/useUISettings.js
@@ -141,7 +141,7 @@ export function useUISettings() {
   const uiSettings = computed(() => getters.getUISettings.value);
 
   const updateUISettings = (settings = {}) => {
-    store.dispatch('updateUISettings', {
+    return store.dispatch('updateUISettings', {
       uiSettings: {
         ...uiSettings.value,
         ...settings,

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -58,6 +58,16 @@
           "UPDATE_SUCCESS": "Your Language settings have been updated successfully",
           "UPDATE_ERROR": "There is an error while updating the language settings, please try again",
           "USE_ACCOUNT_DEFAULT": "Use account default"
+        },
+        "TIME_FORMAT": {
+          "TITLE": "Time format",
+          "NOTE": "Choose between 12-hour (AM/PM) and 24-hour time display.",
+          "UPDATE_SUCCESS": "Your time format settings have been updated successfully",
+          "UPDATE_ERROR": "There is an error while updating the time format settings, please try again",
+          "OPTIONS": {
+            "TWELVE_HOUR": "12-hour (1:30 PM)",
+            "TWENTY_FOUR_HOUR": "24-hour (13:30)"
+          }
         }
       },
       "MESSAGE_SIGNATURE_SECTION": {

--- a/app/javascript/dashboard/routes/dashboard/settings/profile/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/profile/Index.vue
@@ -3,6 +3,7 @@ import { mapGetters } from 'vuex';
 import { useAlert } from 'dashboard/composables';
 import { useUISettings } from 'dashboard/composables/useUISettings';
 import { useFontSize } from 'dashboard/composables/useFontSize';
+import { useTimeFormat } from 'dashboard/composables/useTimeFormat';
 import { useBranding } from 'shared/composables/useBranding';
 import { clearCookiesOnLogout } from 'dashboard/store/utils/api.js';
 import { copyTextToClipboard } from 'shared/helpers/clipboard';
@@ -12,6 +13,7 @@ import UserProfilePicture from './UserProfilePicture.vue';
 import UserBasicDetails from './UserBasicDetails.vue';
 import MessageSignature from './MessageSignature.vue';
 import FontSize from './FontSize.vue';
+import TimeFormatSelector from './TimeFormatSelector.vue';
 import UserLanguageSelect from './UserLanguageSelect.vue';
 import HotKeyCard from './HotKeyCard.vue';
 import ChangePassword from './ChangePassword.vue';
@@ -32,6 +34,7 @@ export default {
     MessageSignature,
     SectionLayout,
     FontSize,
+    TimeFormatSelector,
     UserLanguageSelect,
     UserProfilePicture,
     Policy,
@@ -47,11 +50,14 @@ export default {
   setup() {
     const { isEditorHotKeyEnabled, updateUISettings } = useUISettings();
     const { currentFontSize, updateFontSize } = useFontSize();
+    const { currentTimeFormat, updateTimeFormat } = useTimeFormat();
     const { replaceInstallationName } = useBranding();
 
     return {
       currentFontSize,
       updateFontSize,
+      currentTimeFormat,
+      updateTimeFormat,
       isEditorHotKeyEnabled,
       updateUISettings,
       replaceInstallationName,
@@ -247,6 +253,16 @@ export default {
           :description="
             $t('PROFILE_SETTINGS.FORM.INTERFACE_SECTION.LANGUAGE.NOTE')
           "
+        />
+        <TimeFormatSelector
+          :value="currentTimeFormat"
+          :label="
+            $t('PROFILE_SETTINGS.FORM.INTERFACE_SECTION.TIME_FORMAT.TITLE')
+          "
+          :description="
+            $t('PROFILE_SETTINGS.FORM.INTERFACE_SECTION.TIME_FORMAT.NOTE')
+          "
+          @change="updateTimeFormat"
         />
       </div>
     </SectionLayout>

--- a/app/javascript/dashboard/routes/dashboard/settings/profile/TimeFormatSelector.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/profile/TimeFormatSelector.vue
@@ -1,0 +1,62 @@
+<script setup>
+import { computed } from 'vue';
+import FormSelect from 'v3/components/Form/Select.vue';
+import { useTimeFormat } from 'dashboard/composables/useTimeFormat';
+
+const props = defineProps({
+  value: {
+    type: String,
+    default: '12h',
+  },
+  label: {
+    type: String,
+    default: '',
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+});
+
+const emit = defineEmits(['change']);
+
+const { timeFormatOptions } = useTimeFormat();
+
+const selectedValue = computed({
+  get: () => props.value,
+  set: value => {
+    emit('change', value);
+  },
+});
+</script>
+
+<template>
+  <div class="flex gap-2 justify-between w-full items-start">
+    <div>
+      <label class="text-n-gray-12 font-medium leading-6 text-sm">
+        {{ label }}
+      </label>
+      <p class="text-n-gray-11">
+        {{ description }}
+      </p>
+    </div>
+    <FormSelect
+      v-model="selectedValue"
+      name="timeFormat"
+      spacing="compact"
+      class="min-w-28 mt-px"
+      :value="selectedValue"
+      :options="timeFormatOptions"
+      label=""
+    >
+      <option
+        v-for="option in timeFormatOptions"
+        :key="option.value"
+        :value="option.value"
+        :selected="option.value === selectedValue"
+      >
+        {{ option.label }}
+      </option>
+    </FormSelect>
+  </div>
+</template>

--- a/app/javascript/dashboard/store/modules/auth.js
+++ b/app/javascript/dashboard/store/modules/auth.js
@@ -154,7 +154,8 @@ export const actions = {
     }
   },
 
-  updateUISettings: async ({ commit }, params) => {
+  updateUISettings: async ({ commit, state }, params) => {
+    const previousUser = state.currentUser;
     try {
       commit(types.SET_CURRENT_USER_UI_SETTINGS, params);
 
@@ -167,7 +168,8 @@ export const actions = {
         commit(types.SET_CURRENT_USER, response.data);
       }
     } catch (error) {
-      // Ignore error
+      commit(types.SET_CURRENT_USER, previousUser);
+      throw error;
     }
   },
 

--- a/app/javascript/dashboard/store/modules/specs/auth/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/auth/actions.spec.js
@@ -141,6 +141,13 @@ describe('#actions', () => {
   });
 
   describe('#updateUISettings', () => {
+    const previousUser = {
+      id: 1,
+      name: 'John',
+      ui_settings: { is_contact_sidebar_open: false },
+    };
+    const state = { currentUser: previousUser };
+
     it('sends correct actions if API is success', async () => {
       axios.put.mockResolvedValue({
         data: {
@@ -152,7 +159,7 @@ describe('#actions', () => {
         headers: { expiry: 581842904 },
       });
       await actions.updateUISettings(
-        { commit, dispatch },
+        { commit, dispatch, state },
         { uiSettings: { is_contact_sidebar_open: false } }
       );
       expect(commit.mock.calls).toEqual([
@@ -169,6 +176,23 @@ describe('#actions', () => {
             ui_settings: { is_contact_sidebar_open: true },
           },
         ],
+      ]);
+    });
+
+    it('rolls back optimistic update and re-throws on API failure', async () => {
+      axios.put.mockRejectedValue(new Error('Network error'));
+      await expect(
+        actions.updateUISettings(
+          { commit, dispatch, state },
+          { uiSettings: { is_contact_sidebar_open: false } }
+        )
+      ).rejects.toThrow('Network error');
+      expect(commit.mock.calls).toEqual([
+        [
+          types.SET_CURRENT_USER_UI_SETTINGS,
+          { uiSettings: { is_contact_sidebar_open: false } },
+        ],
+        [types.SET_CURRENT_USER, previousUser],
       ]);
     });
   });

--- a/app/javascript/shared/helpers/specs/timeHelper.spec.js
+++ b/app/javascript/shared/helpers/specs/timeHelper.spec.js
@@ -29,11 +29,33 @@ describe('#messageStamp', () => {
 });
 
 describe('#messageTimestamp', () => {
-  it('should return the message date in the specified format if the message was sent in the current year', () => {
+  it('returns the date in the specified format for current-year messages', () => {
     expect(messageTimestamp(1680777464)).toEqual('Apr 6, 2023');
   });
-  it('should return the message date and time in a different format if the message was sent in a different year', () => {
+
+  it('returns date and 12-hour time for cross-year messages with default format', () => {
     expect(messageTimestamp(1612971343)).toEqual('Feb 10 2021, 3:35 PM');
+  });
+
+  it('returns date and 12-hour time for cross-year messages with explicit 12h format', () => {
+    expect(messageTimestamp(1612971343, 'LLL d, h:mm a')).toEqual(
+      'Feb 10 2021, 3:35 PM'
+    );
+  });
+
+  it('returns date and 24-hour time for cross-year messages when 24h format is passed', () => {
+    expect(messageTimestamp(1612971343, 'LLL d, HH:mm')).toEqual(
+      'Feb 10 2021, 15:35'
+    );
+  });
+
+  it('uses the provided format for same-year messages regardless of 12h or 24h', () => {
+    expect(messageTimestamp(1680777464, 'LLL d, h:mm a')).toEqual(
+      'Apr 6, 10:37 AM'
+    );
+    expect(messageTimestamp(1680777464, 'LLL d, HH:mm')).toEqual(
+      'Apr 6, 10:37'
+    );
   });
 });
 

--- a/app/javascript/shared/helpers/timeHelper.js
+++ b/app/javascript/shared/helpers/timeHelper.js
@@ -26,11 +26,11 @@ export const messageStamp = (time, dateFormat = 'h:mm a') => {
 export const messageTimestamp = (time, dateFormat = 'MMM d, yyyy') => {
   const messageTime = fromUnixTime(time);
   const now = new Date();
-  const messageDate = format(messageTime, dateFormat);
   if (!isSameYear(messageTime, now)) {
-    return format(messageTime, 'LLL d y, h:mm a');
+    const timeFormat = dateFormat.includes('HH:mm') ? 'HH:mm' : 'h:mm a';
+    return format(messageTime, `LLL d y, ${timeFormat}`);
   }
-  return messageDate;
+  return format(messageTime, dateFormat);
 };
 
 /**


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

This pull request introduces user-configurable time format settings (12-hour or 24-hour) throughout the dashboard. It adds a new composable for managing time format preferences, updates message and attachment timestamps to respect the selected format, and provides a UI for users to choose their preferred time display in profile settings.

**Time Format Preference Infrastructure:**

* Added a new composable `useTimeFormat` to manage time format options, retrieve the current user preference, and provide computed formats for use in timestamps (`app/javascript/dashboard/composables/useTimeFormat.js`).

**UI Updates for Time Format Selection:**

* Introduced a `TimeFormatSelector` component and integrated it into the profile settings page, allowing users to select between 12-hour and 24-hour time display (`app/javascript/dashboard/routes/dashboard/settings/profile/TimeFormatSelector.vue`, `app/javascript/dashboard/routes/dashboard/settings/profile/Index.vue`). [[1]](diffhunk://#diff-6b8510fa382b5e05889a9604dd6870bd79cc30478107d330336e27e11e4af13cR1-R62) [[2]](diffhunk://#diff-b96645a45c604f51005618dcece8c5f3e4d5f58bfd0e1921c8486885ffd44542R16) [[3]](diffhunk://#diff-b96645a45c604f51005618dcece8c5f3e4d5f58bfd0e1921c8486885ffd44542R37) [[4]](diffhunk://#diff-b96645a45c604f51005618dcece8c5f3e4d5f58bfd0e1921c8486885ffd44542R53-R60) [[5]](diffhunk://#diff-b96645a45c604f51005618dcece8c5f3e4d5f58bfd0e1921c8486885ffd44542R257-R266)

**Timestamp Display Updates:**

* Updated message meta information, activity bubbles, and gallery view attachment timestamps to use the selected time format, ensuring consistency throughout the UI (`app/javascript/dashboard/components-next/message/MessageMeta.vue`, `app/javascript/dashboard/components-next/message/bubbles/Activity.vue`, `app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue`). [[1]](diffhunk://#diff-e41239cf8dda36c1bd1066dbb17588ae8868e56289072c74b3a6d7ef5abdd696R8) [[2]](diffhunk://#diff-e41239cf8dda36c1bd1066dbb17588ae8868e56289072c74b3a6d7ef5abdd696R36-R39) [[3]](diffhunk://#diff-8e7d5b5aa091d23da7cc8d5b24fa22f5be9cbdb49a6301d4769a1871fd4a00b2R5-R13) [[4]](diffhunk://#diff-f3747ee2ccbf3794ee61a77043ebec246b6d1fbfa1c10a6e54d0855243ab7328R10) [[5]](diffhunk://#diff-f3747ee2ccbf3794ee61a77043ebec246b6d1fbfa1c10a6e54d0855243ab7328R65-R66) [[6]](diffhunk://#diff-f3747ee2ccbf3794ee61a77043ebec246b6d1fbfa1c10a6e54d0855243ab7328L72-R75)

**Localization:**

* Added English translations for time format selection and update messages to the settings locale file (`app/javascript/dashboard/i18n/locale/en/settings.json`).
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


resolves #14045
