### PR TITLE
chore: add opt-in Report-Only Content Security Policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -234,6 +234,17 @@ ANDROID_SHA256_CERT_FINGERPRINT=AC:73:8E:DE:EB:56:EA:CC:10:87:02:A7:65:37:7B:38:
 # Comma-separated list of trusted IPs that bypass Rack Attack throttling rules
 # RACK_ATTACK_ALLOWED_IPS=127.0.0.1,::1,192.168.0.10
 
+## Content Security Policy (Report-Only)
+## When enabled, Chatwoot emits a Content-Security-Policy-Report-Only header
+## so violations are reported without blocking content. Use this to discover
+## inline scripts/styles, external assets, and embeds before enforcing a
+## strict policy. Default is off.
+# ENABLE_CSP_REPORT_ONLY=false
+## Optional: endpoint that the browser POSTs CSP violation reports to.
+## Can be a same-origin path (e.g. /csp-violation-report-endpoint) or an
+## absolute URL pointing at a reporting service.
+# CSP_REPORT_URI=
+
 ## SafeFetch private network access
 ## Keep disabled by default. Self-hosted installations can enable this to allow SafeFetch requests to private network URLs.
 # SAFE_FETCH_ALLOW_PRIVATE_NETWORK=false

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,36 +1,47 @@
 # Be sure to restart your server when you modify this file.
+#
+# Define an application-wide Content Security Policy. Chatwoot ships this in
+# Report-Only mode and only when ENABLE_CSP_REPORT_ONLY is truthy, so existing
+# installations are unaffected by default. Operators can opt-in to surface
+# violation reports for their installation, then iteratively tighten the policy
+# before flipping it to enforcement mode.
+#
+# Refs:
+#   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+#   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+#   * https://github.com/chatwoot/chatwoot/issues/404
 
-# Define an application-wide content security policy
-# For further information see the following documentation
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+return unless ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_CSP_REPORT_ONLY', false))
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-# Allow @vite/client to hot reload javascript changes in development
-#   policy.script_src *policy.script_src, :unsafe_eval, "http://#{ ViteRuby.config.host_with_port }" if Rails.env.development?
-# You may need to enable this in production as well depending on your setup.
-#   policy.script_src *policy.script_src, :blob if Rails.env.test?
-#   policy.style_src   :self, :https
-# Allow @vite/client to hot reload style changes in development
-#    policy.style_src *policy.style_src, :unsafe_inline if Rails.env.development?
-# Allow @vite/client to hot reload changes in development
-#    policy.connect_src *policy.connect_src, "ws://#{ ViteRuby.config.host_with_port }" if Rails.env.development?
+Rails.application.config.content_security_policy do |policy|
+  # Deliberately permissive starter policy. The goal of the first rollout is to
+  # collect real-world violation reports without breaking pages, so we keep
+  # 'unsafe-inline'/'unsafe-eval' for now. They should be removed once nonces
+  # or hashes are in place for inline scripts/styles.
+  policy.default_src     :self, :https
+  policy.font_src        :self, :https, :data
+  policy.img_src         :self, :https, :data, :blob
+  policy.media_src       :self, :https, :data, :blob
+  policy.object_src      :none
+  policy.script_src      :self, :https, :unsafe_inline, :unsafe_eval
+  policy.style_src       :self, :https, :unsafe_inline
+  policy.connect_src     :self, :https, 'wss:'
+  policy.frame_src       :self, :https
+  policy.frame_ancestors :self
+  policy.base_uri        :self
+  policy.form_action     :self, :https
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  # Vite dev server needs http+ws to its host for HMR.
+  if Rails.env.development? && defined?(ViteRuby)
+    vite_host = ViteRuby.config.host_with_port
+    policy.script_src(*policy.script_src, "http://#{vite_host}")
+    policy.connect_src(*policy.connect_src, "http://#{vite_host}", "ws://#{vite_host}")
+  end
 
-# If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+  report_uri = ENV.fetch('CSP_REPORT_URI', nil)
+  policy.report_uri(report_uri) if report_uri.present?
+end
 
-# Set the nonce only to specific directives
-# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
-
-# Report CSP violations to a specified URI
-# For further information see the following documentation:
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-# Rails.application.config.content_security_policy_report_only = true
+# Report-only: log violations but never block. Operators flip this to false
+# (and remove unsafe-inline/unsafe-eval) once they have audited their reports.
+Rails.application.config.content_security_policy_report_only = true

