### PR TITLE
fix(whatsapp): use backend webhook base url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ SECRET_KEY_BASE=replace_with_lengthy_secure_hex
 
 # Replace with the URL you are planning to use for your app
 FRONTEND_URL=http://0.0.0.0:3000
+# Public backend URL used for webhook callbacks and other server-origin links
+WEBHOOK_BASE_URL=http://0.0.0.0:3000
 # To use a dedicated URL for help center pages
 # HELPCENTER_URL=http://0.0.0.0:3000
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   skip_before_action :verify_authenticity_token
 
   before_action :set_current_user, unless: :devise_controller?
+  before_action :set_current_webhook_base_url
   around_action :switch_locale
   around_action :handle_with_exception, unless: :devise_controller?
 
@@ -15,6 +16,10 @@ class ApplicationController < ActionController::Base
   def set_current_user
     @user ||= current_user
     Current.user = @user
+  end
+
+  def set_current_webhook_base_url
+    Current.webhook_base_url = request.base_url
   end
 
   def pundit_user

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -195,7 +195,7 @@ class Inbox < ApplicationRecord
     when 'Channel::Line'
       "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/line/#{channel.line_channel_id}"
     when 'Channel::Whatsapp'
-      "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/whatsapp/#{channel.phone_number}"
+      Whatsapp::WebhookUrlBuilder.build(channel.phone_number)
     end
   end
 

--- a/app/services/whatsapp/health_service.rb
+++ b/app/services/whatsapp/health_service.rb
@@ -87,9 +87,6 @@ class Whatsapp::HealthService
   end
 
   def build_expected_webhook_url
-    frontend_url = ENV.fetch('FRONTEND_URL', nil)
-    return nil if frontend_url.blank?
-
-    "#{frontend_url}/webhooks/whatsapp/#{@channel.phone_number}"
+    Whatsapp::WebhookUrlBuilder.build(@channel.phone_number)
   end
 end

--- a/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
@@ -36,7 +36,7 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
       "#{api_base_path}/configs/webhook",
       headers: { 'D360-API-KEY': whatsapp_channel.provider_config['api_key'], 'Content-Type': 'application/json' },
       body: {
-        url: "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/whatsapp/#{whatsapp_channel.phone_number}"
+        url: Whatsapp::WebhookUrlBuilder.build(whatsapp_channel.phone_number)
       }.to_json
     )
     response.success?

--- a/app/services/whatsapp/webhook_setup_service.rb
+++ b/app/services/whatsapp/webhook_setup_service.rb
@@ -67,10 +67,7 @@ class Whatsapp::WebhookSetupService
   end
 
   def build_callback_url
-    frontend_url = ENV.fetch('FRONTEND_URL', nil)
-    phone_number = @channel.phone_number
-
-    "#{frontend_url}/webhooks/whatsapp/#{phone_number}"
+    Whatsapp::WebhookUrlBuilder.build(@channel.phone_number)
   end
 
   def phone_number_verified?

--- a/app/services/whatsapp/webhook_url_builder.rb
+++ b/app/services/whatsapp/webhook_url_builder.rb
@@ -1,0 +1,16 @@
+module Whatsapp::WebhookUrlBuilder
+  class << self
+    def build(phone_number, base_url: nil)
+      resolved_base_url = resolve_base_url(base_url)
+      return nil if resolved_base_url.blank?
+
+      "#{resolved_base_url.chomp('/')}/webhooks/whatsapp/#{phone_number}"
+    end
+
+    private
+
+    def resolve_base_url(base_url)
+      base_url.presence || Current.webhook_base_url.presence || ENV.fetch('WEBHOOK_BASE_URL', nil)
+    end
+  end
+end

--- a/app/services/whatsapp/webhook_url_builder.rb
+++ b/app/services/whatsapp/webhook_url_builder.rb
@@ -10,7 +10,10 @@ module Whatsapp::WebhookUrlBuilder
     private
 
     def resolve_base_url(base_url)
-      base_url.presence || Current.webhook_base_url.presence || ENV.fetch('WEBHOOK_BASE_URL', nil)
+      base_url.presence ||
+        Current.webhook_base_url.presence ||
+        ENV.fetch('WEBHOOK_BASE_URL', nil).presence ||
+        ENV.fetch('FRONTEND_URL', nil)
     end
   end
 end

--- a/lib/current.rb
+++ b/lib/current.rb
@@ -4,6 +4,7 @@ module Current
   thread_mattr_accessor :account_user
   thread_mattr_accessor :executed_by
   thread_mattr_accessor :contact
+  thread_mattr_accessor :webhook_base_url
 
   def self.reset
     Current.user = nil
@@ -11,5 +12,6 @@ module Current
     Current.account_user = nil
     Current.executed_by = nil
     Current.contact = nil
+    Current.webhook_base_url = nil
   end
 end

--- a/spec/services/whatsapp/webhook_setup_service_spec.rb
+++ b/spec/services/whatsapp/webhook_setup_service_spec.rb
@@ -48,10 +48,10 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'registers the phone number and sets up webhook' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(api_client).to receive(:register_phone_number).with('123456789', 223_456)
           expect(api_client).to receive(:subscribe_waba_webhook)
-            .with(waba_id, 'https://app.chatwoot.com/webhooks/whatsapp/+1234567890', 'test_verify_token')
+            .with(waba_id, 'https://api.chatwoot.com/webhooks/whatsapp/+1234567890', 'test_verify_token')
           service.perform
         end
       end
@@ -69,10 +69,10 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'does NOT register phone, but sets up webhook' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(api_client).not_to receive(:register_phone_number)
           expect(api_client).to receive(:subscribe_waba_webhook)
