### PR TITLE
chore: expose advanced_search flag in super_admin UI for self-hosted

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -200,7 +200,6 @@
   display_name: Advanced Search
   enabled: false
   premium: true
-  chatwoot_internal: true
 - name: saml
   display_name: SAML
   enabled: false


### PR DESCRIPTION
## Description

Removes `chatwoot_internal: true` from the `advanced_search` feature flag so self-hosted enterprise userss can toggle it from the super_admin UI instead of going through a rails console.

Fixes # (no issue, internal customer request)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules