### PR TITLE
fix: improve widget select option contrast

### DIFF
--- a/app/javascript/widget/assets/scss/woot.scss
+++ b/app/javascript/widget/assets/scss/woot.scss
@@ -101,6 +101,10 @@ select:not(.reset-base) {
   background-repeat: no-repeat;
   background-size: 9px 6px;
   font-family: inherit;
+
+  option {
+    @apply bg-white text-slate-600;
+  }
 }
 
 p code {


### PR DESCRIPTION
Fixes the native select dropdown contrast in the web widget so options remain readable when the widget is using the dark theme.

## Closes

N/A

## How to test

- Open a dark-themed web widget with a form that includes a select field.
- Open the select dropdown and verify all options are readable against the native dropdown background.
- Confirm the select input itself still matches the widget theme.

## What changed

- Sets native widget select options to a light background with dark text, independent of the widget dark theme variables.

## Validation

- `pnpm exec scss-lint app/javascript/widget/assets/scss/woot.scss`
