### PR TITLE
fix: sync summary conversation counts with reporting events

### DIFF
--- a/app/services/reports/raw_data_source.rb
+++ b/app/services/reports/raw_data_source.rb
@@ -97,7 +97,11 @@ class Reports::RawDataSource < Reports::DataSource
 
   def summary_conversation_counts
     account.conversations
-           .where(created_at: range)
+           .joins(:reporting_events)
+           .where(reporting_events: { 
+             name: summary_metrics.map(&:raw_event_name), 
+             created_at: range 
+           })
            .group(summary_conversation_group_by_key)
            .count
   end


### PR DESCRIPTION
Problem: An inconsistency was identified where team summary reports showed conflicting values between table views and overview cards. This was traced to the summary_conversation_counts method, which calculated the total conversation count independently of the reporting_events snapshots. This led to a denominator mismatch in average metric calculations.

Solution: Updated summary_conversation_counts in RawDataSource to perform an INNER JOIN on reporting_events. This enforces a unified filter, ensuring that the conversation count reflects only the conversations that contributed to the performance metrics being displayed.

Impact: This synchronises the data source across UI components, resolving data drift and ensuring that aggregated averages align with the underlying record counts.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes #14141 

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have not executed the full test suite locally. However, I have verified the architectural logic through static analysis of the data relationships and confirmed that the proposed INNER JOIN correctly aligns the conversation count denominator with the metrics numerator. I have set up the PR to leverage the project's CI pipeline, which will validate these changes against the existing regression tests.


## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
