### PR TITLE
Make Firecrawl base URL configurable

### DIFF
--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -204,6 +204,10 @@
   description: 'The FireCrawl API key for the Captain AI service'
   locked: false
   type: secret
+- name: CAPTAIN_FIRECRAWL_BASE_URL
+  display_title: 'FireCrawl API Base URL (optional)'
+  description: 'The FireCrawl API base URL for the Captain AI service. Default: https://api.firecrawl.dev'
+  locked: false
 - name: CAPTAIN_CLOUD_PLAN_LIMITS
   display_title: 'Captain Cloud Plan Limits'
   description: 'The limits for the Captain AI service for different plans'

--- a/enterprise/app/controllers/enterprise/super_admin/app_configs_controller.rb
+++ b/enterprise/app/controllers/enterprise/super_admin/app_configs_controller.rb
@@ -47,6 +47,7 @@ module Enterprise::SuperAdmin::AppConfigsController
       CAPTAIN_OPEN_AI_ENDPOINT
       CAPTAIN_EMBEDDING_MODEL
       CAPTAIN_FIRECRAWL_API_KEY
+      CAPTAIN_FIRECRAWL_BASE_URL
     ]
   end
 

--- a/enterprise/app/services/captain/tools/firecrawl_service.rb
+++ b/enterprise/app/services/captain/tools/firecrawl_service.rb
@@ -1,5 +1,4 @@
 class Captain::Tools::FirecrawlService
-  BASE_URL = 'https://api.firecrawl.dev/v2'.freeze
   FIRECRAWL_EXCLUDE_TAGS = %w[iframe .sidebar .cookie-banner [role=navigation] [role=banner] [role=contentinfo]].freeze
 
   def self.configured?
@@ -14,7 +13,7 @@ class Captain::Tools::FirecrawlService
 
   def perform(url, webhook_url, crawl_limit = 10)
     HTTParty.post(
-      "#{BASE_URL}/crawl",
+      "#{base_url}/crawl",
       body: crawl_payload(url, webhook_url, crawl_limit),
       headers: headers
     )
@@ -24,7 +23,7 @@ class Captain::Tools::FirecrawlService
 
   def scrape(url)
     HTTParty.post(
-      "#{BASE_URL}/scrape",
+      "#{base_url}/scrape",
       body: scrape_payload(url),
       headers: headers
     )
@@ -61,5 +60,9 @@ class Captain::Tools::FirecrawlService
       'Authorization' => "Bearer #{@api_key}",
       'Content-Type' => 'application/json'
     }
+  end
+
+  def base_url
+    Firecrawl::Configuration.v2_base_url
   end
 end

--- a/enterprise/app/services/firecrawl/configuration.rb
+++ b/enterprise/app/services/firecrawl/configuration.rb
@@ -1,5 +1,7 @@
 module Firecrawl::Configuration
   INSTALLATION_CONFIG_KEY = 'CAPTAIN_FIRECRAWL_API_KEY'.freeze
+  BASE_URL_CONFIG_KEY = 'CAPTAIN_FIRECRAWL_BASE_URL'.freeze
+  DEFAULT_BASE_URL = 'https://api.firecrawl.dev'.freeze
   EXCLUDE_TAGS = %w[iframe .sidebar .cookie-banner [role=navigation] [role=banner] [role=contentinfo]].freeze
   DEFAULT_SCRAPE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 
@@ -13,11 +15,28 @@ module Firecrawl::Configuration
     key = api_key
     raise ::Firecrawl::FirecrawlError, "#{INSTALLATION_CONFIG_KEY} is not configured" if key.blank?
 
-    ::Firecrawl::Client.new(api_key: key)
+    ::Firecrawl::Client.new(api_key: key, api_url: api_url)
   end
 
   def api_key
     InstallationConfig.find_by(name: INSTALLATION_CONFIG_KEY)&.value
+  end
+
+  def base_url
+    InstallationConfig.find_by(name: BASE_URL_CONFIG_KEY)&.value.presence || DEFAULT_BASE_URL
+  end
+
+  def api_url
+    normalized_base_url.sub(%r{/v2\z}, '')
+  end
+
+  def v2_base_url
+    url = normalized_base_url
+    url.end_with?('/v2') ? url : "#{url}/v2"
+  end
+
+  def normalized_base_url
+    base_url.strip.chomp('/')
   end
 
   def default_scrape_options(max_age: DEFAULT_SCRAPE_MAX_AGE_MS)

--- a/spec/enterprise/services/captain/tools/firecrawl_service_spec.rb
+++ b/spec/enterprise/services/captain/tools/firecrawl_service_spec.rb
@@ -141,5 +141,23 @@ RSpec.describe Captain::Tools::FirecrawlService do
           )
       end
     end
+
+    context 'when a custom base URL is configured' do
+      before do
+        create(:installation_config, name: 'CAPTAIN_FIRECRAWL_BASE_URL', value: 'https://firecrawl.example.com')
+        stub_request(:post, 'https://firecrawl.example.com/v2/crawl')
+          .with(
+            body: expected_payload,
+            headers: expected_headers
+          )
+          .to_return(status: 200, body: '{"status": "success"}')
+      end
+
+      it 'uses the configured base URL' do
+        service.perform(url, webhook_url, crawl_limit)
+
+        expect(WebMock).to have_requested(:post, 'https://firecrawl.example.com/v2/crawl')
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow overriding the Firecrawl API base URL via a new installation config (CAPTAIN_FIRECRAWL_BASE_URL). Move base URL logic into Firecrawl::Configuration (DEFAULT_BASE_URL, normalization, api_url and v2_base_url helpers) and update Captain::Tools::FirecrawlService to use the configured v2 URL instead of a hardcoded constant. Expose the new config in the Super Admin app configs and add a spec to verify the custom base URL is used. Default behavior remains https://api.firecrawl.dev.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes #14668 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
