### PR TITLE
feat(webhooks): allow custom headers for webhooks, API channel, and agent bots

### DIFF
--- a/app/controllers/api/v1/accounts/agent_bots_controller.rb
+++ b/app/controllers/api/v1/accounts/agent_bots_controller.rb
@@ -46,7 +46,7 @@ class Api::V1::Accounts::AgentBotsController < Api::V1::Accounts::BaseController
   end
 
   def permitted_params
-    params.permit(:name, :description, :outgoing_url, :avatar, :avatar_url, :bot_type, bot_config: {})
+    params.permit(:name, :description, :outgoing_url, :avatar, :avatar_url, :bot_type, bot_config: {}, additional_headers: {})
   end
 
   def process_avatar_from_url

--- a/app/controllers/api/v1/accounts/webhooks_controller.rb
+++ b/app/controllers/api/v1/accounts/webhooks_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::Accounts::WebhooksController < Api::V1::Accounts::BaseController
   private
 
   def webhook_params
-    params.require(:webhook).permit(:inbox_id, :name, :url, subscriptions: [])
+    params.require(:webhook).permit(:inbox_id, :name, :url, subscriptions: [], additional_headers: {})
   end
 
   def fetch_webhook

--- a/app/controllers/platform/api/v1/agent_bots_controller.rb
+++ b/app/controllers/platform/api/v1/agent_bots_controller.rb
@@ -37,7 +37,7 @@ class Platform::Api::V1::AgentBotsController < PlatformController
   end
 
   def agent_bot_params
-    params.permit(:name, :description, :account_id, :outgoing_url, :avatar, :avatar_url)
+    params.permit(:name, :description, :account_id, :outgoing_url, :avatar, :avatar_url, additional_headers: {})
   end
 
   def process_avatar_from_url

