### PR TITLE
fix: Prevent platform banners cloud check from breaking app boot

### DIFF
--- a/app/controllers/super_admin/platform_banners_controller.rb
+++ b/app/controllers/super_admin/platform_banners_controller.rb
@@ -1,2 +1,9 @@
 class SuperAdmin::PlatformBannersController < SuperAdmin::ApplicationController
+  before_action :ensure_chatwoot_cloud
+
+  private
+
+  def ensure_chatwoot_cloud
+    raise ActionController::RoutingError, 'Not Found' unless ChatwootApp.chatwoot_cloud?
+  end
 end

--- a/app/views/super_admin/application/_navigation.html.erb
+++ b/app/views/super_admin/application/_navigation.html.erb
@@ -34,6 +34,7 @@ as defined by the routes in the `admin/` namespace
       <%= render partial: "nav_item", locals: { icon: 'icon-grid-line', url: super_admin_root_url, label: 'Dashboard' } %>
       <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
         <% next if ["account_users", "access_tokens", "installation_configs", "dashboard", "devise/sessions", "app_configs", "instance_statuses", "settings", "push_diagnostics"].include?  resource.resource %>
+        <% next if resource.resource == "platform_banners" && !ChatwootApp.chatwoot_cloud? %>
         <%= render partial: "nav_item", locals: {
             icon: sidebar_icons[resource.resource.to_sym],
             url: resource_index_route(resource),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -653,7 +653,7 @@ Rails.application.routes.draw do
         delete :avatar, on: :member, action: :destroy_avatar
       end
       resources :platform_apps, only: [:index, :new, :create, :show, :edit, :update, :destroy]
-      resources :platform_banners if ChatwootApp.chatwoot_cloud?
+      resources :platform_banners
       resource :instance_status, only: [:show]
 
       resource :settings, only: [:show] do


### PR DESCRIPTION
The `ChatwootApp.chatwoot_cloud?` gate on the platform banners route in #13943 reads `InstallationConfig` from the database. Because `routes.rb` is evaluated during `Rails.application.initialize!`, this ran before the database existed on a fresh setup, breaking `bundle exec rake db:create` in CI and first-time installs with `ActiveRecord::NoDatabaseError: We could not find your database: chatwoot_test`.

The route is now always mounted, and the cloud check moved to where the database is guaranteed to be available — the controller (`before_action`) and the super admin sidebar partial.

Closes the CI failure introduced by #13943.

## How to test
1. Drop your local databases: `bundle exec rake db:drop`
2. Run `bundle exec rake db:create` — it should succeed (previously failed with `NoDatabaseError`)
3. Bring the DB back: `bundle exec rake db:setup`
4. On a non-cloud install, visit `/super_admin/platform_banners` — should 404, and the sidebar entry should be hidden
5. With `DEPLOYMENT_ENV=cloud` configured (cloud install), the page and sidebar entry should work as before

## What changed
- `config/routes.rb` — always mount `resources :platform_banners` (no DB call at boot)
- `app/controllers/super_admin/platform_banners_controller.rb` — `before_action` raises `ActionController::RoutingError` (404) when not on Chatwoot Cloud
- `app/views/super_admin/application/_navigation.html.erb` — hides the sidebar entry on non-cloud installs