### PR TITLE
fix: show all matches when filtering by multiple labels

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/helpers/filterHelpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers/filterHelpers.js
@@ -46,8 +46,8 @@
  * 2. Nested properties in additional_attributes (browser_language, referer, etc.)
  * 3. Nested properties in custom_attributes (conversation_type, etc.)
  */
-import jsonLogic from 'json-logic-js';
 import { coerceToDate } from '@chatwoot/utils';
+import jsonLogic from 'json-logic-js';
 
 /**
  * Gets a value from a conversation based on the attribute key
@@ -121,7 +121,8 @@ const resolveValue = candidate => {
  * @returns {Boolean} - Returns true if the values are considered equal according to filtering rules
  *
  * This function handles various equality scenarios:
- * 1. When both values are arrays: checks if all items in filterValue exist in conversationValue
+ * 1. When both values are arrays (e.g. labels): matches if any filter value exists in the conversation array
+ *    (mirrors the backend SQL `tag_id IN (...)` OR semantics)
  * 2. When filterValue is an array but conversationValue is not: checks if conversationValue is included in filterValue
  * 3. Otherwise: performs strict equality comparison
  */
@@ -131,8 +132,9 @@ const equalTo = (filterValue, conversationValue) => {
     if (filterValue === 'all') return true;
 
     if (Array.isArray(conversationValue)) {
-      // For array values like labels, check if any of the filter values exist in the array
-      return filterValue.every(val => conversationValue.includes(val));
+      // For array values like labels, match if any filter value is present.
+      // Mirrors the backend SQL `tag_id IN (...)` (OR semantics).
+      return filterValue.some(val => conversationValue.includes(val));
     }
 
     if (!Array.isArray(conversationValue)) {

--- a/app/javascript/dashboard/store/modules/conversations/helpers/specs/filterHelpers.spec.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers/specs/filterHelpers.spec.js
@@ -416,6 +416,40 @@ describe('filterHelpers', () => {
       expect(matchesFilters(conversation, filters)).toBe(true);
     });
 
+    // Multi-label equal_to uses OR semantics to mirror the backend SQL `tag_id IN (...)`:
+    // a conversation matches if ANY of the filter labels is on it.
+    it('should match conversation with equal_to operator when any of multiple filter labels is present', () => {
+      const conversation = { labels: ['support'] };
+      const filters = [
+        {
+          attribute_key: 'labels',
+          filter_operator: 'equal_to',
+          values: [
+            { id: 'support', name: 'Support' },
+            { id: 'urgent', name: 'Urgent' },
+          ],
+          query_operator: 'and',
+        },
+      ];
+      expect(matchesFilters(conversation, filters)).toBe(true);
+    });
+
+    it('should not match conversation with equal_to operator when none of multiple filter labels is present', () => {
+      const conversation = { labels: ['new'] };
+      const filters = [
+        {
+          attribute_key: 'labels',
+          filter_operator: 'equal_to',
+          values: [
+            { id: 'support', name: 'Support' },
+            { id: 'urgent', name: 'Urgent' },
+          ],
+          query_operator: 'and',
+        },
+      ];
+      expect(matchesFilters(conversation, filters)).toBe(false);
+    });
+
     it('should match conversation with is_present operator for labels', () => {
       const conversation = { labels: ['support', 'urgent', 'new'] };
       const filters = [


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes a mismatch between the header count and the conversation list when filtering by multiple labels.

The backend returns conversations that match any of the selected labels (OR), but the frontend was applying an additional check that required conversations to have all selected labels (AND). Because of this, valid results were being filtered out on the client side.

For example, if filtering with `Labels = [A, B]`, the backend returns conversations with A, B, or both. The frontend, however, only showed conversations that had both A and B, hiding the rest.

**Cause**
Frontend `equalTo` helper used `.every()`, enforcing AND logic, while the backend uses OR logic for label filtering.

**Solution**
Replaced `.every()` with `.some()` in the `equalTo` helper so frontend matches backend behavior.

Fixes https://linear.app/chatwoot/issue/CW-6967/conversations-not-loading-when-filtering-by-labels-with-or-condition

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**How to reproduce**
1. Open the conversation list and apply filters
2. Set `Status = Open` and select two or more labels
3. Apply the filter
4. Observe that the header count (e.g. 13) does not match the rendered list (e.g. 5)
5. Try with a single label, results appear correct

<details>

### Screenshots

**Before**
<img width="1602" height="970" alt="Screenshot 2026-04-28 at 10 04 06 PM" src="https://github.com/user-attachments/assets/35e5f4c4-084f-4309-a9e5-3ec3e5f96a9e" />

**After**
<img width="1602" height="970" alt="Screenshot 2026-04-28 at 10 02 20 PM" src="https://github.com/user-attachments/assets/79b8ceba-b535-4a36-a8ed-fc916842fd37" />

</details>

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

