### PR TITLE
fix: prevent duplicate phone numbers during CSV contact import

### DIFF
--- a/app/jobs/data_import_job.rb
+++ b/app/jobs/data_import_job.rb
@@ -36,10 +36,9 @@ class DataImportJob < ApplicationJob
     with_import_file do |file|
       csv_reader(file).each do |row|
         current_contact = @contact_manager.build_contact(row.to_h.with_indifferent_access)
-        if duplicate_phone_number_in_import?(current_contact, imported_phone_numbers) ||
-           duplicate_phone_number_in_db?(current_contact, existing_phone_numbers)
-          append_rejected_contact(row, current_contact, rejected_contacts)
-        elsif current_contact.valid?
+        if current_contact.valid? &&
+           !duplicate_phone_number_in_import?(current_contact, imported_phone_numbers) &&
+           !duplicate_phone_number_in_db?(current_contact, existing_phone_numbers)
           contacts << current_contact
           imported_phone_numbers << current_contact.phone_number if current_contact.phone_number.present?
         else

--- a/app/jobs/data_import_job.rb
+++ b/app/jobs/data_import_job.rb
@@ -30,12 +30,18 @@ class DataImportJob < ApplicationJob
   def parse_csv_and_build_contacts
     contacts = []
     rejected_contacts = []
+    imported_phone_numbers = Set.new
+    existing_phone_numbers = @data_import.account.contacts.where.not(phone_number: [nil, '']).pluck(:phone_number).to_set
 
     with_import_file do |file|
       csv_reader(file).each do |row|
         current_contact = @contact_manager.build_contact(row.to_h.with_indifferent_access)
-        if current_contact.valid?
+        if duplicate_phone_number_in_import?(current_contact, imported_phone_numbers) ||
+           duplicate_phone_number_in_db?(current_contact, existing_phone_numbers)
+          append_rejected_contact(row, current_contact, rejected_contacts)
+        elsif current_contact.valid?
           contacts << current_contact
+          imported_phone_numbers << current_contact.phone_number if current_contact.phone_number.present?
         else
           append_rejected_contact(row, current_contact, rejected_contacts)
         end
@@ -43,6 +49,24 @@ class DataImportJob < ApplicationJob
     end
 
     [contacts, rejected_contacts]
+  end
+
+  def duplicate_phone_number_in_import?(contact, imported_phone_numbers)
+    return false if contact.phone_number.blank?
+    return false unless imported_phone_numbers.include?(contact.phone_number)
+
+    contact.errors.add(:phone_number, :taken)
+    true
+  end
+
+  def duplicate_phone_number_in_db?(contact, existing_phone_numbers)
+    return false if contact.phone_number.blank?
+    # Preserve legacy import behavior: rows matching existing contacts should update, not reject.
+    return false if contact.persisted?
+    return false unless existing_phone_numbers.include?(contact.phone_number)
+
+    contact.errors.add(:phone_number, :taken)
+    true
   end
 
   def append_rejected_contact(row, contact, rejected_contacts)

--- a/app/jobs/data_import_job.rb
+++ b/app/jobs/data_import_job.rb
@@ -75,8 +75,13 @@ class DataImportJob < ApplicationJob
   end
 
   def import_contacts(contacts)
+    persisted_contacts, new_contacts = contacts.partition(&:persisted?)
+    persisted_contacts.each { |contact| contact.save! if contact.changed? }
+    return if new_contacts.blank?
+
     # <struct ActiveRecord::Import::Result failed_instances=[], num_inserts=1, ids=[444, 445], results=[]>
-    Contact.import(contacts, synchronize: contacts, on_duplicate_key_ignore: true, track_validation_failures: true, validate: true, batch_size: 1000)
+    Contact.import(new_contacts, synchronize: new_contacts, on_duplicate_key_ignore: true, track_validation_failures: true, validate: true,
+                                 batch_size: 1000)
   end
 
   def update_data_import_status(processed_records, rejected_records)

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -33,10 +33,10 @@
 #  index_contacts_on_lower_email_account_id              (lower((email)::text), account_id)
 #  index_contacts_on_name_email_phone_number_identifier  (name,email,phone_number,identifier) USING gin
 #  index_contacts_on_nonempty_fields                     (account_id,email,phone_number,identifier) WHERE (((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))
-#  index_contacts_on_phone_number_and_account_id         (phone_number,account_id)
 #  index_resolved_contact_account_id                     (account_id) WHERE (((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))
 #  uniq_email_per_account_contact                        (email,account_id) UNIQUE
 #  uniq_identifier_per_account_contact                   (identifier,account_id) UNIQUE
+#  uniq_phone_number_per_account_contact                 (phone_number,account_id) UNIQUE WHERE ((phone_number IS NOT NULL) AND ((phone_number)::text <> ''::text))
 #
 
 # rubocop:enable Layout/LineLength

