### PR TITLE
fix: make zadd function optimised to stay in rubocop limits

### DIFF
--- a/lib/redis/alfred.rb
+++ b/lib/redis/alfred.rb
@@ -127,13 +127,9 @@ module Redis::Alfred
     # add score and value for a key
     # Modern Redis syntax: zadd(key, [[score, member], ...])
     def zadd(key, score, value = nil)
-      if value.nil? && score.is_a?(Array)
-        # New syntax: score is actually an array of [score, member] pairs
-        $alfred.with { |conn| conn.zadd(key, score) }
-      else
-        # Support old syntax for backward compatibility
-        $alfred.with { |conn| conn.zadd(key, [[score, value]]) }
-      end
+      # New syntax: score is an array of [score, member] pairs; old syntax: discrete score/value
+      pairs = value.nil? && score.is_a?(Array) ? score : [[score, value]]
+      $alfred.with { |conn| conn.zadd(key, pairs) }
     end
 
     # get score of a value for key


### PR DESCRIPTION
## Description
Fixes rubocop for alfred.rb file on develop 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
