### PR TITLE
feat: add attachments section to conversation sidebar

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/components/GalleryView.vue
@@ -22,6 +22,10 @@ const props = defineProps({
     type: Array,
     required: true,
   },
+  autoPlay: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits(['close']);
@@ -309,6 +313,7 @@ onMounted(() => {
               :src="activeAttachment.data_url"
               controls
               playsInline
+              :autoplay="autoPlay"
               class="max-h-full max-w-full object-contain"
               @click.stop
             />
@@ -317,6 +322,7 @@ onMounted(() => {
               v-if="isAudio"
               :key="activeAttachment.message_id"
               controls
+              :autoplay="autoPlay"
               class="w-full max-w-md"
               @click.stop
             >

--- a/app/javascript/dashboard/composables/useUISettings.js
+++ b/app/javascript/dashboard/composables/useUISettings.js
@@ -7,6 +7,7 @@ export const DEFAULT_CONVERSATION_SIDEBAR_ITEMS_ORDER = Object.freeze([
   { name: 'conversation_info' },
   { name: 'contact_attributes' },
   { name: 'contact_notes' },
+  { name: 'shared_files' },
   { name: 'previous_conversation' },
   { name: 'conversation_participants' },
   { name: 'linear_issues' },

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -365,7 +365,19 @@
       "PREVIOUS_CONVERSATION": "Previous Conversations",
       "MACROS": "Macros",
       "LINEAR_ISSUES": "Linked Linear Issues",
-      "SHOPIFY_ORDERS": "Shopify Orders"
+      "SHOPIFY_ORDERS": "Shopify Orders",
+      "SHARED_FILES": "Shared Files"
+    },
+    "SHARED_FILES": {
+      "EMPTY": "No files shared yet",
+      "DOWNLOAD": "Download file",
+      "DOWNLOAD_ERROR": "Could not download the file. Please try again.",
+      "MEDIA_HEADING": "Media",
+      "FILES_HEADING": "Files",
+      "VIEW_ALL": "View all",
+      "SHOW_LESS": "Show less",
+      "MORE_COUNT": "+{count}",
+      "UNTITLED_FILE": "Untitled file"
     },
     "SHOPIFY": {
       "ORDER_ID": "Order #{id}",

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -366,10 +366,10 @@
       "MACROS": "Macros",
       "LINEAR_ISSUES": "Linked Linear Issues",
       "SHOPIFY_ORDERS": "Shopify Orders",
-      "SHARED_FILES": "Shared Files"
+      "SHARED_FILES": "Attachments"
     },
     "SHARED_FILES": {
-      "EMPTY": "No files shared yet",
+      "EMPTY": "No attachments yet",
       "DOWNLOAD": "Download file",
       "DOWNLOAD_ERROR": "Could not download the file. Please try again.",
       "MEDIA_HEADING": "Media",

--- a/app/javascript/dashboard/routes/dashboard/conversation/ContactPanel.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ContactPanel.vue
@@ -17,6 +17,7 @@ import ContactInfo from './contact/ContactInfo.vue';
 import ContactNotes from './contact/ContactNotes.vue';
 import ConversationInfo from './ConversationInfo.vue';
 import CustomAttributes from './customAttributes/CustomAttributes.vue';
+import SharedFiles from './SharedFiles.vue';
 import Draggable from 'vuedraggable';
 import MacrosList from './Macros/List.vue';
 import ShopifyOrdersList from 'dashboard/components/widgets/conversation/ShopifyOrdersList.vue';
@@ -295,6 +296,18 @@ onMounted(() => {
               "
             >
               <ContactNotes :contact-id="contactId" />
+            </AccordionItem>
+          </div>
+          <div v-else-if="element.name === 'shared_files'">
+            <AccordionItem
+              :title="$t('CONVERSATION_SIDEBAR.ACCORDION.SHARED_FILES')"
+              :is-open="isContactSidebarItemOpen('is_shared_files_open')"
+              compact
+              @toggle="
+                value => toggleSidebarUIState('is_shared_files_open', value)
+              "
+            >
+              <SharedFiles />
             </AccordionItem>
           </div>
         </template>

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -47,9 +47,10 @@ const visibleFiles = computed(() =>
     : fileAttachments.value.slice(0, FILES_PEEK_LIMIT)
 );
 
-const mediaOverflow = computed(() =>
-  Math.max(0, mediaAttachments.value.length - MEDIA_PEEK_LIMIT)
-);
+const mediaOverflow = computed(() => {
+  const total = mediaAttachments.value.length;
+  return total > MEDIA_PEEK_LIMIT ? total - (MEDIA_PEEK_LIMIT - 1) : 0;
+});
 
 const showGallery = ref(false);
 const selectedAttachment = ref(null);
@@ -90,19 +91,41 @@ const onTileActivate = (attachment, index) => {
   showGallery.value = true;
 };
 
+const failedThumbs = ref(new Set());
+const failedPreviews = ref(new Set());
+
 const imagePreviewSrc = attachment => {
   const {
+    id,
     file_type: type,
     thumb_url: thumbUrl,
     data_url: dataUrl,
   } = attachment;
-  if (type === ATTACHMENT_TYPES.IMAGE) return thumbUrl || dataUrl;
-  if (isVideoType(type)) return thumbUrl || null;
+  const canUseThumb = thumbUrl && !failedThumbs.value.has(id);
+  if (type === ATTACHMENT_TYPES.IMAGE) {
+    if (canUseThumb) return thumbUrl;
+    return dataUrl;
+  }
+  if (isVideoType(type)) return canUseThumb ? thumbUrl : null;
   return null;
 };
 
-const failedPreviews = ref(new Set());
-const onPreviewError = id => failedPreviews.value.add(id);
+const onPreviewError = attachment => {
+  const {
+    id,
+    file_type: type,
+    thumb_url: thumbUrl,
+    data_url: dataUrl,
+  } = attachment;
+  // First failure on a thumb-backed src: retry with the full url (image)
+  // or hand off to the <video> tag (video).
+  if (thumbUrl && !failedThumbs.value.has(id) && dataUrl) {
+    failedThumbs.value.add(id);
+    if (type === ATTACHMENT_TYPES.IMAGE || isVideoType(type)) return;
+  }
+  failedPreviews.value.add(id);
+};
+
 const hasPreview = attachment =>
   !!imagePreviewSrc(attachment) && !failedPreviews.value.has(attachment.id);
 const hasVideoPreview = attachment =>
@@ -186,7 +209,7 @@ const displaySize = attachment => {
               class="object-cover w-full h-full transition-transform duration-300 group-hover:scale-110"
               loading="lazy"
               :alt="fileNameFromUrl(attachment.data_url)"
-              @error="onPreviewError(attachment.id)"
+              @error="onPreviewError(attachment)"
             />
             <video
               v-else-if="hasVideoPreview(attachment)"
@@ -195,7 +218,7 @@ const displaySize = attachment => {
               muted
               playsinline
               class="object-cover w-full h-full transition-transform duration-300 group-hover:scale-110 pointer-events-none"
-              @error="onPreviewError(attachment.id)"
+              @error="onPreviewError(attachment)"
             />
             <div
               v-else

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n';
 import { useMapGetter } from 'dashboard/composables/store';
 import { useAlert } from 'dashboard/composables';
 import { formatBytes } from 'shared/helpers/FileHelper';
+import { dynamicTime, shortTimestamp } from 'shared/helpers/timeHelper';
 import { downloadFile } from '@chatwoot/utils';
 import {
   ATTACHMENT_TYPES,
@@ -150,6 +151,11 @@ const displaySize = attachment => {
   if (attachment.extension) return attachment.extension.toUpperCase();
   return '—';
 };
+
+const displayTime = attachment => {
+  if (!attachment.created_at) return '';
+  return shortTimestamp(dynamicTime(attachment.created_at), true);
+};
 </script>
 
 <template>
@@ -250,9 +256,16 @@ const displaySize = attachment => {
               </div>
             </div>
 
+            <span
+              v-if="displayTime(attachment)"
+              class="absolute text-xxs font-medium transition-opacity opacity-0 bottom-1.5 ltr:left-1.5 rtl:right-1.5 text-white [text-shadow:_0_1px_3px_rgba(0,0,0,0.95),_0_0_10px_rgba(0,0,0,0.7)] group-hover:opacity-100"
+            >
+              {{ displayTime(attachment) }}
+            </span>
+
             <button
               type="button"
-              class="absolute flex items-center justify-center !p-px transition-all rounded-full opacity-0 bottom-1.5 right-1.5 size-6 bg-white/95 shadow-md group-hover:opacity-100 hover:bg-white disabled:opacity-50"
+              class="absolute flex items-center justify-center !p-px transition-all rounded-full opacity-0 bottom-1.5 ltr:right-1.5 rtl:left-1.5 size-6 bg-white/95 shadow-md group-hover:opacity-100 hover:bg-white disabled:opacity-50"
               :disabled="downloadingId === attachment.id"
               :aria-label="t('CONVERSATION_SIDEBAR.SHARED_FILES.DOWNLOAD')"
               @click.stop="onDownloadFile(attachment)"
@@ -265,11 +278,9 @@ const displaySize = attachment => {
 
           <div
             v-if="isOverflowTile(index)"
-            class="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-n-slate-1/85 via-n-slate-12/75 to-black/90 backdrop-blur-[2px]"
+            class="absolute inset-0 flex items-center justify-center bg-n-slate-5"
           >
-            <span
-              class="text-base font-semibold tracking-tight text-n-slate-1 drop-shadow-sm"
-            >
+            <span class="text-base font-semibold text-n-slate-12">
               {{
                 t('CONVERSATION_SIDEBAR.SHARED_FILES.MORE_COUNT', {
                   count: mediaOverflow,
@@ -336,6 +347,9 @@ const displaySize = attachment => {
             </p>
             <p class="text-xs text-n-slate-11">
               {{ displaySize(attachment) }}
+              <template v-if="displayTime(attachment)">
+                · {{ displayTime(attachment) }}
+              </template>
             </p>
           </a>
           <NextButton

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -29,7 +29,9 @@ const mediaAttachments = computed(() =>
 );
 
 const fileAttachments = computed(() =>
-  allAttachments.value.filter(a => !MEDIA_TYPES.includes(a.file_type))
+  allAttachments.value.filter(
+    a => !MEDIA_TYPES.includes(a.file_type) && a.data_url
+  )
 );
 
 const showAllMedia = ref(false);

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -153,24 +153,22 @@ const displaySize = attachment => {
             {{ mediaAttachments.length }}
           </span>
         </h4>
-        <button
+        <NextButton
           v-if="mediaOverflow > 0"
-          type="button"
-          class="inline-flex items-center gap-0.5 px-1.5 py-0.5 -mr-1.5 rounded-md text-xs font-medium text-n-blue-text hover:bg-n-alpha-1 transition-colors"
-          @click="showAllMedia = !showAllMedia"
-        >
-          {{
+          ghost
+          slate
+          xs
+          trailing-icon
+          :icon="
+            showAllMedia ? 'i-lucide-chevron-up' : 'i-lucide-chevron-right'
+          "
+          :label="
             showAllMedia
               ? t('CONVERSATION_SIDEBAR.SHARED_FILES.SHOW_LESS')
               : t('CONVERSATION_SIDEBAR.SHARED_FILES.VIEW_ALL')
-          }}
-          <Icon
-            :icon="
-              showAllMedia ? 'i-lucide-chevron-up' : 'i-lucide-chevron-right'
-            "
-            class="size-3"
-          />
-        </button>
+          "
+          @click="showAllMedia = !showAllMedia"
+        />
       </header>
       <div class="grid grid-cols-3 gap-1.5">
         <div
@@ -272,24 +270,22 @@ const displaySize = attachment => {
             {{ fileAttachments.length }}
           </span>
         </h4>
-        <button
+        <NextButton
           v-if="fileAttachments.length > FILES_PEEK_LIMIT"
-          type="button"
-          class="inline-flex items-center gap-0.5 px-1.5 py-0.5 -mr-1.5 rounded-md text-xs font-medium text-n-blue-text hover:bg-n-alpha-1 transition-colors"
-          @click="showAllFiles = !showAllFiles"
-        >
-          {{
+          ghost
+          slate
+          xs
+          trailing-icon
+          :icon="
+            showAllFiles ? 'i-lucide-chevron-up' : 'i-lucide-chevron-right'
+          "
+          :label="
             showAllFiles
               ? t('CONVERSATION_SIDEBAR.SHARED_FILES.SHOW_LESS')
               : t('CONVERSATION_SIDEBAR.SHARED_FILES.VIEW_ALL')
-          }}
-          <Icon
-            :icon="
-              showAllFiles ? 'i-lucide-chevron-up' : 'i-lucide-chevron-right'
-            "
-            class="size-3"
-          />
-        </button>
+          "
+          @click="showAllFiles = !showAllFiles"
+        />
       </header>
       <ul class="flex flex-col gap-0.5">
         <li

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -29,12 +29,18 @@ const { t } = useI18n();
 const allAttachments = useMapGetter('getSelectedChatAttachments');
 const attachmentsLoaded = useMapGetter('getSelectedChatAttachmentsLoaded');
 
+const sortedAttachments = computed(() =>
+  [...allAttachments.value].sort(
+    (a, b) => (b.created_at || 0) - (a.created_at || 0)
+  )
+);
+
 const mediaAttachments = computed(() =>
-  allAttachments.value.filter(a => MEDIA_TYPES.includes(a.file_type))
+  sortedAttachments.value.filter(a => MEDIA_TYPES.includes(a.file_type))
 );
 
 const fileAttachments = computed(() =>
-  allAttachments.value.filter(
+  sortedAttachments.value.filter(
     a => !MEDIA_TYPES.includes(a.file_type) && a.data_url
   )
 );

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -5,6 +5,10 @@ import { useMapGetter } from 'dashboard/composables/store';
 import { useAlert } from 'dashboard/composables';
 import { formatBytes } from 'shared/helpers/FileHelper';
 import { downloadFile } from '@chatwoot/utils';
+import {
+  ATTACHMENT_TYPES,
+  MEDIA_TYPES,
+} from 'dashboard/components-next/message/constants';
 
 import GalleryView from 'dashboard/components/widgets/conversation/components/GalleryView.vue';
 import Icon from 'next/icon/Icon.vue';
@@ -12,7 +16,6 @@ import FileIcon from 'next/icon/FileIcon.vue';
 import NextButton from 'dashboard/components-next/button/Button.vue';
 import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
 
-const MEDIA_TYPES = ['image', 'video', 'ig_reel', 'audio'];
 const MEDIA_PEEK_LIMIT = 6;
 const FILES_PEEK_LIMIT = 3;
 
@@ -70,7 +73,8 @@ const onDownloadFile = async attachment => {
   }
 };
 
-const isVideoType = type => ['video', 'ig_reel'].includes(type);
+const isVideoType = type =>
+  [ATTACHMENT_TYPES.VIDEO, ATTACHMENT_TYPES.IG_REEL].includes(type);
 
 const isOverflowTile = index =>
   !showAllMedia.value &&
@@ -92,7 +96,7 @@ const imagePreviewSrc = attachment => {
     thumb_url: thumbUrl,
     data_url: dataUrl,
   } = attachment;
-  if (type === 'image') return thumbUrl || dataUrl;
+  if (type === ATTACHMENT_TYPES.IMAGE) return thumbUrl || dataUrl;
   if (isVideoType(type)) return thumbUrl || null;
   return null;
 };
@@ -107,7 +111,7 @@ const hasVideoPreview = attachment =>
   !failedPreviews.value.has(attachment.id);
 
 const fallbackIcon = type => {
-  if (type === 'audio') return 'i-lucide-music';
+  if (type === ATTACHMENT_TYPES.AUDIO) return 'i-lucide-music';
   if (isVideoType(type)) return 'i-lucide-video';
   return 'i-lucide-image';
 };

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -1,0 +1,344 @@
+<script setup>
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useMapGetter } from 'dashboard/composables/store';
+import { useAlert } from 'dashboard/composables';
+import { formatBytes } from 'shared/helpers/FileHelper';
+import { downloadFile } from '@chatwoot/utils';
+
+import GalleryView from 'dashboard/components/widgets/conversation/components/GalleryView.vue';
+import Icon from 'next/icon/Icon.vue';
+import FileIcon from 'next/icon/FileIcon.vue';
+import NextButton from 'dashboard/components-next/button/Button.vue';
+import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
+
+const MEDIA_TYPES = ['image', 'video', 'ig_reel', 'audio'];
+const MEDIA_PEEK_LIMIT = 6;
+const FILES_PEEK_LIMIT = 3;
+
+const { t } = useI18n();
+
+const allAttachments = useMapGetter('getSelectedChatAttachments');
+const attachmentsLoaded = useMapGetter('getSelectedChatAttachmentsLoaded');
+
+const mediaAttachments = computed(() =>
+  allAttachments.value.filter(a => MEDIA_TYPES.includes(a.file_type))
+);
+
+const fileAttachments = computed(() =>
+  allAttachments.value.filter(a => !MEDIA_TYPES.includes(a.file_type))
+);
+
+const showAllMedia = ref(false);
+const showAllFiles = ref(false);
+
+const visibleMedia = computed(() =>
+  showAllMedia.value
+    ? mediaAttachments.value
+    : mediaAttachments.value.slice(0, MEDIA_PEEK_LIMIT)
+);
+
+const visibleFiles = computed(() =>
+  showAllFiles.value
+    ? fileAttachments.value
+    : fileAttachments.value.slice(0, FILES_PEEK_LIMIT)
+);
+
+const mediaOverflow = computed(() =>
+  Math.max(0, mediaAttachments.value.length - MEDIA_PEEK_LIMIT)
+);
+
+const showGallery = ref(false);
+const selectedAttachment = ref(null);
+const downloadingId = ref(null);
+
+const fileNameFromUrl = url => {
+  if (!url) return '';
+  const name = url.split('/').pop();
+  return name ? decodeURIComponent(name) : '';
+};
+
+const onDownloadFile = async attachment => {
+  const {
+    message_id: messageId,
+    file_type: type,
+    data_url: url,
+    extension,
+  } = attachment;
+  try {
+    downloadingId.value = messageId;
+    await downloadFile({ url, type, extension });
+  } catch (error) {
+    useAlert(t('CONVERSATION_SIDEBAR.SHARED_FILES.DOWNLOAD_ERROR'));
+  } finally {
+    downloadingId.value = null;
+  }
+};
+
+const isVideoType = type => ['video', 'ig_reel'].includes(type);
+
+const isOverflowTile = index =>
+  !showAllMedia.value &&
+  mediaOverflow.value > 0 &&
+  index === MEDIA_PEEK_LIMIT - 1;
+
+const onTileActivate = (attachment, index) => {
+  if (isOverflowTile(index)) {
+    showAllMedia.value = true;
+    return;
+  }
+  selectedAttachment.value = attachment;
+  showGallery.value = true;
+};
+
+const imagePreviewSrc = attachment => {
+  const {
+    file_type: type,
+    thumb_url: thumbUrl,
+    data_url: dataUrl,
+  } = attachment;
+  if (type === 'image') return thumbUrl || dataUrl;
+  if (isVideoType(type)) return thumbUrl || null;
+  return null;
+};
+
+const failedPreviews = ref(new Set());
+const onPreviewError = messageId => failedPreviews.value.add(messageId);
+const hasPreview = attachment =>
+  !!imagePreviewSrc(attachment) &&
+  !failedPreviews.value.has(attachment.message_id);
+const hasVideoPreview = attachment =>
+  isVideoType(attachment.file_type) &&
+  attachment.data_url &&
+  !failedPreviews.value.has(attachment.message_id);
+
+const fallbackIcon = type => {
+  if (type === 'audio') return 'i-lucide-music';
+  if (isVideoType(type)) return 'i-lucide-video';
+  return 'i-lucide-image';
+};
+
+const displayName = attachment =>
+  fileNameFromUrl(attachment.data_url) ||
+  t('CONVERSATION_SIDEBAR.SHARED_FILES.UNTITLED_FILE');
+
+const displaySize = attachment => {
+  if (attachment.file_size) return formatBytes(attachment.file_size);
+  if (attachment.extension) return attachment.extension.toUpperCase();
+  return '—';
+};
+</script>
+
+<template>
+  <div class="flex flex-col gap-5 py-4 px-2">
+    <div v-if="!attachmentsLoaded" class="flex justify-center p-3">
+      <Spinner class="size-5" />
+    </div>
+    <p
+      v-else-if="!allAttachments.length"
+      class="p-3 text-sm text-center text-n-slate-11"
+    >
+      {{ t('CONVERSATION_SIDEBAR.SHARED_FILES.EMPTY') }}
+    </p>
+
+    <section v-if="mediaAttachments.length" class="flex flex-col gap-2.5">
+      <header class="flex items-center justify-between px-0.5">
+        <h4
+          class="text-xs font-semibold tracking-wider uppercase text-n-slate-11"
+        >
+          {{ t('CONVERSATION_SIDEBAR.SHARED_FILES.MEDIA_HEADING') }}
+          <span
+            class="ml-1 font-medium tracking-normal normal-case text-n-slate-10"
+          >
+            {{ mediaAttachments.length }}
+          </span>
+        </h4>
+        <button
+          v-if="mediaOverflow > 0"
+          type="button"
+          class="inline-flex items-center gap-0.5 px-1.5 py-0.5 -mr-1.5 rounded-md text-xs font-medium text-n-blue-text hover:bg-n-alpha-1 transition-colors"
+          @click="showAllMedia = !showAllMedia"
+        >
+          {{
+            showAllMedia
+              ? t('CONVERSATION_SIDEBAR.SHARED_FILES.SHOW_LESS')
+              : t('CONVERSATION_SIDEBAR.SHARED_FILES.VIEW_ALL')
+          }}
+          <Icon
+            :icon="
+              showAllMedia ? 'i-lucide-chevron-up' : 'i-lucide-chevron-right'
+            "
+            class="size-3"
+          />
+        </button>
+      </header>
+      <div class="grid grid-cols-3 gap-1.5">
+        <div
+          v-for="(attachment, index) in visibleMedia"
+          :key="attachment.message_id"
+          role="button"
+          tabindex="0"
+          class="relative w-full overflow-hidden transition-all duration-200 rounded-lg cursor-pointer aspect-square bg-n-slate-3 shadow-sm hover:shadow-md hover:-translate-y-px group focus:outline-none focus-visible:ring-2 focus-visible:ring-n-blue-9"
+          @click="onTileActivate(attachment, index)"
+          @keydown.enter="onTileActivate(attachment, index)"
+          @keydown.space.prevent="onTileActivate(attachment, index)"
+        >
+          <template v-if="!isOverflowTile(index)">
+            <img
+              v-if="hasPreview(attachment)"
+              :src="imagePreviewSrc(attachment)"
+              class="object-cover w-full h-full transition-transform duration-300 group-hover:scale-110"
+              loading="lazy"
+              :alt="fileNameFromUrl(attachment.data_url)"
+              @error="onPreviewError(attachment.message_id)"
+            />
+            <video
+              v-else-if="hasVideoPreview(attachment)"
+              :src="`${attachment.data_url}#t=0.1`"
+              preload="metadata"
+              muted
+              playsinline
+              class="object-cover w-full h-full transition-transform duration-300 group-hover:scale-110 pointer-events-none"
+              @error="onPreviewError(attachment.message_id)"
+            />
+            <div
+              v-else
+              class="flex items-center justify-center w-full h-full bg-gradient-to-br from-n-slate-3 to-n-slate-4"
+            >
+              <Icon
+                :icon="fallbackIcon(attachment.file_type)"
+                class="size-6 text-n-slate-11"
+              />
+            </div>
+
+            <div
+              class="absolute inset-0 transition-opacity duration-200 opacity-0 pointer-events-none group-hover:opacity-100 bg-gradient-to-t from-black/40 via-transparent to-transparent"
+            />
+
+            <div
+              v-if="hasVideoPreview(attachment)"
+              class="absolute inset-0 flex items-center justify-center pointer-events-none bg-gradient-to-t from-black/30 via-transparent to-transparent"
+            >
+              <div
+                class="flex items-center justify-center rounded-full size-7 bg-white/95 shadow-md"
+              >
+                <Icon
+                  icon="i-lucide-play"
+                  class="ml-0.5 size-3.5 text-n-slate-12"
+                />
+              </div>
+            </div>
+
+            <button
+              type="button"
+              class="absolute flex items-center justify-center !p-px transition-all rounded-full opacity-0 bottom-1.5 right-1.5 size-6 bg-white/95 shadow-md group-hover:opacity-100 hover:bg-white disabled:opacity-50"
+              :disabled="downloadingId === attachment.message_id"
+              :aria-label="t('CONVERSATION_SIDEBAR.SHARED_FILES.DOWNLOAD')"
+              @click.stop="onDownloadFile(attachment)"
+              @keydown.enter.stop
+              @keydown.space.stop
+            >
+              <Icon icon="i-lucide-download" class="size-3 text-n-black" />
+            </button>
+          </template>
+
+          <div
+            v-if="isOverflowTile(index)"
+            class="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-n-slate-1/85 via-n-slate-12/75 to-black/90 backdrop-blur-[2px]"
+          >
+            <span
+              class="text-base font-semibold tracking-tight text-n-slate-1 drop-shadow-sm"
+            >
+              {{
+                t('CONVERSATION_SIDEBAR.SHARED_FILES.MORE_COUNT', {
+                  count: mediaOverflow,
+                })
+              }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section v-if="fileAttachments.length" class="flex flex-col gap-2.5">
+      <header class="flex items-center justify-between px-0.5">
+        <h4
+          class="text-xs font-semibold tracking-wider uppercase text-n-slate-11"
+        >
+          {{ t('CONVERSATION_SIDEBAR.SHARED_FILES.FILES_HEADING') }}
+          <span
+            class="ml-1 font-medium tracking-normal normal-case text-n-slate-10"
+          >
+            {{ fileAttachments.length }}
+          </span>
+        </h4>
+        <button
+          v-if="fileAttachments.length > FILES_PEEK_LIMIT"
+          type="button"
+          class="inline-flex items-center gap-0.5 px-1.5 py-0.5 -mr-1.5 rounded-md text-xs font-medium text-n-blue-text hover:bg-n-alpha-1 transition-colors"
+          @click="showAllFiles = !showAllFiles"
+        >
+          {{
+            showAllFiles
+              ? t('CONVERSATION_SIDEBAR.SHARED_FILES.SHOW_LESS')
+              : t('CONVERSATION_SIDEBAR.SHARED_FILES.VIEW_ALL')
+          }}
+          <Icon
+            :icon="
+              showAllFiles ? 'i-lucide-chevron-up' : 'i-lucide-chevron-right'
+            "
+            class="size-3"
+          />
+        </button>
+      </header>
+      <ul class="flex flex-col gap-0.5">
+        <li
+          v-for="attachment in visibleFiles"
+          :key="attachment.message_id"
+          class="flex items-center gap-3 px-2 py-2 transition-colors rounded-lg hover:bg-n-slate-3 group"
+        >
+          <div
+            class="flex items-center justify-center rounded-lg size-9 shrink-0 bg-gradient-to-br from-n-slate-3 to-n-slate-4 ring-1 ring-inset ring-n-slate-4/40"
+          >
+            <FileIcon
+              :file-type="attachment.extension?.toLowerCase() || ''"
+              class="size-4 text-n-slate-11"
+            />
+          </div>
+          <a
+            :href="attachment.data_url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex-1 min-w-0"
+            :title="displayName(attachment)"
+          >
+            <p class="text-sm font-medium truncate text-n-slate-12 mb-1">
+              {{ displayName(attachment) }}
+            </p>
+            <p class="text-xs text-n-slate-11">
+              {{ displaySize(attachment) }}
+            </p>
+          </a>
+          <NextButton
+            ghost
+            slate
+            sm
+            icon="i-lucide-download"
+            class="opacity-0 group-hover:opacity-100"
+            :is-loading="downloadingId === attachment.message_id"
+            :aria-label="t('CONVERSATION_SIDEBAR.SHARED_FILES.DOWNLOAD')"
+            @click="onDownloadFile(attachment)"
+          />
+        </li>
+      </ul>
+    </section>
+
+    <GalleryView
+      v-if="showGallery && selectedAttachment"
+      v-model:show="showGallery"
+      :attachment="selectedAttachment"
+      :all-attachments="mediaAttachments"
+      @close="showGallery = false"
+    />
+  </div>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -59,14 +59,9 @@ const fileNameFromUrl = url => {
 };
 
 const onDownloadFile = async attachment => {
-  const {
-    message_id: messageId,
-    file_type: type,
-    data_url: url,
-    extension,
-  } = attachment;
+  const { id, file_type: type, data_url: url, extension } = attachment;
   try {
-    downloadingId.value = messageId;
+    downloadingId.value = id;
     await downloadFile({ url, type, extension });
   } catch (error) {
     useAlert(t('CONVERSATION_SIDEBAR.SHARED_FILES.DOWNLOAD_ERROR'));
@@ -103,14 +98,13 @@ const imagePreviewSrc = attachment => {
 };
 
 const failedPreviews = ref(new Set());
-const onPreviewError = messageId => failedPreviews.value.add(messageId);
+const onPreviewError = id => failedPreviews.value.add(id);
 const hasPreview = attachment =>
-  !!imagePreviewSrc(attachment) &&
-  !failedPreviews.value.has(attachment.message_id);
+  !!imagePreviewSrc(attachment) && !failedPreviews.value.has(attachment.id);
 const hasVideoPreview = attachment =>
   isVideoType(attachment.file_type) &&
   attachment.data_url &&
-  !failedPreviews.value.has(attachment.message_id);
+  !failedPreviews.value.has(attachment.id);
 
 const fallbackIcon = type => {
   if (type === 'audio') return 'i-lucide-music';
@@ -130,7 +124,7 @@ const displaySize = attachment => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-5 py-4 px-2">
+  <div class="flex flex-col gap-5 p-2">
     <div v-if="!attachmentsLoaded" class="flex justify-center p-3">
       <Spinner class="size-5" />
     </div>
@@ -173,7 +167,7 @@ const displaySize = attachment => {
       <div class="grid grid-cols-3 gap-1.5">
         <div
           v-for="(attachment, index) in visibleMedia"
-          :key="attachment.message_id"
+          :key="attachment.id"
           role="button"
           tabindex="0"
           class="relative w-full overflow-hidden transition-all duration-200 rounded-lg cursor-pointer aspect-square bg-n-slate-3 shadow-sm hover:shadow-md hover:-translate-y-px group focus:outline-none focus-visible:ring-2 focus-visible:ring-n-blue-9"
@@ -188,7 +182,7 @@ const displaySize = attachment => {
               class="object-cover w-full h-full transition-transform duration-300 group-hover:scale-110"
               loading="lazy"
               :alt="fileNameFromUrl(attachment.data_url)"
-              @error="onPreviewError(attachment.message_id)"
+              @error="onPreviewError(attachment.id)"
             />
             <video
               v-else-if="hasVideoPreview(attachment)"
@@ -197,7 +191,7 @@ const displaySize = attachment => {
               muted
               playsinline
               class="object-cover w-full h-full transition-transform duration-300 group-hover:scale-110 pointer-events-none"
-              @error="onPreviewError(attachment.message_id)"
+              @error="onPreviewError(attachment.id)"
             />
             <div
               v-else
@@ -230,7 +224,7 @@ const displaySize = attachment => {
             <button
               type="button"
               class="absolute flex items-center justify-center !p-px transition-all rounded-full opacity-0 bottom-1.5 right-1.5 size-6 bg-white/95 shadow-md group-hover:opacity-100 hover:bg-white disabled:opacity-50"
-              :disabled="downloadingId === attachment.message_id"
+              :disabled="downloadingId === attachment.id"
               :aria-label="t('CONVERSATION_SIDEBAR.SHARED_FILES.DOWNLOAD')"
               @click.stop="onDownloadFile(attachment)"
               @keydown.enter.stop
@@ -290,7 +284,7 @@ const displaySize = attachment => {
       <ul class="flex flex-col gap-0.5">
         <li
           v-for="attachment in visibleFiles"
-          :key="attachment.message_id"
+          :key="attachment.id"
           class="flex items-center gap-3 px-2 py-2 transition-colors rounded-lg hover:bg-n-slate-3 group"
         >
           <div
@@ -321,7 +315,7 @@ const displaySize = attachment => {
             sm
             icon="i-lucide-download"
             class="opacity-0 group-hover:opacity-100"
-            :is-loading="downloadingId === attachment.message_id"
+            :is-loading="downloadingId === attachment.id"
             :aria-label="t('CONVERSATION_SIDEBAR.SHARED_FILES.DOWNLOAD')"
             @click="onDownloadFile(attachment)"
           />

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -92,7 +92,7 @@ const durations = ref({});
 const onLoadedMetadata = (attachment, event) => {
   const seconds = event.target?.duration;
   if (Number.isFinite(seconds) && seconds > 0) {
-    durations.value = { ...durations.value, [attachment.id]: seconds };
+    durations.value[attachment.id] = seconds;
   }
 };
 
@@ -118,34 +118,31 @@ const onTileActivate = (attachment, index) => {
 const failedThumbs = ref(new Set());
 const failedPreviews = ref(new Set());
 
-const imagePreviewSrc = attachment => {
-  const {
-    id,
-    file_type: type,
-    thumb_url: thumbUrl,
-    data_url: dataUrl,
-  } = attachment;
+const imagePreviewSrc = ({
+  id,
+  file_type: type,
+  thumb_url: thumbUrl,
+  data_url: dataUrl,
+}) => {
   const canUseThumb = thumbUrl && !failedThumbs.value.has(id);
-  if (type === ATTACHMENT_TYPES.IMAGE) {
-    if (canUseThumb) return thumbUrl;
-    return dataUrl;
-  }
+  if (type === ATTACHMENT_TYPES.IMAGE) return canUseThumb ? thumbUrl : dataUrl;
   if (isVideoType(type)) return canUseThumb ? thumbUrl : null;
   return null;
 };
 
-const onPreviewError = attachment => {
-  const {
-    id,
-    file_type: type,
-    thumb_url: thumbUrl,
-    data_url: dataUrl,
-  } = attachment;
-  // First failure on a thumb-backed src: retry with the full url (image)
-  // or hand off to the <video> tag (video).
-  if (thumbUrl && !failedThumbs.value.has(id) && dataUrl) {
+const onPreviewError = ({
+  id,
+  file_type: type,
+  thumb_url: thumbUrl,
+  data_url: dataUrl,
+}) => {
+  const canRetryWithFull = thumbUrl && !failedThumbs.value.has(id) && dataUrl;
+  if (
+    canRetryWithFull &&
+    (type === ATTACHMENT_TYPES.IMAGE || isVideoType(type))
+  ) {
     failedThumbs.value.add(id);
-    if (type === ATTACHMENT_TYPES.IMAGE || isVideoType(type)) return;
+    return;
   }
   failedPreviews.value.add(id);
 };

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -201,7 +201,7 @@ const displayTime = attachment => {
         >
           {{ t('CONVERSATION_SIDEBAR.SHARED_FILES.MEDIA_HEADING') }}
           <span
-            class="ml-1 font-medium tracking-normal normal-case text-n-slate-10"
+            class="ms-1 font-medium tracking-normal normal-case text-n-slate-10"
           >
             {{ mediaAttachments.length }}
           </span>
@@ -284,7 +284,7 @@ const displayTime = attachment => {
               >
                 <Icon
                   icon="i-lucide-play"
-                  class="ml-0.5 size-3.5 text-n-black"
+                  class="ms-0.5 size-3.5 text-n-black"
                 />
               </div>
             </div>
@@ -342,7 +342,7 @@ const displayTime = attachment => {
         >
           {{ t('CONVERSATION_SIDEBAR.SHARED_FILES.FILES_HEADING') }}
           <span
-            class="ml-1 font-medium tracking-normal normal-case text-n-slate-10"
+            class="ms-1 font-medium tracking-normal normal-case text-n-slate-10"
           >
             {{ fileAttachments.length }}
           </span>

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -222,7 +222,7 @@ const displaySize = attachment => {
               >
                 <Icon
                   icon="i-lucide-play"
-                  class="ml-0.5 size-3.5 text-n-slate-12"
+                  class="ml-0.5 size-3.5 text-n-black"
                 />
               </div>
             </div>

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -188,7 +188,7 @@ const displayTime = attachment => {
       <Spinner class="size-5" />
     </div>
     <p
-      v-else-if="!allAttachments.length"
+      v-else-if="!mediaAttachments.length && !fileAttachments.length"
       class="p-3 text-sm text-center text-n-slate-11"
     >
       {{ t('CONVERSATION_SIDEBAR.SHARED_FILES.EMPTY') }}

--- a/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/SharedFiles.vue
@@ -4,7 +4,11 @@ import { useI18n } from 'vue-i18n';
 import { useMapGetter } from 'dashboard/composables/store';
 import { useAlert } from 'dashboard/composables';
 import { formatBytes } from 'shared/helpers/FileHelper';
-import { dynamicTime, shortTimestamp } from 'shared/helpers/timeHelper';
+import {
+  dynamicTime,
+  formatDuration,
+  shortTimestamp,
+} from 'shared/helpers/timeHelper';
 import { downloadFile } from '@chatwoot/utils';
 import {
   ATTACHMENT_TYPES,
@@ -79,6 +83,23 @@ const onDownloadFile = async attachment => {
 
 const isVideoType = type =>
   [ATTACHMENT_TYPES.VIDEO, ATTACHMENT_TYPES.IG_REEL].includes(type);
+
+const isAudioType = type => type === ATTACHMENT_TYPES.AUDIO;
+const isPlayableType = type => isVideoType(type) || isAudioType(type);
+
+const durations = ref({});
+
+const onLoadedMetadata = (attachment, event) => {
+  const seconds = event.target?.duration;
+  if (Number.isFinite(seconds) && seconds > 0) {
+    durations.value = { ...durations.value, [attachment.id]: seconds };
+  }
+};
+
+const displayDuration = attachment => {
+  const seconds = durations.value[attachment.id];
+  return seconds ? formatDuration(Math.round(seconds)) : '';
+};
 
 const isOverflowTile = index =>
   !showAllMedia.value &&
@@ -199,7 +220,7 @@ const displayTime = attachment => {
           @click="showAllMedia = !showAllMedia"
         />
       </header>
-      <div class="grid grid-cols-3 gap-1.5">
+      <div class="grid grid-cols-3 gap-2">
         <div
           v-for="(attachment, index) in visibleMedia"
           :key="attachment.id"
@@ -226,6 +247,7 @@ const displayTime = attachment => {
               muted
               playsinline
               class="object-cover w-full h-full transition-transform duration-300 group-hover:scale-110 pointer-events-none"
+              @loadedmetadata="onLoadedMetadata(attachment, $event)"
               @error="onPreviewError(attachment)"
             />
             <div
@@ -237,6 +259,14 @@ const displayTime = attachment => {
                 class="size-6 text-n-slate-11"
               />
             </div>
+
+            <audio
+              v-if="isAudioType(attachment.file_type) && attachment.data_url"
+              :src="attachment.data_url"
+              preload="metadata"
+              class="hidden"
+              @loadedmetadata="onLoadedMetadata(attachment, $event)"
+            />
 
             <div
               class="absolute inset-0 transition-opacity duration-200 opacity-0 pointer-events-none group-hover:opacity-100 bg-gradient-to-t from-black/40 via-transparent to-transparent"
@@ -255,6 +285,16 @@ const displayTime = attachment => {
                 />
               </div>
             </div>
+
+            <span
+              v-if="
+                isPlayableType(attachment.file_type) &&
+                displayDuration(attachment)
+              "
+              class="absolute text-xxs font-medium tabular-nums transition-opacity bottom-1.5 ltr:right-1.5 rtl:left-1.5 text-white [text-shadow:_0_1px_3px_rgba(0,0,0,0.95),_0_0_10px_rgba(0,0,0,0.7)] group-hover:opacity-0"
+            >
+              {{ displayDuration(attachment) }}
+            </span>
 
             <span
               v-if="displayTime(attachment)"
@@ -371,6 +411,7 @@ const displayTime = attachment => {
       v-model:show="showGallery"
       :attachment="selectedAttachment"
       :all-attachments="mediaAttachments"
+      auto-play
       @close="showGallery = false"
     />
   </div>

--- a/app/javascript/dashboard/store/modules/conversations/getters.js
+++ b/app/javascript/dashboard/store/modules/conversations/getters.js
@@ -57,6 +57,8 @@ const getters = {
   getSelectedChatAttachments: ({ selectedChatId, attachments }) => {
     return attachments[selectedChatId] || [];
   },
+  getSelectedChatAttachmentsLoaded: ({ selectedChatId, attachments }) =>
+    selectedChatId !== null && attachments[selectedChatId] !== undefined,
   getChatListFilters: ({ conversationFilters }) => conversationFilters,
   getLastEmailInSelectedChat: (stage, _getters) => {
     const selectedChat = _getters.getSelectedChat;

--- a/app/javascript/dashboard/store/modules/specs/conversations/getters.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/getters.spec.js
@@ -328,6 +328,31 @@ describe('#getters', () => {
     });
   });
 
+  describe('#getSelectedChatAttachmentsLoaded', () => {
+    it('returns true when attachments have been fetched for the selected chat', () => {
+      const state = { selectedChatId: 1, attachments: { 1: [] } };
+      expect(getters.getSelectedChatAttachmentsLoaded(state)).toBe(true);
+    });
+
+    it('returns true when the fetched attachment list is non-empty', () => {
+      const state = {
+        selectedChatId: 1,
+        attachments: { 1: [{ id: 1, file_name: 'test' }] },
+      };
+      expect(getters.getSelectedChatAttachmentsLoaded(state)).toBe(true);
+    });
+
+    it('returns false when attachments have not been fetched yet', () => {
+      const state = { selectedChatId: 1, attachments: {} };
+      expect(getters.getSelectedChatAttachmentsLoaded(state)).toBe(false);
+    });
+
+    it('returns false when no chat is selected', () => {
+      const state = { selectedChatId: null, attachments: {} };
+      expect(getters.getSelectedChatAttachmentsLoaded(state)).toBe(false);
+    });
+  });
+
   describe('#getContextMenuChatId', () => {
     it('returns the context menu chat id', () => {
       const state = { contextMenuChatId: 1 };

--- a/app/views/api/v1/accounts/conversations/attachments.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/attachments.json.jbuilder
@@ -3,6 +3,7 @@ json.meta do
 end
 
 json.payload @attachments do |attachment|
+  json.id attachment.push_event_data[:id]
   json.message_id attachment.push_event_data[:message_id]
   json.thumb_url attachment.push_event_data[:thumb_url]
   json.data_url attachment.push_event_data[:data_url]

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -1039,6 +1039,8 @@ RSpec.describe 'Conversations API', type: :request do
 
         expect(response).to have_http_status(:success)
         response_body = response.parsed_body
+        attachment = conversation.messages.last.attachments.first
+        expect(response_body['payload'].first['id']).to eq(attachment.id)
         expect(response_body['payload'].first['file_type']).to eq('image')
         expect(response_body['payload'].first['sender']['id']).to eq(conversation.messages.last.sender.id)
       end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds a new **“Attachments”** section to the conversation sidebar, allowing agents to quickly access all attachments exchanged in a conversation without scrolling through messages.

Media files (images, videos, audio) are displayed in a 3-column thumbnail grid, while documents and other files are shown in a list with their type icon, name, and size.

Both sections initially show a preview of recent items with a “View all” option to expand. Clicking on media opens it in the existing gallery viewer.


Fixes https://linear.app/chatwoot/issue/CW-7009/add-shared-media-view-to-the-conversation-sidebar

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

#### Screencast

https://github.com/user-attachments/assets/93920e8b-fd6d-4ce4-98f3-7306dd7bdc91





## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
