### PR TITLE
fix: correct before_action callback and add policy for WorkingHoursController

### DIFF
--- a/app/controllers/api/v1/accounts/working_hours_controller.rb
+++ b/app/controllers/api/v1/accounts/working_hours_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::Accounts::WorkingHoursController < Api::V1::Accounts::BaseControl
   private
 
   def working_hour_params
-    params.require(:working_hour).permit(:inbox_id, :open_hour, :open_minutes, :close_hour, :close_minutes, :closed_all_day)
+    params.require(:working_hour).permit(:open_hour, :open_minutes, :close_hour, :close_minutes, :closed_all_day)
   end
 
   def fetch_working_hour

--- a/app/controllers/api/v1/accounts/working_hours_controller.rb
+++ b/app/controllers/api/v1/accounts/working_hours_controller.rb
@@ -1,9 +1,10 @@
 class Api::V1::Accounts::WorkingHoursController < Api::V1::Accounts::BaseController
   before_action :check_authorization
-  before_action :fetch_webhook, only: [:update]
+  before_action :fetch_working_hour, only: [:update]
 
   def update
     @working_hour.update!(working_hour_params)
+    head :ok
   end
 
   private

--- a/app/policies/working_hour_policy.rb
+++ b/app/policies/working_hour_policy.rb
@@ -1,0 +1,5 @@
+class WorkingHourPolicy < ApplicationPolicy
+  def update?
+    @account_user.administrator?
+  end
+end

--- a/spec/controllers/api/v1/accounts/working_hours_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/working_hours_controller_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Working Hours API', type: :request do
+  let(:account) { create(:account) }
+  let(:inbox) { create(:inbox, account: account) }
+  let(:working_hour) { inbox.working_hours.first }
+
+  describe 'PATCH /api/v1/accounts/:account_id/working_hours/:id' do
+    let(:valid_params) do
+      { working_hour: { open_hour: 8, open_minutes: 30, close_hour: 18, close_minutes: 0, closed_all_day: false } }
+    end
+
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        patch "/api/v1/accounts/#{account.id}/working_hours/#{working_hour.id}", params: valid_params, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated as an agent' do
+      let(:agent) { create(:user, account: account, role: :agent) }
+
+      it 'returns forbidden' do
+        patch "/api/v1/accounts/#{account.id}/working_hours/#{working_hour.id}",
+              params: valid_params,
+              headers: agent.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated as an administrator' do
+      let(:admin) { create(:user, account: account, role: :administrator) }
+
+      it 'updates the working hour and returns ok' do
+        patch "/api/v1/accounts/#{account.id}/working_hours/#{working_hour.id}",
+              params: valid_params,
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(working_hour.reload.open_hour).to eq(8)
+        expect(working_hour.reload.open_minutes).to eq(30)
+      end
+
+      it 'returns not found for a working hour outside the account' do
+        other_inbox = create(:inbox)
+        other_working_hour = other_inbox.working_hours.first
+
+        patch "/api/v1/accounts/#{account.id}/working_hours/#{other_working_hour.id}",
+              params: valid_params,
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description                                                                                                                                                                                                      
                                                                                                                                                                                                                      
The `WorkingHoursController` declared `before_action :fetch_webhook` on the `update` action, but no method named `fetch_webhook` exists in the controller. The correct method is `fetch_working_hour`. Any API consumer calling `PATCH /api/v1/accounts/:account_id/working_hours/:id` would receive a 500 error before reaching the action.                                                                                                                                                                                   
                                                                                                                                                                                                                      
While tracing the bug, two additional gaps were found:                                                                                                                                                              
- The `update` action had no response (`head :ok` missing, no view template)
- No `WorkingHourPolicy` existed, so Pundit would raise `NotDefinedError` before the callback bug was even reached                                                                                                                                                                          

Fixes #13752   

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

A new request spec was created at `spec/controllers/api/v1/accounts/working_hours_controller_spec.rb` covering four scenarios:                                                                                                                                                                                            
                                                                                                                                                                                                                      
1. Unauthenticated request → 401
2. Agent (non-admin) request → 401 (Pundit blocks via WorkingHourPolicy)                                                                                                                                            
3. Admin request with valid params → 200, record updated in DB                                                                                                                                                      
4. Admin request with a working hour from another account → 404                                                                                                                                                     
                                                                                                                                                                                                                      
To reproduce manually:                                                                                                                                                                                              
1. Start the server and authenticate as an administrator
2. Find a working hour ID via the Rails console:                                                                                                                                                                    
     `WorkingHour.first.id`
3. Send `PATCH /api/v1/accounts/:id/working_hours/:working_hour_id` with `{ working_hour: { open_hour: 8, closed_all_day: false } }`                                                                                                                                                 
4. Confirm 200 response and updated values

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
