### PR TITLE
fix: correct avatar initials for phone number contacts

### DIFF
--- a/app/javascript/dashboard/components-next/avatar/Avatar.vue
+++ b/app/javascript/dashboard/components-next/avatar/Avatar.vue
@@ -83,16 +83,33 @@ const STATUS_CLASSES = computed(() => ({
 
 const showDefaultAvatar = computed(() => !props.src && !props.name);
 
+// Check if string looks like a phone number (e.g., "+44 7123456789", "+44 (0) 7700-900123")
+const isPhoneNumber = str => /^\+[\d\s\-().]+$/.test(str.trim());
+
 const initials = computed(() => {
   if (!props.name) return '';
-  const words = removeEmoji(props.name).split(/\s+/);
-  return words.length === 1
-    ? words[0].charAt(0).toUpperCase()
-    : words
-        .slice(0, 2)
-        .map(word => word.charAt(0))
-        .join('')
-        .toUpperCase();
+  const cleanName = removeEmoji(props.name);
+
+  // For phone numbers, use last 2 digits to avoid confusing initials like "+7"
+  if (isPhoneNumber(cleanName)) {
+    const digits = cleanName.replace(/\D/g, '');
+    return digits.slice(-2) || '#';
+  }
+
+  const words = cleanName.split(/\s+/);
+  if (words.length === 1) {
+    return words[0].charAt(0).toUpperCase();
+  }
+  // If the first word starts with a non-alpha prefix (e.g. "+John"),
+  // keep the prefix and take the next char from the same word ("+J")
+  if (/^[^a-zA-Z]/.test(words[0]) && words[0].length > 1) {
+    return words[0].slice(0, 2);
+  }
+  return words
+    .slice(0, 2)
+    .map(word => word.charAt(0))
+    .join('')
+    .toUpperCase();
 });
 
 const getColorsByNameLength = computed(() => {

--- a/app/javascript/dashboard/components-next/avatar/specs/Avatar.spec.js
+++ b/app/javascript/dashboard/components-next/avatar/specs/Avatar.spec.js
@@ -1,0 +1,81 @@
+import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import Avatar from '../Avatar.vue';
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      THUMBNAIL: {
+        AUTHOR: {
+          NOT_AVAILABLE: 'Author not available',
+        },
+      },
+    },
+  },
+});
+
+describe('Avatar', () => {
+  const createWrapper = (props = {}) => {
+    return mount(Avatar, {
+      props: {
+        name: 'John Doe',
+        ...props,
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          Icon: true,
+          ChannelIcon: true,
+        },
+      },
+    });
+  };
+
+  describe('initials generation', () => {
+    it('generates initials from two-word name', () => {
+      const wrapper = createWrapper({ name: 'John Doe' });
+      expect(wrapper.text()).toContain('JD');
+    });
+
+    it('generates single initial from single-word name', () => {
+      const wrapper = createWrapper({ name: 'John' });
+      expect(wrapper.text()).toContain('J');
+    });
+
+    it('generates initials from three-word name using first two words', () => {
+      const wrapper = createWrapper({ name: 'John Doe Smith' });
+      expect(wrapper.text()).toContain('JD');
+    });
+
+    describe('phone number handling', () => {
+      it('uses last 2 digits for phone numbers with spaces', () => {
+        // Issue #2641: "+44 7123456789" was incorrectly showing "+7"
+        const wrapper = createWrapper({ name: '+44 7123456789' });
+        expect(wrapper.text()).toContain('89');
+      });
+
+      it('uses last 2 digits for phone numbers without spaces', () => {
+        const wrapper = createWrapper({ name: '+14155551234' });
+        expect(wrapper.text()).toContain('34');
+      });
+
+      it('uses last 2 digits for phone numbers with dashes', () => {
+        const wrapper = createWrapper({ name: '+1-415-555-1234' });
+        expect(wrapper.text()).toContain('34');
+      });
+
+      it('uses last 2 digits for phone numbers with mixed formatting', () => {
+        const wrapper = createWrapper({ name: '+44 (0) 7700-900123' });
+        expect(wrapper.text()).toContain('23');
+      });
+
+      it('does not treat names starting with + but containing letters as phone numbers', () => {
+        const wrapper = createWrapper({ name: '+John Doe' });
+        // Should use normal initials, not phone number logic
+        expect(wrapper.text()).toContain('+J');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Phone number contacts (e.g. WhatsApp/Twilio) were showing incorrect initials in the Avatar component. A number like `+44 7123456789` produced `+7` because the code took the first character of each word — `+` from `+44` and `7` from the second segment.

Fixes #2641

## What changed

- Added `isPhoneNumber` helper that detects E.164-style numbers (`+` followed by digits, spaces, dashes, parens, dots)
- Phone numbers now use the last 2 digits as initials (e.g. `+44 7123456789` → `89`) instead of symbol-prefixed garbage
- Names with a non-alpha prefix followed by letters (e.g. `+John Doe`) correctly show `+J` instead of `+D`
- Added `Avatar.spec.js` with 8 tests covering normal names, phone number variants, and edge cases

## How to test

1. Create a WhatsApp or Twilio inbox
2. Receive a message from a contact whose name is their phone number (e.g. `+44 7700900123`)
3. Verify the avatar shows `23` instead of `+7`