### PR TITLE
Fix Ctrl/Cmd + Enter inserting newline when sending message

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -711,11 +711,15 @@ function handleLineBreakWhenCmdAndEnterToSendEnabled(event) {
 }
 
 function onKeydown(event) {
+  const isCmdEnter = hasPressedCommandAndEnter(event);
+
+  if (isCmdEnter && isCmdPlusEnterToSendEnabled()) {
+    event.preventDefault();
+    return;
+  }
+
   if (isEnterToSendEnabled()) {
     handleLineBreakWhenEnterToSendEnabled(event);
-  }
-  if (isCmdPlusEnterToSendEnabled()) {
-    handleLineBreakWhenCmdAndEnterToSendEnabled(event);
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes an issue where Ctrl/Cmd + Enter sends a message but also inserts an unwanted newline in the editor.

## Problem
When using the keyboard shortcut to send a message, a newline is inserted into the input field, causing formatting issues.

## Root Cause
The keydown handler did not consistently prevent the default browser behavior before sending the message.

## Solution
- Updated the onKeydown handler in Editor.vue
- Added early detection for Ctrl/Cmd + Enter
- Applied event.preventDefault() before further processing

## Testing
- Ctrl + Enter sends message without inserting newline
- Normal Enter behavior remains unchanged depending on configuration

Fixes #10141 