### PR TITLE
feat(notion): add issue tracker support

### DIFF
--- a/app/controllers/api/v1/accounts/integrations/notion_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/notion_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::Accounts::Integrations::NotionController < Api::V1::Accounts::BaseController
   before_action :fetch_hook, only: [:destroy, :issue_tracker, :update_issue_tracker, :validate_issue_tracker]
+  before_action :check_admin_authorization?, only: [:issue_tracker, :update_issue_tracker, :validate_issue_tracker]
+  before_action :fetch_conversation, only: [:create_issue, :linked_issues]
 
   def destroy
     @hook.destroy!
@@ -28,6 +30,31 @@ class Api::V1::Accounts::Integrations::NotionController < Api::V1::Accounts::Bas
     end
   end
 
+  def create_issue
+    issue = issue_tracker_service.create_issue(permitted_issue_params.to_h, Current.user)
+    if issue[:error]
+      render json: { error: issue[:error] }, status: :unprocessable_entity
+    else
+      Notion::ActivityMessageService.new(
+        conversation: @conversation,
+        action_type: :issue_created,
+        issue_data: { title: issue[:data][:title] },
+        user: Current.user
+      ).perform
+      render json: issue[:data], status: :ok
+    end
+  end
+
+  def linked_issues
+    issues = issue_tracker_service.linked_issues(permitted_issue_params[:conversation_id])
+
+    if issues[:error]
+      render json: { error: issues[:error] }, status: :unprocessable_entity
+    else
+      render json: issues[:data], status: :ok
+    end
+  end
+
   private
 
   def issue_tracker_settings
@@ -36,6 +63,10 @@ class Api::V1::Accounts::Integrations::NotionController < Api::V1::Accounts::Bas
 
   def issue_tracker_config_service
     Integrations::Notion::IssueTrackerConfigService.new(hook: @hook)
+  end
+
+  def issue_tracker_service
+    Integrations::Notion::IssueTrackerService.new(account: Current.account)
   end
 
   def permitted_issue_tracker_params
@@ -49,6 +80,14 @@ class Api::V1::Accounts::Integrations::NotionController < Api::V1::Accounts::Bas
       :priority_property,
       :label_property
     )
+  end
+
+  def permitted_issue_params
+    params.permit(:conversation_id, :title, :description, :priority, :state_id, label_ids: [])
+  end
+
+  def fetch_conversation
+    @conversation = Current.account.conversations.find_by!(display_id: permitted_issue_params[:conversation_id])
   end
 
   def fetch_hook

--- a/app/controllers/api/v1/accounts/integrations/notion_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/notion_controller.rb
@@ -83,7 +83,7 @@ class Api::V1::Accounts::Integrations::NotionController < Api::V1::Accounts::Bas
   end
 
   def permitted_issue_params
-    params.permit(:conversation_id, :title, :description, :priority, :state_id, label_ids: [])
+    params.permit(:conversation_id, :title, :description, :assignee_id, :project_id, :priority, :state_id, label_ids: [])
   end
 
   def fetch_conversation

--- a/app/controllers/api/v1/accounts/integrations/notion_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/notion_controller.rb
@@ -1,14 +1,57 @@
 class Api::V1::Accounts::Integrations::NotionController < Api::V1::Accounts::BaseController
-  before_action :fetch_hook, only: [:destroy]
+  before_action :fetch_hook, only: [:destroy, :issue_tracker, :update_issue_tracker, :validate_issue_tracker]
 
   def destroy
     @hook.destroy!
     head :ok
   end
 
+  def issue_tracker
+    render json: issue_tracker_settings, status: :ok
+  end
+
+  def update_issue_tracker
+    updated_settings = @hook.settings.to_h.merge(
+      'issue_tracker' => permitted_issue_tracker_params.to_h
+    )
+    @hook.update!(settings: updated_settings)
+
+    render json: issue_tracker_settings, status: :ok
+  end
+
+  def validate_issue_tracker
+    response = issue_tracker_config_service.validate(permitted_issue_tracker_params[:data_source_id])
+    if response[:error]
+      render json: { error: response[:error] }, status: :unprocessable_entity
+    else
+      render json: response[:data], status: :ok
+    end
+  end
+
   private
 
+  def issue_tracker_settings
+    @hook.settings.to_h['issue_tracker'] || {}
+  end
+
+  def issue_tracker_config_service
+    Integrations::Notion::IssueTrackerConfigService.new(hook: @hook)
+  end
+
+  def permitted_issue_tracker_params
+    params.permit(
+      :data_source_id,
+      :title_property,
+      :description_property,
+      :assignee_property,
+      :project_property,
+      :status_property,
+      :priority_property,
+      :label_property
+    )
+  end
+
   def fetch_hook
-    @hook = Integrations::Hook.where(account: Current.account).find_by(app_id: 'notion')
+    @hook = Integrations::Hook.where(account: Current.account).find_by!(app_id: 'notion')
   end
 end

--- a/app/controllers/api/v1/accounts/integrations/notion_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/notion_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::Accounts::Integrations::NotionController < Api::V1::Accounts::Bas
   end
 
   def create_issue
-    issue = issue_tracker_service.create_issue(permitted_issue_params.to_h, Current.user)
+    issue = issue_tracker_service.create_issue(permitted_issue_params.to_h.with_indifferent_access, Current.user)
     if issue[:error]
       render json: { error: issue[:error] }, status: :unprocessable_entity
     else

--- a/app/controllers/api/v1/accounts/integrations/notion_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/notion_controller.rb
@@ -2,8 +2,10 @@ class Api::V1::Accounts::Integrations::NotionController < Api::V1::Accounts::Bas
   before_action :fetch_hook, only: [:destroy, :issue_tracker, :update_issue_tracker, :validate_issue_tracker]
   before_action :check_admin_authorization?, only: [:issue_tracker, :update_issue_tracker, :validate_issue_tracker]
   before_action :fetch_conversation, only: [:create_issue, :linked_issues]
+  before_action :authorize_conversation, only: [:create_issue, :linked_issues]
 
   def destroy
+    Integrations::IssueLink.where(account: Current.account, app_id: 'notion').delete_all
     @hook.destroy!
     head :ok
   end
@@ -88,6 +90,10 @@ class Api::V1::Accounts::Integrations::NotionController < Api::V1::Accounts::Bas
 
   def fetch_conversation
     @conversation = Current.account.conversations.find_by!(display_id: permitted_issue_params[:conversation_id])
+  end
+
+  def authorize_conversation
+    authorize @conversation, :show?
   end
 
   def fetch_hook

--- a/app/javascript/dashboard/api/integrations/notion.js
+++ b/app/javascript/dashboard/api/integrations/notion.js
@@ -1,0 +1,23 @@
+/* global axios */
+
+import ApiClient from '../ApiClient';
+
+class NotionAPI extends ApiClient {
+  constructor() {
+    super('integrations/notion', { accountScoped: true });
+  }
+
+  getIssueTracker() {
+    return axios.get(`${this.url}/issue_tracker`);
+  }
+
+  updateIssueTracker(data) {
+    return axios.patch(`${this.url}/issue_tracker`, data);
+  }
+
+  validateIssueTracker(data) {
+    return axios.post(`${this.url}/validate_issue_tracker`, data);
+  }
+}
+
+export default new NotionAPI();

--- a/app/javascript/dashboard/api/integrations/notion.js
+++ b/app/javascript/dashboard/api/integrations/notion.js
@@ -18,6 +18,16 @@ class NotionAPI extends ApiClient {
   validateIssueTracker(data) {
     return axios.post(`${this.url}/validate_issue_tracker`, data);
   }
+
+  createIssue(data) {
+    return axios.post(`${this.url}/create_issue`, data);
+  }
+
+  getLinkedIssues(conversationId) {
+    return axios.get(
+      `${this.url}/linked_issues?conversation_id=${conversationId}`
+    );
+  }
 }
 
 export default new NotionAPI();

--- a/app/javascript/dashboard/api/specs/integrations/notion.spec.js
+++ b/app/javascript/dashboard/api/specs/integrations/notion.spec.js
@@ -1,0 +1,67 @@
+import NotionAPIClient from '../../integrations/notion';
+import ApiClient from '../../ApiClient';
+
+describe('#notionAPI', () => {
+  const originalAxios = window.axios;
+  const axiosMock = {
+    post: vi.fn(() => Promise.resolve()),
+    get: vi.fn(() => Promise.resolve()),
+    patch: vi.fn(() => Promise.resolve()),
+    delete: vi.fn(() => Promise.resolve()),
+  };
+
+  beforeEach(() => {
+    window.axios = axiosMock;
+  });
+
+  afterEach(() => {
+    window.axios = originalAxios;
+    vi.clearAllMocks();
+  });
+
+  it('creates correct instance', () => {
+    expect(NotionAPIClient).toBeInstanceOf(ApiClient);
+    expect(NotionAPIClient).toHaveProperty('getIssueTracker');
+    expect(NotionAPIClient).toHaveProperty('updateIssueTracker');
+    expect(NotionAPIClient).toHaveProperty('validateIssueTracker');
+  });
+
+  describe('getIssueTracker', () => {
+    it('creates a valid request', () => {
+      NotionAPIClient.getIssueTracker();
+
+      expect(axiosMock.get).toHaveBeenCalledWith(
+        '/api/v1/integrations/notion/issue_tracker'
+      );
+    });
+  });
+
+  describe('updateIssueTracker', () => {
+    it('creates a valid request', () => {
+      const payload = {
+        data_source_id: 'data-source-id',
+        title_property: 'Name',
+      };
+
+      NotionAPIClient.updateIssueTracker(payload);
+
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        '/api/v1/integrations/notion/issue_tracker',
+        payload
+      );
+    });
+  });
+
+  describe('validateIssueTracker', () => {
+    it('creates a valid request', () => {
+      const payload = { data_source_id: 'data-source-id' };
+
+      NotionAPIClient.validateIssueTracker(payload);
+
+      expect(axiosMock.post).toHaveBeenCalledWith(
+        '/api/v1/integrations/notion/validate_issue_tracker',
+        payload
+      );
+    });
+  });
+});

--- a/app/javascript/dashboard/api/specs/integrations/notion.spec.js
+++ b/app/javascript/dashboard/api/specs/integrations/notion.spec.js
@@ -24,6 +24,8 @@ describe('#notionAPI', () => {
     expect(NotionAPIClient).toHaveProperty('getIssueTracker');
     expect(NotionAPIClient).toHaveProperty('updateIssueTracker');
     expect(NotionAPIClient).toHaveProperty('validateIssueTracker');
+    expect(NotionAPIClient).toHaveProperty('createIssue');
+    expect(NotionAPIClient).toHaveProperty('getLinkedIssues');
   });
 
   describe('getIssueTracker', () => {
@@ -61,6 +63,32 @@ describe('#notionAPI', () => {
       expect(axiosMock.post).toHaveBeenCalledWith(
         '/api/v1/integrations/notion/validate_issue_tracker',
         payload
+      );
+    });
+  });
+
+  describe('createIssue', () => {
+    it('creates a valid request', () => {
+      const payload = {
+        title: 'Broken workflow',
+        conversation_id: 42,
+      };
+
+      NotionAPIClient.createIssue(payload);
+
+      expect(axiosMock.post).toHaveBeenCalledWith(
+        '/api/v1/integrations/notion/create_issue',
+        payload
+      );
+    });
+  });
+
+  describe('getLinkedIssues', () => {
+    it('creates a valid request', () => {
+      NotionAPIClient.getLinkedIssues(42);
+
+      expect(axiosMock.get).toHaveBeenCalledWith(
+        '/api/v1/integrations/notion/linked_issues?conversation_id=42'
       );
     });
   });

