### PR TITLE
Fix End Conversation button not properly ending the chat session

### DIFF
--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -291,6 +291,18 @@ export const IFrameHelper = {
     playAudio: () => {
       window.playAudioAlert();
     },
+
+    resetSession: () => {
+      Cookies.remove('cw_conversation');
+
+      const iframe = IFrameHelper.getAppFrame();
+      iframe.src = IFrameHelper.getUrl({
+        baseUrl: window.$chatwoot.baseUrl,
+        websiteToken: window.$chatwoot.websiteToken,
+      });
+
+      onBubbleClick({ toggleValue: false });
+    },
   },
   pushEvent: eventName => {
     IFrameHelper.sendMessage('push-event', { eventName });

--- a/app/javascript/widget/store/modules/conversation/actions.js
+++ b/app/javascript/widget/store/modules/conversation/actions.js
@@ -208,8 +208,22 @@ export const actions = {
     }
   },
 
-  resolveConversation: async () => {
-    await toggleStatus();
+  resolveConversation: async ({ commit, dispatch }) => {
+    try {
+      await toggleStatus();
+      commit('clearConversations');
+      dispatch(
+        'conversationAttributes/clearConversationAttributes',
+        {},
+        { root: true }
+      );
+      dispatch('campaign/resetCampaign', {}, { root: true });
+
+      const { IFrameHelper } = await import('widget/helpers/utils');
+      IFrameHelper.sendMessage({ event: 'resetSession' });
+    } catch (error) {
+      // Ignore error
+    }
   },
 
   setCustomAttributes: async (


### PR DESCRIPTION
# Pull Request Template

## Description
When the "Allow user to exit chat" feature is enabled in Inbox settings, clicking the "End Conversation" button in the widget now properly terminates the session. Previously, the button would disappear but the chat window remained open and functional, allowing users to continue messaging.

Fixes #14297

This fix ensures that when a user clicks "End Conversation":

- The conversation is resolved on the backend
- The widget closes automatically
- The session cookie is cleared
- Reopening the widget starts a fresh conversation

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Enable "Allow user to exit chat" in Inbox Settings → Widget Settings
2. Open the chat widget as a customer
3. Send a message to create a conversation
4. Click the "End Conversation" button
5. Verify: Widget closes and cw_conversation cookie is removed
6. Reopen the widget
7. Verify: Fresh pre-chat form appears instead of previous conversation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
