### PR TITLE
fix: use a dedicated PAT for ghsa linear sync gh action

### DIFF
--- a/.github/scripts/ghsa_linear_sync.py
+++ b/.github/scripts/ghsa_linear_sync.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Sync triage GitHub security advisories to Linear issues.
+
+Behaviour mirrors the previous inline bash workflow: fetch all triage
+advisories, dedupe against Linear by GHSA ID in the issue title, create
+missing Linear issues with full advisory content in the description,
+and post a Discord embed when DISCORD_WEBHOOK_URL is set.
+
+The script prints an aggregate count line; it does not log GHSA IDs or
+Linear ticket URLs, so logs are safe to leave in public Actions output.
+Exit code is non-zero if any creation failed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+GITHUB_API = "https://api.github.com"
+LINEAR_API = "https://api.linear.app/graphql"
+
+SEVERITY_PRIORITY = {"critical": 1, "high": 2, "medium": 3, "low": 4}
+SEVERITY_COLOR = {
+    "critical": 15548997,
+    "high": 15105570,
+    "medium": 15844367,
+    "low": 3066993,
+}
+DEFAULT_COLOR = 9807270
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        sys.exit(f"Missing required env var: {name}")
+    return value
+
+
+def http_json(url: str, headers: dict[str, str], payload: dict[str, Any] | None = None) -> tuple[dict[str, Any] | list[Any], dict[str, str]]:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req_headers = dict(headers)
+    if payload is not None:
+        req_headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=req_headers)
+    with urllib.request.urlopen(req) as resp:
+        body = json.loads(resp.read())
+        return body, dict(resp.headers)
+
+
+def next_link(link_header: str | None) -> str | None:
+    if not link_header:
+        return None
+    for chunk in link_header.split(","):
+        parts = [p.strip() for p in chunk.split(";")]
+        if len(parts) < 2:
+            continue
+        url = parts[0].strip("<>")
+        if parts[1] == 'rel="next"':
+            return url
+    return None
+
+
+def fetch_triage_advisories(repo: str, token: str) -> list[dict[str, Any]]:
+    url: str | None = (
+        f"{GITHUB_API}/repos/{repo}/security-advisories?state=triage&per_page=100"
+    )
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    advisories: list[dict[str, Any]] = []
+    while url:
+        page, resp_headers = http_json(url, headers)
+        assert isinstance(page, list)
+        advisories.extend(page)
+        url = next_link(resp_headers.get("Link"))
+    return advisories
+
+
+def linear_query(query: str, variables: dict[str, Any], api_key: str) -> dict[str, Any]:
+    body, _ = http_json(
+        LINEAR_API,
+        {"Authorization": api_key},
+        {"query": query, "variables": variables},
+    )
+    assert isinstance(body, dict)
+    return body
+
+
+def linear_issue_exists(ghsa_id: str, api_key: str) -> bool:
+    query = (
+        "query($q: String!) { issues(filter: {title: {contains: $q}}, first: 1) "
+        "{ nodes { id } } }"
+    )
+    resp = linear_query(query, {"q": ghsa_id}, api_key)
+    nodes = resp.get("data", {}).get("issues", {}).get("nodes", [])
+    return len(nodes) > 0
+
+
+def linear_create_issue(input_data: dict[str, Any], api_key: str) -> dict[str, str] | None:
+    query = (
+        "mutation($input: IssueCreateInput!) { issueCreate(input: $input) "
+        "{ success issue { identifier url } } }"
+    )
+    resp = linear_query(query, {"input": input_data}, api_key)
+    create = resp.get("data", {}).get("issueCreate") or {}
+    if not create.get("success"):
+        return None
+    return create.get("issue")
+
+
+def reporter_login(advisory: dict[str, Any]) -> str:
+    for credit in advisory.get("credits") or []:
+        user = (credit or {}).get("user") or {}
+        login = user.get("login")
+        if login:
+            return login
+    return "unknown"
+
+
+def cvss_score(advisory: dict[str, Any]) -> str:
+    score = (advisory.get("cvss") or {}).get("score")
+    return str(score) if score is not None else "n/a"
+
+
+def build_description(adv: dict[str, Any]) -> str:
+    return (
+        f"**GHSA:** {adv['ghsa_id']}\n"
+        f"**CVE:** {adv.get('cve_id') or 'n/a'}\n"
+        f"**Severity:** {adv.get('severity') or 'unknown'} (CVSS {cvss_score(adv)})\n"
+        f"**Reporter:** {reporter_login(adv)}\n"
+        f"**Reported:** {(adv.get('created_at') or '').split('T')[0]}\n"
+        f"**Advisory:** {adv['html_url']}\n\n"
+        f"---\n\n"
+        f"{adv.get('description') or 'No description provided.'}"
+    )
+
+
+def post_discord(adv: dict[str, Any], issue: dict[str, str], webhook_url: str) -> None:
+    severity = adv.get("severity") or "unknown"
+    title = f"[{adv['ghsa_id']}] {adv['summary']}"[:250]
+    payload = {
+        "username": "GHSA Sync",
+        "embeds": [
+            {
+                "title": title,
+                "url": issue["url"],
+                "color": SEVERITY_COLOR.get(severity, DEFAULT_COLOR),
+                "fields": [
+                    {"name": "Linear", "value": issue["identifier"], "inline": True},
+                    {
+                        "name": "Severity",
+                        "value": f"{severity} (CVSS {cvss_score(adv)})",
+                        "inline": True,
+                    },
+                    {
+                        "name": "Advisory",
+                        "value": f"[GitHub]({adv['html_url']})",
+                        "inline": True,
+                    },
+                ],
+            }
+        ],
+    }
+    try:
+        http_json(webhook_url, {}, payload)
+    except (urllib.error.URLError, json.JSONDecodeError):
+        pass
+
+
+def main() -> int:
+    repo = required_env("GITHUB_REPOSITORY")
+    gh_token = required_env("GHSA_READ_TOKEN")
+    linear_api_key = required_env("LINEAR_API_KEY")
+    team_id = required_env("LINEAR_TEAM_ID")
+    project_id = required_env("LINEAR_PROJECT_ID")
+    label_id = required_env("LINEAR_LABEL_ID")
+    discord_webhook = os.environ.get("DISCORD_WEBHOOK_URL") or None
+
+    advisories = fetch_triage_advisories(repo, gh_token)
+    print(f"Fetched {len(advisories)} triage advisories")
+
+    created = skipped = failed = 0
+
+    for adv in advisories:
+        ghsa_id = adv.get("ghsa_id")
+        if not ghsa_id:
+            failed += 1
+            continue
+
+        try:
+            if linear_issue_exists(ghsa_id, linear_api_key):
+                skipped += 1
+                continue
+
+            severity = adv.get("severity") or "unknown"
+            issue = linear_create_issue(
+                {
+                    "title": f"[{ghsa_id}] {adv.get('summary', '')}",
+                    "description": build_description(adv),
+                    "teamId": team_id,
+                    "projectId": project_id,
+                    "labelIds": [label_id],
+                    "priority": SEVERITY_PRIORITY.get(severity, 3),
+                },
+                linear_api_key,
+            )
+        except (urllib.error.URLError, KeyError, json.JSONDecodeError):
+            failed += 1
+            continue
+
+        if not issue:
+            failed += 1
+            continue
+
+        created += 1
+        if discord_webhook:
+            post_discord(adv, issue, discord_webhook)
+
+    print(f"Created {created}, skipped {skipped}, failed {failed}")
+    return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/ghsa_linear_sync.py
+++ b/.github/scripts/ghsa_linear_sync.py
@@ -1,24 +1,13 @@
 #!/usr/bin/env python3