--- a/app/javascript/dashboard/components/widgets/conversation/notion/CreateIssue.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/notion/CreateIssue.vue
@@ -1,0 +1,187 @@
+<script setup>
+import { computed, reactive, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useAlert } from 'dashboard/composables';
+import { parseAPIErrorResponse } from 'dashboard/store/utils/api';
+import NotionAPI from 'dashboard/api/integrations/notion';
+import Button from 'dashboard/components-next/button/Button.vue';
+
+const props = defineProps({
+  conversationId: {
+    type: [Number, String],
+    required: true,
+  },
+  title: {
+    type: String,
+    default: '',
+  },
+});
+
+const emit = defineEmits(['close']);
+const { t } = useI18n();
+
+const isCreating = ref(false);
+const isTitleTouched = ref(false);
+
+const formState = reactive({
+  title: props.title,
+  description: '',
+  assigneeId: '',
+  projectId: '',
+  stateId: '',
+  priority: '',
+  labelIds: '',
+});
+
+const titleError = computed(() => {
+  if (!isTitleTouched.value || formState.title.trim()) return '';
+
+  return t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.TITLE.REQUIRED_ERROR');
+});
+
+const isSubmitDisabled = computed(
+  () => !formState.title.trim() || isCreating.value
+);
+
+const compactLabels = labels => {
+  return labels
+    .split(',')
+    .map(label => label.trim())
+    .filter(Boolean);
+};
+
+const errorMessage = (error, fallback) => {
+  const parsedError = parseAPIErrorResponse(error);
+  return typeof parsedError === 'string' ? parsedError : fallback;
+};
+
+const buildPayload = () => {
+  const payload = {
+    conversation_id: props.conversationId,
+    title: formState.title.trim(),
+  };
+
+  if (formState.description.trim()) {
+    payload.description = formState.description.trim();
+  }
+  if (formState.assigneeId.trim()) {
+    payload.assignee_id = formState.assigneeId.trim();
+  }
+  if (formState.projectId.trim()) {
+    payload.project_id = formState.projectId.trim();
+  }
+  if (formState.stateId.trim()) {
+    payload.state_id = formState.stateId.trim();
+  }
+  if (formState.priority.trim()) {
+    payload.priority = formState.priority.trim();
+  }
+  if (formState.labelIds.trim()) {
+    payload.label_ids = compactLabels(formState.labelIds);
+  }
+
+  return payload;
+};
+
+const createIssue = async () => {
+  isTitleTouched.value = true;
+  if (isSubmitDisabled.value) return;
+
+  try {
+    isCreating.value = true;
+    await NotionAPI.createIssue(buildPayload());
+    useAlert(t('INTEGRATION_SETTINGS.NOTION.CREATE.SUCCESS'));
+    emit('close');
+  } catch (error) {
+    useAlert(
+      errorMessage(error, t('INTEGRATION_SETTINGS.NOTION.CREATE.ERROR'))
+    );
+  } finally {
+    isCreating.value = false;
+  }
+};
+</script>
+
+<template>
+  <form class="flex flex-col gap-4" @submit.prevent="createIssue">
+    <woot-input
+      v-model="formState.title"
+      :class="{ error: titleError }"
+      class="w-full"
+      :label="$t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.TITLE.LABEL')"
+      :placeholder="
+        $t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.TITLE.PLACEHOLDER')
+      "
+      :error="titleError"
+      @blur="isTitleTouched = true"
+      @input="isTitleTouched = true"
+    />
+
+    <label class="flex flex-col gap-1 text-sm font-medium text-n-slate-12">
+      {{ $t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.DESCRIPTION.LABEL') }}
+      <textarea
+        v-model="formState.description"
+        rows="3"
+        class="w-full px-3 py-2 text-sm border rounded-lg resize-none border-n-weak bg-n-alpha-1 text-n-slate-12 placeholder:text-n-slate-10 focus:outline-none focus:ring-1 focus:ring-n-brand"
+        :placeholder="
+          $t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.DESCRIPTION.PLACEHOLDER')
+        "
+      />
+    </label>
+
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <woot-input
+        v-model="formState.assigneeId"
+        :label="$t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.ASSIGNEE.LABEL')"
+        :placeholder="
+          $t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.ASSIGNEE.PLACEHOLDER')
+        "
+      />
+      <woot-input
+        v-model="formState.projectId"
+        :label="$t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.PROJECT.LABEL')"
+        :placeholder="
+          $t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.PROJECT.PLACEHOLDER')
+        "
+      />
+      <woot-input
+        v-model="formState.stateId"
+        :label="$t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.STATUS.LABEL')"
+        :placeholder="
+          $t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.STATUS.PLACEHOLDER')
+        "
+      />
+      <woot-input
+        v-model="formState.priority"
+        :label="$t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.PRIORITY.LABEL')"
+        :placeholder="
+          $t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.PRIORITY.PLACEHOLDER')
+        "
+      />
+    </div>
+
+    <woot-input
+      v-model="formState.labelIds"
+      :label="$t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.LABELS.LABEL')"
+      :placeholder="
+        $t('INTEGRATION_SETTINGS.NOTION.CREATE.FORM.LABELS.PLACEHOLDER')
+      "
+    />
+
+    <div class="flex items-center justify-end w-full gap-2 mt-4">
+      <Button
+        faded
+        slate
+        type="reset"
+        :label="$t('INTEGRATION_SETTINGS.NOTION.CREATE.CANCEL')"
+        @click.prevent="emit('close')"
+      />
+      <Button
+        type="submit"
+        :label="$t('INTEGRATION_SETTINGS.NOTION.CREATE.SUBMIT')"
+        :disabled="isSubmitDisabled"
+        :is-loading="isCreating"
+      />
+    </div>
+  </form>
+</template>

--- a/app/javascript/dashboard/components/widgets/conversation/notion/IssuesList.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/notion/IssuesList.vue
@@ -1,0 +1,141 @@
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useAlert } from 'dashboard/composables';
+import { useStoreGetters } from 'dashboard/composables/store';
+import { parseAPIErrorResponse } from 'dashboard/store/utils/api';
+import NotionAPI from 'dashboard/api/integrations/notion';
+import NextButton from 'dashboard/components-next/button/Button.vue';
+import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
+import CreateIssue from './CreateIssue.vue';
+import NotionIssueItem from './NotionIssueItem.vue';
+import NotionSetupCTA from './NotionSetupCTA.vue';
+
+const props = defineProps({
+  conversationId: {
+    type: [Number, String],
+    required: true,
+  },
+  isConfigured: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const { t } = useI18n();
+const getters = useStoreGetters();
+
+const linkedIssues = ref([]);
+const isLoading = ref(false);
+const shouldShowCreateModal = ref(false);
+
+const conversation = computed(
+  () => getters.getConversationById.value(props.conversationId) || {}
+);
+
+const createIssueTitle = computed(() => {
+  const { meta: { sender: { name = null } = {} } = {} } = conversation.value;
+  return t('INTEGRATION_SETTINGS.NOTION.CREATE.DEFAULT_TITLE', {
+    conversationId: conversation.value.id || props.conversationId,
+    name,
+  });
+});
+
+const hasIssues = computed(() => linkedIssues.value.length > 0);
+
+const errorMessage = (error, fallback) => {
+  const parsedError = parseAPIErrorResponse(error);
+  return typeof parsedError === 'string' ? parsedError : fallback;
+};
+
+const loadLinkedIssues = async () => {
+  isLoading.value = true;
+  linkedIssues.value = [];
+  try {
+    const response = await NotionAPI.getLinkedIssues(props.conversationId);
+    linkedIssues.value = response.data || [];
+  } catch (error) {
+    useAlert(
+      errorMessage(error, t('INTEGRATION_SETTINGS.NOTION.LOADING_ERROR'))
+    );
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+const openCreateModal = () => {
+  shouldShowCreateModal.value = true;
+};
+
+const closeCreateModal = () => {
+  shouldShowCreateModal.value = false;
+  loadLinkedIssues();
+};
+
+watch(
+  () => props.conversationId,
+  () => {
+    loadLinkedIssues();
+  }
+);
+
+onMounted(() => {
+  loadLinkedIssues();
+});
+</script>
+
+<template>
+  <div>
+    <div v-if="isConfigured" class="px-4 pt-3 pb-2">
+      <NextButton
+        ghost
+        xs
+        icon="i-lucide-plus"
+        :label="$t('INTEGRATION_SETTINGS.NOTION.ADD_ISSUE_BUTTON')"
+        @click="openCreateModal"
+      />
+    </div>
+
+    <NotionSetupCTA v-else />
+
+    <div v-if="isLoading" class="flex justify-center p-8">
+      <Spinner />
+    </div>
+
+    <div v-else-if="!hasIssues" class="flex justify-center p-4">
+      <p class="text-sm text-n-slate-11">
+        {{ $t('INTEGRATION_SETTINGS.NOTION.NO_LINKED_ISSUES') }}
+      </p>
+    </div>
+
+    <div v-else class="max-h-[300px] overflow-y-auto">
+      <NotionIssueItem
+        v-for="linkedIssue in linkedIssues"
+        :key="linkedIssue.link_id || linkedIssue.id"
+        class="px-4 pt-3 pb-4 border-b border-n-weak last:border-b-0"
+        :issue="linkedIssue"
+      />
+    </div>
+
+    <woot-modal
+      v-model:show="shouldShowCreateModal"
+      :on-close="closeCreateModal"
+      :close-on-backdrop-click="false"
+      class="!items-start [&>div]:!top-12 [&>div]:sticky"
+    >
+      <div class="flex flex-col h-auto overflow-auto">
+        <woot-modal-header
+          :header-title="$t('INTEGRATION_SETTINGS.NOTION.CREATE.TITLE')"
+          :header-content="$t('INTEGRATION_SETTINGS.NOTION.CREATE.DESCRIPTION')"
+        />
+        <div class="flex flex-col px-8 pb-6">
+          <CreateIssue
+            :conversation-id="conversationId"
+            :title="createIssueTitle"
+            @close="closeCreateModal"
+          />
+        </div>
+      </div>
+    </woot-modal>
+  </div>
+</template>

--- a/app/javascript/dashboard/components/widgets/conversation/notion/NotionIssueItem.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/notion/NotionIssueItem.vue
@@ -1,0 +1,49 @@
+<script setup>
+import { computed } from 'vue';
+import { format } from 'date-fns';
+import Icon from 'dashboard/components-next/icon/Icon.vue';
+
+const props = defineProps({
+  issue: {
+    type: Object,
+    required: true,
+  },
+});
+
+const createdAt = computed(() => {
+  if (!props.issue.created_at) return '';
+
+  return format(new Date(props.issue.created_at), 'MMM d, yyyy');
+});
+
+const createdBy = computed(() => props.issue.metadata?.created_by_name);
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <a
+      :href="issue.url"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="flex items-start gap-1.5 text-sm font-medium text-n-slate-12 hover:underline"
+    >
+      <span class="min-w-0 break-words">
+        {{ issue.title }}
+      </span>
+      <Icon icon="i-lucide-external-link" class="mt-0.5 size-3 shrink-0" />
+    </a>
+
+    <div class="flex flex-col gap-1 text-xs text-n-slate-11">
+      <span v-if="createdAt">
+        {{ $t('INTEGRATION_SETTINGS.NOTION.ISSUE.CREATED_AT', { createdAt }) }}
+      </span>
+      <span v-if="createdBy">
+        {{
+          $t('INTEGRATION_SETTINGS.NOTION.ISSUE.CREATED_BY', {
+            name: createdBy,
+          })
+        }}
+      </span>
+    </div>
+  </div>
+</template>

--- a/app/javascript/dashboard/components/widgets/conversation/notion/NotionSetupCTA.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/notion/NotionSetupCTA.vue
@@ -1,0 +1,54 @@
+<script setup>
+import { computed } from 'vue';
+import { useStoreGetters } from 'dashboard/composables/store';
+import { useAdmin } from 'dashboard/composables/useAdmin';
+import { frontendURL } from 'dashboard/helper/URLHelper';
+import NextButton from 'dashboard/components-next/button/Button.vue';
+
+const { isAdmin } = useAdmin();
+const getters = useStoreGetters();
+const accountId = getters.getCurrentAccountId;
+
+const integrationId = 'notion';
+
+const actionURL = computed(() =>
+  frontendURL(
+    `accounts/${accountId.value}/settings/integrations/${integrationId}`
+  )
+);
+
+const openNotionSettings = () => {
+  window.open(actionURL.value, '_blank');
+};
+</script>
+
+<template>
+  <div class="flex flex-col p-3">
+    <div class="w-12 h-12 mb-3">
+      <img
+        :src="`/dashboard/images/integrations/${integrationId}.png`"
+        class="object-contain w-full h-full border rounded-md shadow-sm border-n-weak dark:hidden dark:bg-n-alpha-2"
+      />
+      <img
+        :src="`/dashboard/images/integrations/${integrationId}-dark.png`"
+        class="hidden object-contain w-full h-full border rounded-md shadow-sm border-n-weak dark:block"
+      />
+    </div>
+
+    <div class="flex-1 mb-4">
+      <h3 class="mb-1.5 text-sm font-medium text-n-slate-12">
+        {{ $t('INTEGRATION_SETTINGS.NOTION.CTA.TITLE') }}
+      </h3>
+      <p v-if="isAdmin" class="text-sm text-n-slate-11">
+        {{ $t('INTEGRATION_SETTINGS.NOTION.CTA.DESCRIPTION') }}
+      </p>
+      <p v-else class="text-sm text-n-slate-11">
+        {{ $t('INTEGRATION_SETTINGS.NOTION.CTA.AGENT_DESCRIPTION') }}
+      </p>
+    </div>
+
+    <NextButton v-if="isAdmin" faded slate @click="openNotionSettings">
+      {{ $t('INTEGRATION_SETTINGS.NOTION.CTA.BUTTON_TEXT') }}
+    </NextButton>
+  </div>
+</template>

--- a/app/javascript/dashboard/composables/useUISettings.js
+++ b/app/javascript/dashboard/composables/useUISettings.js
@@ -11,6 +11,7 @@ export const DEFAULT_CONVERSATION_SIDEBAR_ITEMS_ORDER = Object.freeze([
   { name: 'previous_conversation' },
   { name: 'conversation_participants' },
   { name: 'linear_issues' },
+  { name: 'notion_issues' },
   { name: 'shopify_orders' },
 ]);
 

--- a/app/javascript/dashboard/featureFlags.js
+++ b/app/javascript/dashboard/featureFlags.js
@@ -31,6 +31,7 @@ export const FEATURE_FLAGS = {
   INBOUND_EMAILS: 'inbound_emails',
   IP_LOOKUP: 'ip_lookup',
   LINEAR: 'linear_integration',
+  NOTION: 'notion_integration',
   CAPTAIN: 'captain_integration',
   CUSTOM_ROLES: 'custom_roles',
   CHATWOOT_V4: 'chatwoot_v4',

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -366,6 +366,7 @@
       "PREVIOUS_CONVERSATION": "Previous Conversations",
       "MACROS": "Macros",
       "LINEAR_ISSUES": "Linked Linear Issues",
+      "NOTION_ISSUES": "Linked Notion Issues",
       "SHOPIFY_ORDERS": "Shopify Orders",
       "SHARED_FILES": "Attachments"
     },

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -385,6 +385,53 @@
         "MESSAGE": "Deleting this integration will remove access to your Notion workspace and stop all related functionality.",
         "CONFIRM": "Yes, delete",
         "CANCEL": "Cancel"
+      },
+      "ISSUE_TRACKER": {
+        "TITLE": "Issue tracker",
+        "DESCRIPTION": "Map Chatwoot issue fields to Notion data source properties.",
+        "VALIDATE": "Validate",
+        "SAVE": "Save settings",
+        "DATA_SOURCE_REQUIRED": "Data source ID is required",
+        "TITLE_REQUIRED": "Validate the data source to fill the title property",
+        "LOAD_ERROR": "There was an error loading Notion issue tracker settings, please try again",
+        "VALIDATE_SUCCESS": "Notion data source validated successfully",
+        "VALIDATE_ERROR": "There was an error validating the Notion data source, please try again",
+        "SAVE_SUCCESS": "Notion issue tracker settings saved successfully",
+        "SAVE_ERROR": "There was an error saving Notion issue tracker settings, please try again",
+        "FIELDS": {
+          "DATA_SOURCE_ID": {
+            "LABEL": "Data source ID",
+            "PLACEHOLDER": "Enter the Notion data source ID"
+          },
+          "TITLE_PROPERTY": {
+            "LABEL": "Title property",
+            "PLACEHOLDER": "Validate to fill the title property"
+          },
+          "DESCRIPTION_PROPERTY": {
+            "LABEL": "Description property",
+            "PLACEHOLDER": "Description"
+          },
+          "ASSIGNEE_PROPERTY": {
+            "LABEL": "Assignee property",
+            "PLACEHOLDER": "Assignee"
+          },
+          "PROJECT_PROPERTY": {
+            "LABEL": "Project property",
+            "PLACEHOLDER": "Project"
+          },
+          "STATUS_PROPERTY": {
+            "LABEL": "Status property",
+            "PLACEHOLDER": "Status"
+          },
+          "PRIORITY_PROPERTY": {
+            "LABEL": "Priority property",
+            "PLACEHOLDER": "Priority"
+          },
+          "LABEL_PROPERTY": {
+            "LABEL": "Label property",
+            "PLACEHOLDER": "Tags"
+          }
+        }
       }
     }
   },

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -380,6 +380,60 @@
     },
     "NOTION": {
       "HEADER": "Notion",
+      "ADD_ISSUE_BUTTON": "Create Notion issue",
+      "NO_LINKED_ISSUES": "No linked issues found",
+      "LOADING_ERROR": "There was an error fetching Notion issues, please try again",
+      "CREATE": {
+        "TITLE": "Create Notion issue",
+        "DESCRIPTION": "Create a Notion page from this conversation.",
+        "DEFAULT_TITLE": "Conversation (#{conversationId}) with {name}",
+        "SUBMIT": "Create issue",
+        "CANCEL": "Cancel",
+        "SUCCESS": "Issue created successfully",
+        "ERROR": "There was an error creating the issue, please try again",
+        "FORM": {
+          "TITLE": {
+            "LABEL": "Title",
+            "PLACEHOLDER": "Enter title",
+            "REQUIRED_ERROR": "Title is required"
+          },
+          "DESCRIPTION": {
+            "LABEL": "Description",
+            "PLACEHOLDER": "Enter description"
+          },
+          "ASSIGNEE": {
+            "LABEL": "Assignee",
+            "PLACEHOLDER": "Enter Notion user ID"
+          },
+          "PROJECT": {
+            "LABEL": "Project",
+            "PLACEHOLDER": "Enter related Notion page ID"
+          },
+          "STATUS": {
+            "LABEL": "Status",
+            "PLACEHOLDER": "Enter status"
+          },
+          "PRIORITY": {
+            "LABEL": "Priority",
+            "PLACEHOLDER": "Enter priority"
+          },
+          "LABELS": {
+            "LABEL": "Labels",
+            "PLACEHOLDER": "Enter labels separated by commas"
+          }
+        }
+      },
+      "ISSUE": {
+        "OPEN": "Open Notion issue",
+        "CREATED_AT": "Created at {createdAt}",
+        "CREATED_BY": "Created by {name}"
+      },
+      "CTA": {
+        "TITLE": "Set up Notion issue tracker",
+        "AGENT_DESCRIPTION": "Notion issue tracker is not configured. Request your administrator to configure a data source to use this integration.",
+        "DESCRIPTION": "Configure a Notion issue tracker data source to create issues from conversations.",
+        "BUTTON_TEXT": "Configure Notion issue tracker"
+      },
       "DELETE": {
         "TITLE": "Are you sure you want to delete the Notion integration?",
         "MESSAGE": "Deleting this integration will remove access to your Notion workspace and stop all related functionality.",

--- a/app/javascript/dashboard/routes/dashboard/conversation/ContactPanel.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ContactPanel.vue
@@ -24,6 +24,8 @@ import ShopifyOrdersList from 'dashboard/components/widgets/conversation/Shopify
 import SidebarActionsHeader from 'dashboard/components-next/SidebarActionsHeader.vue';
 import LinearIssuesList from 'dashboard/components/widgets/conversation/linear/IssuesList.vue';
 import LinearSetupCTA from 'dashboard/components/widgets/conversation/linear/LinearSetupCTA.vue';
+import NotionIssuesList from 'dashboard/components/widgets/conversation/notion/IssuesList.vue';
+import NotionSetupCTA from 'dashboard/components/widgets/conversation/notion/NotionSetupCTA.vue';
 
 const props = defineProps({
   conversationId: {
@@ -61,17 +63,38 @@ const isLinearFeatureEnabled = computed(() =>
   isCloudFeatureEnabled(FEATURE_FLAGS.LINEAR)
 );
 
+const isNotionFeatureEnabled = computed(() =>
+  isCloudFeatureEnabled(FEATURE_FLAGS.NOTION)
+);
+
 const linearIntegration = useFunctionGetter(
   'integrations/getIntegration',
   'linear'
+);
+
+const notionIntegration = useFunctionGetter(
+  'integrations/getIntegration',
+  'notion'
 );
 
 const isLinearClientIdConfigured = computed(() => {
   return !!linearIntegration.value?.id;
 });
 
+const isNotionClientIdConfigured = computed(() => {
+  return !!notionIntegration.value?.id;
+});
+
 const isLinearConnected = computed(
   () => linearIntegration.value?.enabled || false
+);
+
+const isNotionConnected = computed(
+  () => notionIntegration.value?.enabled || false
+);
+
+const isNotionIssueTrackerConfigured = computed(
+  () => notionIntegration.value?.issue_tracker_configured || false
 );
 
 const store = useStore();
@@ -126,8 +149,7 @@ onMounted(() => {
   conversationSidebarItems.value = conversationSidebarItemsOrder.value;
   getContactDetails();
   store.dispatch('attributes/get', 0);
-  // Load integrations to ensure linear integration state is available
-  store.dispatch('integrations/get', 'linear');
+  store.dispatch('integrations/get');
 });
 </script>
 
@@ -268,6 +290,29 @@ onMounted(() => {
             >
               <LinearSetupCTA v-if="!isLinearConnected" />
               <LinearIssuesList v-else :conversation-id="conversationId" />
+            </AccordionItem>
+          </div>
+          <div
+            v-else-if="
+              element.name === 'notion_issues' &&
+              isNotionFeatureEnabled &&
+              isNotionClientIdConfigured
+            "
+          >
+            <AccordionItem
+              :title="$t('CONVERSATION_SIDEBAR.ACCORDION.NOTION_ISSUES')"
+              :is-open="isContactSidebarItemOpen('is_notion_issues_open')"
+              compact
+              @toggle="
+                value => toggleSidebarUIState('is_notion_issues_open', value)
+              "
+            >
+              <NotionSetupCTA v-if="!isNotionConnected" />
+              <NotionIssuesList
+                v-else
+                :conversation-id="conversationId"
+                :is-configured="isNotionIssueTrackerConfigured"
+              />
             </AccordionItem>
           </div>
           <div

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Notion.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Notion.vue
@@ -6,10 +6,13 @@ import {
   useStore,
 } from 'dashboard/composables/store';
 import { useI18n } from 'vue-i18n';
+import { useAlert } from 'dashboard/composables';
 
-import ButtonNext from 'next/button/Button.vue';
 import notionClient from 'dashboard/api/notion_auth.js';
+import notionAPI from 'dashboard/api/integrations/notion';
 
+import Button from 'dashboard/components-next/button/Button.vue';
+import Input from 'dashboard/components-next/input/Input.vue';
 import Integration from './Integration.vue';
 import SettingsLayout from '../SettingsLayout.vue';
 import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';
@@ -17,18 +20,102 @@ import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';
 const { t } = useI18n();
 const store = useStore();
 const integrationLoaded = ref(false);
+const isLoadingIssueTracker = ref(false);
+const isValidatingIssueTracker = ref(false);
+const isSavingIssueTracker = ref(false);
+const validatedDataSourceId = ref('');
+const issueTrackerErrors = ref({
+  data_source_id: '',
+  title_property: '',
+});
+const issueTrackerForm = ref({
+  data_source_id: '',
+  title_property: '',
+  description_property: '',
+  assignee_property: '',
+  project_property: '',
+  status_property: '',
+  priority_property: '',
+  label_property: '',
+});
+
+const optionalPropertyFields = computed(() => [
+  {
+    key: 'description_property',
+    label: t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.DESCRIPTION_PROPERTY.LABEL'
+    ),
+    placeholder: t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.DESCRIPTION_PROPERTY.PLACEHOLDER'
+    ),
+  },
+  {
+    key: 'assignee_property',
+    label: t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.ASSIGNEE_PROPERTY.LABEL'
+    ),
+    placeholder: t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.ASSIGNEE_PROPERTY.PLACEHOLDER'
+    ),
+  },
+  {
+    key: 'project_property',
+    label: t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.PROJECT_PROPERTY.LABEL'
+    ),
+    placeholder: t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.PROJECT_PROPERTY.PLACEHOLDER'
+    ),
+  },
+  {
+    key: 'status_property',
+    label: t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.STATUS_PROPERTY.LABEL'
+    ),
+    placeholder: t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.STATUS_PROPERTY.PLACEHOLDER'
+    ),
+  },
+  {
+    key: 'priority_property',
+    label: t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.PRIORITY_PROPERTY.LABEL'
+    ),
+    placeholder: t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.PRIORITY_PROPERTY.PLACEHOLDER'
+    ),
+  },
+  {
+    key: 'label_property',
+    label: t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.LABEL_PROPERTY.LABEL'
+    ),
+    placeholder: t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.LABEL_PROPERTY.PLACEHOLDER'
+    ),
+  },
+]);
 
 const integration = useFunctionGetter('integrations/getIntegration', 'notion');
 
 const uiFlags = useMapGetter('integrations/getUIFlags');
 
