### PR TITLE
Use message webhook envelope for conversation_updated

### DIFF
--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -29,7 +29,7 @@ class AgentBotListener < BaseListener
     changed_attributes = extract_changed_attributes(event)
     inbox = conversation.inbox
     event_name = __method__.to_s
-    payload = conversation.webhook_data.merge(event: event_name, changed_attributes: changed_attributes)
+    payload = conversation_updated_payload(conversation, event_name, changed_attributes)
     agent_bots_for(inbox, conversation).each { |agent_bot| process_webhook_bot_event(agent_bot, payload) }
   end
 
@@ -80,6 +80,13 @@ class AgentBotListener < BaseListener
     # Only webhook bots are supported
     payload = message.webhook_data.merge(event: method_name)
     process_webhook_bot_event(agent_bot, payload)
+  end
+
+  def conversation_updated_payload(conversation, event_name, changed_attributes)
+    message = conversation.messages.where(account_id: conversation.account_id).chat.last
+    payload = message&.webhook_data || conversation.webhook_data
+
+    payload.merge(event: event_name, changed_attributes: changed_attributes)
   end
 
   def process_webhook_bot_event(agent_bot, payload)

--- a/spec/listeners/agent_bot_listener_spec.rb
+++ b/spec/listeners/agent_bot_listener_spec.rb
@@ -109,6 +109,10 @@ describe AgentBotListener do
 
   describe '#conversation_updated' do
     let(:event_name) { 'conversation.updated' }
+    let!(:message) do
+      create(:message, message_type: 'outgoing',
+                       account: account, inbox: inbox, conversation: conversation)
+    end
 
     context 'when agent bot is not configured' do
       let!(:event) { Events::Base.new(event_name, Time.zone.now, conversation: conversation) }
@@ -124,9 +128,13 @@ describe AgentBotListener do
 
       it 'sends webhook to the inbox agent bot with changed_attributes' do
         create(:agent_bot_inbox, inbox: inbox, agent_bot: agent_bot)
+        expected_payload = conversation.messages.where(account_id: account.id).chat.last.webhook_data.merge(
+          event: 'conversation_updated',
+          changed_attributes: nil
+        )
         expect(AgentBots::WebhookJob).to receive(:perform_later).with(
           agent_bot.outgoing_url,
-          conversation.webhook_data.merge(event: 'conversation_updated', changed_attributes: nil),
+          expected_payload,
           :agent_bot_webhook, secret: agent_bot.secret, delivery_id: instance_of(String)
         ).once
         listener.conversation_updated(event)
@@ -145,14 +153,32 @@ describe AgentBotListener do
 
       it 'sends webhook with changed_attributes to the assigned agent bot' do
         expected_changed_attributes = [{ 'assignee_agent_bot_id' => { previous_value: nil, current_value: agent_bot.id } }]
+        expected_payload = conversation.messages.where(account_id: account.id).chat.last.webhook_data.merge(
+          event: 'conversation_updated',
+          changed_attributes: expected_changed_attributes
+        )
         expect(AgentBots::WebhookJob).to receive(:perform_later).with(
           agent_bot.outgoing_url,
-          conversation.webhook_data.merge(
-            event: 'conversation_updated',
-            changed_attributes: expected_changed_attributes
-          ),
+          expected_payload,
           :agent_bot_webhook, secret: agent_bot.secret, delivery_id: instance_of(String)
         ).once
+        listener.conversation_updated(event)
+      end
+    end
+
+    context 'when conversation has no chat messages' do
+      let!(:message) { nil }
+      let!(:event) { Events::Base.new(event_name, Time.zone.now, conversation: conversation) }
+
+      it 'falls back to conversation webhook payload' do
+        create(:agent_bot_inbox, inbox: inbox, agent_bot: agent_bot)
+
+        expect(AgentBots::WebhookJob).to receive(:perform_later).with(
+          agent_bot.outgoing_url,
+          conversation.webhook_data.merge(event: 'conversation_updated', changed_attributes: nil),
+          :agent_bot_webhook, secret: agent_bot.secret, delivery_id: instance_of(String)
+        ).once
+
         listener.conversation_updated(event)
       end
     end


### PR DESCRIPTION
## Description

Agent-bot `conversation_updated` webhooks now use the same envelope as
`message_created` / `message_updated` when the conversation has a latest
inbound chat message: payload is built from `message.webhook_data` (message
at top level, `conversation` nested). If there is no such message, behavior
falls back to `conversation.webhook_data`.

Fixes #13993

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

`bundle exec rspec spec/listeners/agent_bot_listener_spec.rb`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules