### PR TITLE
fix: use Date object for cookie expiry to support fractional token_lifespan

### DIFF
--- a/app/javascript/dashboard/store/utils/api.js
+++ b/app/javascript/dashboard/store/utils/api.js
@@ -1,5 +1,4 @@
 import fromUnixTime from 'date-fns/fromUnixTime';
-import differenceInDays from 'date-fns/differenceInDays';
 import Cookies from 'js-cookie';
 import { LOCAL_STORAGE_KEYS } from 'dashboard/constants/localStorage';
 import { SESSION_STORAGE_KEYS } from 'dashboard/constants/sessionStorage';
@@ -31,7 +30,7 @@ export const getHeaderExpiry = response =>
 export const setAuthCredentials = response => {
   const expiryDate = getHeaderExpiry(response);
   Cookies.set('cw_d_session_info', JSON.stringify(response.headers), {
-    expires: differenceInDays(expiryDate, new Date()),
+    expires: expiryDate,
   });
   setUser(response.data.data, expiryDate);
 };

--- a/app/javascript/dashboard/store/utils/specs/api.spec.js
+++ b/app/javascript/dashboard/store/utils/specs/api.spec.js
@@ -1,6 +1,7 @@
 import {
   getLoadingStatus,
   parseAPIErrorResponse,
+  setAuthCredentials,
   setLoadingStatus,
   throwErrorMessage,
   parseLinearAPIErrorResponse,
@@ -71,5 +72,67 @@ describe('#parseLinearAPIErrorResponse', () => {
         'Default Message'
       )
     ).toBe('Error Message [message]');
+  });
+});
+
+describe('#setAuthCredentials', () => {
+  let cookieSpy;
+
+  beforeEach(() => {
+    cookieSpy = vi.spyOn(Cookies, 'set').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cookieSpy.mockRestore();
+  });
+
+  it('sets cookie expiry using exact Date object, preserving fractional day lifespans', () => {
+    const expiryDate = new Date(Date.now() + 12 * 60 * 60 * 1000);
+    const expiryUnix = Math.floor(expiryDate.getTime() / 1000).toString();
+
+    const mockResponse = {
+      headers: {
+        expiry: expiryUnix,
+        'token-type': 'Bearer',
+        uid: 'test@example.com',
+        'access-token': 'abc123',
+        client: 'client123',
+      },
+      data: { data: { id: 1, name: 'Test User' } },
+    };
+
+    setAuthCredentials(mockResponse);
+
+    expect(cookieSpy).toHaveBeenCalledWith(
+      'cw_d_session_info',
+      JSON.stringify(mockResponse.headers),
+      expect.objectContaining({
+        expires: expect.any(Date),
+      })
+    );
+  });
+
+  it('does not truncate sub-day token lifespans to zero', () => {
+    const expiryDate = new Date(Date.now() + 6 * 60 * 60 * 1000);
+    const expiryUnix = Math.floor(expiryDate.getTime() / 1000).toString();
+
+    const mockResponse = {
+      headers: {
+        expiry: expiryUnix,
+        'token-type': 'Bearer',
+        uid: 'test@example.com',
+        'access-token': 'abc123',
+        client: 'client123',
+      },
+      data: { data: { id: 1 } },
+    };
+
+    setAuthCredentials(mockResponse);
+
+    const callArgs = cookieSpy.mock.calls[0];
+    const cookieOptions = callArgs[2];
+
+    expect(cookieOptions.expires).toBeInstanceOf(Date);
+    expect(cookieOptions.expires).not.toBe(0);
   });
 });


### PR DESCRIPTION
## Description

`setAuthCredentials` in `app/javascript/dashboard/store/utils/api.js` 
was calculating cookie expiry using `differenceInDays(expiryDate, new Date())` 
from `date-fns`. This function returns a truncated integer, rounding down 
any fractional day value to zero.

If `token_lifespan` in `config/initializers/devise_token_auth.rb` is 
configured with an hour-based value (e.g. `config.token_lifespan = 5.hours`, 
which equals 0.208 days), the truncation produces `0`. A zero-day cookie 
in `js-cookie` expires at the end of the browser session, causing users 
to be logged out immediately on tab close.

Fixes #14066

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What changed

- Replaced `differenceInDays(expiryDate, new Date())` with `expiryDate` 
  passed directly to `Cookies.set`. The `js-cookie` library accepts a 
  `Date` object natively as the `expires` option, preserving the exact 
  expiry timestamp with no truncation or rounding.
- Removed the now-unused `differenceInDays` import from `date-fns`.

```javascript
// Before
Cookies.set('cw_d_session_info', JSON.stringify(response.headers), {
  expires: differenceInDays(expiryDate, new Date()),
});

// After
Cookies.set('cw_d_session_info', JSON.stringify(response.headers), {
  expires: expiryDate,
});
```

## Answering the need-more-info question

@pranavrajs asked "when would token_lifespan be anything other than integer?"

This occurs when `devise_token_auth` is configured with hour-based lifespans:

```ruby
# config/initializers/devise_token_auth.rb
config.token_lifespan = 5.hours  # 0.208 days → truncates to 0
```

Any non-whole-day configuration triggers this bug.

## How Has This Been Tested?

Added two unit tests to `api.spec.js`:

1. Verifies that `Cookies.set` receives a `Date` object (not an integer) 
   for the `expires` option when `setAuthCredentials` is called
2. Verifies that a 6-hour expiry (sub-day lifespan) is not truncated 
   to `0` — which is what the old `differenceInDays` call would produce

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

> Note: This is my first contribution to Chatwoot. Tests were written 
> based on the existing test patterns in `api.spec.js`. Happy to adjust 
> based on reviewer feedback.