+const isIntegrationEnabled = computed(() => Boolean(integration.value.enabled));
+
 const integrationAction = computed(() => {
-  if (integration.value.enabled) {
+  if (isIntegrationEnabled.value) {
     return 'disconnect';
   }
 
   return '';
 });
+
+const isSettingsLoading = computed(
+  () =>
+    !integrationLoaded.value ||
+    isLoadingIssueTracker.value ||
+    uiFlags.value.isCreatingNotion
+);
 
 const authorize = async () => {
   const response = await notionClient.generateAuthorization();
@@ -39,9 +126,145 @@ const authorize = async () => {
   window.location.href = url;
 };
 
+const getResponseErrorMessage = error => {
+  const responseError = error.response?.data?.error;
+
+  if (typeof responseError === 'string') {
+    return responseError;
+  }
+
+  return responseError?.message || '';
+};
+
+const clearIssueTrackerErrors = () => {
+  issueTrackerErrors.value = {
+    data_source_id: '',
+    title_property: '',
+  };
+};
+
+const applyIssueTrackerSettings = settings => {
+  Object.keys(issueTrackerForm.value).forEach(key => {
+    issueTrackerForm.value[key] = settings[key] || '';
+  });
+  validatedDataSourceId.value = issueTrackerForm.value.data_source_id;
+};
+
+const fetchIssueTrackerSettings = async () => {
+  if (!isIntegrationEnabled.value) {
+    return;
+  }
+
+  try {
+    isLoadingIssueTracker.value = true;
+    const { data } = await notionAPI.getIssueTracker();
+    applyIssueTrackerSettings(data);
+  } catch (error) {
+    useAlert(t('INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.LOAD_ERROR'));
+  } finally {
+    isLoadingIssueTracker.value = false;
+  }
+};
+
 const initializeNotionIntegration = async () => {
   await store.dispatch('integrations/get', 'notion');
   integrationLoaded.value = true;
+  await fetchIssueTrackerSettings();
+};
+
+const handleDataSourceInput = () => {
+  issueTrackerErrors.value.data_source_id = '';
+
+  if (
+    issueTrackerForm.value.data_source_id.trim() !== validatedDataSourceId.value
+  ) {
+    issueTrackerForm.value.title_property = '';
+  }
+};
+
+const validateDataSource = async () => {
+  clearIssueTrackerErrors();
+  const dataSourceId = issueTrackerForm.value.data_source_id.trim();
+
+  if (!dataSourceId) {
+    issueTrackerErrors.value.data_source_id = t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.DATA_SOURCE_REQUIRED'
+    );
+    return;
+  }
+
+  try {
+    isValidatingIssueTracker.value = true;
+    const { data } = await notionAPI.validateIssueTracker({
+      data_source_id: dataSourceId,
+    });
+    issueTrackerForm.value.data_source_id = data.data_source_id;
+    issueTrackerForm.value.title_property = data.title_property;
+    validatedDataSourceId.value = data.data_source_id;
+    useAlert(t('INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.VALIDATE_SUCCESS'));
+  } catch (error) {
+    issueTrackerErrors.value.data_source_id =
+      getResponseErrorMessage(error) ||
+      t('INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.VALIDATE_ERROR');
+  } finally {
+    isValidatingIssueTracker.value = false;
+  }
+};
+
+const validateIssueTrackerForm = () => {
+  clearIssueTrackerErrors();
+  const dataSourceId = issueTrackerForm.value.data_source_id.trim();
+  const titleProperty = issueTrackerForm.value.title_property.trim();
+
+  if (!dataSourceId) {
+    issueTrackerErrors.value.data_source_id = t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.DATA_SOURCE_REQUIRED'
+    );
+  }
+
+  if (!titleProperty) {
+    issueTrackerErrors.value.title_property = t(
+      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.TITLE_REQUIRED'
+    );
+  }
+
+  return dataSourceId && titleProperty;
+};
+
+const buildIssueTrackerPayload = () => {
+  const payload = {
+    data_source_id: issueTrackerForm.value.data_source_id.trim(),
+    title_property: issueTrackerForm.value.title_property.trim(),
+  };
+
+  optionalPropertyFields.value.forEach(({ key }) => {
+    const value = issueTrackerForm.value[key].trim();
+
+    if (value) {
+      payload[key] = value;
+    }
+  });
+
+  return payload;
+};
+
+const saveIssueTrackerSettings = async () => {
+  if (!validateIssueTrackerForm()) {
+    return;
+  }
+
+  try {
+    isSavingIssueTracker.value = true;
+    const { data } = await notionAPI.updateIssueTracker(
+      buildIssueTrackerPayload()
+    );
+    applyIssueTrackerSettings(data);
+    useAlert(t('INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.SAVE_SUCCESS'));
+  } catch (error) {
+    useAlert(t('INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.SAVE_ERROR'));
+  } finally {
+    isSavingIssueTracker.value = false;
+  }
 };
 
 onMounted(() => {
@@ -50,7 +273,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <SettingsLayout :is-loading="!integrationLoaded || uiFlags.isCreatingNotion">
+  <SettingsLayout :is-loading="isSettingsLoading">
     <template #header>
       <BaseSettingsHeader
         :title="$t('INTEGRATION_SETTINGS.NOTION.HEADER')"
@@ -60,27 +283,118 @@ onMounted(() => {
       />
     </template>
     <template #body>
-      <Integration
-        :integration-id="integration.id"
-        :integration-logo="integration.logo"
-        :integration-name="integration.name"
-        :integration-description="integration.description"
-        :integration-enabled="integration.enabled"
-        :integration-action="integrationAction"
-        :delete-confirmation-text="{
-          title: t('INTEGRATION_SETTINGS.NOTION.DELETE.TITLE'),
-          message: t('INTEGRATION_SETTINGS.NOTION.DELETE.MESSAGE'),
-        }"
-      >
-        <template #action>
-          <ButtonNext
-            faded
-            blue
-            :label="t('INTEGRATION_SETTINGS.CONNECT.BUTTON_TEXT')"
-            @click="authorize"
-          />
-        </template>
-      </Integration>
+      <div class="flex flex-col gap-6">
+        <Integration
+          :integration-id="integration.id"
+          :integration-logo="integration.logo"
+          :integration-name="integration.name"
+          :integration-description="integration.description"
+          :integration-enabled="integration.enabled"
+          :integration-action="integrationAction"
+          :delete-confirmation-text="{
+            title: t('INTEGRATION_SETTINGS.NOTION.DELETE.TITLE'),
+            message: t('INTEGRATION_SETTINGS.NOTION.DELETE.MESSAGE'),
+          }"
+        >
+          <template #action>
+            <Button
+              faded
+              blue
+              type="button"
+              :label="t('INTEGRATION_SETTINGS.CONNECT.BUTTON_TEXT')"
+              @click="authorize"
+            />
+          </template>
+        </Integration>
+
+        <div
+          v-if="isIntegrationEnabled"
+          class="p-6 outline outline-n-container outline-1 bg-n-card rounded-xl"
+        >
+          <div class="flex flex-col gap-5">
+            <div>
+              <h3 class="mb-1 text-heading-1 text-n-slate-12">
+                {{ t('INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.TITLE') }}
+              </h3>
+              <p class="mb-0 text-body-main text-n-slate-11">
+                {{ t('INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.DESCRIPTION') }}
+              </p>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div class="md:col-span-2">
+                <Input
+                  v-model="issueTrackerForm.data_source_id"
+                  :label="
+                    t(
+                      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.DATA_SOURCE_ID.LABEL'
+                    )
+                  "
+                  :placeholder="
+                    t(
+                      'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.DATA_SOURCE_ID.PLACEHOLDER'
+                    )
+                  "
+                  :message="issueTrackerErrors.data_source_id"
+                  :message-type="
+                    issueTrackerErrors.data_source_id ? 'error' : 'info'
+                  "
+                  :disabled="isValidatingIssueTracker || isSavingIssueTracker"
+                  @input="handleDataSourceInput"
+                />
+              </div>
+
+              <Input
+                v-model="issueTrackerForm.title_property"
+                :label="
+                  t(
+                    'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.TITLE_PROPERTY.LABEL'
+                  )
+                "
+                :placeholder="
+                  t(
+                    'INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.FIELDS.TITLE_PROPERTY.PLACEHOLDER'
+                  )
+                "
+                :message="issueTrackerErrors.title_property"
+                :message-type="
+                  issueTrackerErrors.title_property ? 'error' : 'info'
+                "
+                disabled
+              />
+
+              <Input
+                v-for="field in optionalPropertyFields"
+                :key="field.key"
+                v-model="issueTrackerForm[field.key]"
+                :label="field.label"
+                :placeholder="field.placeholder"
+                :disabled="isValidatingIssueTracker || isSavingIssueTracker"
+              />
+            </div>
+
+            <div class="flex flex-col justify-end gap-3 sm:flex-row">
+              <Button
+                faded
+                slate
+                type="button"
+                :label="t('INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.VALIDATE')"
+                :is-loading="isValidatingIssueTracker"
+                :disabled="isValidatingIssueTracker || isSavingIssueTracker"
+                @click="validateDataSource"
+              />
+              <Button
+                blue
+                type="button"
+                :label="t('INTEGRATION_SETTINGS.NOTION.ISSUE_TRACKER.SAVE')"
+                :is-loading="isSavingIssueTracker"
+                :disabled="isValidatingIssueTracker || isSavingIssueTracker"
+                @click="saveIssueTrackerSettings"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
     </template>
   </SettingsLayout>
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Notion.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Notion.vue
@@ -307,10 +307,7 @@ onMounted(() => {
           </template>
         </Integration>
 
-        <div
-          v-if="isIntegrationEnabled"
-          class="p-6 outline outline-n-container outline-1 bg-n-card rounded-xl"
-        >
+        <div v-if="isIntegrationEnabled" class="pt-6 border-t border-n-weak">
           <div class="flex flex-col gap-5">
             <div>
               <h3 class="mb-1 text-heading-1 text-n-slate-12">

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -78,6 +78,7 @@ class Account < ApplicationRecord
   has_many :tiktok_channels, dependent: :destroy_async, class_name: '::Channel::Tiktok'
   has_many :hooks, dependent: :destroy_async, class_name: 'Integrations::Hook'
   has_many :inboxes, dependent: :destroy_async
+  has_many :integration_issue_links, dependent: :destroy_async, class_name: 'Integrations::IssueLink'
   has_many :labels, dependent: :destroy_async
   has_many :line_channels, dependent: :destroy_async, class_name: '::Channel::Line'
   has_many :mentions, dependent: :destroy_async

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -110,6 +110,7 @@ class Conversation < ApplicationRecord
   has_many :messages, dependent: :destroy_async, autosave: true
   has_one :csat_survey_response, dependent: :destroy_async
   has_many :conversation_participants, dependent: :destroy_async
+  has_many :integration_issue_links, dependent: :destroy_async, class_name: 'Integrations::IssueLink'
   has_many :notifications, as: :primary_actor, dependent: :destroy_async
   has_many :attachments, through: :messages
   has_many :reporting_events, dependent: :destroy_async

--- a/app/models/integrations/app.rb
+++ b/app/models/integrations/app.rb
@@ -89,6 +89,13 @@ class Integrations::App
     end
   end
 
+  def notion_issue_tracker_configured?(account)
+    return false unless id == 'notion'
+
+    issue_tracker = account.hooks.find_by(app_id: 'notion')&.settings.to_h['issue_tracker'] || {}
+    issue_tracker['data_source_id'].present? && issue_tracker['title_property'].present?
+  end
+
   def hooks
     Current.account.hooks.where(app_id: id)
   end

--- a/app/models/integrations/issue_link.rb
+++ b/app/models/integrations/issue_link.rb
@@ -16,7 +16,7 @@
 # Indexes
 #
 #  index_integrations_issue_links_on_conversation_id_and_app_id  (conversation_id,app_id)
-#  index_issue_links_on_account_app_external_id                  (account_id,app_id,external_id) UNIQUE
+#  index_issue_links_on_account_conversation_app_external_id     (account_id,conversation_id,app_id,external_id) UNIQUE
 #
 class Integrations::IssueLink < ApplicationRecord
   before_validation :ensure_account_id
@@ -25,7 +25,7 @@ class Integrations::IssueLink < ApplicationRecord
   belongs_to :conversation
 
   validates :app_id, :external_id, :external_url, presence: true
-  validates :external_id, uniqueness: { scope: [:account_id, :app_id] }
+  validates :external_id, uniqueness: { scope: [:account_id, :conversation_id, :app_id] }
 
   private
 

--- a/app/models/integrations/issue_link.rb
+++ b/app/models/integrations/issue_link.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: integrations_issue_links
+#
+#  id              :bigint           not null, primary key
+#  external_title  :string
+#  external_url    :text             not null
+#  metadata        :jsonb
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  account_id      :bigint           not null
+#  app_id          :string           not null
+#  conversation_id :bigint           not null
+#  external_id     :string           not null
+#
+# Indexes
+#
+#  index_integrations_issue_links_on_conversation_id_and_app_id  (conversation_id,app_id)
+#  index_issue_links_on_account_app_external_id                  (account_id,app_id,external_id) UNIQUE
+#
+class Integrations::IssueLink < ApplicationRecord
+  belongs_to :account
+  belongs_to :conversation
+
+  validates :app_id, :external_id, :external_url, presence: true
+  validates :external_id, uniqueness: { scope: [:account_id, :app_id] }
+end

--- a/app/models/integrations/issue_link.rb
+++ b/app/models/integrations/issue_link.rb
@@ -19,9 +19,17 @@
 #  index_issue_links_on_account_app_external_id                  (account_id,app_id,external_id) UNIQUE
 #
 class Integrations::IssueLink < ApplicationRecord
+  before_validation :ensure_account_id
+
   belongs_to :account
   belongs_to :conversation
 
   validates :app_id, :external_id, :external_url, presence: true
   validates :external_id, uniqueness: { scope: [:account_id, :app_id] }
+
+  private
+
+  def ensure_account_id
+    self.account_id = conversation&.account_id
+  end
 end

--- a/app/services/notion/activity_message_service.rb
+++ b/app/services/notion/activity_message_service.rb
@@ -1,0 +1,37 @@
+class Notion::ActivityMessageService
+  attr_reader :conversation, :action_type, :issue_data, :user
+
+  def initialize(conversation:, action_type:, user:, issue_data: {})
+    @conversation = conversation
+    @action_type = action_type
+    @issue_data = issue_data
+    @user = user
+  end
+
+  def perform
+    return unless conversation && issue_data[:title] && user
+
+    content = generate_activity_content
+    return unless content
+
+    ::Conversations::ActivityMessageJob.perform_later(conversation, activity_message_params(content))
+  end
+
+  private
+
+  def generate_activity_content
+    case action_type.to_sym
+    when :issue_created
+      I18n.t('conversations.activity.notion.issue_created', user_name: user.name, issue_title: issue_data[:title])
+    end
+  end
+
+  def activity_message_params(content)
+    {
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      message_type: :activity,
+      content: content
+    }
+  end
+end

--- a/app/views/api/v1/models/_app.json.jbuilder
+++ b/app/views/api/v1/models/_app.json.jbuilder
@@ -3,6 +3,7 @@ json.name resource.name
 json.description resource.description
 json.short_description resource.short_description.presence
 json.enabled resource.enabled?(@current_account)
+json.issue_tracker_configured resource.notion_issue_tracker_configured?(@current_account) if resource.id == 'notion'
 
 if Current.account_user&.administrator?
   json.call(resource.params, *resource.params.keys)

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -370,7 +370,7 @@
   type: secret
 - name: NOTION_VERSION
   display_title: 'Notion Version'
-  value: '2022-06-28'
+  value: '2026-03-11'
   locked: false
   description: 'Notion version'
 ## ------ End of Configs added for Notion ------ ##

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,6 +290,8 @@ en:
         issue_created: 'Linear issue %{issue_id} was created by %{user_name}'
         issue_linked: 'Linear issue %{issue_id} was linked by %{user_name}'
         issue_unlinked: 'Linear issue %{issue_id} was unlinked by %{user_name}'
+      notion:
+        issue_created: 'Notion issue %{issue_title} was created by %{user_name}'
       csat:
         not_sent_due_to_messaging_window: 'CSAT survey not sent due to outgoing message restrictions'
       auto_resolve:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -356,6 +356,9 @@ Rails.application.routes.draw do
             resource :notion, controller: 'notion', only: [] do
               collection do
                 delete :destroy
+                get :issue_tracker
+                patch :issue_tracker, action: :update_issue_tracker
+                post :validate_issue_tracker
               end
             end
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -359,6 +359,8 @@ Rails.application.routes.draw do
                 get :issue_tracker
                 patch :issue_tracker, action: :update_issue_tracker
                 post :validate_issue_tracker
+                post :create_issue
+                get :linked_issues
               end
             end
           end

--- a/db/migrate/20260508200438_create_integrations_issue_links.rb
+++ b/db/migrate/20260508200438_create_integrations_issue_links.rb
@@ -1,0 +1,20 @@
+class CreateIntegrationsIssueLinks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :integrations_issue_links do |t|
+      t.references :account, null: false, index: false
+      t.references :conversation, null: false, index: false
+      t.string :app_id, null: false
+      t.string :external_id, null: false
+      t.text :external_url, null: false
+      t.string :external_title
+      t.jsonb :metadata, default: {}
+
+      t.timestamps
+    end
+
+    add_index :integrations_issue_links, [:account_id, :app_id, :external_id],
+              unique: true,
+              name: 'index_issue_links_on_account_app_external_id'
+    add_index :integrations_issue_links, [:conversation_id, :app_id]
+  end
+end

--- a/db/migrate/20260508200438_create_integrations_issue_links.rb
+++ b/db/migrate/20260508200438_create_integrations_issue_links.rb
@@ -1,8 +1,8 @@
 class CreateIntegrationsIssueLinks < ActiveRecord::Migration[7.0]
   def change
     create_table :integrations_issue_links do |t|
-      t.references :account, null: false, index: false
-      t.references :conversation, null: false, index: false
+      t.references :account, null: false, index: false, foreign_key: true
+      t.references :conversation, null: false, index: false, foreign_key: true
       t.string :app_id, null: false
       t.string :external_id, null: false
       t.text :external_url, null: false

--- a/db/migrate/20260508200438_create_integrations_issue_links.rb
+++ b/db/migrate/20260508200438_create_integrations_issue_links.rb
@@ -12,9 +12,9 @@ class CreateIntegrationsIssueLinks < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
-    add_index :integrations_issue_links, [:account_id, :app_id, :external_id],
+    add_index :integrations_issue_links, [:account_id, :conversation_id, :app_id, :external_id],
               unique: true,
-              name: 'index_issue_links_on_account_app_external_id'
+              name: 'index_issue_links_on_account_conversation_app_external_id'
     add_index :integrations_issue_links, [:conversation_id, :app_id]
   end
 end

--- a/db/migrate/20260508200438_create_integrations_issue_links.rb
+++ b/db/migrate/20260508200438_create_integrations_issue_links.rb
@@ -1,8 +1,8 @@
 class CreateIntegrationsIssueLinks < ActiveRecord::Migration[7.0]
   def change
     create_table :integrations_issue_links do |t|
-      t.references :account, null: false, index: false, foreign_key: true
-      t.references :conversation, null: false, index: false, foreign_key: true
+      t.references :account, null: false, index: false, foreign_key: { on_delete: :cascade }
+      t.references :conversation, null: false, index: false, foreign_key: { on_delete: :cascade }
       t.string :app_id, null: false
       t.string :external_id, null: false
       t.text :external_url, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -941,7 +941,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_08_200438) do
     t.jsonb "metadata", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["account_id", "app_id", "external_id"], name: "index_issue_links_on_account_app_external_id", unique: true
+    t.index ["account_id", "conversation_id", "app_id", "external_id"], name: "index_issue_links_on_account_conversation_app_external_id", unique: true
     t.index ["conversation_id", "app_id"], name: "index_integrations_issue_links_on_conversation_id_and_app_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1337,6 +1337,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_08_200438) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "inboxes", "portals"
+  add_foreign_key "integrations_issue_links", "accounts"
+  add_foreign_key "integrations_issue_links", "conversations"
   create_trigger("accounts_after_insert_row_tr", :generated => true, :compatibility => 1).
       on("accounts").
       after(:insert).

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_07_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_08_200438) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -929,6 +929,20 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_07_000000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "settings", default: {}
+  end
+
+  create_table "integrations_issue_links", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "conversation_id", null: false
+    t.string "app_id", null: false
+    t.string "external_id", null: false
+    t.text "external_url", null: false
+    t.string "external_title"
+    t.jsonb "metadata", default: {}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "app_id", "external_id"], name: "index_issue_links_on_account_app_external_id", unique: true
+    t.index ["conversation_id", "app_id"], name: "index_integrations_issue_links_on_conversation_id_and_app_id"
   end
 
   create_table "labels", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1337,8 +1337,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_08_200438) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "inboxes", "portals"
