### PR TITLE
feat(crm): add account owners to contacts and companies

### DIFF
--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -208,14 +208,9 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def fetch_contact
-    contact_scope = Current.account.contacts
-    contact_scope = contact_scope.includes(account_owner: [:account_users, { avatar_attachment: [:blob] }]) if include_account_owner?
+    contact_scope = Current.account.contacts.includes(account_owner: [:account_users, { avatar_attachment: [:blob] }])
     contact_scope = contact_scope.includes(contact_inboxes: [:inbox]) if @include_contact_inboxes
     @contact = contact_scope.find(params[:id])
-  end
-
-  def include_account_owner?
-    %w[show update avatar destroy_custom_attributes].include?(action_name)
   end
 
   def process_avatar_from_url

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -132,7 +132,10 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
   def fetch_contacts(contacts)
     # Build includes hash to avoid separate query when contact_inboxes are needed
-    includes_hash = { avatar_attachment: [:blob] }
+    includes_hash = {
+      avatar_attachment: [:blob],
+      account_owner: [:account_users, { avatar_attachment: [:blob] }]
+    }
     includes_hash[:contact_inboxes] = { inbox: :channel } if @include_contact_inboxes
 
     filtrate(contacts)
@@ -142,7 +145,10 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def fetch_contacts_with_has_more(contacts)
-    includes_hash = { avatar_attachment: [:blob] }
+    includes_hash = {
+      avatar_attachment: [:blob],
+      account_owner: [:account_users, { avatar_attachment: [:blob] }]
+    }
     includes_hash[:contact_inboxes] = { inbox: :channel } if @include_contact_inboxes
 
     # Calculate offset manually to fetch one extra record for has_more check
@@ -171,7 +177,8 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def permitted_params
-    params.permit(:name, :identifier, :email, :phone_number, :avatar, :blocked, :avatar_url, additional_attributes: {}, custom_attributes: {})
+    params.permit(:name, :identifier, :email, :phone_number, :avatar, :blocked, :avatar_url, :account_owner_id,
+                  additional_attributes: {}, custom_attributes: {})
   end
 
   def contact_custom_attributes
@@ -202,8 +209,13 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
 
   def fetch_contact
     contact_scope = Current.account.contacts
+    contact_scope = contact_scope.includes(account_owner: [:account_users, { avatar_attachment: [:blob] }]) if include_account_owner?
     contact_scope = contact_scope.includes(contact_inboxes: [:inbox]) if @include_contact_inboxes
     @contact = contact_scope.find(params[:id])
+  end
+
+  def include_account_owner?
+    %w[show update avatar destroy_custom_attributes].include?(action_name)
   end
 
   def process_avatar_from_url

--- a/app/javascript/dashboard/api/companies.js
+++ b/app/javascript/dashboard/api/companies.js
@@ -1,4 +1,5 @@
 /* global axios */
