### PR TITLE
fix: Stabilize help center builder error spec

### DIFF
--- a/spec/enterprise/services/onboarding/help_center_article_builder_spec.rb
+++ b/spec/enterprise/services/onboarding/help_center_article_builder_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe Onboarding::HelpCenterArticleBuilder do
 
       expect(Firecrawl::Configuration).not_to receive(:client)
       expect { builder.perform }
-        .to raise_error(Onboarding::HelpCenterErrors::ArticleBuildFailed, /no source urls/)
+        .to raise_error(StandardError) { |error|
+          expect(error.class.name).to eq('Onboarding::HelpCenterErrors::ArticleBuildFailed')
+          expect(error.message).to include('no source urls')
+        }
     end
   end
 end


### PR DESCRIPTION
## Description

Stabilizes the enterprise help center article builder source URL validation spec by asserting the custom exception via its class name and message text. This keeps the spec focused on the intended behavior while avoiding brittle custom exception constant identity checks in CI/reloading environments.

A bunch of builds on different PRs have been failing because of this error, sample traces are below:
* https://app.circleci.com/pipelines/github/chatwoot/chatwoot/114064/workflows/bdb6eca9-3b65-4c38-b8cf-f2f8564476f8/jobs/158777
* https://app.circleci.com/pipelines/github/chatwoot/chatwoot/114064/workflows/bdb6eca9-3b65-4c38-b8cf-f2f8564476f8/jobs/158777

Fixes # N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `/Users/sonymathew/.rbenv/shims/bundle exec rspec spec/enterprise/services/onboarding/help_center_article_builder_spec.rb`
- `/Users/sonymathew/.rbenv/shims/bundle exec rubocop spec/enterprise/services/onboarding/help_center_article_builder_spec.rb`
- `git diff --check`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