-  add_foreign_key "integrations_issue_links", "accounts"
-  add_foreign_key "integrations_issue_links", "conversations"
+  add_foreign_key "integrations_issue_links", "accounts", on_delete: :cascade
+  add_foreign_key "integrations_issue_links", "conversations", on_delete: :cascade
   create_trigger("accounts_after_insert_row_tr", :generated => true, :compatibility => 1).
       on("accounts").
       after(:insert).

--- a/lib/integrations/notion/issue_tracker_config_service.rb
+++ b/lib/integrations/notion/issue_tracker_config_service.rb
@@ -25,13 +25,15 @@ class Integrations::Notion::IssueTrackerConfigService
   private
 
   def normalized_properties(properties)
-    properties.to_h.map do |property_name, config|
+    normalized_properties = properties.to_h.map do |property_name, config|
       property = config.with_indifferent_access
       {
         name: property[:name].presence || property_name.to_s,
         type: property[:type]
       }
-    end.sort_by { |property| property[:name].downcase }
+    end
+
+    normalized_properties.sort_by { |property| property[:name].downcase }
   end
 
   def notion_client

--- a/lib/integrations/notion/issue_tracker_config_service.rb
+++ b/lib/integrations/notion/issue_tracker_config_service.rb
@@ -1,0 +1,40 @@
+class Integrations::Notion::IssueTrackerConfigService
+  DATA_SOURCE_PATH = 'data_sources'.freeze
+
+  pattr_initialize [:hook!]
+
+  def validate(data_source_id)
+    return { error: 'Data source is required' } if data_source_id.blank?
+
+    response = notion_client.get("#{DATA_SOURCE_PATH}/#{data_source_id}")
+    return { error: response[:error] } if response[:error]
+
+    properties = normalized_properties(response[:properties])
+    title_property = properties.find { |property| property[:type] == 'title' }
+    return { error: 'Data source must include a title property' } if title_property.blank?
+
+    {
+      data: {
+        data_source_id: response[:id] || data_source_id,
+        title_property: title_property[:name],
+        properties: properties
+      }
+    }
+  end
+
+  private
+
+  def normalized_properties(properties)
+    properties.to_h.map do |property_name, config|
+      property = config.with_indifferent_access
+      {
+        name: property[:name].presence || property_name.to_s,
+        type: property[:type]
+      }
+    end.sort_by { |property| property[:name].downcase }
+  end
+
+  def notion_client
+    @notion_client ||= Notion::ApiClient.new(hook.access_token)
+  end
+end

