### PR TITLE
handle the country code

### DIFF
--- a/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
@@ -51,7 +51,6 @@ const isFormInvalid = computed(() => contactsFormRef.value?.isFormInvalid);
 
 const countriesMap = computed(() => {
   return countries.reduce((acc, country) => {
-    acc[country.code] = country;
     acc[country.id] = country;
     return acc;
   }, {});

--- a/app/javascript/dashboard/modules/search/components/SearchResultContactItem.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchResultContactItem.vue
@@ -49,7 +49,6 @@ const navigateTo = computed(() => {
 
 const countriesMap = computed(() => {
   return countries.reduce((acc, country) => {
-    acc[country.code] = country;
     acc[country.id] = country;
     return acc;
   }, {});


### PR DESCRIPTION
# Pull Request Template

## Description
Fixed an issue in the Contact List where some contacts incorrectly showed Zimbabwe as the location.

The list view was attempting to resolve the country using a mapper lookup against country.code, but that value was not present in this data path. This caused an invalid lookup and resulted in the wrong fallback country being displayed.

Fixes # (issue)
Removed country code from [ContactsCard.vue] and [SearchRsultContactItem.vue] in the Mapper

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Ran specs for updated scenarios
Verified normalization logic locally
Checked updated files for syntax issues
