### PR TITLE
fix(widget/campaign): track user-initiated widget opens explicitly

### DIFF
--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -244,8 +244,8 @@ export const IFrameHelper = {
       removeUnreadClass();
     },
 
-    onBubbleToggle: isOpen => {
-      IFrameHelper.sendMessage('toggle-open', { isOpen });
+    onBubbleToggle: (isOpen, isUserInitiated = false) => {
+      IFrameHelper.sendMessage('toggle-open', { isOpen, isUserInitiated });
       if (isOpen) {
         IFrameHelper.pushEvent('webwidget.triggered');
       }

--- a/app/javascript/sdk/bubbleHelpers.js
+++ b/app/javascript/sdk/bubbleHelpers.js
@@ -71,8 +71,8 @@ export const createBubbleHolder = hideMessageBubble => {
   body.appendChild(bubbleHolder);
 };
 
-const handleBubbleToggle = newIsOpen => {
-  IFrameHelper.events.onBubbleToggle(newIsOpen);
+const handleBubbleToggle = (newIsOpen, isUserInitiated = false) => {
+  IFrameHelper.events.onBubbleToggle(newIsOpen, isUserInitiated);
 
   if (newIsOpen) {
     dispatchWindowEvent({ eventName: CHATWOOT_OPENED });
@@ -83,7 +83,7 @@ const handleBubbleToggle = newIsOpen => {
 };
 
 export const onBubbleClick = (props = {}) => {
-  const { toggleValue } = props;
+  const { toggleValue, isUserInitiated = false } = props;
   const { isOpen } = window.$chatwoot;
   if (isOpen === toggleValue) return;
 
@@ -94,11 +94,13 @@ export const onBubbleClick = (props = {}) => {
   toggleClass(closeBubble, 'woot--hide');
   toggleClass(widgetHolder, 'woot--hide');
 
-  handleBubbleToggle(newIsOpen);
+  handleBubbleToggle(newIsOpen, isUserInitiated);
 };
 
 export const onClickChatBubble = () => {
-  bubbleHolder.addEventListener('click', onBubbleClick);
+  bubbleHolder.addEventListener('click', () =>
+    onBubbleClick({ isUserInitiated: true })
+  );
 };
 
 export const addUnreadClass = () => {

--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -317,7 +317,10 @@ export default {
         } else if (message.event === 'set-color-scheme') {
           this.setColorScheme(message.darkMode);
         } else if (message.event === 'toggle-open') {
-          this.$store.dispatch('appConfig/toggleWidgetOpen', message.isOpen);
+          this.$store.dispatch('appConfig/toggleWidgetOpen', {
+            isWidgetOpen: message.isOpen,
+            isUserInitiated: Boolean(message.isUserInitiated),
+          });
 
           const shouldShowMessageView =
             ['home'].includes(this.$route.name) &&

--- a/app/javascript/widget/store/modules/appConfig.js
+++ b/app/javascript/widget/store/modules/appConfig.js
@@ -14,6 +14,10 @@ const state = {
   showUnreadMessagesDialog: true,
   isWebWidgetTriggered: false,
   isWidgetOpen: false,
+  // True only when the widget was opened by a real user click on the bubble
+  // (not by `window.$chatwoot.toggle('open')`). Resets when the widget is closed.
+  // See #14022.
+  isWidgetOpenedByUser: false,
   position: 'right',
   referrerHost: '',
   showPopoutButton: false,
@@ -35,6 +39,7 @@ export const getters = {
   isRightAligned: $state => $state.position === 'right',
   getHideMessageBubble: $state => $state.hideMessageBubble,
   getIsWidgetOpen: $state => $state.isWidgetOpen,
+  getIsWidgetOpenedByUser: $state => $state.isWidgetOpenedByUser,
   getWidgetColor: $state => $state.widgetColor,
   getReferrerHost: $state => $state.referrerHost,
   isWidgetStyleFlat: $state => $state.widgetStyle === 'flat',
@@ -85,8 +90,18 @@ export const actions = {
       enableEndConversation,
     });
   },
-  toggleWidgetOpen({ commit }, isWidgetOpen) {
-    commit(TOGGLE_WIDGET_OPEN, isWidgetOpen);
+  // Accepts either the legacy boolean form (`isWidgetOpen`) or an object
+  // `{ isWidgetOpen, isUserInitiated }`. The object form is used when the
+  // widget is opened programmatically via `window.$chatwoot.toggle('open')`,
+  // so we can distinguish "user is actively chatting" from "widget was
+  // pre-opened by an integrator script". See #14022.
+  toggleWidgetOpen({ commit }, payload) {
+    const isObjectPayload = typeof payload === 'object' && payload !== null;
+    const isWidgetOpen = isObjectPayload ? payload.isWidgetOpen : payload;
+    const isUserInitiated = isObjectPayload
+      ? Boolean(payload.isUserInitiated)
+      : false;
+    commit(TOGGLE_WIDGET_OPEN, { isWidgetOpen, isUserInitiated });
   },
   setWidgetColor({ commit }, widgetColor) {
     commit(SET_WIDGET_COLOR, widgetColor);
@@ -126,8 +141,15 @@ export const mutations = {
     $state.enableEmojiPicker = data.enableEmojiPicker;
     $state.enableEndConversation = data.enableEndConversation;
   },
-  [TOGGLE_WIDGET_OPEN]($state, isWidgetOpen) {
+  [TOGGLE_WIDGET_OPEN]($state, { isWidgetOpen, isUserInitiated }) {
     $state.isWidgetOpen = isWidgetOpen;
+    if (!isWidgetOpen) {
+      // Any close clears the "opened by user" flag so the next open is
+      // evaluated fresh.
+      $state.isWidgetOpenedByUser = false;
+    } else if (isUserInitiated) {
+      $state.isWidgetOpenedByUser = true;
+    }
   },
   [SET_WIDGET_COLOR]($state, widgetColor) {
     $state.widgetColor = widgetColor;

--- a/app/javascript/widget/store/modules/campaign.js
+++ b/app/javascript/widget/store/modules/campaign.js
@@ -106,13 +106,17 @@ export const actions = {
     {
       commit,
       rootState: {
-        appConfig: { isWidgetOpen },
+        appConfig: { isWidgetOpenedByUser },
       },
     },
     { websiteToken, campaignId }
   ) => {
-    // Disable campaign execution if widget is opened
-    if (!isWidgetOpen) {
+    // Suppress campaign execution only when the visitor has actively opened
+    // the widget themselves. If the widget was pre-opened programmatically
+    // via `window.$chatwoot.toggle('open')` (e.g. inside a `chatwoot:ready`
+    // listener), the visitor hasn't engaged yet and the campaign should
+    // still fire. See #14022.
+    if (!isWidgetOpenedByUser) {
       const { data: campaigns } = await getCampaigns(websiteToken);
       // Check campaign is disabled or not
       const campaign = campaigns.find(item => item.id === campaignId);


### PR DESCRIPTION
## Context

Closes #14022.

When a website integrator calls `window.$chatwoot.toggle('open')` inside their `chatwoot:ready` listener to pre-open the widget, any campaign configured for that page never fires. The visitor lands, the widget is already open, the campaign timer eventually elapses, and `startCampaign` silently skips because `isWidgetOpen` is already `true`.

The bug is that `isWidgetOpen` conflates two distinct states:

| Scenario | `isWidgetOpen` | Should campaign fire? |
|---|---|---|
| Visitor hasn't touched the widget | `false` | Yes |
| Visitor clicked the bubble and is actively chatting | `true` | No |
| Integrator pre-opened via `toggle('open')` | `true` | **Yes — visitor hasn't engaged** |

The existing guard treats rows 2 and 3 identically.

## Approach

Track a finer-grained signal: `isWidgetOpenedByUser`. This is `true` only when a real DOM click on the bubble triggered the open.

The key design choice is **how** we identify a user-initiated open. There is a previous PR (#14100) attempting this fix that infers user intent from the absence of an argument (`toggleValue === undefined` => user-initiated). The Codex review bot correctly flagged that this heuristic is unsound: `window.$chatwoot.toggle()` (with no argument) also reaches the same code path with `toggleValue === undefined`, so SDK-initiated calls get misclassified as user clicks.

This PR takes a stricter approach: **the DOM click listener explicitly passes `isUserInitiated: true`, and every other code path defaults to `false`.** No inference, no edge cases — the trust comes from the source, not the shape of the arguments.

## Changes

- `app/javascript/sdk/bubbleHelpers.js`
  - The DOM click listener in `onClickChatBubble` now invokes `onBubbleClick({ isUserInitiated: true })` explicitly.
  - `onBubbleClick` destructures `isUserInitiated` (default `false`) and forwards it to `handleBubbleToggle`.
  - `handleBubbleToggle` accepts and forwards the flag to `IFrameHelper.events.onBubbleToggle`.

- `app/javascript/sdk/IFrameHelper.js`
  - `events.onBubbleToggle(isOpen, isUserInitiated = false)` includes the flag in the `toggle-open` `postMessage` payload.

- `app/javascript/widget/App.vue`
  - The `toggle-open` handler dispatches `appConfig/toggleWidgetOpen` with the new payload shape `{ isWidgetOpen, isUserInitiated }`.

- `app/javascript/widget/store/modules/appConfig.js`
  - New state field `isWidgetOpenedByUser` (default `false`) and matching getter.
  - `toggleWidgetOpen` action accepts both the legacy boolean form and the new object form (backward-compatible — any external caller still works).
  - `TOGGLE_WIDGET_OPEN` mutation sets `isWidgetOpenedByUser = true` only on a user-initiated open, and clears it on every close (so the next open is evaluated fresh).

- `app/javascript/widget/store/modules/campaign.js`
  - `startCampaign` guard switched from `isWidgetOpen` to `isWidgetOpenedByUser`.

## Trade-offs considered

- **Backward compat in `toggleWidgetOpen`.** I kept the action accepting both a bare boolean and the new object form. The blast radius of breaking the old shape is unknown (external callers, plugins), and the bug doesn't justify a breaking change. The cost is a small bit of payload-shape detection logic.
- **Default to `false`, not `true`.** Defaulting `isUserInitiated` to `false` everywhere means any path I missed conservatively suppresses the new behaviour. Better to fail-closed than fail-open here.
- **Explicit flag vs. inference.** The previous PR's heuristic is simpler but unsound. An explicit flag is slightly more boilerplate (threaded through 5 files) but correct.

## Testing & blockers

- I was unable to run the JS test suite locally on Windows (`pnpm install` was unstable). The natural next step is to add a regression spec in `app/javascript/widget/store/modules/specs/campaign/actions.spec.js` that asserts `setActiveCampaign` is committed when `isWidgetOpen: true, isWidgetOpenedByUser: false`, and that the existing suppression behaviour is preserved when `isWidgetOpenedByUser: true`. Happy to follow up with a spec once I have a working environment.
- Manual verification steps for a reviewer:
  1. Configure a campaign on a page.
  2. Embed Chatwoot with `window.addEventListener('chatwoot:ready', () => window.$chatwoot.toggle('open'))`.
  3. Wait past the campaign delay — campaign should now appear.
  4. Reload, click the bubble manually to open, wait past the delay — campaign should be suppressed.

## Acknowledgement

This PR builds on the analysis and structural approach in #14100 by @Mrsandeep27, with a different choice for how user-initiated opens are detected (explicit flag vs. argument-shape inference) to address the Codex review bot's concern.