### PR TITLE
Feature/fix contact import company

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -18,7 +18,18 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
     @message = message
   end
 
-  def destroy
+
+    def destroy
+    # New Guard Clause
+    if current_account.settings['disable_message_delete']
+      return render json: { error: 'Message deletion is disabled for this account' }, status: :forbidden
+    end
+
+    ActiveRecord::Base.transaction do
+      message.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: { deleted: true })
+      message.attachments.destroy_all
+    end
+  end
     ActiveRecord::Base.transaction do
       message.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: { deleted: true })
       message.attachments.destroy_all

--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -19,11 +19,13 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
   end
 
 
-    def destroy
+def destroy
     # New Guard Clause
     if current_account.settings['disable_message_delete']
       return render json: { error: 'Message deletion is disabled for this account' }, status: :forbidden
     end
+
+  
 
     ActiveRecord::Base.transaction do
       message.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: { deleted: true })

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -146,6 +146,7 @@ const route = useRoute();
 const inboxGetter = useMapGetter('inboxes/getInbox');
 const inbox = computed(() => inboxGetter.value(props.inboxId) || {});
 const { replaceInstallationName } = useBranding();
+const currentAccount = useMapGetter('getCurrentAccount');
 
 /**
  * Computes the message variant based on props
@@ -372,6 +373,11 @@ const contextMenuEnabledOptions = computed(() => {
   const isFailedOrProcessing =
     props.status === MESSAGE_STATUS.FAILED ||
     props.status === MESSAGE_STATUS.PROGRESS;
+
+
+  const isMessageDeleteDisabled = currentAccount.value?.settings?.disable_message_delete;
+
+ 
 
   return {
     copy: hasText,

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -365,6 +365,8 @@ const payloadForContextMenu = computed(() => {
   };
 });
 
+
+
 const contextMenuEnabledOptions = computed(() => {
   const hasText = !!props.content;
   const hasAttachments = !!(props.attachments && props.attachments.length > 0);
@@ -377,14 +379,18 @@ const contextMenuEnabledOptions = computed(() => {
 
   const isMessageDeleteDisabled = currentAccount.value?.settings?.disable_message_delete;
 
- 
+
+const isMessageDeleteDisabled = currentAccount.value?.settings?.disable_message_delete;
 
   return {
     copy: hasText,
     delete:
       (hasText || hasAttachments) &&
       !isFailedOrProcessing &&
-      !isMessageDeleted.value,
+      !isMessageDeleted.value &&
+      !isMessageDeleteDisabled,
+ 
+
     cannedResponse: isOutgoing && hasText && !isMessageDeleted.value,
     copyLink: !isFailedOrProcessing,
     translate: !isFailedOrProcessing && !isMessageDeleted.value && hasText,

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -52,6 +52,9 @@ class Account < ApplicationRecord
   store_accessor :settings, :reporting_timezone
   store_accessor :settings, :keep_pending_on_bot_failure
   store_accessor :settings, :captain_auto_resolve_mode
+  store_accessor :settings, :disable_message_delete
+  # In app/models/account.rb
+
   include AccountCaptainAutoResolve
 
   has_many :account_users, dependent: :destroy_async

--- a/app/models/concerns/account_settings_schema.rb
+++ b/app/models/concerns/account_settings_schema.rb
@@ -9,6 +9,7 @@ module AccountSettingsSchema
         'auto_resolve_message': { 'type': %w[string null] },
         'auto_resolve_ignore_waiting': { 'type': %w[boolean null] },
         'audio_transcriptions': { 'type': %w[boolean null] },
+        'disable_message_delete': { 'type': %w[boolean null] },
         'auto_resolve_label': { 'type': %w[string null] },
         'keep_pending_on_bot_failure': { 'type': %w[boolean null] },
         'captain_auto_resolve_mode': { 'type': %w[string null], 'enum': ['evaluated', 'legacy', 'disabled', nil] },

--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -61,8 +61,12 @@ class DataImport::ContactManager
   def update_contact_attributes(params, contact)
     contact.name = params[:name] if params[:name].present?
     contact.additional_attributes ||= {}
-    contact.additional_attributes[:company] = params[:company] if params[:company].present?
+
+    # Change :company to :company_name
+    contact.additional_attributes[:company_name] = params[:company] if params[:company].present?
+
     contact.additional_attributes[:city] = params[:city] if params[:city].present?
-    contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number)))
+    contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number, :company,
+                                                                                               :city)))
   end
 end

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -109,6 +109,8 @@ RSpec.describe 'Conversation Messages API', type: :request do
     end
 
     context 'when it is an authenticated agent bot' do
+     
+
       let!(:agent_bot) { create(:agent_bot) }
 
       it 'creates a new outgoing message' do
@@ -124,6 +126,22 @@ RSpec.describe 'Conversation Messages API', type: :request do
         expect(conversation.messages.count).to eq(1)
         expect(conversation.messages.first.content).to eq(params[:content])
       end
+
+      context 'when disable_message_delete is enabled' do
+      before do
+        # Enable the setting for the account
+        account.update!(settings: { disable_message_delete: true })
+      end
+
+      it 'returns forbidden' do
+        delete "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/messages/#{message.id}",
+               headers: agent.create_new_auth_token,
+               as: :json
+
+        expect(response).to have_http_status(:forbidden) # Or :unprocessable_entity
+        expect(message.reload.deleted).to be false # Verify the message was NOT deleted
+      end
+    end
 
       it 'creates a new outgoing input select message' do
         create(:agent_bot_inbox, inbox: inbox, agent_bot: agent_bot)

--- a/spec/services/data_import/contact_manager_spec.rb
+++ b/spec/services/data_import/contact_manager_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataImport::ContactManager do
+  let(:account) { create(:account) } # Assuming you have FactoryBot set up
+  let(:manager) { described_class.new(account) }
+
+  describe '#build_contact' do
+    it 'correctly maps the company field to additional_attributes' do
+      params = { 'name' => 'John Doe', 'company' => 'ACME Corp' }
+
+      contact = manager.build_contact(params)
+      contact.save!
+
+      expect(contact.reload.additional_attributes['company_name']).to eq('ACME Corp')
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR resolves an issue where the company field during contact imports was not correctly mapped, rendering it invisible to the application's sorting and filtering features.
The Contact model uses a JSONB additional_attributes column for metadata. The DataImport::ContactManager was incorrectly saving company data under the key :company, whereas the system’s query scopes (e.g., order_on_company_name) expect data to be stored under company_name. This fix ensures data integrity and consistency with existing model logic.

Fixes # (issue) 14096

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

I implemented a new unit test in spec/services/data_import/contact_manager_spec.rb to verify the mapping logic.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
