### PR TITLE
fix(agent-bots): align conversation_updated agent-bot webhook with message webhook shape

### DIFF
--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -29,7 +29,10 @@ class AgentBotListener < BaseListener
     changed_attributes = extract_changed_attributes(event)
     inbox = conversation.inbox
     event_name = __method__.to_s
-    payload = conversation.webhook_data.merge(event: event_name, changed_attributes: changed_attributes)
+    payload = agent_bot_message_shaped_conversation_payload(conversation).merge(
+      event: event_name,
+      changed_attributes: changed_attributes
+    )
     agent_bots_for(inbox, conversation).each { |agent_bot| process_webhook_bot_event(agent_bot, payload) }
   end
 
@@ -87,5 +90,26 @@ class AgentBotListener < BaseListener
 
     AgentBots::WebhookJob.perform_later(agent_bot.outgoing_url, payload, :agent_bot_webhook,
                                         secret: agent_bot.secret, delivery_id: SecureRandom.uuid)
+  end
+
+  # Agent-bot message webhooks use Message#webhook_data (message fields at the root and the
+  # conversation nested under `conversation`). `conversation_updated` previously spread
+  # Conversation#webhook_data at the root, which breaks consumers expecting the message payload shape.
+  def agent_bot_message_shaped_conversation_payload(conversation)
+    {
+      account: conversation.account.webhook_data,
+      additional_attributes: conversation.additional_attributes,
+      content_attributes: {},
+      content_type: nil,
+      content: nil,
+      conversation: conversation.webhook_data,
+      created_at: conversation.updated_at,
+      id: nil,
+      inbox: conversation.inbox.webhook_data,
+      message_type: nil,
+      private: false,
+      sender: nil,
+      source_id: nil
+    }
   end
 end

--- a/spec/listeners/agent_bot_listener_spec.rb
+++ b/spec/listeners/agent_bot_listener_spec.rb
@@ -124,9 +124,13 @@ describe AgentBotListener do
 
       it 'sends webhook to the inbox agent bot with changed_attributes' do
         create(:agent_bot_inbox, inbox: inbox, agent_bot: agent_bot)
+        expected_payload = listener.send(:agent_bot_message_shaped_conversation_payload, conversation).merge(
+          event: 'conversation_updated',
+          changed_attributes: nil
+        )
         expect(AgentBots::WebhookJob).to receive(:perform_later).with(
           agent_bot.outgoing_url,
-          conversation.webhook_data.merge(event: 'conversation_updated', changed_attributes: nil),
+          expected_payload,
           :agent_bot_webhook, secret: agent_bot.secret, delivery_id: instance_of(String)
         ).once
         listener.conversation_updated(event)
@@ -145,12 +149,13 @@ describe AgentBotListener do
 
       it 'sends webhook with changed_attributes to the assigned agent bot' do
         expected_changed_attributes = [{ 'assignee_agent_bot_id' => { previous_value: nil, current_value: agent_bot.id } }]
+        expected_payload = listener.send(:agent_bot_message_shaped_conversation_payload, conversation).merge(
+          event: 'conversation_updated',
+          changed_attributes: expected_changed_attributes
+        )
         expect(AgentBots::WebhookJob).to receive(:perform_later).with(
           agent_bot.outgoing_url,
-          conversation.webhook_data.merge(
-            event: 'conversation_updated',
-            changed_attributes: expected_changed_attributes
-          ),
+          expected_payload,
           :agent_bot_webhook, secret: agent_bot.secret, delivery_id: instance_of(String)
         ).once
         listener.conversation_updated(event)

--- a/spec/listeners/agent_bot_listener_spec.rb
+++ b/spec/listeners/agent_bot_listener_spec.rb
@@ -137,6 +137,32 @@ describe AgentBotListener do
       end
     end
 
+    context 'when agent bot is configured on inbox and event includes changed_attributes' do
+      let!(:event) do
+        Events::Base.new(
+          event_name,
+          Time.zone.now,
+          conversation: conversation,
+          changed_attributes: { 'priority' => %w[low urgent] }
+        )
+      end
+
+      it 'sends message-shaped payload with transformed changed_attributes' do
+        create(:agent_bot_inbox, inbox: inbox, agent_bot: agent_bot)
+        expected_changed = [{ 'priority' => { previous_value: 'low', current_value: 'urgent' } }]
+        expected_payload = listener.send(:agent_bot_message_shaped_conversation_payload, conversation).merge(
+          event: 'conversation_updated',
+          changed_attributes: expected_changed
+        )
+        expect(AgentBots::WebhookJob).to receive(:perform_later).with(
+          agent_bot.outgoing_url,
+          expected_payload,
+          :agent_bot_webhook, secret: agent_bot.secret, delivery_id: instance_of(String)
+        ).once
+        listener.conversation_updated(event)
+      end
+    end
+
     context 'when conversation is assigned to an agent bot' do
       let!(:event) do
         Events::Base.new(event_name, Time.zone.now, conversation: conversation,


### PR DESCRIPTION
## Description
Agent-bot webhooks for `message_created` / `message_updated` are built from `Message#webhook_data`, where the **conversation is nested** under `conversation` and message fields live at the top level.

`conversation_updated` was instead sending **`Conversation#webhook_data` merged at the root**, which makes the payload look like a “conversation object” rather than a “message-shaped envelope”. That breaks webhook consumers that assume a stable agent-bot contract across event types (as described in the issue).

This PR changes **only** `conversation_updated` to emit a **message-shaped payload** (same key layout as `Message#webhook_data`, with `conversation` nested) and keeps `event` + `changed_attributes` merged in the same way as before.

Fixes #13993

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

**Compatibility note (important):**  
If any integration *intentionally* depended on the incorrect flat `conversation_updated` shape, it will need to read `conversation` from the nested field like other message events. Functionally, this aligns the payload with the documented expectation in the issue thread.

## How Has This Been Tested?
- [x] `bundle exec rspec spec/listeners/agent_bot_listener_spec.rb` (11 examples, 0 failures)
- Environment: Postgres + Redis available for `RAILS_ENV=test`, then `rails db:test:prepare`, then the command above.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes