### PR TITLE
Fix: preserve original filename for WhatsApp attachments with special…

### DIFF
--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -8,13 +8,26 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
     @processed_params ||= params[:entry].try(:first).try(:[], 'changes').try(:first).try(:[], 'value')
   end
 
-  def download_attachment_file(attachment_payload)
-    url_response = HTTParty.get(
-      inbox.channel.media_url(attachment_payload[:id]),
-      headers: inbox.channel.api_headers
-    )
-    # This url response will be failure if the access token has expired.
-    inbox.channel.authorization_error! if url_response.unauthorized?
-    Down.download(url_response.parsed_response['url'], headers: inbox.channel.api_headers) if url_response.success?
+def download_attachment_file(attachment_payload)
+  url_response = HTTParty.get(
+    inbox.channel.media_url(attachment_payload[:id]),
+    headers: inbox.channel.api_headers
+  )
+  # This url response will be failure if the access token has expired.
+  inbox.channel.authorization_error! if url_response.unauthorized?
+
+  return unless url_response.success?
+
+  file = Down.download(
+    url_response.parsed_response['url'],
+    headers: inbox.channel.api_headers
+  )
+
+  # Fix: explicitly preserve original filename from WhatsApp payload
+  if attachment_payload[:filename].present?
+    filename = attachment_payload[:filename]
+    file.define_singleton_method(:original_filename) { filename }
   end
+
+  file
 end


### PR DESCRIPTION
## What

Fixes an issue where files received via WhatsApp with special characters (e.g. accented filenames) are downloaded with incorrect file extensions.

## Why

The filename for downloaded attachments was being inferred from the HTTP response headers or URL, which can be unreliable when special characters are present. This resulted in malformed filenames such as:

Número.pdf → Número.pdf-filename=

## How

Instead of relying on the downloaded file’s inferred metadata, this change explicitly sets the filename using the value provided in the WhatsApp attachment payload (`attachment_payload[:filename]`), which serves as the source of truth.
