### PR TITLE
feat: add "Inherit Labels from Contact" automation action

### DIFF
--- a/app/javascript/dashboard/helper/validations.js
+++ b/app/javascript/dashboard/helper/validations.js
@@ -129,6 +129,7 @@ const validateSingleAction = action => {
     'remove_assigned_team',
     'open_conversation',
     'pending_conversation',
+    'inherit_contact_labels',
   ];
 
   if (

--- a/app/javascript/dashboard/i18n/locale/en/automation.json
+++ b/app/javascript/dashboard/i18n/locale/en/automation.json
@@ -157,7 +157,8 @@
       "CHANGE_PRIORITY": "Change Priority",
       "ADD_SLA": "Add SLA",
       "OPEN_CONVERSATION": "Open conversation",
-      "PENDING_CONVERSATION": "Mark conversation as pending"
+      "PENDING_CONVERSATION": "Mark conversation as pending",
+      "INHERIT_CONTACT_LABELS": "Inherit Labels from Contact"
     },
     "MESSAGE_TYPES": {
       "INCOMING": "Incoming Message",

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
@@ -286,6 +286,10 @@ export const AUTOMATIONS = {
         key: 'send_attachment',
         name: 'SEND_ATTACHMENT',
       },
+      {
+        key: 'inherit_contact_labels',
+        name: 'INHERIT_CONTACT_LABELS',
+      },
     ],
   },
   conversation_updated: {
@@ -804,5 +808,10 @@ export const AUTOMATION_ACTION_TYPES = [
     key: 'add_sla',
     label: 'ADD_SLA',
     inputType: 'search_select',
+  },
+  {
+    key: 'inherit_contact_labels',
+    label: 'INHERIT_CONTACT_LABELS',
+    inputType: null,
   },
 ];

--- a/app/models/automation_rule.rb
+++ b/app/models/automation_rule.rb
@@ -43,7 +43,7 @@ class AutomationRule < ApplicationRecord
     %w[send_message add_label remove_label send_email_to_team assign_team assign_agent remove_assigned_agent
        remove_assigned_team send_webhook_event mute_conversation send_attachment change_status resolve_conversation
        open_conversation pending_conversation snooze_conversation change_priority send_email_transcript
-       add_private_note].freeze
+       add_private_note inherit_contact_labels].freeze
   end
 
   def file_base_data

--- a/app/services/automation_rules/action_service.rb
+++ b/app/services/automation_rules/action_service.rb
@@ -22,6 +22,19 @@ class AutomationRules::ActionService < ActionService
 
   private
 
+  def inherit_contact_labels(_params = nil)
+    contact = @conversation.contact
+    return if contact.blank?
+
+    inherited = contact.label_list
+    return if inherited.blank?
+
+    merged = (@conversation.label_list + inherited).uniq
+    return if merged.sort == @conversation.label_list.sort
+
+    @conversation.update_labels(merged)
+  end
+
   def send_attachment(blob_ids)
     return if conversation_a_tweet?
 

--- a/spec/services/automation_rules/action_service_spec.rb
+++ b/spec/services/automation_rules/action_service_spec.rb
@@ -217,5 +217,40 @@ RSpec.describe AutomationRules::ActionService do
         expect(conversation.reload.assignee).to eq(agent)
       end
     end
+
+    describe '#perform with inherit_contact_labels action' do
+      before do
+        rule.actions.delete_if { |a| %w[send_message send_webhook_event].include?(a['action_name']) }
+        rule.actions << { action_name: 'inherit_contact_labels', action_params: [] }
+        rule.save
+      end
+
+      it 'copies labels from the contact onto the conversation' do
+        conversation.contact.update_labels(%w[paid research])
+        described_class.new(rule, account, conversation).perform
+        expect(conversation.reload.label_list.sort).to eq(%w[paid research])
+      end
+
+      it 'merges with existing conversation labels without duplicating' do
+        conversation.contact.update_labels(%w[paid research])
+        conversation.update_labels(%w[paid existing])
+        described_class.new(rule, account, conversation).perform
+        expect(conversation.reload.label_list.sort).to eq(%w[existing paid research])
+      end
+
+      it 'is a no-op when the contact has no labels' do
+        expect { described_class.new(rule, account, conversation).perform }
+          .not_to(change { conversation.reload.label_list })
+      end
+
+      it 'does not re-update when every contact label is already present' do
+        conversation.contact.update_labels(%w[paid])
+        conversation.update_labels(%w[paid extra])
+        allow_any_instance_of(Conversation).to receive(:update_labels).and_call_original # rubocop:disable RSpec/AnyInstance
+        described_class.new(rule, account, conversation).perform
+        # update_labels is called twice during setup; the action itself should not invoke it again
+        expect(conversation.reload.label_list.sort).to eq(%w[extra paid])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds a new automation rule action — **Inherit Labels from Contact** — that copies the contact's current labels onto the conversation when the rule fires. Users opt in by creating an automation rule (typically on `conversation_created`), which lets them scope the inheritance per inbox, per contact filter, etc., using the same configuration surface as every other action.

