### PR TITLE
fix: normalize company name mapping in CSV importer

### DIFF
--- a/app/services/data_import/contact_manager.rb
+++ b/app/services/data_import/contact_manager.rb
@@ -61,8 +61,15 @@ class DataImport::ContactManager
   def update_contact_attributes(params, contact)
     contact.name = params[:name] if params[:name].present?
     contact.additional_attributes ||= {}
-    contact.additional_attributes[:company] = params[:company] if params[:company].present?
+
+    # FIX: Map 'company' from CSV to 'company_name' for UI consistency
+    company_value = params[:company_name] || params[:company]
+    contact.additional_attributes[:company_name] = company_value if company_value.present?
+
     contact.additional_attributes[:city] = params[:city] if params[:city].present?
-    contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(params.except(:identifier, :email, :name, :phone_number)))
+
+    # Ensure we don't duplicate company/company_name/city in custom_attributes
+    filtered_params = params.except(:identifier, :email, :name, :phone_number, :company, :company_name, :city)
+    contact.assign_attributes(custom_attributes: contact.custom_attributes.merge(filtered_params))
   end
 end


### PR DESCRIPTION
## Description
This PR addresses an inconsistency in the CSV contact importer where the `company` field from uploaded files was not consistently mapping to the `company_name` attribute used in the Chatwoot dashboard UI. 

I have updated the `ContactManager` to:
- Support both `:company` and `:company_name` keys during import.
- Prevent data duplication by ensuring these mapped attributes are excluded from the general `custom_attributes` hash.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I verified the attribute mapping logic within the `update_contact_attributes` method to ensure that provided params correctly populate the `additional_attributes` hash and that the merge logic correctly filters out reserved keys.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings