### PR TITLE
fix: prevent greeting messages from firing on activity events (#3657)

### DIFF
--- a/app/services/message_templates/hook_execution_service.rb
+++ b/app/services/message_templates/hook_execution_service.rb
@@ -40,6 +40,8 @@ class MessageTemplates::HookExecutionService
     return false if conversation.campaign.present?
     # should not send if its a tweet message
     return false if conversation.tweet?
+    # should not send for outbound messages
+    return false unless message.incoming?
 
     first_message_from_contact? && inbox.greeting_enabled? && inbox.greeting_message.present?
   end

--- a/spec/services/message_templates/hook_execution_service_spec.rb
+++ b/spec/services/message_templates/hook_execution_service_spec.rb
@@ -270,4 +270,53 @@ describe MessageTemplates::HookExecutionService do
       expect(out_of_office_service).not_to receive(:perform)
     end
   end
+
+  context 'when an activity message is created on a conversation with a prior incoming message' do
+    it 'does not call ::MessageTemplates::Template::Greeting' do
+      contact = create(:contact, email: nil)
+      conversation = create(:conversation, contact: contact)
+      # Disable email collect so no template messages are created when the incoming message arrives
+      conversation.inbox.update(enable_email_collect: false)
+
+      create(:message, conversation: conversation, account: conversation.account, message_type: :incoming)
+
+      # Greeting is enabled after the incoming message exists, simulating a conversation that has not received a greeting yet
+      conversation.inbox.update(greeting_enabled: true, greeting_message: 'Hi, this is a greeting message')
+
+      greeting_service = double
+      allow(MessageTemplates::Template::Greeting).to receive(:new).and_return(greeting_service)
+      allow(greeting_service).to receive(:perform).and_return(true)
+
+      # Activity message — e.g. resolve, assignee change, label added
+      activity_message = create(:message, conversation: conversation, account: conversation.account,
+                                          message_type: 'activity', content: 'Conversation marked resolved!!')
+
+      described_class.new(message: activity_message).perform
+
+      expect(MessageTemplates::Template::Greeting).not_to have_received(:new)
+    end
+
+    it 'does not call ::MessageTemplates::Template::Greeting on outgoing messages' do
+      contact = create(:contact, email: nil)
+      conversation = create(:conversation, contact: contact)
+      # Disable email collect so no template messages are created when the incoming message arrives
+      conversation.inbox.update(enable_email_collect: false)
+
+      create(:message, conversation: conversation, account: conversation.account, message_type: :incoming)
+
+      # Greeting is enabled after the incoming message exists, simulating a conversation that has not received a greeting yet
+      conversation.inbox.update(greeting_enabled: true, greeting_message: 'Hi, this is a greeting message')
+
+      greeting_service = double
+      allow(MessageTemplates::Template::Greeting).to receive(:new).and_return(greeting_service)
+      allow(greeting_service).to receive(:perform).and_return(true)
+
+      outgoing_message = create(:message, conversation: conversation, account: conversation.account,
+                                          message_type: :outgoing)
+
+      described_class.new(message: outgoing_message).perform
+
+      expect(MessageTemplates::Template::Greeting).not_to have_received(:new)
+    end
+  end
 end


### PR DESCRIPTION
Greeting messages currently fire when an `activity` message (status change, label added, assignee change, resolve, etc.) is created on a conversation that has a prior incoming message but no outgoing message yet. The agent appears to send a greeting for an action they didn't take.

Closes #3657

## What changed

`should_send_greeting?` in `app/services/message_templates/hook_execution_service.rb` did not check whether the triggering message is incoming. The existing guards (`campaign`, `tweet`) and `first_message_from_contact?` were not enough: an `activity` message on a conversation that has never had an outgoing reply still satisfied `first_message_from_contact?`, so the greeting fired.

The fix adds one line:

```ruby
return false unless message.incoming?
```

This mirrors the existing pattern in `should_send_out_of_office_message?` in the same file, which already guards on `message.incoming?` for the same reason.

## Why a single guard, not a refactor

`first_message_from_contact?` is a property of the conversation as a whole, not of the triggering message. Pushing the incoming check into that helper would conflate two concepts. Adding the guard at the `should_send_greeting?` level keeps each method's responsibility clean and matches the pattern already used by the sibling `should_send_out_of_office_message?` method.

## Alternatives considered

- **Guard at the top of `perform`.** Would also affect `EmailCollect` and `OutOfOffice`, broadening scope. Rejected — `OutOfOffice` already has its own incoming guard, and `EmailCollect` has different semantics around web-widget contact email collection.
- **Tighten `first_message_from_contact?` to also check `message.incoming?`.** Reasonable but conflates message-level and conversation-level logic.

## Tests

Two new specs in `spec/services/message_templates/hook_execution_service_spec.rb` covering the missing cases:

1. An activity message on a conversation with a prior incoming reply does not retrigger the greeting.
2. An outgoing agent message also does not retrigger the greeting.

Both tests construct the bug's preconditions explicitly: greeting is enabled *after* the prior incoming message exists, simulating the realistic scenario where greetings were toggled on after the conversation was already underway. Without that detail the bug would be masked by the real `Greeting` service running during the incoming message's `after_commit` and creating a `template` message.

The first new test fails on `develop` and passes with the fix — confirming the regression coverage.

## How to verify

```bash
bundle exec rspec spec/services/message_templates/hook_execution_service_spec.rb
```

All 16 specs (14 existing + 2 new) pass.

Manually:
1. Enable greeting on an inbox in a fresh local Chatwoot
2. Open an existing conversation with prior incoming messages and zero outgoing replies
3. Trigger any activity (resolve, label, assignee change)
4. Before this change: greeting message appears in the conversation immediately after the activity. After this change: no greeting fires.

## Notes

- Comment wording on the new guard line matches the existing `should_send_out_of_office_message?` line for consistency, even though `incoming?` filters more than just "outbound" (it also excludes `activity` and `template` messages).
- This issue was filed by a maintainer (`pranavrajs`) in Dec 2021 with severity 4 — included for context, not because the original report needs anything more than what's here.