### PR TITLE
fix: render agent variables in automation messages

### DIFF
--- a/app/drops/user_drop.rb
+++ b/app/drops/user_drop.rb
@@ -7,11 +7,15 @@ class UserDrop < BaseDrop
     @obj.try(:available_name)
   end
 
+  def email
+    @obj.try(:email)
+  end
+
   def first_name
-    @obj.try(:name).try(:split).try(:first).try(:capitalize) if @obj.try(:name).try(:split).try(:size) > 1
+    @obj.try(:name).try(:split).try(:first).try(:capitalize) if @obj.try(:name).try(:split).try(:size).to_i > 1
   end
 
   def last_name
-    @obj.try(:name).try(:split).try(:last).try(:capitalize) if @obj.try(:name).try(:split).try(:size) > 1
+    @obj.try(:name).try(:split).try(:last).try(:capitalize) if @obj.try(:name).try(:split).try(:size).to_i > 1
   end
 end

--- a/app/models/concerns/liquidable.rb
+++ b/app/models/concerns/liquidable.rb
@@ -11,7 +11,7 @@ module Liquidable
   def message_drops
     {
       'contact' => ContactDrop.new(conversation.contact),
-      'agent' => UserDrop.new(sender),
+      'agent' => UserDrop.new(sender || conversation.assignee),
       'conversation' => ConversationDrop.new(conversation),
       'inbox' => InboxDrop.new(inbox),
       'account' => AccountDrop.new(conversation.account)


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where agent variables like `{{agent.name}}`,`{{agent.first_name}}`, `{{agent.last_name}}`, and `{{agent.email}}` were not rendering in automation messages.
In automation, these either showed blank or returned `Liquid error: internal`, while the same variables worked fine in macros.

**Cause**
Automation messages are created without a sender, so agent data was missing during variable rendering. This also caused errors in name handling, and `email` was not defined at all.

**Solution**
* Handle missing agent data safely to avoid errors
* Add support for `{{agent.email}}`
* Fallback to conversation assignee when sender is not present


Fixes https://linear.app/chatwoot/issue/CW-6979/template-variables-not-working-in-automated-messages

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Automation**
<img width="759" height="284" alt="image" src="https://github.com/user-attachments/assets/61a877b7-4984-4a7f-bbef-b8c510dcbdfe" />

**Before**
<img width="404" height="105" alt="image" src="https://github.com/user-attachments/assets/da665ce8-137d-4249-8ee5-a1acc11391db" />


**After**
<img width="564" height="132" alt="image" src="https://github.com/user-attachments/assets/6a80d67c-49c8-4658-b782-ae4acbc77256" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
