### PR TITLE
fix: prevent bulk action checkbox reset in team view

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/conversationBulkActions/BulkTeamActions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/conversationBulkActions/BulkTeamActions.vue
@@ -1,9 +1,8 @@
 <script setup>
-import { useTemplateRef, computed, ref, onMounted } from 'vue';
+import { useTemplateRef, computed, ref } from 'vue';
 import { useI18n, I18nT } from 'vue-i18n';
 import { useToggle } from '@vueuse/core';
 import { vOnClickOutside } from '@vueuse/components';
-import { useStore } from 'vuex';
 import { useMapGetter } from 'dashboard/composables/store';
 
 import Button from 'dashboard/components-next/button/Button.vue';
@@ -19,7 +18,6 @@ const props = defineProps({
 const emit = defineEmits(['select']);
 
 const { t } = useI18n();
-const store = useStore();
 const containerRef = useTemplateRef('containerRef');
 const [showDropdown, toggleDropdown] = useToggle(false);
 const selectedTeam = ref(null);
@@ -77,10 +75,6 @@ const handleDismiss = () => {
   selectedTeam.value = null;
   toggleDropdown(false);
 };
-
-onMounted(() => {
-  store.dispatch('teams/get');
-});
 </script>
 
 <template>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue in team conversation view (/team/:id) where selecting a conversation for bulk actions would immediately reset the checkbox and refetch the list, making bulk selection unusable.

#### Root cause

When the first conversation was selected, `ConversationBulkActions` rendered `BulkTeamActions`, which triggered `teams/get` on mount. That action replaced the teams store data with new object references, causing the `activeTeam` watcher in `ChatList.vue` to fire and run `resetAndFetchData()`. As part of that flow, bulk selections were reset and conversations were refetched.

#### Fix

Removed the unnecessary `store.dispatch('teams/get')` from `BulkTeamActions.onMounted`.

Teams are already loaded from `Sidebar.vue` during dashboard initialization, so this extra fetch was redundant and caused the reference reset that triggered the issue.

Fixes https://linear.app/chatwoot/issue/CW-7078/multi-select-not-working-in-team-conversations

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

#### Screencast

https://github.com/user-attachments/assets/984493de-ec47-4458-925d-9ad4a8ab455f



#### How to reproduce
1. Open a team conversation view `/app/accounts/:account/team/:team_id`
2. Hover a conversation card and click the selection checkbox
3. Notice the checkbox gets cleared and the list refreshes


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