--- a/spec/config/content_security_policy_spec.rb
+++ b/spec/config/content_security_policy_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+describe 'Content Security Policy Configuration' do
+  # rubocop:enable RSpec/DescribeClass
+
+  # The CSP initializer reads ENABLE_CSP_REPORT_ONLY at boot time, so the
+  # current process can only assert the boot-time outcome. We test what the
+  # initializer produces by re-loading it with a stubbed ENV.
+  let(:initializer_path) { Rails.root.join('config/initializers/content_security_policy.rb') }
+
+  def reload_initializer
+    # Reset so a previous run does not leak into this one.
+    Rails.application.config.content_security_policy = nil
+    Rails.application.config.content_security_policy_report_only = false
+    load initializer_path
+  end
+
+  context 'when ENABLE_CSP_REPORT_ONLY is unset (default)' do
+    around do |example|
+      ClimateControl.modify(ENABLE_CSP_REPORT_ONLY: nil) { example.run }
+    end
+
+    it 'does not configure a content security policy' do
+      reload_initializer
+      expect(Rails.application.config.content_security_policy).to be_nil
+    end
+  end
+
+  context 'when ENABLE_CSP_REPORT_ONLY is true' do
+    around do |example|
+      ClimateControl.modify(ENABLE_CSP_REPORT_ONLY: 'true') { example.run }
+    end
+
+    it 'configures a content security policy in report-only mode' do
+      reload_initializer
+      expect(Rails.application.config.content_security_policy).to be_a(ActionDispatch::ContentSecurityPolicy)
+      expect(Rails.application.config.content_security_policy_report_only).to be(true)
+    end
+
+    it 'sets restrictive defaults that still allow https assets' do
+      reload_initializer
+      policy = Rails.application.config.content_security_policy
+
+      expect(policy.default_src).to include("'self'", 'https:')
+      expect(policy.object_src).to eq(["'none'"])
+      expect(policy.frame_ancestors).to eq(["'self'"])
+      expect(policy.base_uri).to eq(["'self'"])
+    end
+
+    it 'does not set a report_uri when CSP_REPORT_URI is unset' do
+      ClimateControl.modify(CSP_REPORT_URI: nil) do
+        reload_initializer
+        # ContentSecurityPolicy stores @report_uri internally; a nil value means
+        # the report-uri directive is omitted from the rendered header.
+        expect(Rails.application.config.content_security_policy.instance_variable_get(:@report_uri)).to be_nil
+      end
+    end
+
+    it 'sets report_uri when CSP_REPORT_URI is provided' do
+      ClimateControl.modify(CSP_REPORT_URI: 'https://example.com/csp-report') do
+        reload_initializer
+        expect(Rails.application.config.content_security_policy.instance_variable_get(:@report_uri)).to eq('https://example.com/csp-report')
+      end
+    end
+  end
+
+  context 'when ENABLE_CSP_REPORT_ONLY is set to a falsy string' do
+    around do |example|
+      ClimateControl.modify(ENABLE_CSP_REPORT_ONLY: 'false') { example.run }
+    end
+
+    it 'does not configure a content security policy' do
+      reload_initializer
+      expect(Rails.application.config.content_security_policy).to be_nil
+    end
+  end
+end

--- a/spec/config/content_security_policy_spec.rb
+++ b/spec/config/content_security_policy_spec.rb
@@ -8,11 +8,14 @@ describe 'Content Security Policy Configuration' do
   # current process can only assert the boot-time outcome. We test what the
   # initializer produces by re-loading it with a stubbed ENV.
   let(:initializer_path) { Rails.root.join('config/initializers/content_security_policy.rb') }
+  let(:config) { Rails.application.config }
 
   def reload_initializer
-    # Reset so a previous run does not leak into this one.
-    Rails.application.config.content_security_policy = nil
-    Rails.application.config.content_security_policy_report_only = false
+    # Reset so a previous run does not leak into this one. The Rails config DSL
+    # method `content_security_policy` is read+block-write only, so we clear the
+    # underlying ivar directly.
+    config.instance_variable_set(:@content_security_policy, nil)
+    config.content_security_policy_report_only = false
     load initializer_path
   end
 
@@ -23,7 +26,7 @@ describe 'Content Security Policy Configuration' do
 
     it 'does not configure a content security policy' do
       reload_initializer
-      expect(Rails.application.config.content_security_policy).to be_nil
+      expect(config.content_security_policy).to be_nil
     end
   end
 
@@ -34,33 +37,31 @@ describe 'Content Security Policy Configuration' do
 
     it 'configures a content security policy in report-only mode' do
       reload_initializer
-      expect(Rails.application.config.content_security_policy).to be_a(ActionDispatch::ContentSecurityPolicy)
-      expect(Rails.application.config.content_security_policy_report_only).to be(true)
+      expect(config.content_security_policy).to be_a(ActionDispatch::ContentSecurityPolicy)
+      expect(config.content_security_policy_report_only).to be(true)
     end
 
     it 'sets restrictive defaults that still allow https assets' do
       reload_initializer
-      policy = Rails.application.config.content_security_policy
+      directives = config.content_security_policy.directives
 
