### PR TITLE
fix: Standardise conversation_updated webhook payload structure. Fix …

### DIFF
--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -29,7 +29,13 @@ class AgentBotListener < BaseListener
     changed_attributes = extract_changed_attributes(event)
     inbox = conversation.inbox
     event_name = __method__.to_s
-    payload = conversation.webhook_data.merge(event: event_name, changed_attributes: changed_attributes)
+    payload = {
+      account: conversation.account.webhook_data,
+      conversation: conversation.webhook_data,
+      inbox: inbox.webhook_data,
+      event: event_name,
+      changed_attributes: changed_attributes
+    }
     agent_bots_for(inbox, conversation).each { |agent_bot| process_webhook_bot_event(agent_bot, payload) }
   end
 

--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -11,7 +11,13 @@ class WebhookListener < BaseListener
     conversation = extract_conversation_and_account(event)[0]
     changed_attributes = extract_changed_attributes(event)
     inbox = conversation.inbox
-    payload = conversation.webhook_data.merge(event: __method__.to_s, changed_attributes: changed_attributes)
+    payload = {
+      account: conversation.account.webhook_data,
+      conversation: conversation.webhook_data,
+      inbox: inbox.webhook_data,
+      event: __method__.to_s,
+      changed_attributes: changed_attributes
+    }
     deliver_webhook_payloads(payload, inbox)
   end
 

--- a/spec/listeners/agent_bot_listener_spec.rb
+++ b/spec/listeners/agent_bot_listener_spec.rb
@@ -126,7 +126,13 @@ describe AgentBotListener do
         create(:agent_bot_inbox, inbox: inbox, agent_bot: agent_bot)
         expect(AgentBots::WebhookJob).to receive(:perform_later).with(
           agent_bot.outgoing_url,
-          conversation.webhook_data.merge(event: 'conversation_updated', changed_attributes: nil),
+          {
+            account: conversation.account.webhook_data,
+            conversation: conversation.webhook_data,
+            inbox: inbox.webhook_data,
+            event: 'conversation_updated',
+            changed_attributes: nil
+          },
           :agent_bot_webhook, secret: agent_bot.secret, delivery_id: instance_of(String)
         ).once
         listener.conversation_updated(event)
@@ -147,10 +153,13 @@ describe AgentBotListener do
         expected_changed_attributes = [{ 'assignee_agent_bot_id' => { previous_value: nil, current_value: agent_bot.id } }]
         expect(AgentBots::WebhookJob).to receive(:perform_later).with(
           agent_bot.outgoing_url,
-          conversation.webhook_data.merge(
+          {
+            account: conversation.account.webhook_data,
+            conversation: conversation.webhook_data,
+            inbox: inbox.webhook_data,
             event: 'conversation_updated',
             changed_attributes: expected_changed_attributes
-          ),
+          },
           :agent_bot_webhook, secret: agent_bot.secret, delivery_id: instance_of(String)
         ).once
         listener.conversation_updated(event)

--- a/spec/listeners/webhook_listener_spec.rb
+++ b/spec/listeners/webhook_listener_spec.rb
@@ -156,7 +156,10 @@ describe WebhookListener do
 
         expect(WebhookJob).to receive(:perform_later).with(
           webhook.url,
-          conversation.webhook_data.merge(
+          {
+            account: conversation.account.webhook_data,
+            conversation: conversation.webhook_data,
+            inbox: inbox.webhook_data,
             event: 'conversation_updated',
             changed_attributes: [
               {
@@ -166,7 +169,7 @@ describe WebhookListener do
                 }
               }
             ]
-          ),
+          },
           :account_webhook,
           secret: webhook.secret, delivery_id: instance_of(String)
         ).once


### PR DESCRIPTION
…#13993

# Pull Request Template

## Description

The conversation_updated webhook was sending conversation data as the
top-level payload, inconsistent with message_created/message_updated
which nest conversation inside a structured envelope.

This wraps the conversation_updated payload with account, conversation,
and inbox keys to match the existing webhook contract.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
