### PR TITLE
chore(readme): update Twitter to X (formerly Twitter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Supercharge your support with Captain, Chatwoot’s AI agent. Captain helps auto
 
 ### 💬 Omnichannel Support Desk
 
-Chatwoot centralizes all customer conversations into one powerful inbox, no matter where your customers reach out from. It supports live chat on your website, email, Facebook, Instagram, Twitter, WhatsApp, Telegram, Line, SMS etc.
+Chatwoot centralizes all customer conversations into one powerful inbox, no matter where your customers reach out from. It supports live chat on your website, email, Facebook, Instagram, X (formerly Twitter), WhatsApp, Telegram, Line, SMS etc.
 
 ### 📚 Help center portal
 


### PR DESCRIPTION
## What

Updates the channel list in the README's "Omnichannel Support Desk" section to reflect Twitter's rebrand to X.

## Why

Twitter rebranded to X in July 2023. Chatwoot's product UI (channel selectors, integration setup screens) already uses "X" terminology, but the top-level project README still lists "Twitter" in the omnichannel feature description. This aligns the README with the rebrand and with Chatwoot's own product naming.

## Trade-off

Used "X (formerly Twitter)" rather than just "X" so existing users and search engines indexing the README on the term "Twitter" still find the relevant section. This is the convention most actively-maintained projects have settled on for the rebrand.