### PR TITLE
docs: add Sealos deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The modern customer support platform, an open-source alternative to Intercom, Ze
   <a href="https://marketplace.digitalocean.com/apps/chatwoot?refcode=f2238426a2a8" alt="Deploy to DigitalOcean">
      <img width="200" alt="Deploy to DO" src="https://www.deploytodo.com/do-btn-blue.svg"/>
   </a>
+  <a href="https://sealos.io/products/app-store/chatwoot/" alt="Deploy on Sealos">
+     <img width="180" alt="Deploy on Sealos" src="https://sealos.io/Deploy-on-Sealos.svg"/>
+  </a>
 </p>
 
 <img src="./.github/screenshots/dashboard.png#gh-light-mode-only" width="100%" alt="Chat dashboard dark mode"/>
@@ -116,6 +119,14 @@ Chatwoot now supports 1-Click deployment to DigitalOcean as a kubernetes app.
 <a href="https://marketplace.digitalocean.com/apps/chatwoot?refcode=f2238426a2a8" alt="Deploy to DigitalOcean">
   <img width="200" alt="Deploy to DO" src="https://www.deploytodo.com/do-btn-blue.svg"/>
 </a>
+
+### Sealos one-click deployment
+
+Chatwoot can also be deployed on Sealos using the one-click template:
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/chatwoot/)
+
+The Sealos template provisions the Chatwoot web service, Sidekiq worker, PostgreSQL, Redis, ingress, and persistent storage for `/app/storage`.
 
 ### Other deployment options
 


### PR DESCRIPTION
## Description

This PR adds Sealos as a one-click deployment option for Chatwoot.

It adds:
- a Deploy on Sealos button to the README deployment buttons
- a short Sealos deployment section under `## Deployment`

This is a documentation-only change and does not change Chatwoot runtime behavior.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- Checked the README change locally.
- Confirmed the Sealos deploy button SVG returns `200`.
- Confirmed the Sealos Chatwoot App Store page returns `200`: https://sealos.io/products/app-store/chatwoot/

Notes:
- The linked Sealos template provisions the Chatwoot web service, Sidekiq worker, PostgreSQL, Redis, ingress, and persistent storage for `/app/storage`.
- This PR does not change application code or deployment defaults in this repository.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