-"""Sync triage GitHub security advisories to Linear issues.
-
-Behaviour mirrors the previous inline bash workflow: fetch all triage
-advisories, dedupe against Linear by GHSA ID in the issue title, create
-missing Linear issues with full advisory content in the description,
-and post a Discord embed when DISCORD_WEBHOOK_URL is set.
-
-The script prints an aggregate count line; it does not log GHSA IDs or
-Linear ticket URLs, so logs are safe to leave in public Actions output.
-Exit code is non-zero if any creation failed.
-"""
+"""Sync triage GitHub security advisories to Linear issues."""
 
 from __future__ import annotations
 
-import json
 import os
 import sys
-import urllib.error
-import urllib.request
 from typing import Any
+
+import requests
 
 GITHUB_API = "https://api.github.com"
 LINEAR_API = "https://api.linear.app/graphql"
@@ -40,34 +29,9 @@ def required_env(name: str) -> str:
     return value
 
 
-def http_json(url: str, headers: dict[str, str], payload: dict[str, Any] | None = None) -> tuple[dict[str, Any] | list[Any], dict[str, str]]:
-    data = json.dumps(payload).encode("utf-8") if payload is not None else None
-    req_headers = dict(headers)
-    if payload is not None:
-        req_headers["Content-Type"] = "application/json"
-    req = urllib.request.Request(url, data=data, headers=req_headers)
-    with urllib.request.urlopen(req) as resp:
-        body = json.loads(resp.read())
-        return body, dict(resp.headers)
-
-
-def next_link(link_header: str | None) -> str | None:
-    if not link_header:
-        return None
-    for chunk in link_header.split(","):
-        parts = [p.strip() for p in chunk.split(";")]
-        if len(parts) < 2:
-            continue
-        url = parts[0].strip("<>")
-        if parts[1] == 'rel="next"':
-            return url
-    return None
-
-
 def fetch_triage_advisories(repo: str, token: str) -> list[dict[str, Any]]:
