### PR TITLE
fix: map contact CSV company column to company_name

### DIFF
--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -65,10 +65,17 @@ class DataImport::ContactManager
     # Store with string keys so values match JSONB / UI expectations (see #14096).
     contact.additional_attributes['company_name'] = company_name if company_name.present?
     contact.additional_attributes['city'] = params[:city] if params[:city].present?
-    contact.assign_attributes(
-      custom_attributes: contact.custom_attributes.merge(
-        params.except(:identifier, :email, :name, :phone_number, :company, :company_name)
-      )
+    merged_custom = strip_legacy_company_custom_keys(contact.custom_attributes).merge(
+      params.except(:identifier, :email, :name, :phone_number, :company, :company_name)
     )
+    contact.assign_attributes(custom_attributes: merged_custom)
+  end
+
+  # Pre-#14096 imports could persist `company` / `company_name` inside custom_attributes.
+  # Drop them before merging new row data so re-imports do not keep stale duplicates.
+  def strip_legacy_company_custom_keys(attrs)
+    return {} if attrs.blank?
+
+    attrs.reject { |key, _| %w[company company_name].include?(key.to_s) }
   end
 end

--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -62,20 +62,15 @@ class DataImport::ContactManager
     contact.name = params[:name] if params[:name].present?
     contact.additional_attributes ||= {}
     company_name = params[:company_name].presence || params[:company].presence
-    # Store with string keys so values match JSONB / UI expectations (see #14096).
-    contact.additional_attributes['company_name'] = company_name if company_name.present?
+    if company_name.present?
+      # Store both keys until company filters/automation rules migrate to company_name.
+      contact.additional_attributes['company'] = company_name
+      contact.additional_attributes['company_name'] = company_name
+    end
     contact.additional_attributes['city'] = params[:city] if params[:city].present?
-    merged_custom = strip_legacy_company_custom_keys(contact.custom_attributes).merge(
+    merged_custom = contact.custom_attributes.merge(
       params.except(:identifier, :email, :name, :phone_number, :company, :company_name)
     )
     contact.assign_attributes(custom_attributes: merged_custom)
-  end
-
-  # Pre-#14096 imports could persist `company` / `company_name` inside custom_attributes.
-  # Drop them before merging new row data so re-imports do not keep stale duplicates.
-  def strip_legacy_company_custom_keys(attrs)
-    return {} if attrs.blank?
-
-    attrs.reject { |key, _| %w[company company_name].include?(key.to_s) }
   end
 end

--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -61,8 +61,14 @@ class DataImport::ContactManager
   def update_contact_attributes(params, contact)
     contact.name = params[:name] if params[:name].present?
     contact.additional_attributes ||= {}
-    contact.additional_attributes[:company] = params[:company] if params[:company].present?
-    contact.additional_attributes[:city] = params[:city] if params[:city].present?
-    contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number)))
+    company_name = params[:company_name].presence || params[:company].presence
+    # Store with string keys so values match JSONB / UI expectations (see #14096).
+    contact.additional_attributes['company_name'] = company_name if company_name.present?
+    contact.additional_attributes['city'] = params[:city] if params[:city].present?
+    contact.assign_attributes(
+      custom_attributes: contact.custom_attributes.merge(
+        params.except(:identifier, :email, :name, :phone_number, :company, :company_name)
+      )
+    )
   end
 end

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DataImportJob do
         expect(data_import.reload.processed_records).to eq(csv_length)
         contact = Contact.find_by(phone_number: '+918080808080')
         expect(contact).to be_truthy
-        expect(contact['additional_attributes']['company']).to eq('My Company Name')
+        expect(contact['additional_attributes']['company_name']).to eq('My Company Name')
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe DataImportJob do
           expect(contact).to be_present
           expect(contact.phone_number).to eq("+#{csv_data[0]['phone_number']}")
           expect(contact.name).to eq((csv_data[0]['name']).to_s)
-          expect(contact.additional_attributes['company']).to eq((csv_data[0]['company']).to_s)
+          expect(contact.additional_attributes['company_name']).to eq((csv_data[0]['company']).to_s)
         end
       end
 
@@ -149,7 +149,7 @@ RSpec.describe DataImportJob do
           expect(contact).to be_present
           expect(contact.email).to eq(csv_data[0]['email'])
           expect(contact.name).to eq((csv_data[0]['name']).to_s)
-          expect(contact.additional_attributes['company']).to eq((csv_data[0]['company']).to_s)
+          expect(contact.additional_attributes['company_name']).to eq((csv_data[0]['company']).to_s)
         end
       end
 

--- a/spec/services/data_import/contact_manager_spec.rb
+++ b/spec/services/data_import/contact_manager_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe DataImport::ContactManager do
   let(:manager) { described_class.new(account) }
 
   describe '#build_contact' do
