### PR TITLE
fix(api): allow agent bots to read conversations and manage labels

### DIFF
--- a/app/controllers/concerns/access_token_auth_helper.rb
+++ b/app/controllers/concerns/access_token_auth_helper.rb
@@ -1,8 +1,9 @@
 module AccessTokenAuthHelper
   BOT_ACCESSIBLE_ENDPOINTS = {
-    'api/v1/accounts/conversations' => %w[toggle_status toggle_typing_status toggle_priority create update custom_attributes],
+    'api/v1/accounts/conversations' => %w[show toggle_status toggle_typing_status toggle_priority create update custom_attributes],
     'api/v1/accounts/conversations/messages' => ['create'],
-    'api/v1/accounts/conversations/assignments' => ['create']
+    'api/v1/accounts/conversations/assignments' => ['create'],
+    'api/v1/accounts/conversations/labels' => %w[index create]
   }.freeze
 
   def ensure_access_token


### PR DESCRIPTION
Agent bots assigned to a conversation can now fetch that conversation's details and manage its labels using their bot token. Previously these two operations returned `Access to this endpoint is not authorized for bots`, even though the same token worked for sending messages, updating the conversation, and setting custom attributes.

Fixes https://linear.app/chatwoot/issue/PLA-174/agent-bot-tokens-cannot-fetch-conversation-details-or-manage-labels