+import snakecaseKeys from 'snakecase-keys';
 import ApiClient from './ApiClient';
 
 export const buildCompanyParams = (page, sort) => {
@@ -17,6 +18,10 @@ export const buildSearchParams = (query, page, sort) => {
   return params;
 };
 
+export const buildCompanyPayload = data => ({
+  company: snakecaseKeys(data, { deep: true }),
+});
+
 class CompanyAPI extends ApiClient {
   constructor() {
     super('companies', { accountScoped: true });
@@ -31,6 +36,14 @@ class CompanyAPI extends ApiClient {
   search(query = '', page = 1, sort = 'name') {
     const requestURL = `${this.url}/search?${buildSearchParams(query, page, sort)}`;
     return axios.get(requestURL);
+  }
+
+  create(data) {
+    return axios.post(this.url, buildCompanyPayload(data));
+  }
+
+  update(id, data) {
+    return axios.patch(`${this.url}/${id}`, buildCompanyPayload(data));
   }
 }
 

--- a/app/javascript/dashboard/api/specs/companies.spec.js
+++ b/app/javascript/dashboard/api/specs/companies.spec.js
@@ -26,6 +26,7 @@ describe('#CompanyAPI', () => {
 
     beforeEach(() => {
       window.axios = axiosMock;
+      vi.clearAllMocks();
     });
 
     afterEach(() => {
@@ -79,6 +80,32 @@ describe('#CompanyAPI', () => {
       expect(axiosMock.get).toHaveBeenCalledWith(
         '/api/v1/companies/search?q=&page=1&sort=name'
       );
+    });
+
+    it('#create wraps company payload and snakecases account owner id', () => {
+      companyAPI.create({
+        name: 'Acme',
+        domain: 'acme.com',
+        accountOwnerId: 7,
+      });
+
+      expect(axiosMock.post).toHaveBeenCalledWith('/api/v1/companies', {
+        company: {
+          name: 'Acme',
+          domain: 'acme.com',
+          account_owner_id: 7,
+        },
+      });
+    });
+
+    it('#update wraps company payload and snakecases account owner id', () => {
+      companyAPI.update(12, { accountOwnerId: 7 });
+
+      expect(axiosMock.patch).toHaveBeenCalledWith('/api/v1/companies/12', {
+        company: {
+          account_owner_id: 7,
+        },
+      });
     });
   });
 });

--- a/app/javascript/dashboard/components-next/AccountOwner/AccountOwnerSelect.vue
+++ b/app/javascript/dashboard/components-next/AccountOwner/AccountOwnerSelect.vue
@@ -35,7 +35,14 @@ const ownerOptions = computed(() => [
 ]);
 
 const handleUpdate = value => {
-  emit('update:modelValue', value === UNASSIGNED_VALUE ? '' : value);
+  if (value === UNASSIGNED_VALUE) {
+    emit('update:modelValue', '');
+    return;
+  }
+
+  if (value === '') return;
+
+  emit('update:modelValue', value);
 };
 </script>
 

--- a/app/javascript/dashboard/components-next/AccountOwner/AccountOwnerSelect.vue
+++ b/app/javascript/dashboard/components-next/AccountOwner/AccountOwnerSelect.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
+
+const props = defineProps({
+  modelValue: {
+    type: [String, Number],
+    default: '',
+  },
+  agents: {
+    type: Array,
+    default: () => [],
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const { t } = useI18n();
+const UNASSIGNED_VALUE = '__account_owner_unassigned__';
+
+const ownerOptions = computed(() => [
+  ...(props.modelValue
+    ? [{ label: t('ACCOUNT_OWNER.UNASSIGNED'), value: UNASSIGNED_VALUE }]
+    : []),
+  ...props.agents.map(agent => ({
+    label:
+      agent.available_name || agent.availableName || agent.name || agent.email,
+    value: agent.id,
+  })),
+]);
+
+const handleUpdate = value => {
+  emit('update:modelValue', value === UNASSIGNED_VALUE ? '' : value);
+};
+</script>
+
+<template>
+  <ComboBox
+    :model-value="modelValue || ''"
+    :options="ownerOptions"
+    :placeholder="t('ACCOUNT_OWNER.LABEL')"
+    :search-placeholder="t('ACCOUNT_OWNER.SEARCH_PLACEHOLDER')"
+    :empty-state="t('ACCOUNT_OWNER.EMPTY_STATE')"
+    :disabled="disabled"
+    @update:model-value="handleUpdate"
+  />
+</template>

--- a/app/javascript/dashboard/components-next/AccountOwner/specs/AccountOwnerSelect.spec.js
+++ b/app/javascript/dashboard/components-next/AccountOwner/specs/AccountOwnerSelect.spec.js
@@ -1,0 +1,105 @@
+import { mount, shallowMount } from '@vue/test-utils';
+import AccountOwnerSelect from '../AccountOwnerSelect.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: key =>
+      ({
+        'ACCOUNT_OWNER.LABEL': 'Account Owner',
+        'ACCOUNT_OWNER.UNASSIGNED': 'Unassigned',
+        'ACCOUNT_OWNER.SEARCH_PLACEHOLDER': 'Search agents',
+        'ACCOUNT_OWNER.EMPTY_STATE': 'No agents found',
+      })[key] || key,
+  }),
+}));
+
+describe('AccountOwnerSelect', () => {
+  it('renders the exact Account Owner label through the combobox placeholder', () => {
+    const wrapper = shallowMount(AccountOwnerSelect, {
+      props: {
+        agents: [{ id: 7, name: 'Asha Agent', email: 'asha@example.com' }],
+        modelValue: '',
+      },
+      global: {
+        stubs: { ComboBox: true },
+      },
+    });
+
+    expect(
+      wrapper.findComponent({ name: 'ComboBox' }).props('placeholder')
+    ).toBe('Account Owner');
+  });
+
+  it('shows Account Owner in the closed control when no owner is selected', () => {
+    const wrapper = mount(AccountOwnerSelect, {
+      props: {
+        agents: [{ id: 7, name: 'Asha Agent', email: 'asha@example.com' }],
+        modelValue: '',
+      },
+      global: {
+        stubs: {
+          OnClickOutside: { template: '<div><slot /></div>' },
+        },
+      },
+    });
+
+    expect(wrapper.find('button').text()).toContain('Account Owner');
+    expect(wrapper.find('button').text()).not.toContain('Unassigned');
+  });
+
+  it('does not include Unassigned as an option when no owner is selected', () => {
+    const wrapper = shallowMount(AccountOwnerSelect, {
+      props: {
+        agents: [{ id: 7, name: 'Asha Agent', email: 'asha@example.com' }],
+        modelValue: '',
+      },
+      global: {
+        stubs: { ComboBox: true },
+      },
+    });
+
+    expect(
+      wrapper.findComponent({ name: 'ComboBox' }).props('options')
+    ).toEqual([{ label: 'Asha Agent', value: 7 }]);
+  });
+
+  it('emits an empty value when Unassigned is selected from an assigned owner', async () => {
+    const wrapper = shallowMount(AccountOwnerSelect, {
+      props: {
+        agents: [{ id: 7, name: 'Asha Agent', email: 'asha@example.com' }],
+        modelValue: 7,
+      },
+      global: {
+        stubs: { ComboBox: true },
+      },
+    });
+    const unassignedOption = wrapper
+      .findComponent({ name: 'ComboBox' })
+      .props('options')
+      .find(option => option.label === 'Unassigned');
+
+    await wrapper
+      .findComponent({ name: 'ComboBox' })
+      .vm.$emit('update:modelValue', unassignedOption.value);
+
+    expect(wrapper.emitted('update:modelValue')[0]).toEqual(['']);
+  });
+
+  it('emits selected owner id', async () => {
+    const wrapper = shallowMount(AccountOwnerSelect, {
+      props: {
+        agents: [{ id: 7, name: 'Asha Agent', email: 'asha@example.com' }],
+        modelValue: '',
+      },
+      global: {
+        stubs: { ComboBox: true },
+      },
+    });
+
+    await wrapper
+      .findComponent({ name: 'ComboBox' })
+      .vm.$emit('update:modelValue', 7);
+
+    expect(wrapper.emitted('update:modelValue')[0]).toEqual([7]);
+  });
+});

--- a/app/javascript/dashboard/components-next/Companies/CompaniesCard/CompaniesCard.vue
+++ b/app/javascript/dashboard/components-next/Companies/CompaniesCard/CompaniesCard.vue
@@ -6,6 +6,7 @@ import { formatDistanceToNow } from 'date-fns';
 import CardLayout from 'dashboard/components-next/CardLayout.vue';
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
+import AccountOwnerSelect from 'dashboard/components-next/AccountOwner/AccountOwnerSelect.vue';
 
 const props = defineProps({
   id: { type: Number, required: true },
@@ -15,9 +16,14 @@ const props = defineProps({
   description: { type: String, default: '' },
   avatarUrl: { type: String, default: '' },
   updatedAt: { type: [String, Number], default: null },
+  accountOwnerId: { type: [Number, String], default: '' },
+  accountOwner: { type: Object, default: null },
+  agents: { type: Array, default: () => [] },
+  isUpdating: { type: Boolean, default: false },
+  ownerPickerResetKey: { type: [Number, String], default: 0 },
 });
 
-const emit = defineEmits(['showCompany']);
+const emit = defineEmits(['showCompany', 'updateOwner']);
 
 const { t } = useI18n();
 
@@ -27,6 +33,27 @@ const displayName = computed(() => props.name || t('COMPANIES.UNNAMED'));
 
 const avatarSource = computed(() => props.avatarUrl || null);
 
+const ownerModelValue = computed(() => props.accountOwnerId || '');
+
+const ownerSelectKey = computed(
+  () => `${ownerModelValue.value || 'unassigned'}-${props.ownerPickerResetKey}`
+);
+
+const accountOwnerTitle = computed(
+  () =>
+    props.accountOwner?.availableName ||
+    props.accountOwner?.available_name ||
+    props.accountOwner?.name ||
+    ''
+);
+
+const handleOwnerUpdate = accountOwnerId => {
+  emit('updateOwner', {
+    id: props.id,
+    accountOwnerId: accountOwnerId || null,
+  });
+};
+
 const formattedUpdatedAt = computed(() => {
   if (!props.updatedAt) return '';
   return formatDistanceToNow(new Date(props.updatedAt), { addSuffix: true });
@@ -35,60 +62,86 @@ const formattedUpdatedAt = computed(() => {
 
 <template>
   <CardLayout layout="row" @click="onClickViewDetails">
-    <div class="flex items-center justify-start flex-1 gap-4">
-      <Avatar
-        :username="displayName"
-        :src="avatarSource"
-        class="shrink-0"
-        :name="name"
-        :size="48"
-        hide-offline-status
-        rounded-full
-      />
-      <div class="flex flex-col gap-0.5 flex-1 min-w-0">
-        <div class="flex flex-wrap items-center gap-x-4 gap-y-1 min-w-0">
-          <span class="text-base font-medium truncate text-n-slate-12">
-            {{ displayName }}
-          </span>
-          <span
-            v-if="domain && description"
-            class="inline-flex items-center gap-1.5 text-sm text-n-slate-11 truncate"
-          >
-            <Icon icon="i-lucide-globe" size="size-3.5 text-n-slate-11" />
-            <span class="truncate">{{ domain }}</span>
-          </span>
-        </div>
-        <div class="flex items-center justify-between">
-          <div class="flex flex-wrap items-center gap-x-3 gap-y-1 min-w-0">
+    <div
+      class="flex flex-col w-full gap-4 sm:flex-row sm:items-center sm:justify-between min-w-0"
+    >
+      <div class="flex items-center justify-start flex-1 gap-4 min-w-0">
+        <Avatar
+          :username="displayName"
+          :src="avatarSource"
+          class="shrink-0"
+          :name="name"
+          :size="48"
+          hide-offline-status
+          rounded-full
+        />
+        <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+          <div class="flex flex-wrap items-center gap-x-4 gap-y-1 min-w-0">
             <span
-              v-if="domain && !description"
-              class="inline-flex items-center gap-1.5 text-sm text-n-slate-11 truncate"
+              class="min-w-0 text-base font-medium truncate text-n-slate-12"
+            >
+              {{ displayName }}
+            </span>
+            <span
+              v-if="domain && description"
+              class="inline-flex items-center gap-1.5 text-sm text-n-slate-11 truncate min-w-0"
             >
               <Icon icon="i-lucide-globe" size="size-3.5 text-n-slate-11" />
-              <span class="truncate">{{ domain }}</span>
-            </span>
-            <span v-if="description" class="text-sm text-n-slate-11 truncate">
-              {{ description }}
-            </span>
-            <div
-              v-if="(description || domain) && contactsCount"
-              class="w-px h-3 bg-n-slate-6"
-            />
-            <span
-              v-if="contactsCount"
-              class="inline-flex items-center gap-1.5 text-sm text-n-slate-11 truncate"
-            >
-              <Icon icon="i-lucide-contact" size="size-3.5 text-n-slate-11" />
-              {{ t('COMPANIES.CONTACTS_COUNT', { n: contactsCount }) }}
+              <span class="truncate min-w-0">{{ domain }}</span>
             </span>
           </div>
-          <span
-            v-if="updatedAt"
-            class="inline-flex items-center gap-1.5 text-sm text-n-slate-11 flex-shrink-0"
-          >
-            {{ formattedUpdatedAt }}
-          </span>
+          <div class="flex items-center justify-between min-w-0 gap-3">
+            <div class="flex flex-wrap items-center gap-x-3 gap-y-1 min-w-0">
+              <span
+                v-if="domain && !description"
+                class="inline-flex items-center gap-1.5 text-sm text-n-slate-11 truncate min-w-0"
+              >
+                <Icon icon="i-lucide-globe" size="size-3.5 text-n-slate-11" />
+                <span class="truncate min-w-0">{{ domain }}</span>
+              </span>
+              <span
+                v-if="description"
+                class="min-w-0 text-sm text-n-slate-11 truncate"
+              >
+                {{ description }}
+              </span>
+              <div
+                v-if="(description || domain) && contactsCount"
+                class="w-px h-3 bg-n-slate-6"
+              />
+              <span
+                v-if="contactsCount"
+                class="inline-flex items-center gap-1.5 text-sm text-n-slate-11 truncate min-w-0"
+              >
+                <Icon icon="i-lucide-contact" size="size-3.5 text-n-slate-11" />
+                {{ t('COMPANIES.CONTACTS_COUNT', { n: contactsCount }) }}
+              </span>
+            </div>
+            <span
+              v-if="updatedAt"
+              class="inline-flex items-center gap-1.5 text-sm text-n-slate-11 flex-shrink-0"
+            >
+              {{ formattedUpdatedAt }}
+            </span>
+          </div>
         </div>
+      </div>
+      <div
+        class="w-full sm:w-56 lg:w-64 shrink-0"
+        :title="accountOwnerTitle"
+        @click.stop
+      >
+        <label class="block mb-1 text-xs font-medium text-n-slate-11">
+          {{ t('ACCOUNT_OWNER.LABEL') }}
+        </label>
+        <AccountOwnerSelect
+          :key="ownerSelectKey"
+          :model-value="ownerModelValue"
+          :agents="agents"
+          :disabled="isUpdating"
+          class="[&>div>button]:h-8"
+          @update:model-value="handleOwnerUpdate"
+        />
       </div>
     </div>
   </CardLayout>

--- a/app/javascript/dashboard/components-next/Companies/CompaniesCard/specs/CompaniesCard.spec.js
+++ b/app/javascript/dashboard/components-next/Companies/CompaniesCard/specs/CompaniesCard.spec.js
@@ -1,0 +1,110 @@
+import { shallowMount } from '@vue/test-utils';
+import CompaniesCard from '../CompaniesCard.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key, values) => {
+      if (key === 'COMPANIES.CONTACTS_COUNT') {
+        return `${values.n} contacts`;
+      }
+
+      return (
+        {
+          'ACCOUNT_OWNER.LABEL': 'Account Owner',
+          'COMPANIES.UNNAMED': 'Unnamed Company',
+        }[key] || key
+      );
+    },
+  }),
+}));
+
+const AccountOwnerSelectStub = {
+  name: 'AccountOwnerSelect',
+  props: {
+    modelValue: { type: [Number, String], default: '' },
+    agents: { type: Array, default: () => [] },
+    disabled: { type: Boolean, default: false },
+  },
+  emits: ['update:modelValue'],
+  template:
+    '<button data-testid="owner-select" @click="$emit(\'update:modelValue\', \'\')">{{ modelValue }}</button>',
+};
+
+const CardLayoutStub = {
+  name: 'CardLayout',
+  emits: ['click'],
+  template:
+    '<div data-testid="company-card" @click="$emit(\'click\', $event)"><slot /></div>',
+};
+
+const mountCard = props =>
+  shallowMount(CompaniesCard, {
+    props: {
+      id: 12,
+      name: 'Acme',
+      ...props,
+    },
+    global: {
+      stubs: {
+        AccountOwnerSelect: AccountOwnerSelectStub,
+        Avatar: true,
+        CardLayout: CardLayoutStub,
+        Icon: true,
+      },
+    },
+  });
+
+describe('CompaniesCard', () => {
+  it('passes account owner state to the shared owner picker', () => {
+    const agents = [{ id: 7, name: 'Asha Agent' }];
+    const wrapper = mountCard({
+      accountOwnerId: 7,
+      agents,
+      isUpdating: true,
+    });
+
+    const ownerSelect = wrapper.findComponent({ name: 'AccountOwnerSelect' });
+
+    expect(ownerSelect.props('modelValue')).toBe(7);
+    expect(ownerSelect.props('agents')).toEqual(agents);
+    expect(ownerSelect.props('disabled')).toBe(true);
+  });
+
+  it('emits null when the owner is cleared', async () => {
+    const wrapper = mountCard({ accountOwnerId: 7 });
+    const ownerSelect = wrapper.findComponent({ name: 'AccountOwnerSelect' });
+
+    await ownerSelect.vm.$emit('update:modelValue', '');
+
+    expect(wrapper.emitted('updateOwner')[0]).toEqual([
+      {
+        id: 12,
+        accountOwnerId: null,
+      },
+    ]);
+  });
+
+  it('keeps owner picker clicks from opening company details', async () => {
+    const wrapper = mountCard({ accountOwnerId: 7 });
+
+    await wrapper.find('[data-testid="owner-select"]').trigger('click');
+
+    expect(wrapper.emitted('showCompany')).toBeUndefined();
+  });
+
+  it('remounts the owner picker when the reset key changes', async () => {
+    const wrapper = mountCard({
+      accountOwnerId: 7,
+      ownerPickerResetKey: 0,
+    });
+    const firstOwnerSelectUid = wrapper.findComponent({
+      name: 'AccountOwnerSelect',
+    }).vm.$.uid;
+
+    await wrapper.setProps({ ownerPickerResetKey: 1 });
+
+    expect(
+      wrapper.findComponent({ name: 'AccountOwnerSelect' }).vm.$.uid
+    ).not.toBe(firstOwnerSelectUid);
+  });
+});

--- a/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
@@ -17,6 +17,9 @@ const props = defineProps({
   email: { type: String, default: '' },
   additionalAttributes: { type: Object, default: () => ({}) },
   phoneNumber: { type: String, default: '' },
+  accountOwnerId: { type: [Number, String], default: '' },
+  accountOwner: { type: Object, default: null },
+  agents: { type: Array, default: () => [] },
   thumbnail: { type: String, default: '' },
   availabilityStatus: { type: String, default: null },
   isExpanded: { type: Boolean, default: false },
@@ -42,6 +45,7 @@ const getInitialContactData = () => ({
   name: props.name,
   email: props.email,
   phoneNumber: props.phoneNumber,
+  accountOwnerId: props.accountOwnerId,
   additionalAttributes: props.additionalAttributes,
 });
 
@@ -82,6 +86,14 @@ const formattedLocation = computed(() => {
     .join(' ');
 });
 
+const accountOwnerName = computed(
+  () =>
+    props.accountOwner?.availableName ||
+    props.accountOwner?.available_name ||
+    props.accountOwner?.name ||
+    ''
+);
+
 const handleFormUpdate = updatedData => {
   Object.assign(contactData.value, updatedData);
 };
@@ -115,7 +127,7 @@ const handleAvatarHover = isHovered => {
         'outline-n-weak !bg-n-slate-3 dark:!bg-n-solid-3': isSelected,
       }"
     >
-      <div class="flex items-center justify-start flex-1 gap-4">
+      <div class="flex items-center justify-start flex-1 min-w-0 gap-4">
         <div
           class="relative"
           @mouseenter="handleAvatarHover(true)"
@@ -143,28 +155,39 @@ const handleAvatarHover = isHovered => {
             </template>
           </Avatar>
         </div>
-        <div class="flex flex-col gap-0.5 flex-1">
-          <div class="flex flex-wrap items-center gap-x-4 gap-y-1">
-            <span class="text-base font-medium truncate text-n-slate-12">
+        <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+          <div class="flex flex-wrap items-center min-w-0 gap-x-4 gap-y-1">
+            <span
+              class="min-w-0 text-base font-medium truncate text-n-slate-12"
+            >
               {{ name }}
             </span>
-            <span class="inline-flex items-center gap-1">
+            <span class="inline-flex items-center min-w-0 gap-1">
               <span
                 v-if="additionalAttributes?.companyName"
                 class="i-ph-building-light size-4 text-n-slate-10 mb-0.5"
               />
               <span
                 v-if="additionalAttributes?.companyName"
-                class="text-sm truncate text-n-slate-11"
+                class="min-w-0 text-sm truncate text-n-slate-11"
               >
                 {{ additionalAttributes.companyName }}
               </span>
             </span>
+            <span
+              v-if="accountOwnerName"
+              class="inline-flex items-center gap-1 min-w-0"
+            >
+              <span class="i-lucide-user-round size-4 text-n-slate-10 mb-0.5" />
+              <span class="min-w-0 text-sm truncate text-n-slate-11">
+                {{ accountOwnerName }}
+              </span>
+            </span>
           </div>
           <div
-            class="flex flex-wrap items-center justify-start gap-x-3 gap-y-1"
+            class="flex flex-wrap items-center justify-start min-w-0 gap-x-3 gap-y-1"
           >
-            <div v-if="email" class="truncate max-w-72" :title="email">
+            <div v-if="email" class="min-w-0 truncate max-w-72" :title="email">
               <span class="text-sm text-n-slate-11">
                 {{ email }}
               </span>
@@ -215,6 +238,7 @@ const handleAvatarHover = isHovered => {
               <ContactsForm
                 ref="contactsFormRef"
                 :contact-data="contactData"
+                :agents="agents"
                 @update="handleFormUpdate"
               />
               <div>

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
@@ -9,6 +9,7 @@ import Input from 'dashboard/components-next/input/Input.vue';
 import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 import PhoneNumberInput from 'dashboard/components-next/phonenumberinput/PhoneNumberInput.vue';
+import AccountOwnerSelect from 'dashboard/components-next/AccountOwner/AccountOwnerSelect.vue';
 
 const props = defineProps({
   contactData: {
@@ -23,6 +24,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  agents: {
+    type: Array,
+    default: () => [],
+  },
 });
 
 const emit = defineEmits(['update']);
@@ -35,6 +40,7 @@ const FORM_CONFIG = {
   EMAIL_ADDRESS: { field: 'email' },
   PHONE_NUMBER: { field: 'phoneNumber' },
   CITY: { field: 'additionalAttributes.city' },
+  ACCOUNT_OWNER: { field: 'accountOwnerId' },
   COUNTRY: { field: 'additionalAttributes.countryCode' },
   BIO: { field: 'additionalAttributes.description' },
   COMPANY_NAME: { field: 'additionalAttributes.companyName' },
@@ -57,6 +63,7 @@ const defaultState = {
   firstName: '',
   lastName: '',
   phoneNumber: '',
+  accountOwnerId: '',
   additionalAttributes: {
     description: '',
     companyName: '',
@@ -77,6 +84,24 @@ const defaultState = {
 
 const state = reactive({ ...defaultState });
 
+const buildSerializableState = () => {
+  const { firstName, lastName, ...stateWithoutNames } = state;
+  return {
+    ...stateWithoutNames,
+    accountOwnerId: state.accountOwnerId || null,
+    additionalAttributes: {
+      ...state.additionalAttributes,
+      socialProfiles: {
+        ...state.additionalAttributes.socialProfiles,
+      },
+    },
+  };
+};
+
+const emitContactUpdate = () => {
+  emit('update', buildSerializableState());
+};
+
 const validationRules = {
   firstName: { required },
   email: { email },
@@ -96,6 +121,7 @@ const prepareStateBasedOnProps = () => {
     name = '',
     email: emailAddress,
     phoneNumber,
+    accountOwnerId = '',
     additionalAttributes = {},
   } = props.contactData || {};
   const { firstName, lastName } = splitName(name || '');
@@ -119,6 +145,7 @@ const prepareStateBasedOnProps = () => {
     lastName,
     email: emailAddress,
     phoneNumber,
+    accountOwnerId: accountOwnerId || '',
     additionalAttributes: {
       description,
       companyName,
@@ -138,12 +165,15 @@ const countryOptions = computed(() =>
 );
 
 const editDetailsForm = computed(() =>
-  Object.keys(FORM_CONFIG).map(key => ({
-    key,
-    placeholder: t(
-      `CONTACTS_LAYOUT.CARD.EDIT_DETAILS_FORM.FORM.${key}.PLACEHOLDER`
-    ),
-  }))
+  Object.keys(FORM_CONFIG)
+    .filter(key => !(props.isNewContact && key === 'ACCOUNT_OWNER'))
+    .map(key => ({
+      key,
+      placeholder:
+        key === 'ACCOUNT_OWNER'
+          ? t('ACCOUNT_OWNER.LABEL')
+          : t(`CONTACTS_LAYOUT.CARD.EDIT_DETAILS_FORM.FORM.${key}.PLACEHOLDER`),
+    }))
 );
 
 const socialProfilesForm = computed(() =>
@@ -202,8 +232,7 @@ const getFormBinding = key => {
 
       const isFormValid = await v$.value.$validate();
       if (isFormValid) {
-        const { firstName, lastName, ...stateWithoutNames } = state;
-        emit('update', stateWithoutNames);
+        emitContactUpdate();
       }
     },
   });
@@ -218,7 +247,12 @@ const getMessageType = key => {
 const handleCountrySelection = value => {
   const selectedCountry = countries.find(option => option.id === value);
   state.additionalAttributes.country = selectedCountry?.name || '';
-  emit('update', state);
+  emitContactUpdate();
+};
+
+const handleAccountOwnerSelection = value => {
+  state.accountOwnerId = value || '';
+  emitContactUpdate();
 };
 
 const resetValidation = () => {
@@ -254,8 +288,20 @@ defineExpose({
       </span>
       <div class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
         <template v-for="item in editDetailsForm" :key="item.key">
+          <AccountOwnerSelect
+            v-if="item.key === 'ACCOUNT_OWNER'"
+            :model-value="state.accountOwnerId"
+            :agents="agents"
+            class="[&>div>button]:h-8"
+            :class="{
+              '[&>div>button]:bg-n-alpha-black2 [&>div>button:not(.focused)]:!outline-transparent':
+                !isDetailsView,
+              '[&>div>button]:!bg-n-alpha-black2': isDetailsView,
+            }"
+            @update:model-value="handleAccountOwnerSelection"
+          />
           <ComboBox
-            v-if="item.key === 'COUNTRY'"
+            v-else-if="item.key === 'COUNTRY'"
             v-model="state.additionalAttributes.countryCode"
             :options="countryOptions"
             :placeholder="item.placeholder"
@@ -321,7 +367,7 @@ defineExpose({
             class="w-auto min-w-[100px] text-sm bg-transparent outline-none reset-base text-n-slate-12 dark:text-n-slate-12 placeholder:text-n-slate-10 dark:placeholder:text-n-slate-10"
             :placeholder="item.placeholder"
             :size="item.placeholder.length"
-            @input="emit('update', state)"
+            @input="emitContactUpdate"
           />
         </div>
       </div>

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/specs/ContactsForm.spec.js
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/specs/ContactsForm.spec.js
@@ -1,0 +1,143 @@
+import { shallowMount } from '@vue/test-utils';
+import ContactsForm from '../ContactsForm.vue';
+
+const tMock = vi.fn(
+  key => ({ 'ACCOUNT_OWNER.LABEL': 'Account Owner' })[key] || key
+);
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: tMock,
+  }),
+}));
+
+describe('ContactsForm', () => {
+  beforeEach(() => {
+    tMock.mockClear();
+  });
+
+  it('passes account owner options and emits accountOwnerId', async () => {
+    const wrapper = shallowMount(ContactsForm, {
+      props: {
+        contactData: {
+          id: 1,
+          name: 'Ada Lovelace',
+          email: 'ada@example.com',
+          phoneNumber: '',
+          accountOwnerId: 7,
+          additionalAttributes: {},
+        },
+        agents: [{ id: 7, name: 'Asha Agent', email: 'asha@example.com' }],
+      },
+      global: {
+        stubs: {
+          Input: true,
+          ComboBox: true,
+          Icon: true,
+          PhoneNumberInput: true,
+          AccountOwnerSelect: true,
+        },
+      },
+    });
+
+    const ownerSelect = wrapper.findComponent({ name: 'AccountOwnerSelect' });
+    expect(ownerSelect.exists()).toBe(true);
+    expect(ownerSelect.props('modelValue')).toBe(7);
+
+    await ownerSelect.vm.$emit('update:modelValue', 8);
+
+    expect(wrapper.emitted('update').at(-1)[0]).toMatchObject({
+      accountOwnerId: 8,
+    });
+  });
+
+  it('keeps the picker model empty and emits null when owner is cleared', async () => {
+    const wrapper = shallowMount(ContactsForm, {
+      props: {
+        contactData: {
+          id: 1,
+          name: 'Ada Lovelace',
+          email: 'ada@example.com',
+          phoneNumber: '',
+          accountOwnerId: 7,
+          additionalAttributes: {},
+        },
+        agents: [{ id: 7, name: 'Asha Agent', email: 'asha@example.com' }],
+      },
+      global: {
+        stubs: {
+          Input: true,
+          ComboBox: true,
+          Icon: true,
+          PhoneNumberInput: true,
+          AccountOwnerSelect: true,
+        },
+      },
+    });
+
+    const ownerSelect = wrapper.findComponent({ name: 'AccountOwnerSelect' });
+
+    await ownerSelect.vm.$emit('update:modelValue', '');
+
+    expect(wrapper.emitted('update').at(-1)[0]).toMatchObject({
+      accountOwnerId: null,
+    });
+    expect(ownerSelect.props('modelValue')).toBe('');
+  });
+
+  it('uses the shared account owner label instead of a nested contact placeholder', () => {
+    shallowMount(ContactsForm, {
+      props: {
+        contactData: {
+          id: 1,
+          name: 'Ada Lovelace',
+          email: 'ada@example.com',
+          phoneNumber: '',
+          additionalAttributes: {},
+        },
+      },
+      global: {
+        stubs: {
+          Input: true,
+          ComboBox: true,
+          Icon: true,
+          PhoneNumberInput: true,
+          AccountOwnerSelect: true,
+        },
+      },
+    });
+
+    expect(tMock).toHaveBeenCalledWith('ACCOUNT_OWNER.LABEL');
+    expect(tMock).not.toHaveBeenCalledWith(
+      'CONTACTS_LAYOUT.CARD.EDIT_DETAILS_FORM.FORM.ACCOUNT_OWNER.PLACEHOLDER'
+    );
+  });
+
+  it('does not render account owner picker for a new contact', () => {
+    const wrapper = shallowMount(ContactsForm, {
+      props: {
+        isNewContact: true,
+        contactData: {
+          id: 1,
+          name: 'Ada Lovelace',
+          email: 'ada@example.com',
+          phoneNumber: '',
+          additionalAttributes: {},
+        },
+      },
+      global: {
+        stubs: {
+          Input: true,
+          ComboBox: true,
+          Icon: true,
+          PhoneNumberInput: true,
+          AccountOwnerSelect: true,
+        },
+      },
+    });
+
+    expect(wrapper.findComponent({ name: 'AccountOwnerSelect' }).exists()).toBe(
+      false
+    );
+  });
+});

--- a/app/javascript/dashboard/components-next/Contacts/Pages/ContactDetails.vue
+++ b/app/javascript/dashboard/components-next/Contacts/Pages/ContactDetails.vue
@@ -17,6 +17,10 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  agents: {
+    type: Array,
+    default: () => [],
+  },
 });
 
 const emit = defineEmits(['goToContactsList']);
@@ -164,6 +168,7 @@ const handleAvatarDelete = async () => {
       <ContactsForm
         ref="contactsFormRef"
         :contact-data="contactData"
+        :agents="agents"
         is-details-view
         @update="handleFormUpdate"
       />

--- a/app/javascript/dashboard/components-next/Contacts/Pages/ContactsList.vue
+++ b/app/javascript/dashboard/components-next/Contacts/Pages/ContactsList.vue
@@ -16,6 +16,10 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
+  agents: {
+    type: Array,
+    default: () => [],
+  },
 });
 
 const emit = defineEmits(['toggleContact']);
@@ -94,6 +98,9 @@ const handleAvatarHover = (id, isHovered) => {
         :email="contact.email"
         :thumbnail="contact.thumbnail"
         :phone-number="contact.phoneNumber"
+        :account-owner-id="contact.accountOwnerId"
+        :account-owner="contact.accountOwner"
+        :agents="agents"
         :additional-attributes="contact.additionalAttributes"
         :availability-status="contact.availabilityStatus"
         :is-expanded="expandedCardId === contact.id"

--- a/app/javascript/dashboard/i18n/locale/en/companies.json
+++ b/app/javascript/dashboard/i18n/locale/en/companies.json
@@ -21,6 +21,8 @@
     "LOADING": "Loading companies...",
     "UNNAMED": "Unnamed Company",
     "CONTACTS_COUNT": "{n} contact | {n} contacts",
+    "ACCOUNT_OWNER_UPDATE_SUCCESS": "Account Owner updated",
+    "ACCOUNT_OWNER_UPDATE_ERROR": "Could not update Account Owner",
     "EMPTY_STATE": {
       "TITLE": "No companies found"
     }

--- a/app/javascript/dashboard/i18n/locale/en/general.json
+++ b/app/javascript/dashboard/i18n/locale/en/general.json
@@ -12,6 +12,12 @@
     "DISCARD": "Discard",
     "PREFERRED": "Preferred"
   },
+  "ACCOUNT_OWNER": {
+    "LABEL": "Account Owner",
+    "UNASSIGNED": "Unassigned",
+    "SEARCH_PLACEHOLDER": "Search agents",
+    "EMPTY_STATE": "No agents found"
+  },
   "CHOICE_TOGGLE": {
     "YES": "Yes",
     "NO": "No"

--- a/app/javascript/dashboard/routes/dashboard/companies/pages/CompaniesIndex.vue
+++ b/app/javascript/dashboard/routes/dashboard/companies/pages/CompaniesIndex.vue
@@ -3,6 +3,8 @@ import { ref, computed, onMounted, reactive } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { useUISettings } from 'dashboard/composables/useUISettings';
+import { useStore, useMapGetter } from 'dashboard/composables/store';
+import { useAlert } from 'dashboard/composables';
 import { debounce } from '@chatwoot/utils';
 import { useCompaniesStore } from 'dashboard/stores/companies';
 
@@ -14,6 +16,7 @@ const DEBOUNCE_DELAY = 300;
 
 const companiesStore = useCompaniesStore();
 
+const store = useStore();
 const route = useRoute();
 const router = useRouter();
 const { t } = useI18n();
@@ -21,12 +24,15 @@ const { t } = useI18n();
 const { updateUISettings, uiSettings } = useUISettings();
 
 const companies = computed(() => companiesStore.getCompaniesList);
+const agents = useMapGetter('agents/getVerifiedAgents');
 const meta = computed(() => companiesStore.getMeta);
 const uiFlags = computed(() => companiesStore.getUIFlags);
 
 const searchQuery = computed(() => route.query?.search || '');
 const searchValue = ref(searchQuery.value);
 const pageNumber = computed(() => Number(route.query?.page) || 1);
+const ownerPickerResetKeys = ref({});
+const updatingCompanyOwnerIds = ref([]);
 
 const parseSortSettings = (sortString = '') => {
   const hasDescending = sortString.startsWith('-');
@@ -121,8 +127,46 @@ const handleSort = async ({ sort, order }) => {
   fetchCompanies(1, searchValue.value, buildSortAttr());
 };
 
+const setCompanyOwnerUpdating = (id, isUpdating) => {
+  if (isUpdating) {
+    updatingCompanyOwnerIds.value = [
+      ...new Set([...updatingCompanyOwnerIds.value, id]),
+    ];
+  } else {
+    updatingCompanyOwnerIds.value = updatingCompanyOwnerIds.value.filter(
+      updatingId => updatingId !== id
+    );
+  }
+};
+
+const isCompanyOwnerUpdating = id => updatingCompanyOwnerIds.value.includes(id);
+
+const resetOwnerPicker = id => {
+  ownerPickerResetKeys.value = {
+    ...ownerPickerResetKeys.value,
+    [id]: (ownerPickerResetKeys.value[id] || 0) + 1,
+  };
+};
+
+const ownerPickerResetKey = id => ownerPickerResetKeys.value[id] || 0;
+
+const updateCompanyOwner = async ({ id, accountOwnerId }) => {
+  setCompanyOwnerUpdating(id, true);
+
+  try {
+    await companiesStore.update({ id, accountOwnerId });
+    useAlert(t('COMPANIES.ACCOUNT_OWNER_UPDATE_SUCCESS'));
+  } catch {
+    resetOwnerPicker(id);
+    useAlert(t('COMPANIES.ACCOUNT_OWNER_UPDATE_ERROR'));
+  } finally {
+    setCompanyOwnerUpdating(id, false);
+  }
+};
+
 onMounted(() => {
   searchValue.value = searchQuery.value;
+  store.dispatch('agents/get');
   fetchCompanies();
 });
 </script>
@@ -165,6 +209,12 @@ onMounted(() => {
         :description="company.description"
         :avatar-url="company.avatarUrl"
         :updated-at="company.updatedAt"
+        :account-owner-id="company.accountOwnerId"
+        :account-owner="company.accountOwner"
+        :agents="agents"
+        :is-updating="isCompanyOwnerUpdating(company.id)"
+        :owner-picker-reset-key="ownerPickerResetKey(company.id)"
+        @update-owner="updateCompanyOwner"
       />
     </div>
   </CompaniesListLayout>

--- a/app/javascript/dashboard/routes/dashboard/contacts/pages/ContactManageView.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/pages/ContactManageView.vue
@@ -19,6 +19,7 @@ const route = useRoute();
 const router = useRouter();
 
 const contact = useMapGetter('contacts/getContactById');
+const agents = useMapGetter('agents/getVerifiedAgents');
 const uiFlags = useMapGetter('contacts/getUIFlags');
 
 const activeTab = ref('attributes');
@@ -90,6 +91,10 @@ const fetchAttributes = () => {
   store.dispatch('attributes/get');
 };
 
+const fetchAgents = () => {
+  store.dispatch('agents/get');
+};
+
 const toggleContactBlock = async isBlocked => {
   const ALERT_MESSAGES = {
     success: {
@@ -118,6 +123,7 @@ const toggleContactBlock = async isBlocked => {
 };
 
 onMounted(() => {
+  fetchAgents();
   fetchActiveContact();
   fetchContactNotes();
   fetchContactConversations();
@@ -147,6 +153,7 @@ onMounted(() => {
       <ContactDetails
         v-else-if="selectedContact"
         :selected-contact="selectedContact"
+        :agents="agents"
         @go-to-contacts-list="goToContactsList"
       />
       <template #sidebar>

--- a/app/javascript/dashboard/routes/dashboard/contacts/pages/ContactsIndex.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/pages/ContactsIndex.vue
@@ -27,6 +27,7 @@ const { t } = useI18n();
 const { updateUISettings, uiSettings } = useUISettings();
 
 const contacts = useMapGetter('contacts/getContactsList');
+const agents = useMapGetter('agents/getVerifiedAgents');
 const uiFlags = useMapGetter('contacts/getUIFlags');
 const customViewsUiFlags = useMapGetter('customViews/getUIFlags');
 const segments = useMapGetter('customViews/getContactCustomViews');
@@ -449,6 +450,8 @@ watch(searchQuery, value => {
 });
 
 onMounted(async () => {
+  store.dispatch('agents/get');
+
   if (!activeSegmentId.value) {
     if (searchQuery.value) {
       await searchContacts(searchQuery.value, pageNumber.value, false, {
@@ -538,6 +541,7 @@ onMounted(async () => {
           <ContactsList
             :contacts="contacts"
             :selected-contact-ids="selectedContactIds"
+            :agents="agents"
             @toggle-contact="toggleContactSelection"
           />
           <Dialog

--- a/app/javascript/dashboard/store/modules/contacts/actions.js
+++ b/app/javascript/dashboard/store/modules/contacts/actions.js
@@ -11,26 +11,48 @@ import { CONTACTS_EVENTS } from '../../../helper/AnalyticsHelper/events';
 
 const buildContactFormData = contactParams => {
   const formData = new FormData();
-  const { additional_attributes = {}, ...contactProperties } = contactParams;
-  Object.keys(contactProperties).forEach(key => {
-    if (contactProperties[key]) {
-      formData.append(key, contactProperties[key]);
+
+  const appendFormDataValue = (key, value) => {
+    if (key === 'account_owner_id' && (value === null || value === '')) {
+      formData.append(key, '');
+      return;
     }
+
+    if (value === undefined || value === null || value === '') {
+      return;
+    }
+
+    if (value instanceof File || value instanceof Blob) {
+      formData.append(key, value);
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        formData.append(key, '[]');
+        return;
+      }
+
+      value.forEach((item, index) => {
+        appendFormDataValue(`${key}[${index}]`, item);
+      });
+      return;
+    }
+
+    if (typeof value === 'object') {
+      Object.entries(value).forEach(([nestedKey, nestedValue]) => {
+        appendFormDataValue(`${key}[${nestedKey}]`, nestedValue);
+      });
+      return;
+    }
+
+    formData.append(key, value);
+  };
+
+  Object.entries(contactParams).forEach(([key, value]) => {
+    appendFormDataValue(key, value);
   });
-  const { social_profiles, ...additionalAttributesProperties } =
-    additional_attributes;
-  Object.keys(additionalAttributesProperties).forEach(key => {
-    formData.append(
-      `additional_attributes[${key}]`,
-      additionalAttributesProperties[key]
-    );
-  });
-  Object.keys(social_profiles).forEach(key => {
-    formData.append(
-      `additional_attributes[social_profiles][${key}]`,
-      social_profiles[key]
-    );
-  });
+
   return formData;
 };
 

--- a/app/javascript/dashboard/store/modules/contacts/actions.js
+++ b/app/javascript/dashboard/store/modules/contacts/actions.js
@@ -11,46 +11,31 @@ import { CONTACTS_EVENTS } from '../../../helper/AnalyticsHelper/events';
 
 const buildContactFormData = contactParams => {
   const formData = new FormData();
-
-  const appendFormDataValue = (key, value) => {
+  const { additional_attributes = {}, ...contactProperties } = contactParams;
+  Object.keys(contactProperties).forEach(key => {
+    const value = contactProperties[key];
     if (key === 'account_owner_id' && (value === null || value === '')) {
       formData.append(key, '');
       return;
     }
 
-    if (value === undefined || value === null || value === '') {
-      return;
-    }
-
-    if (value instanceof File || value instanceof Blob) {
+    if (value) {
       formData.append(key, value);
-      return;
     }
-
-    if (Array.isArray(value)) {
-      if (value.length === 0) {
-        formData.append(key, '[]');
-        return;
-      }
-
-      value.forEach((item, index) => {
-        appendFormDataValue(`${key}[${index}]`, item);
-      });
-      return;
-    }
-
-    if (typeof value === 'object') {
-      Object.entries(value).forEach(([nestedKey, nestedValue]) => {
-        appendFormDataValue(`${key}[${nestedKey}]`, nestedValue);
-      });
-      return;
-    }
-
-    formData.append(key, value);
-  };
-
-  Object.entries(contactParams).forEach(([key, value]) => {
-    appendFormDataValue(key, value);
+  });
+  const { social_profiles = {}, ...additionalAttributesProperties } =
+    additional_attributes;
+  Object.keys(additionalAttributesProperties).forEach(key => {
+    formData.append(
+      `additional_attributes[${key}]`,
+      additionalAttributesProperties[key]
+    );
+  });
+  Object.keys(social_profiles).forEach(key => {
+    formData.append(
+      `additional_attributes[social_profiles][${key}]`,
+      social_profiles[key]
+    );
   });
 
   return formData;

--- a/app/javascript/dashboard/store/modules/specs/contacts/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/contacts/actions.spec.js
@@ -145,6 +145,24 @@ describe('#actions', () => {
         [types.SET_CONTACT_UI_FLAG, { isUpdating: false }],
       ]);
     });
+    it('preserves cleared account_owner_id for FormData updates with avatar uploads', async () => {
+      axios.patch.mockResolvedValue({ data: { payload: contactList[0] } });
+
+      await actions.update(
+        { commit },
+        {
+          id: contactList[0].id,
+          isFormData: true,
+          avatar: new File(['avatar'], 'avatar.png', { type: 'image/png' }),
+          accountOwnerId: null,
+        }
+      );
+
+      const formDataArg = axios.patch.mock.calls[0][1];
+      expect(Array.from(formDataArg.entries())).toEqual(
+        expect.arrayContaining([['account_owner_id', '']])
+      );
+    });
   });
 
   describe('#create', () => {

--- a/app/javascript/dashboard/store/modules/specs/contacts/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/contacts/actions.spec.js
@@ -163,6 +163,35 @@ describe('#actions', () => {
         expect.arrayContaining([['account_owner_id', '']])
       );
     });
+
+    it('preserves cleared additional attributes for FormData updates', async () => {
+      axios.patch.mockResolvedValue({ data: { payload: contactList[0] } });
+
+      await actions.update(
+        { commit },
+        {
+          id: contactList[0].id,
+          isFormData: true,
+          avatar: new File(['avatar'], 'avatar.png', { type: 'image/png' }),
+          additionalAttributes: {
+            city: '',
+            description: '',
+            socialProfiles: {
+              facebook: '',
+            },
+          },
+        }
+      );
+
+      const formDataArg = axios.patch.mock.calls[0][1];
+      expect(Array.from(formDataArg.entries())).toEqual(
+        expect.arrayContaining([
+          ['additional_attributes[city]', ''],
+          ['additional_attributes[description]', ''],
+          ['additional_attributes[social_profiles][facebook]', ''],
+        ])
+      );
+    });
   });
 
   describe('#create', () => {

--- a/app/jobs/agents/destroy_job.rb
+++ b/app/jobs/agents/destroy_job.rb
@@ -7,6 +7,7 @@ class Agents::DestroyJob < ApplicationJob
       remove_user_from_teams(account, user)
       remove_user_from_inboxes(account, user)
       unassign_conversations(account, user)
+      unassign_account_owners(account, user)
     end
   end
 
@@ -34,4 +35,11 @@ class Agents::DestroyJob < ApplicationJob
     user.assigned_conversations.where(account: account).in_batches.update_all(assignee_id: nil)
     # rubocop:enable Rails/SkipsModelValidations
   end
+
+  def unassign_account_owners(account, user)
+    # rubocop:disable Rails/SkipsModelValidations
+    user.owned_contacts.where(account: account).in_batches.update_all(account_owner_id: nil)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
 end
+Agents::DestroyJob.prepend_mod_with('Agents::DestroyJob')

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -2,17 +2,17 @@ class SendReplyJob < ApplicationJob
   queue_as :high
 
   CHANNEL_SERVICES = {
-    'Channel::TwitterProfile' => ::Twitter::SendOnTwitterService,
-    'Channel::TwilioSms' => ::Twilio::SendOnTwilioService,
-    'Channel::Line' => ::Line::SendOnLineService,
-    'Channel::Telegram' => ::Telegram::SendOnTelegramService,
-    'Channel::Whatsapp' => ::Whatsapp::SendOnWhatsappService,
-    'Channel::Sms' => ::Sms::SendOnSmsService,
-    'Channel::Instagram' => ::Instagram::SendOnInstagramService,
-    'Channel::Tiktok' => ::Tiktok::SendOnTiktokService,
-    'Channel::Email' => ::Email::SendOnEmailService,
-    'Channel::WebWidget' => ::Messages::SendEmailNotificationService,
-    'Channel::Api' => ::Messages::SendEmailNotificationService
+    'Channel::TwitterProfile' => 'Twitter::SendOnTwitterService',
+    'Channel::TwilioSms' => 'Twilio::SendOnTwilioService',
+    'Channel::Line' => 'Line::SendOnLineService',
+    'Channel::Telegram' => 'Telegram::SendOnTelegramService',
+    'Channel::Whatsapp' => 'Whatsapp::SendOnWhatsappService',
+    'Channel::Sms' => 'Sms::SendOnSmsService',
+    'Channel::Instagram' => 'Instagram::SendOnInstagramService',
+    'Channel::Tiktok' => 'Tiktok::SendOnTiktokService',
+    'Channel::Email' => 'Email::SendOnEmailService',
+    'Channel::WebWidget' => 'Messages::SendEmailNotificationService',
+    'Channel::Api' => 'Messages::SendEmailNotificationService'
   }.freeze
 
   def perform(message_id)
@@ -21,10 +21,10 @@ class SendReplyJob < ApplicationJob
 
     return send_on_facebook_page(message) if channel_name == 'Channel::FacebookPage'
 
-    service_class = CHANNEL_SERVICES[channel_name]
-    return unless service_class
+    service_class_name = CHANNEL_SERVICES[channel_name]
+    return unless service_class_name
 
-    service_class.new(message: message).perform
+    service_class_name.constantize.new(message: message).perform
   end
 
   private

--- a/app/models/concerns/account_owner_validatable.rb
+++ b/app/models/concerns/account_owner_validatable.rb
@@ -1,0 +1,16 @@
+module AccountOwnerValidatable
+  extend ActiveSupport::Concern
+
+  included do
+    validate :account_owner_must_belong_to_account
+  end
+
+  private
+
+  def account_owner_must_belong_to_account
+    return if account_owner_id.blank? || account.blank?
+    return if account.users.exists?(id: account_owner_id)
+
+    errors.add(:account_owner_id, "must belong to the same account as the #{self.class.model_name.singular}")
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -46,6 +46,7 @@ class Contact < ApplicationRecord
   include AvailabilityStatusable
   include Labelable
   include LlmFormattable
+  include AccountOwnerValidatable
 
   validates :account_id, presence: true
   validates :email, allow_blank: true, uniqueness: { scope: [:account_id], case_sensitive: false },
@@ -68,7 +69,6 @@ class Contact < ApplicationRecord
   after_update_commit :dispatch_update_event
   after_destroy_commit :dispatch_destroy_event
   before_save :sync_contact_attributes
-  validate :account_owner_must_belong_to_account
 
   enum contact_type: { visitor: 0, lead: 1, customer: 2 }
 
@@ -133,10 +133,6 @@ class Contact < ApplicationRecord
     )
   }
 
-  # Find contacts that:
-  # 1. Have no identification (email, phone_number, and identifier are NULL or empty string)
-  # 2. Have no conversations
-  # 3. Are older than the specified time period
   scope :stale_without_conversations, lambda { |time_period|
     where('contacts.email IS NULL OR contacts.email = ?', '')
       .where('contacts.phone_number IS NULL OR contacts.phone_number = ?', '')
@@ -196,14 +192,6 @@ class Contact < ApplicationRecord
   end
 
   private
-
-  def account_owner_must_belong_to_account
-    return if account_owner_id.blank?
-    return if account.blank?
-    return if account.users.exists?(id: account_owner_id)
-
-    errors.add(:account_owner_id, 'must belong to the same account as the contact')
-  end
 
   def ip_lookup
     return unless account.feature_enabled?('ip_lookup')

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -56,6 +56,7 @@ class Contact < ApplicationRecord
             format: { with: /\+[1-9]\d{1,14}\z/, message: I18n.t('errors.contacts.phone_number.invalid') }
 
   belongs_to :account
+  belongs_to :account_owner, class_name: 'User', optional: true, inverse_of: :owned_contacts
   has_many :conversations, dependent: :destroy_async
   has_many :contact_inboxes, dependent: :destroy_async
   has_many :csat_survey_responses, dependent: :destroy_async
@@ -67,6 +68,7 @@ class Contact < ApplicationRecord
   after_update_commit :dispatch_update_event
   after_destroy_commit :dispatch_destroy_event
   before_save :sync_contact_attributes
+  validate :account_owner_must_belong_to_account
 
   enum contact_type: { visitor: 0, lead: 1, customer: 2 }
 
@@ -194,6 +196,14 @@ class Contact < ApplicationRecord
   end
 
   private
+
+  def account_owner_must_belong_to_account
+    return if account_owner_id.blank?
+    return if account.blank?
+    return if account.users.exists?(id: account_owner_id)
+
+    errors.add(:account_owner_id, 'must belong to the same account as the contact')
+  end
 
   def ip_lookup
     return unless account.feature_enabled?('ip_lookup')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -88,6 +88,11 @@ class User < ApplicationRecord
   has_many :accounts, through: :account_users
   accepts_nested_attributes_for :account_users
 
+  has_many :owned_contacts,
+           class_name: 'Contact',
+           foreign_key: 'account_owner_id',
+           dependent: :nullify,
+           inverse_of: :account_owner
   has_many :assigned_conversations, foreign_key: 'assignee_id', class_name: 'Conversation', dependent: :nullify, inverse_of: :assignee
   alias_attribute :conversations, :assigned_conversations
   has_many :csat_survey_responses, foreign_key: 'assigned_agent_id', dependent: :nullify, inverse_of: :assigned_agent

--- a/app/views/api/v1/accounts/contacts/active.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/active.json.jbuilder
@@ -6,7 +6,7 @@ end
 json.payload do
   json.array! @contacts do |contact|
     json.partial! 'api/v1/models/contact', formats: [:json], resource: contact,
-                                                     with_contact_inboxes: @include_contact_inboxes,
-                                                     with_account_owner: true
+                                           with_contact_inboxes: @include_contact_inboxes,
+                                           with_account_owner: true
   end
 end

--- a/app/views/api/v1/accounts/contacts/active.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/active.json.jbuilder
@@ -5,6 +5,8 @@ end
 
 json.payload do
   json.array! @contacts do |contact|
-    json.partial! 'api/v1/models/contact', formats: [:json], resource: contact, with_contact_inboxes: @include_contact_inboxes
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: contact,
+                                                     with_contact_inboxes: @include_contact_inboxes,
+                                                     with_account_owner: true
   end
 end

--- a/app/views/api/v1/accounts/contacts/avatar.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/avatar.json.jbuilder
@@ -1,4 +1,4 @@
 json.payload do
   json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: false,
-                                                   with_account_owner: true
+                                         with_account_owner: true
 end

--- a/app/views/api/v1/accounts/contacts/avatar.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/avatar.json.jbuilder
@@ -1,3 +1,4 @@
 json.payload do
-  json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: false
+  json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: false,
+                                                   with_account_owner: true
 end

--- a/app/views/api/v1/accounts/contacts/create.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/create.json.jbuilder
@@ -1,7 +1,7 @@
 json.payload do
   json.contact do
     json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: true,
-                                                     with_account_owner: true
+                                           with_account_owner: true
   end
   json.contact_inbox do
     json.inbox @contact_inbox&.inbox

--- a/app/views/api/v1/accounts/contacts/create.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/create.json.jbuilder
@@ -1,6 +1,7 @@
 json.payload do
   json.contact do
-    json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: true
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: true,
+                                                     with_account_owner: true
   end
   json.contact_inbox do
     json.inbox @contact_inbox&.inbox

--- a/app/views/api/v1/accounts/contacts/destroy_custom_attributes.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/destroy_custom_attributes.json.jbuilder
@@ -1,4 +1,4 @@
 json.payload do
   json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: true,
-                                                   with_account_owner: true
+                                         with_account_owner: true
 end

--- a/app/views/api/v1/accounts/contacts/destroy_custom_attributes.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/destroy_custom_attributes.json.jbuilder
@@ -1,3 +1,4 @@
 json.payload do
-  json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: true
+  json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: true,
+                                                   with_account_owner: true
 end

--- a/app/views/api/v1/accounts/contacts/filter.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/filter.json.jbuilder
@@ -6,7 +6,7 @@ end
 json.payload do
   json.array! @contacts do |contact|
     json.partial! 'api/v1/models/contact', formats: [:json], resource: contact,
-                                                     with_contact_inboxes: @include_contact_inboxes,
-                                                     with_account_owner: true
+                                           with_contact_inboxes: @include_contact_inboxes,
+                                           with_account_owner: true
   end
 end

--- a/app/views/api/v1/accounts/contacts/filter.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/filter.json.jbuilder
@@ -5,6 +5,8 @@ end
 
 json.payload do
   json.array! @contacts do |contact|
-    json.partial! 'api/v1/models/contact', formats: [:json], resource: contact, with_contact_inboxes: @include_contact_inboxes
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: contact,
+                                                     with_contact_inboxes: @include_contact_inboxes,
+                                                     with_account_owner: true
   end
 end

--- a/app/views/api/v1/accounts/contacts/index.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/index.json.jbuilder
@@ -6,7 +6,7 @@ end
 json.payload do
   json.array! @contacts do |contact|
     json.partial! 'api/v1/models/contact', formats: [:json], resource: contact,
-                                                     with_contact_inboxes: @include_contact_inboxes,
-                                                     with_account_owner: true
+                                           with_contact_inboxes: @include_contact_inboxes,
+                                           with_account_owner: true
   end
 end

--- a/app/views/api/v1/accounts/contacts/index.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/index.json.jbuilder
@@ -5,6 +5,8 @@ end
 
 json.payload do
   json.array! @contacts do |contact|
-    json.partial! 'api/v1/models/contact', formats: [:json], resource: contact, with_contact_inboxes: @include_contact_inboxes
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: contact,
+                                                     with_contact_inboxes: @include_contact_inboxes,
+                                                     with_account_owner: true
   end
 end

--- a/app/views/api/v1/accounts/contacts/search.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/search.json.jbuilder
@@ -7,7 +7,7 @@ end
 json.payload do
   json.array! @contacts do |contact|
     json.partial! 'api/v1/models/contact', formats: [:json], resource: contact,
-                                                     with_contact_inboxes: @include_contact_inboxes,
-                                                     with_account_owner: true
+                                           with_contact_inboxes: @include_contact_inboxes,
+                                           with_account_owner: true
   end
 end

--- a/app/views/api/v1/accounts/contacts/search.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/search.json.jbuilder
@@ -6,6 +6,8 @@ end
 
 json.payload do
   json.array! @contacts do |contact|
-    json.partial! 'api/v1/models/contact', formats: [:json], resource: contact, with_contact_inboxes: @include_contact_inboxes
+    json.partial! 'api/v1/models/contact', formats: [:json], resource: contact,
+                                                     with_contact_inboxes: @include_contact_inboxes,
+                                                     with_account_owner: true
   end
 end

--- a/app/views/api/v1/accounts/contacts/show.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/show.json.jbuilder
@@ -1,5 +1,5 @@
 json.payload do
   json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact,
-                                                   with_contact_inboxes: @include_contact_inboxes,
-                                                   with_account_owner: true
+                                         with_contact_inboxes: @include_contact_inboxes,
+                                         with_account_owner: true
 end

--- a/app/views/api/v1/accounts/contacts/show.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/show.json.jbuilder
@@ -1,3 +1,5 @@
 json.payload do
-  json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: @include_contact_inboxes
+  json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact,
+                                                   with_contact_inboxes: @include_contact_inboxes,
+                                                   with_account_owner: true
 end

--- a/app/views/api/v1/accounts/contacts/update.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/update.json.jbuilder
@@ -1,5 +1,5 @@
 json.payload do
   json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact,
-                                                   with_contact_inboxes: @include_contact_inboxes,
-                                                   with_account_owner: true
+                                         with_contact_inboxes: @include_contact_inboxes,
+                                         with_account_owner: true
 end

--- a/app/views/api/v1/accounts/contacts/update.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/update.json.jbuilder
@@ -1,3 +1,5 @@
 json.payload do
-  json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact, with_contact_inboxes: @include_contact_inboxes
+  json.partial! 'api/v1/models/contact', formats: [:json], resource: @contact,
+                                                   with_contact_inboxes: @include_contact_inboxes,
+                                                   with_account_owner: true
 end

--- a/app/views/api/v1/models/_contact.json.jbuilder
+++ b/app/views/api/v1/models/_contact.json.jbuilder
@@ -8,6 +8,16 @@ json.blocked resource.blocked
 json.identifier resource.identifier
 json.thumbnail resource.avatar_url
 json.custom_attributes resource.custom_attributes
+if defined?(with_account_owner) && with_account_owner.present?
+  json.account_owner_id resource.account_owner_id
+  if resource.account_owner.present?
+    json.account_owner do
+      json.partial! 'api/v1/models/agent', formats: [:json], resource: resource.account_owner
+    end
+  else
+    json.account_owner nil
+  end
+end
 json.last_activity_at resource.last_activity_at.to_i if resource[:last_activity_at].present?
 json.created_at resource.created_at.to_i if resource[:created_at].present?
 # we only want to output contact inbox when its /contacts endpoints

--- a/db/migrate/20260505000000_add_account_owner_to_contacts_and_companies.rb
+++ b/db/migrate/20260505000000_add_account_owner_to_contacts_and_companies.rb
@@ -1,0 +1,28 @@
+class AddAccountOwnerToContactsAndCompanies < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    add_column :contacts, :account_owner_id, :integer
+    add_column :companies, :account_owner_id, :integer
+
+    add_index :contacts, :account_owner_id, algorithm: :concurrently
+    add_index :companies, :account_owner_id, algorithm: :concurrently
+
+    add_foreign_key :contacts, :users, column: :account_owner_id, on_delete: :nullify, validate: false
+    add_foreign_key :companies, :users, column: :account_owner_id, on_delete: :nullify, validate: false
+
+    validate_foreign_key :contacts, :users, column: :account_owner_id
+    validate_foreign_key :companies, :users, column: :account_owner_id
+  end
+
+  def down
+    remove_foreign_key :contacts, column: :account_owner_id
+    remove_foreign_key :companies, column: :account_owner_id
+
+    remove_index :contacts, :account_owner_id, algorithm: :concurrently
+    remove_index :companies, :account_owner_id, algorithm: :concurrently
+
+    remove_column :contacts, :account_owner_id
+    remove_column :companies, :account_owner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_30_114500) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_05_000000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -612,8 +612,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_30_114500) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "contacts_count"
+    t.integer "account_owner_id"
     t.index ["account_id", "domain"], name: "index_companies_on_account_and_domain", unique: true, where: "(domain IS NOT NULL)"
     t.index ["account_id"], name: "index_companies_on_account_id"
+    t.index ["account_owner_id"], name: "index_companies_on_account_owner_id"
     t.index ["name", "account_id"], name: "index_companies_on_name_and_account_id"
   end
 
@@ -650,12 +652,14 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_30_114500) do
     t.string "country_code", default: ""
     t.boolean "blocked", default: false, null: false
     t.bigint "company_id"
+    t.integer "account_owner_id"
     t.index "lower((email)::text), account_id", name: "index_contacts_on_lower_email_account_id"
     t.index ["account_id", "contact_type"], name: "index_contacts_on_account_id_and_contact_type"
     t.index ["account_id", "email", "phone_number", "identifier"], name: "index_contacts_on_nonempty_fields", where: "(((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))"
     t.index ["account_id", "last_activity_at"], name: "index_contacts_on_account_id_and_last_activity_at", order: { last_activity_at: "DESC NULLS LAST" }
     t.index ["account_id"], name: "index_contacts_on_account_id"
     t.index ["account_id"], name: "index_resolved_contact_account_id", where: "(((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))"
+    t.index ["account_owner_id"], name: "index_contacts_on_account_owner_id"
     t.index ["blocked"], name: "index_contacts_on_blocked"
     t.index ["company_id"], name: "index_contacts_on_company_id"
     t.index ["email", "account_id"], name: "uniq_email_per_account_contact", unique: true
@@ -1318,6 +1322,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_30_114500) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "companies", "users", column: "account_owner_id", on_delete: :nullify
+  add_foreign_key "contacts", "users", column: "account_owner_id", on_delete: :nullify
   add_foreign_key "inboxes", "portals"
   create_trigger("accounts_after_insert_row_tr", :generated => true, :compatibility => 1).
       on("accounts").

--- a/enterprise/app/controllers/api/v1/accounts/companies_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/companies_controller.rb
@@ -55,6 +55,7 @@ class Api::V1::Accounts::CompaniesController < Api::V1::Accounts::EnterpriseAcco
 
   def fetch_companies(companies)
     filtrate(companies)
+      .includes(account_owner: [:account_users, { avatar_attachment: [:blob] }])
       .page(@current_page)
       .per(RESULTS_PER_PAGE)
   end
@@ -66,10 +67,16 @@ class Api::V1::Accounts::CompaniesController < Api::V1::Accounts::EnterpriseAcco
   end
 
   def fetch_company
-    @company = Current.account.companies.find(params[:id])
+    company_scope = Current.account.companies
+    company_scope = company_scope.includes(account_owner: [:account_users, { avatar_attachment: [:blob] }]) if include_account_owner?
+    @company = company_scope.find(params[:id])
+  end
+
+  def include_account_owner?
+    %w[show update].include?(action_name)
   end
 
   def company_params
-    params.require(:company).permit(:name, :domain, :description, :avatar)
+    params.require(:company).permit(:name, :domain, :description, :avatar, :account_owner_id)
   end
 end

--- a/enterprise/app/jobs/enterprise/agents/destroy_job.rb
+++ b/enterprise/app/jobs/enterprise/agents/destroy_job.rb
@@ -1,0 +1,11 @@
+module Enterprise::Agents::DestroyJob
+  private
+
+  def unassign_account_owners(account, user)
+    super
+
+    # rubocop:disable Rails/SkipsModelValidations
+    user.owned_companies.where(account: account).in_batches.update_all(account_owner_id: nil)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/enterprise/app/models/company.rb
+++ b/enterprise/app/models/company.rb
@@ -27,8 +27,10 @@ class Company < ApplicationRecord
   }
   validates :domain, uniqueness: { scope: :account_id }, if: -> { domain.present? }
   validates :description, length: { maximum: Limits::COMPANY_DESCRIPTION_LENGTH_LIMIT }
+  validate :account_owner_must_belong_to_account
 
   belongs_to :account
+  belongs_to :account_owner, class_name: 'User', optional: true, inverse_of: :owned_companies
   has_many :contacts, dependent: :nullify
   after_create_commit :fetch_favicon, if: -> { domain.present? }
 
@@ -46,6 +48,14 @@ class Company < ApplicationRecord
   }
 
   private
+
+  def account_owner_must_belong_to_account
+    return if account_owner_id.blank?
+    return if account.blank?
+    return if account.users.exists?(id: account_owner_id)
+
+    errors.add(:account_owner_id, 'must belong to the same account as the company')
+  end
 
   def fetch_favicon
     Avatar::AvatarFromFaviconJob.set(wait: 5.seconds).perform_later(self)

--- a/enterprise/app/models/company.rb
+++ b/enterprise/app/models/company.rb
@@ -19,6 +19,8 @@
 #
 class Company < ApplicationRecord
   include Avatarable
+  include AccountOwnerValidatable
+
   validates :account_id, presence: true
   validates :name, presence: true, length: { maximum: Limits::COMPANY_NAME_LENGTH_LIMIT }
   validates :domain, allow_blank: true, format: {
@@ -27,7 +29,6 @@ class Company < ApplicationRecord
   }
   validates :domain, uniqueness: { scope: :account_id }, if: -> { domain.present? }
   validates :description, length: { maximum: Limits::COMPANY_DESCRIPTION_LENGTH_LIMIT }
-  validate :account_owner_must_belong_to_account
 
   belongs_to :account
   belongs_to :account_owner, class_name: 'User', optional: true, inverse_of: :owned_companies
@@ -48,14 +49,6 @@ class Company < ApplicationRecord
   }
 
   private
-
-  def account_owner_must_belong_to_account
-    return if account_owner_id.blank?
-    return if account.blank?
-    return if account.users.exists?(id: account_owner_id)
-
-    errors.add(:account_owner_id, 'must belong to the same account as the company')
-  end
 
   def fetch_favicon
     Avatar::AvatarFromFaviconJob.set(wait: 5.seconds).perform_later(self)

--- a/enterprise/app/models/enterprise/concerns/user.rb
+++ b/enterprise/app/models/enterprise/concerns/user.rb
@@ -6,6 +6,11 @@ module Enterprise::Concerns::User
 
     has_many :captain_responses, class_name: 'Captain::AssistantResponse', dependent: :nullify, as: :documentable
     has_many :copilot_threads, dependent: :destroy_async
+    has_many :owned_companies,
+             class_name: 'Company',
+             foreign_key: 'account_owner_id',
+             dependent: :nullify,
+             inverse_of: :account_owner
   end
 
   def ensure_installation_pricing_plan_quantity

--- a/enterprise/app/views/api/v1/accounts/companies/_company.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/companies/_company.json.jbuilder
@@ -4,5 +4,13 @@ json.contacts_count company.contacts_count
 json.domain company.domain
 json.description company.description
 json.avatar_url company.avatar_url
+json.account_owner_id company.account_owner_id
+if company.account_owner.present?
+  json.account_owner do
+    json.partial! 'api/v1/models/agent', formats: [:json], resource: company.account_owner
+  end
+else
+  json.account_owner nil
+end
 json.created_at company.created_at
 json.updated_at company.updated_at

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -54,6 +54,25 @@ RSpec.describe 'Contacts API', type: :request do
         expect(contact_inboxes_source_ids).to include(contact_inbox.source_id)
       end
 
+      it 'returns account owner details for owned and unowned contacts' do
+        owner = create(:user, account: account)
+        contact.update!(account_owner: owner)
+
+        get "/api/v1/accounts/#{account.id}/contacts",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        response_body = response.parsed_body
+        owned_contact_payload = response_body['payload'].find { |payload| payload['id'] == contact.id }
+        unowned_contact_payload = response_body['payload'].find { |payload| payload['id'] == contact_1.id }
+
+        expect(owned_contact_payload['account_owner_id']).to eq(owner.id)
+        expect(owned_contact_payload['account_owner']['id']).to eq(owner.id)
+        expect(unowned_contact_payload['account_owner_id']).to be_nil
+        expect(unowned_contact_payload['account_owner']).to be_nil
+      end
+
       it 'returns all contacts without contact inboxes' do
         get "/api/v1/accounts/#{account.id}/contacts?include_contact_inboxes=false",
             headers: admin.create_new_auth_token,
@@ -503,6 +522,20 @@ RSpec.describe 'Contacts API', type: :request do
         expect(response).to conform_schema(200)
         expect(response.body).to include(contact.name)
       end
+
+      it 'shows the account owner' do
+        owner = create(:user, account: account)
+        contact.update!(account_owner: owner)
+
+        get "/api/v1/accounts/#{account.id}/contacts/#{contact.id}",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        json_response = response.parsed_body
+        expect(json_response['payload']['account_owner_id']).to eq(owner.id)
+        expect(json_response['payload']['account_owner']['email']).to eq(owner.email)
+      end
     end
   end
 
@@ -574,6 +607,41 @@ RSpec.describe 'Contacts API', type: :request do
         expect(json_response['payload']['contact']['custom_attributes']).to eq({ 'test' => 'test', 'test1' => 'test1' })
       end
 
+      it 'creates the contact with an account owner' do
+        owner = create(:user, account: account)
+
+        post "/api/v1/accounts/#{account.id}/contacts",
+             headers: admin.create_new_auth_token,
+             params: valid_params.merge(account_owner_id: owner.id),
+             as: :json
+
+        expect(response).to have_http_status(:success)
+
+        contact = Contact.last
+        expect(contact.account_owner).to eq(owner)
+
+        json_response = response.parsed_body
+        expect(json_response['payload']['contact']['account_owner_id']).to eq(owner.id)
+        expect(json_response['payload']['contact']['account_owner']['id']).to eq(owner.id)
+        expect(json_response['payload']['contact']['account_owner']['name']).to eq(owner.name)
+      end
+
+      it 'rejects an account owner from another account' do
+        other_owner = create(:user, account: create(:account))
+
+        expect do
+          post "/api/v1/accounts/#{account.id}/contacts",
+               headers: admin.create_new_auth_token,
+               params: valid_params.merge(account_owner_id: other_owner.id),
+               as: :json
+        end.not_to change(Contact, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['message']).to include(
+          'Account owner must belong to the same account as the contact'
+        )
+      end
+
       it 'does not create the contact' do
         valid_params[:name] = 'test' * 999
 
@@ -629,6 +697,37 @@ RSpec.describe 'Contacts API', type: :request do
         # custom attributes are merged properly without overwriting existing ones
         expect(contact.custom_attributes).to eq({ 'test' => 'new test', 'test1' => 'test1', 'test2' => 'test2' })
         expect(contact.additional_attributes).to eq({ 'attr1' => 'attr1', 'attr2' => 'new attr2', 'attr3' => 'attr3' })
+      end
+
+      it 'updates the account owner' do
+        owner = create(:user, account: account)
+
+        patch "/api/v1/accounts/#{account.id}/contacts/#{contact.id}",
+              headers: admin.create_new_auth_token,
+              params: { account_owner_id: owner.id },
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(contact.reload.account_owner).to eq(owner)
+
+        json_response = response.parsed_body
+        expect(json_response['payload']['account_owner_id']).to eq(owner.id)
+        expect(json_response['payload']['account_owner']['id']).to eq(owner.id)
+      end
+
+      it 'rejects an account owner from another account' do
+        other_owner = create(:user, account: create(:account))
+
+        patch "/api/v1/accounts/#{account.id}/contacts/#{contact.id}",
+              headers: admin.create_new_auth_token,
+              params: { account_owner_id: other_owner.id },
+              as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(contact.reload.account_owner_id).to be_nil
+        expect(response.parsed_body['message']).to include(
+          'Account owner must belong to the same account as the contact'
+        )
       end
 
       it 'prevents the update of contact of another account' do

--- a/spec/enterprise/controllers/api/v1/accounts/companies_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/companies_controller_spec.rb
@@ -68,6 +68,25 @@ RSpec.describe 'Companies API', type: :request do
         expect(company_data['contacts_count']).to eq(5)
       end
 
+      it 'returns account owner details for owned and unowned companies' do
+        owner = create(:user, account: account)
+        company1.update!(account_owner: owner)
+
+        get "/api/v1/accounts/#{account.id}/companies",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        response_body = response.parsed_body
+        owned_company_payload = response_body['payload'].find { |c| c['id'] == company1.id }
+        unowned_company_payload = response_body['payload'].find { |c| c['id'] == company2.id }
+
+        expect(owned_company_payload['account_owner_id']).to eq(owner.id)
+        expect(owned_company_payload['account_owner']['id']).to eq(owner.id)
+        expect(unowned_company_payload['account_owner_id']).to be_nil
+        expect(unowned_company_payload['account_owner']).to be_nil
+      end
+
       it 'does not return companies from other accounts' do
         other_account = create(:account)
         create(:company, name: 'Other Account Company', account: other_account)
@@ -259,6 +278,56 @@ RSpec.describe 'Companies API', type: :request do
         expect(response_body['payload']['domain']).to eq('newcompany.com')
       end
 
+      it 'creates a new company with an account owner' do
+        owner = create(:user, account: account)
+
+        expect do
+          post "/api/v1/accounts/#{account.id}/companies",
+               params: {
+                 company: {
+                   name: 'New Company',
+                   domain: 'newcompany.com',
+                   description: 'A new company',
+                   account_owner_id: owner.id
+                 }
+               },
+               headers: admin.create_new_auth_token,
+               as: :json
+        end.to change(Company, :count).by(1)
+
+        expect(response).to have_http_status(:success)
+
+        company = Company.last
+        expect(company.account_owner).to eq(owner)
+
+        response_body = response.parsed_body
+        expect(response_body['payload']['account_owner_id']).to eq(owner.id)
+        expect(response_body['payload']['account_owner']['id']).to eq(owner.id)
+      end
+
+      it 'rejects an account owner from another account' do
+        other_owner = create(:user, account: create(:account))
+
+        expect do
+          post "/api/v1/accounts/#{account.id}/companies",
+               params: {
+                 company: {
+                   name: 'New Company',
+                   domain: 'newcompany.com',
+                   description: 'A new company',
+                   account_owner_id: other_owner.id
+                 }
+               },
+               headers: admin.create_new_auth_token,
+               as: :json
+        end.not_to change(Company, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['message']).to include(
+          'Account owner must belong to the same account as the company'
+        )
+      end
+
       it 'returns error for invalid params' do
         invalid_params = { company: { name: '' } }
 
@@ -301,6 +370,37 @@ RSpec.describe 'Companies API', type: :request do
         response_body = response.parsed_body
         expect(response_body['payload']['name']).to eq('Updated Company Name')
         expect(response_body['payload']['domain']).to eq('updated.com')
+      end
+
+      it 'updates the account owner' do
+        owner = create(:user, account: account)
+
+        patch "/api/v1/accounts/#{account.id}/companies/#{company.id}",
+              params: { company: { account_owner_id: owner.id } },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(company.reload.account_owner).to eq(owner)
+
+        response_body = response.parsed_body
+        expect(response_body['payload']['account_owner_id']).to eq(owner.id)
+        expect(response_body['payload']['account_owner']['email']).to eq(owner.email)
+      end
+
+      it 'rejects an account owner from another account' do
+        other_owner = create(:user, account: create(:account))
+
+        patch "/api/v1/accounts/#{account.id}/companies/#{company.id}",
+              params: { company: { account_owner_id: other_owner.id } },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(company.reload.account_owner_id).to be_nil
+        expect(response.parsed_body['message']).to include(
+          'Account owner must belong to the same account as the company'
+        )
       end
     end
   end

--- a/spec/enterprise/jobs/agents/destroy_job_spec.rb
+++ b/spec/enterprise/jobs/agents/destroy_job_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Agents::DestroyJob do
+  describe '#perform' do
+    it 'clears company ownership only for the account the user is removed from' do
+      account = create(:account)
+      other_account = create(:account)
+      user = create(:user, account: account)
+      create(:account_user, account: other_account, user: user)
+      owned_company = create(:company, account: account, account_owner: user)
+      other_company = create(:company, account: other_account, account_owner: user)
+
+      described_class.perform_now(account, user)
+
+      expect(owned_company.reload.account_owner).to be_nil
+      expect(other_company.reload.account_owner).to eq(user)
+    end
+  end
+end

--- a/spec/enterprise/models/company_spec.rb
+++ b/spec/enterprise/models/company_spec.rb
@@ -22,6 +22,27 @@ RSpec.describe Company, type: :model do
     it { is_expected.to have_many(:contacts).dependent(:nullify) }
   end
 
+  describe 'account owner validation' do
+    let(:account) { create(:account) }
+    let(:owner) { create(:user, account: account) }
+    let(:other_owner) { create(:user, account: create(:account)) }
+
+    it 'allows an account owner from the same account' do
+      company = build(:company, account: account, account_owner: owner)
+
+      expect(company).to be_valid
+    end
+
+    it 'rejects an account owner from another account' do
+      company = build(:company, account: account, account_owner: other_owner)
+
+      expect(company).not_to be_valid
+      expect(company.errors[:account_owner_id]).to include(
+        'must belong to the same account as the company'
+      )
+    end
+  end
+
   describe 'scopes' do
     let(:account) { create(:account) }
     let!(:company_b) { create(:company, name: 'B Company', account: account) }

--- a/spec/enterprise/models/user_spec.rb
+++ b/spec/enterprise/models/user_spec.rb
@@ -2,8 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe User do
+RSpec.describe User, type: :model do
   let!(:user) { create(:user) }
+
+  context 'with associations' do
+    it { is_expected.to have_many(:owned_companies).dependent(:nullify) }
+  end
 
   describe 'before validation for pricing plans' do
     let!(:existing_user) { create(:user) }

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -16,5 +16,11 @@ FactoryBot.define do
     trait :with_long_description do
       description { 'A' * 500 }
     end
+
+    trait :with_account_owner do
+      after(:build) do |company|
+        company.account_owner ||= create(:user, account: company.account)
+      end
+    end
   end
 end

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -16,5 +16,11 @@ FactoryBot.define do
     trait :with_phone_number do
       phone_number { Faker::PhoneNumber.cell_phone_in_e164 }
     end
+
+    trait :with_account_owner do
+      after(:build) do |contact|
+        contact.account_owner ||= create(:user, account: contact.account)
+      end
+    end
   end
 end

--- a/spec/jobs/agents/destroy_job_spec.rb
+++ b/spec/jobs/agents/destroy_job_spec.rb
@@ -30,5 +30,17 @@ RSpec.describe Agents::DestroyJob do
       expect(user.notification_settings.length).to eq 0
       expect(user.assigned_conversations.where(account: account).length).to eq 0
     end
+
+    it 'clears contact ownership only for the account the user is removed from' do
+      other_account = create(:account)
+      create(:account_user, account: other_account, user: user)
+      owned_contact = create(:contact, account: account, account_owner: user)
+      other_contact = create(:contact, account: other_account, account_owner: user)
+
+      described_class.perform_now(account, user)
+
+      expect(owned_contact.reload.account_owner).to be_nil
+      expect(other_contact.reload.account_owner).to eq(user)
+    end
   end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -25,6 +25,27 @@ RSpec.describe Contact do
     end
   end
 
+  describe 'account owner validation' do
+    let(:account) { create(:account) }
+    let(:owner) { create(:user, account: account) }
+    let(:other_owner) { create(:user, account: create(:account)) }
+
+    it 'allows an account owner from the same account' do
+      contact = build(:contact, account: account, account_owner: owner)
+
+      expect(contact).to be_valid
+    end
+
+    it 'rejects an account owner from another account' do
+      contact = build(:contact, account: account, account_owner: other_owner)
+
+      expect(contact).not_to be_valid
+      expect(contact.errors[:account_owner_id]).to include(
+        'must belong to the same account as the contact'
+      )
+    end
+  end
+
   context 'when prepare contact attributes before validation' do
     it 'sets email to lowercase' do
       contact = create(:contact, email: 'Test@test.com')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe User do
   context 'with associations' do
     it { is_expected.to have_many(:accounts).through(:account_users) }
     it { is_expected.to have_many(:account_users) }
+    it { is_expected.to have_many(:owned_contacts).dependent(:nullify) }
     it { is_expected.to have_many(:assigned_conversations).dependent(:nullify) }
     it { is_expected.to have_many(:inbox_members).dependent(:destroy_async) }
     it { is_expected.to have_many(:notification_settings).dependent(:destroy_async) }

--- a/swagger/definitions/index.yml
+++ b/swagger/definitions/index.yml
@@ -266,6 +266,10 @@ contact_list_item:
   $ref: ./resource/contact_list_item.yml
 contacts_list_response:
   $ref: ./resource/contacts_list_response.yml
+contact_create_response:
+  $ref: ./resource/contact_create_response.yml
+contact_update_response:
+  $ref: ./resource/contact_update_response.yml
 contact_show_response:
   $ref: ./resource/contact_show_response.yml
 contact_conversation_message:

--- a/swagger/definitions/request/contact/create_payload.yml
+++ b/swagger/definitions/request/contact/create_payload.yml
@@ -18,6 +18,12 @@ properties:
     type: boolean
     description: whether the contact is blocked or not
     example: false
+  account_owner_id:
+    type:
+      - integer
+      - 'null'
+    description: ID of the account user assigned as the contact owner. Set to null to clear the owner when applicable.
+    example: 1
   phone_number:
     type: string
     description: phone number of the contact

--- a/swagger/definitions/request/contact/update_payload.yml
+++ b/swagger/definitions/request/contact/update_payload.yml
@@ -12,6 +12,12 @@ properties:
     type: boolean
     description: whether the contact is blocked or not
     example: false
+  account_owner_id:
+    type:
+      - integer
+      - 'null'
+    description: ID of the account user assigned as the contact owner. Set to null to clear the owner when applicable.
+    example: 1
   phone_number:
     type: string
     description: phone number of the contact

--- a/swagger/definitions/resource/contact.yml
+++ b/swagger/definitions/resource/contact.yml
@@ -26,6 +26,16 @@ properties:
         blocked:
           type: boolean
           description: Whether the contact is blocked
+        account_owner_id:
+          type:
+            - integer
+            - 'null'
+          description: The ID of the account user assigned as the contact owner
+        account_owner:
+          anyOf:
+            - $ref: '#/components/schemas/agent'
+            - type: 'null'
+          description: The account user assigned as the contact owner
         identifier:
           type: string
           description: The identifier of the contact

--- a/swagger/definitions/resource/contact_create_response.yml
+++ b/swagger/definitions/resource/contact_create_response.yml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  payload:
+    type: object
+    properties:
+      contact:
+        $ref: '#/components/schemas/contact_list_item'
+        description: Created contact details
+      contact_inbox:
+        $ref: '#/components/schemas/contact_inbox'
+        description: Contact inbox details when an inbox is provided

--- a/swagger/definitions/resource/contact_list_item.yml
+++ b/swagger/definitions/resource/contact_list_item.yml
@@ -41,6 +41,16 @@ properties:
   blocked:
     type: boolean
     description: Whether the contact is blocked
+  account_owner_id:
+    type:
+      - integer
+      - 'null'
+    description: The ID of the account user assigned as the contact owner
+  account_owner:
+    anyOf:
+      - $ref: '#/components/schemas/agent'
+      - type: 'null'
+    description: The account user assigned as the contact owner
   identifier:
     type:
       - string
@@ -64,4 +74,4 @@ properties:
     type: array
     description: List of inboxes associated with this contact
     items:
-      $ref: '#/components/schemas/contact_inbox' 
+      $ref: '#/components/schemas/contact_inbox'

--- a/swagger/definitions/resource/contact_update_response.yml
+++ b/swagger/definitions/resource/contact_update_response.yml
@@ -1,0 +1,5 @@
+type: object
+properties:
+  payload:
+    $ref: '#/components/schemas/contact_list_item'
+    description: Updated contact details

--- a/swagger/paths/application/contacts/crud.yml
+++ b/swagger/paths/application/contacts/crud.yml
@@ -50,12 +50,12 @@ put:
         schema:
           $ref: '#/components/schemas/contact_update_payload'
   responses:
-    '204':
+    '200':
       description: Success
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/contact_base'
+            $ref: '#/components/schemas/contact_update_response'
     '404':
       description: Contact not found
       content:

--- a/swagger/paths/application/contacts/list_create.yml
+++ b/swagger/paths/application/contacts/list_create.yml
@@ -46,7 +46,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/extended_contact'
+            $ref: '#/components/schemas/contact_create_response'
     '400':
       description: Bad Request Error
       content:

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -2730,7 +2730,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/extended_contact"
+                  "$ref": "#/components/schemas/contact_create_response"
                 }
               }
             }
@@ -2831,12 +2831,12 @@
           }
         },
         "responses": {
-          "204": {
+          "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/contact_base"
+                  "$ref": "#/components/schemas/contact_update_response"
                 }
               }
             }
@@ -9401,6 +9401,24 @@
                   "type": "boolean",
                   "description": "Whether the contact is blocked"
                 },
+                "account_owner_id": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "The ID of the account user assigned as the contact owner"
+                },
+                "account_owner": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/agent"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The account user assigned as the contact owner"
+                },
                 "identifier": {
                   "type": "string",
                   "description": "The identifier of the contact"
@@ -11670,6 +11688,14 @@
             "description": "whether the contact is blocked or not",
             "example": false
           },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of the account user assigned as the contact owner. Set to null to clear the owner when applicable.",
+            "example": 1
+          },
           "phone_number": {
             "type": "string",
             "description": "phone number of the contact",
@@ -11722,6 +11748,14 @@
             "type": "boolean",
             "description": "whether the contact is blocked or not",
             "example": false
+          },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of the account user assigned as the contact owner. Set to null to clear the owner when applicable.",
+            "example": 1
           },
           "phone_number": {
             "type": "string",
@@ -14059,6 +14093,24 @@
             "type": "boolean",
             "description": "Whether the contact is blocked"
           },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "The ID of the account user assigned as the contact owner"
+          },
+          "account_owner": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/agent"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The account user assigned as the contact owner"
+          },
           "identifier": {
             "type": [
               "string",
@@ -14106,6 +14158,30 @@
               "$ref": "#/components/schemas/contact_list_item"
             },
             "description": "List of contacts"
+          }
+        }
+      },
+      "contact_create_response": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "contact": {
+                "$ref": "#/components/schemas/contact_list_item"
+              },
+              "contact_inbox": {
+                "$ref": "#/components/schemas/contact_inbox"
+              }
+            }
+          }
+        }
+      },
+      "contact_update_response": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "$ref": "#/components/schemas/contact_list_item"
           }
         }
       },

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -1273,7 +1273,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/extended_contact"
+                  "$ref": "#/components/schemas/contact_create_response"
                 }
               }
             }
