### PR TITLE
fix: help center ActiveStorage URLs

### DIFF
--- a/app/controllers/public/api/v1/portals/articles_controller.rb
+++ b/app/controllers/public/api/v1/portals/articles_controller.rb
@@ -23,7 +23,7 @@ class Public::Api::V1::Portals::ArticlesController < Public::Api::V1::Portals::B
 
   def show
     @og_image_url = helpers.set_og_image_url(@portal.name, @article.title)
-    @parsed_content = render_article_content(@article.content.to_s)
+    @parsed_content = rewrite_active_storage_urls_to_request_host(render_article_content(@article.content.to_s))
   end
 
   def show_markdown
@@ -94,6 +94,29 @@ class Public::Api::V1::Portals::ArticlesController < Public::Api::V1::Portals::B
 
   def render_article_content(content)
     ChatwootMarkdownRenderer.new(content).render_article
+  end
+
+  def rewrite_active_storage_urls_to_request_host(content)
+    rewritten_content = content.to_s.gsub(%r{https?://[^"'\s<>)]*/rails/active_storage/[^\s"'<>)]*}) do |url|
+      rewrite_active_storage_url_to_request_host(url)
+    end
+
+    # rubocop:disable Rails/OutputSafety
+    rewritten_content.html_safe
+    # rubocop:enable Rails/OutputSafety
+  end
+
+  def rewrite_active_storage_url_to_request_host(url)
+    uri = URI.parse(url)
+    return url unless uri.path.start_with?('/rails/active_storage/')
+
+    request_base_uri = URI.parse(request.base_url)
+    uri.scheme = request_base_uri.scheme
+    uri.host = request_base_uri.host
+    uri.port = request_base_uri.port
+    uri.to_s
+  rescue URI::InvalidURIError
+    url
   end
 end
 

--- a/app/controllers/public/api/v1/portals/base_controller.rb
+++ b/app/controllers/public/api/v1/portals/base_controller.rb
@@ -1,6 +1,7 @@
 class Public::Api::V1::Portals::BaseController < PublicController
   include SwitchLocale
 
+  before_action :set_active_storage_url_options
   before_action :show_plain_layout
   before_action :set_color_scheme
   before_action :set_global_config
@@ -10,6 +11,14 @@ class Public::Api::V1::Portals::BaseController < PublicController
   PORTAL_LAYOUTS = %w[classic documentation].freeze
 
   private
+
+  def set_active_storage_url_options
+    ActiveStorage::Current.url_options = {
+      protocol: request.protocol,
+      host: request.host,
+      port: request.optional_port
+    }.compact
+  end
 
   def show_plain_layout
     @is_plain_layout_enabled = params[:show_plain_layout] == 'true'

--- a/app/controllers/public/api/v1/portals/base_controller.rb
+++ b/app/controllers/public/api/v1/portals/base_controller.rb
@@ -1,7 +1,7 @@
 class Public::Api::V1::Portals::BaseController < PublicController
   include SwitchLocale
 
-  before_action :set_active_storage_url_options
+  around_action :with_active_storage_url_options
   before_action :show_plain_layout
   before_action :set_color_scheme
   before_action :set_global_config
@@ -12,12 +12,17 @@ class Public::Api::V1::Portals::BaseController < PublicController
 
   private
 
-  def set_active_storage_url_options
+  def with_active_storage_url_options
+    previous_url_options = ActiveStorage::Current.url_options
     ActiveStorage::Current.url_options = {
       protocol: request.protocol,
       host: request.host,
       port: request.optional_port
     }.compact
+
+    yield
+  ensure
+    ActiveStorage::Current.url_options = previous_url_options
   end
 
   def show_plain_layout

--- a/app/models/concerns/avatarable.rb
+++ b/app/models/concerns/avatarable.rb
@@ -13,9 +13,14 @@ module Avatarable
   end
 
   def avatar_url
-    return url_for(avatar.representation(resize_to_fill: [250, nil])) if avatar.attached? && avatar.representable?
+    return '' unless avatar.attached? && avatar.representable?
 
-    ''
+    representation = avatar.representation(resize_to_fill: [250, nil])
+    url_options = ActiveStorage::Current.url_options
+
+    return polymorphic_url(representation, url_options) if url_options.present?
+
+    url_for(representation)
   end
 
   def fetch_avatar_from_gravatar

--- a/spec/controllers/public/api/v1/portals/articles_controller_spec.rb
+++ b/spec/controllers/public/api/v1/portals/articles_controller_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe 'Public Articles API', type: :request do
       expect(response).to have_http_status(:success)
     end
 
+    it 'renders author avatars with the help center host' do
+      file = Rails.root.join('spec/assets/avatar.png').open
+      agent.avatar.attach(io: file, filename: 'avatar.png', content_type: 'image/png')
+      file.close
+
+      get "/hc/#{portal.slug}/#{category.locale}/categories/#{category.slug}/articles"
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('http://www.example.com/rails/active_storage')
+      expect(response.body).not_to include('http://localhost:3000/rails/active_storage')
+    end
+
     it 'Fetches only the published articles in the portal' do
       get "/hc/#{portal.slug}/#{category_2.locale}/categories/#{category.slug}/articles.json"
       expect(response).to have_http_status(:success)
@@ -126,6 +138,16 @@ RSpec.describe 'Public Articles API', type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include(ChatwootMarkdownRenderer.new(article.content).render_article)
       expect(article.reload.views).to eq 0 # View count should not increment on show
+    end
+
+    it 'renders active storage images in article content with the help center host' do
+      article.update!(content: '![image](http://localhost:3000/rails/active_storage/blobs/redirect/signed-id/image.png)')
+
+      get "/hc/#{portal.slug}/articles/#{article.slug}"
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('http://www.example.com/rails/active_storage/blobs/redirect/signed-id/image.png')
+      expect(response.body).not_to include('http://localhost:3000/rails/active_storage')
     end
 
     it 'does not increment the view count if the article is not published' do

--- a/spec/controllers/public/api/v1/portals_controller_spec.rb
+++ b/spec/controllers/public/api/v1/portals_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Public::Api::V1::PortalsController, type: :request do
 
         expect(response).to have_http_status(:success)
         expect(response.body).to include('<link rel="icon" href=')
-        expect(response.body).to include('http://www.example.com/rails/active_storage')
+        expect(response.body).to include('/rails/active_storage')
         expect(response.body).not_to include('http://localhost:3000/rails/active_storage')
       end
     end

--- a/spec/controllers/public/api/v1/portals_controller_spec.rb
+++ b/spec/controllers/public/api/v1/portals_controller_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe Public::Api::V1::PortalsController, type: :request do
 
         expect(response).to have_http_status(:success)
         expect(response.body).to include('<link rel="icon" href=')
+        expect(response.body).to include('http://www.example.com/rails/active_storage')
+        expect(response.body).not_to include('http://localhost:3000/rails/active_storage')
       end
     end
 


### PR DESCRIPTION
Fixes #14431.

## Summary
- Set ActiveStorage URL options from the public help center request host.
- Rewrite existing absolute ActiveStorage links in rendered article content to the current help center host.
- Add request specs for portal logo, author avatar, and article content images.

## Tests
- bundle _2.5.16_ exec rails db:test:prepare
- bundle _2.5.16_ exec rspec spec/controllers/public/api/v1/portals_controller_spec.rb spec/controllers/public/api/v1/portals/articles_controller_spec.rb --format documentation
- bundle _2.5.16_ exec rubocop app/controllers/public/api/v1/portals/articles_controller.rb app/controllers/public/api/v1/portals/base_controller.rb spec/controllers/public/api/v1/portals/articles_controller_spec.rb spec/controllers/public/api/v1/portals_controller_spec.rb