-    url: str | None = (
-        f"{GITHUB_API}/repos/{repo}/security-advisories?state=triage&per_page=100"
-    )
+    url: str | None = f"{GITHUB_API}/repos/{repo}/security-advisories"
+    params: dict[str, Any] | None = {"state": "triage", "per_page": 100}
     headers = {
         "Accept": "application/vnd.github+json",
         "Authorization": f"Bearer {token}",
@@ -75,21 +39,24 @@ def fetch_triage_advisories(repo: str, token: str) -> list[dict[str, Any]]:
     }
     advisories: list[dict[str, Any]] = []
     while url:
-        page, resp_headers = http_json(url, headers)
-        assert isinstance(page, list)
-        advisories.extend(page)
-        url = next_link(resp_headers.get("Link"))
+        r = requests.get(url, headers=headers, params=params, timeout=30)
+        r.raise_for_status()
+        advisories.extend(r.json())
+        next_link = r.links.get("next")
+        url = next_link["url"] if next_link else None
+        params = None
     return advisories
 
 
-def linear_query(query: str, variables: dict[str, Any], api_key: str) -> dict[str, Any]:
-    body, _ = http_json(
+def linear_call(query: str, variables: dict[str, Any], api_key: str) -> dict[str, Any]:
+    r = requests.post(
         LINEAR_API,
-        {"Authorization": api_key},
-        {"query": query, "variables": variables},
+        headers={"Authorization": api_key},
+        json={"query": query, "variables": variables},
+        timeout=30,
     )
-    assert isinstance(body, dict)
-    return body
+    r.raise_for_status()
+    return r.json()
 
 
 def linear_issue_exists(ghsa_id: str, api_key: str) -> bool:
@@ -97,9 +64,8 @@ def linear_issue_exists(ghsa_id: str, api_key: str) -> bool:
         "query($q: String!) { issues(filter: {title: {contains: $q}}, first: 1) "
         "{ nodes { id } } }"
     )
-    resp = linear_query(query, {"q": ghsa_id}, api_key)
-    nodes = resp.get("data", {}).get("issues", {}).get("nodes", [])
-    return len(nodes) > 0
+    resp = linear_call(query, {"q": ghsa_id}, api_key)
+    return len(resp.get("data", {}).get("issues", {}).get("nodes", [])) > 0
 
 
 def linear_create_issue(input_data: dict[str, Any], api_key: str) -> dict[str, str] | None:
