### PR TITLE
fix(integrations): redact sensitive hook settings in dashboard API

### DIFF
--- a/app/models/integrations/hook.rb
+++ b/app/models/integrations/hook.rb
@@ -64,6 +64,19 @@ class Integrations::Hook < ApplicationRecord
     update(status: 'disabled')
   end
 
+  # Returns settings filtered by the integration's `visible_properties` allowlist
+  # so secrets configured under `settings` (api keys, service-account credentials, etc.)
+  # are not serialized back to the dashboard. Integrations that do not declare
+  # `visible_properties` retain the previous behavior to preserve compatibility.
+  def filtered_settings
+    return settings if app.blank?
+
+    visible_properties = app.params[:visible_properties]
+    return settings if visible_properties.blank?
+
+    settings.to_h.slice(*visible_properties.map(&:to_s))
+  end
+
   def process_event(_event)
     # OpenAI integration migrated to Captain::EditorService
     # Other integrations (slack, dialogflow, etc.) handled via HookJob

--- a/app/views/api/v1/models/_hook.json.jbuilder
+++ b/app/views/api/v1/models/_hook.json.jbuilder
@@ -5,5 +5,5 @@ json.inbox resource.inbox&.slice(:id, :name)
 json.account_id resource.account_id
 json.hook_type resource.hook_type
 
-json.settings resource.settings if Current.account_user&.administrator?
+json.settings resource.filtered_settings if Current.account_user&.administrator?
 json.reference_id resource.reference_id if Current.account_user&.administrator?

--- a/config/integration/apps.yml
+++ b/config/integration/apps.yml
@@ -55,7 +55,7 @@ openai:
         'validation': '',
       },
     ]
-  visible_properties: ['api_key', 'label_suggestion']
+  visible_properties: ['label_suggestion']
 linear:
   id: linear
   logo: linear.png

--- a/spec/controllers/api/v1/accounts/integrations/apps_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/apps_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Integration Apps API', type: :request do
         end
       end
 
-      it 'will return sensitive information for openai app for admins' do
+      it 'redacts sensitive openai hook settings even for admins' do
         openai = create(:integrations_hook, :openai, account: account)
         get api_v1_account_integrations_apps_url(account),
             headers: admin.create_new_auth_token,
@@ -75,7 +75,22 @@ RSpec.describe 'Integration Apps API', type: :request do
         expect(response).to have_http_status(:success)
 
         app = response.parsed_body['payload'].find { |int_app| int_app['id'] == openai.app.id }
-        expect(app['hooks'].first['settings']).not_to be_nil
+        settings = app['hooks'].first['settings']
+        expect(settings).not_to be_nil
+        expect(settings).not_to have_key('api_key')
+      end
+
+      it 'serializes only the visible settings keys for admins' do
+        hook = create(:integrations_hook, :openai, account: account, settings: { api_key: 'sk-secret', label_suggestion: true })
+        get api_v1_account_integrations_apps_url(account),
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+
+        app = response.parsed_body['payload'].find { |int_app| int_app['id'] == hook.app.id }
+        settings = app['hooks'].first['settings']
+        expect(settings).to eq('label_suggestion' => true)
       end
     end
   end
@@ -115,7 +130,7 @@ RSpec.describe 'Integration Apps API', type: :request do
         expect(app['hooks'].first['settings']).to be_nil
       end
 
-      it 'will return sensitive information for openai app for admins' do
+      it 'redacts sensitive openai hook settings even for admins' do
         openai = create(:integrations_hook, :openai, account: account)
         get api_v1_account_integrations_app_url(account_id: account.id, id: openai.app.id),
             headers: admin.create_new_auth_token,
@@ -124,7 +139,9 @@ RSpec.describe 'Integration Apps API', type: :request do
         expect(response).to have_http_status(:success)
 
         app = response.parsed_body
-        expect(app['hooks'].first['settings']).not_to be_nil
+        settings = app['hooks'].first['settings']
+        expect(settings).not_to be_nil
+        expect(settings).not_to have_key('api_key')
       end
     end
   end


### PR DESCRIPTION
The authenticated integrations endpoint `GET /api/v1/accounts/:id/integrations/apps` was serializing the full `settings` JSONB blob of every connected hook to administrators. For self-hosted instances configuring OpenAI, Google Translate, or Dialogflow, this returned raw API keys and Google service-account credentials (including `private_key`) in the browser network response. Even authorized admins should not have configured secrets re-served to their browser, where they can be observed by extensions, screen-share tools, or any script running on the page.

The codebase already had the necessary infrastructure: each integration in `config/integration/apps.yml` declares a `visible_properties` allowlist (today consumed only by `MultipleIntegrationHooks.vue` for table column rendering). This change wires the same allowlist through the backend serializer so secrets remain on the server while the dashboard UI keeps the data it actually needs.

## Closes

- Closes #14042

## How to reproduce (before this fix)

1. On a self-hosted instance, sign in as an administrator
2. Configure the OpenAI, Google Translate, or Dialogflow integration with real credentials
3. Open browser devtools Network tab and trigger `GET /api/v1/accounts/:account_id/integrations/apps`
4. Observe `payload[].hooks[].settings` containing raw `api_key` / `credentials.private_key` values

## What changed

- Adds `Integrations::Hook#filtered_settings`, returning `settings` filtered by the integration's `visible_properties` allowlist when defined, and the unmodified `settings` otherwise. Integrations that do not declare `visible_properties` (Slack, Linear, Notion, Webhook, Dashboard apps, Shopify) keep their existing serialization to avoid breaking their dashboards.
- Switches `app/views/api/v1/models/_hook.json.jbuilder` to render `filtered_settings` for admins.
- Removes `api_key` from OpenAI's `visible_properties`. OpenAI is `allow_multiple_hooks: false`, so its UI uses `SingleIntegrationHooks.vue`, which does not read `visible_properties` — there is no UI impact from this removal.
- Updates the two existing controller specs that previously asserted admins received the full `settings` blob, now asserting `api_key` is filtered out. Adds one new spec verifying that an admin response contains only the visible (non-sensitive) keys.

## Trade-offs considered

- **Allowlist (`visible_properties`) vs. denylist of known-sensitive keys**: chose the allowlist because the convention already exists in the codebase and is opt-in per integration. A denylist would silently miss any new sensitive key a future integration introduces.
- **Backfill / migration of existing data**: not needed. Stored data is unchanged; only the API response is filtered.
- **Tests for Dialogflow and Google Translate**: not added in this PR. The factory only ships an `:openai` trait, and adding factory traits for the others would expand scope. The OpenAI test exercises the same code path; the same allowlist mechanism handles every integration that declares `visible_properties`.