### PR TITLE
fix: keep agents action visible in teams edit/add view

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/teams/AgentSelector.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/teams/AgentSelector.vue
@@ -132,8 +132,10 @@ const headers = computed(() => [
     </template>
   </BaseTable>
 
-  <div class="flex items-center justify-between mt-4">
-    <p class="text-body-main text-n-slate-11">
+  <div
+    class="sticky bottom-0 py-4 px-8 -mx-8 z-20 flex items-center justify-between bg-n-surface-1 border-t border-n-weak"
+  >
+    <p class="text-body-main text-n-slate-11 mb-0">
       {{
         $t('TEAMS_SETTINGS.AGENTS.SELECTED_COUNT', {
           selected: selectedAgents.length,

--- a/app/javascript/dashboard/routes/dashboard/settings/teams/Create/AddAgents.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/teams/Create/AddAgents.vue
@@ -88,7 +88,7 @@ export default {
 </script>
 
 <template>
-  <div class="h-full w-full p-8 col-span-6 overflow-auto">
+  <div class="h-full w-full px-8 pt-8 col-span-6 overflow-auto">
     <form class="flex flex-col gap-4 mx-0" @submit.prevent="addAgents">
       <PageHeader
         :header-title="headerTitle"

--- a/app/javascript/dashboard/routes/dashboard/settings/teams/Edit/EditAgents.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/teams/Edit/EditAgents.vue
@@ -103,7 +103,7 @@ export default {
 </script>
 
 <template>
-  <div class="h-full w-full p-8 col-span-6 overflow-auto">
+  <div class="h-full w-full px-8 pt-8 col-span-6 overflow-auto">
     <form class="flex flex-col gap-4 mx-0" @submit.prevent="addAgents">
       <PageHeader
         :header-title="headerTitle"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the “Add agents” action button getting pushed below the fold when a team has a long list of agents. Now the footer sticky, so the button remains visible and accessible without scrolling, regardless of the list length.

Fixes https://linear.app/chatwoot/issue/CW-6966/add-agents-button-is-not-visible-when-the-list-of-team-members-is-long

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screencast

**Before**

https://github.com/user-attachments/assets/f7a4004a-8b19-41de-877e-d9ba6d089762



**After**

https://github.com/user-attachments/assets/c1d238c5-7297-40ea-b352-e549782f2a99




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
