### PR TITLE
fix: persist SAML relay state in ACS URL for mobile login

### DIFF
--- a/enterprise/config/initializers/omniauth_saml.rb
+++ b/enterprise/config/initializers/omniauth_saml.rb
@@ -21,9 +21,15 @@ SAML_SETUP_PROC = proc do |env|
     settings = AccountSamlSettings.find_by(account_id: account_id)
 
     if settings
+      # Carry the relay state in the ACS URL (like account_id) so the mobile
+      # signal survives the cross-site callback POST without relying on the
+      # session cookie or the IdP echoing RelayState back.
+      acs_url = "#{ENV.fetch('FRONTEND_URL', 'http://localhost:3000')}/omniauth/saml/callback?account_id=#{account_id}"
+      acs_url += "&RelayState=#{ERB::Util.url_encode(relay_state)}" if relay_state.present?
+
       # Configure the strategy options dynamically
       env['omniauth.strategy'].options[:idp_sso_service_url_runtime_params] = { RelayState: :RelayState }
-      env['omniauth.strategy'].options[:assertion_consumer_service_url] = "#{ENV.fetch('FRONTEND_URL', 'http://localhost:3000')}/omniauth/saml/callback?account_id=#{account_id}"
+      env['omniauth.strategy'].options[:assertion_consumer_service_url] = acs_url
       env['omniauth.strategy'].options[:sp_entity_id] = settings.sp_entity_id
       env['omniauth.strategy'].options[:idp_entity_id] = settings.idp_entity_id
       env['omniauth.strategy'].options[:idp_sso_service_url] = settings.sso_url

--- a/enterprise/config/initializers/omniauth_saml.rb
+++ b/enterprise/config/initializers/omniauth_saml.rb
@@ -9,6 +9,7 @@ SAML_SETUP_PROC = proc do |env|
   account_id = request.params['account_id'] ||
                env['omniauth.params']&.dig('account_id')
   relay_state = request.params['RelayState'] || ''
+  for_mobile = relay_state.casecmp('mobile').zero?
 
   if account_id
     # Keep SAML request context in OmniAuth env so the callback can be processed
@@ -21,11 +22,13 @@ SAML_SETUP_PROC = proc do |env|
     settings = AccountSamlSettings.find_by(account_id: account_id)
 
     if settings
-      # Carry the relay state in the ACS URL (like account_id) so the mobile
-      # signal survives the cross-site callback POST without relying on the
-      # session cookie or the IdP echoing RelayState back.
+      # Carry the relay state in the ACS URL (like account_id) only for mobile,
+      # so the mobile signal survives the cross-site callback POST without
+      # relying on the session cookie or the IdP echoing RelayState back. Web
+      # logins keep the registered ACS URL untouched so strict IdPs that
+      # validate it exactly are unaffected.
       acs_url = "#{ENV.fetch('FRONTEND_URL', 'http://localhost:3000')}/omniauth/saml/callback?account_id=#{account_id}"
-      acs_url += "&RelayState=#{ERB::Util.url_encode(relay_state)}" if relay_state.present?
+      acs_url += "&RelayState=#{ERB::Util.url_encode(relay_state)}" if for_mobile
 
       # Configure the strategy options dynamically
       env['omniauth.strategy'].options[:idp_sso_service_url_runtime_params] = { RelayState: :RelayState }


### PR DESCRIPTION
Mobile SAML login routed users to the web login page instead of the `chatwootapp://` deep link. Mobile is detected via `RelayState=mobile`, but after the callback was made session-independent, the only carriers left were the Rails session cookie (dropped on the cross-site IdP POST under `SameSite=Lax`) and the IdP echoing `RelayState` back (not guaranteed).

This PR fixes it by baking the relay state into the ACS URL query string the same way `account_id` is carried, so it returns as a plain callback param regardless of cookie or IdP echo behavior. Web flow is unchanged since the param is only appended when a relay state is present.

Related: https://github.com/chatwoot/chatwoot/pull/14467
Fixes: CW-7183