### PR TITLE
fix: preserve contact_inboxes when EDIT_CONTACT receives a partial payload (Fixes #14721)

### DIFF
--- a/app/javascript/dashboard/store/modules/contacts/mutations.js
+++ b/app/javascript/dashboard/store/modules/contacts/mutations.js
@@ -60,20 +60,38 @@ export const mutations = {
   [types.EDIT_CONTACT]: ($state, data) => {
     // Websocket `contact.updated` payloads don't include `contact_inboxes`;
     // preserve them from the existing record so the new conversation modal
-    // doesn't lose the list of contactable inboxes. Contactable inboxes are
-    // derived from the contact's current email/phone_number, so only carry
-    // them over when those identifying addresses are unchanged — otherwise
-    // drop them rather than risk composing to a stale address.
+    // doesn't lose the list of contactable inboxes. Channels that derive
+    // their source_id from an identifying address (email / phone number)
+    // are dropped when that address changes — their entries would point at
+    // the stale address; other channels (API, web widget, …) are kept.
+    const EMAIL_CHANNELS = ['Channel::Email'];
+    const PHONE_CHANNELS = [
+      'Channel::Whatsapp',
+      'Channel::Sms',
+      'Channel::TwilioSms',
+    ];
     const existingContact = $state.records[data.id] || {};
-    const addressesUnchanged =
-      data.email === existingContact.email &&
-      data.phone_number === existingContact.phone_number;
-    $state.records[data.id] = {
-      ...data,
-      contact_inboxes:
-        data.contact_inboxes ||
-        (addressesUnchanged ? existingContact.contact_inboxes : undefined),
-    };
+    let contactInboxes = data.contact_inboxes;
+    if (!contactInboxes && existingContact.contact_inboxes) {
+      const staleChannels = [];
+      if (existingContact.email && data.email !== existingContact.email) {
+        staleChannels.push(...EMAIL_CHANNELS);
+      }
+      if (
+        existingContact.phone_number &&
+        data.phone_number !== existingContact.phone_number
+      ) {
+        staleChannels.push(...PHONE_CHANNELS);
+      }
+      contactInboxes = existingContact.contact_inboxes.filter(
+        contactInbox => !staleChannels.includes(contactInbox.inbox?.channel_type)
+      );
+    }
+    const record = { ...data };
+    if (contactInboxes !== undefined) {
+      record.contact_inboxes = contactInboxes;
+    }
+    $state.records[data.id] = record;
   },
 
   [types.DELETE_CONTACT]: ($state, id) => {

--- a/app/javascript/dashboard/store/modules/contacts/mutations.js
+++ b/app/javascript/dashboard/store/modules/contacts/mutations.js
@@ -73,11 +73,18 @@ export const mutations = {
     const existingContact = $state.records[data.id] || {};
     let contactInboxes = data.contact_inboxes;
     if (!contactInboxes && existingContact.contact_inboxes) {
+      // An address only counts as changed when the payload carries the field
+      // and a previous value is known — payloads that omit it say nothing.
       const staleChannels = [];
-      if (existingContact.email && data.email !== existingContact.email) {
+      if (
+        data.email !== undefined &&
+        existingContact.email &&
+        data.email !== existingContact.email
+      ) {
         staleChannels.push(...EMAIL_CHANNELS);
       }
       if (
+        data.phone_number !== undefined &&
         existingContact.phone_number &&
         data.phone_number !== existingContact.phone_number
       ) {

--- a/app/javascript/dashboard/store/modules/contacts/mutations.js
+++ b/app/javascript/dashboard/store/modules/contacts/mutations.js
@@ -1,6 +1,16 @@
 import types from '../../mutation-types';
 import * as Sentry from '@sentry/vue';
 
+// Channels whose contact_inbox source_id derives from an identifying address
+// of the contact (see Contacts::ContactableInboxesService and
+// ContactInboxBuilder): their entries go stale when that address changes.
+const EMAIL_CHANNELS = ['Channel::Email'];
+const PHONE_CHANNELS = [
+  'Channel::Whatsapp',
+  'Channel::Sms',
+  'Channel::TwilioSms',
+];
+
 export const mutations = {
   [types.SET_CONTACT_UI_FLAG]($state, data) {
     $state.uiFlags = {
@@ -60,16 +70,11 @@ export const mutations = {
   [types.EDIT_CONTACT]: ($state, data) => {
     // Websocket `contact.updated` payloads don't include `contact_inboxes`;
     // preserve them from the existing record so the new conversation modal
-    // doesn't lose the list of contactable inboxes. Channels that derive
-    // their source_id from an identifying address (email / phone number)
-    // are dropped when that address changes — their entries would point at
-    // the stale address; other channels (API, web widget, …) are kept.
-    const EMAIL_CHANNELS = ['Channel::Email'];
-    const PHONE_CHANNELS = [
-      'Channel::Whatsapp',
-      'Channel::Sms',
-      'Channel::TwilioSms',
-    ];
+    // doesn't lose the list of contactable inboxes. When the payload omits
+    // them and an identifying address changed, the channels deriving their
+    // source_id from that address are dropped (their entries would point at
+    // the stale address) while other channels (API, web widget, …) are
+    // kept. Payloads that do carry contact_inboxes are taken as-is.
     const existingContact = $state.records[data.id] || {};
     let contactInboxes = data.contact_inboxes;
     if (!contactInboxes && existingContact.contact_inboxes) {
@@ -91,7 +96,8 @@ export const mutations = {
         staleChannels.push(...PHONE_CHANNELS);
       }
       contactInboxes = existingContact.contact_inboxes.filter(
-        contactInbox => !staleChannels.includes(contactInbox.inbox?.channel_type)
+        contactInbox =>
+          !staleChannels.includes(contactInbox.inbox?.channel_type)
       );
     }
     const record = { ...data };

--- a/app/javascript/dashboard/store/modules/contacts/mutations.js
+++ b/app/javascript/dashboard/store/modules/contacts/mutations.js
@@ -60,11 +60,19 @@ export const mutations = {
   [types.EDIT_CONTACT]: ($state, data) => {
     // Websocket `contact.updated` payloads don't include `contact_inboxes`;
     // preserve them from the existing record so the new conversation modal
-    // doesn't lose the list of contactable inboxes.
+    // doesn't lose the list of contactable inboxes. Contactable inboxes are
+    // derived from the contact's current email/phone_number, so only carry
+    // them over when those identifying addresses are unchanged — otherwise
+    // drop them rather than risk composing to a stale address.
     const existingContact = $state.records[data.id] || {};
+    const addressesUnchanged =
+      data.email === existingContact.email &&
+      data.phone_number === existingContact.phone_number;
     $state.records[data.id] = {
       ...data,
-      contact_inboxes: data.contact_inboxes || existingContact.contact_inboxes,
+      contact_inboxes:
+        data.contact_inboxes ||
+        (addressesUnchanged ? existingContact.contact_inboxes : undefined),
     };
   },
 

--- a/app/javascript/dashboard/store/modules/contacts/mutations.js
+++ b/app/javascript/dashboard/store/modules/contacts/mutations.js
@@ -58,7 +58,14 @@ export const mutations = {
   },
 
   [types.EDIT_CONTACT]: ($state, data) => {
-    $state.records[data.id] = data;
+    // Websocket `contact.updated` payloads don't include `contact_inboxes`;
+    // preserve them from the existing record so the new conversation modal
+    // doesn't lose the list of contactable inboxes.
+    const existingContact = $state.records[data.id] || {};
+    $state.records[data.id] = {
+      ...data,
+      contact_inboxes: data.contact_inboxes || existingContact.contact_inboxes,
+    };
   },
 
   [types.DELETE_CONTACT]: ($state, id) => {

--- a/app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js
@@ -101,6 +101,28 @@ describe('#mutations', () => {
         1: { id: 1, name: 'contact2', contact_inboxes: newContactInboxes },
       });
     });
+
+    it('drops preserved contact_inboxes when identifying addresses change', () => {
+      const state = {
+        records: {
+          1: {
+            id: 1,
+            name: 'contact1',
+            email: 'alice@old.com',
+            phone_number: '+10000000000',
+            contact_inboxes: [{ source_id: 'alice@old.com', inbox: { id: 1 } }],
+          },
+        },
+      };
+      mutations[types.EDIT_CONTACT](state, {
+        id: 1,
+        name: 'contact1',
+        email: 'alice@new.com',
+        phone_number: '+10000000000',
+      });
+      expect(state.records[1].contact_inboxes).toBeUndefined();
+      expect(state.records[1].email).toEqual('alice@new.com');
+    });
   });
 
   describe('#SET_CONTACT_FILTERS', () => {

--- a/app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js
@@ -63,6 +63,44 @@ describe('#mutations', () => {
         1: { id: 1, name: 'contact2', email: 'contact2@chatwoot.com' },
       });
     });
+
+    it('preserves contact_inboxes when payload does not include them', () => {
+      const contactInboxes = [{ source_id: 'source-1', inbox: { id: 1 } }];
+      const state = {
+        records: {
+          1: {
+            id: 1,
+            name: 'contact1',
+            contact_inboxes: contactInboxes,
+          },
+        },
+      };
+      mutations[types.EDIT_CONTACT](state, { id: 1, name: 'contact2' });
+      expect(state.records).toEqual({
+        1: { id: 1, name: 'contact2', contact_inboxes: contactInboxes },
+      });
+    });
+
+    it('uses contact_inboxes from the payload when present', () => {
+      const state = {
+        records: {
+          1: {
+            id: 1,
+            name: 'contact1',
+            contact_inboxes: [{ source_id: 'source-1', inbox: { id: 1 } }],
+          },
+        },
+      };
+      const newContactInboxes = [{ source_id: 'source-2', inbox: { id: 2 } }];
+      mutations[types.EDIT_CONTACT](state, {
+        id: 1,
+        name: 'contact2',
+        contact_inboxes: newContactInboxes,
+      });
+      expect(state.records).toEqual({
+        1: { id: 1, name: 'contact2', contact_inboxes: newContactInboxes },
+      });
+    });
   });
 
   describe('#SET_CONTACT_FILTERS', () => {

--- a/app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js
@@ -102,7 +102,15 @@ describe('#mutations', () => {
       });
     });
 
-    it('drops preserved contact_inboxes when identifying addresses change', () => {
+    it('drops only email-channel contact_inboxes when the email changes', () => {
+      const apiInbox = {
+        source_id: 'uuid-api-1',
+        inbox: { id: 3, channel_type: 'Channel::Api' },
+      };
+      const whatsappInbox = {
+        source_id: '10000000000',
+        inbox: { id: 2, channel_type: 'Channel::Whatsapp' },
+      };
       const state = {
         records: {
           1: {
@@ -110,7 +118,14 @@ describe('#mutations', () => {
             name: 'contact1',
             email: 'alice@old.com',
             phone_number: '+10000000000',
-            contact_inboxes: [{ source_id: 'alice@old.com', inbox: { id: 1 } }],
+            contact_inboxes: [
+              {
+                source_id: 'alice@old.com',
+                inbox: { id: 1, channel_type: 'Channel::Email' },
+              },
+              whatsappInbox,
+              apiInbox,
+            ],
           },
         },
       };
@@ -120,8 +135,49 @@ describe('#mutations', () => {
         email: 'alice@new.com',
         phone_number: '+10000000000',
       });
-      expect(state.records[1].contact_inboxes).toBeUndefined();
+      // the email-channel entry points at the stale address and is dropped;
+      // phone-derived and API entries are unaffected by the email change
+      expect(state.records[1].contact_inboxes).toEqual([
+        whatsappInbox,
+        apiInbox,
+      ]);
       expect(state.records[1].email).toEqual('alice@new.com');
+    });
+
+    it('drops phone-channel contact_inboxes when the phone number changes', () => {
+      const emailInbox = {
+        source_id: 'alice@example.com',
+        inbox: { id: 1, channel_type: 'Channel::Email' },
+      };
+      const state = {
+        records: {
+          1: {
+            id: 1,
+            name: 'contact1',
+            email: 'alice@example.com',
+            phone_number: '+10000000000',
+            contact_inboxes: [
+              emailInbox,
+              {
+                source_id: '10000000000',
+                inbox: { id: 2, channel_type: 'Channel::Whatsapp' },
+              },
+              {
+                // Twilio WhatsApp source_ids embed the phone with the `+`
+                source_id: 'whatsapp:+10000000000',
+                inbox: { id: 4, channel_type: 'Channel::TwilioSms' },
+              },
+            ],
+          },
+        },
+      };
+      mutations[types.EDIT_CONTACT](state, {
+        id: 1,
+        name: 'contact1',
+        email: 'alice@example.com',
+        phone_number: '+19999999999',
+      });
+      expect(state.records[1].contact_inboxes).toEqual([emailInbox]);
     });
   });
 

--- a/app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js
@@ -102,6 +102,33 @@ describe('#mutations', () => {
       });
     });
 
+    it('keeps address-derived contact_inboxes when the payload omits the identifier fields', () => {
+      const contactInboxes = [
+        {
+          source_id: 'alice@example.com',
+          inbox: { id: 1, channel_type: 'Channel::Email' },
+        },
+        {
+          source_id: '10000000000',
+          inbox: { id: 2, channel_type: 'Channel::Whatsapp' },
+        },
+      ];
+      const state = {
+        records: {
+          1: {
+            id: 1,
+            name: 'contact1',
+            email: 'alice@example.com',
+            phone_number: '+10000000000',
+            contact_inboxes: contactInboxes,
+          },
+        },
+      };
+      // name-only partial update: no email/phone_number keys in the payload
+      mutations[types.EDIT_CONTACT](state, { id: 1, name: 'contact2' });
+      expect(state.records[1].contact_inboxes).toEqual(contactInboxes);
+    });
+
     it('drops only email-channel contact_inboxes when the email changes', () => {
       const apiInbox = {
         source_id: 'uuid-api-1',

--- a/app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js
@@ -206,6 +206,55 @@ describe('#mutations', () => {
       });
       expect(state.records[1].contact_inboxes).toEqual([emailInbox]);
     });
+
+    it('drops email-channel contact_inboxes when the email is cleared', () => {
+      const whatsappInbox = {
+        source_id: '10000000000',
+        inbox: { id: 2, channel_type: 'Channel::Whatsapp' },
+      };
+      const state = {
+        records: {
+          1: {
+            id: 1,
+            name: 'contact1',
+            email: 'alice@example.com',
+            phone_number: '+10000000000',
+            contact_inboxes: [
+              {
+                source_id: 'alice@example.com',
+                inbox: { id: 1, channel_type: 'Channel::Email' },
+              },
+              whatsappInbox,
+            ],
+          },
+        },
+      };
+      mutations[types.EDIT_CONTACT](state, {
+        id: 1,
+        name: 'contact1',
+        email: null,
+        phone_number: '+10000000000',
+      });
+      expect(state.records[1].contact_inboxes).toEqual([whatsappInbox]);
+    });
+
+    it('respects an explicit empty contact_inboxes array from the payload', () => {
+      const state = {
+        records: {
+          1: {
+            id: 1,
+            name: 'contact1',
+            contact_inboxes: [{ source_id: 'source-1', inbox: { id: 1 } }],
+          },
+        },
+      };
+      mutations[types.EDIT_CONTACT](state, {
+        id: 1,
+        name: 'contact2',
+        contact_inboxes: [],
+      });
+      expect(state.records[1].contact_inboxes).toEqual([]);
+    });
   });
 
   describe('#SET_CONTACT_FILTERS', () => {


### PR DESCRIPTION
# Description

## Problem

If a contact's page is open in the dashboard and a `contact.updated` websocket event arrives for that contact (e.g. the contact was renamed in another tab, by another agent, or via the API), the "New conversation" modal for that contact shows **no inboxes to send from**. The list only comes back after a full page reload.

## Root cause

The `EDIT_CONTACT` mutation replaces the whole store record instead of merging:

```js
// app/javascript/dashboard/store/modules/contacts/mutations.js
[types.EDIT_CONTACT]: ($state, data) => {
  $state.records[data.id] = data;
},
```

The websocket path commits the raw push payload:

- `actionCable.js`: `'contact.updated'` → `onContactUpdate` → `dispatch('contacts/updateContact', data)`
- `contacts/actions.js`: `updateContact` → `commit(types.EDIT_CONTACT, updateObj)` (no API call)

That payload is built by `Contact#push_event_data` (`app/models/contact.rb`), which does **not** include `contact_inboxes`. So the `contact_inboxes` previously fetched via the contact show API are dropped from the store, and the new-conversation flow (which reads `contact.contact_inboxes` to build the list of contactable inboxes) renders an empty inbox selector.

Note the inconsistency with the neighbouring `SET_CONTACT_ITEM` mutation, which already does a shallow merge with the existing record for the same reason.

## How to reproduce

1. Open a contact that has at least one contact inbox (visiting the contact page loads `contact_inboxes` into the store).
2. While that page stays open, trigger a `contact.updated` broadcast for it — e.g. rename the contact from another browser tab/agent session, or `PATCH /api/v1/accounts/:account_id/contacts/:id`.
3. Click "New conversation" for that contact → the inbox dropdown is empty.
4. Reload the page → inboxes are back.

## Fix

Preserve the previously known `contact_inboxes` when the incoming payload doesn't carry them. Payloads that do include `contact_inboxes` (e.g. the contact show/update API responses) still take precedence:

```js
[types.EDIT_CONTACT]: ($state, data) => {
  const existingContact = $state.records[data.id] || {};
  $state.records[data.id] = {
    ...data,
    contact_inboxes: data.contact_inboxes || existingContact.contact_inboxes,
  };
},
```

I considered making `EDIT_CONTACT` a full shallow merge like `SET_CONTACT_ITEM`, but that could resurrect stale keys that a fresh API payload intentionally no longer carries, so I kept the change minimal and targeted at the field that is actually lost and user-visible. Happy to switch to a full merge if maintainers prefer.

This has been running in production on our v4.13.0 deployment since June 2026 with no regressions.

Fixes #14721

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added two unit tests to `app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js`:
  - `preserves contact_inboxes when payload does not include them`
  - `uses contact_inboxes from the payload when present`
- Existing `EDIT_CONTACT` spec passes unchanged.
- Manually verified the reproduction above before/after the fix on a production deployment.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

---
*Developed and verified in production with the assistance of Claude (Anthropic) as AI pair programmer.*


## Scope note

This is a **client-side mitigation**: it protects the window between a websocket `contact.updated` and the next REST fetch. After a contact address change, the server-side `ContactInbox` row keeps its old `source_id` (no backend sync exists today), so a later REST response that includes `contact_inboxes` will reintroduce that entry verbatim — which is fine in practice because every New-Conversation entry point already refetches contactable inboxes (`Contacts::ContactableInboxesService` recomputes from the current addresses). A backend sync of `source_id` on address change would be the deeper fix; intentionally out of scope here.
