### PR TITLE
fix: correct zh-CN assignee assignment translation

### DIFF
--- a/config/locales/zh_CN.yml
+++ b/config/locales/zh_CN.yml
@@ -257,7 +257,7 @@ zh_CN:
         removed: '%{user_name} 取消了优先级'
       assignee:
         self_assigned: '%{user_name} 自行分配这次会话'
-        assigned: '由 %{user_name} 分配给 %{assignee_name}'
+        assigned: '%{user_name} 将该会话分配给 %{assignee_name}'
         removed: '对话未被 %{user_name} 分配'
       team:
         assigned: '由 %{user_name} 分配给 %{team_name}'


### PR DESCRIPTION
## What
Fix incorrect placeholder order in zh-CN translation for assignee assignment message.

## Why
The current translation reverses the assigner and assignee, resulting in incorrect meaning.

## How
Updated the translation string to correctly reflect that `%{user_name}` assigns the conversation to `%{assignee_name}`.

## Linked issues

Closes #13393