@@ -1374,12 +1374,12 @@
           }
         },
         "responses": {
-          "204": {
+          "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/contact_base"
+                  "$ref": "#/components/schemas/contact_update_response"
                 }
               }
             }
@@ -7908,6 +7908,24 @@
                   "type": "boolean",
                   "description": "Whether the contact is blocked"
                 },
+                "account_owner_id": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "The ID of the account user assigned as the contact owner"
+                },
+                "account_owner": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/agent"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The account user assigned as the contact owner"
+                },
                 "identifier": {
                   "type": "string",
                   "description": "The identifier of the contact"
@@ -10177,6 +10195,14 @@
             "description": "whether the contact is blocked or not",
             "example": false
           },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of the account user assigned as the contact owner. Set to null to clear the owner when applicable.",
+            "example": 1
+          },
           "phone_number": {
             "type": "string",
             "description": "phone number of the contact",
@@ -10229,6 +10255,14 @@
             "type": "boolean",
             "description": "whether the contact is blocked or not",
             "example": false
+          },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of the account user assigned as the contact owner. Set to null to clear the owner when applicable.",
+            "example": 1
           },
           "phone_number": {
             "type": "string",
@@ -12566,6 +12600,24 @@
             "type": "boolean",
             "description": "Whether the contact is blocked"
           },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "The ID of the account user assigned as the contact owner"
