### PR TITLE
feat(inbox): Add beta badge for TikTok and Voice channels

### DIFF
--- a/app/javascript/dashboard/components/ChannelSelector.vue
+++ b/app/javascript/dashboard/components/ChannelSelector.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { useI18n } from 'vue-i18n';
 import Icon from 'next/icon/Icon.vue';
+import Label from 'dashboard/components-next/label/Label.vue';
 
 defineProps({
   title: {
@@ -48,13 +49,13 @@ const { t } = useI18n();
         <h3 class="text-n-slate-12 text-sm text-start font-medium capitalize">
           {{ title }}
         </h3>
-        <span
+        <Label
           v-if="isBeta && !isComingSoon"
           v-tooltip.top="t('GENERAL.BETA_DESCRIPTION')"
-          class="text-xs font-medium text-n-blue-11 bg-n-blue-3 leading-none rounded-md px-2 py-1"
-        >
-          {{ t('GENERAL.BETA') }}
-        </span>
+          :label="t('GENERAL.BETA')"
+          color="blue"
+          compact
+        />
       </div>
       <p class="text-n-slate-11 text-start text-sm">
         {{ description }}

--- a/app/javascript/dashboard/components/ChannelSelector.vue
+++ b/app/javascript/dashboard/components/ChannelSelector.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from 'vue-i18n';
 import Icon from 'next/icon/Icon.vue';
 
 defineProps({
@@ -18,7 +19,13 @@ defineProps({
     type: Boolean,
     default: false,
   },
+  isBeta: {
+    type: Boolean,
+    default: false,
+  },
 });
+
+const { t } = useI18n();
 </script>
 
 <template>
@@ -37,9 +44,18 @@ defineProps({
     </div>
 
     <div class="flex flex-col items-start gap-1.5">
-      <h3 class="text-n-slate-12 text-sm text-start font-medium capitalize">
-        {{ title }}
-      </h3>
+      <div class="flex items-center gap-2">
+        <h3 class="text-n-slate-12 text-sm text-start font-medium capitalize">
+          {{ title }}
+        </h3>
+        <span
+          v-if="isBeta && !isComingSoon"
+          v-tooltip.top="t('GENERAL.BETA_DESCRIPTION')"
+          class="text-xs font-medium text-n-blue-11 bg-n-blue-3 leading-none rounded-md px-2 py-1"
+        >
+          {{ t('GENERAL.BETA') }}
+        </span>
+      </div>
       <p class="text-n-slate-11 text-start text-sm">
         {{ description }}
       </p>
@@ -50,7 +66,7 @@ defineProps({
       class="absolute inset-0 flex items-center justify-center backdrop-blur-[2px] rounded-2xl bg-gradient-to-br from-n-surface-1/90 via-n-surface-1/70 to-n-surface-1/95 cursor-not-allowed"
     >
       <span class="text-n-slate-12 font-medium text-sm">
-        {{ $t('CHANNEL_SELECTOR.COMING_SOON') }} 🚀
+        {{ t('CHANNEL_SELECTOR.COMING_SOON') }} 🚀
       </span>
     </div>
   </button>

--- a/app/javascript/dashboard/components/widgets/ChannelItem.vue
+++ b/app/javascript/dashboard/components/widgets/ChannelItem.vue
@@ -77,6 +77,10 @@ const isComingSoon = computed(() => {
   return ['voice'].includes(key) && !isActive.value;
 });
 
+const isBeta = computed(() => {
+  return ['tiktok', 'voice'].includes(props.channel.key);
+});
+
 const onItemClick = () => {
   if (isActive.value) {
     emit('channelItemClick', props.channel.key);
@@ -90,6 +94,7 @@ const onItemClick = () => {
     :description="channel.description"
     :icon="channel.icon"
     :is-coming-soon="isComingSoon"
+    :is-beta="isBeta"
     :disabled="!isActive"
     @click="onItemClick"
   />


### PR DESCRIPTION
TikTok and Voice channels in the inbox creation flow now display a small "Beta" badge next to their title, signaling that these integrations are still being polished while keeping them available for users to try.
Fixes https://linear.app/chatwoot/issue/CW-7026/add-beta-label-for-tiktok-and-voice-inboxes