### PR TITLE
fix(facebook): trigger Reauthorize banner when page permissions are revoked (code 190 / OAuthException)

### DIFF
--- a/app/services/facebook/send_on_facebook_service.rb
+++ b/app/services/facebook/send_on_facebook_service.rb
@@ -114,10 +114,14 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
   def handle_facebook_error(exception)
     # Refer: https://github.com/jgorset/facebook-messenger/blob/64fe1f5cef4c1e3fca295b205037f64dfebdbcab/lib/facebook/messenger/error.rb
     # https://developers.facebook.com/docs/graph-api/guides/error-handling/
-    # Classify any authentication failure as a channel authorization error
-    # rather than relying on exact error-message matching, which misses
+    # Classify authentication failures as channel authorization errors
+    # instead of relying on exact error-message matching, which misses
     # scope-revocation errors such as "permission(s) must be granted before
-    # impersonating a user's page".
+    # impersonating a user's page". Only token-validation errors qualify:
+    # Graph API code 190 or the known token-invalidation messages. A bare
+    # OAuthException is intentionally not enough, since per-recipient send
+    # failures (e.g. code 200 "This person isn't available right now") also
+    # surface as OAuthException but reconnecting the Page won't fix them.
     return unless authorization_error?(exception)
 
     channel.authorization_error!
@@ -125,7 +129,6 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
 
   def authorization_error?(exception)
     exception.code.to_i == 190 ||
-      exception.type.to_s == 'OAuthException' ||
       exception.to_s.include?('The session has been invalidated') ||
       exception.to_s.include?('Error validating access token')
   end

--- a/app/services/facebook/send_on_facebook_service.rb
+++ b/app/services/facebook/send_on_facebook_service.rb
@@ -113,8 +113,20 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
 
   def handle_facebook_error(exception)
     # Refer: https://github.com/jgorset/facebook-messenger/blob/64fe1f5cef4c1e3fca295b205037f64dfebdbcab/lib/facebook/messenger/error.rb
-    return unless exception.to_s.include?('The session has been invalidated') || exception.to_s.include?('Error validating access token')
+    # https://developers.facebook.com/docs/graph-api/guides/error-handling/
+    # Classify any authentication failure as a channel authorization error
+    # rather than relying on exact error-message matching, which misses
+    # scope-revocation errors such as "permission(s) must be granted before
+    # impersonating a user's page".
+    return unless authorization_error?(exception)
 
     channel.authorization_error!
+  end
+
+  def authorization_error?(exception)
+    exception.code.to_i == 190 ||
+      exception.type.to_s == 'OAuthException' ||
+      exception.to_s.include?('The session has been invalidated') ||
+      exception.to_s.include?('Error validating access token')
   end
 end

--- a/spec/services/facebook/send_on_facebook_service_spec.rb
+++ b/spec/services/facebook/send_on_facebook_service_spec.rb
@@ -79,14 +79,16 @@ describe Facebook::SendOnFacebookService do
         expect(message.reload.status).to eq('failed')
       end
 
-      it 'marks OAuthException without code 190 as an authorization error' do
+      it 'does not flag a per-recipient OAuthException (code 200) as an authorization error' do
         message = create(:message, message_type: 'outgoing', inbox: facebook_inbox, account: account, conversation: conversation)
         allow(bot).to receive(:deliver).and_raise(
-          Facebook::Messenger::FacebookError.new('message' => 'Some unexpected OAuth failure', 'type' => 'OAuthException')
+          Facebook::Messenger::FacebookError.new('message' => "This person isn't available right now.", 'type' => 'OAuthException', 'code' => 200,
+                                                 'error_subcode' => 1_545_041)
         )
         described_class.new(message: message).perform
 
-        expect(facebook_channel.authorization_error_count).to eq(1)
+        expect(facebook_channel.authorization_error_count).to eq(0)
+        expect(message.reload.status).to eq('failed')
       end
 
       it 'does not flag unrelated errors as authorization errors' do

