### PR TITLE
fix(voice): reuse conversations for outbound calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -593,7 +593,7 @@ GEM
       sidekiq
     newrelic_rpm (9.6.0)
       base64
-    nio4r (2.7.3)
+    nio4r (2.7.5)
     nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -682,7 +682,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (7.0.5)
-    puma (6.4.3)
+    puma (8.0.2)
       nio4r (~> 2.0)
     pundit (2.3.0)
       activesupport (>= 3.0.0)

--- a/enterprise/app/services/voice/outbound_call_builder.rb
+++ b/enterprise/app/services/voice/outbound_call_builder.rb
@@ -19,7 +19,7 @@ class Voice::OutboundCallBuilder
 
     ActiveRecord::Base.transaction do
       contact_inbox = ensure_contact_inbox!
-      conversation = @existing_conversation || create_conversation!(contact_inbox)
+      conversation = @existing_conversation || resolve_conversation!(contact_inbox)
       call_sid = initiate_call!
       call = create_call!(conversation, call_sid)
       message = Voice::CallMessageBuilder.new(call).perform!
@@ -37,6 +37,18 @@ class Voice::OutboundCallBuilder
     ) do |record|
       record.source_id = contact.phone_number
     end
+  end
+
+  def resolve_conversation!(contact_inbox)
+    conversation = if inbox.lock_to_single_conversation
+                     contact_inbox.conversations.last
+                   else
+                     contact_inbox.conversations.where.not(status: :resolved).last
+                   end
+    return create_conversation!(contact_inbox) unless conversation
+
+    conversation.open! unless conversation.open?
+    conversation
   end
 
   def create_conversation!(contact_inbox)

--- a/spec/enterprise/services/voice/outbound_call_builder_spec.rb
+++ b/spec/enterprise/services/voice/outbound_call_builder_spec.rb
@@ -56,6 +56,60 @@ RSpec.describe Voice::OutboundCallBuilder do
       expect(call.conversation.additional_attributes).not_to include('call_status', 'call_direction', 'agent_id', 'conference_sid')
     end
 
+    it 'reuses an existing open conversation for the contact' do
+      contact_inbox = create(:contact_inbox, contact: contact, inbox: inbox, source_id: contact.phone_number)
+      existing_conversation = create(:conversation, account: account, inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+
+      call = nil
+      expect do
+        call = described_class.perform!(
+          account: account,
+          inbox: inbox,
+          user: user,
+          contact: contact
+        )
+      end.to change(Call, :count).by(1).and not_change(account.conversations, :count)
+
+      expect(call.conversation).to eq(existing_conversation)
+      expect(existing_conversation.messages.voice_calls.last.call).to eq(call)
+    end
+
+    it 'reuses and reopens the last conversation when the inbox is locked to a single conversation' do
+      inbox.update!(lock_to_single_conversation: true)
+      contact_inbox = create(:contact_inbox, contact: contact, inbox: inbox, source_id: contact.phone_number)
+      existing_conversation = create(:conversation, account: account, inbox: inbox, contact: contact, contact_inbox: contact_inbox, status: :resolved)
+
+      call = nil
+      expect do
+        call = described_class.perform!(
+          account: account,
+          inbox: inbox,
+          user: user,
+          contact: contact
+        )
+      end.to change(Call, :count).by(1).and not_change(account.conversations, :count)
+
+      expect(call.conversation).to eq(existing_conversation)
+      expect(existing_conversation.reload).to be_open
+    end
+
+    it 'creates a new conversation when the last conversation is resolved and the inbox is not locked' do
+      contact_inbox = create(:contact_inbox, contact: contact, inbox: inbox, source_id: contact.phone_number)
+      create(:conversation, account: account, inbox: inbox, contact: contact, contact_inbox: contact_inbox, status: :resolved)
+
+      call = nil
+      expect do
+        call = described_class.perform!(
+          account: account,
+          inbox: inbox,
+          user: user,
+          contact: contact
+        )
+      end.to change(account.conversations, :count).by(1).and change(Call, :count).by(1)
+
+      expect(call.conversation).to be_open
+    end
+
     it 'raises an error when contact is missing a phone number' do
       contact.update!(phone_number: nil)
 


### PR DESCRIPTION
Outbound Twilio voice calls now attach the call bubble to the reusable conversation for that contact instead of always creating a fresh conversation. This makes the voice call flow respect the same open-or-single-conversation routing used by incoming messages.

## Closes

Closes #14663

## How to reproduce

1. Configure a Twilio voice-enabled inbox.
2. Enable the inbox setting to lock the contact to a single conversation.
3. Open an existing conversation for a contact in that inbox.
4. Start a Twilio voice call from the conversation sidebar.

## What changed

- Updated `Voice::OutboundCallBuilder` to resolve an existing conversation before creating a new one.
- Reused the last conversation when `lock_to_single_conversation` is enabled, reopening it before adding the outgoing voice call bubble.
- Preserved the existing behavior of creating a new conversation when the previous one is resolved and the single-conversation lock is disabled.
- Added Enterprise voice service specs for open conversation reuse, locked conversation reuse, and unlocked resolved conversation behavior.