### PR TITLE
fix: initialize default audio alert tone

### DIFF
--- a/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js
@@ -88,7 +88,7 @@ export class DashboardAudioNotificationHelper {
       tone: audioAlertTone,
     };
 
-    if (previousAudioTone !== audioAlertTone) {
+    if (!this.audioConfig.audio || previousAudioTone !== audioAlertTone) {
       this.intializeAudio();
     }
 

--- a/app/javascript/dashboard/helper/AudioAlerts/specs/DashboardAudioNotificationHelper.spec.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/specs/DashboardAudioNotificationHelper.spec.js
@@ -1,0 +1,87 @@
+import { DashboardAudioNotificationHelper } from '../DashboardAudioNotificationHelper';
+import { initFaviconSwitcher } from '../faviconHelper';
+
+vi.mock('dashboard/store', () => ({
+  default: {
+    getters: {
+      getMineChats: vi.fn(),
+      getSelectedChat: null,
+      getCurrentAccountId: 1,
+      getConversationById: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../faviconHelper', () => ({
+  initFaviconSwitcher: vi.fn(),
+  showBadgeOnFavicon: vi.fn(),
+}));
+
+vi.mock('dashboard/composables', () => ({
+  useAlert: vi.fn(),
+}));
+
+describe('DashboardAudioNotificationHelper', () => {
+  let store;
+  let load;
+
+  beforeEach(() => {
+    load = vi.fn();
+    global.Audio = vi.fn().mockImplementation(src => ({
+      src,
+      load,
+      play: vi.fn(),
+    }));
+
+    store = {
+      getters: {
+        getMineChats: vi.fn().mockReturnValue([]),
+        getSelectedChat: null,
+        getCurrentAccountId: 1,
+        getConversationById: vi.fn(),
+      },
+    };
+  });
+
+  it('initializes the default audio tone when the helper has no audio loaded', () => {
+    const helper = new DashboardAudioNotificationHelper(store);
+
+    helper.set({
+      currentUser: { id: 1 },
+      alwaysPlayAudioAlert: false,
+      alertIfUnreadConversationExist: false,
+      audioAlertType: 'all',
+      audioAlertTone: 'ding',
+    });
+
+    expect(global.Audio).toHaveBeenCalledWith('/audio/dashboard/ding.mp3');
+    expect(load).toHaveBeenCalled();
+    expect(helper.audioConfig.audio).toBeTruthy();
+    expect(initFaviconSwitcher).toHaveBeenCalled();
+  });
+
+  it('reinitializes audio when the alert tone changes', () => {
+    const helper = new DashboardAudioNotificationHelper(store);
+
+    helper.set({
+      currentUser: { id: 1 },
+      alwaysPlayAudioAlert: false,
+      alertIfUnreadConversationExist: false,
+      audioAlertType: 'all',
+      audioAlertTone: 'ding',
+    });
+
+    helper.set({
+      currentUser: { id: 1 },
+      alwaysPlayAudioAlert: false,
+      alertIfUnreadConversationExist: false,
+      audioAlertType: 'all',
+      audioAlertTone: 'bell',
+    });
+
+    expect(global.Audio).toHaveBeenNthCalledWith(
+      2,
+      '/audio/dashboard/bell.mp3'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Initialize dashboard audio when no audio element has been loaded yet, even if the selected tone is still the default `ding`
- Add coverage for default tone initialization and tone changes

Fixes #14295

## Tests
- corepack pnpm vitest run app/javascript/dashboard/helper/AudioAlerts/specs/DashboardAudioNotificationHelper.spec.js app/javascript/dashboard/helper/AudioAlerts/specs/AudioNotificationStore.spec.js app/javascript/dashboard/helper/AudioAlerts/specs/AudioMessageHelper.spec.js --no-coverage --no-cache
- .\\node_modules\\.bin\\eslint.CMD app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js app/javascript/dashboard/helper/AudioAlerts/specs/DashboardAudioNotificationHelper.spec.js