### PR TITLE
fix: trigger widget campaign when already open

### DIFF
--- a/app/javascript/widget/store/modules/campaign.js
+++ b/app/javascript/widget/store/modules/campaign.js
@@ -102,23 +102,14 @@ export const actions = {
       );
     }
   },
-  startCampaign: async (
-    {
-      commit,
-      rootState: {
-        appConfig: { isWidgetOpen },
-      },
-    },
-    { websiteToken, campaignId }
-  ) => {
-    // Disable campaign execution if widget is opened
-    if (!isWidgetOpen) {
-      const { data: campaigns } = await getCampaigns(websiteToken);
-      // Check campaign is disabled or not
-      const campaign = campaigns.find(item => item.id === campaignId);
-      if (campaign) {
-        commit('setActiveCampaign', campaign);
-      }
+  startCampaign: async ({ commit }, { websiteToken, campaignId }) => {
+    const { data: campaigns } = await getCampaigns(websiteToken);
+    // Activate campaign if it exists in latest campaign list.
+    // This must work even when widget is already open
+    // (eg: programmatic toggle("open") on chatwoot:ready).
+    const campaign = campaigns.find(item => item.id === campaignId);
+    if (campaign) {
+      commit('setActiveCampaign', campaign);
     }
   },
 

--- a/app/javascript/widget/store/modules/specs/campaign/actions.spec.js
+++ b/app/javascript/widget/store/modules/specs/campaign/actions.spec.js
@@ -188,6 +188,21 @@ describe('#actions', () => {
         { campaignId: 32 }
       );
     });
+    it('starts campaign even if widget is already open', async () => {
+      API.get.mockResolvedValue({ data: campaigns });
+      await actions.startCampaign(
+        {
+          dispatch,
+          getters: { getCampaigns: campaigns },
+          commit,
+          rootState: {
+            appConfig: { isWidgetOpen: true },
+          },
+        },
+        { campaignId: 1 }
+      );
+      expect(commit.mock.calls).toEqual([['setActiveCampaign', campaigns[0]]]);
+    });
     it('start campaign if campaign id passed', async () => {
       API.get.mockResolvedValue({ data: campaigns });
       await actions.startCampaign(


### PR DESCRIPTION
## Summary
- Fix `startCampaign` so it still activates a campaign when the widget is already open.
- This restores triggered campaigns for sites that call `window.$chatwoot.toggle('open')` on `chatwoot:ready` before a scheduled campaign fires.
- Add a regression test for `isWidgetOpen: true`.

Fixes #14022

## Test plan
- [x] `pnpm test app/javascript/widget/store/modules/specs/campaign/actions.spec.js`
- [ ] Manual QA (not performed in this PR)