--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -53,7 +53,6 @@ class DataImport::ContactManager
     contact.email = params[:email] if params[:email].present?
     contact.phone_number = format_phone_number(params[:phone_number]) if params[:phone_number].present?
     update_contact_attributes(params, contact)
-    contact.save
   end
 
   private

--- a/db/migrate/20260426202403_add_unique_index_on_phone_number_and_account_id_to_contacts.rb
+++ b/db/migrate/20260426202403_add_unique_index_on_phone_number_and_account_id_to_contacts.rb
@@ -1,0 +1,54 @@
+class AddUniqueIndexOnPhoneNumberAndAccountIdToContacts < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    if duplicate_phone_numbers_exist?
+      raise ActiveRecord::IrreversibleMigration, <<~MESSAGE
+        Cannot add unique index uniq_phone_number_per_account_contact because duplicate
+        non-empty phone numbers already exist per account in contacts.
+        Please deduplicate existing contacts and re-run this migration.
+      MESSAGE
+    end
+
+    # Remove existing non-unique index first
+    remove_index :contacts,
+                 name: 'index_contacts_on_phone_number_and_account_id',
+                 algorithm: :concurrently,
+                 if_exists: true
+
+    # Add unique constraint matching email and identifier pattern
+    # allow_blank: true means NULL and empty string are allowed
+    # We use a partial index to only enforce uniqueness on non-blank phone numbers
+    add_index :contacts, [:phone_number, :account_id],
+              unique: true,
+              where: "phone_number IS NOT NULL AND phone_number != ''",
+              name: 'uniq_phone_number_per_account_contact',
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :contacts,
+                 name: 'uniq_phone_number_per_account_contact',
+                 algorithm: :concurrently,
+                 if_exists: true
+
+    add_index :contacts, [:phone_number, :account_id],
+              name: 'index_contacts_on_phone_number_and_account_id',
+              algorithm: :concurrently
+  end
+
+  private
+
+  def duplicate_phone_numbers_exist?
+    duplicate_rows_sql = <<~SQL.squish
+      SELECT 1
+      FROM contacts
+      WHERE phone_number IS NOT NULL AND phone_number != ''
+      GROUP BY account_id, phone_number
+      HAVING COUNT(*) > 1
+      LIMIT 1
+    SQL
+
+    connection.select_value(duplicate_rows_sql).present?
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_10_092753) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_26_202403) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -381,11 +381,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_10_092753) do
     t.integer "sync_status"
     t.datetime "last_synced_at"
     t.datetime "last_sync_attempted_at"
+    t.index ["account_id", "sync_status"], name: "index_captain_documents_on_account_id_and_sync_status"
     t.index ["account_id"], name: "index_captain_documents_on_account_id"
     t.index ["assistant_id", "external_link"], name: "index_captain_documents_on_assistant_id_and_external_link", unique: true
     t.index ["assistant_id"], name: "index_captain_documents_on_assistant_id"
     t.index ["status"], name: "index_captain_documents_on_status"
-    t.index ["account_id", "sync_status"], name: "index_captain_documents_on_account_id_and_sync_status"
   end
 
   create_table "captain_inboxes", force: :cascade do |t|
@@ -670,7 +670,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_10_092753) do
     t.index ["email", "account_id"], name: "uniq_email_per_account_contact", unique: true
     t.index ["identifier", "account_id"], name: "uniq_identifier_per_account_contact", unique: true
     t.index ["name", "email", "phone_number", "identifier"], name: "index_contacts_on_name_email_phone_number_identifier", opclass: :gin_trgm_ops, using: :gin
-    t.index ["phone_number", "account_id"], name: "index_contacts_on_phone_number_and_account_id"
+    t.index ["phone_number", "account_id"], name: "uniq_phone_number_per_account_contact", unique: true, where: "((phone_number IS NOT NULL) AND ((phone_number)::text <> ''::text))"
   end
 
   create_table "conversation_participants", force: :cascade do |t|
@@ -1096,6 +1096,15 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_10_092753) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "portal_members", force: :cascade do |t|
+    t.bigint "portal_id"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["portal_id", "user_id"], name: "index_portal_members_on_portal_id_and_user_id", unique: true
+    t.index ["user_id", "portal_id"], name: "index_portal_members_on_user_id_and_portal_id", unique: true
+  end
+
   create_table "portals", force: :cascade do |t|
     t.integer "account_id", null: false
     t.string "name", null: false
@@ -1246,6 +1255,14 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_10_092753) do
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_teams_on_account_id"
     t.index ["name", "account_id"], name: "index_teams_on_name_and_account_id", unique: true
+  end
+
+  create_table "telegram_bots", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "auth_key"
+    t.integer "account_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "users", id: :serial, force: :cascade do |t|

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -142,6 +142,30 @@ RSpec.describe DataImportJob do
         expect(existing_contact.reload.email).to eq('newperson@example.com')
         expect(existing_contact.name).to eq('New Person')
       end
