### PR TITLE
fix(reports): include timezone_offset for summary report APIs + dashboard client

### DIFF
--- a/app/controllers/api/v2/accounts/summary_reports_controller.rb
+++ b/app/controllers/api/v2/accounts/summary_reports_controller.rb
@@ -34,7 +34,8 @@ class Api::V2::Accounts::SummaryReportsController < Api::V1::Accounts::BaseContr
     @builder_params = {
       since: permitted_params[:since],
       until: permitted_params[:until],
-      business_hours: ActiveModel::Type::Boolean.new.cast(permitted_params[:business_hours])
+      business_hours: ActiveModel::Type::Boolean.new.cast(permitted_params[:business_hours]),
+      timezone_offset: permitted_params[:timezone_offset]
     }
   end
 
@@ -45,7 +46,7 @@ class Api::V2::Accounts::SummaryReportsController < Api::V1::Accounts::BaseContr
   end
 
   def permitted_params
-    params.permit(:since, :until, :business_hours)
+    params.permit(:since, :until, :business_hours, :timezone_offset)
   end
 
   def date_range_too_long?

--- a/app/helpers/api/v2/accounts/reports_helper.rb
+++ b/app/helpers/api/v2/accounts/reports_helper.rb
@@ -60,7 +60,8 @@ module Api::V2::Accounts::ReportsHelper
       {
         since: params[:since],
         until: params[:until],
-        business_hours: ActiveModel::Type::Boolean.new.cast(params[:business_hours])
+        business_hours: ActiveModel::Type::Boolean.new.cast(params[:business_hours]),
+        timezone_offset: params[:timezone_offset]
       }
     )
   end

--- a/app/javascript/dashboard/api/summaryReports.js
+++ b/app/javascript/dashboard/api/summaryReports.js
@@ -1,6 +1,8 @@
 /* global axios */
 import ApiClient from './ApiClient';
 
+const getTimeOffset = () => -new Date().getTimezoneOffset() / 60;
+
 class SummaryReportsAPI extends ApiClient {
   constructor() {
     super('summary_reports', { accountScoped: true, apiVersion: 'v2' });
@@ -12,6 +14,7 @@ class SummaryReportsAPI extends ApiClient {
         since,
         until,
         business_hours: businessHours,
+        timezone_offset: getTimeOffset(),
       },
     });
   }
@@ -22,6 +25,7 @@ class SummaryReportsAPI extends ApiClient {
         since,
         until,
         business_hours: businessHours,
+        timezone_offset: getTimeOffset(),
       },
     });
   }
@@ -32,6 +36,7 @@ class SummaryReportsAPI extends ApiClient {
         since,
         until,
         business_hours: businessHours,
+        timezone_offset: getTimeOffset(),
       },
     });
   }
@@ -42,6 +47,7 @@ class SummaryReportsAPI extends ApiClient {
         since,
         until,
         business_hours: businessHours,
+        timezone_offset: getTimeOffset(),
       },
     });
   }

--- a/spec/controllers/api/v2/accounts/summary_reports_controller_spec.rb
+++ b/spec/controllers/api/v2/accounts/summary_reports_controller_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe 'Summary Reports API', type: :request do
         {
           since: start_of_today.to_s,
           until: end_of_today.to_s,
-          business_hours: true
+          business_hours: true,
+          timezone_offset: 330
         }
       end
 
@@ -76,7 +77,8 @@ RSpec.describe 'Summary Reports API', type: :request do
         {
           since: start_of_today.to_s,
           until: end_of_today.to_s,
-          business_hours: true
+          business_hours: true,
+          timezone_offset: 330
         }
       end
 
@@ -130,7 +132,8 @@ RSpec.describe 'Summary Reports API', type: :request do
         {
           since: start_of_today.to_s,
           until: end_of_today.to_s,
-          business_hours: true
+          business_hours: true,
+          timezone_offset: 330
         }
       end
 


### PR DESCRIPTION
## Description
Summary reports endpoints (`/api/v2/.../summary_reports/*`) and the dashboard `summaryReports` API client did not include `timezone_offset`, while other report endpoints (via `reports.js`) already do.

That mismatch can cause **team report “cards” vs “table/overview” values to disagree** for the same selected date range, especially around **day boundaries** when the UI/browser timezone differs from UTC.

This PR:
- Permits and forwards `timezone_offset` through `Api::V2::Accounts::SummaryReportsController`
- Ensures report CSV helper params include `timezone_offset` where applicable
- Updates `dashboard/api/summaryReports.js` to send `timezone_offset` consistently (same approach as `dashboard/api/reports.js`)
- Updates request specs to assert the builder receives `timezone_offset`

Fixes #14141

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- [x] `bundle exec rspec spec/controllers/api/v2/accounts/summary_reports_controller_spec.rb` (13 examples, 0 failures)
- [x] Manual API smoke check against a running local Rails server:
  - `GET /health` → 200
  - `GET /api/v2/accounts/:account_id/summary_reports/team?...&timezone_offset=...` → 200 + valid JSON payload

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes