### PR TITLE
fix: prevent WhatsApp message status downgrades

### DIFF
--- a/app/services/messages/status_update_service.rb
+++ b/app/services/messages/status_update_service.rb
@@ -1,4 +1,10 @@
 class Messages::StatusUpdateService
+  STATUS_PRIORITY = {
+    'sent' => 1,
+    'delivered' => 2,
+    'read' => 3
+  }.freeze
+
   attr_reader :message, :status, :external_error
 
   def initialize(message, status, external_error = nil)
@@ -25,10 +31,12 @@ class Messages::StatusUpdateService
 
   def valid_status_transition?
     return false unless Message.statuses.key?(status)
+    return true if status == 'failed'
 
-    # Don't allow changing from 'read' to 'delivered'
-    return false if message.read? && status == 'delivered'
+    current_priority = STATUS_PRIORITY[message.status]
+    next_priority = STATUS_PRIORITY[status]
+    return true if current_priority.blank? || next_priority.blank?
 
-    true
+    next_priority >= current_priority
   end
 end

--- a/app/services/messages/status_update_service.rb
+++ b/app/services/messages/status_update_service.rb
@@ -22,11 +22,11 @@ class Messages::StatusUpdateService
   private
 
   def update_message_status
-    # Update status and set external_error only when failed
-    message.update!(
-      status: status,
-      external_error: (status == 'failed' ? external_error : nil)
-    )
+    update_attributes = { status: status }
+    update_attributes[:external_error] = nil unless status == 'failed'
+    update_attributes[:external_error] = external_error if status == 'failed' && !external_error.nil?
+
+    message.update!(update_attributes)
   end
 
   def valid_status_transition?

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -57,12 +57,13 @@ class Whatsapp::IncomingMessageBaseService
   end
 
   def update_message_with_status(message, status)
-    message.status = status[:status]
+    external_error = nil
     if status[:status] == 'failed' && status[:errors].present?
       error = status[:errors]&.first
-      message.external_error = "#{error[:code]}: #{error[:title]}"
+      external_error = "#{error[:code]}: #{error[:title]}"
     end
-    message.save!
+
+    Messages::StatusUpdateService.new(message, status[:status], external_error).perform
   end
 
   def create_messages

--- a/spec/services/messages/status_update_service_spec.rb
+++ b/spec/services/messages/status_update_service_spec.rb
@@ -27,6 +27,21 @@ describe Messages::StatusUpdateService do
         expect(message.reload.status).to eq('failed')
         expect(message.reload.external_error).to eq('some error')
       end
+
+      it 'updates delivered messages to read' do
+        message.update!(status: 'delivered')
+        service = described_class.new(message, 'read')
+        service.perform
+        expect(message.reload.status).to eq('read')
+      end
+
+      it 'allows failed status from read messages' do
+        message.update!(status: 'read')
+        service = described_class.new(message, 'failed', 'some error')
+        service.perform
+        expect(message.reload.status).to eq('failed')
+        expect(message.reload.external_error).to eq('some error')
+      end
     end
 
     context 'when status is invalid' do
@@ -38,6 +53,20 @@ describe Messages::StatusUpdateService do
       it 'prevents transition from read to delivered' do
         message.update!(status: 'read')
         service = described_class.new(message, 'delivered')
+        expect(service.perform).to be false
+        expect(message.reload.status).to eq('read')
+      end
+
+      it 'prevents transition from delivered to sent' do
+        message.update!(status: 'delivered')
+        service = described_class.new(message, 'sent')
+        expect(service.perform).to be false
+        expect(message.reload.status).to eq('delivered')
+      end
+
+      it 'prevents transition from read to sent' do
+        message.update!(status: 'read')
+        service = described_class.new(message, 'sent')
         expect(service.perform).to be false
         expect(message.reload.status).to eq('read')
       end

--- a/spec/services/messages/status_update_service_spec.rb
+++ b/spec/services/messages/status_update_service_spec.rb
@@ -28,6 +28,14 @@ describe Messages::StatusUpdateService do
         expect(message.reload.external_error).to eq('some error')
       end
 
