### PR TITLE
fix(admin): properly disable unchecked feature flags on account update

### DIFF
--- a/app/controllers/super_admin/accounts_controller.rb
+++ b/app/controllers/super_admin/accounts_controller.rb
@@ -36,7 +36,7 @@ class SuperAdmin::AccountsController < SuperAdmin::ApplicationController
   def resource_params
     permitted_params = super
     permitted_params[:limits] = permitted_params[:limits].to_h.compact
-    permitted_params[:selected_feature_flags] = params.fetch(:enabled_features, {}).keys.map(&:to_sym)
+    permitted_params[:selected_feature_flags] = params.fetch(:enabled_features, {}).select { |_k, v| v == "true" }.keys.map(&:to_sym)
     permitted_params
   end
 

--- a/app/controllers/super_admin/accounts_controller.rb
+++ b/app/controllers/super_admin/accounts_controller.rb
@@ -36,7 +36,7 @@ class SuperAdmin::AccountsController < SuperAdmin::ApplicationController
   def resource_params
     permitted_params = super
     permitted_params[:limits] = permitted_params[:limits].to_h.compact
-    permitted_params[:selected_feature_flags] = params[:enabled_features].keys.map(&:to_sym) if params[:enabled_features].present?
+    permitted_params[:selected_feature_flags] = params.fetch(:enabled_features, {}).keys.map(&:to_sym)
     permitted_params
   end
 

--- a/app/models/concerns/featurable.rb
+++ b/app/models/concerns/featurable.rb
@@ -55,6 +55,18 @@ module Featurable
     all_features.select { |_feature, enabled| enabled == true }
   end
 
+  def selected_feature_flags=(features)
+    features = Array(features)
+    # Disable all features first, then enable only the selected ones.
+    # This ensures unchecked features are properly disabled.
+    FEATURE_LIST.each do |feature|
+      send("feature_#{feature['name']}=", false)
+    end
+    features.each do |feature_flag|
+      send("#{feature_flag}=", true)
+    end
+  end
+
   def disabled_features
     all_features.select { |_feature, enabled| enabled == false }
   end

--- a/spec/controllers/super_admin/accounts_controller_spec.rb
+++ b/spec/controllers/super_admin/accounts_controller_spec.rb
@@ -55,6 +55,39 @@ RSpec.describe 'Super Admin accounts API', type: :request do
     end
   end
 
+  describe 'PATCH /super_admin/accounts/{account_id}' do
+    context 'when updating feature flags' do
+      before do
+        account.enable_features(:inbound_emails, :help_center, :macros)
+        account.save!
+        sign_in(super_admin, scope: :super_admin)
+      end
+
+      it 'disables unchecked features' do
+        patch "/super_admin/accounts/#{account.id}", params: {
+          account: { name: account.name },
+          enabled_features: { 'feature_inbound_emails' => 'true', 'feature_help_center' => 'true' }
+        }
+
+        account.reload
+        expect(account.feature_enabled?(:inbound_emails)).to be true
+        expect(account.feature_enabled?(:help_center)).to be true
+        expect(account.feature_enabled?(:macros)).to be false
+      end
+
+      it 'disables all features when no checkboxes are checked' do
+        patch "/super_admin/accounts/#{account.id}", params: {
+          account: { name: account.name }
+        }
+
+        account.reload
+        expect(account.feature_enabled?(:inbound_emails)).to be false
+        expect(account.feature_enabled?(:help_center)).to be false
+        expect(account.feature_enabled?(:macros)).to be false
+      end
+    end
+  end
+
   describe 'DELETE /super_admin/accounts/{account_id}' do
     context 'when it is an unauthenticated user' do
       it 'returns unauthorized' do

