### PR TITLE
fix: prevent duplicate conversations from concurrent WhatsApp messages

### DIFF
--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -39,8 +39,8 @@ class Whatsapp::IncomingMessageBaseService
     return unless @contact
     return if @contact.blocked? && !outgoing_echo
 
+    set_conversation
     ActiveRecord::Base.transaction do
-      set_conversation
       create_messages
     end
   end

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -130,16 +130,19 @@ class Whatsapp::IncomingMessageBaseService
   end
 
   def set_conversation
-    # if lock to single conversation is disabled, we will create a new conversation if previous conversation is resolved
-    @conversation = if @inbox.lock_to_single_conversation
-                      @contact_inbox.conversations.last
-                    else
-                      @contact_inbox.conversations
-                                    .where.not(status: :resolved).last
-                    end
-    return if @conversation
+    # Acquire a row-level lock on the contact_inbox before the find-or-create so
+    # that two workers processing messages from the same contact simultaneously
+    # cannot both observe "no conversation" and both call Conversation.create!.
+    @contact_inbox.with_lock do
+      @conversation = if @inbox.lock_to_single_conversation
+                        @contact_inbox.conversations.last
+                      else
+                        @contact_inbox.conversations
+                                      .where.not(status: :resolved).last
+                      end
 
-    @conversation = ::Conversation.create!(conversation_params)
+      @conversation ||= ::Conversation.create!(conversation_params)
+    end
   end
 
   def attach_files

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -569,5 +569,27 @@ describe Whatsapp::IncomingMessageService do
       expect(whatsapp_channel.inbox.conversations.count).to eq(1)
       expect(whatsapp_channel.inbox.messages.count).to eq(2)
     end
+
+    it 'acquires a row-level lock on contact_inbox before finding or creating a conversation' do
+      text_params = {
+        'contacts' => [{ 'profile' => { 'name' => 'Race Tester' }, 'wa_id' => wa_id }],
+        'messages' => [{ 'from' => wa_id, 'id' => 'msg-lock-test-001',
+                         'text' => { 'body' => 'lock test' },
+                         'timestamp' => '1633034394', 'type' => 'text' }]
+      }.with_indifferent_access
+
+      service = described_class.new(inbox: whatsapp_channel.inbox, params: text_params)
+      contact_inbox_spy = nil
+
+      allow_any_instance_of(described_class).to receive(:set_conversation).and_wrap_original do |original, *args|
+        contact_inbox_spy = service.instance_variable_get(:@contact_inbox)
+        allow(contact_inbox_spy).to receive(:with_lock).and_call_original
+        original.call(*args)
+      end
+
+      service.perform
+
+      expect(contact_inbox_spy).to have_received(:with_lock)
+    end
   end
 end

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -524,4 +524,50 @@ describe Whatsapp::IncomingMessageService do
       end
     end
   end
