### PR TITLE
fix: render markdown in CSAT survey messages

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/CSAT.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/CSAT.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue';
 import BaseBubble from './Base.vue';
+import FormattedContent from './Text/FormattedContent.vue';
 import { useI18n } from 'vue-i18n';
 import { CSAT_RATINGS, CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
 import { useMessageContext } from '../provider.js';
@@ -41,7 +42,8 @@ const starRatingValue = computed(() => {
 
 <template>
   <BaseBubble class="px-4 py-3" data-bubble-name="csat">
-    <h4>{{ content || t('CONVERSATION.CSAT_REPLY_MESSAGE') }}</h4>
+    <FormattedContent v-if="content" :content="content" />
+    <h4 v-else>{{ t('CONVERSATION.CSAT_REPLY_MESSAGE') }}</h4>
     <dl v-if="isRatingSubmitted" class="mt-4">
       <dt class="text-n-slate-11 italic">
         {{ t('CONVERSATION.RATING_TITLE') }}

--- a/app/javascript/entrypoints/survey.js
+++ b/app/javascript/entrypoints/survey.js
@@ -1,8 +1,10 @@
 import { createApp } from 'vue';
 import { createI18n } from 'vue-i18n';
+import VueDOMPurifyHTML from 'vue-dompurify-html';
 import store from '../survey/store';
 import i18nMessages from '../survey/i18n';
 import App from '../survey/App.vue';
+import { domPurifyConfig } from '../shared/helpers/HTMLSanitizer';
 
 const app = createApp(App);
 const i18n = createI18n({
@@ -12,6 +14,7 @@ const i18n = createI18n({
 
 app.use(i18n);
 app.use(store);
+app.use(VueDOMPurifyHTML, domPurifyConfig);
 
 window.onload = () => {
   window.WOOT_SURVEY = app.mount('#app');

--- a/app/javascript/shared/components/CustomerSatisfaction.vue
+++ b/app/javascript/shared/components/CustomerSatisfaction.vue
@@ -4,6 +4,7 @@ import Spinner from 'shared/components/Spinner.vue';
 import { CSAT_RATINGS, CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
 import FluentIcon from 'shared/components/FluentIcon/Index.vue';
 import StarRating from 'shared/components/StarRating.vue';
+import { useMessageFormatter } from 'shared/composables/useMessageFormatter';
 import { getContrastingTextColor } from '@chatwoot/utils';
 
 export default {
@@ -29,6 +30,10 @@ export default {
       type: String,
       default: '',
     },
+  },
+  setup() {
+    const { formatMessage } = useMessageFormatter();
+    return { formatMessage };
   },
   data() {
     return {
@@ -58,6 +63,9 @@ export default {
       return this.isRatingSubmitted
         ? this.$t('CSAT.SUBMITTED_TITLE')
         : this.message || this.$t('CSAT.TITLE');
+    },
+    formattedTitle() {
+      return this.formatMessage(this.title, false);
     },
     isEmojiType() {
       return this.displayType === CSAT_DISPLAY_TYPES.EMOJI;
@@ -122,9 +130,10 @@ export default {
     class="customer-satisfaction w-full bg-n-background dark:bg-n-solid-3 shadow-[0_0.25rem_6px_rgba(50,50,93,0.08),0_1px_3px_rgba(0,0,0,0.05)] ltr:rounded-bl-[0.25rem] rtl:rounded-br-[0.25rem] rounded-lg inline-block leading-[1.5] mt-1 border-t-2 border-t-n-brand border-solid"
     :style="{ borderColor: widgetColor }"
   >
-    <h6 class="text-n-slate-12 text-sm font-medium pt-5 px-2.5 text-center">
-      {{ title }}
-    </h6>
+    <h6
+      v-dompurify-html="formattedTitle"
+      class="text-n-slate-12 text-sm font-medium pt-5 px-2.5 text-center prose prose-bubble"
+    />
     <div v-if="isEmojiType" class="ratings flex justify-around py-5 px-4">
       <button
         v-for="rating in ratings"

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -6,6 +6,7 @@ import Rating from 'survey/components/Rating.vue';
 import Feedback from 'survey/components/Feedback.vue';
 import Banner from 'survey/components/Banner.vue';
 import StarRating from 'shared/components/StarRating.vue';
+import { useMessageFormatter } from 'shared/composables/useMessageFormatter';
 import { getSurveyDetails, updateSurvey } from 'survey/api/survey';
 
 import { CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
@@ -19,6 +20,10 @@ export default {
     Banner,
     Feedback,
     StarRating,
+  },
+  setup() {
+    const { formatMessage } = useMessageFormatter();
+    return { formatMessage };
   },
   data() {
     return {
@@ -71,6 +76,9 @@ export default {
         return this.errorMessage;
       }
       return this.$t('SURVEY.RATING.SUCCESS_MESSAGE');
+    },
+    formattedMessageContent() {
+      return this.formatMessage(this.messageContent, false);
     },
   },
   async mounted() {
@@ -158,12 +166,11 @@ export default {
     >
       <div class="w-full px-12 pt-12 pb-6 m-auto my-0">
         <img v-if="logo" :src="logo" alt="Chatwoot logo" class="mb-6 logo" />
-        <p
+        <div
           v-if="!isRatingSubmitted"
-          class="mb-8 text-lg leading-relaxed text-n-slate-12"
-        >
-          {{ messageContent }}
-        </p>
+          v-dompurify-html="formattedMessageContent"
+          class="mb-8 text-lg leading-relaxed text-n-slate-12 prose prose-bubble"
+        />
         <Banner
           v-if="shouldShowBanner"
           :show-success="shouldShowSuccessMessage"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes CSAT survey messages so markdown formatting in survey questions (links, bold, italic, etc.) renders correctly instead of appearing as raw markdown text. Previously, agent-authored prompts such as `Help us improve! [Share your experience](https://...)` were displayed with literal markdown syntax, causing links and formatting to break.

Editor messages already passed through the markdown formatter, but the three CSAT survey render surfaces did not. This change aligns CSAT rendering with the existing editor message behavior.

Fixes https://linear.app/chatwoot/issue/CW-7105/markdown-editor-bug-links-are-not-parsed-properly

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="584" height="244" alt="image" src="https://github.com/user-attachments/assets/4ccd5b38-69c5-4284-b2e8-4d78e267a016" />
<img width="422" height="666" alt="image" src="https://github.com/user-attachments/assets/4e1125b0-c6b5-4379-a691-4917184a6d97" />

<img width="773" height="468" alt="image" src="https://github.com/user-attachments/assets/bb075c94-d2f8-4d73-a212-66cc8e7c2a9f" />


**After**
<img width="566" height="216" alt="image" src="https://github.com/user-attachments/assets/ca5b5438-3da7-4f83-8ce4-dd746191eb98" />
<img width="424" height="665" alt="image" src="https://github.com/user-attachments/assets/c63ae6b2-f8fa-44fd-a305-0a9099f7c013" />
<img width="772" height="399" alt="image" src="https://github.com/user-attachments/assets/4f4cca4b-6688-407b-84f3-7df49f68a7d8" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
