### PR TITLE
feat: send WhatsApp template as an automation action

### DIFF
--- a/app/javascript/dashboard/components/widgets/AutomationActionInput.vue
+++ b/app/javascript/dashboard/components/widgets/AutomationActionInput.vue
@@ -1,11 +1,13 @@
 <script>
 import AutomationActionTeamMessageInput from './AutomationActionTeamMessageInput.vue';
 import AutomationActionFileInput from './AutomationFileInput.vue';
+import AutomationActionWhatsappTemplateInput from './AutomationActionWhatsappTemplateInput.vue';
 import WootMessageEditor from 'dashboard/components/widgets/WootWriter/Editor.vue';
 export default {
   components: {
     AutomationActionTeamMessageInput,
     AutomationActionFileInput,
+    AutomationActionWhatsappTemplateInput,
     WootMessageEditor,
   },
   props: {
@@ -189,6 +191,10 @@ export default {
       enable-variables
       :placeholder="$t('AUTOMATION.ACTION.TEAM_MESSAGE_INPUT_PLACEHOLDER')"
       class="action-message"
+    />
+    <AutomationActionWhatsappTemplateInput
+      v-if="inputType === 'whatsapp_template'"
+      v-model="castMessageVmodel"
     />
     <p v-if="errorMessage" class="filter-error">
       {{ errorMessage }}

--- a/app/javascript/dashboard/components/widgets/AutomationActionWhatsappTemplateInput.vue
+++ b/app/javascript/dashboard/components/widgets/AutomationActionWhatsappTemplateInput.vue
@@ -1,0 +1,353 @@
+<script>
+import { mapGetters } from 'vuex';
+
+const DEFAULT_CONFIG = () => ({
+  inbox_ids: [],
+  template_name: '',
+  template_language: '',
+  template_namespace: null,
+  template_category: '',
+  template_body: '',
+  processed_params: {},
+});
+
+// Tokens the user can drop into a variable input. Substitution happens
+// server-side; this list drives the in-form hint only.
+const PLACEHOLDER_TOKENS = [
+  '{{contact.name}}',
+  '{{contact.email}}',
+  '{{contact.phone_number}}',
+  '{{conversation.id}}',
+  '{{agent.name}}',
+];
+
+const templateKey = template =>
+  template ? `${template.name}|||${template.language}` : '';
+
+export default {
+  props: {
+    value: {
+      type: [Object, Array],
+      default: () => null,
+    },
+  },
+  data() {
+    return {
+      config: this.unwrap(this.value),
+      placeholderTokens: PLACEHOLDER_TOKENS,
+    };
+  },
+  computed: {
+    ...mapGetters({ allInboxes: 'inboxes/getInboxes' }),
+    whatsappInboxes() {
+      return (this.allInboxes || []).filter(
+        inbox => inbox.channel_type === 'Channel::Whatsapp'
+      );
+    },
+    selectedInboxes: {
+      get() {
+        const ids = this.config.inbox_ids || [];
+        return this.whatsappInboxes.filter(i => ids.includes(i.id));
+      },
+      set(value) {
+        this.update({ inbox_ids: (value || []).map(i => i.id) });
+      },
+    },
+    // Templates that exist (by name+language) on every selected inbox. We
+    // intersect because the same rule may fire on any of the picked inboxes
+    // and the chosen template has to be approved on all of them.
+    availableTemplates() {
+      const inboxes = this.selectedInboxes;
+      if (!inboxes.length) return [];
+
+      const templatesPerInbox = inboxes.map(inbox =>
+        this.$store.getters['inboxes/getWhatsAppTemplates'](inbox.id).filter(
+          t => (t.status || '').toLowerCase() === 'approved'
+        )
+      );
+
+      const [first, ...rest] = templatesPerInbox;
+      if (!first) return [];
+
+      return first.filter(template =>
+        rest.every(list =>
+          list.some(
+            other =>
+              other.name === template.name &&
+              other.language === template.language
+          )
+        )
+      );
+    },
+    templateOptions() {
+      return this.availableTemplates.map(t => ({
+        ...t,
+        key: templateKey(t),
+        display_name: `${t.name} · ${t.language}`,
+      }));
+    },
+    selectedTemplate: {
+      get() {
+        if (!this.config.template_name) return null;
+        const key = `${this.config.template_name}|||${this.config.template_language}`;
+        return this.templateOptions.find(t => t.key === key) || null;
+      },
+      set(value) {
+        if (!value) {
+          this.update({
+            template_name: '',
+            template_language: '',
+            template_namespace: null,
+            template_category: '',
+            template_body: '',
+            processed_params: {},
+          });
+          return;
+        }
+        this.update({
+          template_name: value.name,
+          template_language: value.language,
+          template_namespace: value.namespace || null,
+          template_category: value.category || '',
+          template_body: this.bodyText(value),
+          processed_params: this.initialParamsFor(value),
+        });
+      },
+    },
+    bodyVariableKeys() {
+      const body = this.config.template_body || '';
+      const matches = body.match(/{{\s*\d+\s*}}/g) || [];
+      return matches.map(token => token.replace(/[^0-9]/g, ''));
+    },
+    renderedBody() {
+      const body = this.config.template_body || '';
+      if (!body) return '';
+      return body.replace(/{{\s*(\d+)\s*}}/g, (match, key) => {
+        const value = (this.config.processed_params || {})[key];
+        return value ? value : match;
+      });
+    },
+    placeholdersHint() {
+      return this.placeholderTokens.join(', ');
+    },
+  },
+  watch: {
+    value: {
+      handler(newValue) {
+        const next = this.unwrap(newValue);
+        if (JSON.stringify(next) !== JSON.stringify(this.config)) {
+          this.config = next;
+        }
+      },
+      deep: true,
+    },
+    // If the user removes an inbox and the previously-selected template is
+    // no longer present on all selected inboxes, clear it out so we don't
+    // submit a stale template name.
+    availableTemplates() {
+      if (!this.config.template_name) return;
+      const key = `${this.config.template_name}|||${this.config.template_language}`;
+      if (!this.templateOptions.some(t => t.key === key)) {
+        this.selectedTemplate = null;
+      }
+    },
+  },
+  mounted() {
+    // Emit the normalised shape on mount so a freshly-added action stores
+    // an object rather than the empty array set by resetAction().
+    if (Array.isArray(this.value) || !this.value) {
+      this.emitConfig();
+    }
+  },
+  methods: {
+    unwrap(value) {
+      if (!value) return DEFAULT_CONFIG();
+      if (Array.isArray(value)) {
+        return { ...DEFAULT_CONFIG(), ...(value[0] || {}) };
+      }
+      return { ...DEFAULT_CONFIG(), ...value };
+    },
+    update(patch) {
+      this.config = { ...this.config, ...patch };
+      this.emitConfig();
+    },
+    updateVariable(key, value) {
+      const next = { ...(this.config.processed_params || {}), [key]: value };
+      this.update({ processed_params: next });
+    },
+    emitConfig() {
+      this.$emit('input', this.config);
+    },
+    bodyText(template) {
+      const body = (template.components || []).find(c => c.type === 'BODY');
+      return body ? body.text || '' : '';
+    },
+    initialParamsFor(template) {
+      const body = this.bodyText(template);
+      const matches = body.match(/{{\s*\d+\s*}}/g) || [];
+      const params = {};
+      matches.forEach(token => {
+        const key = token.replace(/[^0-9]/g, '');
+        params[key] = '';
+      });
+      return params;
+    },
+    insertToken(key, token) {
+      const current = (this.config.processed_params || {})[key] || '';
+      this.updateVariable(key, `${current}${token}`);
+    },
+  },
+};
+</script>
+
+<template>
+  <div class="wa-template-input">
+    <div class="form-row">
+      <label class="form-row__label">
+        {{ $t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.INBOX_LABEL') }}
+      </label>
+      <div class="multiselect-wrap--small">
+        <multiselect
+          v-model="selectedInboxes"
+          track-by="id"
+          label="name"
+          :placeholder="
+            $t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.INBOX_PLACEHOLDER')
+          "
+          multiple
+          selected-label
+          :select-label="$t('FORMS.MULTISELECT.ENTER_TO_SELECT')"
+          deselect-label=""
+          :max-height="160"
+          :options="whatsappInboxes"
+          :allow-empty="true"
+          :option-height="40"
+        />
+      </div>
+      <p
+        v-if="!whatsappInboxes.length"
+        class="form-row__hint form-row__hint--warn"
+      >
+        {{ $t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.NO_WA_INBOXES') }}
+      </p>
+    </div>
+
+    <div v-if="selectedInboxes.length" class="form-row">
+      <label class="form-row__label">
+        {{ $t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.TEMPLATE_LABEL') }}
+      </label>
+      <div class="multiselect-wrap--small">
+        <multiselect
+          v-model="selectedTemplate"
+          track-by="key"
+          label="display_name"
+          :placeholder="
+            $t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.TEMPLATE_PLACEHOLDER')
+          "
+          selected-label
+          :select-label="$t('FORMS.MULTISELECT.ENTER_TO_SELECT')"
+          deselect-label=""
+          :max-height="200"
+          :options="templateOptions"
+          :allow-empty="true"
+          :option-height="40"
+        />
+      </div>
+      <p
+        v-if="selectedInboxes.length && !templateOptions.length"
+        class="form-row__hint form-row__hint--warn"
+      >
+        {{ $t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.NO_COMMON_TEMPLATES') }}
+      </p>
+    </div>
+
+    <div v-if="selectedTemplate" class="wa-template-preview">
+      <p class="wa-template-preview__label">
+        {{ $t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.BODY_LABEL') }}
+      </p>
+      <p class="wa-template-preview__body">{{ renderedBody }}</p>
+    </div>
+
+    <div v-if="selectedTemplate && bodyVariableKeys.length" class="form-row">
+      <label class="form-row__label">
+        {{ $t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.VARIABLES_LABEL') }}
+      </label>
+      <p class="form-row__hint">
+        {{ $t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.VARIABLES_HINT') }}
+        <code class="wa-template-tokens">{{ placeholdersHint }}</code>
+      </p>
+      <div
+        v-for="key in bodyVariableKeys"
+        :key="key"
+        class="wa-template-variable"
+      >
+        <span class="wa-template-variable__key">{{ `{{${key}}}` }}</span>
+        <input
+          type="text"
+          :value="(config.processed_params || {})[key] || ''"
+          class="wa-template-variable__input"
+          :placeholder="
+            $t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.VARIABLE_PLACEHOLDER')
+          "
+          @input="updateVariable(key, $event.target.value)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.wa-template-input {
+  @apply mt-2;
+}
+
+.form-row {
+  @apply mb-3;
+
+  &__label {
+    @apply block text-sm font-medium text-slate-700 dark:text-slate-100 mb-1;
+  }
+
+  &__hint {
+    @apply text-xs text-slate-500 dark:text-slate-300 mt-1;
+
+    &--warn {
+      @apply text-yellow-700 dark:text-yellow-400;
+    }
+  }
+}
+
+.wa-template-tokens {
+  @apply block mt-1 px-2 py-1 rounded text-xs bg-slate-50 dark:bg-slate-900 text-slate-700 dark:text-slate-200;
+  font-family: monospace;
+}
+
+.wa-template-preview {
+  @apply rounded-md p-3 my-3 bg-white dark:bg-slate-900 border border-solid border-slate-100 dark:border-slate-700;
+
+  &__label {
+    @apply text-xs font-semibold text-slate-500 dark:text-slate-300 mb-1;
+  }
+
+  &__body {
+    @apply text-sm whitespace-pre-wrap text-slate-800 dark:text-slate-50 mb-0;
+    font-family: monospace;
+  }
+}
+
+.wa-template-variable {
+  @apply flex items-center gap-2 mb-2;
+
+  &__key {
+    @apply text-xs font-mono px-2 py-1 rounded bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-100;
+  }
+
+  &__input {
+    @apply flex-grow mb-0;
+  }
+}
+
+.multiselect {
+  @apply mb-0;
+}
+</style>

--- a/app/javascript/dashboard/composables/useAutomation.js
+++ b/app/javascript/dashboard/composables/useAutomation.js
@@ -236,6 +236,11 @@ export function useAutomation() {
         message: params[0].message,
       };
     }
+    // whatsapp_template stores a single config object inside the params
+    // array. Unwrap it for the form; actionQueryGenerator re-wraps on save.
+    if (inputType === 'whatsapp_template') {
+      return params[0] || {};
+    }
     return [...params];
   };
 

--- a/app/javascript/dashboard/helper/automationHelper.js
+++ b/app/javascript/dashboard/helper/automationHelper.js
@@ -335,7 +335,11 @@ export const getCustomAttributeType = (automationTypes, automation, key) => {
  * @returns {boolean} True if the action input should be shown, false otherwise.
  */
 export const showActionInput = (automationActionTypes, action) => {
-  if (action === 'send_email_to_team' || action === 'send_message')
+  if (
+    action === 'send_email_to_team' ||
+    action === 'send_message' ||
+    action === 'send_whatsapp_template'
+  )
     return false;
   const type = automationActionTypes.find(i => i.key === action).inputType;
   return !!type;

--- a/app/javascript/dashboard/helper/validations.js
+++ b/app/javascript/dashboard/helper/validations.js
@@ -134,6 +134,21 @@ const validateSingleAction = action => {
     'remove_assigned_team',
   ];
 
+  if (action.action_name === 'send_whatsapp_template') {
+    const config = Array.isArray(action.action_params)
+      ? action.action_params[0]
+      : action.action_params;
+    if (
+      !config ||
+      !Array.isArray(config.inbox_ids) ||
+      config.inbox_ids.length === 0 ||
+      !config.template_name
+    ) {
+      return ACTION_PARAMETERS_REQUIRED;
+    }
+    return null;
+  }
+
   if (
     !noParamActions.includes(action.action_name) &&
     (!action.action_params || action.action_params.length === 0)

--- a/app/javascript/dashboard/i18n/locale/en/automation.json
+++ b/app/javascript/dashboard/i18n/locale/en/automation.json
@@ -96,7 +96,19 @@
       "TEAM_MESSAGE_INPUT_PLACEHOLDER": "Enter your message here",
       "TEAM_DROPDOWN_PLACEHOLDER": "Select teams",
       "EMAIL_INPUT_PLACEHOLDER": "Enter email",
-      "URL_INPUT_PLACEHOLDER": "Enter URL"
+      "URL_INPUT_PLACEHOLDER": "Enter URL",
+      "WHATSAPP_TEMPLATE": {
+        "INBOX_LABEL": "WhatsApp inboxes",
+        "INBOX_PLACEHOLDER": "Select one or more WhatsApp inboxes",
+        "NO_WA_INBOXES": "No WhatsApp inboxes are connected to this account.",
+        "TEMPLATE_LABEL": "Template",
+        "TEMPLATE_PLACEHOLDER": "Choose an approved template",
+        "NO_COMMON_TEMPLATES": "The selected inboxes don't share any approved template. Pick inboxes that have the same template approved.",
+        "BODY_LABEL": "Template body",
+        "VARIABLES_LABEL": "Variables",
+        "VARIABLES_HINT": "Fill each variable. Use these placeholders to substitute live data at send time:",
+        "VARIABLE_PLACEHOLDER": "Static text or a placeholder"
+      }
     },
     "TOGGLE": {
       "ACTIVATION_TITLE": "Activate Automation Rule",

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
@@ -607,6 +607,11 @@ export const AUTOMATION_ACTION_TYPES = [
     inputType: 'textarea',
   },
   {
+    key: 'send_whatsapp_template',
+    label: 'Send a WhatsApp template',
+    inputType: 'whatsapp_template',
+  },
+  {
     key: 'change_priority',
     label: 'Change Priority',
     inputType: 'search_select',

--- a/app/models/automation_rule.rb
+++ b/app/models/automation_rule.rb
@@ -27,6 +27,7 @@ class AutomationRule < ApplicationRecord
   validate :json_conditions_format
   validate :json_actions_format
   validate :query_operator_presence
+  validate :whatsapp_template_action_inboxes
   validates :account_id, presence: true
 
   after_update_commit :reauthorized!, if: -> { saved_change_to_conditions? }
@@ -39,8 +40,8 @@ class AutomationRule < ApplicationRecord
   end
 
   def actions_attributes
-    %w[send_message add_label remove_label send_email_to_team assign_team assign_agent send_webhook_event mute_conversation
-       send_attachment change_status resolve_conversation snooze_conversation change_priority send_email_transcript].freeze
+    %w[send_message send_whatsapp_template add_label remove_label send_email_to_team assign_team assign_agent send_webhook_event
+       mute_conversation send_attachment change_status resolve_conversation snooze_conversation change_priority send_email_transcript].freeze
   end
 
   def file_base_data
@@ -82,6 +83,30 @@ class AutomationRule < ApplicationRecord
 
     operators = conditions.select { |obj, _| obj['query_operator'].nil? }
     errors.add(:conditions, 'Automation conditions should have query operator.') if operators.length > 1
+  end
+
+  def whatsapp_template_action_inboxes
+    return if actions.blank?
+    return if account.blank?
+
+    template_actions = actions.select { |obj| obj['action_name'] == 'send_whatsapp_template' }
+    template_actions.each { |action| validate_single_template_action(action) }
+  end
+
+  def validate_single_template_action(action)
+    config = Array(action['action_params']).first
+    inbox_ids = config.is_a?(Hash) ? Array(config['inbox_ids'] || config[:inbox_ids]) : []
+
+    if inbox_ids.blank?
+      errors.add(:actions, 'send_whatsapp_template requires at least one WhatsApp inbox.')
+      return
+    end
+
+    non_whatsapp = account.inboxes.where(id: inbox_ids).where.not(channel_type: 'Channel::Whatsapp').pluck(:id)
+    errors.add(:actions, "Inboxes #{non_whatsapp.join(',')} are not WhatsApp inboxes.") if non_whatsapp.any?
+
+    template_name = config['template_name'].presence || config[:template_name].presence
+    errors.add(:actions, 'send_whatsapp_template requires a template_name.') if template_name.blank?
   end
 end
 

--- a/app/services/automation_rules/action_service.rb
+++ b/app/services/automation_rules/action_service.rb
@@ -47,6 +47,64 @@ class AutomationRules::ActionService < ActionService
     Messages::MessageBuilder.new(nil, @conversation, params).perform
   end
 
+  # Sends a pre-approved WhatsApp template as an outgoing message.
+  # action_params shape (single-element array containing one config hash):
+  #   [{
+  #     "inbox_ids":          [Integer, ...],            # WhatsApp inboxes this rule fires on
+  #     "template_name":      "appointment_reminder",
+  #     "template_language":  "en_US",
+  #     "template_namespace": nil,
+  #     "template_category":  "MARKETING",
+  #     "processed_params":   { "1" => "{{contact.name}}", "2" => "tomorrow" }
+  #   }]
+  # Placeholders like `{{contact.name}}` are resolved at send time. The action
+  # no-ops when the matched conversation isn't on one of the configured inboxes,
+  # so the same rule can fan across multiple WhatsApp numbers without firing
+  # on unrelated channels.
+  def send_whatsapp_template(params)
+    config = Array(params).first
+    return if config.blank?
+
+    config = config.with_indifferent_access
+    return unless whatsapp_template_target?(config)
+
+    processed = AutomationRules::TemplatePlaceholderService.new(@conversation).substitute_processed_params(config[:processed_params])
+
+    builder_params = {
+      content: rendered_template_body(config, processed),
+      private: false,
+      content_attributes: { automation_rule_id: @rule.id },
+      template_params: {
+        name: config[:template_name],
+        namespace: config[:template_namespace],
+        language: config[:template_language],
+        category: config[:template_category],
+        processed_params: processed
+      }
+    }
+
+    Messages::MessageBuilder.new(nil, @conversation, builder_params).perform
+  end
+
+  def whatsapp_template_target?(config)
+    return false unless @conversation.inbox&.channel_type == 'Channel::Whatsapp'
+
+    inbox_ids = Array(config[:inbox_ids]).map(&:to_i)
+    return false if inbox_ids.blank?
+
+    inbox_ids.include?(@conversation.inbox_id)
+  end
+
+  # Rendered body lets us store a readable copy on the message record. The
+  # actual outbound payload to WhatsApp is built from processed_params by
+  # Whatsapp::SendOnWhatsappService — we don't reach that pipeline ourselves.
+  def rendered_template_body(config, processed)
+    body = config[:template_body].presence || ''
+    return body if processed.blank?
+
+    body.gsub(/{{\s*(\d+)\s*}}/) { |match| processed[Regexp.last_match(1)].presence || match }
+  end
+
   def send_email_to_team(params)
     teams = Team.where(id: params[0][:team_ids])
 

--- a/app/services/automation_rules/template_placeholder_service.rb
+++ b/app/services/automation_rules/template_placeholder_service.rb
@@ -1,0 +1,69 @@
+class AutomationRules::TemplatePlaceholderService
+  # Substitutes `{{namespace.attribute}}` tokens inside a WhatsApp template
+  # parameter value at rule-execution time. Tokens that don't match a known
+  # attribute (or resolve to nil/empty) are replaced with an empty string so
+  # the WhatsApp API never receives a literal placeholder.
+  TOKEN_REGEX = /{{\s*([a-z_]+)\.([a-z_]+)\s*}}/i
+
+  def initialize(conversation)
+    @conversation = conversation
+    @contact = conversation.contact
+    @assignee = conversation.assignee
+  end
+
+  def substitute(value)
+    return value unless value.is_a?(String)
+
+    value.gsub(TOKEN_REGEX) do
+      namespace = Regexp.last_match(1).downcase
+      attribute = Regexp.last_match(2).downcase
+      resolve(namespace, attribute).to_s
+    end
+  end
+
+  def substitute_processed_params(processed_params)
+    return {} if processed_params.blank?
+
+    processed_params.transform_values { |v| substitute(v) }
+  end
+
+  private
+
+  def resolve(namespace, attribute)
+    case namespace
+    when 'contact'
+      contact_attribute(attribute)
+    when 'conversation'
+      conversation_attribute(attribute)
+    when 'agent'
+      agent_attribute(attribute)
+    end
+  end
+
+  def contact_attribute(attribute)
+    return if @contact.blank?
+
+    case attribute
+    when 'name' then @contact.name
+    when 'email' then @contact.email
+    when 'phone_number' then @contact.phone_number
+    when 'identifier' then @contact.identifier
+    end
+  end
+
+  def conversation_attribute(attribute)
+    case attribute
+    when 'id' then @conversation.display_id
+    when 'display_id' then @conversation.display_id
+    end
+  end
+
+  def agent_attribute(attribute)
+    return if @assignee.blank?
+
+    case attribute
+    when 'name' then @assignee.name
+    when 'email' then @assignee.email
+    end
+  end
+end

--- a/spec/models/automation_rule_spec.rb
+++ b/spec/models/automation_rule_spec.rb
@@ -62,6 +62,51 @@ RSpec.describe AutomationRule do
     end
   end
 
+  describe 'send_whatsapp_template action validation' do
+    let(:account) { create(:account) }
+    let(:whatsapp_inbox) { create(:channel_whatsapp, account: account, sync_templates: false, validate_provider_config: false).inbox }
+    let(:other_whatsapp_inbox) do
+      create(:channel_whatsapp, account: account, sync_templates: false, validate_provider_config: false).inbox
+    end
+    let(:web_inbox) { create(:inbox, account: account) }
+
+    def build_rule(action_params)
+      build(:automation_rule,
+            account: account,
+            event_name: 'conversation_created',
+            conditions: [{ attribute_key: 'status', filter_operator: 'equal_to', values: ['open'], query_operator: nil }],
+            actions: [{ action_name: 'send_whatsapp_template', action_params: action_params }])
+    end
+
+    it 'is valid with one or more WhatsApp inboxes and a template_name' do
+      rule = build_rule([{
+                          inbox_ids: [whatsapp_inbox.id, other_whatsapp_inbox.id],
+                          template_name: 'sample_shipping_confirmation',
+                          template_language: 'en_US',
+                          processed_params: { '1' => '{{contact.name}}' }
+                        }])
+      expect(rule).to be_valid
+    end
+
+    it 'is invalid when no inboxes are configured' do
+      rule = build_rule([{ inbox_ids: [], template_name: 'sample_shipping_confirmation' }])
+      expect(rule).to be_invalid
+      expect(rule.errors[:actions].join).to include('requires at least one WhatsApp inbox')
+    end
+
+    it 'is invalid when a non-WhatsApp inbox is configured' do
+      rule = build_rule([{ inbox_ids: [web_inbox.id], template_name: 'sample_shipping_confirmation' }])
+      expect(rule).to be_invalid
+      expect(rule.errors[:actions].join).to include('are not WhatsApp inboxes')
+    end
+
+    it 'is invalid when template_name is missing' do
+      rule = build_rule([{ inbox_ids: [whatsapp_inbox.id] }])
+      expect(rule).to be_invalid
+      expect(rule.errors[:actions].join).to include('requires a template_name')
+    end
+  end
+
   describe 'reauthorizable' do
     context 'when prompt_reauthorization!' do
       it 'marks the rule inactive' do

--- a/spec/services/automation_rules/action_service_spec.rb
+++ b/spec/services/automation_rules/action_service_spec.rb
@@ -117,5 +117,72 @@ RSpec.describe AutomationRules::ActionService do
         expect(mailer).to have_received(:conversation_transcript).exactly(1).times
       end
     end
+
+    describe '#perform with send_whatsapp_template action' do
+      let(:whatsapp_channel) { create(:channel_whatsapp, account: account, sync_templates: false, validate_provider_config: false) }
+      let(:whatsapp_inbox) { whatsapp_channel.inbox }
+      let(:other_whatsapp_inbox) do
+        create(:channel_whatsapp, account: account, sync_templates: false, validate_provider_config: false).inbox
+      end
+      let(:contact) { create(:contact, account: account, name: 'Jane Doe', email: 'jane@example.com') }
+      let(:contact_inbox) { create(:contact_inbox, contact: contact, inbox: whatsapp_inbox, source_id: '+1234567890') }
+      let(:wa_conversation) { create(:conversation, account: account, inbox: whatsapp_inbox, contact: contact, contact_inbox: contact_inbox) }
+
+      let(:template_config) do
+        {
+          'inbox_ids' => [whatsapp_inbox.id, other_whatsapp_inbox.id],
+          'template_name' => 'sample_shipping_confirmation',
+          'template_language' => 'en_US',
+          'template_namespace' => '23423423_2342423_324234234_2343224',
+          'template_category' => 'SHIPPING_UPDATE',
+          'template_body' => 'Hi {{1}}, your order ships in {{2}} business days.',
+          'processed_params' => { '1' => '{{contact.name}}', '2' => '3' }
+        }
+      end
+
+      let(:template_rule) do
+        create(:automation_rule, account: account,
+                                 event_name: 'conversation_created',
+                                 actions: [{ action_name: 'send_whatsapp_template', action_params: [template_config] }])
+      end
+
+      it 'creates a message with template_params and resolves placeholders' do
+        expect do
+          described_class.new(template_rule, account, wa_conversation).perform
+        end.to change { wa_conversation.messages.count }.by(1)
+
+        message = wa_conversation.messages.last
+        expect(message.additional_attributes['template_params']).to include(
+          'name' => 'sample_shipping_confirmation',
+          'language' => 'en_US'
+        )
+        expect(message.additional_attributes['template_params']['processed_params']).to eq('1' => 'Jane Doe', '2' => '3')
+        expect(message.content).to eq('Hi Jane Doe, your order ships in 3 business days.')
+        expect(message.content_attributes['automation_rule_id']).to eq(template_rule.id)
+      end
+
+      it 'no-ops when the conversation is not on a configured inbox' do
+        unrelated_conversation = create(:conversation, account: account)
+        expect do
+          described_class.new(template_rule, account, unrelated_conversation).perform
+        end.not_to(change { unrelated_conversation.messages.count })
+      end
+
+      it 'no-ops when the conversation is not on a WhatsApp inbox at all' do
+        non_wa_inbox = create(:inbox, account: account)
+        non_wa_conversation = create(:conversation, account: account, inbox: non_wa_inbox)
+        # Make the action target this non-WA inbox to prove the channel check
+        # wins regardless of inbox_ids membership.
+        template_rule.update_columns(actions: [
+                                       {
+                                         action_name: 'send_whatsapp_template',
+                                         action_params: [template_config.merge('inbox_ids' => [non_wa_inbox.id])]
+                                       }
+                                     ])
+        expect do
+          described_class.new(template_rule.reload, account, non_wa_conversation).perform
+        end.not_to(change { non_wa_conversation.messages.count })
+      end
+    end
   end
 end

--- a/spec/services/automation_rules/template_placeholder_service_spec.rb
+++ b/spec/services/automation_rules/template_placeholder_service_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe AutomationRules::TemplatePlaceholderService do
+  let(:account) { create(:account) }
+  let(:agent) { create(:user, account: account, name: 'Alice Agent', email: 'alice@example.com') }
+  let(:contact) { create(:contact, account: account, name: 'Bob Buyer', email: 'bob@example.com', phone_number: '+15551234567') }
+  let(:conversation) { create(:conversation, account: account, contact: contact, assignee: agent) }
+
+  subject(:service) { described_class.new(conversation) }
+
+  describe '#substitute' do
+    it 'resolves contact tokens' do
+      expect(service.substitute('Hi {{contact.name}}, email {{contact.email}}')).to eq('Hi Bob Buyer, email bob@example.com')
+    end
+
+    it 'resolves conversation tokens' do
+      expect(service.substitute('Ref #{{conversation.display_id}}')).to eq("Ref ##{conversation.display_id}")
+    end
+
+    it 'resolves agent tokens' do
+      expect(service.substitute('Reply to {{agent.name}}')).to eq('Reply to Alice Agent')
+    end
+
+    it 'leaves unrecognised tokens empty rather than literal placeholders' do
+      expect(service.substitute('Code: {{contact.unknown}}!')).to eq('Code: !')
+    end
+
+    it 'is whitespace-tolerant inside the token' do
+      expect(service.substitute('Hi {{ contact.name }}')).to eq('Hi Bob Buyer')
+    end
+
+    it 'returns non-string values unchanged' do
+      expect(service.substitute(nil)).to be_nil
+      expect(service.substitute(42)).to eq(42)
+    end
+  end
+
+  describe '#substitute_processed_params' do
+    it 'transforms every value in the hash' do
+      result = service.substitute_processed_params('1' => '{{contact.name}}', '2' => 'literal')
+      expect(result).to eq('1' => 'Bob Buyer', '2' => 'literal')
+    end
+
+    it 'returns an empty hash for blank input' do
+      expect(service.substitute_processed_params(nil)).to eq({})
+      expect(service.substitute_processed_params({})).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a new **Send a WhatsApp template** automation action. The existing **Send a message** action only accepts free text, so rules can't fire approved WhatsApp templates — this PR plugs that gap end-to-end.
- The action lets you pick *multiple* WhatsApp inboxes; the template dropdown intersects approved templates across the picked inboxes, so the same rule can fan across multiple WhatsApp numbers without misfiring on unrelated channels.
- Variables support runtime placeholders: `{{contact.name}}`, `{{contact.email}}`, `{{contact.phone_number}}`, `{{conversation.id}}`, `{{agent.name}}` — substituted by `AutomationRules::TemplatePlaceholderService` before the message is built.

## How it works
1. UI: `AutomationActionWhatsappTemplateInput.vue` renders a 3-step inline picker (inboxes → template → variables) with a live body preview.
2. The action is stored as `[{ inbox_ids, template_name, template_language, template_namespace, template_category, template_body, processed_params }]`.
3. At fire time, `AutomationRules::ActionService#send_whatsapp_template` checks the conversation's inbox is in `inbox_ids` AND is a `Channel::Whatsapp`. Otherwise it no-ops. Then placeholders are substituted and a Message is built with `template_params` in `additional_attributes`, which the existing `Whatsapp::SendOnWhatsappService` already handles.
4. `AutomationRule` validates at save time that every referenced inbox is a WhatsApp inbox in the same account and that `template_name` is present.

## Test plan
- [ ] Backend specs:
  - [ ] `spec/services/automation_rules/template_placeholder_service_spec.rb`
  - [ ] `spec/services/automation_rules/action_service_spec.rb` — new `send_whatsapp_template` block
  - [ ] `spec/models/automation_rule_spec.rb` — new validation block
- [ ] Manual UI:
  - [ ] Create a rule with event = Conversation Created, action = Send a WhatsApp template, pick a WhatsApp inbox, pick an approved template with `{{1}}`, set the variable to `{{contact.name}}`, save.
  - [ ] Open a new WhatsApp conversation matching the rule → confirm a template message is sent with the contact name filled in.
  - [ ] Repeat with a non-WhatsApp conversation matching the rule → confirm no message is sent.
  - [ ] Try saving the rule with no inboxes / a non-WhatsApp inbox / no template → confirm validation rejects it.
  - [ ] Reopen the rule for editing → confirm the inbox list, template, and variable values round-trip correctly.