### PR TITLE
feat(help-center): add root sitemap.xml with sitemapindex for all por…

### DIFF
--- a/app/controllers/public/api/v1/sitemaps_controller.rb
+++ b/app/controllers/public/api/v1/sitemaps_controller.rb
@@ -1,0 +1,7 @@
+class Public::Api::V1::SitemapsController < PublicController
+  def index
+    @portals = Portal.active
+    @base_url = ChatwootApp.help_center_root.to_s
+    @base_url = "https://#{@base_url}" unless @base_url.include?('://')
+  end
+end

--- a/app/views/public/api/v1/sitemaps/index.xml.erb
+++ b/app/views/public/api/v1/sitemaps/index.xml.erb
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <% @portals.each do |portal| %>
+    <sitemap>
+      <loc><%= @base_url %>/hc/<%= portal.slug %>/sitemap.xml</loc>
+      <lastmod><%= portal.updated_at.to_date.iso8601 %></lastmod>
+    </sitemap>
+  <% end %>
+</sitemapindex>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -552,6 +552,7 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'sitemap.xml', to: 'public/api/v1/sitemaps#index'
   get 'hc/:slug', to: 'public/api/v1/portals#show'
   get 'hc/:slug/sitemap.xml', to: 'public/api/v1/portals#sitemap'
   get 'hc/:slug/:locale', to: 'public/api/v1/portals#show'


### PR DESCRIPTION
Description:
  Adds a `/sitemap.xml` endpoint that returns a sitemapindex listing all active Help Center portal sitemaps. This resolves `FATAL ActionController::RoutingError` errors logged
  whenever search engine crawlers probe the standard sitemap URL, and makes Help Center content discoverable by crawlers.

  Fixes #14029

  Type of change:
  - Bug fix (non-breaking change which fixes an issue)
  - New feature (non-breaking change which adds functionality)

  How Has This Been Tested:
  1. Created a Help Center portal via Rails console
  2. Visited /sitemap.xml — returns a valid <sitemapindex> with one <sitemap> entry per active portal
  3. Followed the <loc> URL to /hc/test-docs/sitemap.xml — returns the per-portal <urlset> with article URLs
  4. Confirmed no FATAL routing errors in Rails logs when hitting /sitemap.xml

  Checklist:
  - My code follows the style guidelines of this project
  - I have performed a self-review of my code
  - I have commented on my code, particularly in hard-to-understand areas (no comments needed — code is self-explanatory)
  - I have made corresponding changes to the documentation
  - My changes generate no new warnings
  - I have added tests that prove my fix is effective or that my feature works (can add if requested)
  - New and existing unit tests pass locally with my changes
  - Any dependent changes have been merged and published in downstream modules