-    it 'maps CSV company column to additional_attributes company_name' do
+    it 'maps CSV company column to additional_attributes company keys' do
       contact = manager.build_contact(
         email: 'user@example.com',
         company: 'Imported Co'
       )
 
       expect(contact.additional_attributes['company_name']).to eq('Imported Co')
-      expect(contact.additional_attributes['company']).to be_nil
+      expect(contact.additional_attributes['company']).to eq('Imported Co')
     end
 
     it 'prefers company_name when both company and company_name are present' do
@@ -23,6 +23,7 @@ RSpec.describe DataImport::ContactManager do
       )
 
       expect(contact.additional_attributes['company_name']).to eq('Canonical name')
+      expect(contact.additional_attributes['company']).to eq('Canonical name')
     end
 
     it 'does not duplicate company fields into custom_attributes' do
@@ -35,9 +36,9 @@ RSpec.describe DataImport::ContactManager do
       expect(contact.custom_attributes).to eq({ 'custom_field' => 'x' })
     end
 
-    it 'removes legacy company keys from existing custom_attributes on re-import' do
+    it 'preserves legitimate company custom attributes on re-import' do
       create(:contact, :with_email, account: account, email: 'legacy@example.com',
-                                   custom_attributes: { 'company' => 'Stale', 'company_name' => 'Also stale', 'foo' => 'bar' })
+                                   custom_attributes: { 'company' => 'Custom company', 'company_name' => 'Custom company name', 'foo' => 'bar' })
 
       contact = manager.build_contact(
         email: 'legacy@example.com',
@@ -46,7 +47,9 @@ RSpec.describe DataImport::ContactManager do
       )
 
       expect(contact.additional_attributes['company_name']).to eq('Acme Inc')
-      expect(contact.custom_attributes.keys).not_to include('company', 'company_name')
+      expect(contact.additional_attributes['company']).to eq('Acme Inc')
+      expect(contact.custom_attributes['company']).to eq('Custom company')
+      expect(contact.custom_attributes['company_name']).to eq('Custom company name')
       expect(contact.custom_attributes['foo']).to eq('updated')
     end
   end

--- a/spec/services/data_import/contact_manager_spec.rb
+++ b/spec/services/data_import/contact_manager_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe DataImport::ContactManager do
+  let(:account) { create(:account) }
+  let(:manager) { described_class.new(account) }
+
+  describe '#build_contact' do
+    it 'maps CSV company column to additional_attributes company_name' do
+      contact = manager.build_contact(
+        email: 'user@example.com',
+        company: 'Imported Co'
+      )
+
+      expect(contact.additional_attributes['company_name']).to eq('Imported Co')
+      expect(contact.additional_attributes['company']).to be_nil
+    end
+
+    it 'prefers company_name when both company and company_name are present' do
+      contact = manager.build_contact(
+        email: 'user@example.com',
+        company: 'Legacy column',
+        company_name: 'Canonical name'
+      )
+
+      expect(contact.additional_attributes['company_name']).to eq('Canonical name')
+    end
+
+    it 'does not duplicate company fields into custom_attributes' do
+      contact = manager.build_contact(
+        email: 'user@example.com',
+        company: 'Imported Co',
+        custom_field: 'x'
+      )
+
+      expect(contact.custom_attributes).to eq({ 'custom_field' => 'x' })
+    end
+  end
+end

--- a/spec/services/data_import/contact_manager_spec.rb
+++ b/spec/services/data_import/contact_manager_spec.rb
@@ -34,5 +34,20 @@ RSpec.describe DataImport::ContactManager do
 
       expect(contact.custom_attributes).to eq({ 'custom_field' => 'x' })
     end
+
+    it 'removes legacy company keys from existing custom_attributes on re-import' do
+      create(:contact, :with_email, account: account, email: 'legacy@example.com',
+                                   custom_attributes: { 'company' => 'Stale', 'company_name' => 'Also stale', 'foo' => 'bar' })
+
+      contact = manager.build_contact(
+        email: 'legacy@example.com',
+        company: 'Acme Inc',
+        foo: 'updated'
+      )
+
+      expect(contact.additional_attributes['company_name']).to eq('Acme Inc')
+      expect(contact.custom_attributes.keys).not_to include('company', 'company_name')
+      expect(contact.custom_attributes['foo']).to eq('updated')
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Contact CSV import wrote `additional_attributes[:company]`, while the rest of Chatwoot uses `company_name` for the Company field.
- Import now maps `company` or `company_name` CSV columns to `additional_attributes['company_name']`, preferring `company_name` when both are set.
- Exclude `company` / `company_name` from the `custom_attributes` merge so they are not duplicated there.

Fixes #14096

## Test plan
- [x] `mise x ruby@3.4.4 -- bundle exec rspec spec/services/data_import/contact_manager_spec.rb spec/jobs/data_import_job_spec.rb`