### PR TITLE
fix(webhook): include private messages in conversation webhook data

### DIFF
--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -33,7 +33,7 @@ class Conversations::EventDataPresenter < SimpleDelegator
   end
 
   def webhook_push_messages
-    [messages.where(account_id: account_id).chat.last&.webhook_push_event_data].compact
+    [messages.where(account_id: account_id).where.not(message_type: :activity).last&.webhook_push_event_data].compact
   end
 
   def push_meta

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -68,5 +68,18 @@ RSpec.describe Conversations::EventDataPresenter do
     it 'returns empty messages when conversation has no chat messages' do
       expect(presenter.webhook_data[:messages]).to eq([])
     end
+
+    it 'includes private messages in webhook payload when they are the last message' do
+      public_message = create(:message, conversation: conversation, account: conversation.account,
+                                        message_type: :outgoing, content: 'Public message')
+      private_message = create(:message, conversation: conversation, account: conversation.account,
+                                         message_type: :outgoing, content: 'Private note',
+                                         private: true)
+
+      webhook_message = presenter.webhook_data[:messages].first
+
+      expect(webhook_message[:id]).to eq(private_message.id)
+      expect(webhook_message[:content]).to eq('Private note')
+    end
   end
 end


### PR DESCRIPTION
## Summary

When a private message (internal note) triggers a `message_created` webhook, the conversation data embedded in the payload shows the last public message's content instead of the private message's content. This makes webhook consumers receive incorrect data for workflows that depend on private/internal notes.

**Root cause**: `Conversations::EventDataPresenter#webhook_push_messages` uses the `.chat` scope which filters out private messages (`where(private: false)`). When a private message is the most recent message, the scope skips it and returns the last public message instead.

**Fix**: Changed `webhook_push_messages` to exclude only activity-type messages (system events) instead of filtering all private messages. The top-level `content` field in the webhook payload was always correct; the bug was in the nested `conversation.messages` array.

Closes #14023

## How to reproduce

1. Configure a webhook to trigger on `message_created`
2. Send a public message in a conversation
3. Send a private message (internal note) in the same conversation
4. Check the webhook payload
5. **Before fix**: `conversation.messages[0].content` shows the public message, not the private note
6. **After fix**: `conversation.messages[0].content` correctly shows the private note

## What changed

- `app/presenters/conversations/event_data_presenter.rb` — Changed `webhook_push_messages` from using `.chat` scope (excludes private) to `.where.not(message_type: :activity)` (excludes only system activity messages)
- `spec/presenters/conversations/event_data_presenter_spec.rb` — Added regression test verifying private messages appear in webhook data

## Trade-offs

The `push_messages` method (used for ActionCable real-time updates) still uses the `.chat` scope, which is correct since the chat UI should filter out private notes. Only the webhook path is changed, since webhook consumers need accurate data about the event that triggered the webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)