### PR TITLE
fix(twilio): resolve Content template by content_sid to prevent duplicate friendly_name collision

### DIFF
--- a/app/javascript/dashboard/components-next/content-templates/ContentTemplateParser.vue
+++ b/app/javascript/dashboard/components-next/content-templates/ContentTemplateParser.vue
@@ -133,7 +133,7 @@ const sendMessage = () => {
   v$.value.$touch();
   if (v$.value.$invalid || isFormInvalid.value) return;
 
-  const { friendly_name, language } = props.template;
+  const { friendly_name, language, content_sid } = props.template;
 
   // Process parameters and extract filename from media URL if needed
   const processedParameters = { ...processedParams.value };
@@ -153,6 +153,10 @@ const sendMessage = () => {
     message: renderedTemplate.value,
     templateParams: {
       name: friendly_name,
+      // Twilio allows multiple Content templates with the same friendly_name,
+      // so we send the exact content_sid to make sure the backend resolves the
+      // template the agent actually selected (not the first name match).
+      content_sid,
       language,
       processed_params: processedParameters,
     },

--- a/app/services/twilio/template_processor_service.rb
+++ b/app/services/twilio/template_processor_service.rb
@@ -13,13 +13,31 @@ class Twilio::TemplateProcessorService
 
   private
 
-  def find_template
-    channel.content_templates&.dig('templates')&.find do |template|
-      template['friendly_name'] == template_params['name'] &&
-        template['language'] == (template_params['language'] || 'en') &&
-        template['status'] == 'approved'
-    end
+def find_template
+  templates = channel.content_templates&.dig('templates')
+  return nil if templates.blank?
+
+  # Prefer the exact content_sid when the caller provided it. Twilio allows
+  # multiple Content templates to share the same friendly_name (the SID is the
+  # real identifier), so resolving only by name can pick the wrong template
+  # and send the wrong body/variables. See find_template_by_name.
+  if template_params['content_sid'].present?
+    exact = templates.find { |template| template['content_sid'] == template_params['content_sid'] }
+    return exact if exact
   end
+
+  find_template_by_name(templates)
+end
+
+# Fallback for callers that only send the template name (no content_sid).
+# Picks the first approved template matching name + language.
+def find_template_by_name(templates)
+  templates.find do |template|
+    template['friendly_name'] == template_params['name'] &&
+      template['language'] == (template_params['language'] || 'en') &&
+      template['status'] == 'approved'
+  end
+end
 
   def build_content_variables(template)
     case template['template_type']


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the wrong Twilio Content template could be sent to the
end user when two approved templates share the same `friendly_name`.

## Problem

Twilio's Content API uses the `content_sid` (`HX...`) as the unique
identifier for a template. The `friendly_name` is a human-readable label
and is **not required to be unique** — Twilio allows multiple approved
templates to share the same name.

`Twilio::TemplateProcessorService#find_template` resolved the template to
send using only `friendly_name` + language + status, returning the **first
match** via Ruby's `Enumerable#find`. When two approved templates share a
name (e.g. an older variable-based version and a newer static one), the
wrong template can be picked, causing the recipient to receive a message
with incorrect content or unexpected variable substitutions (e.g. `{{1}}`
filled with an unrelated value).

### Example

Two approved templates both named `my_followup_es` [es]:
- `HXaaa...` → `"Buenos días {{1}}: ¿Le puedo ayudar?"` (expects a name variable)
- `HXbbb...` → `"¿Le puedo ayudar con su solicitud?"` (no variables)

The agent selects `HXbbb...` in the UI (the static version). Chatwoot
calls `find_template` with `name: "my_followup_es"`. `.find` returns
`HXaaa...` (first match). Twilio renders `{{1}}` with a value from a
different context and the contact receives the wrong message.

## Root cause

`ContentTemplateParser.vue` extracted only `friendly_name`, `language` and
`processed_params` from the selected template object, silently discarding
the `content_sid` that uniquely identifies the template the agent chose.
The backend then re-resolved by name, which is ambiguous with duplicate
names.

## Fix

**Frontend** (`ContentTemplateParser.vue`): include the selected template's
`content_sid` in the `templateParams` payload sent to the API.

**Backend** (`Twilio::TemplateProcessorService`): if `template_params`
contains a `content_sid`, find the template by that exact SID first. Fall
back to the existing name-based lookup when `content_sid` is absent, so
the change is **fully backward compatible** with existing messages or
integrations that only provide the template name.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested this fix manually
- [x] The change is backward compatible (callers without `content_sid` keep existing behavior)
