### PR TITLE
fix(editor): Refresh reply editor when reply window reopens in real-time

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -804,6 +804,11 @@ watch(
 );
 
 watch(
+  computed(() => props.disabled),
+  () => editorView?.setProps({})
+);
+
+watch(
   computed(() => props.updateSelectionWith),
   (newValue, oldValue) => {
     if (!editorView) return;


### PR DESCRIPTION
On WhatsApp and any channel that disables the reply editor outside its messaging window (WhatsApp Cloud, Twilio WhatsApp, API channels with `agent_reply_time_window` set), when the window was already expired and a new inbound message arrived in real-time, the "messaging restricted" banner correctly hid but the editor itself stayed un-typeable until the agent refreshed the page. This made the dashboard look like it accepted replies even though typing did nothing.

Fixes [CW-7087](https://linear.app/chatwoot/issue/CW-7087/reply-editor-stays-disabled-after-real-time-incoming-message-reopens)

#### How to reproduce

1. Open a WhatsApp conversation whose last incoming message is older than 24h, so `can_reply` is `false` (banner shown, editor greyed out).
2. With the dashboard open on that conversation, have the customer send a fresh inbound message (or simulate one via the channel's webhook).
3. Before the fix: banner disappears, editor wrapper loses its disabled styling, but clicking into the editor and typing does nothing — refresh required.
4. After the fix: banner disappears and the editor accepts input immediately.