### PR TITLE
fix(companies): persist active sidebar tab on company detail

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/companies/pages/CompanyDetailView.vue
+++ b/app/javascript/dashboard/routes/dashboard/companies/pages/CompanyDetailView.vue
@@ -68,6 +68,11 @@ const SIDEBAR_TABS_OPTIONS = [
   { key: 'CONTACTS', value: 'contacts' },
 ];
 
+const getTabFromQuery = () =>
+  SIDEBAR_TABS_OPTIONS.some(option => option.value === route.query.tab)
+    ? route.query.tab
+    : 'history';
+
 const sidebarTabs = computed(() =>
   SIDEBAR_TABS_OPTIONS.map(tab => ({
     label: {
@@ -123,6 +128,7 @@ const loadSidebarTab = tab => {
 const handleSidebarTabChange = tab => {
   activeSidebarTab.value = tab.value;
   loadSidebarTab(tab.value);
+  router.replace({ query: { ...route.query, tab: tab.value } });
 };
 
 const handleContactSearch = async query => {
@@ -189,13 +195,16 @@ watch(
   async id => {
     companiesStore.resetCompanyDetailState();
     clearSelectedCandidate();
-    activeSidebarTab.value = 'history';
+    activeSidebarTab.value = getTabFromQuery();
     if (!id) return;
     await Promise.allSettled([
       companiesStore.show(id),
       companiesStore.getCompanyContacts(id),
       companiesStore.getCompanyConversations(id),
     ]);
+    if (activeSidebarTab.value === 'notes') {
+      companiesStore.getCompanyNotes(id);
+    }
   },
   { immediate: true }
 );

--- a/app/javascript/dashboard/routes/dashboard/companies/pages/CompanyDetailView.vue
+++ b/app/javascript/dashboard/routes/dashboard/companies/pages/CompanyDetailView.vue
@@ -197,14 +197,15 @@ watch(
     clearSelectedCandidate();
     activeSidebarTab.value = getTabFromQuery();
     if (!id) return;
-    await Promise.allSettled([
+    const requests = [
       companiesStore.show(id),
       companiesStore.getCompanyContacts(id),
       companiesStore.getCompanyConversations(id),
-    ]);
+    ];
     if (activeSidebarTab.value === 'notes') {
-      companiesStore.getCompanyNotes(id);
+      requests.push(companiesStore.getCompanyNotes(id));
     }
+    await Promise.allSettled(requests);
   },
   { immediate: true }
 );


### PR DESCRIPTION
On a company's detail page, the sidebar tab you last viewed (History / Notes / Contacts) is now remembered when you navigate away and come back. 

### How to reproduce 
1. Open a company detail page.
2. Switch the right sidebar to the **Contacts** tab.
3. Click into one of the contacts (navigates to the contact's page).
4. Press the browser **Back** button.
5. ❌ The company page reopens on the **History** tab instead of **Contacts**.

### What changed
- The active sidebar tab is persisted to the route query (`?tab=contacts`) via `router.replace`, so switching tabs updates the URL without adding extra back-history entries.
- On mount, the view initializes the active tab from the query (validated against the known tabs, defaulting to `history`) instead of always forcing `history`.
- If the restored tab is **Notes**, its data is fetched on load.
Single-file change; `TabBar` already reacts to `initial-active-tab`, so no other components needed updates.