## When you'd use this

Common scenarios where contact-level labels exist but don't carry to conversations today:

- **External CRM / integration adds a label to the contact.** You tag a contact `paid`, `vip`, `trial`, `cohort-2025-q1`, or similar — via a mu-plugin, webhook, or sync script tied to your billing / CRM. Today none of that flows to the conversations the same contact then opens, so label-based filters, SLA policies, and dashboards miss the new conversations until an agent manually tags them.
- **Compliance / restricted flows.** Contacts marked `legal-review`, `do-not-reply`, or `blocked` need that visibility on every new conversation immediately — not after an agent notices the contact-level tag.
- **Tier / segment visibility.** `tier-1`, `tier-2`, `enterprise` labels on contacts should show up on conversations so triage and routing rules can act on them without re-tagging.
- **Language or routing preference.** Contacts pre-tagged with `lang-fr`, `lang-es`, etc. carry that to every conversation for downstream routing rules.
- **Cohort / source tracking.** Marketing-sourced contacts tagged `partner-acme`, `event-2025-q2`, etc. need consistent labelling on conversations for reporting.

In each case the fix today is either (a) duplicating the tagging logic into a separate webhook that runs on conversation_created, or (b) running an external sync script after the fact. This PR makes it a first-class automation action so neither is necessary.

### Recipe — recommended setup

```
Event:      Conversation Created
Conditions: (none — or scope by inbox / status / channel as needed)
Action:     Inherit Labels from Contact
```

Pair with existing actions (`assign_team`, `change_priority`, etc.) in the same rule if you want labels + routing in one place. The action is idempotent, so re-running it on a conversation that already has the contact's labels is a no-op.

## Why an automation action and not a listener / contact callback

- Automation rules are already the user-configured surface for "do X when Y happens to a conversation." Adding it here keeps the configuration story consistent — scopable by inbox, channel, language, etc., disable-able with one click, visible in the same UI as every other rule.
- An always-on listener (an earlier draft of this PR) would have required a separate account-level setting to disable, and would have given users no way to scope it.

## Why a new action is necessary at all

Automation rule conditions cannot today filter by "contact has label X" at `conversation_created` time: `AutomationRules::ConditionsFilterService` resolves `attribute_key: 'labels'` against the conversation's own labels (`build_label_query_string` joins against `taggable_type='Conversation'`). At conversation_created time the conversation has zero labels, so the condition self-defeats. Building this as a new action sidesteps that bind — the rule matches on whatever conditions you want (or none), and the action itself does the contact-label inheritance.

## What's in the box

- **Backend**
  - `inherit_contact_labels` registered on `AutomationRule#actions_attributes`.
  - Implemented as a private method on `AutomationRules::ActionService` (intentionally not on the shared `ActionService` parent, since Macros' allow-list does not include it — happy to move if maintainers prefer).
  - **Idempotent**: merges with the conversation's existing labels and short-circuits when the resulting set is unchanged, so it doesn't fire redundant `conversation_updated` events or activity messages on conversations that already have those labels.
- **Frontend**
  - Action registered on `conversation_created` in `AUTOMATIONS`.
  - Added to `AUTOMATION_ACTION_TYPES` with `inputType: null` (no parameters).
  - Added to the `noParamActions` allow-list in `validations.js` so the rule form doesn't flag "Action parameters are required" — same treatment as `mute_conversation`, `remove_assigned_agent`, etc.
  - Labelled "Inherit Labels from Contact" in `app/javascript/dashboard/i18n/locale/en/automation.json`.
- **Spec**: covers happy path, merge-with-existing-labels, contact-with-no-labels no-op, and the unchanged-set short-circuit.

## Available on which events

For now, `conversation_created` only. The action itself doesn't care about the event name, so it would also work on `conversation_updated` / `conversation_opened` if maintainers want it surfaced there too — let me know and I'll add the entries.

## Test plan

- [x] `bundle exec rspec spec/services/automation_rules/action_service_spec.rb` — covers the new action (4 cases).
- [x] Manual end-to-end on a self-hosted Chatwoot 4.13.0 install: backend patch applied, Vite assets rebuilt, automation rule created via the dashboard UI (Event: Conversation Created, Action: Inherit Labels from Contact), verified the rule editor renders without console errors and the form saves cleanly.
- [ ] Manual: send a real message from a labelled contact (e.g., one tagged `paid`) and confirm the new conversation inherits the label end-to-end through the live message pipeline.