### PR TITLE
Fix: Incorrectly rendered country for contacts missing country attribute

### DIFF
--- a/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
@@ -63,8 +63,13 @@ const countryDetails = computed(() => {
 
   if (!country && !countryCode) return null;
 
-  const activeCountry =
-    countriesMap.value[country] || countriesMap.value[countryCode];
+  let activeCountry = null;
+
+  if (country && countriesMap.value[country]) {
+    activeCountry = countriesMap.value[country];
+  } else if (countryCode && countriesMap.value[countryCode]) {
+    activeCountry = countriesMap.value[countryCode];
+  }
 
   if (!activeCountry) return null;
 


### PR DESCRIPTION
Fixes #14238  incorrect country rendering in the contact list.

Changes made
Added guard checks before accessing countriesMap
Ensured undefined values are not used as lookup keys
Reasoning

The issue occurred because the code attempted to access countriesMap with an undefined key, leading to incorrect fallback behavior.

This fix ensures only valid country identifiers are used.

Notes

Kept the solution minimal and consistent with existing logic.