### PR TITLE
fix(data-import): store company under company_name attribute

### DIFF
--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -61,7 +61,7 @@ class DataImport::ContactManager
   def update_contact_attributes(params, contact)
     contact.name = params[:name] if params[:name].present?
     contact.additional_attributes ||= {}
-    contact.additional_attributes[:company] = params[:company] if params[:company].present?
+    contact.additional_attributes[:company_name] = params[:company] if params[:company].present?
     contact.additional_attributes[:city] = params[:city] if params[:city].present?
     contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number)))
   end

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DataImportJob do
         expect(data_import.reload.processed_records).to eq(csv_length)
         contact = Contact.find_by(phone_number: '+918080808080')
         expect(contact).to be_truthy
-        expect(contact['additional_attributes']['company']).to eq('My Company Name')
+        expect(contact['additional_attributes']['company_name']).to eq('My Company Name')
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe DataImportJob do
           expect(contact).to be_present
           expect(contact.phone_number).to eq("+#{csv_data[0]['phone_number']}")
           expect(contact.name).to eq((csv_data[0]['name']).to_s)
-          expect(contact.additional_attributes['company']).to eq((csv_data[0]['company']).to_s)
+          expect(contact.additional_attributes['company_name']).to eq((csv_data[0]['company']).to_s)
         end
       end
 
@@ -149,7 +149,7 @@ RSpec.describe DataImportJob do
           expect(contact).to be_present
           expect(contact.email).to eq(csv_data[0]['email'])
           expect(contact.name).to eq((csv_data[0]['name']).to_s)
-          expect(contact.additional_attributes['company']).to eq((csv_data[0]['company']).to_s)
+          expect(contact.additional_attributes['company_name']).to eq((csv_data[0]['company']).to_s)
         end
       end
 


### PR DESCRIPTION
Contact CSV imports were silently dropping the `company` column. The import service was writing `additional_attributes[:company]`, but every reader in the product (sort scope, contact serializer, dashboard `ContactInfo`/`ContactForm` views) uses `company_name`. The imported value landed in the database but never surfaced in the Company field anywhere in the UI. This change aligns the import key with the rest of the codebase so imported companies appear correctly without any schema or migration changes.

## Closes

- Closes #14096
- Re-resolves #9907 (closed previously due to inactivity)

## How to reproduce (before this fix)

1. Import a CSV containing a `company` column for at least one contact
2. Open that contact in the dashboard
3. The Company field is empty, even though `additional_attributes.company` is populated on the contact record

## What changed

- `DataImport::ContactManager#update_contact_attributes` now writes `additional_attributes[:company_name]` instead of `:company`, matching the convention used by the sort scope (`Contact.order_on_company_name`) and the dashboard contact views
- Updated three existing assertions in `spec/jobs/data_import_job_spec.rb` that locked in the buggy `'company'` key so the suite reflects the corrected behavior