### PR TITLE
fix: support availability_status param in update API

### DIFF
--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -24,7 +24,9 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
 
   def update
     @agent.update!(agent_params.slice(:name).compact)
-    @agent.current_account_user.update!(agent_params.slice(*account_user_attributes).compact)
+    account_user_params = agent_params.slice(*account_user_attributes).compact
+    account_user_params[:availability] ||= agent_params[:availability_status] if agent_params[:availability_status]
+    @agent.current_account_user.update!(account_user_params)
   end
 
   def destroy
@@ -72,7 +74,7 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
   end
 
   def allowed_agent_params
-    [:name, :email, :role, :availability, :auto_offline]
+    [:name, :email, :role, :availability, :availability_status, :auto_offline]
   end
 
   def agent_params

--- a/spec/controllers/api/v1/accounts/agents_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/agents_controller_spec.rb
@@ -127,6 +127,18 @@ RSpec.describe 'Agents API', type: :request do
         expect(other_agent.reload.name).to eq(params[:name])
       end
 
+      it 'modifies agent availability using availability_status param' do
+        put "/api/v1/accounts/#{account.id}/agents/#{other_agent.id}",
+            params: { availability_status: 'offline' },
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        response_data = response.parsed_body
+        expect(response_data['availability_status']).to eq('offline')
+        expect(other_agent.reload.account_users.first.availability).to eq('offline')
+      end
+
       it 'modifies an agents account user attributes' do
         put "/api/v1/accounts/#{account.id}/agents/#{other_agent.id}",
             params: { role: 'administrator', availability: 'busy', auto_offline: false },


### PR DESCRIPTION
# Pull Request Template

## Description

This PR updates the PATCH/PUT `/api/v1/accounts/:account_id/agents/:id` endpoint to support both `availability` and `availability_status` parameters, as documented in Swagger/OpenAPI.  
Fixes [#13873](https://github.com/chatwoot/chatwoot/issues/13873): Agent PATCH endpoint ignores `availability_status` parameter (Swagger API mismatch).

- The controller now maps `availability_status` to `availability` for backwards compatibility.
- Added/updated request specs to ensure both parameter names are supported and covered by tests.

**Note on implementation:**  
This PR follows the solution proposed in [#13873](https://github.com/chatwoot/chatwoot/issues/13873) to ensure API contract compatibility. In addition to the suggested fix, I have added/updated automated request specs to verify that both `availability` and `availability_status` parameters are supported, ensuring this remains covered in future releases.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Manual PATCH/PUT requests to `/api/v1/accounts/:account_id/agents/:id` with both `availability` and `availability_status` parameters.
- Verified that the agent’s availability is updated and the response reflects the correct status.
- Automated request specs added/updated to cover both parameter names.
- Full RSpec suite run; all relevant tests pass. Existing unrelated pipeline failures do not affect this change.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not needed, API contract now matches docs)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (not applicable)