### PR TITLE
fix(whatsapp): restrict OGG voice recording to WhatsApp Cloud inboxes

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -375,10 +375,10 @@ export default {
       return `draft-${this.conversationIdByRoute}-${this.replyType}`;
     },
     audioRecordFormat() {
-      if (this.isAWhatsAppChannel) {
+      if (this.isAWhatsAppCloudChannel) {
         return AUDIO_FORMATS.OGG;
       }
-      if (this.isATelegramChannel) {
+      if (this.isAWhatsAppChannel || this.isATelegramChannel) {
         return AUDIO_FORMATS.MP3;
       }
       if (this.isAPIInbox) {


### PR DESCRIPTION
Recording and sending an audio message from a **Twilio WhatsApp** inbox failed silently — Twilio rejected the media with delivery error `63019` ("Media failed to download") and the voice note never reached the customer. This restores audio sending for Twilio WhatsApp (and 360dialog) inboxes.

Closes Regression from #14606

## How to reproduce

1. Open a conversation in a **Twilio WhatsApp** inbox.
2. Record a voice message in the reply box and send it.
3. Before this fix: the message fails to deliver and a `Webhooks::TwilioDeliveryStatusJob` is enqueued with `ErrorCode: 63019`, `ErrorMessage: "Media failed to download"`.
4. After this fix: the audio is recorded as MP3 and delivers normally.

## What changed

PR #14606 added WhatsApp **Cloud** voice notes, which require OGG/Opus. It changed `audioRecordFormat` in `ReplyBox.vue` to return OGG for `isAWhatsAppChannel` — but that getter is also `true` for Twilio WhatsApp inboxes. The OGG handling (content-type normalization + the `voice: true` flag) lives only in `WhatsappCloudService`, so Twilio could not download/process the remuxed OGG file.

This change scopes OGG to `isAWhatsAppCloudChannel`. Twilio WhatsApp, 360dialog, and Telegram fall back to MP3 exactly as they did before the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)