### PR TITLE
add social profile username validation

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
@@ -13,6 +13,9 @@ import NextButton from 'dashboard/components-next/button/Button.vue';
 import Avatar from 'next/avatar/Avatar.vue';
 import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
 
+const validSocialProfileUsername = value =>
+  !value || /^[A-Za-z0-9._-]+$/.test(value);
+
 export default {
   components: {
     NextButton,
@@ -59,6 +62,8 @@ export default {
         linkedin: '',
         github: '',
         telegram: '',
+        instagram: '',
+        tiktok: '',
       },
       socialProfileKeys: [
         { key: 'facebook', prefixURL: 'https://facebook.com/' },
@@ -66,6 +71,7 @@ export default {
         { key: 'linkedin', prefixURL: 'https://linkedin.com/' },
         { key: 'github', prefixURL: 'https://github.com/' },
         { key: 'telegram', prefixURL: 'https://t.me/' },
+        { key: 'instagram', prefixURL: 'https://instagram.com/' },
         { key: 'tiktok', prefixURL: 'https://tiktok.com/@' },
       ],
     };
@@ -81,6 +87,15 @@ export default {
     companyName: {},
     phoneNumber: {},
     bio: {},
+    socialProfileUserNames: {
+      facebook: { validSocialProfileUsername },
+      twitter: { validSocialProfileUsername },
+      linkedin: { validSocialProfileUsername },
+      github: { validSocialProfileUsername },
+      telegram: { validSocialProfileUsername },
+      instagram: { validSocialProfileUsername },
+      tiktok: { validSocialProfileUsername },
+    },
   },
   computed: {
     parsePhoneNumber() {
@@ -414,10 +429,18 @@ export default {
         </span>
         <input
           v-model="socialProfileUserNames[socialProfile.key]"
+          @input="v$.socialProfileUserNames[socialProfile.key].$touch()"
+          @blur="v$.socialProfileUserNames[socialProfile.key].$touch()"
           class="input-group-field ltr:!rounded-l-none rtl:!rounded-r-none !mb-0"
           type="text"
         />
       </div>
+      <p
+          v-if="v$.socialProfileUserNames[socialProfile.key].$error"
+          class="mt-1 text-xs text-red-500"
+        >
+          Invalid {{ socialProfile.key }} username
+        </p>
     </div>
     <div class="flex flex-row justify-start w-full gap-2 px-0 py-2">
       <NextButton

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
@@ -426,21 +426,25 @@ export default {
           <span
             class="flex items-center h-10 px-2 text-sm border-solid border-y ltr:border-l rtl:border-r ltr:rounded-l-md rtl:rounded-r-md bg-n-solid-3 text-n-slate-11 border-n-weak"
           >
-          {{ socialProfile.prefixURL }}
+            {{ socialProfile.prefixURL }}
           </span>
           <input
             v-model="socialProfileUserNames[socialProfile.key]"
-            @input="v$.socialProfileUserNames[socialProfile.key].$touch()"
-            @blur="v$.socialProfileUserNames[socialProfile.key].$touch()"
             class="input-group-field ltr:!rounded-l-none rtl:!rounded-r-none !mb-0"
             type="text"
+            @input="v$.socialProfileUserNames[socialProfile.key].$touch()"
+            @blur="v$.socialProfileUserNames[socialProfile.key].$touch()"
           />
         </div>
         <p
           v-if="v$.socialProfileUserNames[socialProfile.key].$error"
           class="mt-1 text-xs text-red-500"
         >
-          Invalid {{ socialProfile.key }} username
+          {{
+            $t('CONTACT_FORM.FORM.SOCIAL_PROFILE.INVALID_USERNAME', {
+              platform: socialProfile.key,
+            })
+          }}
         </p>
       </div>
     </div>

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
@@ -16,6 +16,9 @@ import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
 const validSocialProfileUsername = value =>
   !value || /^[A-Za-z0-9._-]+$/.test(value);
 
+const validLinkedInUsername = value =>
+  !value || /^[A-Za-z0-9._/-]+$/.test(value);
+
 export default {
   components: {
     NextButton,
@@ -90,7 +93,7 @@ export default {
     socialProfileUserNames: {
       facebook: { validSocialProfileUsername },
       twitter: { validSocialProfileUsername },
-      linkedin: { validSocialProfileUsername },
+      linkedin: { validLinkedInUsername },
       github: { validSocialProfileUsername },
       telegram: { validSocialProfileUsername },
       instagram: { validSocialProfileUsername },
@@ -440,11 +443,7 @@ export default {
           v-if="v$.socialProfileUserNames[socialProfile.key].$error"
           class="mt-1 text-xs text-red-500"
         >
-          {{
-            $t('CONTACT_FORM.FORM.SOCIAL_PROFILE.INVALID_USERNAME', {
-              platform: socialProfile.key,
-            })
-          }}
+          {{ $t('CONTACT_FORM.ERROR_MESSAGE') }}
         </p>
       </div>
     </div>

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
@@ -420,27 +420,29 @@ export default {
       <div
         v-for="socialProfile in socialProfileKeys"
         :key="socialProfile.key"
-        class="flex items-stretch w-full mb-4"
+        class="w-full mb-4"
       >
-        <span
-          class="flex items-center h-10 px-2 text-sm border-solid border-y ltr:border-l rtl:border-r ltr:rounded-l-md rtl:rounded-r-md bg-n-solid-3 text-n-slate-11 border-n-weak"
-        >
+        <div class="flex items-stretch w-full">
+          <span
+            class="flex items-center h-10 px-2 text-sm border-solid border-y ltr:border-l rtl:border-r ltr:rounded-l-md rtl:rounded-r-md bg-n-solid-3 text-n-slate-11 border-n-weak"
+          >
           {{ socialProfile.prefixURL }}
-        </span>
-        <input
-          v-model="socialProfileUserNames[socialProfile.key]"
-          @input="v$.socialProfileUserNames[socialProfile.key].$touch()"
-          @blur="v$.socialProfileUserNames[socialProfile.key].$touch()"
-          class="input-group-field ltr:!rounded-l-none rtl:!rounded-r-none !mb-0"
-          type="text"
-        />
-      </div>
-      <p
+          </span>
+          <input
+            v-model="socialProfileUserNames[socialProfile.key]"
+            @input="v$.socialProfileUserNames[socialProfile.key].$touch()"
+            @blur="v$.socialProfileUserNames[socialProfile.key].$touch()"
+            class="input-group-field ltr:!rounded-l-none rtl:!rounded-r-none !mb-0"
+            type="text"
+          />
+        </div>
+        <p
           v-if="v$.socialProfileUserNames[socialProfile.key].$error"
           class="mt-1 text-xs text-red-500"
         >
           Invalid {{ socialProfile.key }} username
         </p>
+      </div>
     </div>
     <div class="flex flex-row justify-start w-full gap-2 px-0 py-2">
       <NextButton


### PR DESCRIPTION
## Summary
Adds validation for social profile username fields in ContactForm.vue.

## Changes
- Rejects spaces, URLs, and unsupported symbols
- Adds inline field-level validation messages
- Supports username-only input based on existing prefixURL behavior
- Added missing Instagram entry to rendered social profile keys

## Verification
- Checked the code locally
- Used the component preview to view the form
- Could not fully test the save flow in my local setup

## Linked issues

Closes #14240
