### PR TITLE
fix(slack): Convert Slack emoji shortcodes to unicode in messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,8 @@ gem 'twitty', '~> 0.1.5'
 gem 'koala'
 # slack client
 gem 'slack-ruby-client', '~> 2.7.0'
+# emoji shortcode to unicode conversion for slack messages
+gem 'gemoji'
 # for dialogflow integrations
 gem 'google-cloud-dialogflow-v2', '>= 0.24.0'
 gem 'grpc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,6 +349,7 @@ GEM
       googleapis-common-protos-types (>= 1.3.1, < 2.a)
       googleauth (~> 1.0)
       grpc (~> 1.36)
+    gemoji (4.1.0)
     geocoder (1.8.1)
     gli (2.22.2)
       ostruct
@@ -1072,6 +1073,7 @@ DEPENDENCIES
   fcm
   flag_shih_tzu
   foreman
+  gemoji
   geocoder
   gmail_xoauth
   google-cloud-dialogflow-v2 (>= 0.24.0)

--- a/lib/integrations/slack/emoji_converter.rb
+++ b/lib/integrations/slack/emoji_converter.rb
@@ -1,14 +1,33 @@
 module Integrations::Slack::EmojiConverter
   EMOJI_SHORTCODE_PATTERN = /:([a-zA-Z0-9_+-]+):/
 
