### PR TITLE
fix: Fixes 14052 send each attachment individually but add caption to…

### DIFF
--- a/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
@@ -72,25 +72,27 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
   end
 
   def send_attachment_message(phone_number, message)
-    attachment = message.attachments.first
-    type = %w[image audio video].include?(attachment.file_type) ? attachment.file_type : 'document'
-    type_content = {
-      'link': attachment.download_url
-    }
-    type_content['caption'] = message.outgoing_content unless %w[audio sticker].include?(type)
-    type_content['filename'] = attachment.file.filename if type == 'document'
+    message_id = nil
+    message.attachments.each_with_index do |attachment, index|
+      type = %w[image audio video].include?(attachment.file_type) ? attachment.file_type : 'document'
+      type_content = {
+        'link': attachment.download_url
+      }
+      type_content['caption'] = message.outgoing_content if index.zero? && !%w[audio sticker].include?(type)
+      type_content['filename'] = attachment.file.filename if type == 'document'
 
-    response = HTTParty.post(
-      "#{api_base_path}/messages",
-      headers: api_headers,
-      body: {
-        'to' => phone_number,
-        'type' => type,
-        type.to_s => type_content
-      }.to_json
-    )
-
-    process_response(response, message)
+      response = HTTParty.post(
+        "#{api_base_path}/messages",
+        headers: api_headers,
+        body: {
+          'to' => phone_number,
+          'type' => type,
+          type.to_s => type_content
+        }.to_json
+      )
+      message_id = process_response(response, message)
+    end
+    message_id
   end
 
   def error_message(response)

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -115,26 +115,28 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   end
 
   def send_attachment_message(phone_number, message)
-    attachment = message.attachments.first
-    type = %w[image audio video].include?(attachment.file_type) ? attachment.file_type : 'document'
-    type_content = {
-      'link': attachment.download_url
-    }
-    type_content['caption'] = message.outgoing_content unless %w[audio sticker].include?(type)
-    type_content['filename'] = attachment.file.filename if type == 'document'
-    response = HTTParty.post(
-      "#{phone_id_path}/messages",
-      headers: api_headers,
-      body: {
-        :messaging_product => 'whatsapp',
-        :context => whatsapp_reply_context(message),
-        'to' => phone_number,
-        'type' => type,
-        type.to_s => type_content
-      }.to_json
-    )
-
-    process_response(response, message)
+    message_id = nil
+    message.attachments.each_with_index do |attachment, index|
+      type = %w[image audio video].include?(attachment.file_type) ? attachment.file_type : 'document'
+      type_content = {
+        'link': attachment.download_url
+      }
+      type_content['caption'] = message.outgoing_content if index.zero? && !%w[audio sticker].include?(type)
+      type_content['filename'] = attachment.file.filename if type == 'document'
+      response = HTTParty.post(
+        "#{phone_id_path}/messages",
+        headers: api_headers,
+        body: {
+          :messaging_product => 'whatsapp',
+          :context => whatsapp_reply_context(message),
+          'to' => phone_number,
+          'type' => type,
+          type.to_s => type_content
+        }.to_json
+      )
+      message_id = process_response(response, message)
+    end
+    message_id
   end
 
   def error_message(response)

--- a/spec/services/whatsapp/providers/whatsapp360_dialog_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp360_dialog_service_spec.rb
@@ -7,6 +7,47 @@ describe Whatsapp::Providers::Whatsapp360DialogService do
   let!(:whatsapp_channel) { create(:channel_whatsapp, sync_templates: false, validate_provider_config: false) }
   let(:response_headers) { { 'Content-Type' => 'application/json' } }
   let(:whatsapp_response) { { messages: [{ id: 'message_id' }] } }
