### PR TITLE
Support availability_status when updating agents

### DIFF
--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -68,11 +68,11 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
   end
 
   def account_user_attributes
-    [:role, :availability, :auto_offline]
+    [:role, :availability, :availability_status, :auto_offline]
   end
 
   def allowed_agent_params
-    [:name, :email, :role, :availability, :auto_offline]
+    [:name, :email, :role, :availability, :availability_status, :auto_offline]
   end
 
   def agent_params

--- a/spec/controllers/api/v1/accounts/agents_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/agents_controller_spec.rb
@@ -140,8 +140,20 @@ RSpec.describe 'Agents API', type: :request do
         expect(response_data['auto_offline']).to be(false)
         expect(other_agent.account_users.first.role).to eq('administrator')
       end
+
+      it 'updates availability using availability_status parameter' do
+        patch "/api/v1/accounts/#{account.id}/agents/#{other_agent.id}",
+              params: { availability_status: 'busy' },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['availability_status']).to eq('busy')
+        expect(other_agent.account_users.first.reload.availability_status).to eq('busy')
+      end
     end
   end
+
 
   describe 'POST /api/v1/accounts/{account.id}/agents' do
     let(:other_agent) { create(:user, account: account, role: :agent) }


### PR DESCRIPTION
## Summary
Fixes agent availability updates when the API receives `availability_status`.

Previously, the agents update endpoint allowed `availability`, but not `availability_status`. Because of that, when API users sent `availability_status`, Rails ignored the parameter and the agent availability did not update.

## What changed
- Added `availability_status` to permitted agent params
- Added `availability_status` to account user update attributes
- Added a request spec that sends `availability_status: 'busy'` and checks that the response and account user record are updated correctly

## Why this fixes the issue
The controller now permits `availability_status`, so the value is passed into the account user update instead of being ignored.

The new request spec covers the exact case from the issue: updating an agent using `availability_status`.

## Testing
- Ran `git diff --check`
- Result: no whitespace errors

Note:
I could not run RSpec locally because Bundler is not available in my Windows environment.