### PR TITLE
fix(contacts): resolve Zimbabwe fallback bug when countryCode is set …

### DIFF
--- a/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
@@ -51,7 +51,6 @@ const isFormInvalid = computed(() => contactsFormRef.value?.isFormInvalid);
 
 const countriesMap = computed(() => {
   return countries.reduce((acc, country) => {
-    acc[country.code] = country;
     acc[country.id] = country;
     return acc;
   }, {});
@@ -64,7 +63,7 @@ const countryDetails = computed(() => {
   if (!country && !countryCode) return null;
 
   const activeCountry =
-    countriesMap.value[country] || countriesMap.value[countryCode];
+    (country && countriesMap.value[country]) || countriesMap.value[countryCode];
 
   if (!activeCountry) return null;
 

--- a/app/javascript/dashboard/components-next/Contacts/ContactsCard/specs/ContactsCard.spec.js
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsCard/specs/ContactsCard.spec.js
@@ -1,0 +1,70 @@
+import countries from 'shared/constants/countries';
+
+// Reproduces the countriesMap and countryDetails logic from ContactsCard.vue
+// to verify the fix for the Zimbabwe display bug (issue #14238).
+function buildCountriesMap() {
+  return countries.reduce((acc, country) => {
+    acc[country.id] = country;
+    return acc;
+  }, {});
+}
+
+function resolveCountryDetails(additionalAttributes) {
+  const countriesMap = buildCountriesMap();
+  const { country, countryCode, city } = additionalAttributes || {};
+
+  if (!country && !countryCode) return null;
+
+  const activeCountry =
+    (country && countriesMap[country]) || countriesMap[countryCode];
+
+  if (!activeCountry) return null;
+
+  return {
+    countryCode: activeCountry.id,
+    city: city ? `${city},` : null,
+    name: activeCountry.name,
+  };
+}
+
+describe('ContactsCard country resolution', () => {
+  it('returns null when neither country nor countryCode is set', () => {
+    expect(resolveCountryDetails({})).toBeNull();
+    expect(resolveCountryDetails({ city: 'Cape Town' })).toBeNull();
+  });
+
+  it('resolves correctly from countryCode alone (regression for Zimbabwe bug)', () => {
+    const result = resolveCountryDetails({ countryCode: 'US' });
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('United States');
+    expect(result.countryCode).toBe('US');
+  });
+
+  it('does not display Zimbabwe for contacts with only a countryCode', () => {
+    const result = resolveCountryDetails({ countryCode: 'ZA' });
+    expect(result.name).toBe('South Africa');
+    expect(result.name).not.toBe('Zimbabwe');
+  });
+
+  it('resolves correctly when country name is provided directly', () => {
+    // country name is stored as the id (e.g. "DE") in some integrations
+    const result = resolveCountryDetails({ country: 'DE' });
+    expect(result.name).toBe('Germany');
+  });
+
+  it('prefers country over countryCode when both are present', () => {
+    const result = resolveCountryDetails({ country: 'FR', countryCode: 'DE' });
+    expect(result.name).toBe('France');
+  });
+
+  it('falls back to countryCode when country value does not match any entry', () => {
+    const result = resolveCountryDetails({ country: 'Unknown', countryCode: 'GB' });
+    expect(result.name).toBe('United Kingdom');
+  });
+
+  it('includes city in the result when present', () => {
+    const result = resolveCountryDetails({ countryCode: 'AU', city: 'Sydney' });
+    expect(result.city).toBe('Sydney,');
+    expect(result.name).toBe('Australia');
+  });
+});


### PR DESCRIPTION
…but country is absent

The countriesMap reducer was keying on `country.code`, which doesn't exist in the countries constant (the property is `id`). Every iteration wrote to `acc[undefined]`, leaving Zimbabwe — the last entry — as the sole value at that key. Any contact whose `country` attribute was unset would resolve to `acc[undefined]` (Zimbabwe) instead of falling through to the correct `countryCode` lookup.

Two-part fix:
1. Remove the dead `acc[country.code]` line from the reducer.
2. Guard the `country` lookup so an unset attribute never hits the map (`(country && countriesMap[country]) || countriesMap[countryCode]`).

Adds unit specs covering the regression and the happy-path lookups.

Closes #14238

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