+          },
+          "account_owner": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/agent"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The account user assigned as the contact owner"
+          },
           "identifier": {
             "type": [
               "string",
@@ -12613,6 +12665,30 @@
               "$ref": "#/components/schemas/contact_list_item"
             },
             "description": "List of contacts"
+          }
+        }
+      },
+      "contact_create_response": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "contact": {
+                "$ref": "#/components/schemas/contact_list_item"
+              },
+              "contact_inbox": {
+                "$ref": "#/components/schemas/contact_inbox"
+              }
+            }
+          }
+        }
+      },
+      "contact_update_response": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "$ref": "#/components/schemas/contact_list_item"
           }
         }
       },

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -1173,6 +1173,24 @@
                   "type": "boolean",
                   "description": "Whether the contact is blocked"
                 },
+                "account_owner_id": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "The ID of the account user assigned as the contact owner"
+                },
+                "account_owner": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/agent"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The account user assigned as the contact owner"
+                },
                 "identifier": {
                   "type": "string",
                   "description": "The identifier of the contact"
@@ -3442,6 +3460,14 @@
             "description": "whether the contact is blocked or not",
             "example": false
           },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of the account user assigned as the contact owner. Set to null to clear the owner when applicable.",
+            "example": 1
+          },
           "phone_number": {
             "type": "string",
             "description": "phone number of the contact",
@@ -3494,6 +3520,14 @@
             "type": "boolean",
             "description": "whether the contact is blocked or not",
             "example": false
+          },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of the account user assigned as the contact owner. Set to null to clear the owner when applicable.",
+            "example": 1
           },
           "phone_number": {
             "type": "string",
@@ -5831,6 +5865,24 @@
             "type": "boolean",
             "description": "Whether the contact is blocked"
           },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "The ID of the account user assigned as the contact owner"
