### PR TITLE
fix: prevent code block overflow in message bubble

### DIFF
--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -554,11 +554,10 @@ provideMessageContext({
         <Avatar v-bind="avatarInfo" :size="24" />
       </div>
       <div
-        class="[grid-area:bubble] flex"
+        class="[grid-area:bubble] flex min-w-0"
         :class="{
           'ltr:ml-8 rtl:mr-8 justify-end': orientation === ORIENTATION.RIGHT,
           'ltr:mr-8 rtl:ml-8': orientation === ORIENTATION.LEFT,
-          'min-w-0': variant === MESSAGE_VARIANTS.EMAIL,
         }"
         @contextmenu="openContextMenu($event)"
       >

--- a/app/javascript/dashboard/components-next/message/bubbles/Base.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Base.vue
@@ -95,7 +95,7 @@ const replyToPreview = computed(() => {
 
 <template>
   <div
-    class="text-sm"
+    class="text-sm min-w-0"
     :class="[
       messageClass,
       {


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes long `<pre>` code blocks overflowing the message bubble in smaller screens and narrow layouts.

The bubble's flex/grid layout could not shrink below the intrinsic width of the code content, causing overflow.

Adding `min-w-0` to the `[grid-area:bubble]` wrapper across all variants and the bubble root allows the bubble to shrink correctly, so `<pre>` blocks now scroll horizontally within the bubble.

Fixes https://linear.app/chatwoot/issue/CW-7192/code-block-pre-overflows-message-bubble-in-narrow-panels

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**

<img width="664" height="670" alt="image" src="https://github.com/user-attachments/assets/5320385b-ec23-47a9-9909-ddf102a4278e" />



**After**

   <img width="651" height="670" alt="image" src="https://github.com/user-attachments/assets/0d315022-4651-4800-8b06-df726213a994" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