@@ -107,7 +73,7 @@ def linear_create_issue(input_data: dict[str, Any], api_key: str) -> dict[str, s
         "mutation($input: IssueCreateInput!) { issueCreate(input: $input) "
         "{ success issue { identifier url } } }"
     )
-    resp = linear_query(query, {"input": input_data}, api_key)
+    resp = linear_call(query, {"input": input_data}, api_key)
     create = resp.get("data", {}).get("issueCreate") or {}
     if not create.get("success"):
         return None
@@ -117,9 +83,8 @@ def linear_create_issue(input_data: dict[str, Any], api_key: str) -> dict[str, s
 def reporter_login(advisory: dict[str, Any]) -> str:
     for credit in advisory.get("credits") or []:
         user = (credit or {}).get("user") or {}
-        login = user.get("login")
-        if login:
-            return login
+        if user.get("login"):
+            return user["login"]
     return "unknown"
 
 
@@ -168,8 +133,8 @@ def post_discord(adv: dict[str, Any], issue: dict[str, str], webhook_url: str) -
         ],
     }
     try:
-        http_json(webhook_url, {}, payload)
-    except (urllib.error.URLError, json.JSONDecodeError):
+        requests.post(webhook_url, json=payload, timeout=10)
+    except requests.RequestException:
         pass
 
 
@@ -210,7 +175,7 @@ def main() -> int:
                 },
                 linear_api_key,
             )
-        except (urllib.error.URLError, KeyError, json.JSONDecodeError):
+        except requests.RequestException:
             failed += 1
             continue
 

--- a/.github/workflows/ghsa-linear-sync.yml
+++ b/.github/workflows/ghsa-linear-sync.yml
@@ -33,6 +33,7 @@ jobs:
           LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
           LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}
           LINEAR_LABEL_ID: ${{ secrets.LINEAR_LABEL_ID }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           created_count=0
           skipped_count=0
@@ -71,7 +72,7 @@ jobs:
             body=$(printf '**GHSA:** %s\n**CVE:** %s\n**Severity:** %s (CVSS %s)\n**Reporter:** %s\n**Reported:** %s\n**Advisory:** %s\n\n---\n\n%s' \
               "$ghsa_id" "$cve_id" "$severity" "$cvss" "$reporter" "$created_date" "$html_url" "$description")
 
-            success=$(curl -s -X POST https://api.linear.app/graphql \
+            create_response=$(curl -s -X POST https://api.linear.app/graphql \
               -H "Content-Type: application/json" \
               -H "Authorization: $LINEAR_API_KEY" \
               -d "$(jq -n \
@@ -82,14 +83,51 @@ jobs:
                 --arg labelId "$LINEAR_LABEL_ID" \
                 --argjson priority "$priority" \
                 '{
-                  query: "mutation($input: IssueCreateInput!) { issueCreate(input: $input) { success } }",
+                  query: "mutation($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { identifier url } } }",
                   variables: {input: {title: $title, description: $body, teamId: $teamId, projectId: $projectId, labelIds: [$labelId], priority: $priority}}
-                }')" | jq -r '.data.issueCreate.success // false')
+                }')")
+            success=$(printf '%s' "$create_response" | jq -r '.data.issueCreate.success // false')
 
-            if [ "$success" = "true" ]; then
-              created_count=$((created_count+1))
-            else
+            if [ "$success" != "true" ]; then
               failed_count=$((failed_count+1))
+              continue
+            fi
+
+            created_count=$((created_count+1))
+
+            if [ -n "${DISCORD_WEBHOOK_URL:-}" ]; then
+              linear_url=$(printf '%s' "$create_response" | jq -r '.data.issueCreate.issue.url')
+              linear_id=$(printf '%s' "$create_response" | jq -r '.data.issueCreate.issue.identifier')
+              case "$severity" in
+                critical) color=15548997 ;;
+                high)     color=15105570 ;;
+                medium)   color=15844367 ;;
+                low)      color=3066993  ;;
+                *)        color=9807270  ;;
+              esac
+              discord_payload=$(jq -n \
+                --arg title "$title" \
+                --arg url "$linear_url" \
+                --arg ident "$linear_id" \
+                --arg severity "$severity" \
+                --arg cvss "$cvss" \
+                --arg advisory "$html_url" \
+                --argjson color "$color" \
+                '{
+                  username: "GHSA Sync",
+                  embeds: [{
+                    title: ($title | .[0:250]),
+                    url: $url,
+                    color: $color,
+                    fields: [
+                      {name: "Linear", value: $ident, inline: true},
+                      {name: "Severity", value: "\($severity) (CVSS \($cvss))", inline: true},
+                      {name: "Advisory", value: "[GitHub](\($advisory))", inline: true}
+                    ]
+                  }]
+                }')
+              curl -s -o /dev/null -X POST -H "Content-Type: application/json" \
+                -d "$discord_payload" "$DISCORD_WEBHOOK_URL" || true
             fi
           done < <(jq -c '.[]' advisories.json)
           echo "Created $created_count, skipped $skipped_count, failed $failed_count"