+          },
+          "account_owner": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/agent"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The account user assigned as the contact owner"
+          },
           "identifier": {
             "type": [
               "string",
@@ -5878,6 +5930,30 @@
               "$ref": "#/components/schemas/contact_list_item"
             },
             "description": "List of contacts"
+          }
+        }
+      },
+      "contact_create_response": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "contact": {
+                "$ref": "#/components/schemas/contact_list_item"
+              },
+              "contact_inbox": {
+                "$ref": "#/components/schemas/contact_inbox"
+              }
+            }
+          }
+        }
+      },
+      "contact_update_response": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "$ref": "#/components/schemas/contact_list_item"
           }
         }
       },

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -588,6 +588,24 @@
                   "type": "boolean",
                   "description": "Whether the contact is blocked"
                 },
+                "account_owner_id": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "The ID of the account user assigned as the contact owner"
+                },
+                "account_owner": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/agent"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The account user assigned as the contact owner"
+                },
                 "identifier": {
                   "type": "string",
                   "description": "The identifier of the contact"
@@ -2857,6 +2875,14 @@
             "description": "whether the contact is blocked or not",
             "example": false
           },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of the account user assigned as the contact owner. Set to null to clear the owner when applicable.",
+            "example": 1
+          },
           "phone_number": {
             "type": "string",
             "description": "phone number of the contact",
@@ -2909,6 +2935,14 @@
             "type": "boolean",
             "description": "whether the contact is blocked or not",
             "example": false
+          },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of the account user assigned as the contact owner. Set to null to clear the owner when applicable.",
+            "example": 1
           },
           "phone_number": {
             "type": "string",
@@ -5246,6 +5280,24 @@
             "type": "boolean",
             "description": "Whether the contact is blocked"
           },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "The ID of the account user assigned as the contact owner"
