### PR TITLE
fix: prevent duplicate WhatsApp contacts for normalized numbers

### DIFF
--- a/app/services/whatsapp/phone_number_normalization_service.rb
+++ b/app/services/whatsapp/phone_number_normalization_service.rb
@@ -10,28 +10,74 @@ class Whatsapp::PhoneNumberNormalizationService
   #   - Cloud: "5541988887777" (clean number)
   #   - Twilio: "whatsapp:+5541988887777" (prefixed format)
   # @param provider [Symbol] :cloud or :twilio
-  # @return [String] Existing normalized source_id, or normalized provider format if no contact exists
+  # @return [String] Existing source_id if found, otherwise original incoming raw_number
   def normalize_and_find_contact_by_provider(raw_number, provider)
-    # Extract clean number based on provider format
     clean_number = extract_clean_number(raw_number, provider)
 
-    # Find appropriate normalizer for the country
     normalizer = find_normalizer_for_country(clean_number)
     return raw_number unless normalizer
 
-    # Normalize the clean number
-    normalized_clean_number = normalizer.normalize(clean_number)
+    possible_numbers = possible_numbers_for(clean_number, normalizer)
 
-    # Format for provider and check for existing contact
-    provider_format = format_for_provider(normalized_clean_number, provider)
-    existing_contact_inbox = find_existing_contact_inbox(provider_format)
+    possible_numbers.each do |possible_number|
+      provider_format = format_for_provider(possible_number, provider)
+      existing_contact_inbox = find_existing_contact_inbox(provider_format)
 
-    existing_contact_inbox&.source_id || provider_format
+      return existing_contact_inbox.source_id if existing_contact_inbox
+    end
+
+    raw_number
   end
 
   private
 
   attr_reader :inbox
+
+  def possible_numbers_for(clean_number, normalizer)
+    numbers = [clean_number, normalizer.normalize(clean_number)]
+
+    if normalizer.is_a?(Whatsapp::PhoneNormalizers::BrazilPhoneNormalizer)
+      numbers.concat(brazil_possible_numbers(clean_number))
+    elsif normalizer.is_a?(Whatsapp::PhoneNormalizers::ArgentinaPhoneNormalizer)
+      numbers.concat(argentina_possible_numbers(clean_number))
+    end
+
+    numbers.compact.uniq
+  end
+
+  def brazil_possible_numbers(clean_number)
+    return [] unless clean_number.start_with?('55')
+
+    country_code = clean_number[0, 2]
+    area_code = clean_number[2, 2]
+    subscriber_number = clean_number[4..]
+
+    return [] if area_code.blank? || subscriber_number.blank?
+
+    possible_numbers = []
+
+    if clean_number.length == 12
+      possible_numbers << "#{country_code}#{area_code}9#{subscriber_number}"
+    elsif clean_number.length == 13 && clean_number[4] == '9'
+      possible_numbers << "#{country_code}#{area_code}#{clean_number[5..]}"
+    end
+
+    possible_numbers
+  end
+
+  def argentina_possible_numbers(clean_number)
+    return [] unless clean_number.start_with?('54')
+
+    possible_numbers = []
+
+    if clean_number.start_with?('549')
+      possible_numbers << clean_number.sub(/^549/, '54')
+    else
+      possible_numbers << clean_number.sub(/^54/, '549')
+    end
+
+    possible_numbers
+  end
 
   def find_normalizer_for_country(waid)
     NORMALIZERS.map(&:new)

--- a/app/services/whatsapp/phone_number_normalization_service.rb
+++ b/app/services/whatsapp/phone_number_normalization_service.rb
@@ -10,7 +10,7 @@ class Whatsapp::PhoneNumberNormalizationService
   #   - Cloud: "5541988887777" (clean number)
   #   - Twilio: "whatsapp:+5541988887777" (prefixed format)
   # @param provider [Symbol] :cloud or :twilio
-  # @return [String] Normalized source_id in provider format or original if not found
+  # @return [String] Existing normalized source_id, or normalized provider format if no contact exists
   def normalize_and_find_contact_by_provider(raw_number, provider)
     # Extract clean number based on provider format
     clean_number = extract_clean_number(raw_number, provider)
@@ -26,7 +26,7 @@ class Whatsapp::PhoneNumberNormalizationService
     provider_format = format_for_provider(normalized_clean_number, provider)
     existing_contact_inbox = find_existing_contact_inbox(provider_format)
 
-    existing_contact_inbox&.source_id || raw_number
+    existing_contact_inbox&.source_id || provider_format
   end
 
   private


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes #13986

This PR fixes an issue where WhatsApp contacts could be duplicated for Brazilian phone numbers when the same customer number is received in different formats, especially with WhatsApp Coexistence / device-initiated echo messages.

Chatwoot already normalizes supported WhatsApp phone number formats, including Brazilian numbers where the additional mobile `9` digit may be missing. However, when the normalization service did not find an existing `ContactInbox`, it returned the original raw number instead of the normalized provider-format number.

That meant a new contact could still be created with the non-normalized source ID, even though the number had already been normalized internally.

This change updates the fallback behavior so that, when a normalizer exists, Chatwoot returns the normalized provider-format source ID even if no existing contact inbox is found.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I reviewed the WhatsApp contact normalization flow and confirmed that:

- WhatsApp Cloud API numbers continue to use the `:cloud` provider format.
- Twilio WhatsApp numbers continue to use the `whatsapp:+` provider format.
- Existing contacts are still matched first through `find_existing_contact_inbox(provider_format)`.
- If no existing contact inbox is found, the service now returns the normalized provider-format source ID instead of the raw number.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