--- a/.github/workflows/ghsa-linear-sync.yml
+++ b/.github/workflows/ghsa-linear-sync.yml
@@ -12,125 +12,16 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Fetch triage advisories
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Sync advisories
         env:
-          GH_TOKEN: ${{ secrets.GHSA_READ_TOKEN }}
-        run: |
-          gh api --paginate \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${{ github.repository }}/security-advisories?state=triage&per_page=100" \
-            | jq -cs 'add | [.[] | {
-                ghsa_id, cve_id, summary, severity, state, html_url,
-                description, created_at,
-                cvss_score: .cvss.score,
-                reporter: ([.credits[]?.user.login] | first // "unknown")
-              }]' > advisories.json
-          echo "Fetched $(jq 'length' advisories.json) triage advisories"
-
-      - name: Create Linear issues for new advisories
-        env:
+          GHSA_READ_TOKEN: ${{ secrets.GHSA_READ_TOKEN }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
           LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}
           LINEAR_LABEL_ID: ${{ secrets.LINEAR_LABEL_ID }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-        run: |
-          created_count=0
-          skipped_count=0
-          failed_count=0
-          while read -r advisory; do
-            ghsa_id=$(printf '%s' "$advisory" | jq -r '.ghsa_id')
-            summary=$(printf '%s' "$advisory" | jq -r '.summary')
-            severity=$(printf '%s' "$advisory" | jq -r '.severity // "unknown"')
-            cve_id=$(printf '%s' "$advisory" | jq -r '.cve_id // "n/a"')
-            cvss=$(printf '%s' "$advisory" | jq -r '.cvss_score // "n/a"')
-            reporter=$(printf '%s' "$advisory" | jq -r '.reporter')
-            html_url=$(printf '%s' "$advisory" | jq -r '.html_url')
-            created_date=$(printf '%s' "$advisory" | jq -r '.created_at' | cut -dT -f1)
-            description=$(printf '%s' "$advisory" | jq -r '.description // "No description provided."')
-
-            existing=$(curl -s -X POST https://api.linear.app/graphql \
-              -H "Content-Type: application/json" \
-              -H "Authorization: $LINEAR_API_KEY" \
-              -d "$(jq -n --arg q "$ghsa_id" '{query: "query($q: String!) { issues(filter: {title: {contains: $q}}, first: 1) { nodes { id } } }", variables: {q: $q}}')" \
-              | jq '.data.issues.nodes | length')
-
-            if [ "${existing:-0}" -gt 0 ] 2>/dev/null; then
-              skipped_count=$((skipped_count+1))
-              continue
-            fi
-
-            priority=3
-            case "$severity" in
-              critical) priority=1 ;;
-              high)     priority=2 ;;
-              medium)   priority=3 ;;
-              low)      priority=4 ;;
-            esac
-
-            title="[$ghsa_id] $summary"
-            body=$(printf '**GHSA:** %s\n**CVE:** %s\n**Severity:** %s (CVSS %s)\n**Reporter:** %s\n**Reported:** %s\n**Advisory:** %s\n\n---\n\n%s' \
-              "$ghsa_id" "$cve_id" "$severity" "$cvss" "$reporter" "$created_date" "$html_url" "$description")
-
-            create_response=$(curl -s -X POST https://api.linear.app/graphql \
-              -H "Content-Type: application/json" \
-              -H "Authorization: $LINEAR_API_KEY" \
-              -d "$(jq -n \
-                --arg title "$title" \
-                --arg body "$body" \
-                --arg teamId "$LINEAR_TEAM_ID" \
-                --arg projectId "$LINEAR_PROJECT_ID" \
-                --arg labelId "$LINEAR_LABEL_ID" \
-                --argjson priority "$priority" \
-                '{
-                  query: "mutation($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { identifier url } } }",
-                  variables: {input: {title: $title, description: $body, teamId: $teamId, projectId: $projectId, labelIds: [$labelId], priority: $priority}}
-                }')")
-            success=$(printf '%s' "$create_response" | jq -r '.data.issueCreate.success // false')
-
-            if [ "$success" != "true" ]; then
-              failed_count=$((failed_count+1))
-              continue
-            fi
-
-            created_count=$((created_count+1))
-
-            if [ -n "${DISCORD_WEBHOOK_URL:-}" ]; then
-              linear_url=$(printf '%s' "$create_response" | jq -r '.data.issueCreate.issue.url')
-              linear_id=$(printf '%s' "$create_response" | jq -r '.data.issueCreate.issue.identifier')
-              case "$severity" in
-                critical) color=15548997 ;;
-                high)     color=15105570 ;;
-                medium)   color=15844367 ;;
-                low)      color=3066993  ;;
-                *)        color=9807270  ;;
-              esac
-              discord_payload=$(jq -n \
-                --arg title "$title" \
-                --arg url "$linear_url" \
-                --arg ident "$linear_id" \
-                --arg severity "$severity" \
-                --arg cvss "$cvss" \
-                --arg advisory "$html_url" \
-                --argjson color "$color" \
-                '{
-                  username: "GHSA Sync",
-                  embeds: [{
-                    title: ($title | .[0:250]),
-                    url: $url,
-                    color: $color,
-                    fields: [
-                      {name: "Linear", value: $ident, inline: true},
-                      {name: "Severity", value: "\($severity) (CVSS \($cvss))", inline: true},
-                      {name: "Advisory", value: "[GitHub](\($advisory))", inline: true}
-                    ]
-                  }]
-                }')
-              curl -s -o /dev/null -X POST -H "Content-Type: application/json" \
-                -d "$discord_payload" "$DISCORD_WEBHOOK_URL" || true
-            fi
-          done < <(jq -c '.[]' advisories.json)
-          echo "Created $created_count, skipped $skipped_count, failed $failed_count"
-          if [ "$failed_count" -gt 0 ]; then
-            exit 1
-          fi
+        run: python3 .github/scripts/ghsa_linear_sync.py

--- a/.github/workflows/ghsa-linear-sync.yml
+++ b/.github/workflows/ghsa-linear-sync.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Install dependencies
+        run: pip install requests==2.32.3
       - name: Sync advisories
         env:
           GHSA_READ_TOKEN: ${{ secrets.GHSA_READ_TOKEN }}

--- a/.github/workflows/ghsa-linear-sync.yml
+++ b/.github/workflows/ghsa-linear-sync.yml
@@ -8,12 +8,10 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    permissions:
-      security-events: read
     steps:
       - name: Fetch triage advisories
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GHSA_READ_TOKEN }}
         run: |
           gh api --paginate \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/ghsa-linear-sync.yml
+++ b/.github/workflows/ghsa-linear-sync.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 4 * * *'  # daily at 09:30 IST
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The default `GITHUB_TOKEN` cannot read `/repos/.../security-advisories`; that endpoint requires the `repository_advisories` permission, which is not available to the GitHub Actions installation token.

Switche to a fine-grained PAT stored in `GHSA_READ_TOKEN`.

Tested locally: the same PAT returns the full triage list

Changes
----
- Switch to custom token
- Add a discord alert for new advisories
- Switch to python