--- a/lib/integrations/notion/issue_tracker_service.rb
+++ b/lib/integrations/notion/issue_tracker_service.rb
@@ -1,0 +1,175 @@
+class Integrations::Notion::IssueTrackerService
+  pattr_initialize [:account!]
+
+  def create_issue(params, user = nil)
+    return { error: 'Title is required' } if params[:title].blank?
+    return { error: 'Conversation is required' } if params[:conversation_id].blank?
+
+    conversation = account.conversations.find_by!(display_id: params[:conversation_id])
+    response = notion_client.post('/pages', page_payload(params, user, conversation))
+    return { error: response[:error] } if response[:error]
+
+    issue_link = create_issue_link(response, params, user, conversation)
+    { data: serialized_issue_link(issue_link) }
+  end
+
+  def linked_issues(conversation_id)
+    conversation = account.conversations.find_by!(display_id: conversation_id)
+    issue_links = Integrations::IssueLink
+                  .where(account: account, conversation: conversation, app_id: 'notion')
+                  .order(created_at: :desc, id: :desc)
+
+    { data: issue_links.map { |issue_link| serialized_issue_link(issue_link) } }
+  end
+
+  private
+
+  def page_payload(params, user, conversation)
+    {
+      parent: { data_source_id: issue_tracker_settings['data_source_id'] },
+      properties: page_properties(params),
+      children: page_children(params, user, conversation)
+    }
+  end
+
+  def page_properties(params)
+    properties = {
+      issue_tracker_settings['title_property'] => title_property(params[:title])
+    }
+
+    add_description_property(properties, params)
+    add_status_property(properties, params)
+    add_priority_property(properties, params)
+    add_label_property(properties, params)
+    properties
+  end
+
+  def add_description_property(properties, params)
+    property = issue_tracker_settings['description_property']
+    return if property.blank? || params[:description].blank?
+
+    properties[property] = rich_text_property(params[:description])
+  end
+
+  def add_status_property(properties, params)
+    property = issue_tracker_settings['status_property']
+    return if property.blank? || params[:state_id].blank?
+
+    properties[property] = { status: { name: params[:state_id] } }
+  end
+
+  def add_priority_property(properties, params)
+    property = issue_tracker_settings['priority_property']
+    return if property.blank? || params[:priority].blank?
+
+    properties[property] = priority_property(params[:priority])
+  end
+
+  def add_label_property(properties, params)
+    property = issue_tracker_settings['label_property']
+    labels = Array(params[:label_ids]).reject(&:blank?)
+    return if property.blank? || labels.blank?
+
+    properties[property] = { multi_select: labels.map { |label| { name: label } } }
+  end
+
+  def page_children(params, user, conversation)
+    children = []
+    children << paragraph_block(params[:description]) if params[:description].present?
+    children << paragraph_block("Created by #{user.name}") if user
+    children << conversation_link_block(conversation)
+    children
+  end
+
+  def conversation_link_block(conversation)
+    conversation_link = conversation_url(conversation)
+    {
+      object: 'block',
+      type: 'paragraph',
+      paragraph: {
+        rich_text: [
+          text('Chatwoot conversation: '),
+          text(conversation_link, link: conversation_link)
+        ]
+      }
+    }
+  end
+
+  def paragraph_block(content)
+    {
+      object: 'block',
+      type: 'paragraph',
+      paragraph: {
+        rich_text: [text(content)]
+      }
+    }
+  end
+
+  def title_property(content)
+    { title: [text(content)] }
+  end
+
+  def rich_text_property(content)
+    { rich_text: [text(content)] }
+  end
+
+  def priority_property(priority)
+    priority_string = priority.to_s
+    return { number: priority_string.to_i } if priority_string.match?(/\A\d+\z/)
+
+    { select: { name: priority_string } }
+  end
+
+  def text(content, link: nil)
+    text = { content: content.to_s }
+    text[:link] = { url: link } if link
+
+    {
+      type: 'text',
+      text: text
+    }
+  end
+
+  def create_issue_link(response, params, user, conversation)
+    Integrations::IssueLink.create!(
+      account: account,
+      conversation: conversation,
+      app_id: 'notion',
+      external_id: response[:id],
+      external_url: response[:url],
+      external_title: params[:title],
+      metadata: {
+        data_source_id: issue_tracker_settings['data_source_id'],
+        created_by: user&.id,
+        created_by_name: user&.name
+      }
+    )
+  end
+
+  def serialized_issue_link(issue_link)
+    {
+      id: issue_link.external_id,
+      title: issue_link.external_title,
+      url: issue_link.external_url,
+      link_id: issue_link.id,
+      created_at: issue_link.created_at.iso8601,
+      metadata: issue_link.metadata
+    }
+  end
+
+  def conversation_url(conversation)
+    "#{ENV.fetch('FRONTEND_URL', nil)}/app/accounts/#{account.id}/conversations/#{conversation.display_id}"
+  end
+
+  def issue_tracker_settings
+    @issue_tracker_settings ||= notion_hook.settings.to_h['issue_tracker'] || {}
+  end
+
+  def notion_hook
+    @notion_hook ||= account.hooks.find_by!(app_id: 'notion')
+  end
+
+  def notion_client
+    @notion_client ||= Notion::ApiClient.new(notion_hook.access_token)
+  end
+end

--- a/lib/integrations/notion/issue_tracker_service.rb
+++ b/lib/integrations/notion/issue_tracker_service.rb
@@ -2,6 +2,7 @@ class Integrations::Notion::IssueTrackerService
   pattr_initialize [:account!]
 
   def create_issue(params, user = nil)
+    return { error: 'Notion issue tracker is not configured' } unless issue_tracker_configured?
     return { error: 'Title is required' } if params[:title].blank?
     return { error: 'Conversation is required' } if params[:conversation_id].blank?
 
@@ -38,6 +39,8 @@ class Integrations::Notion::IssueTrackerService
     }
 
     add_description_property(properties, params)
+    add_assignee_property(properties, params)
+    add_project_property(properties, params)
     add_status_property(properties, params)
     add_priority_property(properties, params)
     add_label_property(properties, params)
@@ -49,6 +52,20 @@ class Integrations::Notion::IssueTrackerService
     return if property.blank? || params[:description].blank?
 
     properties[property] = rich_text_property(params[:description])
+  end
+
+  def add_assignee_property(properties, params)
+    property = issue_tracker_settings['assignee_property']
+    return if property.blank? || params[:assignee_id].blank?
+
+    properties[property] = { people: [{ id: params[:assignee_id] }] }
+  end
+
+  def add_project_property(properties, params)
+    property = issue_tracker_settings['project_property']
+    return if property.blank? || params[:project_id].blank?
+
+    properties[property] = { relation: [{ id: params[:project_id] }] }
   end
 
   def add_status_property(properties, params)
@@ -163,6 +180,10 @@ class Integrations::Notion::IssueTrackerService
 
   def issue_tracker_settings
     @issue_tracker_settings ||= notion_hook.settings.to_h['issue_tracker'] || {}
+  end
+
+  def issue_tracker_configured?
+    issue_tracker_settings['data_source_id'].present? && issue_tracker_settings['title_property'].present?
   end
 
   def notion_hook

--- a/lib/notion/api_client.rb
+++ b/lib/notion/api_client.rb
@@ -1,0 +1,41 @@
+class Notion::ApiClient
+  BASE_URL = 'https://api.notion.com/v1'.freeze
+
+  def initialize(access_token)
+    raise ArgumentError, 'Missing Credentials' if access_token.blank?
+
+    @access_token = access_token
+  end
+
+  def get(path)
+    process_response(HTTParty.get(url_for(path), headers: headers))
+  end
+
+  def post(path, body = {})
+    process_response(HTTParty.post(url_for(path), headers: headers, body: body.to_json))
+  end
+
+  def patch(path, body = {})
+    process_response(HTTParty.patch(url_for(path), headers: headers, body: body.to_json))
+  end
+
+  private
+
+  def url_for(path)
+    "#{BASE_URL}/#{path.to_s.sub(%r{\A/+}, '')}"
+  end
+
+  def headers
+    {
+      'Authorization' => "Bearer #{@access_token}",
+      'Content-Type' => 'application/json',
+      'Notion-Version' => GlobalConfigService.load('NOTION_VERSION', '2026-03-11')
+    }
+  end
+
+  def process_response(response)
+    return response.parsed_response.with_indifferent_access if response.success?
+
+    { error: response.parsed_response, error_code: response.code }
+  end
+end

--- a/spec/controllers/api/v1/accounts/integrations/apps_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/apps_controller_spec.rb
@@ -40,6 +40,32 @@ RSpec.describe 'Integration Apps API', type: :request do
         expect(app['hooks'].first['settings']).to be_nil
       end
 
+      it 'returns notion issue tracker configuration status without exposing settings to agents' do
+        account.enable_features('notion_integration')
+        notion_hook = create(
+          :integrations_hook,
+          account: account,
+          app_id: 'notion',
+          settings: {
+            'issue_tracker' => {
+              'data_source_id' => 'data-source-id',
+              'title_property' => 'Title'
+            }
+          }
+        )
+
+        with_modified_env NOTION_CLIENT_ID: 'notion-client-id' do
+          get api_v1_account_integrations_apps_url(account),
+              headers: agent.create_new_auth_token,
+              as: :json
+        end
+
+        expect(response).to have_http_status(:success)
+        app = response.parsed_body['payload'].find { |int_app| int_app['id'] == notion_hook.app.id }
+        expect(app['issue_tracker_configured']).to be(true)
+        expect(app['hooks'].first['settings']).to be_nil
+      end
+
       it 'returns all active apps with sensitive information if user is an admin' do
         first_app = Integrations::App.all.find { |app| app.active?(account) }
         get api_v1_account_integrations_apps_url(account),

