### PR TITLE
feat: send WhatsApp template as a cross-channel automation action

### DIFF
--- a/app/javascript/dashboard/components/widgets/AutomationActionInput.vue
+++ b/app/javascript/dashboard/components/widgets/AutomationActionInput.vue
@@ -1,6 +1,7 @@
 <script>
 import AutomationActionTeamMessageInput from './AutomationActionTeamMessageInput.vue';
 import AutomationActionFileInput from './AutomationFileInput.vue';
+import AutomationActionWhatsappTemplateInput from './AutomationActionWhatsappTemplateInput.vue';
 import WootMessageEditor from 'dashboard/components/widgets/WootWriter/Editor.vue';
 import NextButton from 'dashboard/components-next/button/Button.vue';
 import SingleSelect from 'dashboard/components-next/filter/inputs/SingleSelect.vue';
@@ -11,6 +12,7 @@ export default {
   components: {
     AutomationActionTeamMessageInput,
     AutomationActionFileInput,
+    AutomationActionWhatsappTemplateInput,
     WootMessageEditor,
     NextButton,
     SingleSelect,
@@ -93,7 +95,9 @@ export default {
       return this.actionTypes.map(a => ({ id: a.key, name: a.label }));
     },
     isVerticalLayout() {
-      return ['team_message', 'textarea'].includes(this.inputType);
+      return ['team_message', 'textarea', 'whatsapp_template'].includes(
+        this.inputType
+      );
     },
     castMessageVmodel: {
       get() {
@@ -193,6 +197,10 @@ export default {
         enable-variables
         :placeholder="$t('AUTOMATION.ACTION.TEAM_MESSAGE_INPUT_PLACEHOLDER')"
         class="[&_.ProseMirror-menubar]:hidden px-3 py-1 bg-n-alpha-1 rounded-lg outline outline-1 outline-n-weak dark:outline-n-strong"
+      />
+      <AutomationActionWhatsappTemplateInput
+        v-if="inputType === 'whatsapp_template'"
+        v-model="castMessageVmodel"
       />
     </div>
     <span v-if="errorMessage" class="text-sm text-n-ruby-11">

--- a/app/javascript/dashboard/components/widgets/AutomationActionWhatsappTemplateInput.vue
+++ b/app/javascript/dashboard/components/widgets/AutomationActionWhatsappTemplateInput.vue
@@ -5,6 +5,15 @@ import { useI18n } from 'vue-i18n';
 import SingleSelect from 'dashboard/components-next/filter/inputs/SingleSelect.vue';
 import NextInput from 'dashboard/components-next/input/Input.vue';
 
+const props = defineProps({
+  modelValue: {
+    type: [Object, Array],
+    default: () => null,
+  },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
 // Tokens the rule author can drop into a variable input. Substitution
 // happens server-side via Liquid drops, so anything supported by the
 // existing message drops (contact / conversation / inbox / account / agent)
@@ -27,15 +36,6 @@ const defaultConfig = () => ({
   template_body: '',
   processed_params: {},
 });
-
-const props = defineProps({
-  modelValue: {
-    type: [Object, Array],
-    default: () => null,
-  },
-});
-
-const emit = defineEmits(['update:modelValue']);
 
 const { t } = useI18n();
 const store = useStore();
@@ -155,7 +155,7 @@ const renderedBody = computed(() => {
   if (!body) return '';
   return body.replace(/{{\s*(\d+)\s*}}/g, (match, key) => {
     const value = (config.value.processed_params || {})[key];
-    return value ? value : match;
+    return value || match;
   });
 });
 
@@ -196,7 +196,9 @@ const formatVariableKey = key => `{{${key}}}`;
       <SingleSelect
         v-model="selectedInboxOption"
         :options="whatsappInboxOptions"
-        :placeholder="t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.INBOX_PLACEHOLDER')"
+        :placeholder="
+          t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.INBOX_PLACEHOLDER')
+        "
       />
       <p
         v-if="!whatsappInboxOptions.length"
@@ -248,7 +250,9 @@ const formatVariableKey = key => `{{${key}}}`;
         :key="key"
         class="flex items-center gap-2 mt-2"
       >
-        <span class="wa-template-variable__key">{{ formatVariableKey(key) }}</span>
+        <span class="wa-template-variable__key">{{
+          formatVariableKey(key)
+        }}</span>
         <NextInput
           :model-value="(config.processed_params || {})[key] || ''"
           type="text"

--- a/app/javascript/dashboard/components/widgets/AutomationActionWhatsappTemplateInput.vue
+++ b/app/javascript/dashboard/components/widgets/AutomationActionWhatsappTemplateInput.vue
@@ -1,0 +1,301 @@
+<script setup>
+import { computed, watch, onMounted } from 'vue';
+import { useStore } from 'vuex';
+import { useI18n } from 'vue-i18n';
+import SingleSelect from 'dashboard/components-next/filter/inputs/SingleSelect.vue';
+import NextInput from 'dashboard/components-next/input/Input.vue';
+
+// Tokens the rule author can drop into a variable input. Substitution
+// happens server-side via Liquid drops, so anything supported by the
+// existing message drops (contact / conversation / inbox / account / agent)
+// works — this list is just the most useful shortcuts.
+const PLACEHOLDER_TOKENS = [
+  '{{contact.name}}',
+  '{{contact.email}}',
+  '{{contact.phone_number}}',
+  '{{conversation.display_id}}',
+  '{{inbox.name}}',
+  '{{agent.name}}',
+];
+
+const defaultConfig = () => ({
+  inbox_id: null,
+  template_name: '',
+  template_language: '',
+  template_namespace: null,
+  template_category: '',
+  template_body: '',
+  processed_params: {},
+});
+
+const props = defineProps({
+  modelValue: {
+    type: [Object, Array],
+    default: () => null,
+  },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const { t } = useI18n();
+const store = useStore();
+
+const unwrap = value => {
+  if (!value) return defaultConfig();
+  if (Array.isArray(value)) return { ...defaultConfig(), ...(value[0] || {}) };
+  return { ...defaultConfig(), ...value };
+};
+
+const config = computed(() => unwrap(props.modelValue));
+
+const updateConfig = patch => {
+  emit('update:modelValue', { ...config.value, ...patch });
+};
+
+const allInboxes = computed(() => store.getters['inboxes/getInboxes'] || []);
+
+const whatsappInboxOptions = computed(() =>
+  allInboxes.value
+    .filter(inbox => inbox.channel_type === 'Channel::Whatsapp')
+    .map(inbox => ({ id: inbox.id, name: inbox.name }))
+);
+
+const selectedInboxOption = computed({
+  get: () => {
+    if (!config.value.inbox_id) return null;
+    return (
+      whatsappInboxOptions.value.find(o => o.id === config.value.inbox_id) ||
+      null
+    );
+  },
+  set: option => {
+    updateConfig({
+      inbox_id: option ? option.id : null,
+      template_name: '',
+      template_language: '',
+      template_namespace: null,
+      template_category: '',
+      template_body: '',
+      processed_params: {},
+    });
+  },
+});
+
+const bodyText = template => {
+  const body = (template?.components || []).find(c => c.type === 'BODY');
+  return body ? body.text || '' : '';
+};
+
+const availableTemplates = computed(() => {
+  if (!config.value.inbox_id) return [];
+  return store.getters['inboxes/getWhatsAppTemplates'](
+    config.value.inbox_id
+  ).filter(tpl => (tpl.status || '').toLowerCase() === 'approved');
+});
+
+const templateOptions = computed(() =>
+  availableTemplates.value.map(tpl => ({
+    id: `${tpl.name}|||${tpl.language}`,
+    name: `${tpl.name} · ${tpl.language}`,
+    raw: tpl,
+  }))
+);
+
+const selectedTemplateOption = computed({
+  get: () => {
+    if (!config.value.template_name) return null;
+    const id = `${config.value.template_name}|||${config.value.template_language}`;
+    return templateOptions.value.find(o => o.id === id) || null;
+  },
+  set: option => {
+    if (!option) {
+      updateConfig({
+        template_name: '',
+        template_language: '',
+        template_namespace: null,
+        template_category: '',
+        template_body: '',
+        processed_params: {},
+      });
+      return;
+    }
+    const raw =
+      option.raw ||
+      availableTemplates.value.find(
+        tpl => `${tpl.name}|||${tpl.language}` === option.id
+      );
+    if (!raw) return;
+
+    const body = bodyText(raw);
+    const matches = body.match(/{{\s*\d+\s*}}/g) || [];
+    const initialParams = {};
+    matches.forEach(token => {
+      initialParams[token.replace(/[^0-9]/g, '')] = '';
+    });
+
+    updateConfig({
+      template_name: raw.name,
+      template_language: raw.language,
+      template_namespace: raw.namespace || null,
+      template_category: raw.category || '',
+      template_body: body,
+      processed_params: initialParams,
+    });
+  },
+});
+
+const bodyVariableKeys = computed(() => {
+  const body = config.value.template_body || '';
+  const matches = body.match(/{{\s*\d+\s*}}/g) || [];
+  return matches.map(token => token.replace(/[^0-9]/g, ''));
+});
+
+const renderedBody = computed(() => {
+  const body = config.value.template_body || '';
+  if (!body) return '';
+  return body.replace(/{{\s*(\d+)\s*}}/g, (match, key) => {
+    const value = (config.value.processed_params || {})[key];
+    return value ? value : match;
+  });
+});
+
+const updateVariable = (key, value) => {
+  const next = { ...(config.value.processed_params || {}), [key]: value };
+  updateConfig({ processed_params: next });
+};
+
+watch(availableTemplates, () => {
+  if (!config.value.template_name) return;
+  const id = `${config.value.template_name}|||${config.value.template_language}`;
+  if (!templateOptions.value.some(o => o.id === id)) {
+    selectedTemplateOption.value = null;
+  }
+});
+
+onMounted(() => {
+  if (Array.isArray(props.modelValue) || !props.modelValue) {
+    emit('update:modelValue', config.value);
+  }
+});
+
+const placeholdersHint = computed(() => PLACEHOLDER_TOKENS.join(', '));
+
+const formatVariableKey = key => `{{${key}}}`;
+</script>
+
+<template>
+  <div class="wa-template-input flex flex-col gap-3 w-full">
+    <p class="form-row__hint">
+      {{ t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.OVERVIEW') }}
+    </p>
+
+    <div class="form-row">
+      <label class="form-row__label">
+        {{ t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.INBOX_LABEL') }}
+      </label>
+      <SingleSelect
+        v-model="selectedInboxOption"
+        :options="whatsappInboxOptions"
+        :placeholder="t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.INBOX_PLACEHOLDER')"
+      />
+      <p
+        v-if="!whatsappInboxOptions.length"
+        class="form-row__hint form-row__hint--warn"
+      >
+        {{ t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.NO_WA_INBOXES') }}
+      </p>
+    </div>
+
+    <div v-if="config.inbox_id" class="form-row">
+      <label class="form-row__label">
+        {{ t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.TEMPLATE_LABEL') }}
+      </label>
+      <SingleSelect
+        v-model="selectedTemplateOption"
+        :options="templateOptions"
+        :placeholder="
+          t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.TEMPLATE_PLACEHOLDER')
+        "
+      />
+      <p
+        v-if="config.inbox_id && !templateOptions.length"
+        class="form-row__hint form-row__hint--warn"
+      >
+        {{ t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.NO_TEMPLATES') }}
+      </p>
+    </div>
+
+    <div v-if="config.template_name" class="wa-template-preview">
+      <p class="wa-template-preview__label">
+        {{ t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.BODY_LABEL') }}
+      </p>
+      <p class="wa-template-preview__body">{{ renderedBody }}</p>
+    </div>
+
+    <div
+      v-if="config.template_name && bodyVariableKeys.length"
+      class="form-row"
+    >
+      <label class="form-row__label">
+        {{ t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.VARIABLES_LABEL') }}
+      </label>
+      <p class="form-row__hint">
+        {{ t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.VARIABLES_HINT') }}
+      </p>
+      <code class="wa-template-tokens">{{ placeholdersHint }}</code>
+      <div
+        v-for="key in bodyVariableKeys"
+        :key="key"
+        class="flex items-center gap-2 mt-2"
+      >
+        <span class="wa-template-variable__key">{{ formatVariableKey(key) }}</span>
+        <NextInput
+          :model-value="(config.processed_params || {})[key] || ''"
+          type="text"
+          size="sm"
+          class="flex-1"
+          :placeholder="
+            t('AUTOMATION.ACTION.WHATSAPP_TEMPLATE.VARIABLE_PLACEHOLDER')
+          "
+          @update:model-value="value => updateVariable(key, value)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.form-row__label {
+  @apply block text-sm font-medium text-n-slate-12 mb-1;
+}
+
+.form-row__hint {
+  @apply text-xs text-n-slate-11 mt-1;
+
+  &--warn {
+    @apply text-n-amber-11;
+  }
+}
+
+.wa-template-tokens {
+  @apply block mt-1 px-2 py-1 rounded text-xs bg-n-alpha-black2 text-n-slate-12;
+  font-family: monospace;
+}
+
+.wa-template-preview {
+  @apply rounded-md p-3 bg-n-alpha-black2 border border-solid border-n-weak;
+
+  &__label {
+    @apply text-xs font-semibold text-n-slate-11 mb-1;
+  }
+
+  &__body {
+    @apply text-sm whitespace-pre-wrap text-n-slate-12 mb-0;
+    font-family: monospace;
+  }
+}
+
+.wa-template-variable__key {
+  @apply text-xs font-mono px-2 py-1 rounded bg-n-alpha-black2 text-n-slate-12 flex-shrink-0;
+}
+</style>

--- a/app/javascript/dashboard/composables/useEditableAutomation.js
+++ b/app/javascript/dashboard/composables/useEditableAutomation.js
@@ -95,6 +95,11 @@ export function useEditableAutomation() {
         message: params[0].message,
       };
     }
+    // whatsapp_template stores a single config object inside the params
+    // array. Unwrap it for the form; actionQueryGenerator re-wraps on save.
+    if (inputType === 'whatsapp_template') {
+      return params[0] || {};
+    }
     return [...params];
   };
 

--- a/app/javascript/dashboard/helper/automationHelper.js
+++ b/app/javascript/dashboard/helper/automationHelper.js
@@ -335,7 +335,11 @@ export const getCustomAttributeType = (automationTypes, automation, key) => {
  * @returns {boolean} True if the action input should be shown, false otherwise.
  */
 export const showActionInput = (automationActionTypes, action) => {
-  if (action === 'send_email_to_team' || action === 'send_message')
+  if (
+    action === 'send_email_to_team' ||
+    action === 'send_message' ||
+    action === 'send_whatsapp_template'
+  )
     return false;
   const type = automationActionTypes.find(i => i.key === action).inputType;
   return !!type;

--- a/app/javascript/dashboard/helper/validations.js
+++ b/app/javascript/dashboard/helper/validations.js
@@ -131,6 +131,16 @@ const validateSingleAction = action => {
     'pending_conversation',
   ];
 
+  if (action.action_name === 'send_whatsapp_template') {
+    const config = Array.isArray(action.action_params)
+      ? action.action_params[0]
+      : action.action_params;
+    if (!config || !config.inbox_id || !config.template_name) {
+      return ACTION_PARAMETERS_REQUIRED;
+    }
+    return null;
+  }
+
   if (
     !noParamActions.includes(action.action_name) &&
     (!action.action_params || action.action_params.length === 0)

--- a/app/javascript/dashboard/i18n/locale/en/automation.json
+++ b/app/javascript/dashboard/i18n/locale/en/automation.json
@@ -99,7 +99,20 @@
       "TEAM_MESSAGE_INPUT_PLACEHOLDER": "Enter your message here",
       "TEAM_DROPDOWN_PLACEHOLDER": "Select teams",
       "EMAIL_INPUT_PLACEHOLDER": "Enter email",
-      "URL_INPUT_PLACEHOLDER": "Enter URL"
+      "URL_INPUT_PLACEHOLDER": "Enter URL",
+      "WHATSAPP_TEMPLATE": {
+        "OVERVIEW": "Pick a WhatsApp inbox and an approved template. When this rule fires on any conversation, the template is sent to the contact's phone number through the selected WhatsApp inbox — regardless of which channel the conversation came in on.",
+        "INBOX_LABEL": "Send from",
+        "INBOX_PLACEHOLDER": "Choose a WhatsApp inbox to send from",
+        "NO_WA_INBOXES": "No WhatsApp inboxes are connected to this account.",
+        "TEMPLATE_LABEL": "Template",
+        "TEMPLATE_PLACEHOLDER": "Choose an approved template",
+        "NO_TEMPLATES": "This inbox has no approved templates yet.",
+        "BODY_LABEL": "Template body",
+        "VARIABLES_LABEL": "Variables",
+        "VARIABLES_HINT": "Fill each variable. Use these placeholders for live contact / conversation / agent data at send time:",
+        "VARIABLE_PLACEHOLDER": "Static text or a placeholder"
+      }
     },
     "TOGGLE": {
       "ACTIVATION_TITLE": "Activate Automation Rule",
@@ -153,6 +166,7 @@
       "SEND_WEBHOOK_EVENT": "Send Webhook Event",
       "SEND_ATTACHMENT": "Send Attachment",
       "SEND_MESSAGE": "Send a Message",
+      "SEND_WHATSAPP_TEMPLATE": "Send a WhatsApp Template",
       "ADD_PRIVATE_NOTE": "Add a Private Note",
       "CHANGE_PRIORITY": "Change Priority",
       "ADD_SLA": "Add SLA",

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
@@ -791,6 +791,11 @@ export const AUTOMATION_ACTION_TYPES = [
     inputType: 'textarea',
   },
   {
+    key: 'send_whatsapp_template',
+    label: 'SEND_WHATSAPP_TEMPLATE',
+    inputType: 'whatsapp_template',
+  },
+  {
     key: 'add_private_note',
     label: 'ADD_PRIVATE_NOTE',
     inputType: 'textarea',

--- a/app/models/automation_rule.rb
+++ b/app/models/automation_rule.rb
@@ -116,17 +116,28 @@ class AutomationRule < ApplicationRecord
   end
 
   def validate_single_whatsapp_template_action(action)
+    config = whatsapp_template_config(action)
+    validate_whatsapp_template_inbox(config)
+    errors.add(:actions, 'send_whatsapp_template requires a template_name.') if whatsapp_template_name(config).blank?
+  end
+
+  def whatsapp_template_config(action)
     config = Array(action['action_params']).first
-    inbox_id = config.is_a?(Hash) ? (config['inbox_id'] || config[:inbox_id]) : nil
-    template_name = config.is_a?(Hash) ? (config['template_name'].presence || config[:template_name].presence) : nil
+    config.is_a?(Hash) ? config : {}
+  end
+
+  def whatsapp_template_name(config)
+    config['template_name'].presence || config[:template_name].presence
+  end
+
+  def validate_whatsapp_template_inbox(config)
+    inbox_id = config['inbox_id'] || config[:inbox_id]
 
     if inbox_id.blank?
       errors.add(:actions, 'send_whatsapp_template requires a WhatsApp inbox to send from.')
     elsif account.inboxes.where(id: inbox_id, channel_type: 'Channel::Whatsapp').none?
       errors.add(:actions, "Inbox #{inbox_id} is not a WhatsApp inbox in this account.")
     end
-
-    errors.add(:actions, 'send_whatsapp_template requires a template_name.') if template_name.blank?
   end
 end
 

--- a/app/models/automation_rule.rb
+++ b/app/models/automation_rule.rb
@@ -28,6 +28,7 @@ class AutomationRule < ApplicationRecord
   validate :json_actions_format
   validate :query_operator_presence
   validate :query_operator_value
+  validate :whatsapp_template_action_config
   validates :account_id, presence: true
 
   after_update_commit :reauthorized!, if: -> { saved_change_to_conditions? }
@@ -40,10 +41,10 @@ class AutomationRule < ApplicationRecord
   end
 
   def actions_attributes
-    %w[send_message add_label remove_label send_email_to_team assign_team assign_agent remove_assigned_agent
-       remove_assigned_team send_webhook_event mute_conversation send_attachment change_status resolve_conversation
-       open_conversation pending_conversation snooze_conversation change_priority send_email_transcript
-       add_private_note].freeze
+    %w[send_message send_whatsapp_template add_label remove_label send_email_to_team assign_team assign_agent
+       remove_assigned_agent remove_assigned_team send_webhook_event mute_conversation send_attachment change_status
+       resolve_conversation open_conversation pending_conversation snooze_conversation change_priority
+       send_email_transcript add_private_note].freeze
   end
 
   def file_base_data
@@ -103,6 +104,29 @@ class AutomationRule < ApplicationRecord
 
     operator = query_operator.upcase
     errors.add(:conditions, 'Query operator must be either "AND" or "OR"') unless %w[AND OR].include?(operator)
+  end
+
+  def whatsapp_template_action_config
+    return if actions.blank?
+    return if account.blank?
+
+    actions.select { |obj| obj['action_name'] == 'send_whatsapp_template' }.each do |action|
+      validate_single_whatsapp_template_action(action)
+    end
+  end
+
+  def validate_single_whatsapp_template_action(action)
+    config = Array(action['action_params']).first
+    inbox_id = config.is_a?(Hash) ? (config['inbox_id'] || config[:inbox_id]) : nil
+    template_name = config.is_a?(Hash) ? (config['template_name'].presence || config[:template_name].presence) : nil
+
+    if inbox_id.blank?
+      errors.add(:actions, 'send_whatsapp_template requires a WhatsApp inbox to send from.')
+    elsif account.inboxes.where(id: inbox_id, channel_type: 'Channel::Whatsapp').none?
+      errors.add(:actions, "Inbox #{inbox_id} is not a WhatsApp inbox in this account.")
+    end
+
+    errors.add(:actions, 'send_whatsapp_template requires a template_name.') if template_name.blank?
   end
 end
 

--- a/app/services/automation_rules/action_service.rb
+++ b/app/services/automation_rules/action_service.rb
@@ -67,10 +67,17 @@ class AutomationRules::ActionService < ActionService
   #   * contact missing or contact.phone_number blank
   #   * configured inbox not found, deleted, or not a WhatsApp channel
   def send_whatsapp_template(params)
-    config = Array(params).first
+    config = Array(params).first&.with_indifferent_access
     return if config.blank?
 
-    config = config.with_indifferent_access
+    target = resolve_whatsapp_target(config)
+    return if target.blank?
+
+    processed = AutomationRules::TemplatePlaceholderService.new(@conversation).substitute_processed_params(config[:processed_params])
+    Messages::MessageBuilder.new(nil, target, whatsapp_builder_params(config, processed)).perform
+  end
+
+  def resolve_whatsapp_target(config)
     inbox = whatsapp_target_inbox(config[:inbox_id])
     return if inbox.blank?
 
@@ -80,21 +87,7 @@ class AutomationRules::ActionService < ActionService
     contact_inbox = ContactInboxBuilder.new(contact: contact, inbox: inbox).perform
     return if contact_inbox.blank?
 
-    target_conversation = whatsapp_target_conversation(contact_inbox)
-    processed = AutomationRules::TemplatePlaceholderService.new(@conversation).substitute_processed_params(config[:processed_params])
-
-    Messages::MessageBuilder.new(nil, target_conversation, {
-                                  content: rendered_template_body(config, processed),
-                                  private: false,
-                                  content_attributes: { automation_rule_id: @rule.id },
-                                  template_params: {
-                                    name: config[:template_name],
-                                    namespace: config[:template_namespace],
-                                    language: config[:template_language],
-                                    category: config[:template_category],
-                                    processed_params: processed
-                                  }
-                                }).perform
+    whatsapp_target_conversation(contact_inbox)
   end
 
   def whatsapp_target_inbox(inbox_id)
@@ -105,6 +98,21 @@ class AutomationRules::ActionService < ActionService
 
   def whatsapp_target_conversation(contact_inbox)
     ConversationBuilder.new(params: ActionController::Parameters.new({}), contact_inbox: contact_inbox).perform
+  end
+
+  def whatsapp_builder_params(config, processed)
+    {
+      content: rendered_template_body(config, processed),
+      private: false,
+      content_attributes: { automation_rule_id: @rule.id },
+      template_params: {
+        name: config[:template_name],
+        namespace: config[:template_namespace],
+        language: config[:template_language],
+        category: config[:template_category],
+        processed_params: processed
+      }
+    }
   end
 
   # Rendered body is stored on the message record for the agent UI; the

--- a/app/services/automation_rules/action_service.rb
+++ b/app/services/automation_rules/action_service.rb
@@ -47,6 +47,76 @@ class AutomationRules::ActionService < ActionService
     Messages::MessageBuilder.new(nil, @conversation, params).perform
   end
 
+  # Sends an approved WhatsApp template to the contact's phone number,
+  # independent of what channel triggered the rule. Use case: an "I made
+  # payment" email comes in, the rule fires on the email conversation, and
+  # an acknowledgement template is sent to the same contact via WhatsApp.
+  #
+  # action_params shape (single-element array containing one config hash):
+  #   [{
+  #     "inbox_id":           5,                       # WhatsApp inbox to send FROM (required)
+  #     "template_name":      "appointment_reminder",
+  #     "template_language":  "en_US",
+  #     "template_namespace": nil,
+  #     "template_category":  "MARKETING",
+  #     "template_body":      "Hi {{1}}, ...",         # cached for content rendering
+  #     "processed_params":   { "1" => "{{contact.name}}", "2" => "tomorrow" }
+  #   }]
+  #
+  # Skip conditions (logged, no error):
+  #   * contact missing or contact.phone_number blank
+  #   * configured inbox not found, deleted, or not a WhatsApp channel
+  def send_whatsapp_template(params)
+    config = Array(params).first
+    return if config.blank?
+
+    config = config.with_indifferent_access
+    inbox = whatsapp_target_inbox(config[:inbox_id])
+    return if inbox.blank?
+
+    contact = @conversation.contact
+    return if contact.blank? || contact.phone_number.blank?
+
+    contact_inbox = ContactInboxBuilder.new(contact: contact, inbox: inbox).perform
+    return if contact_inbox.blank?
+
+    target_conversation = whatsapp_target_conversation(contact_inbox)
+    processed = AutomationRules::TemplatePlaceholderService.new(@conversation).substitute_processed_params(config[:processed_params])
+
+    Messages::MessageBuilder.new(nil, target_conversation, {
+                                  content: rendered_template_body(config, processed),
+                                  private: false,
+                                  content_attributes: { automation_rule_id: @rule.id },
+                                  template_params: {
+                                    name: config[:template_name],
+                                    namespace: config[:template_namespace],
+                                    language: config[:template_language],
+                                    category: config[:template_category],
+                                    processed_params: processed
+                                  }
+                                }).perform
+  end
+
+  def whatsapp_target_inbox(inbox_id)
+    return if inbox_id.blank?
+
+    @account.inboxes.find_by(id: inbox_id, channel_type: 'Channel::Whatsapp')
+  end
+
+  def whatsapp_target_conversation(contact_inbox)
+    ConversationBuilder.new(params: ActionController::Parameters.new({}), contact_inbox: contact_inbox).perform
+  end
+
+  # Rendered body is stored on the message record for the agent UI; the
+  # actual outbound payload to WhatsApp is built from processed_params by
+  # Whatsapp::SendOnWhatsappService.
+  def rendered_template_body(config, processed)
+    body = config[:template_body].presence || ''
+    return body if processed.blank?
+
+    body.gsub(/{{\s*(\d+)\s*}}/) { |match| processed[Regexp.last_match(1)].presence || match }
+  end
+
   def add_private_note(message)
     return if conversation_a_tweet?
 

--- a/app/services/automation_rules/template_placeholder_service.rb
+++ b/app/services/automation_rules/template_placeholder_service.rb
@@ -1,0 +1,41 @@
+class AutomationRules::TemplatePlaceholderService
+  include EmailHelper
+
+  # Resolves `{{ namespace.attribute }}` placeholders inside WhatsApp template
+  # parameter values at rule-execution time, using the Liquid drops Chatwoot
+  # already exposes for message rendering. The drops give us a single
+  # extensible surface (contact / conversation / inbox / account / agent) so
+  # rule authors can use the same tokens they already see in canned responses
+  # and campaign templates.
+  #
+  # Tokens that don't resolve produce an empty string rather than the literal
+  # placeholder, so the WhatsApp API never receives a `{{1}}`-style sentinel
+  # when contact data is missing.
+  def initialize(trigger_conversation)
+    @conversation = trigger_conversation
+    @drops = build_drops
+  end
+
+  def substitute(value)
+    return value unless value.is_a?(String)
+    return value unless value.include?('{{')
+
+    Liquid::Template.parse(value).render(@drops)
+  rescue Liquid::Error
+    value
+  end
+
+  def substitute_processed_params(processed_params)
+    return {} if processed_params.blank?
+
+    processed_params.transform_values { |v| substitute(v) }
+  end
+
+  private
+
+  def build_drops
+    drops = message_drops(@conversation)
+    drops['agent'] = UserDrop.new(@conversation.assignee) if @conversation.assignee.present?
+    drops
+  end
+end

--- a/spec/models/automation_rule_spec.rb
+++ b/spec/models/automation_rule_spec.rb
@@ -137,4 +137,46 @@ RSpec.describe AutomationRule do
       end
     end
   end
+
+  describe 'send_whatsapp_template action validation' do
+    let(:account) { create(:account) }
+    let(:whatsapp_inbox) { create(:channel_whatsapp, account: account, sync_templates: false, validate_provider_config: false).inbox }
+    let(:web_inbox) { create(:inbox, account: account) }
+
+    def build_rule(action_params)
+      build(:automation_rule,
+            account: account,
+            event_name: 'conversation_created',
+            conditions: [{ attribute_key: 'status', filter_operator: 'equal_to', values: ['open'], query_operator: nil }],
+            actions: [{ action_name: 'send_whatsapp_template', action_params: action_params }])
+    end
+
+    it 'is valid with a WhatsApp inbox and template_name' do
+      rule = build_rule([{
+                          inbox_id: whatsapp_inbox.id,
+                          template_name: 'sample_shipping_confirmation',
+                          template_language: 'en_US',
+                          processed_params: { '1' => '{{contact.name}}' }
+                        }])
+      expect(rule).to be_valid
+    end
+
+    it 'is invalid without an inbox_id' do
+      rule = build_rule([{ inbox_id: nil, template_name: 'sample_shipping_confirmation' }])
+      expect(rule).to be_invalid
+      expect(rule.errors[:actions].join).to include('requires a WhatsApp inbox')
+    end
+
+    it 'is invalid when the inbox is not a WhatsApp inbox' do
+      rule = build_rule([{ inbox_id: web_inbox.id, template_name: 'sample_shipping_confirmation' }])
+      expect(rule).to be_invalid
+      expect(rule.errors[:actions].join).to include('not a WhatsApp inbox')
+    end
+
+    it 'is invalid when template_name is missing' do
+      rule = build_rule([{ inbox_id: whatsapp_inbox.id }])
+      expect(rule).to be_invalid
+      expect(rule.errors[:actions].join).to include('requires a template_name')
+    end
+  end
 end

--- a/spec/services/automation_rules/action_service_spec.rb
+++ b/spec/services/automation_rules/action_service_spec.rb
@@ -274,12 +274,15 @@ RSpec.describe AutomationRules::ActionService do
       end
 
       it 'no-ops when the configured inbox is not a WhatsApp inbox' do
-        template_rule.update_columns(actions: [
-                                       {
-                                         action_name: 'send_whatsapp_template',
-                                         action_params: [template_config.merge('inbox_id' => email_inbox.id)]
-                                       }
-                                     ])
+        # The model-level whatsapp_template_action_config validation already
+        # blocks this state at save time. To exercise the runtime guard
+        # independently (e.g. inbox channel changed after a rule was saved),
+        # mutate the persisted JSONB column directly so model validations
+        # don't re-run.
+        bad_params = [template_config.merge('inbox_id' => email_inbox.id)]
+        AutomationRule.where(id: template_rule.id).update_all(actions: [ # rubocop:disable Rails/SkipsModelValidations
+                                                                { action_name: 'send_whatsapp_template', action_params: bad_params }
+                                                              ])
         expect do
           described_class.new(template_rule.reload, account, trigger_conversation).perform
         end.not_to(change(Message, :count))

--- a/spec/services/automation_rules/action_service_spec.rb
+++ b/spec/services/automation_rules/action_service_spec.rb
@@ -217,5 +217,73 @@ RSpec.describe AutomationRules::ActionService do
         expect(conversation.reload.assignee).to eq(agent)
       end
     end
+
+    describe '#perform with send_whatsapp_template action' do
+      let(:whatsapp_channel) { create(:channel_whatsapp, account: account, sync_templates: false, validate_provider_config: false) }
+      let(:whatsapp_inbox) { whatsapp_channel.inbox }
+      let(:email_inbox) { create(:inbox, account: account) }
+      let(:contact) { create(:contact, account: account, name: 'Jane Doe', email: 'jane@example.com', phone_number: '+15551234567') }
+      # Trigger conversation is on a NON-WhatsApp channel — proving the action is
+      # cross-channel: an email rule firing dispatches a WhatsApp template.
+      let(:trigger_conversation) { create(:conversation, account: account, inbox: email_inbox, contact: contact) }
+
+      let(:template_config) do
+        {
+          'inbox_id' => whatsapp_inbox.id,
+          'template_name' => 'sample_shipping_confirmation',
+          'template_language' => 'en_US',
+          'template_namespace' => '23423423_2342423_324234234_2343224',
+          'template_category' => 'SHIPPING_UPDATE',
+          'template_body' => 'Hi {{1}}, your order ships in {{2}} business days.',
+          'processed_params' => { '1' => '{{contact.name}}', '2' => '3' }
+        }
+      end
+
+      let(:template_rule) do
+        create(:automation_rule, account: account,
+                                 event_name: 'conversation_created',
+                                 actions: [{ action_name: 'send_whatsapp_template', action_params: [template_config] }])
+      end
+
+      it 'creates a WhatsApp conversation/message for the contact when triggered on a different channel' do
+        expect do
+          described_class.new(template_rule, account, trigger_conversation).perform
+        end.to change { whatsapp_inbox.conversations.count }.by(1)
+
+        wa_conv = whatsapp_inbox.conversations.last
+        expect(wa_conv.contact_id).to eq(contact.id)
+        expect(wa_conv.messages.count).to eq(1)
+
+        message = wa_conv.messages.last
+        expect(message.additional_attributes['template_params']).to include(
+          'name' => 'sample_shipping_confirmation',
+          'language' => 'en_US'
+        )
+        expect(message.additional_attributes['template_params']['processed_params']).to eq('1' => 'Jane Doe', '2' => '3')
+        # Body is the rendered template (Liquid drops resolve {{contact.name}} → 'Jane Doe').
+        expect(message.content).to eq('Hi Jane Doe, your order ships in 3 business days.')
+        expect(message.content_attributes['automation_rule_id']).to eq(template_rule.id)
+      end
+
+      it 'no-ops when the contact has no phone number' do
+        no_phone = create(:contact, account: account, name: 'Bob', email: 'bob@example.com', phone_number: nil)
+        no_phone_conv = create(:conversation, account: account, inbox: email_inbox, contact: no_phone)
+        expect do
+          described_class.new(template_rule, account, no_phone_conv).perform
+        end.not_to(change { whatsapp_inbox.conversations.count })
+      end
+
+      it 'no-ops when the configured inbox is not a WhatsApp inbox' do
+        template_rule.update_columns(actions: [
+                                       {
+                                         action_name: 'send_whatsapp_template',
+                                         action_params: [template_config.merge('inbox_id' => email_inbox.id)]
+                                       }
+                                     ])
+        expect do
+          described_class.new(template_rule.reload, account, trigger_conversation).perform
+        end.not_to(change(Message, :count))
+      end
+    end
   end
 end

--- a/spec/services/automation_rules/template_placeholder_service_spec.rb
+++ b/spec/services/automation_rules/template_placeholder_service_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe AutomationRules::TemplatePlaceholderService do
+  subject(:service) { described_class.new(conversation) }
+
   let(:account) { create(:account) }
   let(:agent) { create(:user, account: account, name: 'Alice Agent', email: 'alice@example.com') }
   let(:contact) { create(:contact, account: account, name: 'Bob Buyer', email: 'bob@example.com', phone_number: '+15551234567') }
   let(:inbox) { create(:inbox, account: account, name: 'Support Email') }
   let(:conversation) { create(:conversation, account: account, inbox: inbox, contact: contact, assignee: agent) }
-
-  subject(:service) { described_class.new(conversation) }
 
   describe '#substitute' do
     it 'resolves contact tokens via Liquid drops' do
@@ -23,7 +23,7 @@ RSpec.describe AutomationRules::TemplatePlaceholderService do
     end
 
     it 'resolves agent tokens when an assignee exists' do
-      expect(service.substitute('Reply to {{agent.name}}')).to eq("Reply to #{agent.available_name}")
+      expect(service.substitute('Reply to {{agent.name}}')).to eq("Reply to #{agent.name}")
     end
 
     it 'leaves agent tokens empty when there is no assignee' do

--- a/spec/services/automation_rules/template_placeholder_service_spec.rb
+++ b/spec/services/automation_rules/template_placeholder_service_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe AutomationRules::TemplatePlaceholderService do
+  let(:account) { create(:account) }
+  let(:agent) { create(:user, account: account, name: 'Alice Agent', email: 'alice@example.com') }
+  let(:contact) { create(:contact, account: account, name: 'Bob Buyer', email: 'bob@example.com', phone_number: '+15551234567') }
+  let(:inbox) { create(:inbox, account: account, name: 'Support Email') }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox, contact: contact, assignee: agent) }
+
+  subject(:service) { described_class.new(conversation) }
+
+  describe '#substitute' do
+    it 'resolves contact tokens via Liquid drops' do
+      expect(service.substitute('Hi {{contact.name}}, email {{contact.email}}')).to eq('Hi Bob Buyer, email bob@example.com')
+    end
+
+    it 'resolves inbox tokens (handy when the trigger inbox name is descriptive)' do
+      expect(service.substitute('Thanks for emailing {{inbox.name}}')).to eq('Thanks for emailing Support Email')
+    end
+
+    it 'resolves conversation tokens' do
+      expect(service.substitute('Ref #{{conversation.display_id}}')).to eq("Ref ##{conversation.display_id}")
+    end
+
+    it 'resolves agent tokens when an assignee exists' do
+      expect(service.substitute('Reply to {{agent.name}}')).to eq("Reply to #{agent.available_name}")
+    end
+
+    it 'leaves agent tokens empty when there is no assignee' do
+      conversation.update!(assignee: nil)
+      svc = described_class.new(conversation.reload)
+      expect(svc.substitute('Reply to {{agent.name}}')).to eq('Reply to ')
+    end
+
+    it 'passes through values that contain no liquid markers' do
+      expect(service.substitute('Tomorrow at 3pm')).to eq('Tomorrow at 3pm')
+    end
+
+    it 'returns non-string values unchanged' do
+      expect(service.substitute(nil)).to be_nil
+      expect(service.substitute(42)).to eq(42)
+    end
+  end
+
+  describe '#substitute_processed_params' do
+    it 'transforms every value in the hash' do
+      result = service.substitute_processed_params('1' => '{{contact.name}}', '2' => 'literal')
+      expect(result).to eq('1' => 'Bob Buyer', '2' => 'literal')
+    end
+
+    it 'returns an empty hash for blank input' do
+      expect(service.substitute_processed_params(nil)).to eq({})
+      expect(service.substitute_processed_params({})).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
Supersedes #14460 (the original PR was force-pushed after close, which GitHub blocks reopening — so this is a new PR with the same branch).

## Summary
- Adds a new **Send a WhatsApp Template** automation action that's intentionally **cross-channel** — the rule can fire on any conversation (email, web chat, SMS, …) and the action sends an approved WhatsApp template to the contact's phone number through a configured WhatsApp inbox.
- Use case: an "I made payment" email comes in → rule fires on the email conversation → an acknowledgement template is sent to the same contact via WhatsApp. No inbox condition required on the rule.
- Variables support Chatwoot's existing Liquid drops, so rule authors can use `{{contact.name}}`, `{{contact.email}}`, `{{contact.phone_number}}`, `{{conversation.display_id}}`, `{{inbox.name}}`, `{{agent.name}}`, custom attributes, etc.

## How it works
1. UI: `AutomationActionWhatsappTemplateInput.vue` (Vue 3 script-setup). Three-step picker: pick a WhatsApp inbox to send from → pick an approved template → fill its variables (with a placeholders hint). Live body preview.
2. The action stores `[{ inbox_id, template_name, template_language, template_namespace, template_category, template_body, processed_params }]`.
3. At fire time, `AutomationRules::ActionService#send_whatsapp_template`:
   - Skips silently if `contact.phone_number` is blank or the configured inbox is missing / not a WhatsApp channel.
   - `ContactInboxBuilder` finds/creates a ContactInbox for the contact on the configured WhatsApp inbox.
   - `ConversationBuilder` reuses an existing conversation when the inbox is `lock_to_single_conversation?` (the WhatsApp default) or creates a new one.
   - Resolves placeholders via `AutomationRules::TemplatePlaceholderService` (Liquid drops), then `Messages::MessageBuilder` creates an outgoing message with `template_params` in `additional_attributes`. `Whatsapp::SendOnWhatsappService` dispatches it as a template.
4. `AutomationRule` validates at save time that the configured inbox is `Channel::Whatsapp` in the same account and that `template_name` is present.

## Test plan
- [ ] Backend specs:
  - [ ] `spec/services/automation_rules/template_placeholder_service_spec.rb` — Liquid drop substitution, missing assignee, blank input
  - [ ] `spec/services/automation_rules/action_service_spec.rb` — cross-channel send (email trigger → WhatsApp message created on the target inbox), phone-missing no-op, non-WhatsApp inbox no-op
  - [ ] `spec/models/automation_rule_spec.rb` — validation errors for missing inbox / non-WA inbox / missing template_name
- [ ] Manual UI:
  - [ ] Create a rule, event = Message Created, condition = Message contains "payment".
  - [ ] Add action **Send a WhatsApp Template** → pick a WhatsApp inbox → pick an approved template with `{{1}}` → set variable to `{{contact.name}}` → save.
  - [ ] Send an email matching the condition to the support inbox from a contact that has a phone number set.
  - [ ] Confirm a new (or existing) WhatsApp conversation on the configured inbox receives the template with `{{contact.name}}` resolved.
  - [ ] Repeat with a contact that has no phone number → confirm no WhatsApp message is sent.
  - [ ] Save the rule with no inbox / a non-WhatsApp inbox / no template → confirm validation rejects it.
  - [ ] Reopen the rule for editing → confirm the inbox, template, and variable values round-trip correctly.