+
+  describe 'race condition: concurrent messages from the same contact' do
+    before do
+      stub_request(:post, 'https://waba.360dialog.io/v1/configs/webhook')
+    end
+
+    after do
+      Redis::Alfred.scan_each(match: 'MESSAGE_SOURCE_KEY::*') do |key|
+        Redis::Alfred.delete(key)
+      end
+    end
+
+    let!(:whatsapp_channel) { create(:channel_whatsapp, sync_templates: false) }
+    let(:wa_id) { '5511999990000' }
+
+    let(:image_params) do
+      {
+        'contacts' => [{ 'profile' => { 'name' => 'Race Tester' }, 'wa_id' => wa_id }],
+        'messages' => [{ 'from' => wa_id, 'id' => 'msg-image-001',
+                         'image' => { 'id' => 'b1c68f38-8734-4ad3-b4a1-ef0c10d683', 'mime_type' => 'image/jpeg' },
+                         'timestamp' => '1633034394', 'type' => 'image' }]
+      }.with_indifferent_access
+    end
+
+    let(:audio_params) do
+      {
+        'contacts' => [{ 'profile' => { 'name' => 'Race Tester' }, 'wa_id' => wa_id }],
+        'messages' => [{ 'from' => wa_id, 'id' => 'msg-audio-002',
+                         'audio' => { 'id' => 'a2d79e49-9845-5be4-c5b2-fg1d21e794' },
+                         'timestamp' => '1633034395', 'type' => 'audio' }]
+      }.with_indifferent_access
+    end
+
+    it 'creates only one conversation when two different messages arrive for the same contact with no existing conversation' do
+      stub_request(:get, whatsapp_channel.media_url('b1c68f38-8734-4ad3-b4a1-ef0c10d683'))
+        .to_return(status: 200, body: '', headers: { 'Content-Type' => 'image/jpeg' })
+      stub_request(:get, whatsapp_channel.media_url('a2d79e49-9845-5be4-c5b2-fg1d21e794'))
+        .to_return(status: 200, body: '', headers: { 'Content-Type' => 'audio/ogg' })
+
+      described_class.new(inbox: whatsapp_channel.inbox, params: image_params).perform
+      described_class.new(inbox: whatsapp_channel.inbox, params: audio_params).perform
+
+      expect(whatsapp_channel.inbox.conversations.count).to eq(1)
+      expect(whatsapp_channel.inbox.messages.count).to eq(2)
+    end
+  end
 end

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -581,7 +581,7 @@ describe Whatsapp::IncomingMessageService do
       service = described_class.new(inbox: whatsapp_channel.inbox, params: text_params)
       contact_inbox_spy = nil
 
-      allow_any_instance_of(described_class).to receive(:set_conversation).and_wrap_original do |original, *args|
+      allow(service).to receive(:set_conversation).and_wrap_original do |original, *args|
         contact_inbox_spy = service.instance_variable_get(:@contact_inbox)
         allow(contact_inbox_spy).to receive(:with_lock).and_call_original
         original.call(*args)


### PR DESCRIPTION
## Description
                                                                                                                                                                                                                      
When a WhatsApp contact sends two messages in rapid succession (e.g. an image followed immediately by an audio clip ~214 ms apart), Chatwoot creates two separate conversations instead of appending both messages to the same thread.                                                                                                                                       
                                                                                                                                                                                                                      
The root cause is a race condition in `Whatsapp::IncomingMessageBaseService#set_conversation`. The existing `MessageDedupLock` is keyed on `source_id` and correctly prevents the same message from being processed twice — but two different messages (image and audio) each hold their own lock and can both reach `set_conversation` concurrently.  Without serialisation at the conversation level, both workers observe no active conversation and both call `Conversation.create!`.                                                                                                                                                
                                                                                                                                                                                                                      
The fix wraps the find-or-create block in `@contact_inbox.with_lock`, which issues a `SELECT ... FOR UPDATE` on the contact inbox row. The second worker blocks until the first commits its new conversation, then finds it on its own query instead of creating a duplicate.                                                                                                                                                                              
                                                                                                                                                                                                                      
Fixes #14071

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

 A new test case was added to `spec/services/whatsapp/incoming_message_service_spec.rb` under a dedicated `describe 'race condition'` block:                                                                                                                                                                                  
- Two distinct message payloads (image and audio) are sent from the same contact with no prior conversation                                                                                                                                                                                
- Asserts only one conversation is created and both messages land in it                                                                                                                                             
                                                                                                                                                                                                                      
To reproduce manually:
1. Configure a WhatsApp inbox                                                                                                                                                                                       
2. Send an image and an audio message from the same contact within milliseconds (or simulate via Rails console):                                                                                                                                                                    
     ```ruby                                                                                                                                                                                                          
     inbox = Inbox.find(<id>)                                                                                                                                                                                         
     t1 = Thread.new { Whatsapp::IncomingMessageService.new(inbox: inbox, params: image_params).perform }                                                                                                             
     t2 = Thread.new { Whatsapp::IncomingMessageService.new(inbox: inbox, params: audio_params).perform }                                                                                                             
     [t1, t2].each(&:join)                                                                                                                                                                                            
     inbox.conversations.count # should be 1                                                                                                                                                                          
3. Confirm only one conversation is created with both messages in it 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