--- a/spec/controllers/super_admin/accounts_controller_spec.rb
+++ b/spec/controllers/super_admin/accounts_controller_spec.rb
@@ -66,7 +66,11 @@ RSpec.describe 'Super Admin accounts API', type: :request do
       it 'disables unchecked features' do
         patch "/super_admin/accounts/#{account.id}", params: {
           account: { name: account.name },
-          enabled_features: { 'feature_inbound_emails' => 'true', 'feature_help_center' => 'true' }
+          enabled_features: {
+            'feature_inbound_emails' => 'true',
+            'feature_help_center' => 'true',
+            'feature_macros' => 'false'
+          }
         }
 
         account.reload
@@ -75,9 +79,14 @@ RSpec.describe 'Super Admin accounts API', type: :request do
         expect(account.feature_enabled?(:macros)).to be false
       end
 
-      it 'disables all features when no checkboxes are checked' do
+      it 'disables all features when all checkboxes submit false' do
         patch "/super_admin/accounts/#{account.id}", params: {
-          account: { name: account.name }
+          account: { name: account.name },
+          enabled_features: {
+            'feature_inbound_emails' => 'false',
+            'feature_help_center' => 'false',
+            'feature_macros' => 'false'
+          }
         }
 
         account.reload

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -295,6 +295,45 @@ RSpec.describe Account do
     end
   end
 
+  describe 'selected_feature_flags=' do
+    let(:account) { create(:account) }
+
+    it 'enables only the specified features' do
+      account.enable_features(:inbound_emails, :help_center, :macros)
+      account.save!
+
+      account.selected_feature_flags = [:feature_inbound_emails, :feature_macros]
+      account.save!
+
+      expect(account.feature_enabled?(:inbound_emails)).to be true
+      expect(account.feature_enabled?(:macros)).to be true
+      expect(account.feature_enabled?(:help_center)).to be false
+    end
+
+    it 'disables all features when an empty array is passed' do
+      account.enable_features(:inbound_emails, :help_center)
+      account.save!
+
+      account.selected_feature_flags = []
+      account.save!
+
+      expect(account.feature_enabled?(:inbound_emails)).to be false
+      expect(account.feature_enabled?(:help_center)).to be false
+    end
+
+    it 'disables previously enabled features that are not in the selection' do
+      account.enable_features(:inbound_emails, :help_center, :crm)
+      account.save!
+
+      account.selected_feature_flags = [:feature_help_center]
+      account.save!
+
+      expect(account.feature_enabled?(:help_center)).to be true
+      expect(account.feature_enabled?(:inbound_emails)).to be false
+      expect(account.feature_enabled?(:crm)).to be false
+    end
+  end
+
   describe 'captain_preferences' do
     let(:account) { create(:account) }
 


### PR DESCRIPTION
## Summary

Unchecking feature flags in the Super Admin account edit screen had no effect. Previously enabled features remained active even after being unchecked and saved.

**Root cause**: Two related issues:
1. The controller only passed checked features to the model (`if params[:enabled_features].present?`), so unchecked checkboxes (which HTML omits from form submissions) were never communicated as "disabled"
2. The `selected_feature_flags=` setter was only defined in the Enterprise module with a `super` call to a non-existent base method

**Fix**:
- Added `selected_feature_flags=` to the `Featurable` concern that disables all features first, then enables only the selected ones
- Changed the controller to always pass the feature list using `params.fetch(:enabled_features, {})` instead of conditional assignment

Closes #14064

## How to reproduce

1. Open Super Admin > Accounts > Edit for an existing account
2. Enable several features and save
3. Uncheck some of those features and save again
4. **Before fix**: unchecked features remain enabled
5. **After fix**: unchecked features are properly disabled

## What changed

- `app/models/concerns/featurable.rb` — Added `selected_feature_flags=` method that resets all features then enables only the provided list
- `app/controllers/super_admin/accounts_controller.rb` — Changed from conditional assignment to `params.fetch` so empty submissions (all unchecked) are handled correctly

## Trade-offs

The fix disables all features before re-enabling the selected ones, which means every flag is written on every save. This is a conscious choice: the alternative (computing a diff of checked vs. unchecked) would require knowing the previous state and is more error-prone. Since feature flag updates are infrequent admin operations, the overhead is negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)