### PR TITLE
use company_name for contact imports

### DIFF
--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -61,7 +61,11 @@ class DataImport::ContactManager
   def update_contact_attributes(params, contact)
     contact.name = params[:name] if params[:name].present?
     contact.additional_attributes ||= {}
-    contact.additional_attributes[:company] = params[:company] if params[:company].present?
+    if params[:company_name].present?
+      contact.additional_attributes[:company_name] = params[:company_name]
+    elsif params[:company].present?
+      contact.additional_attributes[:company_name] = params[:company]
+    end
     contact.additional_attributes[:city] = params[:city] if params[:city].present?
     contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number)))
   end


### PR DESCRIPTION
## Description

Fixes incorrect mapping of the "company" field during contact import. Now, both "company" and "company_name" CSV columns are mapped to `additional_attributes[:company_name]`, ensuring the company name displays correctly in the Chatwoot UI.

Closes #14096

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Imported CSV files with both "company" and "company_name" columns.
- Verified that the company name appears correctly for imported contacts in the UI.
- Confirmed that no other import functionality was affected.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules