### PR TITLE
fix(csat): Require confirmation before submitting rating

### DIFF
--- a/app/javascript/shared/components/CustomerSatisfaction.vue
+++ b/app/javascript/shared/components/CustomerSatisfaction.vue
@@ -81,10 +81,11 @@ export default {
 
   methods: {
     buttonClass(rating) {
+      const isLocked = this.isRatingSubmitted || this.isUpdating;
       return [
         { selected: rating.value === this.selectedRating },
-        { disabled: this.isRatingSubmitted },
-        { hover: this.isRatingSubmitted },
+        { disabled: isLocked },
+        { hover: isLocked },
         'emoji-button',
       ];
     },
@@ -108,11 +109,11 @@ export default {
     },
 
     selectRating(rating) {
-      if (this.isRatingSubmitted) return;
+      if (this.isRatingSubmitted || this.isUpdating) return;
       this.selectedRating = rating.value;
     },
     selectStarRating(value) {
-      if (this.isRatingSubmitted) return;
+      if (this.isRatingSubmitted || this.isUpdating) return;
       this.selectedRating = value;
     },
   },
@@ -140,7 +141,7 @@ export default {
     <StarRating
       v-else-if="isStarType"
       :selected-rating="selectedRating"
-      :is-disabled="isRatingSubmitted"
+      :is-disabled="isRatingSubmitted || isUpdating"
       @select-rating="selectStarRating"
     />
     <form

--- a/app/javascript/shared/components/CustomerSatisfaction.vue
+++ b/app/javascript/shared/components/CustomerSatisfaction.vue
@@ -49,8 +49,8 @@ export default {
         ?.feedback_message;
     },
     isButtonDisabled() {
-      if (!this.selectedRating) return true;
-      if (this.isRatingSubmitted && !this.feedback) return true;
+      if (!(this.selectedRating && this.feedback)) return true;
+      if (this.isUpdating) return true;
       return false;
     },
     textColor() {
@@ -81,7 +81,7 @@ export default {
 
   methods: {
     buttonClass(rating) {
-      const isLocked = this.isRatingSubmitted || this.isUpdating;
+      const isLocked = this.isFeedbackSubmitted || this.isUpdating;
       return [
         { selected: rating.value === this.selectedRating },
         { disabled: isLocked },
@@ -109,12 +109,14 @@ export default {
     },
 
     selectRating(rating) {
-      if (this.isRatingSubmitted || this.isUpdating) return;
+      if (this.isFeedbackSubmitted || this.isUpdating) return;
       this.selectedRating = rating.value;
+      this.onSubmit();
     },
     selectStarRating(value) {
-      if (this.isRatingSubmitted || this.isUpdating) return;
+      if (this.isFeedbackSubmitted || this.isUpdating) return;
       this.selectedRating = value;
+      this.onSubmit();
     },
   },
 };
@@ -141,7 +143,7 @@ export default {
     <StarRating
       v-else-if="isStarType"
       :selected-rating="selectedRating"
-      :is-disabled="isRatingSubmitted || isUpdating"
+      :is-disabled="isFeedbackSubmitted || isUpdating"
       @select-rating="selectStarRating"
     />
     <form
@@ -163,7 +165,7 @@ export default {
           color: textColor,
         }"
       >
-        <Spinner v-if="isUpdating" />
+        <Spinner v-if="isUpdating && feedback" />
         <FluentIcon v-else icon="chevron-right" />
       </button>
     </form>

--- a/app/javascript/shared/components/CustomerSatisfaction.vue
+++ b/app/javascript/shared/components/CustomerSatisfaction.vue
@@ -90,6 +90,7 @@ export default {
       ];
     },
     async onSubmit() {
+      if (this.isUpdating) return;
       this.isUpdating = true;
       try {
         await this.$store.dispatch('message/update', {

--- a/app/javascript/shared/components/CustomerSatisfaction.vue
+++ b/app/javascript/shared/components/CustomerSatisfaction.vue
@@ -49,7 +49,9 @@ export default {
         ?.feedback_message;
     },
     isButtonDisabled() {
-      return !(this.selectedRating && this.feedback);
+      if (!this.selectedRating) return true;
+      if (this.isRatingSubmitted && !this.feedback) return true;
+      return false;
     },
     textColor() {
       return getContrastingTextColor(this.widgetColor);
@@ -106,12 +108,12 @@ export default {
     },
 
     selectRating(rating) {
+      if (this.isRatingSubmitted) return;
       this.selectedRating = rating.value;
-      this.onSubmit();
     },
     selectStarRating(value) {
+      if (this.isRatingSubmitted) return;
       this.selectedRating = value;
-      this.onSubmit();
     },
   },
 };
@@ -160,7 +162,7 @@ export default {
           color: textColor,
         }"
       >
-        <Spinner v-if="isUpdating && feedback" />
+        <Spinner v-if="isUpdating" />
         <FluentIcon v-else icon="chevron-right" />
       </button>
     </form>

--- a/app/javascript/survey/components/Feedback.vue
+++ b/app/javascript/survey/components/Feedback.vue
@@ -15,6 +15,14 @@ export default {
       type: Boolean,
       default: false,
     },
+    isButtonDisabled: {
+      type: Boolean,
+      default: false,
+    },
+    selectedRating: {
+      type: Number,
+      default: null,
+    },
   },
   emits: ['sendFeedback'],
   data() {
@@ -22,8 +30,16 @@ export default {
       feedback: '',
     };
   },
+  computed: {
+    isSubmitDisabled() {
+      return (
+        this.isButtonDisabled || !this.selectedRating || !this.feedback.trim()
+      );
+    },
+  },
   methods: {
     onClick() {
+      if (this.isSubmitDisabled) return;
       this.$emit('sendFeedback', this.feedback);
     },
   },
@@ -41,7 +57,7 @@ export default {
       :placeholder="$t('SURVEY.FEEDBACK.PLACEHOLDER')"
     />
     <div class="flex items-center float-right font-medium">
-      <CustomButton @click="onClick">
+      <CustomButton :disabled="isSubmitDisabled" @click="onClick">
         <Spinner v-if="isUpdating" class="p-0" />
         {{ $t('SURVEY.FEEDBACK.BUTTON_TEXT') }}
       </CustomButton>

--- a/app/javascript/survey/components/Rating.vue
+++ b/app/javascript/survey/components/Rating.vue
@@ -7,6 +7,10 @@ export default {
       type: Number,
       default: null,
     },
+    isDisabled: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ['selectRating'],
   data() {
@@ -19,12 +23,13 @@ export default {
     buttonClass(rating) {
       return [
         { selected: rating.value === this.selectedRating },
-        { disabled: !!this.selectedRating },
-        { hover: !!this.selectedRating },
+        { disabled: this.isDisabled },
+        { hover: this.isDisabled },
         'emoji-button shadow-none text-3xl lg:text-4xl outline-none mr-8',
       ];
     },
     onClick(rating) {
+      if (this.isDisabled) return;
       this.$emit('selectRating', rating.value);
     },
   },

--- a/app/javascript/survey/i18n/locale/en.json
+++ b/app/javascript/survey/i18n/locale/en.json
@@ -3,7 +3,6 @@
     "DESCRIPTION": "Dear customer 👋, please take a few moments to share feedback about the conversation you had with {inboxName}.",
     "RATING": {
       "LABEL": "Rate your conversation",
-      "SUBMIT_BUTTON_TEXT": "Submit Rating",
       "SUCCESS_MESSAGE": "Thank you for submitting the rating"
     },
     "FEEDBACK": {

--- a/app/javascript/survey/i18n/locale/en.json
+++ b/app/javascript/survey/i18n/locale/en.json
@@ -3,6 +3,7 @@
     "DESCRIPTION": "Dear customer 👋, please take a few moments to share feedback about the conversation you had with {inboxName}.",
     "RATING": {
       "LABEL": "Rate your conversation",
+      "SUBMIT_BUTTON_TEXT": "Submit Rating",
       "SUCCESS_MESSAGE": "Thank you for submitting the rating"
     },
     "FEEDBACK": {

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -27,6 +27,7 @@ export default {
       errorMessage: null,
       selectedRating: null,
       feedbackMessage: '',
+      hasSubmittedFeedback: false,
       isUpdating: false,
       logo: '',
       inboxName: '',
@@ -43,10 +44,14 @@ export default {
       return this.surveyDetails && this.surveyDetails.rating;
     },
     isFeedbackSubmitted() {
-      return this.surveyDetails && this.surveyDetails.feedback_message;
+      return (
+        this.hasSubmittedFeedback || !!this.surveyDetails?.feedback_message
+      );
     },
     isButtonDisabled() {
-      return !(this.selectedRating && this.feedback);
+      if (!this.selectedRating) return true;
+      if (this.isUpdating) return true;
+      return false;
     },
     isEmojiType() {
       return this.displayType === CSAT_DISPLAY_TYPES.EMOJI;
@@ -84,7 +89,7 @@ export default {
     },
     sendFeedback(message) {
       this.feedbackMessage = message;
-      this.updateSurveyDetails();
+      this.updateSurveyDetails({ markFeedbackSubmitted: true });
     },
     async getSurveyDetails() {
       this.isLoading = true;
@@ -107,7 +112,7 @@ export default {
         this.isLoading = false;
       }
     },
-    async updateSurveyDetails() {
+    async updateSurveyDetails({ markFeedbackSubmitted = false } = {}) {
       this.isUpdating = true;
       try {
         const data = {
@@ -128,6 +133,9 @@ export default {
           rating: this.selectedRating,
           feedback_message: this.feedbackMessage,
         };
+        if (markFeedbackSubmitted) {
+          this.hasSubmittedFeedback = true;
+        }
       } catch (error) {
         const errorMessage = error?.response?.data?.error;
         this.errorMessage = errorMessage || this.$t('SURVEY.API.ERROR_MESSAGE');

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -1,7 +1,6 @@
 <script>
 import { useAlert } from 'dashboard/composables';
 import Branding from 'shared/components/Branding.vue';
-import CustomButton from 'shared/components/Button.vue';
 import Spinner from 'shared/components/Spinner.vue';
 import Rating from 'survey/components/Rating.vue';
 import Feedback from 'survey/components/Feedback.vue';
@@ -15,7 +14,6 @@ export default {
   name: 'Response',
   components: {
     Branding,
-    CustomButton,
     Rating,
     Spinner,
     Banner,
@@ -80,9 +78,8 @@ export default {
   },
   methods: {
     selectRating(rating) {
+      if (this.isFeedbackSubmitted || this.isUpdating) return;
       this.selectedRating = rating;
-    },
-    submitRating() {
       this.updateSurveyDetails();
     },
     sendFeedback(message) {
@@ -183,25 +180,16 @@ export default {
         <Rating
           v-if="isEmojiType"
           :selected-rating="selectedRating"
-          :is-disabled="isRatingSubmitted || isUpdating"
+          :is-disabled="isFeedbackSubmitted || isUpdating"
           @select-rating="selectRating"
         />
         <StarRating
           v-if="isStarType"
           :selected-rating="selectedRating"
-          :is-disabled="isRatingSubmitted || isUpdating"
+          :is-disabled="isFeedbackSubmitted || isUpdating"
           class="[&>button>span]:text-4xl !justify-start !px-0"
           @select-rating="selectRating"
         />
-        <div
-          v-if="selectedRating && !isRatingSubmitted"
-          class="flex items-center justify-end mt-4 font-medium"
-        >
-          <CustomButton :disabled="isUpdating" @click="submitRating">
-            <Spinner v-if="isUpdating" class="p-0" />
-            {{ $t('SURVEY.RATING.SUBMIT_BUTTON_TEXT') }}
-          </CustomButton>
-        </div>
         <Feedback
           v-if="enableFeedbackForm"
           :is-updating="isUpdating"

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -183,13 +183,13 @@ export default {
         <Rating
           v-if="isEmojiType"
           :selected-rating="selectedRating"
-          :is-disabled="isRatingSubmitted"
+          :is-disabled="isRatingSubmitted || isUpdating"
           @select-rating="selectRating"
         />
         <StarRating
           v-if="isStarType"
           :selected-rating="selectedRating"
-          :is-disabled="isRatingSubmitted"
+          :is-disabled="isRatingSubmitted || isUpdating"
           class="[&>button>span]:text-4xl !justify-start !px-0"
           @select-rating="selectRating"
         />

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -1,6 +1,7 @@
 <script>
 import { useAlert } from 'dashboard/composables';
 import Branding from 'shared/components/Branding.vue';
+import CustomButton from 'shared/components/Button.vue';
 import Spinner from 'shared/components/Spinner.vue';
 import Rating from 'survey/components/Rating.vue';
 import Feedback from 'survey/components/Feedback.vue';
@@ -14,6 +15,7 @@ export default {
   name: 'Response',
   components: {
     Branding,
+    CustomButton,
     Rating,
     Spinner,
     Banner,
@@ -79,6 +81,8 @@ export default {
   methods: {
     selectRating(rating) {
       this.selectedRating = rating;
+    },
+    submitRating() {
       this.updateSurveyDetails();
     },
     sendFeedback(message) {
@@ -179,6 +183,7 @@ export default {
         <Rating
           v-if="isEmojiType"
           :selected-rating="selectedRating"
+          :is-disabled="isRatingSubmitted"
           @select-rating="selectRating"
         />
         <StarRating
@@ -188,6 +193,15 @@ export default {
           class="[&>button>span]:text-4xl !justify-start !px-0"
           @select-rating="selectRating"
         />
+        <div
+          v-if="selectedRating && !isRatingSubmitted"
+          class="flex items-center justify-end mt-4 font-medium"
+        >
+          <CustomButton :disabled="isUpdating" @click="submitRating">
+            <Spinner v-if="isUpdating" class="p-0" />
+            {{ $t('SURVEY.RATING.SUBMIT_BUTTON_TEXT') }}
+          </CustomButton>
+        </div>
         <Feedback
           v-if="enableFeedbackForm"
           :is-updating="isUpdating"


### PR DESCRIPTION
Customers reported that the CSAT survey was recording their rating the instant they tapped a star — leaving no chance to correct an accidental pick. This change lets the customer freely change their selection until they actually submit the comment/feedback. The rating still saves on click (so we don't lose ratings when a customer never types a comment), but it stays editable until the comment form is submitted. Once that happens, the rating locks.

The flow on both surfaces:

- Customer taps a star/emoji → rating is saved.
- Customer taps a different star/emoji → previous save is overwritten with the new value.
- Customer types a comment and submits → latest rating + comment are saved together.
- After that submit, the rating is locked and can't be changed.

Two surfaces are updated:

- **Standalone survey page** (`/survey/responses/:uuid`) — the rating buttons remain re-tappable until the Feedback form is submitted; once submitted, both rating and feedback lock.
- **In-conversation widget CSAT** — same behavior, the inline arrow-submit button on the feedback form is the locking action.

In-flight guards prevent a race where the customer changes their pick mid-network-call (raised by the codex review on the earlier revision): while a save is in flight, the rating controls are temporarily disabled so the request and the displayed selection can't diverge.

## Closes

- https://linear.app/chatwoot/issue/CW-7061/csat-star-rating-submits-on-first-click-needs-confirmation-step

## How to test

**Standalone survey page**
1. Enable CSAT on any inbox (Settings → Inboxes → Configuration → CSAT survey).
2. Resolve a conversation in that inbox so a CSAT message is generated.
3. Open the survey URL: `{FRONTEND_URL}/survey/responses/{conversation.uuid}` (easiest: `bundle exec rails runner 'puts Conversation.joins(:messages).where(messages: { content_type: "input_csat" }).last.csat_survey_link'`).
4. Tap a star/emoji — confirm the rating saves (Network panel shows a PUT to `/public/api/v1/csat_survey/{uuid}`).
5. Tap a different star/emoji — confirm a second PUT goes out with the new value; the latest selection is reflected.
6. Type a comment and hit Submit feedback — confirm rating + feedback persist; both controls now lock.
7. Reload the page — the locked state is rehydrated correctly.

**Widget CSAT**
1. From an inbox with CSAT enabled, resolve a conversation that has an active widget session.
2. In the widget, the CSAT card appears with stars/emojis + the inline comment box.
3. Tap a star/emoji — confirm a PATCH goes out and the selection visibly updates.
4. Tap different stars/emojis — confirm each overrides the previous save.
5. Type a comment and click the arrow — rating + comment submit together; stars lock.

Both display types (emoji and 5-star) should behave consistently.

## What changed

- `app/javascript/survey/views/Response.vue` — `selectRating()` saves on every tap and short-circuits while a save is in flight (or after feedback was submitted). Rating components are disabled by `isFeedbackSubmitted || isUpdating` so the lock follows the feedback submission, not the first rating tap.
- `app/javascript/survey/components/Rating.vue` — new `isDisabled` prop. The disabled / hover styling and click guard key off it instead of the presence of `selectedRating`, so emojis stay re-clickable until the feedback step locks them.
- `app/javascript/shared/components/CustomerSatisfaction.vue` — same shape for the widget: rating click auto-submits and re-clicks override the previous save; controls disabled while a submit is in flight; emoji-button styling and the inline `StarRating` lock on `isFeedbackSubmitted || isUpdating`.