### PR TITLE
feat: enable companies for Business cloud plans

### DIFF
--- a/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
+++ b/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
@@ -19,7 +19,15 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
     channel_voice
   ].freeze
 
-  BUSINESS_PLAN_FEATURES = %w[sla custom_roles csat_review_notes conversation_required_attributes advanced_assignment custom_tools].freeze
+  BUSINESS_PLAN_FEATURES = %w[
+    sla
+    custom_roles
+    csat_review_notes
+    conversation_required_attributes
+    advanced_assignment
+    custom_tools
+    companies
+  ].freeze
   ENTERPRISE_PLAN_FEATURES = %w[audit_logs disable_branding saml].freeze
   PREMIUM_PLAN_FEATURES = (STARTUP_PLAN_FEATURES + BUSINESS_PLAN_FEATURES + ENTERPRISE_PLAN_FEATURES).freeze
 

--- a/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
@@ -134,10 +134,6 @@ describe Enterprise::Billing::HandleStripeEventService do
   end
 
   describe 'plan-specific feature management' do
-    it 'includes companies in the Business plan feature set' do
-      expect(described_class::BUSINESS_PLAN_FEATURES).to include('companies')
-    end
-
     context 'with default plan (Hacker)' do
       it 'disables all premium features' do
         allow(subscription).to receive(:[]).with('plan')

--- a/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
@@ -181,6 +181,7 @@ describe Enterprise::Billing::HandleStripeEventService do
         described_class::BUSINESS_PLAN_FEATURES.each do |feature|
           expect(account).not_to be_feature_enabled(feature)
         end
+        expect(account).not_to be_feature_enabled('companies')
 
         described_class::ENTERPRISE_PLAN_FEATURES.each do |feature|
           expect(account).not_to be_feature_enabled(feature)
@@ -203,6 +204,7 @@ describe Enterprise::Billing::HandleStripeEventService do
         described_class::BUSINESS_PLAN_FEATURES.each do |feature|
           expect(account).to be_feature_enabled(feature)
         end
+        expect(account).to be_feature_enabled('companies')
 
         described_class::ENTERPRISE_PLAN_FEATURES.each do |feature|
           expect(account).not_to be_feature_enabled(feature)
@@ -225,6 +227,7 @@ describe Enterprise::Billing::HandleStripeEventService do
         described_class::BUSINESS_PLAN_FEATURES.each do |feature|
           expect(account).to be_feature_enabled(feature)
         end
+        expect(account).to be_feature_enabled('companies')
 
         described_class::ENTERPRISE_PLAN_FEATURES.each do |feature|
           expect(account).to be_feature_enabled(feature)

--- a/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
@@ -134,6 +134,10 @@ describe Enterprise::Billing::HandleStripeEventService do
   end
 
   describe 'plan-specific feature management' do
+    it 'includes companies in the Business plan feature set' do
+      expect(described_class::BUSINESS_PLAN_FEATURES).to include('companies')
+    end
+
     context 'with default plan (Hacker)' do
       it 'disables all premium features' do
         allow(subscription).to receive(:[]).with('plan')
@@ -181,7 +185,6 @@ describe Enterprise::Billing::HandleStripeEventService do
         described_class::BUSINESS_PLAN_FEATURES.each do |feature|
           expect(account).not_to be_feature_enabled(feature)
         end
-        expect(account).not_to be_feature_enabled('companies')
 
         described_class::ENTERPRISE_PLAN_FEATURES.each do |feature|
           expect(account).not_to be_feature_enabled(feature)
@@ -204,7 +207,6 @@ describe Enterprise::Billing::HandleStripeEventService do
         described_class::BUSINESS_PLAN_FEATURES.each do |feature|
           expect(account).to be_feature_enabled(feature)
         end
-        expect(account).to be_feature_enabled('companies')
 
         described_class::ENTERPRISE_PLAN_FEATURES.each do |feature|
           expect(account).not_to be_feature_enabled(feature)
@@ -227,7 +229,6 @@ describe Enterprise::Billing::HandleStripeEventService do
         described_class::BUSINESS_PLAN_FEATURES.each do |feature|
           expect(account).to be_feature_enabled(feature)
         end
-        expect(account).to be_feature_enabled('companies')
 
         described_class::ENTERPRISE_PLAN_FEATURES.each do |feature|
           expect(account).to be_feature_enabled(feature)


### PR DESCRIPTION
Enable the Companies feature automatically for Chatwoot Cloud accounts on the Business plan and higher.

## Closes
None.

## How to test
Upgrade or reconcile a Cloud account on Business or Enterprise and verify Companies is available. Reconcile a Startups account and verify Companies remains disabled.

## What changed
- Added companies to the Business plan feature set, which Enterprise inherits through the existing hierarchy.
- Added billing specs that assert Companies is disabled for Startups and enabled for Business and Enterprise.