### PR TITLE
Fix: Incorrect company name when importing contact containing both company and Company Name

### DIFF
--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -61,7 +61,8 @@ class DataImport::ContactManager
   def update_contact_attributes(params, contact)
     contact.name = params[:name] if params[:name].present?
     contact.additional_attributes ||= {}
-    contact.additional_attributes[:company] = params[:company] if params[:company].present?
+    company_name = params[:company_name] || params[:company]
+    contact.additional_attributes[:company_name] = company_name if company_name.present?
     contact.additional_attributes[:city] = params[:city] if params[:city].present?
     contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number)))
   end

--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -61,8 +61,10 @@ class DataImport::ContactManager
   def update_contact_attributes(params, contact)
     contact.name = params[:name] if params[:name].present?
     contact.additional_attributes ||= {}
-    company_name = params[:company_name] || params[:company]
-    contact.additional_attributes[:company_name] = company_name if company_name.present?
+    company_name = params[:company_name].presence || params[:company].presence
+    if company_name
+      contact.additional_attributes[:company_name] = company_name
+    end
     contact.additional_attributes[:city] = params[:city] if params[:city].present?
     contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number)))
   end


### PR DESCRIPTION
Fixes #14096 

This issue was about imported contact data not displaying the company correctly in the UI.

Specifically, when importing contacts via CSV, even if the file included company-related fields like “company” or “company_name”, the value was not appearing in the Company field in the application.

So the problem was not with the UI itself, but with how the data was being stored during the import process.

Changes Included
Introduced a unified variable (company_name) to handle both company and company_name inputs.
Updated the attribute mapping to consistently use company_name, which aligns with how the rest of the application stores and reads company data.
Ensured that the value is only assigned when present, preventing empty or invalid data from being saved.