### PR TITLE
fix: restrict conversation reassignment to administrators when setting is enabled

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
@@ -20,7 +20,8 @@ class Api::V1::Accounts::Conversations::AssignmentsController < Api::V1::Account
   end
 
   def self_assigning_unassigned_conversation?
-    params[:assignee_id].to_i == Current.user&.id &&
+    !agent_bot_assignment? &&
+      params[:assignee_id].to_i == Current.user&.id &&
       @conversation.assignee_id.nil? &&
       @conversation.assignee_agent_bot_id.nil?
   end

--- a/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::Accounts::Conversations::AssignmentsController < Api::V1::Account
   # assigns agent/team to a conversation
   def create
     if params.key?(:assignee_id) || agent_bot_assignment?
+      authorize_assignment!
       set_agent
     elsif params.key?(:team_id)
       set_team
@@ -11,6 +12,16 @@ class Api::V1::Accounts::Conversations::AssignmentsController < Api::V1::Account
   end
 
   private
+
+  def authorize_assignment!
+    return if self_assigning_unassigned_conversation?
+
+    authorize @conversation, :assign?
+  end
+
+  def self_assigning_unassigned_conversation?
+    params[:assignee_id].to_i == Current.user&.id && @conversation.assignee_id.nil?
+  end
 
   def set_agent
     resource = Conversations::AssignmentService.new(

--- a/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
@@ -20,7 +20,9 @@ class Api::V1::Accounts::Conversations::AssignmentsController < Api::V1::Account
   end
 
   def self_assigning_unassigned_conversation?
-    params[:assignee_id].to_i == Current.user&.id && @conversation.assignee_id.nil?
+    params[:assignee_id].to_i == Current.user&.id &&
+      @conversation.assignee_id.nil? &&
+      @conversation.assignee_agent_bot_id.nil?
   end
 
   def set_agent

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -117,7 +117,8 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def permitted_settings_attributes
-    [:auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting, :audio_transcriptions, :auto_resolve_label]
+    [:auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting, :audio_transcriptions, :auto_resolve_label,
+     :restrict_conversation_reassignment]
   end
 
   def check_signup_enabled

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -51,6 +51,7 @@ class Account < ApplicationRecord
   store_accessor :settings, :captain_models, :captain_features
   store_accessor :settings, :reporting_timezone
   store_accessor :settings, :keep_pending_on_bot_failure
+  store_accessor :settings, :restrict_conversation_reassignment
   store_accessor :settings, :captain_auto_resolve_mode
   include AccountCaptainAutoResolve
 

--- a/app/models/concerns/account_settings_schema.rb
+++ b/app/models/concerns/account_settings_schema.rb
@@ -11,6 +11,7 @@ module AccountSettingsSchema
         'audio_transcriptions': { 'type': %w[boolean null] },
         'auto_resolve_label': { 'type': %w[string null] },
         'keep_pending_on_bot_failure': { 'type': %w[boolean null] },
+        'restrict_conversation_reassignment': { 'type': %w[boolean null] },
         'captain_auto_resolve_mode': { 'type': %w[string null], 'enum': ['evaluated', 'legacy', 'disabled', nil] },
         'conversation_required_attributes': {
           'type': %w[array null],

--- a/app/policies/conversation_policy.rb
+++ b/app/policies/conversation_policy.rb
@@ -4,7 +4,7 @@ class ConversationPolicy < ApplicationPolicy
   end
 
   def assign?
-    administrator? || !account.restrict_conversation_reassignment
+    administrator? || agent_bot? || !account.restrict_conversation_reassignment
   end
 
   def destroy?

--- a/app/policies/conversation_policy.rb
+++ b/app/policies/conversation_policy.rb
@@ -3,6 +3,10 @@ class ConversationPolicy < ApplicationPolicy
     true
   end
 
+  def assign?
+    administrator? || !account.restrict_conversation_reassignment
+  end
+
   def destroy?
     administrator?
   end

--- a/spec/controllers/api/v1/accounts/conversations/assignments_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/assignments_controller_spec.rb
@@ -160,6 +160,49 @@ RSpec.describe 'Conversation Assignment API', type: :request do
       end
     end
 
+    context 'when account has restrict_conversation_reassignment enabled' do
+      let(:agent) { create(:user, account: account, role: :agent) }
+      let(:administrator) { create(:user, account: account, role: :administrator) }
+      let(:another_agent) { create(:user, account: account, role: :agent) }
+
+      before do
+        account.update!(settings: account.settings.merge('restrict_conversation_reassignment' => true))
+        create(:inbox_member, inbox: conversation.inbox, user: agent)
+        create(:inbox_member, inbox: conversation.inbox, user: administrator)
+      end
+
+      it 'returns unauthorized when an agent tries to reassign the conversation' do
+        post api_v1_account_conversation_assignments_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { assignee_id: another_agent.id },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'allows an administrator to reassign the conversation' do
+        post api_v1_account_conversation_assignments_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { assignee_id: agent.id },
+             headers: administrator.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.assignee).to eq(agent)
+      end
+
+      it 'allows an agent to self-assign an unassigned conversation' do
+        conversation.update!(assignee_id: nil)
+
+        post api_v1_account_conversation_assignments_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { assignee_id: agent.id },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.assignee).to eq(agent)
+      end
+    end
+
     context 'when conversation already has a team' do
       let(:agent) { create(:user, account: account, role: :agent) }
       let(:team) { create(:team, account: account) }

--- a/spec/controllers/api/v1/accounts/conversations/assignments_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/assignments_controller_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe 'Conversation Assignment API', type: :request do
       end
 
       it 'allows an agent to self-assign an unassigned conversation' do
-        conversation.update!(assignee_id: nil)
+        conversation.update!(assignee_id: nil, assignee_agent_bot_id: nil)
 
         post api_v1_account_conversation_assignments_url(account_id: account.id, conversation_id: conversation.display_id),
              params: { assignee_id: agent.id },
@@ -200,6 +200,19 @@ RSpec.describe 'Conversation Assignment API', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(conversation.reload.assignee).to eq(agent)
+      end
+
+      it 'blocks an agent from self-assigning a bot-owned conversation' do
+        agent_bot = create(:agent_bot, account: account)
+        create(:agent_bot_inbox, inbox: conversation.inbox, agent_bot: agent_bot)
+        conversation.update!(assignee_id: nil, assignee_agent_bot_id: agent_bot.id)
+
+        post api_v1_account_conversation_assignments_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { assignee_id: agent.id },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 


### PR DESCRIPTION
## Description

When `restrict_conversation_reassignment` is enabled on an account,
agents should not be able to reassign conversations to other agents
only administrators can. However, there was no enforcement of this
setting at the API level, so any agent could still reassign freely
regardless of the setting.

Fixes #14095

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added 3 new test cases to `assignments_controller_spec.rb`:

1. Agent attempting reassignment returns `401 Unauthorized`
2. Administrator can still reassign freely
3. Agent can always self-assign an unassigned conversation
   (picking up work should never be blocked)

All 12 examples pass locally, 0 failures.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
