### PR TITLE
fix: cannot resize pasted images

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@amplitude/analytics-browser": "^2.11.10",
     "@breezystack/lamejs": "^1.2.7",
     "@chatwoot/ninja-keys": "1.2.3",
-    "@chatwoot/prosemirror-schema": "1.3.21",
+    "@chatwoot/prosemirror-schema": "1.3.22",
     "@chatwoot/utils": "^0.0.55",
     "@formkit/core": "^1.7.2",
     "@formkit/vue": "^1.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: 1.2.3
         version: 1.2.3
       '@chatwoot/prosemirror-schema':
-        specifier: 1.3.21
-        version: 1.3.21
+        specifier: 1.3.22
+        version: 1.3.22
       '@chatwoot/utils':
         specifier: ^0.0.55
         version: 0.0.55
@@ -458,8 +458,8 @@ packages:
   '@chatwoot/ninja-keys@1.2.3':
     resolution: {integrity: sha512-xM8d9P5ikDMZm2WbaCTk/TW5HFauylrU3cJ75fq5je6ixKwyhl/0kZbVN/vbbZN4+AUX/OaSIn6IJbtCgIF67g==}
 
-  '@chatwoot/prosemirror-schema@1.3.21':
-    resolution: {integrity: sha512-Y/OfXH1orK14foRcMrUees8lDjnDS9qZylVMyrstbfNyP5hbkBofsGAi6SP+5oIbPZ8iSG0sJyXtscoXpu/OFw==}
+  '@chatwoot/prosemirror-schema@1.3.22':
+    resolution: {integrity: sha512-0r+PT8xhQLCKCpoV9k9XVTTRECs/0Nr37wbcLsRS7yvc7WkF9FY05z2hGCRJReWmTOcmmshHtb042LVP+MyB/w==}
 
   '@chatwoot/utils@0.0.55':
     resolution: {integrity: sha512-8G6HYQe1ZEYfJEsSYfDVvE+uhf98JDRjtGlpB+bzMko+yltbrk4yACSo/ImC3jSaJ6K8yPTSjJToSRmsQbL2iQ==}
@@ -5128,7 +5128,7 @@ snapshots:
       hotkeys-js: 3.8.7
       lit: 2.2.6
 
-  '@chatwoot/prosemirror-schema@1.3.21':
+  '@chatwoot/prosemirror-schema@1.3.22':
     dependencies:
       markdown-it-sup: 2.0.0
       prosemirror-commands: 1.7.1


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where images pasted into the editor could not be resized immediately after insertion. In certain cases, pasted images were wrapped in inline elements that caused the resize logic to calculate an invalid width and exit early. The updated dependency includes a fix that falls back to the editor's width when necessary, ensuring that image resizing works correctly without requiring a page reload.

### Prosemirror PR https://github.com/chatwoot/prosemirror-schema/pull/53

Fixes https://linear.app/chatwoot/issue/CW-7256/cannot-resize-image-right-after-pasting-a-content

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Steps to test:**

1. Open the link inside https://linear.app/chatwoot/issue/CW-7256/cannot-resize-image-right-after-pasting-a-content#comment-633b4d9c.
2. Copy the content from the page.
3. Paste the copied content into the editor.
4. Wait for the image upload to complete.
5. Try resizing the pasted image.
6. Verify that the image can be resized immediately without requiring a page reload.



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
