### PR TITLE
chore(features): document bit-position constraint and guard 63-feature ceiling

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1,11 +1,31 @@
 # DO NOT change the order of features EVER
 ############################################
+# Positions in this file map 1-to-1 to bit positions in the
+# `accounts.feature_flags` bigint column (via `flag_shih_tzu`). Inserting,
+# removing, or reordering entries shifts every following bit and silently
+# reinterprets stored `feature_flags` values for every existing account.
+#
+# The column is a signed bigint (max 2^63 − 1), which gives 63 usable bits.
+# Bit 63 is the sign bit: enabling the 64th feature on any account triggers
+# `ActiveModel::RangeError` on save. A spec in `spec/config/features_spec.rb`
+# enforces this ceiling.
+#
+# Protocol for changes:
+#   - Adding a feature → APPEND to the end of this file. Never insert in
+#     the middle.
+#   - Retiring a feature → mark `deprecated: true`. Never delete the entry
+#     (deletion shifts every following bit).
+#   - Out of slots (63 reached) → RECLAIM a `deprecated: true` entry by
+#     renaming it in place. Recent precedents: commits c7ce26c9, d6827eb2,
+#     b25e85ed, bb235ea5.
+#
+# Field reference:
 # name: the name to be used internally in the code
 # display_name: the name to be used in the UI
 # enabled: whether the feature is enabled by default
 # help_url: the url to the help center article
 # chatwoot_internal: whether the feature is internal to Chatwoot and should not be shown in the UI for other self hosted installations
-# deprecated: purpose of feature flag is done, no need to show it in the UI anymore
+# deprecated: purpose of feature flag is done, no need to show it in the UI anymore. Keep the entry so the bit slot stays reserved.
 - name: inbound_emails
   display_name: Inbound Emails
   enabled: true

--- a/spec/config/features_spec.rb
+++ b/spec/config/features_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+# The accounts.feature_flags column is a signed bigint, which gives 63 usable
+# bit slots (bit 63 is the sign bit). Each entry in config/features.yml is
+# bound to the bit position implied by its index in the file, so inserting,
+# removing, or reordering entries silently reinterprets stored feature_flags
+# values for every existing account.
+#
+# These specs are deliberately minimal regressions:
+#   * Cap the count so a 64th feature can't ship without triaging the column
+#     overflow first (an issue and a discussion thread should accompany any
+#     bump above 63 — likely a reclaim of a deprecated slot).
+#   * Detect duplicate names so a typo or merge conflict cannot quietly map
+#     two features to the same bit.
+# rubocop:disable RSpec/DescribeClass
+describe 'config/features.yml' do
+  # rubocop:enable RSpec/DescribeClass
+  let(:features) { YAML.safe_load(Rails.root.join('config/features.yml').read) }
+
+  it 'stays within the 63-bit ceiling of the signed bigint feature_flags column' do
+    expect(features.size).to be <= 63,
+                              "config/features.yml has #{features.size} entries, but the signed bigint " \
+                              'accounts.feature_flags column only supports 63 bit slots (bit 63 is the sign bit). ' \
+                              'Reclaim a `deprecated: true` entry by renaming it in place instead of appending. ' \
+                              'See the protocol notes at the top of config/features.yml.'
+  end
+
+  it 'has no duplicate feature names' do
+    names = features.pluck('name')
+    duplicates = names.tally.select { |_, n| n > 1 }.keys
+    expect(duplicates).to be_empty, "Duplicate feature names in config/features.yml: #{duplicates}"
+  end
+end


### PR DESCRIPTION
## Why

`config/features.yml` positions map 1-to-1 to bit positions in the `accounts.feature_flags` signed bigint column, which gives only 63 usable slots (bit 63 is the sign bit). The file is currently at **exactly 63 entries**, so the next feature appended without first reclaiming a `deprecated: true` slot will trigger `ActiveModel::RangeError` on every account that enables it.

This isn't theoretical — we hit it in our environment when #12231 was rebased on `develop`: the inserted-in-the-middle entry shifted `advanced_assignment` from bit 62 to bit 63, silently misaligned feature lists for 12 accounts, and broke every SuperAdmin save with:

```
ActiveModel::RangeError (18444351259918991351 is out of range
                        for ActiveModel::Type::Integer with limit 8 bytes)
  enterprise/app/controllers/enterprise/super_admin/accounts_controller.rb:24
```

Full write-up in #14474; reproduction details in the comment on #12231.

The file header already says `# DO NOT change the order of features EVER`, but it doesn't explain *why* or what to do once the list is full — both of which become non-obvious when a contributor is racing to ship.

## What this PR does

- **Expand the header in `config/features.yml`** to document the protocol explicitly: append-only, reclaim `deprecated: true` slots when full, never delete or reorder. References the recent reclaim precedents (`c7ce26c9`, `d6827eb2`, `b25e85ed`, `bb235ea5`).

- **Add `spec/config/features_spec.rb`** that fails CI when:
  - the entry count exceeds 63 (with a message pointing at the reclaim pattern), or
  - a duplicate name slips in (e.g. a merge conflict mapping two features to the same bit).

The spec is intentionally minimal — it's a regression net, not an architectural change. The structural follow-up (lifting the 63-bit ceiling itself, likely via a second `feature_flags` column when reclaim runs out) is tracked in #14474.

## How to test

```bash
bundle exec rspec spec/config/features_spec.rb
```

Both examples should pass on current `develop`. To verify the count guard fails as intended, append a 64th entry to `config/features.yml` locally and rerun.

## Notes for reviewers

- No runtime code paths change; this is purely a doc + CI guard.
- `Featurable::FEATURE_LIST` already loads the same YAML, but I kept the spec's loading independent so a regression in `Featurable` can't mask a regression in the file itself.
- I'm happy to fold this into a larger structural PR if maintainers prefer to address the ceiling here too — let me know which direction is more useful.