### PR TITLE
fix: normalize agent bot conversation_updated webhook payload shape

### DIFF
--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -24,14 +24,21 @@ class AgentBotListener < BaseListener
     agent_bots_for(inbox, conversation).each { |agent_bot| process_webhook_bot_event(agent_bot, payload) }
   end
 
-  def conversation_updated(event)
-    conversation = extract_conversation_and_account(event)[0]
-    changed_attributes = extract_changed_attributes(event)
-    inbox = conversation.inbox
-    event_name = __method__.to_s
-    payload = conversation.webhook_data.merge(event: event_name, changed_attributes: changed_attributes)
-    agent_bots_for(inbox, conversation).each { |agent_bot| process_webhook_bot_event(agent_bot, payload) }
-  end
+ def conversation_updated(event)
+  conversation = extract_conversation_and_account(event)[0]
+  changed_attributes = extract_changed_attributes(event)
+  inbox = conversation.inbox
+  event_name = __method__.to_s
+  # Fix for #13993: wrap in consistent envelope matching other conversation
+  # events so bot consumers get a stable top-level contract.
+  payload = {
+    event: event_name,
+    account: conversation.account.webhook_data,
+    conversation: conversation.webhook_data,
+    changed_attributes: changed_attributes
+  }
+  agent_bots_for(inbox, conversation).each { |agent_bot| process_webhook_bot_event(agent_bot, payload) }
+end
 
   def message_created(event)
     message = extract_message_and_account(event)[0]


### PR DESCRIPTION
## Problem
`conversation_updated` agent-bot webhooks were sending conversation fields 
at the root level of the payload, inconsistent with all other agent-bot events.

Before this fix, bots received:
{ "id": 2374, "inbox_id": 88933, "event": "conversation_updated" }

## Fix
Wrap the payload in a consistent envelope matching other conversation events:
{ event, account, conversation, changed_attributes }

So bot consumers get a stable top-level contract regardless of event type.

Fixes #13993