### PR TITLE
Remove Instagram scopes from Facebook auth

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Facebook.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Facebook.vue
@@ -168,7 +168,7 @@ export default {
         },
         {
           scope:
-            'pages_manage_metadata,business_management,pages_messaging,instagram_basic,pages_show_list,pages_read_engagement,instagram_manage_messages',
+            'pages_manage_metadata,business_management,pages_messaging,pages_show_list,pages_read_engagement',
         }
       );
     },

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/facebook/Reauthorize.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/facebook/Reauthorize.vue
@@ -78,7 +78,7 @@ export default {
         },
         {
           scope:
-            'pages_manage_metadata,business_management,pages_messaging,instagram_basic,pages_show_list,pages_read_engagement,instagram_manage_messages',
+            'pages_manage_metadata,business_management,pages_messaging,pages_show_list,pages_read_engagement',
           auth_type: 'reauthorize',
         }
       );


### PR DESCRIPTION
Fixes #13860.

This removes the Instagram-related permissions from the Facebook OAuth scope used when creating and reauthorizing Facebook inboxes.

Removed scopes:
- `instagram_basic`
- `instagram_manage_messages`

Verification:
- `pnpm exec eslint app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Facebook.vue app/javascript/dashboard/routes/dashboard/settings/inbox/facebook/Reauthorize.vue`