### PR TITLE
Sync conversation sender after contact updates

### DIFF
--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -177,6 +177,7 @@ class ActionCableConnector extends BaseActionCableConnector {
 
   onContactUpdate = data => {
     this.app.$store.dispatch('contacts/updateContact', data);
+    this.app.$store.dispatch('syncContactInConversations', data);
   };
 
   onNotificationCreated = data => {

--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -437,6 +437,20 @@ const actions = {
     commit(types.UPDATE_CONVERSATION_CONTACT, data);
   },
 
+  syncContactInConversations({ state, commit }, contact) {
+    const contactId = contact?.id;
+    if (!contactId) return;
+
+    state.allConversations.forEach(conversation => {
+      if (conversation?.meta?.sender?.id !== contactId) return;
+
+      commit(types.UPDATE_CONVERSATION_CONTACT, {
+        conversationId: conversation.id,
+        ...contact,
+      });
+    });
+  },
+
   setActiveInbox({ commit }, inboxId) {
     commit(types.SET_ACTIVE_INBOX, inboxId);
   },


### PR DESCRIPTION
## Description

Take-home exercise PR only (not intended for merge).

This includes a potential fix for #13051 by syncing `conversation.meta.sender` in the frontend store when `contact.updated` websocket events arrive, so canned response contact variables can resolve updated contact data without refresh.

Fixes #13051

## Notes

Please do not review for merge. This PR is shared only as part of an external interview take-home submission.