--- a/spec/services/facebook/send_on_facebook_service_spec.rb
+++ b/spec/services/facebook/send_on_facebook_service_spec.rb
@@ -63,6 +63,43 @@ describe Facebook::SendOnFacebookService do
         expect(message.reload.external_error).to eq('Error validating access token')
       end
 
+      it 'marks missing granular facebook scopes (code 190) as an authorization error' do
+        message = create(:message, message_type: 'outgoing', inbox: facebook_inbox, account: account, conversation: conversation)
+        allow(bot).to receive(:deliver).and_raise(
+          Facebook::Messenger::FacebookError.new(
+            'message' => "permission(s) must be granted before impersonating a user's page.",
+            'type' => 'OAuthException',
+            'code' => 190,
+            'fbtrace_id' => 'BLBz/WZt8dN'
+          )
+        )
+        described_class.new(message: message).perform
+
+        expect(facebook_channel.authorization_error_count).to eq(1)
+        expect(message.reload.status).to eq('failed')
+      end
+
+      it 'marks OAuthException without code 190 as an authorization error' do
+        message = create(:message, message_type: 'outgoing', inbox: facebook_inbox, account: account, conversation: conversation)
+        allow(bot).to receive(:deliver).and_raise(
+          Facebook::Messenger::FacebookError.new('message' => 'Some unexpected OAuth failure', 'type' => 'OAuthException')
+        )
+        described_class.new(message: message).perform
+
+        expect(facebook_channel.authorization_error_count).to eq(1)
+      end
+
+      it 'does not flag unrelated errors as authorization errors' do
+        message = create(:message, message_type: 'outgoing', inbox: facebook_inbox, account: account, conversation: conversation)
+        allow(bot).to receive(:deliver).and_raise(
+          Facebook::Messenger::FacebookError.new('message' => 'Temporary server error', 'type' => 'FacebookApiException', 'code' => 2)
+        )
+        described_class.new(message: message).perform
+
+        expect(facebook_channel.authorization_error_count).to eq(0)
+        expect(message.reload.status).to eq('failed')
+      end
+
       it 'if message with attachment is sent from chatwoot and is outgoing' do
         message = build(:message, message_type: 'outgoing', inbox: facebook_inbox, account: account, conversation: conversation)
         attachment = message.attachments.new(account_id: message.account_id, file_type: :image)


### PR DESCRIPTION
When a Facebook Page access token becomes invalid because the administrator revoked permissions or omitted the page during a subsequent OAuth flow, Meta rejects outgoing messages with a Graph API error of code `190` / type `OAuthException` (e.g. _"... permission(s) must be granted before impersonating a user's page."_). Chatwoot ignored these failures, so the **Reauthorize** banner never appeared on the inbox settings page and the page could not be reconnected from the UI (it is filtered out of _Add Inbox > Facebook_ because it already exists). With this change, those errors are treated as channel authorization errors and the banner shows up so the inbox can be reconnected.

Closes #14729

## How to reproduce
1. Add a Facebook inbox with two pages: Page A and Page B.
2. Re-run the Facebook App OAuth (e.g. add a new channel) but uncheck Page A.
3. Send a message to Page A from Chatwoot.
4. Before the fix: the message fails, but no **Reauthorize** banner appears on the Page A inbox settings page, and Page A is missing from _Add Inbox > Facebook_.
5. After the fix: the **Reauthorize** banner appears, letting the user reconnect Page A.

## What changed
- `app/services/facebook/send_on_facebook_service.rb`: `handle_facebook_error` now classifies any Graph API error code `190` or `OAuthException` as a channel authorization error instead of relying on exact error-message matching. The legacy message-string checks (`The session has been invalidated`, `Error validating access token`) are kept as a fallback. This mirrors the existing behavior already used for Instagram.
- `spec/services/facebook/send_on_facebook_service_spec.rb`: added coverage for the scope-revocation error (code `190`), a generic `OAuthException` without code `190`, and a negative case ensuring unrelated errors are not flagged.
