### PR TITLE
feat: add dedicated color tokens for voice call widget

### DIFF
--- a/app/javascript/dashboard/assets/scss/_next-colors.scss
+++ b/app/javascript/dashboard/assets/scss/_next-colors.scss
@@ -146,7 +146,7 @@
     --border-blue: 39, 129, 246, 0.5;
     --white-alpha: 255, 255, 255, 0.8;
 
-    // Voice call widget — light mode uses the alpha-3 surface.
+    // Voice call widget - light mode
     --call-widget: 33, 34, 38, 0.95;
     --call-widget-border: 255, 255, 255, 0.1;
     --call-widget-text: 237, 238, 240, 1;
@@ -298,8 +298,7 @@
     --border-container: 255, 255, 255, 0;
     --white-alpha: 255, 255, 255, 0.1;
 
-    // Voice call widget — dark mode: background #32353D; internal border is
-    // Overlays/White-3 (#ffffff @ 6.9%).
+    // Voice call widget - dark mode
     --call-widget: 50, 53, 61, 1;
     --call-widget-border: 255, 255, 255, 0.07;
     --call-widget-text: 237, 238, 240, 1;

--- a/app/javascript/dashboard/assets/scss/_next-colors.scss
+++ b/app/javascript/dashboard/assets/scss/_next-colors.scss
@@ -145,6 +145,12 @@
     --black-alpha-2: 0, 0, 0, 0.04;
     --border-blue: 39, 129, 246, 0.5;
     --white-alpha: 255, 255, 255, 0.8;
+
+    // Voice call widget — light mode uses the alpha-3 surface.
+    --call-widget: 33, 34, 38, 0.95;
+    --call-widget-border: 255, 255, 255, 0.1;
+    --call-widget-text: 237, 238, 240, 1;
+    --call-widget-sub-text: 173, 177, 184, 1;
   }
 
   .dark {
@@ -291,6 +297,13 @@
     --border-blue: 39, 129, 246, 0.5;
     --border-container: 255, 255, 255, 0;
     --white-alpha: 255, 255, 255, 0.1;
+
+    // Voice call widget — dark mode: background #32353D; internal border is
+    // Overlays/White-3 (#ffffff @ 6.9%).
+    --call-widget: 50, 53, 61, 1;
+    --call-widget-border: 255, 255, 255, 0.07;
+    --call-widget-text: 237, 238, 240, 1;
+    --call-widget-sub-text: 173, 177, 184, 1;
   }
 }
 // NEXT COLORS END

