### PR TITLE
Fix: Custom Attribute Regex Validation Not working in UI

### DIFF
--- a/app/javascript/dashboard/components/CustomAttribute.vue
+++ b/app/javascript/dashboard/components/CustomAttribute.vue
@@ -136,7 +136,7 @@ export default {
         regexValidation: value => {
           if (!this.attributeRegex) return true;
           try {
-            return getRegexp(this.attributeRegex).test(value || '');
+            return getRegexp(this.attributeRegex).test(value ?? '');
           } catch (exception) {
             return true; // fallback for malformed or incorrect regex
           }

--- a/app/javascript/dashboard/components/CustomAttribute.vue
+++ b/app/javascript/dashboard/components/CustomAttribute.vue
@@ -134,10 +134,16 @@ export default {
       editedValue: {
         required,
         regexValidation: value => {
-          return !(
-            this.attributeRegex && !getRegexp(this.attributeRegex).test(value)
-          );
-        },
+          if(!this.attributeRegex) 
+             return true;
+          try{
+            return getRegexp(this.attributeRegex).test(value || '');
+          }
+          catch (exception)
+          {
+            return true; // fallback for malformed or incorrect regex
+          }
+        }
       },
     };
   },

--- a/app/javascript/dashboard/components/CustomAttribute.vue
+++ b/app/javascript/dashboard/components/CustomAttribute.vue
@@ -134,16 +134,13 @@ export default {
       editedValue: {
         required,
         regexValidation: value => {
-          if(!this.attributeRegex) 
-             return true;
-          try{
+          if (!this.attributeRegex) return true;
+          try {
             return getRegexp(this.attributeRegex).test(value || '');
-          }
-          catch (exception)
-          {
+          } catch (exception) {
             return true; // fallback for malformed or incorrect regex
           }
-        }
+        },
       },
     };
   },


### PR DESCRIPTION
Fixes #13771 

Changes Included
Simplified the regex validation logic to make it more explicit and readable.
Added a guard clause to skip validation when no regex pattern is provided.
Introduced error handling to prevent runtime failures when an invalid or malformed regex is encountered.
Ensured validation only runs when a valid regex exists, preventing unintended bypass or crashes.