### PR TITLE
feat(auth): add language switcher to pre-auth screens

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/login.json
+++ b/app/javascript/dashboard/i18n/locale/en/login.json
@@ -23,6 +23,7 @@
     "FORGOT_PASSWORD": "Forgot your password?",
     "CREATE_NEW_ACCOUNT": "Create a new account",
     "SUBMIT": "Login",
+    "LANGUAGE_SELECTOR_LABEL": "Language",
     "SAML": {
       "LABEL": "Login via SSO",
       "TITLE": "Initiate Single Sign-on (SSO)",

--- a/app/javascript/entrypoints/v3app.js
+++ b/app/javascript/entrypoints/v3app.js
@@ -1,5 +1,6 @@
 import { createApp } from 'vue';
 import { createI18n } from 'vue-i18n';
+import { directive as onClickaway } from 'vue3-click-away';
 
 import i18nMessages from 'dashboard/i18n';
 import * as Sentry from '@sentry/vue';
@@ -31,6 +32,7 @@ app.use(router);
 // Vue.use(VueRouter);
 // Vue.use(VueI18n);
 // Vue.prototype.$emitter = emitter;
+app.directive('on-clickaway', onClickaway);
 app.component('fluent-icon', FluentIcon);
 
 if (window.errorLoggingConfig) {

--- a/app/javascript/v3/App.vue
+++ b/app/javascript/v3/App.vue
@@ -1,15 +1,20 @@
 <script>
 import SnackbarContainer from './components/SnackBar/Container.vue';
+import LocaleSwitcher from './components/LocaleSwitcher.vue';
+
+const LOCALE_STORAGE_KEY = 'cw.auth.locale';
 
 export default {
-  components: { SnackbarContainer },
+  components: { SnackbarContainer, LocaleSwitcher },
   data() {
     return { theme: 'light' };
   },
   mounted() {
     this.setColorTheme();
     this.listenToThemeChanges();
-    this.setLocale(window.chatwootConfig.selectedLocale);
+    this.setLocale(
+      this.readStoredLocale() || window.chatwootConfig.selectedLocale
+    );
   },
   methods: {
     setColorTheme() {
@@ -39,6 +44,13 @@ export default {
         this.$root.$i18n.locale = locale;
       }
     },
+    readStoredLocale() {
+      try {
+        return localStorage.getItem(LOCALE_STORAGE_KEY);
+      } catch (_) {
+        return null;
+      }
+    },
   },
 };
 </script>
@@ -46,6 +58,7 @@ export default {
 <template>
   <div class="h-full min-h-screen w-full antialiased" :class="theme">
     <router-view />
+    <LocaleSwitcher />
     <SnackbarContainer />
   </div>
 </template>

--- a/app/javascript/v3/components/LocaleSwitcher.vue
+++ b/app/javascript/v3/components/LocaleSwitcher.vue
@@ -1,0 +1,77 @@
+<script setup>
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useConfig } from 'dashboard/composables/useConfig';
+
+import Button from 'dashboard/components-next/button/Button.vue';
+
+const STORAGE_KEY = 'cw.auth.locale';
+
+const { t, locale } = useI18n();
+const { enabledLanguages } = useConfig();
+
+const isOpen = ref(false);
+
+const options = computed(() => enabledLanguages ?? []);
+const currentLabel = computed(() => {
+  const match = options.value.find(o => o.iso_639_1_code === locale.value);
+  return match?.name ?? t('LOGIN.LANGUAGE_SELECTOR_LABEL');
+});
+
+const toggleMenu = () => {
+  isOpen.value = !isOpen.value;
+};
+
+const handleSelect = code => {
+  locale.value = code;
+  try {
+    localStorage.setItem(STORAGE_KEY, code);
+  } catch (_) {
+    // localStorage unavailable (private mode, SSR) — fall back to in-memory only.
+  }
+  isOpen.value = false;
+};
+</script>
+
+<template>
+  <div
+    v-if="options.length > 1"
+    class="fixed bottom-4 inset-x-0 flex justify-center pointer-events-none z-50"
+  >
+    <div
+      v-on-clickaway="() => (isOpen = false)"
+      class="relative pointer-events-auto"
+    >
+      <Button
+        icon="i-lucide-globe"
+        size="sm"
+        color="slate"
+        variant="faded"
+        trailing-icon
+        class="!w-fit max-w-64"
+        :class="{ 'dark:!bg-n-alpha-2 !bg-n-slate-9/20': isOpen }"
+        :label="currentLabel"
+        :aria-label="t('LOGIN.LANGUAGE_SELECTOR_LABEL')"
+        @click="toggleMenu"
+      />
+      <div
+        v-if="isOpen"
+        class="absolute bottom-full mb-1 ltr:left-1/2 rtl:right-1/2 ltr:-translate-x-1/2 rtl:translate-x-1/2 select-none max-w-64 flex flex-col gap-1 bg-n-alpha-3 backdrop-blur-[100px] p-1 shadow-lg z-40 rounded-lg border border-n-weak dark:border-n-strong/50"
+      >
+        <Button
+          v-for="lang in options"
+          :key="lang.iso_639_1_code"
+          :label="lang.name"
+          :icon="lang.iso_639_1_code === locale ? 'i-lucide-check' : ''"
+          size="sm"
+          variant="ghost"
+          color="slate"
+          trailing-icon
+          class="!justify-end !px-2.5 !h-7"
+          :class="{ '!bg-n-alpha-2': lang.iso_639_1_code === locale }"
+          @click="handleSelect(lang.iso_639_1_code)"
+        />
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
# Pull Request Template

## Description

Pre-auth pages (login, signup, MFA verification, password reset, SSO) have no signed-in user, so `SwitchLocale#switch_locale` falls all the way back to `I18n.default_locale` (`en`) and the v3 SPA boots in English regardless of the visitor's browser preference. This forces installations whose authenticated users normally see a non-English UI to also expose a localized pre-auth flow — most visibly painful with MFA enabled, where the verification dialog is the first screen many users land on after typing their password.

This PR adds a small `SelectMenu`-style language picker fixed at the bottom of the v3 layout. It lists `window.chatwootConfig.enabledLanguages` (so the installation's `available_locales_with_name` allow-list is respected), mutates the global vue-i18n locale reactively (no reload), persists the choice in `localStorage` under `cw.auth.locale`, and re-applies it on subsequent visits before falling back to `window.chatwootConfig.selectedLocale`.

The component:

- hides itself when only one language is enabled (single-locale installs see nothing);
- closes on outside click via `v-on-clickaway`;
- opens the menu upward so the footer placement doesn't clip at the viewport bottom;
- reuses `components-next/button/Button.vue` for visual parity with the dashboard popups;
- never POSTs the chosen locale — authenticated users' `ui_settings.locale` remains the source of truth once they log in. The pre-auth `localStorage` and the authenticated user preference stay deliberately decoupled.

A follow-up commit registers the `vue3-click-away` directive in `app/javascript/entrypoints/v3app.js`, mirroring the existing registration in `dashboard.js` and `widget.js`. Without it, the v3 bundle treated `v-on-clickaway` as an unknown directive and outside clicks didn't close the menu (addressed Codex review feedback).

Fixes # (no linked issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested manually in local dev (Docker, Vite HMR) against `/app/login`, `/auth/signup`, `/auth/password/new`, and `/app/login/sso`. Verified using Chrome DevTools:

1. Open `/app/login` in a private window (no prior `localStorage`). A small pill with a globe icon appears at the bottom-center.
2. Click it → the popup opens upward, showing each language from `enabledLanguages` with a check icon next to the active one.
3. Pick another language → form labels and submit button text update instantly, no reload. `localStorage.cw.auth.locale` is set to the picked code.
4. Click anywhere outside the popup → the menu closes (verifies the `vue3-click-away` directive is correctly registered in the v3 bundle).
5. Reload → the page still boots in the picked language.
6. Visit `/auth/signup`, `/auth/password/new`, `/app/login/sso` — the switcher renders on each.
7. Trigger an MFA-required login → the verification dialog now renders in the picked language.
8. Sign in as a user whose `ui_settings.locale` is set → the dashboard UI follows that preference, independent of the pre-auth choice.
9. Console is free of Vue warnings (no "Failed to resolve directive: on-clickaway").

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules