### PR TITLE
feat: enable quoted reply for everyone

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -5,7 +5,6 @@ import { useAlert } from 'dashboard/composables';
 import { useUISettings } from 'dashboard/composables/useUISettings';
 import { useTrack } from 'dashboard/composables';
 import keyboardEventListenerMixins from 'shared/mixins/keyboardEventListenerMixins';
-import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 
 import ReplyToMessage from './ReplyToMessage.vue';
 import AttachmentPreview from 'dashboard/components/widgets/AttachmentsPreview.vue';
@@ -144,8 +143,6 @@ export default {
       currentUser: 'getCurrentUser',
       lastEmail: 'getLastEmailInSelectedChat',
       globalConfig: 'globalConfig/get',
-      accountId: 'getCurrentAccountId',
-      isFeatureEnabledonAccount: 'accounts/isFeatureEnabledonAccount',
     }),
     currentContact() {
       const senderId = this.currentChat?.meta?.sender?.id;
@@ -384,14 +381,8 @@ export default {
       const { slug = '' } = portal;
       return slug;
     },
-    isQuotedEmailReplyEnabled() {
-      return this.isFeatureEnabledonAccount(
-        this.accountId,
-        FEATURE_FLAGS.QUOTED_EMAIL_REPLY
-      );
-    },
     quotedReplyPreference() {
-      if (!this.isAnEmailChannel || !this.isQuotedEmailReplyEnabled) {
+      if (!this.isAnEmailChannel) {
         return false;
       }
 
@@ -416,11 +407,7 @@ export default {
       return truncatePreviewText(this.quotedEmailText, 80);
     },
     shouldShowQuotedReplyToggle() {
-      return (
-        this.isAnEmailChannel &&
-        !this.isOnPrivateNote &&
-        this.isQuotedEmailReplyEnabled
-      );
+      return this.isAnEmailChannel && !this.isOnPrivateNote;
     },
     shouldShowQuotedPreview() {
       return (
@@ -577,7 +564,6 @@ export default {
     },
     shouldIncludeQuotedEmail() {
       return (
-        this.isQuotedEmailReplyEnabled &&
         this.quotedReplyPreference &&
         this.shouldShowQuotedReplyToggle &&
         !!this.quotedEmailText

--- a/app/javascript/dashboard/featureFlags.js
+++ b/app/javascript/dashboard/featureFlags.js
@@ -43,7 +43,6 @@ export const FEATURE_FLAGS = {
   CAPTAIN_TASKS: 'captain_tasks',
   CAPTAIN_DOCUMENT_AUTO_SYNC: 'captain_document_auto_sync',
   SAML: 'saml',
-  QUOTED_EMAIL_REPLY: 'quoted_email_reply',
   COMPANIES: 'companies',
   ADVANCED_SEARCH: 'advanced_search',
   CONVERSATION_REQUIRED_ATTRIBUTES: 'conversation_required_attributes',

--- a/config/features.yml
+++ b/config/features.yml
@@ -219,6 +219,7 @@
 - name: quoted_email_reply
   display_name: Quoted Email Reply
   enabled: false
+  deprecated: true
 - name: companies
   display_name: Companies
   enabled: false

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -181,10 +181,6 @@ describe Messages::MessageBuilder do
       end
 
       context 'when custom email content is provided' do
-        before do
-          account.enable_features('quoted_email_reply')
-        end
-
         it 'creates message with custom HTML email content' do
           params = ActionController::Parameters.new({
                                                       content: 'Regular message content',


### PR DESCRIPTION
Quoted email replies is now available to every account by default. Previously this was gated behind the `quoted_email_reply` account-level feature flag, so accounts needed it toggled on (via Super Admin) before agents saw the toggle in the reply box.

## How to test

1. Open any conversation on an email inbox.
2. Confirm the **Quote previous email** toggle is visible in the reply box (and is **not** visible on private notes or non-email channels).
3. Toggle it on, type a reply, and send — the outbound email should include the quoted prior email below your message.
4. Toggle it off and send another reply — the quoted block should not appear.
5. The toggle preference should persist per channel type (UI setting), as before.
6. Verify the toggle works on a brand new account with no feature flags flipped on (previously it would have been hidden).

## What changed

- Removed all `isFeatureEnabledonAccount(..., QUOTED_EMAIL_REPLY)` gates from `ReplyBox.vue`, so the toggle and quoted-content behavior are unconditional on email channels.
- Removed the `QUOTED_EMAIL_REPLY` constant from `dashboard/featureFlags.js`.
- Marked the flag as `deprecated: true` in `config/features.yml` (kept the entry in place to preserve FlagShihTzu bit positions on existing accounts; `deprecated: true` hides it from the Super Admin UI).
- Dropped the now-unnecessary `account.enable_features('quoted_email_reply')` setup from the message builder spec.