+          },
+          "account_owner": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/agent"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The account user assigned as the contact owner"
+          },
           "identifier": {
             "type": [
               "string",
@@ -5293,6 +5345,30 @@
               "$ref": "#/components/schemas/contact_list_item"
             },
             "description": "List of contacts"
+          }
+        }
+      },
+      "contact_create_response": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "contact": {
+                "$ref": "#/components/schemas/contact_list_item"
+              },
+              "contact_inbox": {
+                "$ref": "#/components/schemas/contact_inbox"
+              }
+            }
+          }
+        }
+      },
+      "contact_update_response": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "$ref": "#/components/schemas/contact_list_item"
           }
         }
       },

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -1349,6 +1349,24 @@
                   "type": "boolean",
                   "description": "Whether the contact is blocked"
                 },
+                "account_owner_id": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "The ID of the account user assigned as the contact owner"
+                },
+                "account_owner": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/agent"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The account user assigned as the contact owner"
+                },
                 "identifier": {
                   "type": "string",
                   "description": "The identifier of the contact"
@@ -3618,6 +3636,14 @@
             "description": "whether the contact is blocked or not",
             "example": false
           },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of the account user assigned as the contact owner. Set to null to clear the owner when applicable.",
+            "example": 1
+          },
           "phone_number": {
             "type": "string",
             "description": "phone number of the contact",
@@ -3670,6 +3696,14 @@
             "type": "boolean",
             "description": "whether the contact is blocked or not",
             "example": false
+          },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of the account user assigned as the contact owner. Set to null to clear the owner when applicable.",
+            "example": 1
           },
           "phone_number": {
             "type": "string",
@@ -6007,6 +6041,24 @@
             "type": "boolean",
             "description": "Whether the contact is blocked"
           },