+  # Pattern to match fenced code blocks (```...```) and inline code (`...`)
+  # We need to preserve emoji shortcodes inside these
+  CODE_BLOCK_PATTERN = /```[\s\S]*?```|`[^`]+`/
+
   def self.convert_slack_emoji(text)
     return text if text.blank?
 
-    text.gsub(EMOJI_SHORTCODE_PATTERN) do |match|
+    # Extract code blocks and replace with placeholders to preserve them
+    code_blocks = []
+    preserved_text = text.gsub(CODE_BLOCK_PATTERN) do |match|
+      code_blocks << match
+      "\x00CODE_BLOCK_#{code_blocks.length - 1}\x00"
+    end
+
+    # Convert emoji shortcodes in the non-code portions
+    converted_text = preserved_text.gsub(EMOJI_SHORTCODE_PATTERN) do |match|
       shortcode = Regexp.last_match(1)
       emoji = find_emoji(shortcode)
       emoji ? emoji.raw : match
     end
+
+    # Restore the code blocks
+    code_blocks.each_with_index do |block, index|
+      converted_text = converted_text.gsub("\x00CODE_BLOCK_#{index}\x00", block)
+    end
+
+    converted_text
   end
 
   def self.find_emoji(shortcode)

--- a/lib/integrations/slack/emoji_converter.rb
+++ b/lib/integrations/slack/emoji_converter.rb
@@ -12,6 +12,9 @@ module Integrations::Slack::EmojiConverter
   end
 
   def self.find_emoji(shortcode)
+    # rubocop:disable Rails/DynamicFindBy
+    # find_by_alias is a method from the gemoji gem, not an ActiveRecord dynamic finder
     Emoji.find_by_alias(shortcode) || Emoji.find_by_alias(shortcode.tr('-', '_'))
+    # rubocop:enable Rails/DynamicFindBy
   end
 end

--- a/lib/integrations/slack/emoji_converter.rb
+++ b/lib/integrations/slack/emoji_converter.rb
@@ -1,0 +1,17 @@
+module Integrations::Slack::EmojiConverter
+  EMOJI_SHORTCODE_PATTERN = /:([a-zA-Z0-9_+-]+):/
+
+  def self.convert_slack_emoji(text)
+    return text if text.blank?
+
+    text.gsub(EMOJI_SHORTCODE_PATTERN) do |match|
+      shortcode = Regexp.last_match(1)
+      emoji = find_emoji(shortcode)
+      emoji ? emoji.raw : match
+    end
+  end
+
+  def self.find_emoji(shortcode)
+    Emoji.find_by_alias(shortcode) || Emoji.find_by_alias(shortcode.tr('-', '_'))
+  end
+end

--- a/lib/integrations/slack/slack_message_helper.rb
+++ b/lib/integrations/slack/slack_message_helper.rb
@@ -35,7 +35,7 @@ module Integrations::Slack::SlackMessageHelper
       message_type: :outgoing,
       account_id: conversation.account_id,
       inbox_id: conversation.inbox_id,
-      content: Slack::Messages::Formatting.unescape(params[:event][:text] || ''),
+      content: process_slack_message_content(params[:event][:text]),
       external_source_id_slack: params[:event][:ts],
       private: private_note?,
       sender: resolved_sender,
@@ -106,5 +106,10 @@ module Integrations::Slack::SlackMessageHelper
 
   def private_note?
     params[:event][:text].strip.downcase.starts_with?('note:', 'private:')
+  end
+
+  def process_slack_message_content(text)
+    unescaped_text = Slack::Messages::Formatting.unescape(text || '')
+    Integrations::Slack::EmojiConverter.convert_slack_emoji(unescaped_text)
   end
 end

--- a/spec/lib/integrations/slack/emoji_converter_spec.rb
+++ b/spec/lib/integrations/slack/emoji_converter_spec.rb
@@ -91,6 +91,46 @@ describe Integrations::Slack::EmojiConverter do
         expect(result).to include('🙂')
       end
     end
+
+    context 'when text contains code blocks' do
+      it 'preserves emoji shortcodes inside inline code' do
+        text = 'Use the `:smile:` emoji'
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to include('`:smile:`')
+        expect(result).not_to include('😄')
+      end
+
+      it 'preserves emoji shortcodes inside fenced code blocks' do
+        text = "Here's how:\n```\nreact_with :thumbsup:\n```"
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to include(':thumbsup:')
+        expect(result).not_to include('👍')
+      end
+
+      it 'converts emoji outside code while preserving inside' do
+        text = ':smile: Here is code: `:thumbsup:` and more :heart:'
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to include('😄')
+        expect(result).to include('❤️')
+        expect(result).to include('`:thumbsup:`')
+        expect(result).not_to include(':smile:')
+        expect(result).not_to include(':heart:')
+      end
+
+      it 'handles multiple inline code blocks' do
+        text = 'Use `:smile:` or `:heart:` shortcuts'
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to include('`:smile:`')
+        expect(result).to include('`:heart:`')
+      end
+
+      it 'handles multiline fenced code blocks' do
+        text = "Code:\n```ruby\ndef emoji\n  :smile:\nend\n```\nDone :thumbsup:"
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to include(':smile:')
+        expect(result).to include('👍')
+      end
+    end
   end
 
   describe '.find_emoji' do

--- a/spec/lib/integrations/slack/emoji_converter_spec.rb
+++ b/spec/lib/integrations/slack/emoji_converter_spec.rb
@@ -1,0 +1,148 @@
+require 'rails_helper'
+
+describe Integrations::Slack::EmojiConverter do
+  describe '.convert_slack_emoji' do
+    context 'when text is blank' do
+      it 'returns the original text for nil' do
+        expect(described_class.convert_slack_emoji(nil)).to be_nil
+      end
+
+      it 'returns the original text for empty string' do
+        expect(described_class.convert_slack_emoji('')).to eq('')
+      end
+    end
+
+    context 'when text contains no emoji shortcodes' do
+      it 'returns the original text unchanged' do
+        text = 'Hello, this is a regular message without emojis.'
+        expect(described_class.convert_slack_emoji(text)).to eq(text)
+      end
+
+      it 'handles text with colons that are not emoji shortcodes' do
+        text = 'Time is 10:30 and ratio is 1:2'
+        expect(described_class.convert_slack_emoji(text)).to eq(text)
+      end
+    end
+
+    context 'when text contains valid emoji shortcodes' do
+      it 'converts :smile: to the smile emoji' do
+        text = 'Hello :smile:'
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to include('😄')
+        expect(result).not_to include(':smile:')
+      end
+
+      it 'converts :thumbsup: to the thumbs up emoji' do
+        text = 'Great job :thumbsup:'
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to include('👍')
+        expect(result).not_to include(':thumbsup:')
+      end
+
+      it 'converts :heart: to the heart emoji' do
+        text = 'I :heart: this'
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to include('❤️')
+        expect(result).not_to include(':heart:')
+      end
+
+      it 'converts multiple emoji shortcodes in the same text' do
+        text = ':smile: Hello :thumbsup: World :heart:'
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to include('😄')
+        expect(result).to include('👍')
+        expect(result).to include('❤️')
+      end
+
+      it 'handles emoji shortcodes with underscores' do
+        text = ':slightly_smiling_face:'
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to include('🙂')
+      end
+
+      it 'handles emoji shortcodes with plus signs' do
+        text = ':+1:'
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to include('👍')
+      end
+    end
+
+    context 'when text contains invalid emoji shortcodes' do
+      it 'leaves unknown shortcodes unchanged' do
+        text = 'Hello :unknown_emoji_xyz:'
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to eq(text)
+      end
+
+      it 'handles mixed valid and invalid shortcodes' do
+        text = ':smile: and :nonexistent_emoji:'
+        result = described_class.convert_slack_emoji(text)
+        expect(result).to include('😄')
+        expect(result).to include(':nonexistent_emoji:')
+      end
+    end
+
+    context 'when shortcodes use hyphens instead of underscores' do
+      it 'converts shortcodes with hyphens by trying underscore variant' do
+        # Some Slack clients use hyphens, but gemoji uses underscores
+        text = ':slightly-smiling-face:'
+        result = described_class.convert_slack_emoji(text)
+        # Should convert because we try the underscore variant
+        expect(result).to include('🙂')
+      end
+    end
+  end
+
+  describe '.find_emoji' do
+    it 'finds emoji by exact alias' do
+      emoji = described_class.find_emoji('smile')
+      expect(emoji).not_to be_nil
+      expect(emoji.raw).to eq('😄')
+    end
+
+    it 'finds emoji when shortcode has hyphens by converting to underscores' do
+      emoji = described_class.find_emoji('slightly-smiling-face')
+      expect(emoji).not_to be_nil
+      expect(emoji.raw).to eq('🙂')
+    end
+
+    it 'returns nil for unknown shortcode' do
+      emoji = described_class.find_emoji('this_emoji_does_not_exist_xyz')
+      expect(emoji).to be_nil
+    end
+
+    it 'handles numeric aliases like +1' do
+      emoji = described_class.find_emoji('+1')
+      expect(emoji).not_to be_nil
+      expect(emoji.raw).to eq('👍')
+    end
+  end
+
+  describe 'EMOJI_SHORTCODE_PATTERN' do
+    let(:pattern) { Integrations::Slack::EmojiConverter::EMOJI_SHORTCODE_PATTERN }
+
+    it 'matches simple shortcodes' do
+      expect(':smile:').to match(pattern)
+    end
+
+    it 'matches shortcodes with underscores' do
+      expect(':thumbs_up:').to match(pattern)
+    end
+
+    it 'matches shortcodes with hyphens' do
+      expect(':thumbs-up:').to match(pattern)
+    end
+
+    it 'matches shortcodes with numbers' do
+      expect(':+1:').to match(pattern)
+    end
+
+    it 'does not match empty shortcodes' do
+      expect('::').not_to match(pattern)
+    end
+
+    it 'does not match single colons' do
+      expect(':').not_to match(pattern)
+    end
+  end
+end

--- a/spec/lib/integrations/slack/emoji_converter_spec.rb
+++ b/spec/lib/integrations/slack/emoji_converter_spec.rb
@@ -122,27 +122,27 @@ describe Integrations::Slack::EmojiConverter do
     let(:pattern) { Integrations::Slack::EmojiConverter::EMOJI_SHORTCODE_PATTERN }
 
     it 'matches simple shortcodes' do
-      expect(':smile:').to match(pattern)
+      expect(pattern.match?(':smile:')).to be true
     end
 
     it 'matches shortcodes with underscores' do
-      expect(':thumbs_up:').to match(pattern)
+      expect(pattern.match?(':thumbs_up:')).to be true
     end
 
     it 'matches shortcodes with hyphens' do
-      expect(':thumbs-up:').to match(pattern)
+      expect(pattern.match?(':thumbs-up:')).to be true
     end
 
     it 'matches shortcodes with numbers' do
-      expect(':+1:').to match(pattern)
+      expect(pattern.match?(':+1:')).to be true
     end
 
     it 'does not match empty shortcodes' do
-      expect('::').not_to match(pattern)
+      expect(pattern.match?('::')).to be false
     end
 
     it 'does not match single colons' do
-      expect(':').not_to match(pattern)
+      expect(pattern.match?(':')).to be false
     end
   end
 end


### PR DESCRIPTION
## Summary

- Add `gemoji` gem for emoji shortcode to unicode conversion
- Create `Integrations::Slack::EmojiConverter` module to handle conversion
- Preserve emoji shortcodes inside code blocks (inline and fenced)
- Add comprehensive test suite for the emoji converter (28 test cases)

## Problem

When users send messages from Slack containing emoji shortcodes (e.g., `:smile:`, `:thumbsup:`), they appear as raw text in Chatwoot conversations instead of being rendered as actual emojis.

## Solution

This PR adds automatic conversion of Slack emoji shortcodes to their unicode equivalents using the `gemoji` gem. The conversion happens during message ingestion, so emojis display correctly in the Chatwoot dashboard.

### Key changes:

1. **New dependency**: Added `gemoji` gem for reliable emoji lookup
2. **New module**: `Integrations::Slack::EmojiConverter` handles the conversion logic
3. **Code block preservation**: Shortcodes inside backticks or fenced code blocks are preserved
4. **Fallback handling**: Unknown shortcodes are left unchanged (no data loss)
5. **Hyphen support**: Handles both `:thumbs-up:` and `:thumbs_up:` formats

## Test plan

- [x] Add unit tests for EmojiConverter module
- [x] Add tests for code block preservation
- [x] Manual testing with Slack integration
- [x] Verify common emoji shortcodes convert correctly
- [x] Verify unknown shortcodes are preserved
- [x] Verify shortcodes in code blocks stay as text