+      it 'preserves external_error when failed status has no error' do
+        message.update!(status: 'failed', external_error: 'previous error')
+        service = described_class.new(message, 'failed')
+        service.perform
+        expect(message.reload.status).to eq('failed')
+        expect(message.reload.external_error).to eq('previous error')
+      end
+
       it 'updates delivered messages to read' do
         message.update!(status: 'delivered')
         service = described_class.new(message, 'read')

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -267,6 +267,44 @@ describe Whatsapp::IncomingMessageService do
         )
       end
 
+      it 'does not downgrade delivered messages to sent' do
+        status_params = {
+          'statuses' => [{ 'recipient_id' => from, 'id' => from, 'status' => 'sent' }]
+        }.with_indifferent_access
+
+        message = Message.find_by!(source_id: from)
+        message.update!(status: :delivered)
+
+        described_class.new(inbox: whatsapp_channel.inbox, params: status_params).perform
+
+        expect(message.reload.status).to eq('delivered')
+      end
+
+      it 'does not downgrade read messages to delivered' do
+        status_params = {
+          'statuses' => [{ 'recipient_id' => from, 'id' => from, 'status' => 'delivered' }]
+        }.with_indifferent_access
+
+        message = Message.find_by!(source_id: from)
+        message.update!(status: :read)
+
+        described_class.new(inbox: whatsapp_channel.inbox, params: status_params).perform
+
+        expect(message.reload.status).to eq('read')
+      end
+
+      it 'updates status message from sent to delivered' do
+        status_params = {
+          'statuses' => [{ 'recipient_id' => from, 'id' => from, 'status' => 'delivered' }]
+        }.with_indifferent_access
+
+        message = Message.find_by!(source_id: from)
+
+        described_class.new(inbox: whatsapp_channel.inbox, params: status_params).perform
+
+        expect(message.reload.status).to eq('delivered')
+      end
+
       it 'update status message to failed' do
         status_params = {
           'statuses' => [{ 'recipient_id' => from, 'id' => from, 'status' => 'failed',

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -318,6 +318,18 @@ describe Whatsapp::IncomingMessageService do
         expect(message.external_error).to eq('123: abc')
       end
 
+      it 'preserves external error when failed status has no errors' do
+        status_params = {
+          'statuses' => [{ 'recipient_id' => from, 'id' => from, 'status' => 'failed' }]
+        }.with_indifferent_access
+
+        message = Message.find_by!(source_id: from)
+        message.update!(status: :failed, external_error: 'previous failure')
+        described_class.new(inbox: whatsapp_channel.inbox, params: status_params).perform
+        expect(message.reload.status).to eq('failed')
+        expect(message.external_error).to eq('previous failure')
+      end
+
       it 'will not throw error if unsupported status' do
         status_params = {
           'statuses' => [{ 'recipient_id' => from, 'id' => from, 'status' => 'deleted',


### PR DESCRIPTION
## Description

Fixes #14529.

WhatsApp Cloud API status webhooks can arrive out of order. A delayed lower-priority status, such as `sent`, should not downgrade a message that is already `delivered` or `read`.

This change centralizes message status transition validation in `Messages::StatusUpdateService` and routes WhatsApp status updates through it.

## Changes

- Add ordered status transition validation for `sent`, `delivered`, and `read`
- Allow `failed` updates to continue recording provider errors
- Use `Messages::StatusUpdateService` for WhatsApp webhook status updates
- Add regression coverage for delivered/read downgrade attempts and valid forward transitions

## Tests

- `bundle _2.5.16_ exec rspec spec/services/messages/status_update_service_spec.rb spec/services/whatsapp/incoming_message_service_spec.rb`
- `bundle _2.5.16_ exec rubocop app/services/messages/status_update_service.rb app/services/whatsapp/incoming_message_base_service.rb spec/services/messages/status_update_service_spec.rb spec/services/whatsapp/incoming_message_service_spec.rb`