### PR TITLE
feat(conversation): surface contact company in list, header, and contact panel

### DIFF
--- a/app/javascript/dashboard/components-next/Conversation/ConversationCard/ConversationCard.vue
+++ b/app/javascript/dashboard/components-next/Conversation/ConversationCard/ConversationCard.vue
@@ -43,6 +43,10 @@ const currentContactStatus = computed(
   () => currentContact.value?.availabilityStatus
 );
 
+const currentContactCompanyName = computed(
+  () => currentContact.value?.additionalAttributes?.companyName
+);
+
 const inbox = computed(() => props.stateInbox);
 
 const inboxName = computed(() => inbox.value?.name);
@@ -98,10 +102,23 @@ const onCardClick = e => {
       rounded-full
     />
     <div class="flex flex-col w-full gap-1 min-w-0">
-      <div class="flex items-center justify-between h-6 gap-2">
-        <h4 class="text-base font-medium truncate text-n-slate-12">
-          {{ currentContactName }}
-        </h4>
+      <div class="flex items-center justify-between gap-2">
+        <div class="flex flex-col min-w-0">
+          <h4 class="text-base font-medium truncate text-n-slate-12">
+            {{ currentContactName }}
+          </h4>
+          <span
+            v-if="currentContactCompanyName"
+            class="inline-flex items-center gap-1 min-w-0"
+          >
+            <span
+              class="i-ph-building-light size-3.5 text-n-slate-10 flex-shrink-0"
+            />
+            <span class="text-xs truncate text-n-slate-11">
+              {{ currentContactCompanyName }}
+            </span>
+          </span>
+        </div>
         <div class="flex items-center gap-2">
           <CardPriorityIcon :priority="conversation.priority || null" />
           <div

--- a/app/javascript/dashboard/components-next/Conversation/ConversationCard/ConversationCardExpanded.vue
+++ b/app/javascript/dashboard/components-next/Conversation/ConversationCard/ConversationCardExpanded.vue
@@ -35,6 +35,10 @@ const emit = defineEmits([
 const lastMessageInChat = computed(() => getLastMessage(props.chat));
 const showLabelsSection = computed(() => props.chat.labels?.length > 0);
 
+const currentContactCompanyName = computed(
+  () => props.currentContact?.additional_attributes?.company_name
+);
+
 const voiceCallData = computed(() => {
   const last = lastMessageInChat.value;
   if (last?.content_type !== 'voice_call' || !last.call) {
@@ -150,11 +154,24 @@ const selectedModel = computed({
         :hide-thumbnail="false"
       />
 
-      <h4
-        class="text-heading-3 my-0 capitalize truncate text-n-slate-12 font-medium w-32 flex-shrink-0"
-      >
-        {{ currentContact.name }}
-      </h4>
+      <div class="flex flex-col min-w-0 w-32 flex-shrink-0">
+        <h4
+          class="text-heading-3 my-0 capitalize truncate text-n-slate-12 font-medium"
+        >
+          {{ currentContact.name }}
+        </h4>
+        <span
+          v-if="currentContactCompanyName"
+          class="inline-flex items-center gap-1 min-w-0"
+        >
+          <span
+            class="i-ph-building-light size-3 text-n-slate-10 flex-shrink-0"
+          />
+          <span class="text-xs truncate text-n-slate-11">
+            {{ currentContactCompanyName }}
+          </span>
+        </span>
+      </div>
 
       <CardContent
         :last-message="lastMessageInChat"

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue
@@ -38,6 +38,10 @@ const unreadCount = computed(() => props.chat.unread_count);
 const hasUnread = computed(() => unreadCount.value > 0);
 const lastMessageInChat = computed(() => getLastMessage(props.chat));
 
+const currentContactCompanyName = computed(
+  () => props.currentContact?.additional_attributes?.company_name
+);
+
 const voiceCallData = computed(() => {
   const last = lastMessageInChat.value;
   if (last?.content_type !== 'voice_call' || !last.call) {
@@ -174,6 +178,17 @@ watch(
       >
         {{ currentContact.name }}
       </h4>
+      <span
+        v-if="currentContactCompanyName"
+        class="inline-flex items-center gap-1 my-0 mx-2 max-w-[calc(100%-1rem)]"
+      >
+        <span
+          class="i-ph-building-light size-3 text-n-slate-10 flex-shrink-0"
+        />
+        <span class="text-xs truncate text-n-slate-11">
+          {{ currentContactCompanyName }}
+        </span>
+      </span>
       <VoiceCallStatus
         v-if="voiceCallData.status"
         key="voice-status-row"

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
@@ -71,6 +71,10 @@ const currentContact = computed(() =>
   store.getters['contacts/getContact'](props.chat.meta.sender.id)
 );
 
+const currentContactCompanyName = computed(
+  () => currentContact.value?.additional_attributes?.company_name
+);
+
 const isSnoozed = computed(
   () => currentChat.value.status === wootConstants.STATUS_TYPE.SNOOZED
 );
@@ -146,6 +150,16 @@ const copyConversationId = async () => {
         <div
           class="flex items-center gap-1 overflow-hidden text-xs conversation--header--actions text-n-slate-11 text-ellipsis whitespace-nowrap"
         >
+          <span
+            v-if="currentContactCompanyName"
+            class="inline-flex items-center gap-1 min-w-0"
+          >
+            <span
+              class="i-ph-building-light size-3 text-n-slate-10 flex-shrink-0"
+            />
+            <span class="truncate">{{ currentContactCompanyName }}</span>
+          </span>
+          <span v-if="currentContactCompanyName">•</span>
           <button
             type="button"
             class="truncate text-label-small text-n-slate-11 hover:text-n-slate-12 !p-0 cucursor-pointer"

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -7,6 +7,8 @@ import {
 } from 'shared/helpers/CustomErrors';
 import { dynamicTime } from 'shared/helpers/timeHelper';
 import { useAdmin } from 'dashboard/composables/useAdmin';
+import { frontendURL } from 'dashboard/helper/URLHelper.js';
+import { INSTALLATION_TYPES } from 'dashboard/constants/installationTypes';
 import ContactInfoRow from './ContactInfoRow.vue';
 import Avatar from 'next/avatar/Avatar.vue';
 import SocialIcons from './SocialIcons.vue';
@@ -59,6 +61,21 @@ export default {
     ...mapGetters({ uiFlags: 'contacts/getUIFlags' }),
     contactProfileLink() {
       return `/app/accounts/${this.$route.params.accountId}/contacts/${this.contact.id}`;
+    },
+    installationType() {
+      return window.globalConfig?.INSTALLATION_IDENTIFIER || '';
+    },
+    isCompaniesAvailable() {
+      return [INSTALLATION_TYPES.CLOUD, INSTALLATION_TYPES.ENTERPRISE].includes(
+        this.installationType
+      );
+    },
+    companyDetailUrl() {
+      if (!this.isCompaniesAvailable) return '';
+      if (!this.contact?.company_id) return '';
+      return frontendURL(
+        `accounts/${this.$route.params.accountId}/companies/${this.contact.company_id}`
+      );
     },
     additionalAttributes() {
       return this.contact.additional_attributes || {};
@@ -265,6 +282,7 @@ export default {
             :title="$t('CONTACT_PANEL.IDENTIFIER')"
           />
           <ContactInfoRow
+            :href="companyDetailUrl"
             :value="additionalAttributes.company_name"
             icon="building-bank"
             emoji="🏢"

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -8,6 +8,7 @@ import {
 import { dynamicTime } from 'shared/helpers/timeHelper';
 import { useAdmin } from 'dashboard/composables/useAdmin';
 import { frontendURL } from 'dashboard/helper/URLHelper.js';
+import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import ContactInfoRow from './ContactInfoRow.vue';
 import Avatar from 'next/avatar/Avatar.vue';
 import SocialIcons from './SocialIcons.vue';
@@ -61,12 +62,21 @@ export default {
       uiFlags: 'contacts/getUIFlags',
       isOnChatwootCloud: 'globalConfig/isOnChatwootCloud',
       globalConfig: 'globalConfig/get',
+      isFeatureEnabledOnAccount: 'accounts/isFeatureEnabledonAccount',
     }),
     contactProfileLink() {
       return `/app/accounts/${this.$route.params.accountId}/contacts/${this.contact.id}`;
     },
     isCompaniesAvailable() {
-      return this.isOnChatwootCloud || this.globalConfig.isEnterprise;
+      const isSupportedInstall =
+        this.isOnChatwootCloud || this.globalConfig.isEnterprise;
+      return (
+        isSupportedInstall &&
+        this.isFeatureEnabledOnAccount(
+          this.$route.params.accountId,
+          FEATURE_FLAGS.COMPANIES
+        )
+      );
     },
     companyDetailUrl() {
       if (!this.isCompaniesAvailable) return '';

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -8,7 +8,6 @@ import {
 import { dynamicTime } from 'shared/helpers/timeHelper';
 import { useAdmin } from 'dashboard/composables/useAdmin';
 import { frontendURL } from 'dashboard/helper/URLHelper.js';
-import { INSTALLATION_TYPES } from 'dashboard/constants/installationTypes';
 import ContactInfoRow from './ContactInfoRow.vue';
 import Avatar from 'next/avatar/Avatar.vue';
 import SocialIcons from './SocialIcons.vue';
@@ -58,17 +57,16 @@ export default {
     };
   },
   computed: {
-    ...mapGetters({ uiFlags: 'contacts/getUIFlags' }),
+    ...mapGetters({
+      uiFlags: 'contacts/getUIFlags',
+      isOnChatwootCloud: 'globalConfig/isOnChatwootCloud',
+      globalConfig: 'globalConfig/get',
+    }),
     contactProfileLink() {
       return `/app/accounts/${this.$route.params.accountId}/contacts/${this.contact.id}`;
     },
-    installationType() {
-      return window.globalConfig?.INSTALLATION_IDENTIFIER || '';
-    },
     isCompaniesAvailable() {
-      return [INSTALLATION_TYPES.CLOUD, INSTALLATION_TYPES.ENTERPRISE].includes(
-        this.installationType
-      );
+      return this.isOnChatwootCloud || this.globalConfig.isEnterprise;
     },
     companyDetailUrl() {
       if (!this.isCompaniesAvailable) return '';

--- a/app/views/api/v1/models/_contact.json.jbuilder
+++ b/app/views/api/v1/models/_contact.json.jbuilder
@@ -7,6 +7,7 @@ json.phone_number resource.phone_number
 json.blocked resource.blocked
 json.identifier resource.identifier
 json.thumbnail resource.avatar_url
+json.company_id resource.company_id
 json.custom_attributes resource.custom_attributes
 json.last_activity_at resource.last_activity_at.to_i if resource[:last_activity_at].present?
 json.created_at resource.created_at.to_i if resource[:created_at].present?

--- a/enterprise/app/views/api/v1/accounts/companies/contacts/_contact.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/companies/contacts/_contact.json.jbuilder
@@ -1,5 +1,4 @@
 json.partial! 'api/v1/models/contact', formats: [:json], resource: contact, with_contact_inboxes: false
-json.company_id contact.company_id
 json.linked_to_current_company contact.company_id == @company.id
 if contact.company.present?
   json.company do


### PR DESCRIPTION
When agents work a queue of conversations, knowing which company the contact represents is critical context — currently the company exists on the contact record but is only visible if you open the right-side details panel. This PR surfaces a contact's company in three places it was previously invisible: under the contact name on the conversation list card, in the conversation header meta-row, and as a clickable link on the existing contact details panel that takes you to the new Companies detail page.

## How to test

1. Open a conversation whose contact has a company set. The conversation list card now shows a small building icon + company name under the contact's name.
2. Open the same conversation. The header meta-row (next to the conversation id) now shows the same building icon + company name.
3. In the right-side contact details panel, the existing "Company" row is now a link on cloud and enterprise installs. Clicking it opens the Companies detail page for that company. On community installs the row remains plain text (current behavior).
4. Open a conversation whose contact has no company. The list card and header look exactly as they do today (no pill, no extra row height). The contact panel "Company" row renders as plain text.
5. Open Contacts > a contact > History. The conversation cards there now show the same company pill — same data, same look.
6. Switch the conversation list to the expanded layout. Each row's name column shows the name on the first line and the company pill on the second line, without breaking column alignment.

## What changed

- `app/views/api/v1/models/_contact.json.jbuilder` — exposes `company_id` (existing column on `contacts`) on the v1 contact serializer so the contact panel can build a router link to `/app/accounts/:accountId/companies/:companyId`.
- `enterprise/app/views/api/v1/accounts/companies/contacts/_contact.json.jbuilder` — drops a now-redundant explicit `json.company_id` line; the field is inherited from the OSS partial that renders just above it.
- `app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue`, `app/javascript/dashboard/components-next/Conversation/ConversationCard/ConversationCard.vue`, `app/javascript/dashboard/components-next/Conversation/ConversationCard/ConversationCardExpanded.vue` — adds a `currentContactCompanyName` computed and a Phosphor `i-ph-building-light` pill rendered conditionally below the contact name. Mirrors the icon + style already shipped in `ContactsCard.vue`.
- `app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue` — adds the same pill as a meta-row segment before the conversation-id badge, with a bullet separator.
- `app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue` — wraps the existing Company row in an `:href` that points to the Companies detail page when the install supports it (cloud or enterprise) and the contact has a `company_id`. On community installs or contacts without a company, `:href=""` keeps the row as plain text via `ContactInfoRow`'s existing href branch.

The existing data shapes are reused: where the receiving component sees a camelCased contact (`contacts/getContactById`), the access path is `additionalAttributes.companyName`; where it sees raw store data (`contacts/getContact`), the path is `additional_attributes.company_name`. The contact data is already shipped on the conversation list API via `meta.sender.additional_attributes.company_name`, so no new fetches.
