### PR TITLE
feat(attachments): add XML and PFX file support

### DIFF
--- a/app/javascript/dashboard/components-next/icon/FileIcon.vue
+++ b/app/javascript/dashboard/components-next/icon/FileIcon.vue
@@ -27,6 +27,7 @@ const fileTypeIcon = computed(() => {
     txt: 'i-woot-file-txt',
     xls: 'i-woot-file-xls',
     xlsx: 'i-woot-file-xls',
+    xml: 'i-woot-file-txt',
     zip: 'i-woot-file-zip',
   };
 

--- a/app/javascript/shared/constants/messages.js
+++ b/app/javascript/shared/constants/messages.js
@@ -39,12 +39,14 @@ export const ALLOWED_FILE_TYPES =
   'audio/*,' +
   'video/*,' +
   '.3gpp,' +
+  '.xls, .xlsx, .xml, .pfx,' +
   'text/csv, text/plain, application/json, application/pdf, text/rtf,' +
   'application/xml, text/xml,' +
   'application/zip, application/x-7z-compressed application/vnd.rar application/x-tar,' +
   'application/msword, application/vnd.ms-excel, application/vnd.ms-powerpoint, application/vnd.oasis.opendocument.text,' +
   'application/vnd.openxmlformats-officedocument.presentationml.presentation, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,' +
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document,';
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document,' +
+  'application/x-pkcs12, application/pkcs12,';
 
 export const CSAT_RATINGS = [
   {

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -25,8 +25,9 @@ class Attachment < ApplicationRecord
   include Rails.application.routes.url_helpers
 
   ACCEPTABLE_FILE_TYPES = %w[
-    text/csv text/plain text/rtf
+    text/csv text/plain text/rtf text/xml
     application/json application/pdf
+    application/xml
     application/zip application/x-7z-compressed application/vnd.rar application/x-tar
     application/msword application/vnd.ms-excel application/vnd.ms-powerpoint application/rtf
     application/vnd.oasis.opendocument.text
@@ -35,7 +36,7 @@ class Attachment < ApplicationRecord
     application/vnd.openxmlformats-officedocument.wordprocessingml.document
     application/x-pkcs12 application/pkcs12
   ].freeze
-  ACCEPTABLE_FILE_EXTENSIONS = %w[pfx].freeze
+  ACCEPTABLE_FILE_EXTENSIONS = %w[pfx xml].freeze
   GENERIC_FILE_CONTENT_TYPES = %w[application/octet-stream].freeze
   belongs_to :account
   belongs_to :message


### PR DESCRIPTION
Update frontend allowed file types and FileIcon mapping, and backend Attachment constants to accept .xml and .pfx files

# Pull Request Template

## Description
Customer also wanted XML support along with .pfx

Following up on #14456

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
locally

<img width="864" height="512" alt="CleanShot 2026-05-22 at 11 43 20@2x" src="https://github.com/user-attachments/assets/4cbf65d4-b919-4a4b-bf75-a4f2e8690586" />

<img width="870" height="1440" alt="CleanShot 2026-05-22 at 11 44 03@2x" src="https://github.com/user-attachments/assets/e763b49d-4365-4c45-9b43-b0c39af87656" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
