### PR TITLE
fix: TypeError in EmailMeta when message has no sender (Fixes #14720)

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/Email/EmailMeta.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Email/EmailMeta.vue
@@ -28,7 +28,8 @@ const ccEmail = computed(() => {
 
 const senderName = computed(() => {
   const fromEmailAddress = fromEmail.value[0] ?? '';
-  const senderEmail = sender.value.email ?? '';
+  // sender can be null (e.g. API-created or imported messages without a sender)
+  const senderEmail = sender.value?.email ?? '';
 
   if (!fromEmailAddress && !senderEmail) return null;
 


### PR DESCRIPTION
# Pull Request Template

## Description

Opening a conversation that contains an email-bubble message without an associated `sender` crashes the rendering of the entire conversation view with:

```
TypeError: Cannot read properties of null (reading 'email')
```

**Root cause**

In `app/javascript/dashboard/components-next/message/bubbles/Email/EmailMeta.vue`, the `senderName` computed dereferences the sender without a null guard:

```js
const senderEmail = sender.value.email ?? '';
```

However, `sender` is explicitly nullable throughout the stack:

- `Message` model: `belongs_to :sender, polymorphic: true, optional: true`, and `merge_sender_attributes` only includes `sender` in the payload when it is present.
- `Message.vue` declares the prop as `sender: { type: Object, default: null }`.
- The message context typedef in `components-next/message/provider.js` documents it as `Ref<Sender|null>` with default `null`.

The `?? ''` fallback only protects against `email` being null/undefined after the property access succeeds — it does not protect against `sender.value` itself being `null`. When a message has email content attributes (so `fromEmail[0]` is truthy and the meta block renders) but no sender record — e.g. messages created via the API or synced/imported from an external email system — the computed throws during render and the whole conversation message list fails to render (blank/broken conversation, every message disappears, not just the offending one).

**Fix**

Use optional chaining, matching the pattern already used for `contentAttributes` in the same file:

```js
const senderEmail = sender.value?.email ?? '';
```

The only other `sender` access in this computed, `sender.value.name`, is unreachable when `sender` is null after this change: it requires `fromEmailAddress === senderEmail` with `senderEmail` non-empty, which implies a non-null sender (when both are empty the computed returns early). So no further guards are needed.

**Steps to reproduce**

1. Create a message with email content attributes but no sender — `sender` is an optional association, so e.g. in `rails console`:
   ```ruby
   conversation.messages.create!(
     account_id: conversation.account_id,
     inbox_id: conversation.inbox_id,
     message_type: :outgoing,
     content: 'hello',
     content_attributes: { email: { from: ['agent@example.com'] } }
   )
   ```
   (In the wild this happens with messages created through the API / imported from external email systems, where `content_attributes.email` is set but no `User`/`Contact` sender is associated.)
2. Open the conversation in the dashboard.
3. The conversation view fails to render with `TypeError: Cannot read properties of null (reading 'email')` from the `senderName` computed.

Fixes #14720

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Reproduced the crash on v4.13.0 and verified the same unguarded access exists on current `develop` (`EmailMeta.vue`, `senderName` computed).
- With the fix applied (running in production on our fork since 2026-06-08), conversations containing sender-less email messages render correctly: the meta block falls back to showing just the raw `from` address (the `v-else` branch), and `senderName` behaves exactly as before for messages that do have a sender.
- Note on specs: there are currently no specs for the `components-next/message/bubbles/Email` components; the component consumes the inject-based message context plus a Vuex getter (`getSelectedChatAttachments`), so a unit spec needs a small wrapper harness around `provideMessageContext`. Happy to add one in this PR if the maintainers want it.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (see note above — can add on request)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (N/A)

---
*Developed and verified in production with the assistance of Claude (Anthropic) as AI pair programmer.*
