### PR TITLE
fix(perf): force better index for pending_reponses longest first sort

### DIFF
--- a/app/models/concerns/sort_handler.rb
+++ b/app/models/concerns/sort_handler.rb
@@ -19,7 +19,7 @@ module SortHandler
     end
 
     def sort_on_waiting_since(sort_direction = :asc)
-      order(generate_sql_query("waiting_since #{sort_direction.to_s.upcase} NULLS LAST, created_at ASC"))
+      order(generate_sql_query("(waiting_since IS NULL), waiting_since #{sort_direction.to_s.upcase}, created_at ASC"))
     end
 
     def last_messaged_conversations

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -879,6 +879,31 @@ RSpec.describe Conversation do
           conversation_4.id
         ]
       end
+
+      context 'when some conversations have a null waiting_since' do
+        before do
+          # rubocop:disable Rails/SkipsModelValidations
+          conversation_5.update_column(:waiting_since, nil)
+          conversation_2.update_column(:waiting_since, nil)
+          # rubocop:enable Rails/SkipsModelValidations
+        end
+
+        it 'places null waiting_since conversations at the end in ascending order' do
+          records = described_class.sort_on_waiting_since
+          expect(records.map(&:id)).to eq [
+            conversation_4.id, conversation_6.id, conversation_7.id, conversation_3.id, conversation_1.id,
+            conversation_5.id, conversation_2.id
+          ]
+        end
+
+        it 'places null waiting_since conversations at the end in descending order' do
+          records = described_class.sort_on_waiting_since(:desc)
+          expect(records.map(&:id)).to eq [
+            conversation_1.id, conversation_3.id, conversation_7.id, conversation_6.id, conversation_4.id,
+            conversation_5.id, conversation_2.id
+          ]
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Description

Fix a Postgres planner trap on the "Pending Response: Longest first" sort that causes the conversation list to hang on busy accounts.

The current `sort_on_waiting_since` generates query with  `ORDER BY waiting_since ASC NULLS LAST, created_at ASC`. That order-by is exactly the shape of the single-column `index_conversations_on_waiting_since` btree, so the planner picks a forward index walk thinking `LIMIT 25` will stop early. In practice the per-account matches are spread along the global waiting_since timeline, so the scan reads tens of millions of rows from other accounts and discards them via the filter before producing any results which in turn causes the requests to time out and the conversation list spinner never resolves.

DESC direction and every other sort (`priority`, `created_at`, `last_activity_at`) are unaffected. They fall through to `conv_acid_inbid_stat_asgnid_idx` (account-scoped composite), which is the right index for this access pattern.

This change leads the ORDER BY with the expression `(waiting_since IS NULL)`, which no column-only btree can satisfy. The planner falls back to the same account-scoped index used by every other sort, and sorts in memory. Same logical NULLS LAST output for both directions; no behavior change for users.

Fixes https://linear.app/chatwoot/issue/CW-6965

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Existing specs pass
- [x] Added new specs to cover NULL case
- [x] Verify results and order for old and new query in prod
- [x] Tested in prod since staging data was not sufficient

`EXPLAIN (ANALYZE, BUFFERS)` for the same query (status=0, ASC, LIMIT 25) on a representative production account, before vs after:

| Metric | Before | After |
| --- | --- | --- |
| Execution time | 34,679 ms | 0.71 ms |
| Rows discarded by filter | 36,906,962 | 0 |
| Shared buffer hits | 12,699,924 | 11 |
| Blocks read from disk | 851,226 | 112 |
| I/O read time | 17,785 ms | 0.3 ms |
| Pages dirtied / written | 98 / 31,043 | 0 / 0 |

Verified on two production accounts: identical row IDs in identical order between the old and new ORDER BY for both ASC and DESC. A NULL-bucket regression spec was added covering ASC/DESC tail ordering when some conversations have a null `waiting_since`.

Roughly `49,000×` faster on this query (34,679 ms → 0.71 ms), and trivially less I/O and buffer pressure on the cluster while it runs.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules