### PR TITLE
Fix/brazil whatsapp duplicate contacts

### DIFF
--- a/app/services/whatsapp/phone_number_normalization_service.rb
+++ b/app/services/whatsapp/phone_number_normalization_service.rb
@@ -10,28 +10,74 @@ class Whatsapp::PhoneNumberNormalizationService
   #   - Cloud: "5541988887777" (clean number)
   #   - Twilio: "whatsapp:+5541988887777" (prefixed format)
   # @param provider [Symbol] :cloud or :twilio
-  # @return [String] Existing normalized source_id, or normalized provider format if no contact exists
+  # @return [String] Existing source_id if found, otherwise original incoming raw_number
   def normalize_and_find_contact_by_provider(raw_number, provider)
-    # Extract clean number based on provider format
     clean_number = extract_clean_number(raw_number, provider)
 
-    # Find appropriate normalizer for the country
     normalizer = find_normalizer_for_country(clean_number)
     return raw_number unless normalizer
 
-    # Normalize the clean number
-    normalized_clean_number = normalizer.normalize(clean_number)
+    possible_numbers = possible_numbers_for(clean_number, normalizer)
 
-    # Format for provider and check for existing contact
-    provider_format = format_for_provider(normalized_clean_number, provider)
-    existing_contact_inbox = find_existing_contact_inbox(provider_format)
+    possible_numbers.each do |possible_number|
+      provider_format = format_for_provider(possible_number, provider)
+      existing_contact_inbox = find_existing_contact_inbox(provider_format)
 
-    existing_contact_inbox&.source_id || provider_format
+      return existing_contact_inbox.source_id if existing_contact_inbox
+    end
+
+    raw_number
   end
 
   private
 
   attr_reader :inbox
+
+  def possible_numbers_for(clean_number, normalizer)
+    numbers = [clean_number, normalizer.normalize(clean_number)]
+
+    if normalizer.is_a?(Whatsapp::PhoneNormalizers::BrazilPhoneNormalizer)
+      numbers.concat(brazil_possible_numbers(clean_number))
+    elsif normalizer.is_a?(Whatsapp::PhoneNormalizers::ArgentinaPhoneNormalizer)
+      numbers.concat(argentina_possible_numbers(clean_number))
+    end
+
+    numbers.compact.uniq
+  end
+
+  def brazil_possible_numbers(clean_number)
+    return [] unless clean_number.start_with?('55')
+
+    country_code = clean_number[0, 2]
+    area_code = clean_number[2, 2]
+    subscriber_number = clean_number[4..]
+
+    return [] if area_code.blank? || subscriber_number.blank?
+
+    possible_numbers = []
+
+    if clean_number.length == 12
+      possible_numbers << "#{country_code}#{area_code}9#{subscriber_number}"
+    elsif clean_number.length == 13 && clean_number[4] == '9'
+      possible_numbers << "#{country_code}#{area_code}#{clean_number[5..]}"
+    end
+
+    possible_numbers
+  end
+
+  def argentina_possible_numbers(clean_number)
+    return [] unless clean_number.start_with?('54')
+
+    possible_numbers = []
+
+    if clean_number.start_with?('549')
+      possible_numbers << clean_number.sub(/^549/, '54')
+    else
+      possible_numbers << clean_number.sub(/^54/, '549')
+    end
+
+    possible_numbers
+  end
 
   def find_normalizer_for_country(waid)
     NORMALIZERS.map(&:new)

--- a/app/services/whatsapp/phone_number_normalization_service.rb
+++ b/app/services/whatsapp/phone_number_normalization_service.rb
@@ -10,7 +10,7 @@ class Whatsapp::PhoneNumberNormalizationService
   #   - Cloud: "5541988887777" (clean number)
   #   - Twilio: "whatsapp:+5541988887777" (prefixed format)
   # @param provider [Symbol] :cloud or :twilio
-  # @return [String] Normalized source_id in provider format or original if not found
+  # @return [String] Existing normalized source_id, or normalized provider format if no contact exists
   def normalize_and_find_contact_by_provider(raw_number, provider)
     # Extract clean number based on provider format
     clean_number = extract_clean_number(raw_number, provider)
@@ -26,7 +26,7 @@ class Whatsapp::PhoneNumberNormalizationService
     provider_format = format_for_provider(normalized_clean_number, provider)
     existing_contact_inbox = find_existing_contact_inbox(provider_format)
 
-    existing_contact_inbox&.source_id || raw_number
+    existing_contact_inbox&.source_id || provider_format
   end
 
   private


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes #13986

This PR fixes duplicate WhatsApp contacts created for Brazilian and Argentine phone number variants.

When WhatsApp Coexistence receives device-initiated or echo messages, the same customer can arrive with different valid number formats. For example, Brazil numbers may arrive with or without the extra mobile 9, and Argentina numbers may arrive with or without the extra 9 after country code 54.

Previously, Whatsapp::PhoneNumberNormalizationService checked only one normalized number format. If an existing contact_inbox was stored using the alternate format, Chatwoot did not find it and created a duplicate contact and conversation.

This change updates the normalization lookup to:

- Check the incoming number first.
- Check the normalized number.
- Check Brazil-specific alternate formats.
- Check Argentina-specific alternate formats.
- Reuse the existing contact_inbox if any candidate matches.
- Fall back to the original incoming number if no existing contact is found.

This preserves existing behavior for new contacts while preventing duplicate contacts for known WhatsApp number variants.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Tested using the affected WhatsApp and Twilio inbound message specs.

Run:
bundle exec rspec spec/services/twilio/incoming_message_service_spec.rb
bundle exec rspec spec/services/whatsapp/incoming_message_service_spec.rb

Verified scenarios include:

Brazilian WhatsApp numbers with and without the ninth digit.
Argentine WhatsApp numbers with and without the extra 9 after country code.
Existing contact inbox is reused when an alternate number format already exists.
New contact inbox is created using the original incoming number when no existing contact is found.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
