### PR TITLE
fix: store imported contact company under company_name key

### DIFF
--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -61,7 +61,8 @@ class DataImport::ContactManager
   def update_contact_attributes(params, contact)
     contact.name = params[:name] if params[:name].present?
     contact.additional_attributes ||= {}
-    contact.additional_attributes[:company] = params[:company] if params[:company].present?
+    company_value = params[:company] || params[:company_name]
+    contact.additional_attributes[:company_name] = company_value if company_value.present?
     contact.additional_attributes[:city] = params[:city] if params[:city].present?
     contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number)))
   end

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DataImportJob do
         expect(data_import.reload.processed_records).to eq(csv_length)
         contact = Contact.find_by(phone_number: '+918080808080')
         expect(contact).to be_truthy
-        expect(contact['additional_attributes']['company']).to eq('My Company Name')
+        expect(contact['additional_attributes']['company_name']).to eq('My Company Name')
       end
     end
 

--- a/spec/services/data_import/contact_manager_spec.rb
+++ b/spec/services/data_import/contact_manager_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe DataImport::ContactManager do
+  let(:account) { create(:account) }
+  let(:contact_manager) { described_class.new(account) }
+
+  describe '#build_contact' do
+    context 'when building a contact with company field' do
+      let(:params) do
+        {
+          name: 'John Doe',
+          email: 'john@example.com',
+          company: 'Acme Corp'
+        }
+      end
+
+      it 'stores company under company_name key in additional_attributes' do
+        contact = contact_manager.build_contact(params)
+        expect(contact.additional_attributes['company_name']).to eq('Acme Corp')
+      end
+    end
+
+    context 'when building a contact with company_name field' do
+      let(:params) do
+        {
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+          company_name: 'Tech Inc'
+        }
+      end
+
+      it 'stores company_name under company_name key in additional_attributes' do
+        contact = contact_manager.build_contact(params)
+        expect(contact.additional_attributes['company_name']).to eq('Tech Inc')
+      end
+    end
+
+    context 'when building a contact with both company and company_name fields' do
+      let(:params) do
+        {
+          name: 'Bob Smith',
+          email: 'bob@example.com',
+          company: 'Old Company',
+          company_name: 'New Company'
+        }
+      end
+
+      it 'prioritizes company_name over company' do
+        contact = contact_manager.build_contact(params)
+        expect(contact.additional_attributes['company_name']).to eq('New Company')
+      end
+    end
+  end
+
+  describe '#find_existing_contact' do
+    let!(:existing_contact) { create(:contact, account: account, email: 'existing@example.com') }
+
+    context 'when updating existing contact with company field' do
+      let(:params) do
+        {
+          email: 'existing@example.com',
+          company: 'Updated Company'
+        }
+      end
+
+      it 'stores company under company_name key in additional_attributes' do
+        contact = contact_manager.find_existing_contact(params)
+        expect(contact.additional_attributes['company_name']).to eq('Updated Company')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Fixes #14096

CSV imports were storing the company field under additional_attributes[:company], while the rest of the app reads and sorts by additional_attributes['company_name']. This caused imported company data to be missing from the UI and unavailable for correct sorting.

This PR updates DataImport::ContactManager so that company values from CSV imports are consistently stored under company_name.

Changes included:
- Updated `ContactManager#update_contact_attributes` to store company values under `company_name`
- Mapped both `company` and `company_name` CSV columns to `company_name`
- Updated the existing assertion in `data_import_job_spec.rb`
- Added specs covering company handling in `ContactManager`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with updated and newly added specs covering CSV contact imports and company field mapping.
