### PR TITLE
feat(slack): post Slack thread updates when a contact's email changes

### DIFF
--- a/app/jobs/hook_job.rb
+++ b/app/jobs/hook_job.rb
@@ -23,25 +23,33 @@ class HookJob < MutexApplicationJob
   private
 
   def process_slack_integration(hook, event_name, event_data)
-    message = event_data[:message]
-
     case event_name
     when 'message.created'
-      if message.attachments.blank?
-        ::SendOnSlackJob.perform_later(message, hook)
-      else
-        ::SendOnSlackJob.set(wait: 2.seconds).perform_later(message, hook)
-      end
+      send_slack_message_created(hook, event_data[:message])
     when 'message.updated'
-      # Only interactive bot messages store responses via content_attributes (submitted_values / submitted_email).
-      # Skip other content types to avoid unnecessary job enqueues on every message update.
-      return unless message.content_type.in?(Integrations::Slack::UpdateSlackMessageService::SUPPORTED_CONTENT_TYPES)
-      # Guard against redundant Slack updates when unrelated attributes change (e.g. status)
-      # while submitted_values is already present on the message.
-      return unless event_data[:previous_changes]&.key?('content_attributes')
-
-      ::UpdateSlackMessageJob.perform_later(message, hook)
+      send_slack_message_updated(hook, event_data[:message], event_data[:previous_changes])
+    when 'contact.updated'
+      ::SendContactUpdateOnSlackJob.perform_later(event_data[:contact], hook, event_data[:changed_attributes] || {})
     end
+  end
+
+  def send_slack_message_created(hook, message)
+    if message.attachments.blank?
+      ::SendOnSlackJob.perform_later(message, hook)
+    else
+      ::SendOnSlackJob.set(wait: 2.seconds).perform_later(message, hook)
+    end
+  end
+
+  def send_slack_message_updated(hook, message, previous_changes)
+    # Only interactive bot messages store responses via content_attributes (submitted_values / submitted_email).
+    # Skip other content types to avoid unnecessary job enqueues on every message update.
+    return unless message.content_type.in?(Integrations::Slack::UpdateSlackMessageService::SUPPORTED_CONTENT_TYPES)
+    # Guard against redundant Slack updates when unrelated attributes change (e.g. status)
+    # while submitted_values is already present on the message.
+    return unless previous_changes&.key?('content_attributes')
+
+    ::UpdateSlackMessageJob.perform_later(message, hook)
   end
 
   def process_dialogflow_integration(hook, event_name, event_data)

--- a/app/jobs/hook_job.rb
+++ b/app/jobs/hook_job.rb
@@ -29,8 +29,16 @@ class HookJob < MutexApplicationJob
     when 'message.updated'
       send_slack_message_updated(hook, event_data[:message], event_data[:previous_changes])
     when 'contact.updated'
-      ::SendContactUpdateOnSlackJob.perform_later(event_data[:contact], hook, event_data[:changed_attributes] || {})
+      send_slack_contact_updated(hook, event_data[:contact], event_data[:changed_attributes])
     end
+  end
+
+  def send_slack_contact_updated(hook, contact, changed_attributes)
+    # contact.updated fires on every contact touch (e.g. last_activity_at on each
+    # message), so gate on an email change before enqueuing.
+    return unless changed_attributes&.key?('email')
+
+    ::SendContactUpdateOnSlackJob.perform_later(contact, hook, changed_attributes)
   end
 
   def send_slack_message_created(hook, message)

--- a/app/jobs/send_contact_update_on_slack_job.rb
+++ b/app/jobs/send_contact_update_on_slack_job.rb
@@ -1,0 +1,13 @@
+class SendContactUpdateOnSlackJob < ApplicationJob
+  queue_as :low
+
+  def perform(contact, hook, changed_attributes = {})
+    return unless changed_attributes.key?('email')
+
+    Integrations::Slack::SendContactUpdateService.new(
+      contact: contact,
+      hook: hook,
+      changed_attributes: changed_attributes
+    ).perform
+  end
+end

--- a/app/jobs/send_contact_update_on_slack_job.rb
+++ b/app/jobs/send_contact_update_on_slack_job.rb
@@ -1,9 +1,7 @@
 class SendContactUpdateOnSlackJob < ApplicationJob
   queue_as :low
 