--- a/app/javascript/dashboard/components-next/webhook/HeadersEditor.vue
+++ b/app/javascript/dashboard/components-next/webhook/HeadersEditor.vue
@@ -25,7 +25,9 @@ const { t } = useI18n();
 const rows = computed({
   get() {
     const entries = Object.entries(props.modelValue || {});
-    return entries.length ? entries.map(([name, value]) => ({ name, value })) : [{ name: '', value: '' }];
+    return entries.length
+      ? entries.map(([name, value]) => ({ name, value }))
+      : [{ name: '', value: '' }];
   },
   set(value) {
     const headers = {};
@@ -38,7 +40,9 @@ const rows = computed({
 });
 
 const updateRow = (index, key, value) => {
-  const next = rows.value.map((row, idx) => (idx === index ? { ...row, [key]: value } : row));
+  const next = rows.value.map((row, idx) =>
+    idx === index ? { ...row, [key]: value } : row
+  );
   rows.value = next;
 };
 

--- a/app/javascript/dashboard/components-next/webhook/HeadersEditor.vue
+++ b/app/javascript/dashboard/components-next/webhook/HeadersEditor.vue
@@ -1,0 +1,104 @@
+<script setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import NextButton from 'dashboard/components-next/button/Button.vue';
+
+const props = defineProps({
+  modelValue: {
+    type: Object,
+    default: () => ({}),
+  },
+  label: {
+    type: String,
+    default: '',
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const { t } = useI18n();
+
+const rows = computed({
+  get() {
+    const entries = Object.entries(props.modelValue || {});
+    return entries.length ? entries.map(([name, value]) => ({ name, value })) : [{ name: '', value: '' }];
+  },
+  set(value) {
+    const headers = {};
+    value.forEach(({ name, value: headerValue }) => {
+      const trimmedName = (name || '').trim();
+      if (trimmedName) headers[trimmedName] = headerValue ?? '';
+    });
+    emit('update:modelValue', headers);
+  },
+});
+
+const updateRow = (index, key, value) => {
+  const next = rows.value.map((row, idx) => (idx === index ? { ...row, [key]: value } : row));
+  rows.value = next;
+};
+
+const addRow = () => {
+  rows.value = [...rows.value, { name: '', value: '' }];
+};
+
+const removeRow = index => {
+  const next = rows.value.filter((_, idx) => idx !== index);
+  rows.value = next.length ? next : [{ name: '', value: '' }];
+};
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <label v-if="label" class="text-sm font-medium text-n-slate-12">
+      {{ label }}
+    </label>
+    <p v-if="description" class="text-xs text-n-slate-11">
+      {{ description }}
+    </p>
+    <div class="flex flex-col gap-2">
+      <div
+        v-for="(row, index) in rows"
+        :key="index"
+        class="flex items-center gap-2"
+      >
+        <input
+          :value="row.name"
+          type="text"
+          class="!mb-0 flex-1 font-mono"
+          :placeholder="t('WEBHOOK_HEADERS.NAME_PLACEHOLDER')"
+          @input="event => updateRow(index, 'name', event.target.value)"
+        />
+        <input
+          :value="row.value"
+          type="text"
+          class="!mb-0 flex-1 font-mono"
+          :placeholder="t('WEBHOOK_HEADERS.VALUE_PLACEHOLDER')"
+          @input="event => updateRow(index, 'value', event.target.value)"
+        />
+        <NextButton
+          v-tooltip.top="t('WEBHOOK_HEADERS.REMOVE')"
+          type="button"
+          icon="i-lucide-trash-2"
+          slate
+          faded
+          @click="removeRow(index)"
+        />
+      </div>
+    </div>
+    <div>
+      <NextButton
+        type="button"
+        icon="i-lucide-plus"
+        slate
+        faded
+        :label="t('WEBHOOK_HEADERS.ADD')"
+        @click="addRow"
+      />
+    </div>
+  </div>
+</template>

--- a/app/javascript/dashboard/i18n/locale/en/agentBots.json
+++ b/app/javascript/dashboard/i18n/locale/en/agentBots.json
@@ -98,6 +98,10 @@
         "PLACEHOLDER": "https://example.com/webhook",
         "REQUIRED": "Webhook URL is required"
       },
+      "ADDITIONAL_HEADERS": {
+        "LABEL": "Custom headers",
+        "DESC": "Headers sent with every webhook request. Useful for static auth tokens (for example Authorization: Bearer ...). Chatwoot-managed headers (Content-Type, X-Chatwoot-*) cannot be overridden."
+      },
       "ERRORS": {
         "NAME": "Bot name is required",
         "URL": "Webhook URL is required",

--- a/app/javascript/dashboard/i18n/locale/en/components.json
+++ b/app/javascript/dashboard/i18n/locale/en/components.json
@@ -1,4 +1,10 @@
 {
+  "WEBHOOK_HEADERS": {
+    "NAME_PLACEHOLDER": "Header name (for example Authorization)",
+    "VALUE_PLACEHOLDER": "Header value",
+    "ADD": "Add header",
+    "REMOVE": "Remove header"
+  },
   "PAGINATION_FOOTER": {
     "SHOWING": "Showing {startItem} - {endItem} of {totalItems} item | Showing {startItem} - {endItem} of {totalItems} items",
     "CURRENT_PAGE_INFO": "{currentPage} of {totalPages} page | {currentPage} of {totalPages} pages"

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -94,6 +94,10 @@
           "RESET_SUCCESS": "Webhook secret regenerated successfully",
           "RESET_ERROR": "Unable to regenerate webhook secret. Please try again"
         },
+        "CHANNEL_WEBHOOK_HEADERS": {
+          "LABEL": "Additional headers",
+          "DESC": "Send these headers with API channel webhook requests. Chatwoot security headers are managed automatically."
+        },
         "CHANNEL_DOMAIN": {
           "LABEL": "Website Domain",
           "PLACEHOLDER": "Enter your website domain (eg: acme.com)"
@@ -376,6 +380,10 @@
           "LABEL": "Webhook URL",
           "SUBTITLE": "Configure the URL where you want to receive callbacks on events.",
           "PLACEHOLDER": "Webhook URL"
+        },
+        "HEADERS": {
+          "LABEL": "Additional headers",
+          "DESC": "Send these headers with API channel webhook requests. Chatwoot security headers are managed automatically."
         },
         "SUBMIT_BUTTON": "Create API Channel",
         "API": {

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -69,6 +69,10 @@
           "PLACEHOLDER": "Example: {webhookExampleURL}",
           "ERROR": "Please enter a valid URL"
         },
+        "HEADERS": {
+          "LABEL": "Custom headers",
+          "DESC": "Headers sent with every webhook request. Useful for static auth tokens (for example Authorization: Bearer ...). Chatwoot-managed headers (Content-Type, X-Chatwoot-*) cannot be overridden."
+        },
         "EDIT_SUBMIT": "Update webhook",
         "ADD_SUBMIT": "Create webhook"
       },

--- a/app/javascript/dashboard/routes/dashboard/settings/agentBots/components/AgentBotModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agentBots/components/AgentBotModal.vue
@@ -14,6 +14,7 @@ import Input from 'dashboard/components-next/input/Input.vue';
 import TextArea from 'dashboard/components-next/textarea/TextArea.vue';
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
 import AccessToken from 'dashboard/routes/dashboard/settings/profile/AccessToken.vue';
+import HeadersEditor from 'dashboard/components-next/webhook/HeadersEditor.vue';
 
 const props = defineProps({
   type: {
@@ -43,6 +44,7 @@ const formState = reactive({
   botUrl: '',
   botAvatar: null,
   botAvatarUrl: '',
+  botAdditionalHeaders: {},
 });
 
 const [showAccessToken, toggleAccessToken] = useToggle();
@@ -122,6 +124,7 @@ const resetForm = () => {
     botUrl: '',
     botAvatar: null,
     botAvatarUrl: '',
+    botAdditionalHeaders: {},
   });
   v$.value.$reset();
 };
@@ -161,6 +164,7 @@ const handleSubmit = async () => {
     outgoing_url: formState.botUrl,
     bot_type: 'webhook',
     avatar: formState.botAvatar,
+    additional_headers: formState.botAdditionalHeaders,
   };
 
   const isCreate = props.type === MODAL_TYPES.CREATE;
@@ -220,11 +224,13 @@ const initializeForm = () => {
       bot_config: botConfig,
       access_token: botAccessToken,
       secret: botSecretValue,
+      additional_headers: botAdditionalHeaders,
     } = props.selectedBot;
     formState.botName = name || '';
     formState.botDescription = description || '';
     formState.botUrl = botUrl || botConfig?.webhook_url || '';
     formState.botAvatarUrl = thumbnail || '';
+    formState.botAdditionalHeaders = { ...(botAdditionalHeaders || {}) };
 
     if (props.type === MODAL_TYPES.EDIT) {
       if (botAccessToken) accessToken.value = botAccessToken;
@@ -343,6 +349,12 @@ defineExpose({ dialogRef });
           :message="botUrlError"
           :message-type="botUrlError ? 'error' : 'info'"
           @blur="v$.botUrl.$touch()"
+        />
+
+        <HeadersEditor
+          v-model="formState.botAdditionalHeaders"
+          :label="$t('AGENT_BOTS.FORM.ADDITIONAL_HEADERS.LABEL')"
+          :description="$t('AGENT_BOTS.FORM.ADDITIONAL_HEADERS.DESC')"
         />
       </div>
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -40,6 +40,7 @@ import ColorPicker from 'dashboard/components-next/colorpicker/ColorPicker.vue';
 import SelectInput from 'dashboard/components-next/select/Select.vue';
 import Widget from 'dashboard/modules/widget-preview/components/Widget.vue';
 import AccessToken from 'dashboard/routes/dashboard/settings/profile/AccessToken.vue';
+import HeadersEditor from 'dashboard/components-next/webhook/HeadersEditor.vue';
 import { copyTextToClipboard } from 'shared/helpers/clipboard';
 
 export default {
@@ -74,6 +75,7 @@ export default {
     AccountHealth,
     Widget,
     AccessToken,
+    HeadersEditor,
   },
   mixins: [inboxMixin],
   setup() {
@@ -94,6 +96,7 @@ export default {
       selectedInboxName: '',
       channelWebsiteUrl: '',
       webhookUrl: '',
+      additionalHeaders: {},
       channelWelcomeTitle: '',
       channelWelcomeTagline: '',
       selectedFeatureFlags: [],
@@ -445,6 +448,7 @@ export default {
       this.avatarUrl = this.inbox.avatar_url;
       this.selectedInboxName = this.inbox.name;
       this.webhookUrl = this.inbox.webhook_url;
+      this.additionalHeaders = { ...(this.inbox.additional_headers || {}) };
       this.greetingEnabled = this.inbox.greeting_enabled || false;
       this.greetingMessage = this.inbox.greeting_message || '';
       this.emailCollectEnabled = this.inbox.enable_email_collect;
@@ -579,6 +583,7 @@ export default {
             widget_color: this.inbox.widget_color,
             website_url: this.channelWebsiteUrl,
             webhook_url: this.webhookUrl,
+            additional_headers: this.additionalHeaders,
             welcome_title: this.channelWelcomeTitle || '',
             welcome_tagline: this.channelWelcomeTagline || '',
             selectedFeatureFlags: this.selectedFeatureFlags,
@@ -590,7 +595,10 @@ export default {
         if (this.avatarFile) {
           payload.avatar = this.avatarFile;
         }
-        await this.$store.dispatch('inboxes/updateInbox', payload);
+        await this.$store.dispatch('inboxes/updateInbox', {
+          ...payload,
+          formData: !this.isAPIInbox || !!this.avatarFile,
+        });
         useAlert(this.$t('INBOX_MGMT.EDIT.API.SUCCESS_MESSAGE'));
         this.showBusinessNameInput = false;
       } catch (error) {
@@ -783,6 +791,24 @@ export default {
                     : ''
                 "
                 @blur="v$.webhookUrl.$touch"
+              />
+            </SettingsFieldSection>
+
+            <SettingsFieldSection
+              v-if="isAPIInbox"
+              :label="
+                $t(
+                  'INBOX_MGMT.ADD.WEBSITE_CHANNEL.CHANNEL_WEBHOOK_HEADERS.LABEL'
+                )
+              "
+            >
+              <HeadersEditor
+                v-model="additionalHeaders"
+                :description="
+                  $t(
+                    'INBOX_MGMT.ADD.WEBSITE_CHANNEL.CHANNEL_WEBHOOK_HEADERS.DESC'
+                  )
+                "
               />
             </SettingsFieldSection>
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Api.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Api.vue
@@ -6,6 +6,7 @@ import { required } from '@vuelidate/validators';
 import router from '../../../../index';
 import PageHeader from '../../SettingsSubPageHeader.vue';
 import NextButton from 'dashboard/components-next/button/Button.vue';
+import HeadersEditor from 'dashboard/components-next/webhook/HeadersEditor.vue';
 
 const shouldBeWebhookUrl = (value = '') =>
   value ? value.startsWith('http') : true;
@@ -14,6 +15,7 @@ export default {
   components: {
     PageHeader,
     NextButton,
+    HeadersEditor,
   },
   setup() {
     return { v$: useVuelidate() };
@@ -22,6 +24,7 @@ export default {
     return {
       channelName: '',
       webhookUrl: '',
+      additionalHeaders: {},
     };
   },
   computed: {
@@ -46,6 +49,7 @@ export default {
           channel: {
             type: 'api',
             webhook_url: this.webhookUrl,
+            additional_headers: this.additionalHeaders,
           },
         });
 
@@ -110,6 +114,13 @@ export default {
           {{ $t('INBOX_MGMT.ADD.API_CHANNEL.WEBHOOK_URL.SUBTITLE') }}
         </p>
       </div>
+
+      <HeadersEditor
+        v-model="additionalHeaders"
+        class="mb-4"
+        :label="$t('INBOX_MGMT.ADD.API_CHANNEL.HEADERS.LABEL')"
+        :description="$t('INBOX_MGMT.ADD.API_CHANNEL.HEADERS.DESC')"
+      />
 
       <div class="w-full mt-4">
         <NextButton

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
@@ -6,6 +6,7 @@ import { getI18nKey } from 'dashboard/routes/dashboard/settings/helper/settingsH
 import { copyTextToClipboard } from 'shared/helpers/clipboard';
 import { useAlert } from 'dashboard/composables';
 import NextButton from 'dashboard/components-next/button/Button.vue';
+import HeadersEditor from 'dashboard/components-next/webhook/HeadersEditor.vue';
 
 const { EXAMPLE_WEBHOOK_URL } = wootConstants;
 
@@ -25,6 +26,7 @@ const SUPPORTED_WEBHOOK_EVENTS = [
 export default {
   components: {
     NextButton,
+    HeadersEditor,
   },
   props: {
     value: {
@@ -59,6 +61,7 @@ export default {
       url: this.value.url || '',
       name: this.value.name || '',
       subscriptions: this.value.subscriptions || [],
+      additionalHeaders: { ...(this.value.additional_headers || {}) },
       secretVisible: false,
       supportedWebhookEvents: SUPPORTED_WEBHOOK_EVENTS,
     };
@@ -85,6 +88,7 @@ export default {
         url: this.url,
         name: this.name,
         subscriptions: this.subscriptions,
+        additional_headers: this.additionalHeaders,
       });
     },
     async copySecret() {
@@ -179,6 +183,12 @@ export default {
           </label>
         </div>
       </div>
+      <HeadersEditor
+        v-model="additionalHeaders"
+        class="mb-4"
+        :label="$t('INTEGRATION_SETTINGS.WEBHOOK.FORM.HEADERS.LABEL')"
+        :description="$t('INTEGRATION_SETTINGS.WEBHOOK.FORM.HEADERS.DESC')"
+      />
     </div>
 
     <div class="flex flex-row justify-end w-full gap-2 px-0 py-2">

--- a/app/javascript/dashboard/store/modules/agentBots.js
+++ b/app/javascript/dashboard/store/modules/agentBots.js
@@ -4,6 +4,15 @@ import AgentBotsAPI from '../../api/agentBots';
 import InboxesAPI from '../../api/inboxes';
 import { throwErrorMessage } from '../utils/api';
 
+const appendAdditionalHeaders = (formData, additionalHeaders) => {
+  if (!additionalHeaders) return;
+  Object.entries(additionalHeaders).forEach(([name, value]) => {
+    const trimmedName = (name || '').trim();
+    if (!trimmedName) return;
+    formData.append(`additional_headers[${trimmedName}]`, value ?? '');
+  });
+};
+
 export const state = {
   records: [],
   uiFlags: {
@@ -65,6 +74,8 @@ export const actions = {
         formData.append('avatar', botData.avatar);
       }
 
+      appendAdditionalHeaders(formData, botData.additional_headers);
+
       const response = await AgentBotsAPI.create(formData);
       commit(types.ADD_AGENT_BOT, response.data);
       return response.data;
@@ -89,6 +100,8 @@ export const actions = {
       if (data.avatar) {
         formData.append('avatar', data.avatar);
       }
+
+      appendAdditionalHeaders(formData, data.additional_headers);
 
       const response = await AgentBotsAPI.update(id, formData);
       commit(types.EDIT_AGENT_BOT, response.data);

--- a/app/javascript/dashboard/store/modules/inboxes/channelActions.js
+++ b/app/javascript/dashboard/store/modules/inboxes/channelActions.js
@@ -21,7 +21,14 @@ export const buildInboxData = inboxParams => {
     }
   }
   Object.keys(channelParams).forEach(key => {
-    formData.append(`channel[${key}]`, channel[key]);
+    const value = channel[key];
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      Object.keys(value).forEach(nestedKey => {
+        formData.append(`channel[${key}][${nestedKey}]`, value[nestedKey]);
+      });
+    } else {
+      formData.append(`channel[${key}]`, value);
+    }
   });
   return formData;
 };

--- a/app/javascript/dashboard/store/modules/specs/inboxes/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/inboxes/actions.spec.js
@@ -1,11 +1,34 @@
 import axios from 'axios';
 import { actions } from '../../inboxes';
+import { buildInboxData } from '../../inboxes/channelActions';
 import * as types from '../../../mutation-types';
 import inboxList from './fixtures';
 
 const commit = vi.fn();
 global.axios = axios;
 vi.mock('axios');
+
+describe('#buildInboxData', () => {
+  it('serializes nested channel object values for form data payloads', () => {
+    const formData = buildInboxData({
+      name: 'API Inbox',
+      channel: {
+        type: 'api',
+        additional_headers: {
+          Authorization: 'Bearer token',
+          'X-Custom-Header': 'custom-value',
+        },
+      },
+    });
+
+    expect(Array.from(formData.entries())).toEqual([
+      ['name', 'API Inbox'],
+      ['channel[type]', 'api'],
+      ['channel[additional_headers][Authorization]', 'Bearer token'],
+      ['channel[additional_headers][X-Custom-Header]', 'custom-value'],
+    ]);
+  });
+});
 
 describe('#actions', () => {
   describe('#get', () => {

--- a/app/jobs/agent_bots/webhook_job.rb
+++ b/app/jobs/agent_bots/webhook_job.rb
@@ -9,7 +9,7 @@ class AgentBots::WebhookJob < WebhookJob
                           additional_headers: kwargs[:additional_headers]).handle_failure(error)
   end
 
-  def perform(url, payload, webhook_type = :agent_bot_webhook, secret: nil, delivery_id: nil, additional_headers: nil)
+  def perform(url, payload, webhook_type = :agent_bot_webhook, secret: nil, delivery_id: nil, additional_headers: nil) # rubocop:disable Metrics/ParameterLists
     super(url, payload, webhook_type, secret: secret, delivery_id: delivery_id, additional_headers: additional_headers)
   rescue Webhooks::Trigger::RetryableError => e
     Rails.logger.warn("[AgentBots::WebhookJob] attempt #{executions} failed #{e.class.name} payload=#{payload.to_json}")

--- a/app/jobs/agent_bots/webhook_job.rb
+++ b/app/jobs/agent_bots/webhook_job.rb
@@ -2,7 +2,7 @@ class AgentBots::WebhookJob < WebhookJob
   queue_as :high
   retry_on Webhooks::Trigger::RetryableError, wait: 3.seconds, attempts: 3 do |job, error|
     url, payload, webhook_type = job.arguments
-    kwargs = job.arguments.last.is_a?(Hash) ? job.arguments.last : {}
+    kwargs = job.arguments.last.is_a?(Hash) ? job.arguments.last.symbolize_keys : {}
     Webhooks::Trigger.new(url, payload, webhook_type || :agent_bot_webhook,
                           secret: kwargs[:secret],
                           delivery_id: kwargs[:delivery_id],

--- a/app/jobs/agent_bots/webhook_job.rb
+++ b/app/jobs/agent_bots/webhook_job.rb
@@ -3,12 +3,14 @@ class AgentBots::WebhookJob < WebhookJob
   retry_on Webhooks::Trigger::RetryableError, wait: 3.seconds, attempts: 3 do |job, error|
     url, payload, webhook_type = job.arguments
     kwargs = job.arguments.last.is_a?(Hash) ? job.arguments.last : {}
-    Webhooks::Trigger.new(url, payload, webhook_type || :agent_bot_webhook, secret: kwargs[:secret],
-                                                                            delivery_id: kwargs[:delivery_id]).handle_failure(error)
+    Webhooks::Trigger.new(url, payload, webhook_type || :agent_bot_webhook,
+                          secret: kwargs[:secret],
+                          delivery_id: kwargs[:delivery_id],
+                          additional_headers: kwargs[:additional_headers]).handle_failure(error)
   end
 
-  def perform(url, payload, webhook_type = :agent_bot_webhook, secret: nil, delivery_id: nil)
-    super(url, payload, webhook_type, secret: secret, delivery_id: delivery_id)
+  def perform(url, payload, webhook_type = :agent_bot_webhook, secret: nil, delivery_id: nil, additional_headers: nil)
+    super(url, payload, webhook_type, secret: secret, delivery_id: delivery_id, additional_headers: additional_headers)
   rescue Webhooks::Trigger::RetryableError => e
     Rails.logger.warn("[AgentBots::WebhookJob] attempt #{executions} failed #{e.class.name} payload=#{payload.to_json}")
     raise

--- a/app/jobs/agent_bots/webhook_job.rb
+++ b/app/jobs/agent_bots/webhook_job.rb
@@ -10,7 +10,9 @@ class AgentBots::WebhookJob < WebhookJob
   end
 
   def perform(url, payload, webhook_type = :agent_bot_webhook, secret: nil, delivery_id: nil, additional_headers: nil) # rubocop:disable Metrics/ParameterLists
-    super(url, payload, webhook_type, secret: secret, delivery_id: delivery_id, additional_headers: additional_headers)
+    kwargs = { secret: secret, delivery_id: delivery_id }
+    kwargs[:additional_headers] = additional_headers if additional_headers.present?
+    super(url, payload, webhook_type, **kwargs)
   rescue Webhooks::Trigger::RetryableError => e
     Rails.logger.warn("[AgentBots::WebhookJob] attempt #{executions} failed #{e.class.name} payload=#{payload.to_json}")
     raise

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -1,7 +1,7 @@
 class WebhookJob < ApplicationJob
   queue_as :medium
   #  There are 3 types of webhooks, account, inbox and agent_bot
-  def perform(url, payload, webhook_type = :account_webhook, secret: nil, delivery_id: nil)
-    Webhooks::Trigger.execute(url, payload, webhook_type, secret: secret, delivery_id: delivery_id)
+  def perform(url, payload, webhook_type = :account_webhook, secret: nil, delivery_id: nil, additional_headers: nil)
+    Webhooks::Trigger.execute(url, payload, webhook_type, secret: secret, delivery_id: delivery_id, additional_headers: additional_headers)
   end
 end

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -2,6 +2,8 @@ class WebhookJob < ApplicationJob
   queue_as :medium
   #  There are 3 types of webhooks, account, inbox and agent_bot
   def perform(url, payload, webhook_type = :account_webhook, secret: nil, delivery_id: nil, additional_headers: nil) # rubocop:disable Metrics/ParameterLists
-    Webhooks::Trigger.execute(url, payload, webhook_type, secret: secret, delivery_id: delivery_id, additional_headers: additional_headers)
+    kwargs = { secret: secret, delivery_id: delivery_id }
+    kwargs[:additional_headers] = additional_headers if additional_headers.present?
+    Webhooks::Trigger.execute(url, payload, webhook_type, **kwargs)
   end
 end

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -1,7 +1,7 @@
 class WebhookJob < ApplicationJob
   queue_as :medium
   #  There are 3 types of webhooks, account, inbox and agent_bot
-  def perform(url, payload, webhook_type = :account_webhook, secret: nil, delivery_id: nil, additional_headers: nil)
+  def perform(url, payload, webhook_type = :account_webhook, secret: nil, delivery_id: nil, additional_headers: nil) # rubocop:disable Metrics/ParameterLists
     Webhooks::Trigger.execute(url, payload, webhook_type, secret: secret, delivery_id: delivery_id, additional_headers: additional_headers)
   end
 end

--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -85,7 +85,9 @@ class AgentBotListener < BaseListener
   def process_webhook_bot_event(agent_bot, payload)
     return if agent_bot.outgoing_url.blank?
 
-    AgentBots::WebhookJob.perform_later(agent_bot.outgoing_url, payload, :agent_bot_webhook,
-                                        secret: agent_bot.secret, delivery_id: SecureRandom.uuid)
+    kwargs = { secret: agent_bot.secret, delivery_id: SecureRandom.uuid }
+    kwargs[:additional_headers] = agent_bot.additional_headers if agent_bot.additional_headers.present?
+
+    AgentBots::WebhookJob.perform_later(agent_bot.outgoing_url, payload, :agent_bot_webhook, **kwargs)
   end
 end

--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -111,9 +111,10 @@ class WebhookListener < BaseListener
     account.webhooks.account_type.each do |webhook|
       next unless webhook.subscriptions.include?(payload[:event])
 
-      WebhookJob.perform_later(webhook.url, payload, :account_webhook,
-                               secret: webhook.secret,
-                               delivery_id: SecureRandom.uuid)
+      WebhookJob.perform_later(
+        webhook.url, payload, :account_webhook,
+        **webhook_kwargs(secret: webhook.secret, additional_headers: webhook.additional_headers)
+      )
     end
   end
 
@@ -121,8 +122,16 @@ class WebhookListener < BaseListener
     return unless inbox.channel_type == 'Channel::Api'
     return if inbox.channel.webhook_url.blank?
 
-    WebhookJob.perform_later(inbox.channel.webhook_url, payload, :api_inbox_webhook,
-                             secret: inbox.channel.secret, delivery_id: SecureRandom.uuid)
+    WebhookJob.perform_later(
+      inbox.channel.webhook_url, payload, :api_inbox_webhook,
+      **webhook_kwargs(secret: inbox.channel.secret, additional_headers: inbox.channel.additional_headers)
+    )
+  end
+
+  def webhook_kwargs(secret:, additional_headers:)
+    kwargs = { secret: secret, delivery_id: SecureRandom.uuid }
+    kwargs[:additional_headers] = additional_headers if additional_headers.present?
+    kwargs
   end
 
   def deliver_webhook_payloads(payload, inbox)

--- a/app/models/agent_bot.rb
+++ b/app/models/agent_bot.rb
@@ -2,16 +2,17 @@
 #
 # Table name: agent_bots
 #
-#  id           :bigint           not null, primary key
-#  bot_config   :jsonb
-#  bot_type     :integer          default("webhook")
-#  description  :string
-#  name         :string
-#  outgoing_url :string
-#  secret       :string
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  account_id   :bigint
+#  id                 :bigint           not null, primary key
+#  additional_headers :jsonb            not null
+#  bot_config         :jsonb
+#  bot_type           :integer          default("webhook")
+#  description        :string
+#  name               :string
+#  outgoing_url       :string
+#  secret             :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  account_id         :bigint
 #
 # Indexes
 #

--- a/app/models/channel/api.rb
+++ b/app/models/channel/api.rb
@@ -4,6 +4,7 @@
 #
 #  id                    :bigint           not null, primary key
 #  additional_attributes :jsonb
+#  additional_headers    :jsonb            not null
 #  hmac_mandatory        :boolean          default(FALSE)
 #  hmac_token            :string
 #  identifier            :string
@@ -23,7 +24,7 @@ class Channel::Api < ApplicationRecord
   include Channelable
 
   self.table_name = 'channel_api'
-  EDITABLE_ATTRS = [:webhook_url, :hmac_mandatory, { additional_attributes: {} }].freeze
+  EDITABLE_ATTRS = [:webhook_url, :hmac_mandatory, { additional_attributes: {}, additional_headers: {} }].freeze
 
   has_secure_token :identifier
   has_secure_token :hmac_token

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -2,16 +2,17 @@
 #
 # Table name: webhooks
 #
-#  id            :bigint           not null, primary key
-#  name          :string
-#  secret        :string
-#  subscriptions :jsonb
-#  url           :text
-#  webhook_type  :integer          default("account_type")
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  account_id    :integer
-#  inbox_id      :integer
+#  id                 :bigint           not null, primary key
+#  additional_headers :jsonb            not null
+#  name               :string
+#  secret             :string
+#  subscriptions      :jsonb
+#  url                :text
+#  webhook_type       :integer          default("account_type")
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  account_id         :integer
+#  inbox_id           :integer
 #
 # Indexes
 #

--- a/app/views/api/v1/accounts/webhooks/_webhook.json.jbuilder
+++ b/app/views/api/v1/accounts/webhooks/_webhook.json.jbuilder
@@ -4,6 +4,7 @@ json.url webhook.url
 json.account_id webhook.account_id
 json.subscriptions webhook.subscriptions
 json.secret webhook.secret
+json.additional_headers webhook.additional_headers
 if webhook.inbox
   json.inbox do
     json.id webhook.inbox.id

--- a/app/views/api/v1/models/_agent_bot.json.jbuilder
+++ b/app/views/api/v1/models/_agent_bot.json.jbuilder
@@ -8,4 +8,5 @@ json.bot_config resource.bot_config
 json.account_id resource.account_id
 json.access_token resource.access_token if resource.access_token.present?
 json.secret resource.secret if !resource.system_bot? && Current.account_user&.administrator?
+json.additional_headers resource.additional_headers unless resource.system_bot?
 json.system_bot resource.system_bot?

--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -119,6 +119,7 @@ if resource.api?
   json.webhook_url resource.channel.try(:webhook_url)
   json.inbox_identifier resource.channel.try(:identifier)
   json.additional_attributes resource.channel.try(:additional_attributes)
+  json.additional_headers resource.channel.try(:additional_headers)
 end
 
 json.provider resource.channel.try(:provider)

--- a/app/views/platform/api/v1/models/_agent_bot.json.jbuilder
+++ b/app/views/platform/api/v1/models/_agent_bot.json.jbuilder
@@ -4,3 +4,4 @@ json.description resource.description
 json.outgoing_url resource.outgoing_url
 json.account_id resource.account_id
 json.access_token resource.access_token.token
+json.additional_headers resource.additional_headers

--- a/db/migrate/20260513120000_add_additional_headers_to_webhook_surfaces.rb
+++ b/db/migrate/20260513120000_add_additional_headers_to_webhook_surfaces.rb
@@ -1,0 +1,7 @@
+class AddAdditionalHeadersToWebhookSurfaces < ActiveRecord::Migration[7.0]
+  def change
+    add_column :webhooks, :additional_headers, :jsonb, default: {}, null: false
+    add_column :agent_bots, :additional_headers, :jsonb, default: {}, null: false
+    add_column :channel_api, :additional_headers, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_07_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_13_120000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -132,6 +132,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_07_000000) do
     t.integer "bot_type", default: 0
     t.jsonb "bot_config", default: {}
     t.string "secret"
+    t.jsonb "additional_headers", default: {}, null: false
     t.index ["account_id"], name: "index_agent_bots_on_account_id"
   end
 
@@ -445,6 +446,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_07_000000) do
     t.boolean "hmac_mandatory", default: false
     t.jsonb "additional_attributes", default: {}
     t.string "secret"
+    t.jsonb "additional_headers", default: {}, null: false
     t.index ["hmac_token"], name: "index_channel_api_on_hmac_token", unique: true
     t.index ["identifier"], name: "index_channel_api_on_identifier", unique: true
   end
@@ -1302,6 +1304,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_07_000000) do
     t.jsonb "subscriptions", default: ["conversation_status_changed", "conversation_updated", "conversation_created", "contact_created", "contact_updated", "message_created", "message_updated", "webwidget_triggered"]
     t.string "name"
     t.string "secret"
+    t.jsonb "additional_headers", default: {}, null: false
     t.index ["account_id", "url"], name: "index_webhooks_on_account_id_and_url", unique: true
   end
 

--- a/lib/webhooks/trigger.rb
+++ b/lib/webhooks/trigger.rb
@@ -1,6 +1,8 @@
 class Webhooks::Trigger
   SUPPORTED_ERROR_HANDLE_EVENTS = %w[message_created message_updated].freeze
   RETRYABLE_AGENT_BOT_STATUSES = [429, 500].freeze
+  # Header names below are managed by Chatwoot and cannot be overridden via additional_headers.
+  RESERVED_HEADERS = %w[content-type accept x-chatwoot-delivery x-chatwoot-timestamp x-chatwoot-signature].freeze
 
   class RetryableError < StandardError
     attr_reader :status
@@ -11,16 +13,17 @@ class Webhooks::Trigger
     end
   end
 
-  def initialize(url, payload, webhook_type, secret: nil, delivery_id: nil)
+  def initialize(url, payload, webhook_type, secret: nil, delivery_id: nil, additional_headers: nil)
     @url = url
     @payload = payload
     @webhook_type = webhook_type
     @secret = secret
     @delivery_id = delivery_id
+    @additional_headers = additional_headers || {}
   end
 
-  def self.execute(url, payload, webhook_type, secret: nil, delivery_id: nil)
-    new(url, payload, webhook_type, secret: secret, delivery_id: delivery_id).execute
+  def self.execute(url, payload, webhook_type, secret: nil, delivery_id: nil, additional_headers: nil)
+    new(url, payload, webhook_type, secret: secret, delivery_id: delivery_id, additional_headers: additional_headers).execute
   end
 
   def execute
@@ -52,7 +55,9 @@ class Webhooks::Trigger
   end
 
   def request_headers(body)
-    headers = { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
+    headers = sanitized_additional_headers
+    headers['Content-Type'] = 'application/json'
+    headers['Accept'] = 'application/json'
     headers['X-Chatwoot-Delivery'] = @delivery_id if @delivery_id.present?
     if @secret.present?
       ts = Time.now.to_i.to_s
@@ -60,6 +65,17 @@ class Webhooks::Trigger
       headers['X-Chatwoot-Signature'] = "sha256=#{OpenSSL::HMAC.hexdigest('SHA256', @secret, "#{ts}.#{body}")}"
     end
     headers
+  end
+
+  def sanitized_additional_headers
+    return {} if @additional_headers.blank?
+
+    @additional_headers.each_with_object({}) do |(name, value), headers|
+      key = name.to_s.strip
+      next if key.empty? || RESERVED_HEADERS.include?(key.downcase)
+
+      headers[key] = value.to_s
+    end
   end
 
   def handle_error(error)

--- a/lib/webhooks/trigger.rb
+++ b/lib/webhooks/trigger.rb
@@ -13,7 +13,7 @@ class Webhooks::Trigger
     end
   end
 
-  def initialize(url, payload, webhook_type, secret: nil, delivery_id: nil, additional_headers: nil)
+  def initialize(url, payload, webhook_type, secret: nil, delivery_id: nil, additional_headers: nil) # rubocop:disable Metrics/ParameterLists
     @url = url
     @payload = payload
     @webhook_type = webhook_type
@@ -22,7 +22,7 @@ class Webhooks::Trigger
     @additional_headers = additional_headers || {}
   end
 
-  def self.execute(url, payload, webhook_type, secret: nil, delivery_id: nil, additional_headers: nil)
+  def self.execute(url, payload, webhook_type, secret: nil, delivery_id: nil, additional_headers: nil) # rubocop:disable Metrics/ParameterLists
     new(url, payload, webhook_type, secret: secret, delivery_id: delivery_id, additional_headers: additional_headers).execute
   end
 

--- a/spec/jobs/agent_bots/webhook_job_spec.rb
+++ b/spec/jobs/agent_bots/webhook_job_spec.rb
@@ -30,6 +30,44 @@ RSpec.describe AgentBots::WebhookJob do
     perform_enqueued_jobs { job }
   end
 
+  context 'with additional headers' do
+    subject(:job) do
+      described_class.perform_later(
+        url, payload, webhook_type,
+        secret: 'secret',
+        delivery_id: 'delivery-id',
+        additional_headers: { 'Authorization' => 'Bearer bot-token' }
+      )
+    end
+
+    it 'serializes keyword arguments and passes additional headers to the trigger' do
+      expect(Webhooks::Trigger).to receive(:execute).with(
+        url, payload, webhook_type,
+        secret: 'secret',
+        delivery_id: 'delivery-id',
+        additional_headers: { 'Authorization' => 'Bearer bot-token' }
+      )
+      perform_enqueued_jobs { job }
+    end
+
+    it 'keeps additional headers available when retry handling is exhausted' do
+      allow(Webhooks::Trigger).to receive(:execute).and_raise(retryable_error)
+      trigger_instance = instance_double(Webhooks::Trigger, handle_failure: true)
+      allow(Webhooks::Trigger).to receive(:new).and_return(trigger_instance)
+      allow(Rails.logger).to receive(:warn)
+
+      perform_enqueued_jobs { job }
+
+      expect(Webhooks::Trigger).to have_received(:new).with(
+        url, payload, webhook_type,
+        secret: 'secret',
+        delivery_id: 'delivery-id',
+        additional_headers: { 'Authorization' => 'Bearer bot-token' }
+      )
+      expect(trigger_instance).to have_received(:handle_failure).with(instance_of(Webhooks::Trigger::RetryableError))
+    end
+  end
+
   it 'configures retry handlers for 429 and 500 errors' do
     handlers = described_class.rescue_handlers.map(&:first)
 

--- a/spec/jobs/webhook_job_spec.rb
+++ b/spec/jobs/webhook_job_spec.rb
@@ -28,4 +28,25 @@ RSpec.describe WebhookJob do
       perform_enqueued_jobs { job }
     end
   end
+
+  context 'with additional headers' do
+    subject(:job) do
+      described_class.perform_later(
+        url, payload, webhook_type,
+        secret: 'secret',
+        delivery_id: 'delivery-id',
+        additional_headers: { 'Authorization' => 'Bearer token' }
+      )
+    end
+
+    it 'serializes keyword arguments and passes additional headers to the trigger' do
+      expect(Webhooks::Trigger).to receive(:execute).with(
+        url, payload, webhook_type,
+        secret: 'secret',
+        delivery_id: 'delivery-id',
+        additional_headers: { 'Authorization' => 'Bearer token' }
+      )
+      perform_enqueued_jobs { job }
+    end
+  end
 end

--- a/spec/lib/webhooks/trigger_spec.rb
+++ b/spec/lib/webhooks/trigger_spec.rb
@@ -209,6 +209,36 @@ describe Webhooks::Trigger do
       end
     end
 
+    context 'with additional headers' do
+      it 'adds custom headers to the request' do
+        expect(SafeFetch).to receive(:fetch) do |_received_url, **options, &block|
+          expect(options[:headers]['Authorization']).to eq('Bearer token')
+          expect(options[:headers]['X-Custom-Header']).to eq('custom-value')
+          block.call(fetch_result)
+        end
+
+        trigger.execute(
+          url, payload, webhook_type,
+          additional_headers: { 'Authorization' => 'Bearer token', 'X-Custom-Header' => 'custom-value' }
+        )
+      end
+
+      it 'does not allow custom headers to override Chatwoot managed headers' do
+        expect(SafeFetch).to receive(:fetch) do |_received_url, **options, &block|
+          expect(options[:headers]['Content-Type']).to eq('application/json')
+          expect(options[:headers]['Accept']).to eq('application/json')
+          expect(options[:headers]['X-Chatwoot-Delivery']).to eq('test-uuid')
+          block.call(fetch_result)
+        end
+
+        trigger.execute(
+          url, payload, webhook_type,
+          delivery_id: 'test-uuid',
+          additional_headers: { 'content-type' => 'text/plain', 'Accept' => 'text/plain', 'X-Chatwoot-Delivery' => 'override' }
+        )
+      end
+    end
+
     context 'with secret' do
       let(:secret) { 'test-secret' }
 

--- a/spec/listeners/agent_bot_listener_spec.rb
+++ b/spec/listeners/agent_bot_listener_spec.rb
@@ -32,6 +32,17 @@ describe AgentBotListener do
         listener.message_created(event)
       end
 
+      it 'passes additional headers to the agent bot webhook job' do
+        agent_bot.update!(additional_headers: { 'Authorization' => 'Bearer bot-token' })
+        create(:agent_bot_inbox, inbox: inbox, agent_bot: agent_bot)
+        expect(AgentBots::WebhookJob).to receive(:perform_later).with(
+          agent_bot.outgoing_url, message.webhook_data.merge(event: 'message_created'),
+          :agent_bot_webhook, secret: agent_bot.secret, delivery_id: instance_of(String),
+                              additional_headers: { 'Authorization' => 'Bearer bot-token' }
+        ).once
+        listener.message_created(event)
+      end
+
       it 'does not send message to agent bot if url is empty' do
         agent_bot = create(:agent_bot, outgoing_url: '')
         create(:agent_bot_inbox, inbox: inbox, agent_bot: agent_bot)

--- a/spec/listeners/webhook_listener_spec.rb
+++ b/spec/listeners/webhook_listener_spec.rb
@@ -34,6 +34,15 @@ describe WebhookListener do
         ).once
         listener.message_created(message_created_event)
       end
+
+      it 'passes additional headers to the webhook job' do
+        webhook = create(:webhook, inbox: inbox, account: account, additional_headers: { 'Authorization' => 'Bearer token' })
+        expect(WebhookJob).to receive(:perform_later).with(
+          webhook.url, message.webhook_data.merge(event: 'message_created'), :account_webhook,
+          secret: webhook.secret, delivery_id: instance_of(String), additional_headers: { 'Authorization' => 'Bearer token' }
+        ).once
+        listener.message_created(message_created_event)
+      end
     end
 
     context 'when webhook is configured and event is not subscribed' do
@@ -60,6 +69,25 @@ describe WebhookListener do
         expect(WebhookJob).to receive(:perform_later).with(
           channel_api.webhook_url, api_message.webhook_data.merge(event: 'message_created'),
           :api_inbox_webhook, secret: channel_api.secret, delivery_id: instance_of(String)
+        ).once
+        listener.message_created(api_event)
+      end
+
+      it 'passes additional headers for API channel webhooks' do
+        channel_api = create(:channel_api, account: account, additional_headers: { 'X-API-Key' => 'secret' })
+        api_inbox = channel_api.inbox
+        api_conversation = create(:conversation, account: account, inbox: api_inbox, assignee: user)
+        api_message = create(
+          :message,
+          message_type: 'outgoing',
+          account: account,
+          inbox: api_inbox,
+          conversation: api_conversation
+        )
+        api_event = Events::Base.new(event_name, Time.zone.now, message: api_message)
+        expect(WebhookJob).to receive(:perform_later).with(
+          channel_api.webhook_url, api_message.webhook_data.merge(event: 'message_created'),
+          :api_inbox_webhook, secret: channel_api.secret, delivery_id: instance_of(String), additional_headers: { 'X-API-Key' => 'secret' }
         ).once
         listener.message_created(api_event)
       end


### PR DESCRIPTION
## Summary
- Add `additional_headers` storage for account webhooks, API channel webhooks, and agent bot webhooks.
- Send configured headers during webhook delivery while preserving Chatwoot-managed headers.
- Add dashboard header editors for webhook integrations, API channel inboxes, and agent bots.

## Validation
- `bundle _2.5.16_ exec rspec spec/lib/webhooks/trigger_spec.rb spec/jobs/webhook_job_spec.rb spec/jobs/agent_bots/webhook_job_spec.rb spec/listeners/webhook_listener_spec.rb spec/listeners/agent_bot_listener_spec.rb`
- `bundle _2.5.16_ exec rubocop lib/webhooks/trigger.rb app/jobs/webhook_job.rb app/jobs/agent_bots/webhook_job.rb app/listeners/webhook_listener.rb app/listeners/agent_bot_listener.rb spec/lib/webhooks/trigger_spec.rb spec/jobs/webhook_job_spec.rb spec/jobs/agent_bots/webhook_job_spec.rb spec/listeners/webhook_listener_spec.rb spec/listeners/agent_bot_listener_spec.rb`
- `pnpm test app/javascript/dashboard/store/modules/specs/inboxes/actions.spec.js`
- `pnpm exec eslint app/javascript/dashboard/store/modules/inboxes/channelActions.js app/javascript/dashboard/store/modules/specs/inboxes/actions.spec.js app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Api.vue app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue`

Closes #4732