--- a/spec/controllers/api/v1/accounts/integrations/notion_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/notion_controller_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'Notion Integration API', type: :request do
   let(:account) { create(:account) }
+  let(:admin) { create(:user, account: account, role: :administrator) }
   let(:agent) { create(:user, account: account, role: :agent) }
+  let(:issue_tracker_service) { instance_double(Integrations::Notion::IssueTrackerService) }
   let!(:hook) do
     create(
       :integrations_hook,
@@ -20,10 +22,116 @@ RSpec.describe 'Notion Integration API', type: :request do
     )
   end
 
+  describe 'POST /api/v1/accounts/:account_id/integrations/notion/create_issue' do
+    let(:inbox) { create(:inbox, account: account) }
+    let(:conversation) { create(:conversation, account: account, inbox: inbox) }
+    let(:issue_params) do
+      {
+        title: 'Sample Issue',
+        description: 'This is a sample issue.',
+        priority: 'High',
+        state_id: 'In progress',
+        label_ids: ['Billing'],
+        conversation_id: conversation.display_id
+      }
+    end
+
+    before do
+      allow(Integrations::Notion::IssueTrackerService).to receive(:new).with(account: account).and_return(issue_tracker_service)
+    end
+
+    it 'returns the created issue for an agent' do
+      allow(issue_tracker_service).to receive(:create_issue).with(issue_params.stringify_keys, agent).and_return(
+        data: { id: 'page-1', title: 'Sample Issue', url: 'https://notion.so/page-1' }
+      )
+
+      post "/api/v1/accounts/#{account.id}/integrations/notion/create_issue",
+           params: issue_params,
+           headers: agent.create_new_auth_token,
+           as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        'id' => 'page-1',
+        'title' => 'Sample Issue',
+        'url' => 'https://notion.so/page-1'
+      )
+    end
+
+    it 'creates activity message when the issue is created by an agent' do
+      allow(issue_tracker_service).to receive(:create_issue).with(issue_params.stringify_keys, agent).and_return(
+        data: { id: 'page-1', title: 'Sample Issue', url: 'https://notion.so/page-1' }
+      )
+
+      expect do
+        post "/api/v1/accounts/#{account.id}/integrations/notion/create_issue",
+             params: issue_params,
+             headers: agent.create_new_auth_token,
+             as: :json
+      end.to have_enqueued_job(Conversations::ActivityMessageJob)
+        .with(conversation, {
+                account_id: conversation.account_id,
+                inbox_id: conversation.inbox_id,
+                message_type: :activity,
+                content: "Notion issue Sample Issue was created by #{agent.name}"
+              })
+    end
+
+    it 'returns error message and does not create activity message when creation fails' do
+      allow(issue_tracker_service).to receive(:create_issue).with(issue_params.stringify_keys, agent).and_return(error: 'error message')
+
+      expect do
+        post "/api/v1/accounts/#{account.id}/integrations/notion/create_issue",
+             params: issue_params,
+             headers: agent.create_new_auth_token,
+             as: :json
+      end.not_to have_enqueued_job(Conversations::ActivityMessageJob)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq('error' => 'error message')
+    end
+  end
+
+  describe 'GET /api/v1/accounts/:account_id/integrations/notion/linked_issues' do
+    let(:conversation) { create(:conversation, account: account) }
+
+    before do
+      allow(Integrations::Notion::IssueTrackerService).to receive(:new).with(account: account).and_return(issue_tracker_service)
+    end
+
+    it 'returns linked Notion issues for an agent' do
+      allow(issue_tracker_service).to receive(:linked_issues).with(conversation.display_id).and_return(
+        data: [{ id: 'page-1', title: 'Sample Issue', url: 'https://notion.so/page-1' }]
+      )
+
+      get "/api/v1/accounts/#{account.id}/integrations/notion/linked_issues",
+          params: { conversation_id: conversation.display_id },
+          headers: agent.create_new_auth_token,
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        [{ 'id' => 'page-1', 'title' => 'Sample Issue', 'url' => 'https://notion.so/page-1' }]
+      )
+    end
+
+    it 'returns error message when linked issues cannot be loaded' do
+      allow(issue_tracker_service).to receive(:linked_issues).with(conversation.display_id).and_return(error: 'error message')
+
+      get "/api/v1/accounts/#{account.id}/integrations/notion/linked_issues",
+          params: { conversation_id: conversation.display_id },
+          headers: agent.create_new_auth_token,
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq('error' => 'error message')
+    end
+  end
+
   describe 'GET /api/v1/accounts/:account_id/integrations/notion/issue_tracker' do
     it 'returns the stored issue tracker settings' do
       get "/api/v1/accounts/#{account.id}/integrations/notion/issue_tracker",
-          headers: agent.create_new_auth_token,
+          headers: admin.create_new_auth_token,
           as: :json
 
       expect(response).to have_http_status(:ok)
@@ -32,6 +140,14 @@ RSpec.describe 'Notion Integration API', type: :request do
         'title_property' => 'Name',
         'status_property' => 'Status'
       )
+    end
+
+    it 'does not allow agents to access issue tracker settings' do
+      get "/api/v1/accounts/#{account.id}/integrations/notion/issue_tracker",
+          headers: agent.create_new_auth_token,
+          as: :json
+
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 
@@ -49,7 +165,7 @@ RSpec.describe 'Notion Integration API', type: :request do
               label_property: 'Tags',
               unpermitted_property: 'Ignored'
             },
-            headers: agent.create_new_auth_token,
+            headers: admin.create_new_auth_token,
             as: :json
 
       expect(response).to have_http_status(:ok)
@@ -89,7 +205,7 @@ RSpec.describe 'Notion Integration API', type: :request do
 
       post "/api/v1/accounts/#{account.id}/integrations/notion/validate_issue_tracker",
            params: { data_source_id: 'data-source-1' },
-           headers: agent.create_new_auth_token,
+           headers: admin.create_new_auth_token,
            as: :json
 
       expect(response).to have_http_status(:ok)
@@ -108,7 +224,7 @@ RSpec.describe 'Notion Integration API', type: :request do
 
       post "/api/v1/accounts/#{account.id}/integrations/notion/validate_issue_tracker",
            params: { data_source_id: 'missing-data-source' },
-           headers: agent.create_new_auth_token,
+           headers: admin.create_new_auth_token,
            as: :json
 
       expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/controllers/api/v1/accounts/integrations/notion_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/notion_controller_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe 'Notion Integration API', type: :request do
       {
         title: 'Sample Issue',
         description: 'This is a sample issue.',
+        assignee_id: 'notion-user-1',
+        project_id: 'project-page-1',
         priority: 'High',
         state_id: 'In progress',
         label_ids: ['Billing'],

--- a/spec/controllers/api/v1/accounts/integrations/notion_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/notion_controller_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe 'Notion Integration API', type: :request do
+  let(:account) { create(:account) }
+  let(:agent) { create(:user, account: account, role: :agent) }
+  let!(:hook) do
+    create(
+      :integrations_hook,
+      account: account,
+      app_id: 'notion',
+      access_token: 'notion_access_token',
+      settings: {
+        'workspace_name' => 'Support workspace',
+        'issue_tracker' => {
+          'data_source_id' => 'data-source-1',
+          'title_property' => 'Name',
+          'status_property' => 'Status'
+        }
+      }
+    )
+  end
+
+  describe 'GET /api/v1/accounts/:account_id/integrations/notion/issue_tracker' do
+    it 'returns the stored issue tracker settings' do
+      get "/api/v1/accounts/#{account.id}/integrations/notion/issue_tracker",
+          headers: agent.create_new_auth_token,
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'data_source_id' => 'data-source-1',
+        'title_property' => 'Name',
+        'status_property' => 'Status'
+      )
+    end
+  end
+
+  describe 'PATCH /api/v1/accounts/:account_id/integrations/notion/issue_tracker' do
+    it 'stores permitted issue tracker settings and keeps blank optional mappings' do
+      patch "/api/v1/accounts/#{account.id}/integrations/notion/issue_tracker",
+            params: {
+              data_source_id: 'data-source-2',
+              title_property: 'Task',
+              description_property: 'Description',
+              assignee_property: '',
+              project_property: 'Project',
+              status_property: 'Status',
+              priority_property: '',
+              label_property: 'Tags',
+              unpermitted_property: 'Ignored'
+            },
+            headers: agent.create_new_auth_token,
+            as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'data_source_id' => 'data-source-2',
+        'title_property' => 'Task',
+        'description_property' => 'Description',
+        'assignee_property' => '',
+        'project_property' => 'Project',
+        'status_property' => 'Status',
+        'priority_property' => '',
+        'label_property' => 'Tags'
+      )
+      expect(hook.reload.settings['workspace_name']).to eq('Support workspace')
+      expect(hook.settings['issue_tracker']).to eq(response.parsed_body)
+    end
+  end
+
+  describe 'POST /api/v1/accounts/:account_id/integrations/notion/validate_issue_tracker' do
+    let(:service) { instance_double(Integrations::Notion::IssueTrackerConfigService) }
+
+    before do
+      allow(Integrations::Notion::IssueTrackerConfigService).to receive(:new).with(hook: hook).and_return(service)
+    end
+
+    it 'returns normalized data source properties' do
+      allow(service).to receive(:validate).with('data-source-1').and_return(
+        data: {
+          data_source_id: 'data-source-1',
+          title_property: 'Name',
+          properties: [
+            { name: 'Name', type: 'title' },
+            { name: 'Status', type: 'status' }
+          ]
+        }
+      )
+
+      post "/api/v1/accounts/#{account.id}/integrations/notion/validate_issue_tracker",
+           params: { data_source_id: 'data-source-1' },
+           headers: agent.create_new_auth_token,
+           as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'data_source_id' => 'data-source-1',
+        'title_property' => 'Name',
+        'properties' => [
+          { 'name' => 'Name', 'type' => 'title' },
+          { 'name' => 'Status', 'type' => 'status' }
+        ]
+      )
+    end
+
+    it 'returns validation errors' do
+      allow(service).to receive(:validate).with('missing-data-source').and_return(error: 'Unable to access data source')
+
+      post "/api/v1/accounts/#{account.id}/integrations/notion/validate_issue_tracker",
+           params: { data_source_id: 'missing-data-source' },
+           headers: agent.create_new_auth_token,
+           as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq('error' => 'Unable to access data source')
+    end
+  end
+end

--- a/spec/controllers/api/v1/accounts/integrations/notion_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/notion_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Notion Integration API', type: :request do
     end
 
     it 'returns the created issue for an agent' do
