### PR TITLE
fix: voice note recording fails on stereo/multichannel microphones (MP3 conversion)

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/AudioRecorder.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/AudioRecorder.vue
@@ -4,7 +4,7 @@ import { ref, onMounted, onUnmounted } from 'vue';
 import WaveSurfer from 'wavesurfer.js';
 import RecordPlugin from 'wavesurfer.js/dist/plugins/record.js';
 import { format, intervalToDuration } from 'date-fns';
-import { convertAudio } from './utils/audioConversionUtils';
+import { convertAudio, convertToWav } from './utils/audioConversionUtils';
 
 const props = defineProps({
   audioRecordFormat: {
@@ -82,35 +82,50 @@ const initWaveSurfer = () => {
     isPlaying.value = false;
   });
 
-  record.value.on('record-end', async blob => {
+  // Fall back from the requested format to WAV, and finally to the original
+  // blob, so a conversion failure never loses the recording.
+  const buildAudioBlob = async blob => {
     try {
-      const audioBlob = await convertAudio(blob, props.audioRecordFormat);
-      // Use the converted blob's actual type, which may differ from the
-      // requested format when the browser can't produce it (e.g. Safari falls
-      // back to MP3 instead of OGG). This keeps the filename, content type, and
-      // voice-note flag consistent with the real bytes.
-      const audioType = audioBlob.type || props.audioRecordFormat;
-      const ext = AUDIO_EXTENSION_MAP[audioType] || 'mp3';
-      const fileName = `${getUuid()}.${ext}`;
-      const file = new File([audioBlob], fileName, {
-        type: audioType,
-      });
-      if (recordedAudioUrl.value) URL.revokeObjectURL(recordedAudioUrl.value);
-      recordedAudioUrl.value = URL.createObjectURL(audioBlob);
-      wavesurfer.value.load(recordedAudioUrl.value);
-      emit('finishRecord', {
-        name: file.name,
-        type: file.type,
-        size: file.size,
-        file,
-      });
-      hasRecording.value = true;
-      isRecording.value = false;
-    } catch (error) {
-      isRecording.value = false;
-      hasRecording.value = false;
-      emit('recordError', { error });
+      return await convertAudio(blob, props.audioRecordFormat);
+    } catch (conversionError) {
+      try {
+        return await convertToWav(blob);
+      } catch (wavError) {
+        return blob;
+      }
     }
+  };
+
+  record.value.on('record-end', async blob => {
+    isRecording.value = false;
+
+    if (!blob || blob.size === 0) {
+      hasRecording.value = false;
+      emit('recordError', { error: new Error('Empty recording') });
+      return;
+    }
+
+    const audioBlob = await buildAudioBlob(blob);
+    // Use the converted blob's actual type, which may differ from the
+    // requested format when the browser can't produce it (e.g. Safari falls
+    // back to MP3 instead of OGG). This keeps the filename, content type, and
+    // voice-note flag consistent with the real bytes.
+    const audioType = audioBlob.type.split(';')[0] || props.audioRecordFormat;
+    const ext = AUDIO_EXTENSION_MAP[audioType] || 'mp3';
+    const fileName = `${getUuid()}.${ext}`;
+    const file = new File([audioBlob], fileName, {
+      type: audioType,
+    });
+    if (recordedAudioUrl.value) URL.revokeObjectURL(recordedAudioUrl.value);
+    recordedAudioUrl.value = URL.createObjectURL(audioBlob);
+    wavesurfer.value.load(recordedAudioUrl.value);
+    emit('finishRecord', {
+      name: file.name,
+      type: file.type,
+      size: file.size,
+      file,
+    });
+    hasRecording.value = true;
   });
 
   record.value.on('record-progress', time => {

--- a/app/javascript/dashboard/components/widgets/WootWriter/utils/audioConversionUtils.js
+++ b/app/javascript/dashboard/components/widgets/WootWriter/utils/audioConversionUtils.js
@@ -68,21 +68,33 @@ export const convertToWav = async audioBlob => {
 
 /**
  * Encodes audio samples to MP3 format.
- * @param {number} channels - Number of audio channels.
+ * @param {number} channels - 1 (mono) or 2 (stereo).
  * @param {number} sampleRate - Sample rate in Hz.
- * @param {Int16Array} samples - Audio samples to be encoded.
+ * @param {Int16Array[]} channelSamples - One Int16Array per channel.
  * @param {number} bitrate - MP3 bitrate (default: 128)
  * @returns {Blob} - The MP3 encoded audio as a Blob.
  */
-export const encodeToMP3 = (channels, sampleRate, samples, bitrate = 128) => {
+export const encodeToMP3 = (
+  channels,
+  sampleRate,
+  channelSamples,
+  bitrate = 128
+) => {
   const outputBuffer = [];
   const encoder = new lamejs.Mp3Encoder(channels, sampleRate, bitrate);
   const maxSamplesPerFrame = 1152;
+  const totalSamples = channelSamples[0].length;
 
-  for (let offset = 0; offset < samples.length; offset += maxSamplesPerFrame) {
-    const sliceEnd = Math.min(offset + maxSamplesPerFrame, samples.length);
-    const sampleSlice = samples.subarray(offset, sliceEnd);
-    const mp3Buffer = encoder.encodeBuffer(sampleSlice);
+  for (let offset = 0; offset < totalSamples; offset += maxSamplesPerFrame) {
+    const sliceEnd = Math.min(offset + maxSamplesPerFrame, totalSamples);
+    const left = channelSamples[0].subarray(offset, sliceEnd);
+    const mp3Buffer =
+      channels === 2
+        ? encoder.encodeBuffer(
+            left,
+            channelSamples[1].subarray(offset, sliceEnd)
+          )
+        : encoder.encodeBuffer(left);
 
     if (mp3Buffer.length > 0) {
       outputBuffer.push(new Int8Array(mp3Buffer));
@@ -99,6 +111,8 @@ export const encodeToMP3 = (channels, sampleRate, samples, bitrate = 128) => {
 
 /**
  * Converts an audio Blob to an MP3 format Blob.
+ * Audio is downmixed to mono before encoding to support stereo and
+ * multichannel microphones.
  * @param {Blob} audioBlob - The audio data as a Blob.
  * @param {number} bitrate - MP3 bitrate (default: 128)
  * @returns {Promise<Blob>} - A Blob containing the MP3 encoded audio.
@@ -106,32 +120,26 @@ export const encodeToMP3 = (channels, sampleRate, samples, bitrate = 128) => {
 export const convertToMp3 = async (audioBlob, bitrate = 128) => {
   try {
     const audioBuffer = await decodeAudioData(audioBlob);
-    const samples = new Int16Array(
-      audioBuffer.length * audioBuffer.numberOfChannels
-    );
-    let offset = 0;
-    for (let i = 0; i < audioBuffer.length; i += 1) {
-      for (
-        let channel = 0;
-        channel < audioBuffer.numberOfChannels;
-        channel += 1
-      ) {
-        const sample = Math.max(
-          -1,
-          Math.min(1, audioBuffer.getChannelData(channel)[i])
-        );
-        samples[offset] = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
-        offset += 1;
-      }
+    const { numberOfChannels, length, sampleRate } = audioBuffer;
+
+    const channelData = [];
+    for (let channel = 0; channel < numberOfChannels; channel += 1) {
+      channelData.push(audioBuffer.getChannelData(channel));
     }
-    return encodeToMP3(
-      audioBuffer.numberOfChannels,
-      audioBuffer.sampleRate,
-      samples,
-      bitrate
-    );
+
+    const mono = new Int16Array(length);
+    for (let i = 0; i < length; i += 1) {
+      let sum = 0;
+      for (let channel = 0; channel < numberOfChannels; channel += 1) {
+        sum += channelData[channel][i];
+      }
+      const sample = Math.max(-1, Math.min(1, sum / numberOfChannels));
+      mono[i] = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+    }
+
+    return encodeToMP3(1, sampleRate, [mono], bitrate);
   } catch (error) {
-    throw new Error('Conversion to MP3 failed.');
+    throw new Error(`Conversion to MP3 failed: ${error.message}`);
   }
 };
 

--- a/app/javascript/dashboard/components/widgets/WootWriter/utils/specs/audioConversionUtils.spec.js
+++ b/app/javascript/dashboard/components/widgets/WootWriter/utils/specs/audioConversionUtils.spec.js
@@ -1,0 +1,86 @@
+import { encodeToMP3, convertToMp3 } from '../audioConversionUtils';
+
+const SAMPLE_RATE = 44100;
+
+const buildSineSamples = (length, frequency = 440) => {
+  const samples = new Int16Array(length);
+  for (let i = 0; i < length; i += 1) {
+    samples[i] = Math.round(
+      Math.sin((2 * Math.PI * frequency * i) / SAMPLE_RATE) * 0x7fff * 0.5
+    );
+  }
+  return samples;
+};
+
+const buildFakeAudioBuffer = (numberOfChannels, length) => {
+  const channels = [];
+  for (let channel = 0; channel < numberOfChannels; channel += 1) {
+    const data = new Float32Array(length);
+    for (let i = 0; i < length; i += 1) {
+      data[i] = Math.sin((2 * Math.PI * 440 * i) / SAMPLE_RATE) * 0.5;
+    }
+    channels.push(data);
+  }
+  return {
+    numberOfChannels,
+    length,
+    sampleRate: SAMPLE_RATE,
+    getChannelData: channel => channels[channel],
+  };
+};
+
+const stubAudioContext = audioBuffer => {
+  window.AudioContext = vi.fn().mockImplementation(() => ({
+    decodeAudioData: vi.fn().mockResolvedValue(audioBuffer),
+  }));
+};
+
+describe('#encodeToMP3', () => {
+  it('encodes mono samples into a non-empty audio/mp3 blob', () => {
+    const samples = buildSineSamples(SAMPLE_RATE);
+    const blob = encodeToMP3(1, SAMPLE_RATE, [samples]);
+
+    expect(blob.type).toEqual('audio/mp3');
+    expect(blob.size).toBeGreaterThan(0);
+  });
+
+  it('encodes stereo samples with separate channel buffers without throwing', () => {
+    const left = buildSineSamples(SAMPLE_RATE, 440);
+    const right = buildSineSamples(SAMPLE_RATE, 880);
+    const blob = encodeToMP3(2, SAMPLE_RATE, [left, right]);
+
+    expect(blob.type).toEqual('audio/mp3');
+    expect(blob.size).toBeGreaterThan(0);
+  });
+});
+
+describe('#convertToMp3', () => {
+  const audioBlob = {
+    type: 'audio/webm',
+    arrayBuffer: async () => new ArrayBuffer(8),
+  };
+
+  it.each([1, 2, 6])(
+    'downmixes a %i-channel recording to mono and returns an mp3 blob',
+    async numberOfChannels => {
+      stubAudioContext(buildFakeAudioBuffer(numberOfChannels, SAMPLE_RATE));
+
+      const blob = await convertToMp3(audioBlob);
+
+      expect(blob.type).toEqual('audio/mp3');
+      expect(blob.size).toBeGreaterThan(0);
+    }
+  );
+
+  it('preserves the original error message when decoding fails', async () => {
+    window.AudioContext = vi.fn().mockImplementation(() => ({
+      decodeAudioData: vi
+        .fn()
+        .mockRejectedValue(new Error('Unable to decode audio data')),
+    }));
+
+    await expect(convertToMp3(audioBlob)).rejects.toThrow(
+      'Conversion to MP3 failed: Unable to decode audio data'
+    );
+  });
+});


### PR DESCRIPTION
## Description

`convertToMp3` passed a single interleaved sample buffer to lamejs, but lamejs'
stereo encoder requires separate left/right buffers, so recordings from
stereo/multichannel microphones (and some Bluetooth headsets) failed with
`Conversion to MP3 failed.` The catch also discarded the original error,
making the failure undiagnosable.

## Fix

- Downmix voice notes to mono before encoding (removes all multichannel
  failure modes and produces smaller files — mono is standard for voice).
- Fix `encodeToMP3` to take one buffer per channel and use lamejs' stereo
  API correctly.
- Preserve the original error message.
- Add a fallback chain (requested format → WAV → original blob) and an
  empty-recording guard in `AudioRecorder.vue` so a conversion failure can
  never silently lose the user's recording.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New vitest unit tests: `encodeToMP3` mono/stereo, `convertToMp3` with
  1/2/6-channel AudioBuffers (stubbed `decodeAudioData`), and error-message
  preservation.
- Manual recording from the ReplyBox with mono and stereo input devices.
