### PR TITLE
fix: validate label titles against account labels in conversations an…

### DIFF
--- a/app/controllers/concerns/label_concern.rb
+++ b/app/controllers/concerns/label_concern.rb
@@ -1,10 +1,19 @@
 module LabelConcern
   def create
-    model.update_labels(permitted_params[:labels])
+    model.update_labels(valid_labels)
     @labels = model.label_list
   end
 
   def index
     @labels = model.label_list
+  end
+
+  private
+
+  def valid_labels
+    posted = Array(permitted_params[:labels])
+    return [] if posted.blank?
+
+    model.account.labels.where(title: posted).pluck(:title)
   end
 end

--- a/app/controllers/concerns/label_concern.rb
+++ b/app/controllers/concerns/label_concern.rb
@@ -11,7 +11,7 @@ module LabelConcern
   private
 
   def valid_labels
-    posted = Array(permitted_params[:labels])
+    posted = Array(permitted_params[:labels]).map { |title| title.to_s.downcase }
     return [] if posted.blank?
 
     model.account.labels.where(title: posted).pluck(:title)

--- a/spec/controllers/api/v1/accounts/contacts/labels_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/labels_controller_spec.rb
@@ -52,6 +52,11 @@ RSpec.describe 'Contact Label API', type: :request do
     context 'when it is an authenticated user' do
       let(:agent) { create(:user, account: account, role: :agent) }
 
+      before do
+        create(:label, account: account, title: 'label3')
+        create(:label, account: account, title: 'label4')
+      end
+
       it 'creates labels for the contact' do
         post api_v1_account_contact_labels_url(account_id: account.id, contact_id: contact.id),
              params: { labels: %w[label3 label4] },
@@ -61,6 +66,18 @@ RSpec.describe 'Contact Label API', type: :request do
         expect(response).to have_http_status(:success)
         expect(response.body).to include('label3')
         expect(response.body).to include('label4')
+      end
+
+      it 'drops labels that are not defined on the account' do
+        post api_v1_account_contact_labels_url(account_id: account.id, contact_id: contact.id),
+             params: { labels: %w[label3 unknown] },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include('label3')
+        expect(response.body).not_to include('unknown')
+        expect(contact.reload.label_list).to contain_exactly('label3')
       end
     end
   end

--- a/spec/controllers/api/v1/accounts/contacts/labels_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/labels_controller_spec.rb
@@ -79,6 +79,17 @@ RSpec.describe 'Contact Label API', type: :request do
         expect(response.body).not_to include('unknown')
         expect(contact.reload.label_list).to contain_exactly('label3')
       end
+
+      it 'matches account labels case-insensitively' do
+        create(:label, account: account, title: 'urgent')
+        post api_v1_account_contact_labels_url(account_id: account.id, contact_id: contact.id),
+             params: { labels: %w[Urgent] },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(contact.reload.label_list).to contain_exactly('urgent')
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/accounts/conversations/labels_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/labels_controller_spec.rb
@@ -85,6 +85,17 @@ RSpec.describe 'Conversation Label API', type: :request do
         expect(response.body).not_to include('unknown')
         expect(conversation.reload.label_list).to contain_exactly('label3')
       end
+
+      it 'matches account labels case-insensitively' do
+        create(:label, account: account, title: 'urgent')
+        post api_v1_account_conversation_labels_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { labels: %w[Urgent] },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.label_list).to contain_exactly('urgent')
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/accounts/conversations/labels_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/labels_controller_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe 'Conversation Label API', type: :request do
 
       before do
         conversation.update_labels('label1, label2')
+        create(:label, account: account, title: 'label3')
+        create(:label, account: account, title: 'label4')
         create(:inbox_member, inbox: conversation.inbox, user: agent)
       end
 
@@ -70,6 +72,18 @@ RSpec.describe 'Conversation Label API', type: :request do
         expect(response).to have_http_status(:success)
         expect(response.body).to include('label3')
         expect(response.body).to include('label4')
+      end
+
+      it 'drops labels that are not defined on the account' do
+        post api_v1_account_conversation_labels_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { labels: %w[label3 unknown] },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include('label3')
+        expect(response.body).not_to include('unknown')
+        expect(conversation.reload.label_list).to contain_exactly('label3')
       end
     end
   end