-  def perform(contact, hook, changed_attributes = {})
-    return unless changed_attributes.key?('email')
-
+  def perform(contact, hook, changed_attributes)
     Integrations::Slack::SendContactUpdateService.new(
       contact: contact,
       hook: hook,

--- a/app/listeners/hook_listener.rb
+++ b/app/listeners/hook_listener.rb
@@ -18,7 +18,7 @@ class HookListener < BaseListener
 
   def contact_updated(event)
     contact = extract_contact_and_account(event)[0]
-    execute_account_hooks(event, contact.account, contact: contact)
+    execute_account_hooks(event, contact.account, contact: contact, changed_attributes: event.data[:changed_attributes])
   end
 
   def conversation_created(event)
@@ -59,7 +59,7 @@ class HookListener < BaseListener
     return false if hook.disabled?
 
     supported_events_map = {
-      'slack' => ['message.created', 'message.updated'],
+      'slack' => ['message.created', 'message.updated', 'contact.updated'],
       'dialogflow' => ['message.created', 'message.updated'],
       'google_translate' => ['message.created'],
       'leadsquared' => ['contact.updated', 'conversation.created', 'conversation.resolved']

--- a/lib/integrations/slack/send_contact_update_service.rb
+++ b/lib/integrations/slack/send_contact_update_service.rb
@@ -1,0 +1,54 @@
+class Integrations::Slack::SendContactUpdateService
+  pattr_initialize [:contact!, :hook!, :changed_attributes!]
+
+  def perform
+    return if contact.email.blank?
+    return unless active_conversations_with_slack_integration.any?
+
+    active_conversations_with_slack_integration.each do |conversation|
+      send_contact_update_to_slack(conversation)
+    end
+  end
+
+  private
+
+  def active_conversations_with_slack_integration
+    @active_conversations_with_slack_integration ||= contact.conversations
+                                                            .where(status: %w[open pending])
+                                                            .where.not(identifier: [nil, ''])
+  end
+
+  def send_contact_update_to_slack(conversation)
+    return if conversation.identifier.blank?
+
+    slack_client.chat_postMessage(
+      channel: hook.reference_id,
+      text: contact_update_message,
+      thread_ts: conversation.identifier,
+      unfurl_links: false
+    )
+  rescue Slack::Web::Api::Errors::IsArchived, Slack::Web::Api::Errors::AccountInactive, Slack::Web::Api::Errors::MissingScope,
+         Slack::Web::Api::Errors::InvalidAuth,
+         Slack::Web::Api::Errors::ChannelNotFound, Slack::Web::Api::Errors::NotInChannel => e
+    Rails.logger.error e
+    hook.prompt_reauthorization!
+    hook.disable
+  rescue Slack::Web::Api::Errors::SlackError => e
+    Rails.logger.error "Failed to send contact update to Slack: #{e.message}"
+  end
+
+  def contact_update_message
+    old_email = changed_attributes['email'][0]
+    new_email = changed_attributes['email'][1]
+
+    if old_email.present?
+      "📧 Contact email updated: #{old_email} → #{new_email}"
+    else
+      "📧 Contact email added: #{new_email}"
+    end
+  end
+
+  def slack_client
+    @slack_client ||= Slack::Web::Client.new(token: hook.access_token)
+  end
+end

--- a/lib/integrations/slack/send_contact_update_service.rb
+++ b/lib/integrations/slack/send_contact_update_service.rb
@@ -1,4 +1,9 @@
 class Integrations::Slack::SendContactUpdateService
+  # Conversations linked to a Slack thread store the Slack message `ts`
+  # (e.g. "1693292344.123456") in `identifier`; other channels reuse the same
+  # column for non-Slack values such as Twilio call SIDs.
+  SLACK_THREAD_TS_FORMAT = '^\d+\.\d+$'.freeze
+
   pattr_initialize [:contact!, :hook!, :changed_attributes!]
 
   def perform
@@ -15,12 +20,10 @@ class Integrations::Slack::SendContactUpdateService
   def active_conversations_with_slack_integration
     @active_conversations_with_slack_integration ||= contact.conversations
                                                             .where(status: %w[open pending])
-                                                            .where.not(identifier: [nil, ''])
+                                                            .where('conversations.identifier ~ ?', SLACK_THREAD_TS_FORMAT)
   end
 
   def send_contact_update_to_slack(conversation)
-    return if conversation.identifier.blank?
-
     slack_client.chat_postMessage(
       channel: hook.reference_id,
       text: contact_update_message,

--- a/lib/integrations/slack/send_contact_update_service.rb
+++ b/lib/integrations/slack/send_contact_update_service.rb
@@ -4,15 +4,29 @@ class Integrations::Slack::SendContactUpdateService
   # column for non-Slack values such as Twilio call SIDs.
   SLACK_THREAD_TS_FORMAT = '^\d+\.\d+$'.freeze
 
+  # Errors that mean every subsequent post would fail the same way, so the
+  # hook is disabled and the conversation loop aborted.
+  FATAL_SLACK_ERRORS = [
+    Slack::Web::Api::Errors::IsArchived,
+    Slack::Web::Api::Errors::AccountInactive,
+    Slack::Web::Api::Errors::MissingScope,
+    Slack::Web::Api::Errors::InvalidAuth,
+    Slack::Web::Api::Errors::ChannelNotFound,
+    Slack::Web::Api::Errors::NotInChannel
+  ].freeze
+
   pattr_initialize [:contact!, :hook!, :changed_attributes!]
 
   def perform
     return if contact.email.blank?
-    return unless active_conversations_with_slack_integration.any?
 
     active_conversations_with_slack_integration.each do |conversation|
       send_contact_update_to_slack(conversation)
     end
+  rescue *FATAL_SLACK_ERRORS => e
+    Rails.logger.error e
+    hook.prompt_reauthorization!
+    hook.disable
   end
 
   private
@@ -30,24 +44,21 @@ class Integrations::Slack::SendContactUpdateService
       thread_ts: conversation.identifier,
       unfurl_links: false
     )
-  rescue Slack::Web::Api::Errors::IsArchived, Slack::Web::Api::Errors::AccountInactive, Slack::Web::Api::Errors::MissingScope,
-         Slack::Web::Api::Errors::InvalidAuth,
-         Slack::Web::Api::Errors::ChannelNotFound, Slack::Web::Api::Errors::NotInChannel => e
-    Rails.logger.error e
-    hook.prompt_reauthorization!
-    hook.disable
+  rescue *FATAL_SLACK_ERRORS
+    raise
   rescue Slack::Web::Api::Errors::SlackError => e
     Rails.logger.error "Failed to send contact update to Slack: #{e.message}"
   end
 
   def contact_update_message
-    old_email = changed_attributes['email'][0]
-    new_email = changed_attributes['email'][1]
+    @contact_update_message ||= begin
+      old_email, new_email = changed_attributes['email']
 
-    if old_email.present?
-      "📧 Contact email updated: #{old_email} → #{new_email}"
-    else
-      "📧 Contact email added: #{new_email}"
+      if old_email.present?
+        "📧 Contact email updated: #{old_email} → #{new_email}"
+      else
+        "📧 Contact email added: #{new_email}"
+      end
     end
   end
 

--- a/spec/jobs/hook_job_spec.rb
+++ b/spec/jobs/hook_job_spec.rb
@@ -105,6 +105,29 @@ RSpec.describe HookJob do
     end
   end
 
+  context 'when handleable events like contact.updated for slack' do
+    let(:contact) { create(:contact, account: account) }
+    let(:slack_hook) { create(:integrations_hook, app_id: 'slack', account: account) }
+    let(:changed_attributes) { { 'email' => [nil, 'new@example.com'] } }
+    let(:contact_event_data) { { contact: contact, changed_attributes: changed_attributes } }
+
+    it 'enqueues SendContactUpdateOnSlackJob with the contact, hook, and changed_attributes' do
+      expect(SendContactUpdateOnSlackJob).to receive(:perform_later).with(contact, slack_hook, changed_attributes)
+      described_class.perform_now(slack_hook, 'contact.updated', contact_event_data)
+    end
+
+    it 'forwards an empty hash when changed_attributes is missing from the payload' do
+      expect(SendContactUpdateOnSlackJob).to receive(:perform_later).with(contact, slack_hook, {})
+      described_class.perform_now(slack_hook, 'contact.updated', { contact: contact })
+    end
+
+    it 'does nothing when the hook is disabled' do
+      slack_hook.update!(status: 'disabled')
+      expect(SendContactUpdateOnSlackJob).not_to receive(:perform_later)
+      described_class.perform_now(slack_hook, 'contact.updated', contact_event_data)
+    end
+  end
+
   context 'when processing leadsquared integration' do
     let(:contact) { create(:contact, account: account) }
     let(:conversation) { create(:conversation, account: account, contact: contact) }

--- a/spec/jobs/hook_job_spec.rb
+++ b/spec/jobs/hook_job_spec.rb
@@ -116,9 +116,15 @@ RSpec.describe HookJob do
       described_class.perform_now(slack_hook, 'contact.updated', contact_event_data)
     end
 
-    it 'forwards an empty hash when changed_attributes is missing from the payload' do
-      expect(SendContactUpdateOnSlackJob).to receive(:perform_later).with(contact, slack_hook, {})
+    it 'does not enqueue when changed_attributes is missing from the payload' do
+      expect(SendContactUpdateOnSlackJob).not_to receive(:perform_later)
       described_class.perform_now(slack_hook, 'contact.updated', { contact: contact })
+    end
+
+    it 'does not enqueue when the update did not touch the email' do
+      expect(SendContactUpdateOnSlackJob).not_to receive(:perform_later)
+      described_class.perform_now(slack_hook, 'contact.updated',
+                                  { contact: contact, changed_attributes: { 'last_activity_at' => [nil, Time.zone.now] } })
     end
 
     it 'does nothing when the hook is disabled' do

--- a/spec/jobs/send_contact_update_on_slack_job_spec.rb
+++ b/spec/jobs/send_contact_update_on_slack_job_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe SendContactUpdateOnSlackJob do
+  let(:account) { create(:account) }
+  let(:contact) { create(:contact, account: account) }
+  let(:hook) { create(:integrations_hook, app_id: 'slack', account: account) }
+  let(:service) { instance_double(Integrations::Slack::SendContactUpdateService, perform: nil) }
+
+  it 'invokes SendContactUpdateService when the email changed' do
+    changed_attributes = { 'email' => [nil, 'new@example.com'] }
+
+    expect(Integrations::Slack::SendContactUpdateService)
+      .to receive(:new).with(contact: contact, hook: hook, changed_attributes: changed_attributes).and_return(service)
+    expect(service).to receive(:perform)
+
+    described_class.perform_now(contact, hook, changed_attributes)
+  end
+
+  it 'is a no-op when the changed_attributes does not include email' do
+    expect(Integrations::Slack::SendContactUpdateService).not_to receive(:new)
+    described_class.perform_now(contact, hook, { 'name' => %w[Old New] })
+  end
+
+  it 'is a no-op when changed_attributes is empty' do
+    expect(Integrations::Slack::SendContactUpdateService).not_to receive(:new)
+    described_class.perform_now(contact, hook, {})
+  end
+end

--- a/spec/jobs/send_contact_update_on_slack_job_spec.rb
+++ b/spec/jobs/send_contact_update_on_slack_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SendContactUpdateOnSlackJob do
   let(:hook) { create(:integrations_hook, app_id: 'slack', account: account) }
   let(:service) { instance_double(Integrations::Slack::SendContactUpdateService, perform: nil) }
 
-  it 'invokes SendContactUpdateService when the email changed' do
+  it 'invokes SendContactUpdateService with the contact, hook, and changed_attributes' do
     changed_attributes = { 'email' => [nil, 'new@example.com'] }
 
     expect(Integrations::Slack::SendContactUpdateService)
@@ -14,15 +14,5 @@ RSpec.describe SendContactUpdateOnSlackJob do
     expect(service).to receive(:perform)
 
     described_class.perform_now(contact, hook, changed_attributes)
-  end
-
-  it 'is a no-op when the changed_attributes does not include email' do
-    expect(Integrations::Slack::SendContactUpdateService).not_to receive(:new)
-    described_class.perform_now(contact, hook, { 'name' => %w[Old New] })
-  end
-
-  it 'is a no-op when changed_attributes is empty' do
-    expect(Integrations::Slack::SendContactUpdateService).not_to receive(:new)
-    described_class.perform_now(contact, hook, {})
   end
 end

--- a/spec/lib/integrations/slack/send_contact_update_service_spec.rb
+++ b/spec/lib/integrations/slack/send_contact_update_service_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+describe Integrations::Slack::SendContactUpdateService do
+  let(:account) { create(:account) }
+  let(:contact) { create(:contact, account: account, email: 'new@example.com') }
+  let(:inbox) { create(:inbox, account: account) }
+  let!(:slack_conversation) do
+    create(:conversation, account: account, inbox: inbox, contact: contact, identifier: '12345.6789', status: :open)
+  end
+  let!(:hook) { create(:integrations_hook, app_id: 'slack', account: account) }
+  let(:slack_client) { instance_double(Slack::Web::Client) }
+  let(:service) { described_class.new(contact: contact, hook: hook, changed_attributes: changed_attributes) }
+
+  before do
+    allow(service).to receive(:slack_client).and_return(slack_client)
+  end
+
+  context 'when the email is being added for the first time' do
+    let(:changed_attributes) { { 'email' => [nil, 'new@example.com'] } }
+
+    it 'posts a thread message announcing the new email' do
+      expect(slack_client).to receive(:chat_postMessage).with(
+        channel: hook.reference_id,
+        text: a_string_including('new@example.com').and(a_string_including('added')),
+        thread_ts: slack_conversation.identifier,
+        unfurl_links: false
+      )
+
+      service.perform
+    end
+  end
+
+  context 'when the email is being changed' do
+    let(:changed_attributes) { { 'email' => ['old@example.com', 'new@example.com'] } }
+
+    it 'posts a thread message showing the old and new emails' do
+      expect(slack_client).to receive(:chat_postMessage).with(
+        hash_including(
+          channel: hook.reference_id,
+          text: a_string_including('old@example.com').and(a_string_including('new@example.com')),
+          thread_ts: slack_conversation.identifier,
+          unfurl_links: false
+        )
+      )
+
+      service.perform
+    end
+  end
+
+  context 'when the contact has no email' do
+    let(:changed_attributes) { { 'email' => ['old@example.com', nil] } }
+
+    it 'is a no-op' do
+      contact.update!(email: nil)
+
+      expect(slack_client).not_to receive(:chat_postMessage)
+      service.perform
+    end
+  end
+
+  context 'when the contact has no conversations linked to a Slack thread' do
+    let(:changed_attributes) { { 'email' => [nil, 'new@example.com'] } }
+
+    it 'is a no-op' do
+      slack_conversation.update!(identifier: nil)
+
+      expect(slack_client).not_to receive(:chat_postMessage)
+      service.perform
+    end
+  end
+
+  context 'when the conversation is resolved' do
+    let(:changed_attributes) { { 'email' => [nil, 'new@example.com'] } }
+
+    it 'skips resolved conversations' do
+      slack_conversation.update!(status: :resolved)
+
+      expect(slack_client).not_to receive(:chat_postMessage)
+      service.perform
+    end
+  end
+
+  context 'when posting against multiple active conversations' do
+    let(:changed_attributes) { { 'email' => [nil, 'new@example.com'] } }
+
+    before do
+      create(:conversation, account: account, inbox: inbox, contact: contact, identifier: '99999.1111', status: :pending)
+    end
+
+    it 'posts an update in each thread' do
+      expect(slack_client).to receive(:chat_postMessage)
+        .with(hash_including(thread_ts: '12345.6789')).once
+      expect(slack_client).to receive(:chat_postMessage)
+        .with(hash_including(thread_ts: '99999.1111')).once
+
+      service.perform
+    end
+  end
+
+  context 'when Slack returns an auth error' do
+    let(:changed_attributes) { { 'email' => [nil, 'new@example.com'] } }
+
+    it 'disables the hook and prompts reauthorization' do
+      allow(slack_client).to receive(:chat_postMessage).and_raise(Slack::Web::Api::Errors::InvalidAuth.new('invalid_auth'))
+      allow(hook).to receive(:prompt_reauthorization!)
+
+      expect { service.perform }.to change { hook.reload.disabled? }.from(false).to(true)
+      expect(hook).to have_received(:prompt_reauthorization!)
+    end
+  end
+end

--- a/spec/lib/integrations/slack/send_contact_update_service_spec.rb
+++ b/spec/lib/integrations/slack/send_contact_update_service_spec.rb
@@ -69,6 +69,17 @@ describe Integrations::Slack::SendContactUpdateService do
     end
   end
 
+  context 'when a conversation identifier is not a Slack thread timestamp' do
+    let(:changed_attributes) { { 'email' => [nil, 'new@example.com'] } }
+
+    it 'skips conversations whose identifier comes from another channel (e.g. a Twilio call SID)' do
+      slack_conversation.update!(identifier: 'CA9f2cb8d9876f1a23b45c6789d0ef1234')
+
+      expect(slack_client).not_to receive(:chat_postMessage)
+      service.perform
+    end
+  end
+
   context 'when the conversation is resolved' do
     let(:changed_attributes) { { 'email' => [nil, 'new@example.com'] } }
 

--- a/spec/lib/integrations/slack/send_contact_update_service_spec.rb
+++ b/spec/lib/integrations/slack/send_contact_update_service_spec.rb
@@ -111,12 +111,40 @@ describe Integrations::Slack::SendContactUpdateService do
   context 'when Slack returns an auth error' do
     let(:changed_attributes) { { 'email' => [nil, 'new@example.com'] } }
 
-    it 'disables the hook and prompts reauthorization' do
+    before do
+      create(:conversation, account: account, inbox: inbox, contact: contact, identifier: '99999.1111', status: :pending)
       allow(slack_client).to receive(:chat_postMessage).and_raise(Slack::Web::Api::Errors::InvalidAuth.new('invalid_auth'))
       allow(hook).to receive(:prompt_reauthorization!)
+    end
 
+    it 'disables the hook and prompts reauthorization' do
       expect { service.perform }.to change { hook.reload.disabled? }.from(false).to(true)
       expect(hook).to have_received(:prompt_reauthorization!)
+    end
+
+    it 'aborts after the first failure instead of repeating it for every conversation' do
+      service.perform
+
+      expect(slack_client).to have_received(:chat_postMessage).once
+      expect(hook).to have_received(:prompt_reauthorization!).once
+    end
+  end
+
+  context 'when Slack returns a transient error' do
+    let(:changed_attributes) { { 'email' => [nil, 'new@example.com'] } }
+
+    it 'continues posting to the remaining conversations' do
+      create(:conversation, account: account, inbox: inbox, contact: contact, identifier: '99999.1111', status: :pending)
+      call_count = 0
+      allow(slack_client).to receive(:chat_postMessage) do
+        call_count += 1
+        raise Slack::Web::Api::Errors::SlackError, 'rate_limited' if call_count == 1
+      end
+
+      service.perform
+
+      expect(slack_client).to have_received(:chat_postMessage).twice
+      expect(hook.reload.disabled?).to be(false)
     end
   end
 end

--- a/spec/listeners/hook_listener_spec.rb
+++ b/spec/listeners/hook_listener_spec.rb
@@ -10,7 +10,8 @@ describe HookListener do
                      account: account, inbox: inbox, conversation: conversation)
   end
   let!(:event) { Events::Base.new(event_name, Time.zone.now, message: message, previous_changes: nil) }
-  let(:contact_event) { Events::Base.new('contact.updated', Time.zone.now, contact: conversation.contact) }
+  let(:contact_changes) { { 'email' => [nil, 'new@example.com'] } }
+  let(:contact_event) { Events::Base.new('contact.updated', Time.zone.now, contact: conversation.contact, changed_attributes: contact_changes) }
   let(:conversation_event) { Events::Base.new('conversation.created', Time.zone.now, conversation: conversation) }
 
   describe '#message_created' do
@@ -122,7 +123,18 @@ describe HookListener do
       it 'enqueues the job for contact.updated' do
         expect(HookJob)
           .to receive(:perform_later)
-          .with(hook, 'contact.updated', { contact: conversation.contact })
+          .with(hook, 'contact.updated', { contact: conversation.contact, changed_attributes: contact_changes })
+
+        listener.contact_updated(contact_event)
+      end
+    end
+
+    context 'with slack hook on contact.updated' do
+      it 'enqueues the job and forwards changed_attributes' do
+        hook = create(:integrations_hook, account: account)
+        expect(HookJob)
+          .to receive(:perform_later)
+          .with(hook, 'contact.updated', { contact: conversation.contact, changed_attributes: contact_changes })
 
         listener.contact_updated(contact_event)
       end


### PR DESCRIPTION
When a contact's email is added or changed in Chatwoot, post a notification into every active Slack thread for that contact. Wires the existing contact.updated dispatcher event into HookJob's slack branch and adds SendContactUpdateOnSlackJob plus
Integrations::Slack::SendContactUpdateService.

Fixes #4729 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I used a local clean installation inside of podman, set up a new slack test app, added it to a server and did a full end-to end test of the functionality in addition to using the expected validation scripts.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas (don't believe any comments are required)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not sure this is possible?)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
