### PR TITLE
fix: incorrect country mapping causing Zimbabwe fallback in contact views

### DIFF
--- a/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
@@ -51,7 +51,7 @@ const isFormInvalid = computed(() => contactsFormRef.value?.isFormInvalid);
 
 const countriesMap = computed(() => {
   return countries.reduce((acc, country) => {
-    acc[country.code] = country;
+    acc[country.dial_code] = country;
     acc[country.id] = country;
     return acc;
   }, {});
@@ -64,7 +64,7 @@ const countryDetails = computed(() => {
   if (!country && !countryCode) return null;
 
   const activeCountry =
-    countriesMap.value[country] || countriesMap.value[countryCode];
+  countriesMap.value[countryCode] || countriesMap.value[country];
 
   if (!activeCountry) return null;
 

--- a/app/javascript/dashboard/modules/search/components/SearchResultContactItem.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchResultContactItem.vue
@@ -49,7 +49,7 @@ const navigateTo = computed(() => {
 
 const countriesMap = computed(() => {
   return countries.reduce((acc, country) => {
-    acc[country.code] = country;
+    acc[country.dial_code] = country;
     acc[country.id] = country;
     return acc;
   }, {});
@@ -66,7 +66,7 @@ const countryDetails = computed(() => {
   if (!country && !countryCode) return null;
 
   const activeCountry =
-    countriesMap.value[country] || countriesMap.value[countryCode];
+  countriesMap.value[countryCode] || countriesMap.value[country];
 
   if (!activeCountry) return null;
 


### PR DESCRIPTION
## What this fixes
Fixes incorrect rendering of "Zimbabwe" for contacts without a valid country.

## Root cause
Country mapping relied on `country.code`, which could lead to incorrect or missing lookups. Additionally, lookup prioritised a less reliable key first.

## Solution
- Updated country mapping to use `country.dial_code`
- Adjusted lookup order to prioritise exact matches (`countryCode`) before fallback
- Applied fix consistently across affected components

## Notes
Minimal change to avoid unintended side effects while improving correctness.