-            .with(waba_id, 'https://app.chatwoot.com/webhooks/whatsapp/+1234567890', 'test_verify_token')
+            .with(waba_id, 'https://api.chatwoot.com/webhooks/whatsapp/+1234567890', 'test_verify_token')
           service.perform
         end
       end
@@ -93,10 +93,10 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'registers the phone number due to pending provisioning state' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(api_client).to receive(:register_phone_number).with('123456789', 223_456)
           expect(api_client).to receive(:subscribe_waba_webhook)
-            .with(waba_id, 'https://app.chatwoot.com/webhooks/whatsapp/+1234567890', 'test_verify_token')
+            .with(waba_id, 'https://api.chatwoot.com/webhooks/whatsapp/+1234567890', 'test_verify_token')
           service.perform
         end
       end
@@ -117,10 +117,10 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'registers the phone number due to throughput not applicable' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(api_client).to receive(:register_phone_number).with('123456789', 223_456)
           expect(api_client).to receive(:subscribe_waba_webhook)
-            .with(waba_id, 'https://app.chatwoot.com/webhooks/whatsapp/+1234567890', 'test_verify_token')
+            .with(waba_id, 'https://api.chatwoot.com/webhooks/whatsapp/+1234567890', 'test_verify_token')
           service.perform
         end
       end
@@ -140,7 +140,7 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'tries to register phone (due to verification error) and proceeds with webhook setup' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(api_client).to receive(:register_phone_number)
           expect(api_client).to receive(:subscribe_waba_webhook)
           expect { service.perform }.not_to raise_error
@@ -156,7 +156,7 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'does not register phone (conservative approach) and proceeds with webhook setup' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(api_client).not_to receive(:register_phone_number)
           expect(api_client).to receive(:subscribe_waba_webhook)
           expect { service.perform }.not_to raise_error
@@ -174,7 +174,7 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'continues with webhook setup even if registration fails' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(api_client).to receive(:register_phone_number)
           expect(api_client).to receive(:subscribe_waba_webhook)
           expect { service.perform }.not_to raise_error
@@ -191,7 +191,7 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'raises an error' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(api_client).to receive(:register_phone_number)
           expect(api_client).to receive(:subscribe_waba_webhook)
           expect { service.perform }.to raise_error(/Webhook setup failed/)
@@ -226,7 +226,7 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'reuses existing PIN' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(api_client).to receive(:register_phone_number).with('123456789', 123_456)
           expect(SecureRandom).not_to receive(:random_number)
           service.perform
@@ -241,13 +241,13 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'raises error with webhook setup failure message' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect { service.perform }.to raise_error(/Webhook setup failed: Invalid access token/)
         end
       end
 
       it 'logs the webhook setup failure' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(Rails.logger).to receive(:error).with('[WHATSAPP] Webhook setup failed: Invalid access token')
           expect { service.perform }.to raise_error(/Webhook setup failed/)
         end
@@ -283,16 +283,16 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'successfully reauthorizes with new access token' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(api_client).not_to receive(:register_phone_number)
           expect(api_client).to receive(:subscribe_waba_webhook)
-            .with(waba_id, 'https://app.chatwoot.com/webhooks/whatsapp/+1234567890', 'existing_verify_token')
+            .with(waba_id, 'https://api.chatwoot.com/webhooks/whatsapp/+1234567890', 'existing_verify_token')
           service_reauth.perform
         end
       end
 
       it 'uses the existing webhook verify token during reauthorization' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(api_client).to receive(:subscribe_waba_webhook)
             .with(waba_id, anything, 'existing_verify_token')
           service_reauth.perform
@@ -312,13 +312,13 @@ describe Whatsapp::WebhookSetupService do
       end
 
       it 'completes successfully without errors' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect { service.perform }.not_to raise_error
         end
       end
 
       it 'does not log any errors' do
-        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+        with_modified_env WEBHOOK_BASE_URL: 'https://api.chatwoot.com' do
           expect(Rails.logger).not_to receive(:error)
           service.perform
         end


### PR DESCRIPTION
# Pull Request Template

## Description

Fix WhatsApp Embedded Signup webhook URL generation by replacing incorrect FRONTEND_URL usage with a backend/public URL resolution strategy.

Previously, Meta received a frontend application URL instead of the actual backend webhook endpoint, causing mismatch during WhatsApp Embedded Signup setup and webhook validation failures.

This PR introduces a centralized Whatsapp::WebhookUrlBuilder to ensure consistent webhook URL generation across all WhatsApp-related flows, including Embedded Signup, health checks, provider integrations, and inbox configuration.

All webhook URLs now correctly point to:
/webhooks/whatsapp/:phone_number

Fixes # (WhatsApp Embedded Signup webhook URL mismatch)


## Type of change
 Bug fix (non-breaking change which fixes an issue)
 New feature
 Breaking change
 Documentation update

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Triggered WhatsApp Embedded Signup flow locally
Verified webhook URL sent to Meta matches backend endpoint format
Confirmed webhook setup succeeds without URL mismatch errors
Ran all WhatsApp-related RSpec tests successfully


## Checklist:

- [Yes] My code follows the style guidelines of this project
- [Yes] I have performed a self-review of my code
- [Yes] I have commented on my code, particularly in hard-to-understand areas
- [Yes] I have made corresponding changes to the documentation
- [Yes] My changes generate no new warnings
- [Yes] I have added tests that prove my fix is effective or that my feature works
- [Yes] New and existing unit tests pass locally with my changes
- [Yes] Any dependent changes have been merged and published in downstream modules
