### PR TITLE
fix: remove invalid Instagram scopes from Facebook Messenger OAuth flow

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Facebook.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Facebook.vue
@@ -168,7 +168,7 @@ export default {
         },
         {
           scope:
-            'pages_manage_metadata,business_management,pages_messaging,instagram_basic,pages_show_list,pages_read_engagement,instagram_manage_messages',
+            'pages_manage_metadata,business_management,pages_messaging,pages_show_list,pages_read_engagement',
         }
       );
     },

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/facebook/Reauthorize.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/facebook/Reauthorize.vue
@@ -78,7 +78,7 @@ export default {
         },
         {
           scope:
-            'pages_manage_metadata,business_management,pages_messaging,instagram_basic,pages_show_list,pages_read_engagement,instagram_manage_messages',
+            'pages_manage_metadata,business_management,pages_messaging,pages_show_list,pages_read_engagement',
           auth_type: 'reauthorize',
         }
       );


### PR DESCRIPTION
Instagram-specific scopes (instagram_basic, instagram_manage_messages) were incorrectly included in the Messenger inbox OAuth request, causing an Invalid Scopes error in the Facebook Login dialog and blocking Meta App Review for production message functionality.

Fixes chatwoot/chatwoot#13860

# Pull Request Template

## Description

The Facebook Messenger OAuth flow in both the inbox creation and reauthorization steps included two Instagram-specific permissions that are not required for Messenger. These scopes (instagram_basic, instagram_manage_messages) require a  separate Meta app review process and cause the OAuth login to fail for apps that have not completed Instagram review.

Removed both scopes from the hardcoded scope string in Facebook.vue and Reauthorize.vue, leaving only the permissions required for Messenger functionality: pages_manage_metadata, business_management, pages_messaging, pages_show_list, and   pages_read_engagement.

## Type of change

Please delete options that are not relevant.

- \[ x\] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

1. Navigate to Settings → Inboxes → Add Inbox → Facebook Messenger
2. Click Login with Facebook
3. Inspect the OAuth popup URL — confirm instagram_basic and instagram_manage_messages are no longer present in the scope parameter
4. Complete the OAuth flow — login succeeds without an "Invalid Scopes" error
5. Repeat steps via Settings → Inboxes → \[Messenger Inbox\] → Reauthorize to confirm the fix applies to the reauthorization flow as well

## Checklist:

- \[ x\] My code follows the style guidelines of this project
- \[ x\] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- \[x \] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- \[ x\] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules