### PR TITLE
fix: Redirect to the conversation URL if custom_view is not available

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
@@ -1,5 +1,6 @@
 /* eslint arrow-body-style: 0 */
 import { frontendURL } from '../../../helper/URLHelper';
+import store from '../../../store';
 import ConversationView from './ConversationView.vue';
 
 const CONVERSATION_PERMISSIONS = [
@@ -9,6 +10,28 @@ const CONVERSATION_PERMISSIONS = [
   'conversation_unassigned_manage',
   'conversation_participating_manage',
 ];
+
+const redirectIfFolderUnavailable = async (to, _from, next) => {
+  let folders = store.getters['customViews/getConversationCustomViews'];
+  if (!folders.length) {
+    await store.dispatch('customViews/get', 'conversation');
+    folders = store.getters['customViews/getConversationCustomViews'];
+  }
+  const folderExists = folders.some(
+    folder => folder.id === Number(to.params.id)
+  );
+  if (!folderExists) {
+    next({
+      name: 'inbox_conversation',
+      params: {
+        accountId: to.params.accountId,
+        conversation_id: to.params.conversation_id,
+      },
+    });
+    return;
+  }
+  next();
+};
 
 export default {
   routes: [
@@ -125,6 +148,7 @@ export default {
         permissions: CONVERSATION_PERMISSIONS,
       },
       component: ConversationView,
+      beforeEnter: redirectIfFolderUnavailable,
       props: route => ({
         conversationId: route.params.conversation_id,
         foldersId: route.params.id,

--- a/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
@@ -11,30 +11,35 @@ const CONVERSATION_PERMISSIONS = [
   'conversation_participating_manage',
 ];
 
-const redirectIfFolderUnavailable = async (to, _from, next) => {
+const isFolderAvailable = async folderId => {
   let folders = store.getters['customViews/getConversationCustomViews'];
   if (!folders.length) {
     await store.dispatch('customViews/get', 'conversation');
     folders = store.getters['customViews/getConversationCustomViews'];
   }
-  const folderExists = folders.some(
-    folder => folder.id === Number(to.params.id)
-  );
-  if (!folderExists) {
-    if (to.params.conversation_id) {
-      next({
-        name: 'inbox_conversation',
-        params: {
-          accountId: to.params.accountId,
-          conversation_id: to.params.conversation_id,
-        },
-      });
-    } else {
-      next({ name: 'home', params: { accountId: to.params.accountId } });
-    }
+  return folders.some(folder => folder.id === Number(folderId));
+};
+
+const redirectFolderListIfUnavailable = async (to, _from, next) => {
+  if (await isFolderAvailable(to.params.id)) {
+    next();
     return;
   }
-  next();
+  next({ name: 'home', params: { accountId: to.params.accountId } });
+};
+
+const redirectFolderConversationIfUnavailable = async (to, _from, next) => {
+  if (await isFolderAvailable(to.params.id)) {
+    next();
+    return;
+  }
+  next({
+    name: 'inbox_conversation',
+    params: {
+      accountId: to.params.accountId,
+      conversation_id: to.params.conversation_id,
+    },
+  });
 };
 
 export default {
@@ -140,7 +145,7 @@ export default {
       meta: {
         permissions: CONVERSATION_PERMISSIONS,
       },
-      beforeEnter: redirectIfFolderUnavailable,
+      beforeEnter: redirectFolderListIfUnavailable,
       component: ConversationView,
       props: route => ({ foldersId: route.params.id }),
     },
@@ -153,7 +158,7 @@ export default {
         permissions: CONVERSATION_PERMISSIONS,
       },
       component: ConversationView,
-      beforeEnter: redirectIfFolderUnavailable,
+      beforeEnter: redirectFolderConversationIfUnavailable,
       props: route => ({
         conversationId: route.params.conversation_id,
         foldersId: route.params.id,

--- a/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
@@ -21,13 +21,17 @@ const redirectIfFolderUnavailable = async (to, _from, next) => {
     folder => folder.id === Number(to.params.id)
   );
   if (!folderExists) {
-    next({
-      name: 'inbox_conversation',
-      params: {
-        accountId: to.params.accountId,
-        conversation_id: to.params.conversation_id,
-      },
-    });
+    if (to.params.conversation_id) {
+      next({
+        name: 'inbox_conversation',
+        params: {
+          accountId: to.params.accountId,
+          conversation_id: to.params.conversation_id,
+        },
+      });
+    } else {
+      next({ name: 'home', params: { accountId: to.params.accountId } });
+    }
     return;
   }
   next();
@@ -136,6 +140,7 @@ export default {
       meta: {
         permissions: CONVERSATION_PERMISSIONS,
       },
+      beforeEnter: redirectIfFolderUnavailable,
       component: ConversationView,
       props: route => ({ foldersId: route.params.id }),
     },


### PR DESCRIPTION
When an agent shares a conversation link copied from a custom view (e.g. /custom_view/{id}/conversations/{id}), the link previously broke for recipients who didn't have access to that custom view. The conversation now loads regardless — if the custom view isn't available to the recipient, they're redirected to the direct conversation URL.

### How to reproduce

1. As Agent A, open a conversation from inside a personal custom view and copy the URL from the address bar.
2. Share the URL with Agent B who does not have access to that custom view.
3. Before this fix, the link failed to load the conversation. After this fix, Agent B lands on the conversation via the direct URL.

### What changed

 - Added a beforeEnter guard on the conversations_through_folders route. It checks the user's available conversation custom views (fetching them on demand for deep links), and if the foldersId in the URL isn't among them, redirects to the inbox_conversation route with the same conversation_id.