-      allow(issue_tracker_service).to receive(:create_issue).with(issue_params.stringify_keys, agent).and_return(
+      allow(issue_tracker_service).to receive(:create_issue).with(issue_params.with_indifferent_access, agent).and_return(
         data: { id: 'page-1', title: 'Sample Issue', url: 'https://notion.so/page-1' }
       )
 
@@ -63,7 +63,7 @@ RSpec.describe 'Notion Integration API', type: :request do
     end
 
     it 'creates activity message when the issue is created by an agent' do
-      allow(issue_tracker_service).to receive(:create_issue).with(issue_params.stringify_keys, agent).and_return(
+      allow(issue_tracker_service).to receive(:create_issue).with(issue_params.with_indifferent_access, agent).and_return(
         data: { id: 'page-1', title: 'Sample Issue', url: 'https://notion.so/page-1' }
       )
 
@@ -82,7 +82,7 @@ RSpec.describe 'Notion Integration API', type: :request do
     end
 
     it 'returns error message and does not create activity message when creation fails' do
-      allow(issue_tracker_service).to receive(:create_issue).with(issue_params.stringify_keys, agent).and_return(error: 'error message')
+      allow(issue_tracker_service).to receive(:create_issue).with(issue_params.with_indifferent_access, agent).and_return(error: 'error message')
 
       expect do
         post "/api/v1/accounts/#{account.id}/integrations/notion/create_issue",

--- a/spec/controllers/api/v1/accounts/integrations/notion_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/notion_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Notion Integration API', type: :request do
   let(:account) { create(:account) }
   let(:admin) { create(:user, account: account, role: :administrator) }
   let(:agent) { create(:user, account: account, role: :agent) }
+  let(:restricted_agent) { create(:user, account: account, role: :agent) }
   let(:issue_tracker_service) { instance_double(Integrations::Notion::IssueTrackerService) }
   let!(:hook) do
     create(
@@ -39,6 +40,7 @@ RSpec.describe 'Notion Integration API', type: :request do
     end
 
     before do
+      create(:inbox_member, user: agent, inbox: inbox)
       allow(Integrations::Notion::IssueTrackerService).to receive(:new).with(account: account).and_return(issue_tracker_service)
     end
 
@@ -92,12 +94,23 @@ RSpec.describe 'Notion Integration API', type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body).to eq('error' => 'error message')
     end
+
+    it 'does not allow agents without conversation access to create issues' do
+      post "/api/v1/accounts/#{account.id}/integrations/notion/create_issue",
+           params: issue_params,
+           headers: restricted_agent.create_new_auth_token,
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(Integrations::Notion::IssueTrackerService).not_to have_received(:new)
+    end
   end
 
   describe 'GET /api/v1/accounts/:account_id/integrations/notion/linked_issues' do
     let(:conversation) { create(:conversation, account: account) }
 
     before do
+      create(:inbox_member, user: agent, inbox: conversation.inbox)
       allow(Integrations::Notion::IssueTrackerService).to receive(:new).with(account: account).and_return(issue_tracker_service)
     end
 
@@ -127,6 +140,33 @@ RSpec.describe 'Notion Integration API', type: :request do
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body).to eq('error' => 'error message')
+    end
+
+    it 'does not allow agents without conversation access to list issues' do
+      get "/api/v1/accounts/#{account.id}/integrations/notion/linked_issues",
+          params: { conversation_id: conversation.display_id },
+          headers: restricted_agent.create_new_auth_token,
+          as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(Integrations::Notion::IssueTrackerService).not_to have_received(:new)
+    end
+  end
+
+  describe 'DELETE /api/v1/accounts/:account_id/integrations/notion' do
+    it 'deletes the notion integration and local issue links' do
+      conversation = create(:conversation, account: account)
+      create(:integrations_issue_link, account: account, conversation: conversation, app_id: 'notion', external_id: 'notion-page-1')
+      create(:integrations_issue_link, account: account, conversation: conversation, app_id: 'linear', external_id: 'linear-issue-1')
+
+      delete "/api/v1/accounts/#{account.id}/integrations/notion",
+             headers: admin.create_new_auth_token,
+             as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(account.hooks.exists?(app_id: 'notion')).to be(false)
+      expect(Integrations::IssueLink.where(account: account, app_id: 'notion')).to be_empty
+      expect(Integrations::IssueLink.where(account: account, app_id: 'linear').count).to eq(1)
     end
   end
 

--- a/spec/factories/integrations/issue_links.rb
+++ b/spec/factories/integrations/issue_links.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :integrations_issue_link, class: 'Integrations::IssueLink' do
+    association :conversation
+    account { conversation.account }
+    app_id { 'notion' }
+    sequence(:external_id) { |n| "issue-#{n}" }
+    external_url { "https://www.notion.so/#{external_id}" }
+    external_title { 'Customer issue' }
+    metadata { {} }
+  end
+end

--- a/spec/lib/integrations/notion/issue_tracker_config_service_spec.rb
+++ b/spec/lib/integrations/notion/issue_tracker_config_service_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe Integrations::Notion::IssueTrackerConfigService do
+  let(:hook) { create(:integrations_hook, app_id: 'notion', access_token: 'notion_access_token') }
+  let(:service) { described_class.new(hook: hook) }
+
+  describe '#validate' do
+    it 'fetches the Notion data source and returns normalized properties' do
+      stub_request(:get, 'https://api.notion.com/v1/data_sources/data-source-1')
+        .to_return(
+          status: 200,
+          body: {
+            id: 'data-source-1',
+            properties: {
+              'Name' => { id: 'title', name: 'Name', type: 'title', title: {} },
+              'Status' => { id: 'status', name: 'Status', type: 'status', status: {} },
+              'Priority' => { id: 'priority', name: 'Priority', type: 'select', select: {} }
+            }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect(service.validate('data-source-1')).to eq(
+        data: {
+          data_source_id: 'data-source-1',
+          title_property: 'Name',
+          properties: [
+            { name: 'Name', type: 'title' },
+            { name: 'Priority', type: 'select' },
+            { name: 'Status', type: 'status' }
+          ]
+        }
+      )
+    end
+
+    it 'returns an error when the data source does not have a title property' do
+      stub_request(:get, 'https://api.notion.com/v1/data_sources/data-source-1')
+        .to_return(
+          status: 200,
+          body: {
+            id: 'data-source-1',
+            properties: {
+              'Status' => { id: 'status', name: 'Status', type: 'status', status: {} }
+            }
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect(service.validate('data-source-1')).to eq(error: 'Data source must include a title property')
+    end
+
+    it 'returns Notion API errors' do
+      stub_request(:get, 'https://api.notion.com/v1/data_sources/missing-data-source')
+        .to_return(
+          status: 404,
+          body: { object: 'error', message: 'Could not find data source' }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect(service.validate('missing-data-source')).to eq(
+        error: { 'object' => 'error', 'message' => 'Could not find data source' }
+      )
+    end
+  end
+end

--- a/spec/lib/integrations/notion/issue_tracker_service_spec.rb
+++ b/spec/lib/integrations/notion/issue_tracker_service_spec.rb
@@ -65,13 +65,15 @@ RSpec.describe Integrations::Notion::IssueTrackerService do
           'data_source_id' => 'data-source-1',
           'title_property' => 'Name',
           'description_property' => 'Description',
+          'assignee_property' => 'DRI',
+          'project_property' => 'Project',
           'status_property' => 'Status',
           'priority_property' => 'Priority',
           'label_property' => 'Tags'
         }
       end
 
-      it 'sends configured rich text, status, select priority, and multi-select properties' do
+      it 'sends configured optional issue properties' do
         stub_notion_page_request(id: 'page-2', url: 'https://notion.so/page-2')
 
         with_modified_env FRONTEND_URL: 'https://app.chatwoot.test' do
@@ -80,6 +82,8 @@ RSpec.describe Integrations::Notion::IssueTrackerService do
               title: 'Export fails',
               description: 'Export fails when invoices include discounts.',
               conversation_id: conversation.display_id,
+              assignee_id: 'notion-user-1',
+              project_id: 'project-page-1',
               state_id: 'In progress',
               priority: 'High',
               label_ids: %w[Billing Exports]
@@ -118,6 +122,17 @@ RSpec.describe Integrations::Notion::IssueTrackerService do
 
       expect(result).to eq(error: { 'object' => 'error', 'message' => 'Invalid property' })
       expect(Integrations::IssueLink.count).to eq(0)
+    end
+
+    context 'when the issue tracker is not configured' do
+      let(:issue_tracker_settings) { {} }
+
+      it 'returns an error without creating a page' do
+        result = service.create_issue({ title: 'Refund request', conversation_id: conversation.display_id }, agent)
+
+        expect(result).to eq(error: 'Notion issue tracker is not configured')
+        expect(WebMock).not_to have_requested(:post, 'https://api.notion.com/v1/pages')
+      end
     end
   end
 
@@ -190,6 +205,8 @@ RSpec.describe Integrations::Notion::IssueTrackerService do
     {
       'Name' => { 'title' => [text_payload('Export fails')] },
       'Description' => { 'rich_text' => [text_payload('Export fails when invoices include discounts.')] },
+      'DRI' => { 'people' => [{ 'id' => 'notion-user-1' }] },
+      'Project' => { 'relation' => [{ 'id' => 'project-page-1' }] },
       'Status' => { 'status' => { 'name' => 'In progress' } },
       'Priority' => { 'select' => { 'name' => 'High' } },
       'Tags' => { 'multi_select' => [{ 'name' => 'Billing' }, { 'name' => 'Exports' }] }

--- a/spec/lib/integrations/notion/issue_tracker_service_spec.rb
+++ b/spec/lib/integrations/notion/issue_tracker_service_spec.rb
@@ -1,0 +1,216 @@
+require 'rails_helper'
+
+RSpec.describe Integrations::Notion::IssueTrackerService do
+  let(:account) { create(:account) }
+  let(:inbox) { create(:inbox, account: account) }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox) }
+  let(:agent) { create(:user, account: account, role: :agent) }
+  let(:issue_tracker_settings) do
+    {
+      'data_source_id' => 'data-source-1',
+      'title_property' => 'Name'
+    }
+  end
+  let(:hook) do
+    create(
+      :integrations_hook,
+      account: account,
+      app_id: 'notion',
+      access_token: 'notion_access_token',
+      settings: { 'issue_tracker' => issue_tracker_settings }
+    )
+  end
+  let(:service) do
+    hook
+    described_class.new(account: account)
+  end
+  let(:conversation_url) { "https://app.chatwoot.test/app/accounts/#{account.id}/conversations/#{conversation.display_id}" }
+  let(:request_body) { {} }
+
+  describe '#create_issue' do
+    it 'creates a Notion page with required properties and stores the issue link' do
+      stub_notion_page_request(id: 'page-1', url: 'https://notion.so/page-1')
+
+      result = nil
+      with_modified_env FRONTEND_URL: 'https://app.chatwoot.test' do
+        result = service.create_issue({ title: 'Refund request', conversation_id: conversation.display_id }, agent)
+      end
+
+      expect(result[:data]).to include(
+        id: 'page-1',
+        title: 'Refund request',
+        url: 'https://notion.so/page-1'
+      )
+      expect(request_body).to eq(minimal_page_payload)
+
+      issue_link = Integrations::IssueLink.last
+      expect(issue_link).to have_attributes(
+        account_id: account.id,
+        conversation_id: conversation.id,
+        app_id: 'notion',
+        external_id: 'page-1',
+        external_url: 'https://notion.so/page-1',
+        external_title: 'Refund request'
+      )
+      expect(issue_link.metadata).to include(
+        'data_source_id' => 'data-source-1',
+        'created_by' => agent.id,
+        'created_by_name' => agent.name
+      )
+    end
+
+    context 'with optional configured properties' do
+      let(:issue_tracker_settings) do
+        {
+          'data_source_id' => 'data-source-1',
+          'title_property' => 'Name',
+          'description_property' => 'Description',
+          'status_property' => 'Status',
+          'priority_property' => 'Priority',
+          'label_property' => 'Tags'
+        }
+      end
+
+      it 'sends configured rich text, status, select priority, and multi-select properties' do
+        stub_notion_page_request(id: 'page-2', url: 'https://notion.so/page-2')
+
+        with_modified_env FRONTEND_URL: 'https://app.chatwoot.test' do
+          service.create_issue(
+            {
+              title: 'Export fails',
+              description: 'Export fails when invoices include discounts.',
+              conversation_id: conversation.display_id,
+              state_id: 'In progress',
+              priority: 'High',
+              label_ids: %w[Billing Exports]
+            },
+            agent
+          )
+        end
+
+        expect(request_body['properties']).to include(optional_page_properties)
+        expect(request_body['children'].first).to eq(description_child)
+      end
+
+      it 'uses a number value for numeric priorities' do
+        stub_notion_page_request(id: 'page-3', url: 'https://notion.so/page-3')
+
+        with_modified_env FRONTEND_URL: 'https://app.chatwoot.test' do
+          service.create_issue(
+            { title: 'Numeric priority', conversation_id: conversation.display_id, priority: '2' },
+            agent
+          )
+        end
+
+        expect(request_body['properties']['Priority']).to eq('number' => 2)
+      end
+    end
+
+    it 'returns Notion API errors without storing a link' do
+      stub_request(:post, 'https://api.notion.com/v1/pages')
+        .to_return(
+          status: 400,
+          body: { object: 'error', message: 'Invalid property' }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      result = service.create_issue({ title: 'Refund request', conversation_id: conversation.display_id }, agent)
+
+      expect(result).to eq(error: { 'object' => 'error', 'message' => 'Invalid property' })
+      expect(Integrations::IssueLink.count).to eq(0)
+    end
+  end
+
+  describe '#linked_issues' do
+    it 'returns local Notion links for the conversation sorted newest first' do
+      older_link = create(
+        :integrations_issue_link,
+        account: account,
+        conversation: conversation,
+        app_id: 'notion',
+        external_id: 'older-page',
+        external_title: 'Older issue',
+        created_at: 2.days.ago
+      )
+      newer_link = create(
+        :integrations_issue_link,
+        account: account,
+        conversation: conversation,
+        app_id: 'notion',
+        external_id: 'newer-page',
+        external_title: 'Newer issue',
+        created_at: 1.hour.ago
+      )
+      create(:integrations_issue_link, account: account, conversation: conversation, app_id: 'linear', external_id: 'linear-issue')
+      create(
+        :integrations_issue_link,
+        account: account,
+        conversation: create(:conversation, account: account),
+        app_id: 'notion',
+        external_id: 'other-page'
+      )
+
+      result = service.linked_issues(conversation.display_id)
+
+      expect(result[:data].pluck(:id)).to eq([newer_link.external_id, older_link.external_id])
+      expect(result[:data].pluck(:title)).to eq(['Newer issue', 'Older issue'])
+    end
+  end
+
+  def stub_notion_page_request(id:, url:)
+    stub_request(:post, 'https://api.notion.com/v1/pages')
+      .with do |request|
+        request_body.replace(JSON.parse(request.body))
+        true
+      end
+      .to_return(
+        status: 200,
+        body: { id: id, url: url }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
+
+  def minimal_page_payload
+    {
+      'parent' => { 'data_source_id' => 'data-source-1' },
+      'properties' => {
+        'Name' => { 'title' => [text_payload('Refund request')] }
+      },
+      'children' => [
+        paragraph_payload(text_payload("Created by #{agent.name}")),
+        paragraph_payload(
+          text_payload('Chatwoot conversation: '),
+          text_payload(conversation_url, link: conversation_url)
+        )
+      ]
+    }
+  end
+
+  def optional_page_properties
+    {
+      'Name' => { 'title' => [text_payload('Export fails')] },
+      'Description' => { 'rich_text' => [text_payload('Export fails when invoices include discounts.')] },
+      'Status' => { 'status' => { 'name' => 'In progress' } },
+      'Priority' => { 'select' => { 'name' => 'High' } },
+      'Tags' => { 'multi_select' => [{ 'name' => 'Billing' }, { 'name' => 'Exports' }] }
+    }
+  end
+
+  def description_child
+    paragraph_payload(text_payload('Export fails when invoices include discounts.'))
+  end
+
+  def paragraph_payload(*rich_text)
+    {
+      'object' => 'block',
+      'type' => 'paragraph',
+      'paragraph' => { 'rich_text' => rich_text }
+    }
+  end
+
+  def text_payload(content, link: nil)
+    text = { 'content' => content }
+    text['link'] = { 'url' => link } if link
+    { 'type' => 'text', 'text' => text }
+  end
+end

--- a/spec/lib/notion/api_client_spec.rb
+++ b/spec/lib/notion/api_client_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Notion::ApiClient do
+  let(:access_token) { 'notion_access_token' }
+  let(:client) { described_class.new(access_token) }
+  let(:headers) do
+    {
+      'Authorization' => "Bearer #{access_token}",
+      'Content-Type' => 'application/json',
+      'Notion-Version' => '2026-03-11'
+    }
+  end
+
+  before do
+    allow(GlobalConfigService).to receive(:load).with('NOTION_VERSION', '2026-03-11').and_return('2026-03-11')
+  end
+
+  it 'sends the configured Notion version header' do
+    stub_request(:get, 'https://api.notion.com/v1/users')
+      .with(headers: headers)
+      .to_return(status: 200, body: { results: [] }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    client.get('/users')
+
+    expect(WebMock).to have_requested(:get, 'https://api.notion.com/v1/users')
+      .with(headers: headers)
+  end
+
+  it 'normalizes failed responses with the response code' do
+    stub_request(:get, 'https://api.notion.com/v1/pages/missing-page')
+      .to_return(status: 404, body: { object: 'error', message: 'Not found' }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    response = client.get('pages/missing-page')
+
+    expect(response).to eq({ error: { 'object' => 'error', 'message' => 'Not found' }, error_code: 404 })
+  end
+
+  it 'raises an error when the access token is missing' do
+    expect { described_class.new(nil) }.to raise_error(ArgumentError, 'Missing Credentials')
+  end
+end

--- a/spec/lib/safe_fetch_spec.rb
+++ b/spec/lib/safe_fetch_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe SafeFetch do
     allow(Resolv).to receive(:getaddresses).with('example.com').and_return(['93.184.216.34'])
   end
 
+  def expect_safe_fetch_error(error_class_name, message = nil, &)
+    expect(&).to raise_error do |error|
+      expect(error.class.name).to eq(error_class_name)
+      expect(error.message).to match(message) if message
+    end
+  end
+
   describe '.fetch' do
     context 'with a valid public URL serving an image' do
       before do
@@ -144,56 +151,66 @@ RSpec.describe SafeFetch do
 
     context 'with URL validation' do
       it 'raises InvalidUrlError for javascript: URLs' do
-        expect { described_class.fetch('javascript:alert(1)') { nil } }
-          .to raise_error(described_class::InvalidUrlError)
+        expect_safe_fetch_error('SafeFetch::InvalidUrlError') do
+          described_class.fetch('javascript:alert(1)') { nil }
+        end
       end
 
       it 'raises InvalidUrlError for mailto: URLs' do
-        expect { described_class.fetch('mailto:test@example.com') { nil } }
-          .to raise_error(described_class::InvalidUrlError)
+        expect_safe_fetch_error('SafeFetch::InvalidUrlError') do
+          described_class.fetch('mailto:test@example.com') { nil }
+        end
       end
 
       it 'raises InvalidUrlError for data: URLs' do
-        expect { described_class.fetch('data:text/html,<x>') { nil } }
-          .to raise_error(described_class::InvalidUrlError)
+        expect_safe_fetch_error('SafeFetch::InvalidUrlError') do
+          described_class.fetch('data:text/html,<x>') { nil }
+        end
       end
 
       it 'raises InvalidUrlError for ftp: URLs' do
-        expect { described_class.fetch('ftp://example.com/file') { nil } }
-          .to raise_error(described_class::InvalidUrlError)
+        expect_safe_fetch_error('SafeFetch::InvalidUrlError') do
+          described_class.fetch('ftp://example.com/file') { nil }
+        end
       end
 
       it 'raises InvalidUrlError for malformed URLs' do
-        expect { described_class.fetch('not_a_url') { nil } }
-          .to raise_error(described_class::InvalidUrlError)
+        expect_safe_fetch_error('SafeFetch::InvalidUrlError') do
+          described_class.fetch('not_a_url') { nil }
+        end
       end
 
       it 'raises InvalidUrlError when host is missing' do
-        expect { described_class.fetch('http:///path') { nil } }
-          .to raise_error(described_class::InvalidUrlError, /missing host/)
+        expect_safe_fetch_error('SafeFetch::InvalidUrlError', /missing host/) do
+          described_class.fetch('http:///path') { nil }
+        end
       end
     end
 
     context 'with SSRF protection (integration with ssrf_filter)' do
       it 'raises UnsafeUrlError for private IP literals (10.x.x.x)' do
-        expect { described_class.fetch('http://10.0.0.1/secret') { nil } }
-          .to raise_error(described_class::UnsafeUrlError)
+        expect_safe_fetch_error('SafeFetch::UnsafeUrlError') do
+          described_class.fetch('http://10.0.0.1/secret') { nil }
+        end
       end
 
       it 'raises UnsafeUrlError for loopback addresses' do
-        expect { described_class.fetch('http://127.0.0.1/secret') { nil } }
-          .to raise_error(described_class::UnsafeUrlError)
+        expect_safe_fetch_error('SafeFetch::UnsafeUrlError') do
+          described_class.fetch('http://127.0.0.1/secret') { nil }
+        end
       end
 
       it 'raises UnsafeUrlError for AWS metadata IP (169.254.169.254)' do
-        expect { described_class.fetch('http://169.254.169.254/latest/meta-data/') { nil } }
-          .to raise_error(described_class::UnsafeUrlError)
+        expect_safe_fetch_error('SafeFetch::UnsafeUrlError') do
+          described_class.fetch('http://169.254.169.254/latest/meta-data/') { nil }
+        end
       end
 
       it 'raises UnsafeUrlError when hostname resolves to a private IP (DNS rebinding)' do
         allow(Resolv).to receive(:getaddresses).with('evil.example.com').and_return(['10.0.0.1'])
-        expect { described_class.fetch('http://evil.example.com/secret') { nil } }
-          .to raise_error(described_class::UnsafeUrlError)
+        expect_safe_fetch_error('SafeFetch::UnsafeUrlError') do
+          described_class.fetch('http://evil.example.com/secret') { nil }
+        end
       end
     end
 
@@ -205,8 +222,9 @@ RSpec.describe SafeFetch do
           headers: { 'Content-Type' => 'text/html' }
         )
 
-        expect { described_class.fetch(url) { nil } }
-          .to raise_error(described_class::UnsupportedContentTypeError)
+        expect_safe_fetch_error('SafeFetch::UnsupportedContentTypeError') do
+          described_class.fetch(url) { nil }
+        end
       end
 
       it 'rejects application/octet-stream responses' do
@@ -216,8 +234,9 @@ RSpec.describe SafeFetch do
           headers: { 'Content-Type' => 'application/octet-stream' }
         )
 
-        expect { described_class.fetch(url) { nil } }
-          .to raise_error(described_class::UnsupportedContentTypeError)
+        expect_safe_fetch_error('SafeFetch::UnsupportedContentTypeError') do
+          described_class.fetch(url) { nil }
+        end
       end
 
       it 'allows video/mp4 responses' do
@@ -266,20 +285,21 @@ RSpec.describe SafeFetch do
           headers: { 'Content-Type' => 'image/webp' }
         )
 
-        expect do
+        expect_safe_fetch_error('SafeFetch::UnsupportedContentTypeError') do
           described_class.fetch(
             url,
             allowed_content_type_prefixes: [],
             allowed_content_types: ['image/png']
           ) { nil }
-        end.to raise_error(described_class::UnsupportedContentTypeError)
+        end
       end
 
       it 'rejects when the content-type header is missing' do
         stub_request(:get, url).to_return(status: 200, body: 'x', headers: {})
 
-        expect { described_class.fetch(url) { nil } }
-          .to raise_error(described_class::UnsupportedContentTypeError)
+        expect_safe_fetch_error('SafeFetch::UnsupportedContentTypeError') do
+          described_class.fetch(url) { nil }
+        end
       end
     end
 
@@ -347,8 +367,9 @@ RSpec.describe SafeFetch do
       end
 
       it 'raises UnsupportedMethodError for unsupported HTTP methods' do
-        expect { described_class.fetch(url, method: :options) { nil } }
-          .to raise_error(described_class::UnsupportedMethodError)
+        expect_safe_fetch_error('SafeFetch::UnsupportedMethodError') do
+          described_class.fetch(url, method: :options) { nil }
+        end
       end
     end
 
@@ -360,8 +381,9 @@ RSpec.describe SafeFetch do
           headers: { 'Content-Type' => 'image/png' }
         )
 
-        expect { described_class.fetch(url, max_bytes: 2) { nil } }
-          .to raise_error(described_class::FileTooLargeError)
+        expect_safe_fetch_error('SafeFetch::FileTooLargeError') do
+          described_class.fetch(url, max_bytes: 2) { nil }
+        end
       end
 
       it 'reads the default cap from GlobalConfigService MAXIMUM_FILE_UPLOAD_SIZE (matching Attachment#validate_file_size)' do
@@ -375,8 +397,9 @@ RSpec.describe SafeFetch do
           headers: { 'Content-Type' => 'image/png' }
         )
 
-        expect { described_class.fetch(url) { nil } }
-          .to raise_error(described_class::FileTooLargeError)
+        expect_safe_fetch_error('SafeFetch::FileTooLargeError') do
+          described_class.fetch(url) { nil }
+        end
       end
 
       it 'falls back to 40 MB when GlobalConfigService returns a non-positive value' do
@@ -414,15 +437,17 @@ RSpec.describe SafeFetch do
       it 'maps Net::ReadTimeout to FetchError' do
         stub_request(:get, url).to_raise(Net::ReadTimeout)
 
-        expect { described_class.fetch(url) { nil } }
-          .to raise_error(described_class::FetchError)
+        expect_safe_fetch_error('SafeFetch::FetchError') do
+          described_class.fetch(url) { nil }
+        end
       end
 
       it 'maps SocketError to FetchError' do
         stub_request(:get, url).to_raise(SocketError.new('connection refused'))
 
-        expect { described_class.fetch(url) { nil } }
-          .to raise_error(described_class::FetchError)
+        expect_safe_fetch_error('SafeFetch::FetchError') do
+          described_class.fetch(url) { nil }
+        end
       end
     end
 
@@ -430,8 +455,9 @@ RSpec.describe SafeFetch do
       it 'raises HttpError with the status code in the message' do
         stub_request(:get, url).to_return(status: 404, body: '', headers: {})
 
-        expect { described_class.fetch(url) { nil } }
-          .to raise_error(described_class::HttpError, /404/)
+        expect_safe_fetch_error('SafeFetch::HttpError', /404/) do
+          described_class.fetch(url) { nil }
+        end
       end
     end
   end

--- a/spec/models/integrations/issue_link_spec.rb
+++ b/spec/models/integrations/issue_link_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Integrations::IssueLink do
+  describe 'associations' do
+    it { is_expected.to belong_to(:account) }
+    it { is_expected.to belong_to(:conversation) }
+  end
+
+  describe 'validations' do
+    subject { build(:integrations_issue_link) }
+
+    it { is_expected.to validate_presence_of(:app_id) }
+    it { is_expected.to validate_presence_of(:external_id) }
+    it { is_expected.to validate_presence_of(:external_url) }
+
+    it 'validates external ID uniqueness within an account and app' do
+      account = create(:account)
+      conversation = create(:conversation, account: account)
+      create(:integrations_issue_link, account: account, conversation: conversation, app_id: 'notion', external_id: 'issue-1')
+
+      duplicate = build(:integrations_issue_link, account: account, conversation: conversation, app_id: 'notion', external_id: 'issue-1')
+      different_app = build(:integrations_issue_link, account: account, conversation: conversation, app_id: 'linear', external_id: 'issue-1')
+      different_account = build(:integrations_issue_link, app_id: 'notion', external_id: 'issue-1')
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:external_id]).to include('has already been taken')
+      expect(different_app).to be_valid
+      expect(different_account).to be_valid
+    end
+  end
+end

--- a/spec/models/integrations/issue_link_spec.rb
+++ b/spec/models/integrations/issue_link_spec.rb
@@ -13,17 +13,21 @@ RSpec.describe Integrations::IssueLink do
     it { is_expected.to validate_presence_of(:external_id) }
     it { is_expected.to validate_presence_of(:external_url) }
 
-    it 'validates external ID uniqueness within an account and app' do
+    it 'validates external ID uniqueness within a conversation and app' do
       account = create(:account)
       conversation = create(:conversation, account: account)
+      other_conversation = create(:conversation, account: account)
       create(:integrations_issue_link, account: account, conversation: conversation, app_id: 'notion', external_id: 'issue-1')
 
       duplicate = build(:integrations_issue_link, account: account, conversation: conversation, app_id: 'notion', external_id: 'issue-1')
+      different_conversation = build(:integrations_issue_link, account: account, conversation: other_conversation,
+                                                               app_id: 'notion', external_id: 'issue-1')
       different_app = build(:integrations_issue_link, account: account, conversation: conversation, app_id: 'linear', external_id: 'issue-1')
       different_account = build(:integrations_issue_link, app_id: 'notion', external_id: 'issue-1')
 
       expect(duplicate).not_to be_valid
       expect(duplicate.errors[:external_id]).to include('has already been taken')
+      expect(different_conversation).to be_valid
       expect(different_app).to be_valid
       expect(different_account).to be_valid
     end

--- a/spec/models/integrations/issue_link_spec.rb
+++ b/spec/models/integrations/issue_link_spec.rb
@@ -27,5 +27,15 @@ RSpec.describe Integrations::IssueLink do
       expect(different_app).to be_valid
       expect(different_account).to be_valid
     end
+
+    it 'derives the account from the conversation' do
+      account = create(:account)
+      conversation = create(:conversation, account: account)
+      issue_link = build(:integrations_issue_link, account: create(:account), conversation: conversation)
+
+      issue_link.valid?
+
+      expect(issue_link.account_id).to eq(account.id)
+    end
   end
 end


### PR DESCRIPTION
Adds Notion issue tracker support so teams can configure one Notion data source and create linked Notion issues directly from Chatwoot conversations. The integration mirrors Linear's core create fields while keeping only the title and configured data source mandatory.

Closes
- #14414

How to test
1. Enable the Notion integration for an account and configure `NOTION_CLIENT_ID`, `NOTION_CLIENT_SECRET`, and the callback URL.
2. Connect Notion from Settings -> Integrations -> Notion.
3. In the Notion integration settings, validate a Notion data source ID, review the detected title property, map any optional fields, and save.
4. Open a conversation, expand Linked Notion Issues in the sidebar, and create a Notion issue with a title plus any optional fields.
5. Confirm the new Notion page is created in the configured data source, contains a Chatwoot conversation link, and appears in the conversation sidebar.

What changed
- Updates Chatwoot's Notion API version default to `2026-03-11`.
- Adds local conversation-scoped integration issue links for external issue trackers.
- Adds Notion issue tracker settings validation, create issue, and linked issue endpoints.
- Adds Notion issue tracker settings UI and conversation sidebar UI.