+  let(:conversation) { create(:conversation, inbox: whatsapp_channel.inbox) }
+  let(:message) do
+    create(:message, conversation: conversation, message_type: :outgoing, content: 'test', inbox: whatsapp_channel.inbox)
+  end
+
+  describe '#send_message' do
+    context 'when message has multiple attachments' do
+      it 'sends each attachment as a separate API call and returns the last message id' do
+        attachment1 = message.attachments.new(account_id: message.account_id, file_type: :image)
+        attachment1.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
+        attachment2 = message.attachments.new(account_id: message.account_id, file_type: :image)
+        attachment2.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar2.png', content_type: 'image/png')
+
+        stub_request(:post, 'https://waba.360dialog.io/v1/messages')
+          .to_return(
+            { status: 200, body: { messages: [{ id: 'message_id_1' }] }.to_json, headers: response_headers },
+            { status: 200, body: { messages: [{ id: 'message_id_2' }] }.to_json, headers: response_headers }
+          )
+
+        expect(service.send_message('+123456789', message)).to eq 'message_id_2'
+        expect(WebMock).to have_requested(:post, 'https://waba.360dialog.io/v1/messages').twice
+      end
+
+      it 'includes caption only on the first attachment' do
+        attachment1 = message.attachments.new(account_id: message.account_id, file_type: :image)
+        attachment1.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
+        attachment2 = message.attachments.new(account_id: message.account_id, file_type: :image)
+        attachment2.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar2.png', content_type: 'image/png')
+
+        stub_request(:post, 'https://waba.360dialog.io/v1/messages')
+          .to_return(status: 200, body: whatsapp_response.to_json, headers: response_headers)
+
+        service.send_message('+123456789', message)
+
+        expect(WebMock).to have_requested(:post, 'https://waba.360dialog.io/v1/messages')
+          .with(body: hash_including({ image: WebMock::API.hash_including({ caption: message.content }) }))
+          .once
+        expect(WebMock).to have_requested(:post, 'https://waba.360dialog.io/v1/messages').twice
+      end
+    end
+  end
 
   describe '#sync_templates' do
     context 'when called' do

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -91,6 +91,39 @@ describe Whatsapp::Providers::WhatsappCloudService do
           .to_return(status: 200, body: whatsapp_response.to_json, headers: response_headers)
         expect(service.send_message('+123456789', message)).to eq 'message_id'
       end
+
+      it 'sends each attachment as a separate API call and returns the last message id' do
+        attachment1 = message.attachments.new(account_id: message.account_id, file_type: :image)
+        attachment1.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
+        attachment2 = message.attachments.new(account_id: message.account_id, file_type: :image)
+        attachment2.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar2.png', content_type: 'image/png')
+
+        stub_request(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+          .to_return(
+            { status: 200, body: { messages: [{ id: 'message_id_1' }] }.to_json, headers: response_headers },
+            { status: 200, body: { messages: [{ id: 'message_id_2' }] }.to_json, headers: response_headers }
+          )
+
+        expect(service.send_message('+123456789', message)).to eq 'message_id_2'
+        expect(WebMock).to have_requested(:post, 'https://graph.facebook.com/v13.0/123456789/messages').twice
+      end
+
+      it 'includes caption only on the first attachment when multiple attachments are present' do
+        attachment1 = message.attachments.new(account_id: message.account_id, file_type: :image)
+        attachment1.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
+        attachment2 = message.attachments.new(account_id: message.account_id, file_type: :image)
+        attachment2.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar2.png', content_type: 'image/png')
+
+        stub_request(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+          .to_return(status: 200, body: whatsapp_response.to_json, headers: response_headers)
+
+        service.send_message('+123456789', message)
+
+        expect(WebMock).to have_requested(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+          .with(body: hash_including({ image: WebMock::API.hash_including({ caption: message.content }) }))
+          .once
+        expect(WebMock).to have_requested(:post, 'https://graph.facebook.com/v13.0/123456789/messages').twice
+      end
     end
   end
 


### PR DESCRIPTION
### Description
When a Chatwoot agent sends a message with multiple attachments to a WhatsApp conversation, only the first attachment was forwarded to WhatsApp. The remaining attachments were silently dropped.

The root cause was in both WhatsApp provider services (WhatsappCloudService and Whatsapp360DialogService), where send_attachment_message called message.attachments.first instead of iterating over all attachments. Each attachment has been fixed to send as its own WhatsApp API call (which is the only way the WhatsApp API supports it), with the message caption attached to the first one only to avoid repetition.

Fixes #(issue)

Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Two new unit tests were added to each provider spec (whatsapp_cloud_service_spec.rb and whatsapp360_dialog_service_spec.rb):

Multiple API calls — creates a message with 2 image attachments, stubs the WhatsApp endpoint to return distinct message IDs per call, and asserts the endpoint was hit twice and the last message ID is returned.
Caption placement — same setup, asserts that exactly one of the two requests included the caption and that both requests were made.
To run:


bundle exec rspec spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb spec/services/whatsapp/providers/whatsapp360_dialog_service_spec.rb
### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules