### PR TITLE
fix: whatsapp template failed status

### DIFF
--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -35,6 +35,8 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
                                          parameters: processed_parameters
                                        }, message)
     message.update!(source_id: message_id) if message_id.present?
+  rescue ArgumentError => e
+    message.update!(status: :failed, external_error: e.message)
   end
 
   def send_session_message

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -97,6 +97,23 @@ describe Whatsapp::SendOnWhatsappService do
         expect(message.reload.external_error).to eq('Template not found or invalid template name')
       end
 
+      it 'marks message as failed when template processing raises ArgumentError' do
+        processor = instance_double(Whatsapp::TemplateProcessorService)
+        allow(Whatsapp::TemplateProcessorService).to receive(:new).and_return(processor)
+        allow(processor).to receive(:call).and_raise(ArgumentError, 'Invalid URL scheme: ftp. Only http and https are allowed')
+
+        message = create(:message,
+                         additional_attributes: { template_params: template_params },
+                         conversation: conversation,
+                         message_type: :outgoing,
+                         account: conversation.account)
+
+        described_class.new(message: message).perform
+
+        expect(message.reload.status).to eq('failed')
+        expect(message.reload.external_error).to eq('Invalid URL scheme: ftp. Only http and https are allowed')
+      end
+
       it 'calls channel.send_template when after 24 hour limit' do
         message = create(:message, message_type: :outgoing, content: 'Your package has been shipped. It will be delivered in 3 business days.',
                                    conversation: conversation, additional_attributes: { template_params: template_params },


### PR DESCRIPTION
# Pull Request Template

## Description

When a WhatsApp template message contains an invalid media URL (e.g. a non-http/https scheme or malformed URL), `TemplateProcessorService` raises an ArgumentError during parameter building. This exception was unhandled, causing SendReplyJob to crash silently and the message to remain stuck in sending state indefinitely with no error shown in the UI.

Fixes #13807 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

**Manual testing:**
1. Configure a WhatsApp inbox and send a template message with an invalid URL in the header media parameter (e.g. ftp://invalid.com/image.jpg)
2. Before the fix - the message stays stuck as sending forever with no error indicator
3. After the fix - the message is marked as failed and external_error reflects the reason

**Automated testing:**
- Added one RSpec example to `spec/services/whatsapp/send_on_whatsapp_service_spec.rb`
    - Stubs TemplateProcessorService#call to raise ArgumentError
    - Verifies the message status is set to failed
    - Verifies the error message is stored in external_error

Run with:
bundle exec rspec spec/services/whatsapp/send_on_whatsapp_service_spec.rb


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ x New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
