### PR TITLE
fix: reset widget conversation on restart

### DIFF
--- a/app/javascript/widget/components/ChatFooter.vue
+++ b/app/javascript/widget/components/ChatFooter.vue
@@ -58,8 +58,15 @@ export default {
     emitter.on(BUS_EVENTS.TOGGLE_REPLY_TO_MESSAGE, this.toggleReplyTo);
   },
   methods: {
-    ...mapActions('conversation', ['sendMessage', 'sendAttachment']),
-    ...mapActions('conversationAttributes', ['getAttributes']),
+    ...mapActions('conversation', [
+      'sendMessage',
+      'sendAttachment',
+      'clearConversations',
+    ]),
+    ...mapActions('conversationAttributes', [
+      'getAttributes',
+      'clearConversationAttributes',
+    ]),
     async handleSendMessage(content) {
       await this.sendMessage({
         content,
@@ -80,6 +87,8 @@ export default {
       this.inReplyTo = null;
     },
     startNewConversation() {
+      this.clearConversations();
+      this.clearConversationAttributes();
       this.router.replace({ name: 'prechat-form' });
       IFrameHelper.sendMessage({
         event: 'onEvent',

--- a/app/javascript/widget/components/specs/ChatFooter.spec.js
+++ b/app/javascript/widget/components/specs/ChatFooter.spec.js
@@ -1,0 +1,113 @@
+import { shallowMount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import { useRouter } from 'vue-router';
+
+import ChatFooter from '../ChatFooter.vue';
+import { IFrameHelper } from 'widget/helpers/utils';
+import { CHATWOOT_ON_START_CONVERSATION } from 'widget/constants/sdkEvents';
+
+vi.mock('vue-router', () => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock('widget/helpers/utils', () => ({
+  IFrameHelper: {
+    sendMessage: vi.fn(),
+  },
+}));
+
+const createWrapper = ({ conversationAttributes = {} } = {}) => {
+  const replace = vi.fn();
+  const clearConversations = vi.fn();
+  const clearConversationAttributes = vi.fn();
+
+  vi.mocked(useRouter).mockReturnValue({ replace });
+
+  const store = createStore({
+    modules: {
+      conversation: {
+        namespaced: true,
+        getters: {
+          getConversationSize: () => 1,
+        },
+        actions: {
+          sendMessage: vi.fn(),
+          sendAttachment: vi.fn(),
+          clearConversations,
+        },
+      },
+      conversationAttributes: {
+        namespaced: true,
+        getters: {
+          getConversationParams: () => ({
+            id: 1,
+            status: 'resolved',
+            ...conversationAttributes,
+          }),
+        },
+        actions: {
+          getAttributes: vi.fn(),
+          clearConversationAttributes,
+        },
+      },
+      appConfig: {
+        namespaced: true,
+        getters: {
+          getWidgetColor: () => '#1f93ff',
+          isWidgetStyleFlat: () => false,
+        },
+      },
+      contacts: {
+        namespaced: true,
+        getters: {
+          getCurrentUser: () => ({ has_email: false }),
+        },
+      },
+    },
+  });
+
+  const wrapper = shallowMount(ChatFooter, {
+    global: {
+      plugins: [store],
+      mocks: {
+        $t: key => key,
+      },
+    },
+  });
+
+  return {
+    clearConversationAttributes,
+    clearConversations,
+    replace,
+    wrapper,
+  };
+};
+
+describe('ChatFooter', () => {
+  beforeEach(() => {
+    window.chatwootWebChannel = {
+      allowMessagesAfterResolved: false,
+    };
+    vi.clearAllMocks();
+  });
+
+  it('clears resolved conversation state before starting a new conversation', () => {
+    const {
+      clearConversationAttributes,
+      clearConversations,
+      replace,
+      wrapper,
+    } = createWrapper();
+
+    wrapper.vm.startNewConversation();
+
+    expect(clearConversations).toHaveBeenCalled();
+    expect(clearConversationAttributes).toHaveBeenCalled();
+    expect(replace).toHaveBeenCalledWith({ name: 'prechat-form' });
+    expect(IFrameHelper.sendMessage).toHaveBeenCalledWith({
+      event: 'onEvent',
+      eventIdentifier: CHATWOOT_ON_START_CONVERSATION,
+      data: { hasConversation: true },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Clear the widget conversation messages when a visitor starts a new conversation from a resolved thread
- Clear the resolved conversation attributes before navigating into the new conversation flow
- Add coverage for resetting resolved conversation state from the widget footer

Fixes #12171

## Tests
- corepack pnpm vitest run app/javascript/widget/components/specs/ChatFooter.spec.js app/javascript/widget/store/modules/specs/conversation/mutations.spec.js app/javascript/widget/store/modules/specs/conversationAttributes/mutations.spec.js --no-coverage --no-cache
- .\\node_modules\\.bin\\eslint.CMD app/javascript/widget/components/ChatFooter.vue app/javascript/widget/components/specs/ChatFooter.spec.js