### PR TITLE
fix: preload inbox conversation filter

### DIFF
--- a/app/javascript/shared/composables/specs/useFilter.spec.js
+++ b/app/javascript/shared/composables/specs/useFilter.spec.js
@@ -141,5 +141,24 @@ describe('useFilter', () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toHaveProperty('attribute_key', 'inbox_id');
     });
+
+    it('should normalize conversation inbox route param to a number', () => {
+      const { initializeInboxTeamAndLabelFilterToModal } = useFilter({
+        filteri18nKey: 'TEST',
+        attributeModel: 'conversation',
+      });
+      const result = initializeInboxTeamAndLabelFilterToModal(
+        '1',
+        { name: 'Inbox 1' },
+        null,
+        null,
+        null
+      );
+
+      expect(result[0].values[0]).toEqual({
+        id: 1,
+        name: 'Inbox 1',
+      });
+    });
   });
 });

--- a/app/javascript/shared/composables/useFilter.js
+++ b/app/javascript/shared/composables/useFilter.js
@@ -137,7 +137,7 @@ export const useFilter = ({ filteri18nKey, attributeModel }) => {
         filter_operator: 'equal_to',
         values: [
           {
-            id: conversationInbox,
+            id: Number(conversationInbox),
             name: inbox.name,
           },
         ],


### PR DESCRIPTION
## Summary
- Normalize the conversation inbox route param before initializing the inbox filter
- Add coverage for string route params so the selected inbox matches numeric inbox options

Fixes #14409

## Tests
- corepack pnpm vitest run app/javascript/shared/composables/specs/useFilter.spec.js --no-coverage --no-cache
- .\\node_modules\\.bin\\eslint.CMD app/javascript/shared/composables/useFilter.js app/javascript/shared/composables/specs/useFilter.spec.js