### PR TITLE
fix: disable unchecked features in Super Admin account update

### DIFF
--- a/app/controllers/super_admin/accounts_controller.rb
+++ b/app/controllers/super_admin/accounts_controller.rb
@@ -36,7 +36,9 @@ class SuperAdmin::AccountsController < SuperAdmin::ApplicationController
   def resource_params
     permitted_params = super
     permitted_params[:limits] = permitted_params[:limits].to_h.compact
-    permitted_params[:selected_feature_flags] = params[:enabled_features].keys.map(&:to_sym) if params[:enabled_features].present?
+    if params[:features_submitted].present?
+      permitted_params[:selected_feature_flags] = params[:enabled_features].to_h.keys.map(&:to_sym)
+    end
     permitted_params
   end
 

--- a/app/controllers/super_admin/accounts_controller.rb
+++ b/app/controllers/super_admin/accounts_controller.rb
@@ -36,9 +36,7 @@ class SuperAdmin::AccountsController < SuperAdmin::ApplicationController
   def resource_params
     permitted_params = super
     permitted_params[:limits] = permitted_params[:limits].to_h.compact
-    if params[:features_submitted].present?
-      permitted_params[:selected_feature_flags] = (params[:enabled_features]&.keys || []).map(&:to_sym)
-    end
+    permitted_params[:selected_feature_flags] = (params[:enabled_features]&.keys || []).map(&:to_sym) if params[:features_submitted].present?
     permitted_params
   end
 

--- a/app/controllers/super_admin/accounts_controller.rb
+++ b/app/controllers/super_admin/accounts_controller.rb
@@ -37,7 +37,7 @@ class SuperAdmin::AccountsController < SuperAdmin::ApplicationController
     permitted_params = super
     permitted_params[:limits] = permitted_params[:limits].to_h.compact
     if params[:features_submitted].present?
-      permitted_params[:selected_feature_flags] = params[:enabled_features].to_h.keys.map(&:to_sym)
+      permitted_params[:selected_feature_flags] = (params[:enabled_features]&.keys || []).map(&:to_sym)
     end
     permitted_params
   end

--- a/enterprise/app/views/fields/account_features_field/_form.html.erb
+++ b/enterprise/app/views/fields/account_features_field/_form.html.erb
@@ -2,6 +2,7 @@
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field feature-container">
+  <%= hidden_field_tag 'features_submitted', '1' %>
   <% regular_features, premium_features = SuperAdmin::AccountFeaturesHelper.filtered_features(field.data).partition { |key_array, _val| !SuperAdmin::AccountFeaturesHelper.account_premium_features.include?(key_array.first) } %>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/spec/controllers/super_admin/accounts_controller_spec.rb
+++ b/spec/controllers/super_admin/accounts_controller_spec.rb
@@ -55,6 +55,58 @@ RSpec.describe 'Super Admin accounts API', type: :request do
     end
   end
 
+  describe 'PATCH /super_admin/accounts/{account_id}' do
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized' do
+        patch "/super_admin/accounts/#{account.id}", params: { account: { name: 'Test' } }
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context 'when authenticated as super admin' do
+      before { sign_in(super_admin, scope: :super_admin) }
+
+      it 'enables only the checked features when features_submitted is present' do
+        account.enable_features!('reports')
+        account.enable_features!('channel_email')
+
+        patch "/super_admin/accounts/#{account.id}",
+              params: {
+                account: { name: account.name },
+                features_submitted: '1',
+                enabled_features: { 'feature_reports' => 'true' }
+              }
+
+        expect(response).to have_http_status(:redirect)
+        expect(account.reload.feature_enabled?('reports')).to be(true)
+        expect(account.reload.feature_enabled?('channel_email')).to be(false)
+      end
+
+      it 'disables all features when features_submitted is present but no checkboxes are checked' do
+        account.enable_features!('reports')
+
+        patch "/super_admin/accounts/#{account.id}",
+              params: {
+                account: { name: account.name },
+                features_submitted: '1'
+              }
+
+        expect(response).to have_http_status(:redirect)
+        expect(account.reload.feature_enabled?('reports')).to be(false)
+      end
+
+      it 'does not change features when features_submitted is absent' do
+        account.enable_features!('reports')
+
+        patch "/super_admin/accounts/#{account.id}",
+              params: { account: { name: account.name } }
+
+        expect(response).to have_http_status(:redirect)
+        expect(account.reload.feature_enabled?('reports')).to be(true)
+      end
+    end
+  end
+
   describe 'DELETE /super_admin/accounts/{account_id}' do
     context 'when it is an unauthenticated user' do
       it 'returns unauthorized' do


### PR DESCRIPTION
## Description  

When a Super Admin unchecks one or more feature flags on the account edit form and saves, the unchecked features remain enabled. The root cause is standard HTML browser behavior: unchecked checkboxes are excluded from the form submission entirely. When all features are unchecked, `params[:enabled_features]` is absent, and the controller guard `if params[:enabled_features].present?` evaluates to false — so `selected_feature_flags` is never updated and the account's feature bitmask stays unchanged.                                                                                                                                                                                            
                                                                                                                                                                                                                      
The fix adds a hidden sentinel field (`features_submitted`) to the features form partial. The controller uses this sentinel to distinguish "all features explicitly unchecked" from "this form submission did not include the features section". When the sentinel is present, `selected_feature_flags` is set to whatever checkboxes were checked — an empty array when none are.                                                                                                                                                    
                                                                                                                                                                                                                      
Fixes #14064

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Three test cases were added to `spec/controllers/super_admin/accounts_controller_spec.rb`:
                                                                                                                                                                                                                      
1. Partially unchecking features — only checked features remain enabled, unchecked ones are disabled
2. Unchecking all features (sentinel present, no `enabled_features` param) — all features are disabled                                                                                                                                                                                      
3. Submitting without the sentinel — features are unchanged (guards the non-enterprise / non-features-form path)                                                                                                                                                                         
                                                                                                                                                                                                                      
To reproduce manually (Enterprise edition):                                                                                                                                                                         
1. Go to Super Admin → Accounts → Edit any account                                                                                                                                                                  
2. Enable a feature flag and save — confirm it is enabled                                                                                                                                                           
3. Uncheck that same feature and save — confirm it is now disabled                                                                                                                                                  
4. Uncheck all features and save — confirm all are disabled 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
