### PR TITLE
fix: 13986 whatsapp cloud phone normalization

### DIFF
--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -103,7 +103,7 @@ class Whatsapp::IncomingMessageBaseService
     contact_inbox = ::ContactInboxWithContactBuilder.new(
       source_id: waid,
       inbox: inbox,
-      contact_attributes: { name: "+#{phone_number}", phone_number: "+#{phone_number}" }
+      contact_attributes: { name: "+#{waid}", phone_number: "+#{waid}" }
     ).perform
 
     @contact_inbox = contact_inbox

--- a/app/services/whatsapp/phone_number_normalization_service.rb
+++ b/app/services/whatsapp/phone_number_normalization_service.rb
@@ -26,7 +26,7 @@ class Whatsapp::PhoneNumberNormalizationService
     provider_format = format_for_provider(normalized_clean_number, provider)
     existing_contact_inbox = find_existing_contact_inbox(provider_format)
 
-    existing_contact_inbox&.source_id || raw_number
+    existing_contact_inbox&.source_id || provider_format
   end
 
   private

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -107,6 +107,49 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
       end
     end
 
+    # ref: https://github.com/chatwoot/chatwoot/issues/13986
+    describe 'when echo message has a Brazilian number without the 9th digit' do
+      let(:echo_params_without_9) do
+        {
+          phone_number: whatsapp_channel.phone_number,
+          object: 'whatsapp_business_account',
+          entry: [{
+            changes: [{
+              value: {
+                message_echoes: [{
+                  id: 'wamid.echo001',
+                  to: '558812345678',
+                  timestamp: '1664799904',
+                  type: 'text',
+                  text: { body: 'Echo test' }
+                }]
+              }
+            }]
+          }]
+        }.with_indifferent_access
+      end
+
+      context 'when a contact exists with the normalized number (with 9th digit)' do
+        it 'reuses the existing contact instead of creating a duplicate' do
+          create(:contact, phone_number: '+5588912345678', account: whatsapp_channel.account)
+          described_class.new(inbox: whatsapp_channel.inbox, params: echo_params_without_9, outgoing_echo: true).perform
+          expect(whatsapp_channel.account.contacts.where("phone_number LIKE '+5588%'").count).to eq(1)
+          expect(whatsapp_channel.account.contacts.first.phone_number).to eq('+5588912345678')
+        end
+      end
+
+      context 'when a contact_inbox exists with the normalized source_id (with 9th digit)' do
+        it 'appends the message to the existing conversation' do
+          contact = create(:contact, phone_number: '+5588912345678', account: whatsapp_channel.account)
+          contact_inbox = create(:contact_inbox, contact: contact, inbox: whatsapp_channel.inbox, source_id: '5588912345678')
+          create(:conversation, contact: contact, inbox: whatsapp_channel.inbox, contact_inbox: contact_inbox)
+          described_class.new(inbox: whatsapp_channel.inbox, params: echo_params_without_9, outgoing_echo: true).perform
+          expect(whatsapp_channel.inbox.conversations.count).to eq(1)
+          expect(whatsapp_channel.account.contacts.where("phone_number LIKE '+5588%'").count).to eq(1)
+        end
+      end
+    end
+
     context 'when message is a reply (has context)' do
       let(:reply_params) do
         {


### PR DESCRIPTION
# Pull Request Template

## Description

When WhatsApp Coexistence is enabled, echo messages from the native WhatsApp device create duplicate contacts for                                                                                                                                              Brazilian phone numbers. WhatsApp sometimes sends numbers without the 9th digit (e.g. `558812345678`) while the existing contact is stored with  it (e.g. `5588912345678`). The service now normalizes the number before contact lookup,                                                                                                                                              ensuring the existing contact is matched correctly instead of creating a duplicate

Fixes #13986

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Created a contact with a Brazilian number in E.164 format (`+5588912345678`).
2. Fired `Whatsapp::IncomingMessageWhatsappCloudService` with `outgoing_echo: true` and a `to` field containing the number without the 9th digit (`558812345678`).
3. Verified only one contact exists after processing — no duplicate created.
4. Also verified that when a contact_inbox already exists with the normalized source_id, the message is appended to the existing conversation.



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [] I have commented on my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