### PR DESCRIPTION
The dashboard API endpoints that attach labels to a conversation or contact now reject any title that doesn't exist as a managed `Label` on the account. Previously, posting an arbitrary string like `{"labels":["pizza"]}` would "attach" that name to the conversation while silently creating an orphan row in the global `tags` table — invisible to admins managing labels in the dashboard, missing from reports and label-based filters, and bypassing the product's "labels are first-class records" contract. After this change, only titles that already exist on the account are applied; unknown titles are dropped. Known titles continue to work unchanged, and the dashboard UI is unaffected (its picker was already bound to `account.labels`).

> **Note on existing work:** I noticed [#14159](https://github.com/chatwoot/chatwoot/pull/14159) is already open against this issue. This PR takes a different path on two points the reviewers there flagged — it mirrors the existing widget pattern (`Api::V1::Widget::MessagesController#apply_labels`) by **silently dropping unknown titles instead of returning 422**, which avoids changing observable behavior on the contacts endpoint for callers that previously sent extra titles. Happy to close this in favor of #14159 or fold the diff into a review there if that's preferred.

## Closes
Closes #13918

## How to reproduce
1. Use any account with at least one conversation and an API access token. Make sure no `Label` records named `"pizza"` or `"dinosaur"` exist on the account.
2. Run:
   ```bash
   curl -X POST http://localhost:3000/api/v1/accounts/$ACCT/conversations/$CONV/labels \
     -H "Content-Type: application/json" \
     -H "api_access_token: $TOKEN" \
     -d '{"labels":["pizza","dinosaur"]}'
   ```
3. **Before this PR:** response is `{"payload":["pizza","dinosaur"]}`. Inspect the DB and `ActsAsTaggableOn::Tag.where(name: %w[pizza dinosaur])` now returns rows, but no corresponding `Label` records exist for the account.
4. **After this PR:** response is `{"payload":[]}`. No new `tags` rows are created. Repeat the same flow against `/api/v1/accounts/:id/contacts/:id/labels` — same behavior.
5. To confirm the happy path, create a real label on the account (`account.labels.create!(title: "real")`) and post `{"labels":["real","pizza"]}` — the response now includes `"real"` only.

## What changed

**`app/controllers/concerns/label_concern.rb`** — added a private `valid_labels` helper that filters posted titles through `account.labels` before delegating to `update_labels`:

```ruby
def valid_labels
  posted = Array(permitted_params[:labels])
  return [] if posted.blank?

  model.account.labels.where(title: posted).pluck(:title)
end
```

A few notes on the shape of the fix:

- **Single change, two endpoints fixed.** `LabelConcern` is included by both `Api::V1::Accounts::Conversations::LabelsController` and `Api::V1::Accounts::Contacts::LabelsController`, so the patch lives in exactly one place.
- **`model.account` rather than `Current.account`.** `model` is set by the including controller (`@conversation` or `@contact`); both `belongs_to :account`, so the resolution works in both call sites with no thread-local dependency.
- **Single indexed query** against the existing `(title, account_id)` unique index on `labels` — returns canonical (DB-lowercased) titles, which gives correct case-folding for free.
- **Drops silently rather than 422.** Mirrors the existing widget pattern. Callers can still detect what was filtered because the response body is `model.label_list` after assignment — diffing the posted array against the returned array surfaces the dropped titles without needing a structured error.

## Out of scope (intentionally)

- **`BulkActionsJob` and `ActionService`** also assign `label_list=` without validation, but their inputs come from saved automation rules and agent-selected bulk actions — not free-form request bodies — and tightening them at the model layer risks silently breaking automations whose payloads pre-date stricter validation. Worth a separate PR for defense-in-depth.
- **Per-account scoping of `acts_as_taggable_on`'s `tags` table** is a real underlying concern — the table has no `account_id`, so a stray title posted by one account becomes a row visible across the install — but moving the boundary into the storage layer is a much larger refactor. Controller-layer filtering closes the reported behavior; the schema concern is best handled in its own change.

## Tests

Two existing request specs were implicitly relying on the bug (posting `label3` / `label4` without seeding `Label` records); they now seed real records so they reflect the actual product flow. One new regression spec on each endpoint posts a mix of one known and one unknown title, asserting the unknown title is dropped from both the response body and the model's `label_list`.