--- a/app/javascript/dashboard/components-next/call/CallCard.vue
+++ b/app/javascript/dashboard/components-next/call/CallCard.vue
@@ -75,11 +75,11 @@ const channelIcon = computed(() => {
 
 <template>
   <div
-    class="flex flex-col gap-2 pt-4 bg-n-solid-2/95 rounded-2xl shadow-xl outline outline-1 outline-n-strong backdrop-blur-md"
+    class="flex flex-col gap-1 pt-4 bg-n-call-widget rounded-2xl shadow-xl outline outline-1 outline-n-call-widget-border backdrop-blur-md"
     :class="call?.conversationId ? 'pb-2' : 'pb-4'"
   >
     <!-- Top section: status badge + location/inbox + duration -->
-    <div class="flex flex-col gap-3">
+    <div class="flex flex-col gap-3 pb-3 border-b border-n-call-widget-border">
       <div class="flex items-center gap-2 px-4">
         <!-- Ongoing: status badge on left -->
         <div v-if="isOngoing" class="flex items-center gap-1.5 shrink-0">
@@ -100,10 +100,10 @@ const channelIcon = computed(() => {
           <Icon
             v-else-if="!isOngoing"
             :icon="channelIcon"
-            class="size-3.5 text-n-slate-10 shrink-0"
+            class="size-3.5 text-n-call-widget-sub-text shrink-0"
           />
           <span
-            class="text-xs font-medium text-n-slate-11 tracking-tight truncate"
+            class="text-xs font-medium text-n-call-widget-sub-text tracking-tight truncate"
           >
             {{ callInfo.location }}
           </span>
@@ -112,7 +112,7 @@ const channelIcon = computed(() => {
         <!-- Ongoing: duration on right -->
         <p
           v-if="isOngoing"
-          class="font-display text-base font-medium text-n-slate-11 shrink-0 mb-0 tabular-nums tracking-tight"
+          class="font-display text-base font-medium text-n-call-widget-sub-text shrink-0 mb-0 tabular-nums tracking-tight"
         >
           {{ duration }}
         </p>
@@ -132,7 +132,7 @@ const channelIcon = computed(() => {
             slate
             ghost
             xs
-            class="!rounded-full -my-1"
+            class="!rounded-full -my-1 -me-1 !text-n-call-widget-sub-text"
             @click="$emit('dismiss')"
           />
         </div>
@@ -149,13 +149,13 @@ const channelIcon = computed(() => {
         </div>
         <div class="flex-1 min-w-0">
           <p
-            class="font-display text-sm font-medium text-n-slate-12 truncate mb-0.5 tracking-tight leading-tight"
+            class="font-display text-sm font-medium text-n-call-widget-text truncate mb-0.5 tracking-tight leading-tight"
           >
             {{ callInfo.contactName }}
           </p>
           <p
             v-if="callInfo.phoneNumber"
-            class="text-sm text-n-slate-11 truncate mb-0 tracking-tight leading-tight"
+            class="text-sm text-n-call-widget-sub-text truncate mb-0 tracking-tight leading-tight"
           >
             {{ callInfo.phoneNumber }}
           </p>
@@ -217,23 +217,23 @@ const channelIcon = computed(() => {
     >
       <template #icon>
         <span
-          class="flex items-center gap-1 text-n-slate-11 group-hover:text-n-slate-12"
+          class="flex items-center gap-1 text-n-call-widget-sub-text group-hover:text-n-call-widget-text"
         >
           <Icon
             icon="i-ph-chat-circle-text-bold"
-            class="size-3.5 text-n-slate-11 shrink-0"
+            class="size-3.5 text-n-call-widget-sub-text shrink-0"
           />
           <span class="text-sm tracking-tight tabular-nums">
             #{{ call.conversationId }}
           </span>
           <Icon
             icon="i-ph-caret-right-bold"
-            class="size-3 text-n-slate-11 shrink-0"
+            class="size-3 text-n-call-widget-sub-text shrink-0"
           />
         </span>
       </template>
       <span
-        class="text-sm text-n-slate-11 tracking-tight group-hover:text-n-slate-12"
+        class="text-sm text-n-call-widget-sub-text tracking-tight group-hover:text-n-call-widget-text"
       >
         {{ $t('CONVERSATION.VOICE_WIDGET.GO_TO_CONVERSATION') }}
       </span>

--- a/theme/colors.js
+++ b/theme/colors.js
@@ -258,6 +258,11 @@ export const colors = {
       black2: 'rgba(var(--black-alpha-2))',
       white: 'rgba(var(--white-alpha))',
     },
+    // Voice call widget
+    'call-widget': 'rgba(var(--call-widget))',
+    'call-widget-border': 'rgba(var(--call-widget-border))',
+    'call-widget-text': 'rgba(var(--call-widget-text))',
+    'call-widget-sub-text': 'rgba(var(--call-widget-sub-text))',
     // Border colors
     weak: 'rgb(var(--border-weak) / <alpha-value>)',
     container: 'rgba(var(--border-container))',


### PR DESCRIPTION
# Pull Request Template

## Description

This PR introduces dedicated color tokens for the floating voice call widget instead of reusing generic design tokens. This allows the widget to maintain a distinct dark-card appearance across both light and dark themes.

Adds the following tokens and applies them to `CallCard`:

* `--call-widget`
* `--call-widget-border`
* `--call-widget-text`
* `--call-widget-sub-text`

Fixes https://linear.app/chatwoot/issue/CW-7353/call-notification-window-theme-update-design

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Screenshots

**Light mode**
<img width="1466" height="815" alt="Screenshot 2026-06-16 at 3 47 32 PM" src="https://github.com/user-attachments/assets/732164b1-5488-4cc1-8c71-01245d906842" />


**Dark mode**
<img width="1466" height="815" alt="Screenshot 2026-06-16 at 3 46 54 PM" src="https://github.com/user-attachments/assets/536ab632-4c7c-486b-8fc4-a061ee40b22a" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
