### PR TITLE
Fix: prevent repeated execution of setupAudioListeners on interaction

### DIFF
--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -185,8 +185,16 @@ export const IFrameHelper = {
 
       window.playAudioAlert = () => {};
 
+      const handler = e => {
+        IFrameHelper.setupAudioListeners(e);
+
+        initOnEvents.forEach(evt => {
+          document.removeEventListener(evt, handler);
+        });
+      };
+
       initOnEvents.forEach(e => {
-        document.addEventListener(e, IFrameHelper.setupAudioListeners, false);
+        document.addEventListener(e, handler, false);
       });
 
       if (!window.$chatwoot.resetTriggered) {


### PR DESCRIPTION
## What
Prevents setupAudioListeners from running multiple times on user interaction.

## Why
The current implementation attaches listeners that trigger on every interaction, even though the setup only needs to run once.

## How
Wraps the handler and removes all listeners after the first execution to ensure it only runs once.