+
+      it 'does not persist updates for rejected duplicate rows on existing phone numbers' do
+        duplicate_data = [
+          %w[id name email phone_number],
+          ['1', 'First Name', 'first@example.com', '+918484848484'],
+          ['2', 'Rejected Duplicate', 'rejected@example.com', '+918484848484']
+        ]
+        duplicate_data_import = create(:data_import, import_file: generate_csv_file(duplicate_data))
+        existing_contact = create(:contact, account: duplicate_data_import.account, phone_number: '+918484848484',
+                                            name: 'Original Name', email: 'original@example.com')
+
+        described_class.perform_now(duplicate_data_import)
+
+        expect(duplicate_data_import.account.contacts.where(phone_number: '+918484848484').count).to eq(1)
+        expect(duplicate_data_import.reload.processed_records).to eq(1)
+
+        failed_records = CSV.parse(duplicate_data_import.failed_records.download, headers: true)
+        expect(failed_records.length).to eq(1)
+        expect(failed_records[0]['name']).to eq('Rejected Duplicate')
+        expect(failed_records[0]['errors']).to include('Phone number has already been taken')
+
+        expect(existing_contact.reload.name).to eq('First Name')
+        expect(existing_contact.email).to eq('first@example.com')
+      end
     end
 
     context 'when the data contains existing records' do

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -105,6 +105,43 @@ RSpec.describe DataImportJob do
         expect(contact.email).to eq('ahmed@example.com')
         expect(contact.phone_number).to eq('+971501234567')
       end
+
+      it 'rejects rows with duplicate phone numbers in the same CSV import' do
+        invalid_data = [
+          %w[id name email phone_number],
+          ['1', 'Clarice Uzzell', 'cuzzell0@mozilla.org', '+918484848484'],
+          ['2', 'Marieann Creegan', 'mcreegan1@cornell.edu', '+918484848484']
+        ]
+
+        invalid_data_import = create(:data_import, import_file: generate_csv_file(invalid_data))
+        csv_data = CSV.parse(invalid_data_import.import_file.download, headers: true)
+        csv_length = csv_data.length
+
+        described_class.perform_now(invalid_data_import)
+
+        expect(invalid_data_import.account.contacts.count).to eq(csv_length - 1)
+        expect(invalid_data_import.reload.total_records).to eq(csv_length)
+        expect(invalid_data_import.reload.processed_records).to eq(csv_length - 1)
+        failed_records = CSV.parse(invalid_data_import.failed_records.download, headers: true)
+        expect(failed_records.length).to eq(1)
+        expect(failed_records[0]['errors']).to include('Phone number has already been taken')
+      end
+
+      it 'updates existing contacts when phone numbers already exist in the database' do
+        duplicate_data = [
+          %w[id name email phone_number],
+          ['1', 'New Person', 'newperson@example.com', '+918484848484']
+        ]
+        duplicate_data_import = create(:data_import, import_file: generate_csv_file(duplicate_data))
+        existing_contact = create(:contact, account: duplicate_data_import.account, phone_number: '+918484848484')
+        described_class.perform_now(duplicate_data_import)
+
+        expect(duplicate_data_import.account.contacts.where(phone_number: '+918484848484').count).to eq(1)
+        expect(duplicate_data_import.reload.processed_records).to eq(1)
+        expect(duplicate_data_import.failed_records).not_to be_attached
+        expect(existing_contact.reload.email).to eq('newperson@example.com')
+        expect(existing_contact.name).to eq('New Person')
+      end
     end
 
     context 'when the data contains existing records' do


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes duplicate contact creation during CSV import when multiple rows share the same phone number in the same account.

DataImportJob previously validated contacts before bulk import, but uniqueness checks could miss collisions in batch processing.
The fix now blocks duplicates at parse time and enforces data integrity at the DB level:

- Added in-memory duplicate detection for phone numbers within the same CSV file.
- Added duplicate detection against existing phone numbers already present in the account.
- Rejected duplicate rows are written to failed-records CSV with Phone number has already been taken.
- Added a DB migration introducing a partial unique index on contacts(phone_number, account_id) for non-empty phone numbers:
    - uniq_phone_number_per_account_contact
    - Uses concurrent index operations and includes a precheck to abort migration if existing duplicates are found.
- Also added/updated job specs to cover:
    - duplicate phone numbers inside the same CSV import are rejected
    - duplicate phone numbers already existing in DB are rejected for new rows
    - 
Fixes #12325

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran: bundle exec rspec spec/jobs/data_import_job_spec.rb
- Verified behavior:
  - duplicate phone numbers in a CSV are rejected (not imported)
  - rows with phone numbers already existing for the account are rejected
  - failed-records CSV contains validation error for rejected rows
  - processed/total record counts reflect accepted vs rejected rows correctly


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
