### PR TITLE
fix: #14299 options dropdown is rendered behind the actions header in contacts page

### DIFF
--- a/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactHeader.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactHeader.vue
@@ -32,7 +32,7 @@ const emit = defineEmits([
 </script>
 
 <template>
-  <header class="sticky top-0 z-10 px-6">
+  <header class="sticky top-0 z-30 px-6">
     <div
       class="flex items-start sm:items-center justify-between w-full py-6 gap-2 mx-auto max-w-5xl"
     >


### PR DESCRIPTION
# Pull Request Template

## Description

The options dropdown on the Contacts page is incorrectly displayed behind the actions header, causing visibility and interaction issues due to a layout (z-index) problem.

Fixes # (issue)
#14299

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Reproduced the issue in the Contacts page by selecting multiple contacts and opening the “Ordering” dropdown
Verified that the dropdown is rendered underneath the actions header (z-index issue)
Tested on different screen sizes to confirm the overlap persists in responsive layouts
Checked in latest browser versions (e.g., Chrome and Firefox) to rule out browser-specific behavior

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