+          "account_owner_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "The ID of the account user assigned as the contact owner"
+          },
+          "account_owner": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/agent"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The account user assigned as the contact owner"
+          },
           "identifier": {
             "type": [
               "string",
@@ -6054,6 +6106,30 @@
               "$ref": "#/components/schemas/contact_list_item"
             },
             "description": "List of contacts"
+          }
+        }
+      },
+      "contact_create_response": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "contact": {
+                "$ref": "#/components/schemas/contact_list_item"
+              },
+              "contact_inbox": {
+                "$ref": "#/components/schemas/contact_inbox"
+              }
+            }
+          }
+        }
+      },
+      "contact_update_response": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "$ref": "#/components/schemas/contact_list_item"
           }
         }
       },


### PR DESCRIPTION
Adds account ownership to CRM contacts and companies so teams can assign responsible agents, see owner details in CRM lists, and update ownership from dashboard records and APIs.

### Closes
Closes #14374.

### How to test
- Open Contacts, expand an existing contact, set an account owner, save, then clear it and confirm the owner label updates.
- Open Companies, set and clear an account owner from a company row and confirm only that row is disabled while saving.
- Create or update contacts through the API with `account_owner_id`, and confirm cross-account owners are rejected.

### What changed
- Added account owner associations, account-scoped validation, cleanup on agent destroy, and database fields for contacts and companies.
- Exposed `account_owner_id` and `account_owner` in contact and company API responses, with contact API documentation updates.
- Added shared dashboard account owner picker support for contacts and companies.
