### PR TITLE
[codex] Upgrade net-imap

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -582,7 +582,7 @@ GEM
       uri (>= 0.11.1)
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
-    net-imap (0.4.24)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
# Pull Request Template

## Description

Upgrades `net-imap` from `0.4.24` to `0.6.4.1` so bundle audit no longer flags CVE-2026-47240, CVE-2026-47241, and CVE-2026-47242 in CI.

The advisory affects raw IMAP command arguments. Chatwoot's current IMAP polling path uses fixed fetch attributes and a server-generated search date, so the reachable risk appears low, but upgrading to the patched gem is safer than carrying an audit exception.

Fixes: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `bundle exec bundle audit update`
- `bundle exec bundle audit check -v`
- `bundle exec rspec spec/services/imap/fetch_email_service_spec.rb spec/services/imap/microsoft_fetch_email_service_spec.rb`
- `bundle exec rubocop` (fails on existing unrelated generated DB file offenses in `db/migrate/20230426130150_init_schema.rb` and `db/schema.rb`)
- `git diff --check`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
