### PR TITLE
fix: reset campaign preview before Astro view transition

### DIFF
--- a/app/javascript/entrypoints/sdk.js
+++ b/app/javascript/entrypoints/sdk.js
@@ -43,9 +43,10 @@ const runSDK = ({ baseUrl, websiteToken }) => {
   }
 
   // if this is an astro app
-  document.addEventListener('astro:before-swap', event =>
-    restoreWidgetInDOM(event.newDocument.body)
-  );
+  document.addEventListener('astro:before-swap', event => {
+    IFrameHelper.events.resetTransientView();
+    restoreWidgetInDOM(event.newDocument.body);
+  });
 
   const chatwootSettings = window.chatwootSettings || {};
   let locale = chatwootSettings.locale;

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -268,6 +268,19 @@ export const IFrameHelper = {
     },
 
     resetUnreadMode: () => removeUnreadClass(),
+    resetTransientView: () => {
+      const holderEl = document.querySelector('.woot-widget-holder');
+      if (!holderEl?.classList.contains('has-unread-view')) {
+        return;
+      }
+
+      removeUnreadClass();
+      IFrameHelper.setFrameHeightToFitContent(0, false);
+
+      if (window.$chatwoot.isOpen) {
+        IFrameHelper.events.toggleBubble('close');
+      }
+    },
     handleNotificationDot: event => {
       if (window.$chatwoot.hideMessageBubble) {
         return;

--- a/app/javascript/sdk/specs/IFrameHelper.spec.js
+++ b/app/javascript/sdk/specs/IFrameHelper.spec.js
@@ -1,0 +1,56 @@
+import { IFrameHelper } from '../IFrameHelper';
+
+describe('#IFrameHelper', () => {
+  describe('#resetTransientView', () => {
+    let toggleBubbleSpy;
+
+    beforeEach(() => {
+      window.$chatwoot = { isOpen: true };
+      document.body.innerHTML = `
+        <div class="woot-widget-holder has-unread-view">
+          <iframe id="chatwoot_live_chat_widget" style="height: 293px !important"></iframe>
+        </div>
+      `;
+      toggleBubbleSpy = vi
+        .spyOn(IFrameHelper.events, 'toggleBubble')
+        .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      toggleBubbleSpy.mockRestore();
+      document.body.innerHTML = '';
+      delete window.$chatwoot;
+    });
+
+    it('closes and restores iframe height when the transient unread view is visible', () => {
+      IFrameHelper.events.resetTransientView();
+
+      expect(
+        document
+          .querySelector('.woot-widget-holder')
+          .classList.contains('has-unread-view')
+      ).toBe(false);
+      expect(
+        document
+          .getElementById('chatwoot_live_chat_widget')
+          .style.getPropertyValue('height')
+      ).toBe('100%');
+      expect(toggleBubbleSpy).toHaveBeenCalledWith('close');
+    });
+
+    it('leaves the widget untouched when no transient view is visible', () => {
+      document
+        .querySelector('.woot-widget-holder')
+        .classList.remove('has-unread-view');
+
+      IFrameHelper.events.resetTransientView();
+
+      expect(
+        document
+          .getElementById('chatwoot_live_chat_widget')
+          .style.getPropertyValue('height')
+      ).toBe('293px');
+      expect(toggleBubbleSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
When an Astro View Transition starts while a live chat campaign preview is open, the SDK now clears that transient preview state before preserving the widget DOM. This prevents the widget iframe from carrying the campaign preview height into the next page and reopening as a tiny, deformed chat window.

Closes

- Closes #13153

How to reproduce

1. Install the Chatwoot SDK in an Astro app with View Transitions enabled.
2. Enable a live chat campaign on a page.
3. Wait for the campaign notification to appear.
4. Navigate to another page without clicking or closing the campaign notification.

How to test

1. Repeat the reproduction steps above.
2. Confirm the widget does not automatically reopen as a tiny/deformed chat window after the Astro transition.
3. Confirm a normal chat widget that is not in the campaign/unread preview state is still preserved across Astro navigation.

What changed

- Reset the SDK's transient unread/campaign preview mode before Astro swaps the document body.
- Restore the iframe height before preserving the widget DOM.
- Added SDK coverage for resetting only the transient preview state.