### PR TITLE
fix: escape @ in Hebrew login email placeholder (blank page on /app/login)

### DIFF
--- a/app/javascript/dashboard/i18n/locale/he/login.json
+++ b/app/javascript/dashboard/i18n/locale/he/login.json
@@ -3,7 +3,7 @@
     "TITLE": "התחבר ל Woot",
     "EMAIL": {
       "LABEL": "אימייל",
-      "PLACEHOLDER": "example@companyname.com",
+      "PLACEHOLDER": "example{'@'}companyname.com",
       "ERROR": "נא הכנס כתובת דוא\"ל תקינה"
     },
     "PASSWORD": {


### PR DESCRIPTION
## Description

The Hebrew (`he`) translation of the login page email placeholder contains a raw `@` character:

```json
"PLACEHOLDER": "example@companyname.com"
```

In vue-i18n message syntax, `@` starts a linked message. When the message compiler hits `@c` (not a valid linked-message form), it throws `SyntaxError: Invalid linked format` at runtime. The exception is thrown while rendering the login view, which crashes the whole dashboard app — users of Hebrew-locale installations get a **completely blank white page on `/app/login`** and cannot sign in.

Logged-in users are unaffected (they never render the login view), so the regression is easy to miss — it only surfaces when a session expires or a user signs out.

## How to reproduce

1. Self-hosted Chatwoot v4.14.1 (also reproducible on current `develop`) with `DEFAULT_LOCALE=he`
2. Open `/app/login` in a browser with no active session
3. Blank white page; console shows:
   ```
   SyntaxError: Invalid linked format
   ```

## Fix

Escape the `@` the same way the English source and the Hebrew signup translation already do:

```json
"PLACEHOLDER": "example{'@'}companyname.com"
```

For reference:
- `en/login.json` → `"PLACEHOLDER": "example{'@'}companyname.com"` ✅
- `he/signup.json` → `"PLACEHOLDER": "... bruce{'@'}wayne{'.'}enterprises"` ✅
- `he/login.json` → `"PLACEHOLDER": "example@companyname.com"` ❌ (this PR)

I scanned all other locales' auth-related files (`login.json`, `signup.json`, `resetPassword.json`, `setNewPassword.json`) for unescaped `@` — Hebrew `login.json` is the only affected file.

Note: if translations are managed via Crowdin, this string should be fixed there as well so the next sync doesn't reintroduce the crash.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
