### PR TITLE
fix: validate portal color format

### DIFF
--- a/app/models/portal.rb
+++ b/app/models/portal.rb
@@ -42,6 +42,7 @@ class Portal < ApplicationRecord
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true
   validates :custom_domain, uniqueness: true, allow_nil: true
+  validates :color, format: { with: /\A#(?:\h{3}|\h{6})\z/ }, allow_blank: true
   validate :config_json_format
 
   scope :active, -> { where(archived: false) }


### PR DESCRIPTION
# Pull Request Template

## Description


This PR adds validation for the Help Center portal color field.

Previously, the `color` attribute accepted any string value. This change ensures that only valid color values can be saved when creating or updating a portal, improving data validation and preventing invalid styles from being rendered in the Help Center.

The update adds format validation at the model level while preserving existing portal customization functionality.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