-      expect(policy.default_src).to include("'self'", 'https:')
-      expect(policy.object_src).to eq(["'none'"])
-      expect(policy.frame_ancestors).to eq(["'self'"])
-      expect(policy.base_uri).to eq(["'self'"])
+      expect(directives['default-src']).to include("'self'", 'https:')
+      expect(directives['object-src']).to eq(["'none'"])
+      expect(directives['frame-ancestors']).to eq(["'self'"])
+      expect(directives['base-uri']).to eq(["'self'"])
     end
 
-    it 'does not set a report_uri when CSP_REPORT_URI is unset' do
+    it 'does not set a report-uri directive when CSP_REPORT_URI is unset' do
       ClimateControl.modify(CSP_REPORT_URI: nil) do
         reload_initializer
-        # ContentSecurityPolicy stores @report_uri internally; a nil value means
-        # the report-uri directive is omitted from the rendered header.
-        expect(Rails.application.config.content_security_policy.instance_variable_get(:@report_uri)).to be_nil
+        expect(config.content_security_policy.directives).not_to have_key('report-uri')
       end
     end
 
-    it 'sets report_uri when CSP_REPORT_URI is provided' do
+    it 'sets the report-uri directive when CSP_REPORT_URI is provided' do
       ClimateControl.modify(CSP_REPORT_URI: 'https://example.com/csp-report') do
         reload_initializer
-        expect(Rails.application.config.content_security_policy.instance_variable_get(:@report_uri)).to eq('https://example.com/csp-report')
+        expect(config.content_security_policy.directives['report-uri']).to eq(['https://example.com/csp-report'])
       end
     end
   end
@@ -72,7 +73,7 @@ describe 'Content Security Policy Configuration' do
 
     it 'does not configure a content security policy' do
       reload_initializer
-      expect(Rails.application.config.content_security_policy).to be_nil
+      expect(config.content_security_policy).to be_nil
     end
   end
 end


### PR DESCRIPTION
### Description

Closes #404.

The repo has shipped the Rails-default `config/initializers/content_security_policy.rb` (entirely commented out) since the file was generated. Issue #404 asks for a starter implementation, beginning with reports rather than enforcement.

This PR adds an **opt-in, Report-Only** Content Security Policy:

- New env var `ENABLE_CSP_REPORT_ONLY` (default `false`) — gates the whole policy. Existing installations are **completely unaffected** unless an operator opts in.
- New env var `CSP_REPORT_URI` — optional reporting endpoint for `Content-Security-Policy-Report-Only` violation reports.
- Report-Only header so the browser logs violations but never blocks content. Operators can audit reports, tighten the policy (drop `'unsafe-inline'`/`'unsafe-eval'`, add nonces, etc.), and only then flip to enforcement.
- Vite dev server (`http://`/`ws://`) is allowlisted in development so HMR keeps working.

### Why opt-in by default?

Chatwoot has a large self-hosted footprint with custom inboxes, custom integrations (Stripe, Sentry, Dialogflow, Captain, Shopify, Webpush, custom dashboard apps via iframes), and embedded help-center widgets. Enabling any CSP — even Report-Only — by default would generate noise in operators' Sentry/log pipelines without warning. Making it opt-in lets each operator turn it on deliberately, point reports at their own collector via `CSP_REPORT_URI`, then iterate the policy for their environment. The starter policy is intentionally permissive (`'unsafe-inline'`, `'unsafe-eval'`) — the goal of the first rollout is to **collect data**, not to enforce.

### Type of change

- [x] Chore (refactoring, code cleanup, etc.)
- [x] Documentation update (`.env.example`)
- [x] This change requires a documentation update

### How Has This Been Tested?

- New spec at `spec/config/content_security_policy_spec.rb`, modelled on the existing `spec/config/session_store_spec.rb`. Covers:
  - Default (env unset) → no policy configured.
  - Falsy string (`"false"`) → no policy configured.
  - Truthy string (`"true"`) → policy is configured, `report_only` flag is set, restrictive defaults are present.
  - `CSP_REPORT_URI` unset → no `report-uri` directive.
  - `CSP_REPORT_URI` set → `report-uri` directive contains the configured URL.
- The spec uses `ClimateControl` (already in `Gemfile`'s `development, test` group) to scope env-var changes per example.

### Operator rollout guidance (suggested follow-up doc PR if accepted)

1. Set `CSP_REPORT_URI` to a reporting endpoint (Sentry, report-uri.com, your own ingest).
2. Set `ENABLE_CSP_REPORT_ONLY=true` and restart.
3. Audit reports for at least one full release/feature cycle.
4. Tighten directives in `config/initializers/content_security_policy.rb` based on findings (replace `'unsafe-inline'` with nonces/hashes, remove `:https` wildcards in favour of explicit hosts, etc.).
5. When the report stream is clean, flip `content_security_policy_report_only` to `false` to enforce.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`.env.example`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes — *I do not have a local Chatwoot dev environment; CI will validate.*
- [x] Any dependent changes have been merged and published in downstream modules
