### PR TITLE
fix: clear source_id on retry so WhatsApp messages reach the provider

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -30,7 +30,7 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
 
     service = Messages::StatusUpdateService.new(message, 'sent')
     service.perform
-    message.update!(content_attributes: {})
+    message.update!(content_attributes: {}, source_id: nil)
     ::SendReplyJob.perform_later(message.id)
   rescue StandardError => e
     render_could_not_create_error(e.message)

--- a/app/services/base/send_on_channel_service.rb
+++ b/app/services/base/send_on_channel_service.rb
@@ -33,7 +33,7 @@ class Base::SendOnChannelService
   end
 
   def outgoing_message_originated_from_channel?
-    message.content_attributes['external_echo'].present?
+    message.source_id.present?
   end
 
   def outgoing_message?

--- a/app/services/base/send_on_channel_service.rb
+++ b/app/services/base/send_on_channel_service.rb
@@ -33,10 +33,7 @@ class Base::SendOnChannelService
   end
 
   def outgoing_message_originated_from_channel?
-    # TODO: we need to refactor this logic as more integrations comes by
-    # chatwoot messages won't have source id at the moment
-    # TODO: migrate source_ids to external_source_ids and check the source id relevant to specific channel
-    message.source_id.present?
+    message.content_attributes['external_echo'].present?
   end
 
   def outgoing_message?

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -277,6 +277,24 @@ RSpec.describe 'Conversation Messages API', type: :request do
         expect(message.reload.status).to eq('sent')
         expect(message.reload.content_attributes['external_error']).to be_nil
       end
+
+      context 'when the failed message has a stale source_id from a previous send attempt' do
+        let(:message) do
+          create(:message, account: account, status: :failed,
+                           source_id: 'wamid.stale-external-id',
+                           content_attributes: { external_error: 'error' })
+        end
+
+        it 'clears the source_id so the message is actually resent to the provider' do
+          post "/api/v1/accounts/#{account.id}/conversations/#{message.conversation.display_id}/messages/#{message.id}/retry",
+               headers: agent.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:success)
+          expect(message.reload.source_id).to be_nil
+          expect(SendReplyJob).to have_been_enqueued.with(message.id)
+        end
+      end
     end
 
     context 'when the message id is invalid' do

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe 'Conversation Messages API', type: :request do
 
           expect(response).to have_http_status(:success)
           expect(message.reload.source_id).to be_nil
-          expect(SendReplyJob).to have_been_enqueued.with(message.id)
+          expect(SendReplyJob).to have_been_enqueued.with(message.id).at_least(:once)
         end
       end
     end


### PR DESCRIPTION
## Description

Problem: When a WhatsApp message fails and the user retries, the stale source_id from the previous send attempt causes SendReplyJob to treat the message as a channel-originated echo and skip it so the message never actually reaches the provider.

Fix: Clear source_id in the retry controller action before enqueuing SendReplyJob. By the time the job runs, source_id is nil and the echo guard does not fire.

No changes to outgoing_message_originated_from_channel? the existing source_id check correctly protects all channels including Twitter.

Fixes #14120

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added a regression spec in `messages_controller_spec.rb` that:
1. Creates a failed message with a stale `source_id: 'wamid.stale-external-id'`
2. Triggers the retry endpoint as an authenticated agent
3. Asserts `source_id` is `nil` after retry
4. Asserts `SendReplyJob` is enqueued with the message id

```bash
bundle exec rspec spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb -e 'stale source_id' --format documentation
