### PR TITLE
fix: store imported contact company under company_name key

### DIFF
--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -61,7 +61,7 @@ class DataImport::ContactManager
   def update_contact_attributes(params, contact)
     contact.name = params[:name] if params[:name].present?
     contact.additional_attributes ||= {}
-    contact.additional_attributes[:company] = params[:company] if params[:company].present?
+    contact.additional_attributes[:company_name] = params[:company] if params[:company].present?
     contact.additional_attributes[:city] = params[:city] if params[:city].present?
     contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number)))
   end

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DataImportJob do
         expect(data_import.reload.processed_records).to eq(csv_length)
         contact = Contact.find_by(phone_number: '+918080808080')
         expect(contact).to be_truthy
-        expect(contact['additional_attributes']['company']).to eq('My Company Name')
+        expect(contact['additional_attributes']['company_name']).to eq('My Company Name')
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe DataImportJob do
           expect(contact).to be_present
           expect(contact.phone_number).to eq("+#{csv_data[0]['phone_number']}")
           expect(contact.name).to eq((csv_data[0]['name']).to_s)
-          expect(contact.additional_attributes['company']).to eq((csv_data[0]['company']).to_s)
+          expect(contact.additional_attributes['company_name']).to eq((csv_data[0]['company']).to_s)
         end
       end
 
@@ -149,7 +149,7 @@ RSpec.describe DataImportJob do
           expect(contact).to be_present
           expect(contact.email).to eq(csv_data[0]['email'])
           expect(contact.name).to eq((csv_data[0]['name']).to_s)
-          expect(contact.additional_attributes['company']).to eq((csv_data[0]['company']).to_s)
+          expect(contact.additional_attributes['company_name']).to eq((csv_data[0]['company']).to_s)
         end
       end
 

--- a/spec/services/data_import/contact_manager_spec.rb
+++ b/spec/services/data_import/contact_manager_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe DataImport::ContactManager do
+  let(:account) { create(:account) }
+  let(:manager) { described_class.new(account) }
+
+  describe '#build_contact' do
+    context 'when params include a company' do
+      let(:params) do
+        {
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+          company: 'Acme Corp'
+        }
+      end
+
+      it 'stores company under company_name key so the app can sort and display it' do
+        contact = manager.build_contact(params)
+        contact.save!
+
+        expect(contact.additional_attributes['company_name']).to eq('Acme Corp')
+      end
+
+      it 'does not store company under the legacy company key' do
+        contact = manager.build_contact(params)
+        contact.save!
+
+        expect(contact.additional_attributes['company']).to be_nil
+      end
+    end
+  end
+
+  describe '#find_or_initialize_contact (existing contact update)' do
+    context 'when updating an existing contact with a company' do
+      let!(:existing_contact) { create(:contact, account: account, email: 'jane@example.com') }
+      let(:params) do
+        {
+          email: 'jane@example.com',
+          company: 'Updated Corp'
+        }
+      end
+
+      it 'stores company_name so the contact can be sorted by company' do
+        manager.find_existing_contact(params)
+        existing_contact.reload
+
+        expect(existing_contact.additional_attributes['company_name']).to eq('Updated Corp')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

`DataImport::ContactManager` was storing the CSV `company` field under
`additional_attributes[:company]`, but the rest of the app reads and sorts
by `additional_attributes['company_name']` (see `order_on_company_name` scope
in the Contact model). This meant company data imported via CSV was silently
lost it never appeared in the UI or sorted correctly.

Fixes #14096

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `spec/services/data_import/contact_manager_spec.rb` which directly tests
that `ContactManager#build_contact` and `find_existing_contact` store company
under the `company_name` key. Updated existing assertions in
`spec/jobs/data_import_job_spec.rb` which were previously asserting the wrong key.

**To reproduce before the fix:**
1. Import a CSV with a `company` column
2. Open any imported contact company field is blank
3. Try sorting contacts by company imported contacts are not sorted

All 14 examples pass locally after the fix.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


The auto-assign check failure is a known GitHub permissions limitation with fork PRs  the workflow tries to assign the PR author but lacks the required token permissions when the PR originates from a fork. This is unrelated to the code changes.

All relevant checks pass: backend tests, lint, and frontend tests are green. Tested locally 14 examples, 0 failures.
