### PR TITLE
fix: populate general settings form on hard reload

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -94,8 +94,13 @@ export default {
       return this.getAccount(this.accountId) || {};
     },
   },
-  mounted() {
-    this.initializeAccount();
+  watch: {
+    currentAccount: {
+      immediate: true,
+      handler() {
+        this.initializeAccount();
+      },
+    },
   },
   methods: {
     async initializeAccount() {

--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -95,12 +95,17 @@ export default {
     },
   },
   watch: {
-    currentAccount: {
-      immediate: true,
-      handler() {
+    'currentAccount.id'(id) {
+      if (id) {
         this.initializeAccount();
-      },
+      }
     },
+  },
+  mounted() {
+    // Account already in the store (navigated in): seed immediately.
+    if (this.currentAccount.id) {
+      this.initializeAccount();
+    }
   },
   methods: {
     async initializeAccount() {

--- a/app/javascript/dashboard/routes/dashboard/settings/account/components/AccountId.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/components/AccountId.vue
@@ -8,7 +8,7 @@ import SectionLayout from './SectionLayout.vue';
 const { t } = useI18n();
 const { currentAccount } = useAccount();
 
-const getAccountId = computed(() => currentAccount.value.id.toString());
+const getAccountId = computed(() => currentAccount.value?.id?.toString());
 </script>
 
 <template>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the General Settings page showing an empty **Account name** and **Site language**, along with an **Account ID** console error, when the page is hard reloaded.

### What caused it

The form was populated only once when the page first loaded. On a hard reload, the account details haven't been loaded yet, so there is nothing to populate the form with. At the same time, the Account ID field tried to read a value that wasn't available yet, causing the console error and leaving the page with empty values.

Navigating to the page from another section works because the account data is already loaded by then, which is why the issue only happened on a fresh reload.

### What changed

The page now populates the form as soon as the account data becomes available, instead of only on the initial load. The Account ID display also waits for the value to become available instead of throwing an error while the account is still loading.




Fixes https://linear.app/chatwoot/issue/CW-7306/account-settings-form-is-empty-on-hard-reload-of-the-general-settings

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### How to reproduce

1. Go to **Settings → Account Settings**
2. Hard reload the page.
3. Confirm the **Account name**, **Site language**, and **Account ID** are populated, with no console errors.
4. Navigate to the page from another section and confirm it still works as expected.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
