### PR TITLE
fix: apply load-with-retry to captioned attachments and standalone video

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/Video.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Video.vue
@@ -1,21 +1,15 @@
 <script setup>
-import { ref, computed } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import BaseBubble from './Base.vue';
 import Icon from 'next/icon/Icon.vue';
+import { useLoadWithRetry } from 'dashboard/composables/loadWithRetry';
 import { useSnakeCase } from 'dashboard/composables/useTransformKeys';
 import { useMessageContext } from '../provider.js';
 import GalleryView from 'dashboard/components/widgets/conversation/components/GalleryView.vue';
 import { ATTACHMENT_TYPES } from '../constants';
 
-const emit = defineEmits(['error']);
-const hasError = ref(false);
 const showGallery = ref(false);
 const { filteredCurrentChatAttachments, attachments } = useMessageContext();
-
-const handleError = () => {
-  hasError.value = true;
-  emit('error');
-};
 
 const attachment = computed(() => {
   return attachments.value[0];
@@ -24,6 +18,20 @@ const attachment = computed(() => {
 const isReel = computed(() => {
   return attachment.value.fileType === ATTACHMENT_TYPES.IG_REEL;
 });
+
+const { isLoaded, hasError, loadWithRetry } = useLoadWithRetry({
+  mediaType: 'video',
+});
+
+onMounted(() => {
+  if (attachment.value?.dataUrl) {
+    loadWithRetry(attachment.value.dataUrl);
+  }
+});
+
+const handleError = () => {
+  hasError.value = true;
+};
 </script>
 
 <template>
@@ -32,7 +40,13 @@ const isReel = computed(() => {
     data-bubble-name="video"
     @click="showGallery = true"
   >
-    <div class="relative group rounded-lg overflow-hidden">
+    <div v-if="hasError" class="flex items-center gap-1 text-center rounded-lg">
+      <Icon icon="i-lucide-circle-off" class="text-n-slate-11" />
+      <p class="mb-0 text-n-slate-11">
+        {{ $t('COMPONENTS.MEDIA.VIDEO_UNAVAILABLE') }}
+      </p>
+    </div>
+    <div v-else-if="isLoaded" class="relative group rounded-lg overflow-hidden">
       <div
         v-if="isReel"
         class="absolute p-2 flex items-start justify-end right-0 pointer-events-none"
@@ -48,7 +62,6 @@ const isReel = computed(() => {
           'max-w-full': !isReel,
         }"
         @click.stop
-        @error="handleError"
       />
     </div>
   </BaseBubble>
@@ -57,7 +70,7 @@ const isReel = computed(() => {
     v-model:show="showGallery"
     :attachment="useSnakeCase(attachment)"
     :all-attachments="filteredCurrentChatAttachments"
-    @error="onError"
+    @error="handleError"
     @close="() => (showGallery = false)"
   />
 </template>

--- a/app/javascript/dashboard/components-next/message/chips/Audio.vue
+++ b/app/javascript/dashboard/components-next/message/chips/Audio.vue
@@ -7,6 +7,7 @@ import {
   getCurrentInstance,
 } from 'vue';
 import Icon from 'next/icon/Icon.vue';
+import { useLoadWithRetry } from 'dashboard/composables/loadWithRetry';
 import { timeStampAppendedURL } from 'dashboard/helper/URLHelper';
 import { downloadFile } from '@chatwoot/utils';
 import { useEmitter } from 'dashboard/composables/emitter';
@@ -25,6 +26,10 @@ const { attachment } = defineProps({
 
 defineOptions({
   inheritAttrs: false,
+});
+
+const { isLoaded, hasError, loadWithRetry } = useLoadWithRetry({
+  mediaType: 'audio',
 });
 
 const timeStampURL = computed(() => {
@@ -73,7 +78,9 @@ const resolveStreamingDuration = () => {
 };
 
 const onLoadedMetadata = () => {
-  const d = audioPlayer.value?.duration;
+  if (!audioPlayer.value) return;
+  audioPlayer.value.playbackRate = playbackSpeed.value;
+  const d = audioPlayer.value.duration;
   if (!Number.isFinite(d)) {
     resolveStreamingDuration();
     return;
@@ -85,13 +92,10 @@ const playbackSpeedLabel = computed(() => {
   return `${playbackSpeed.value}x`;
 });
 
-// There maybe a chance that the audioPlayer ref is not available
-// When the onLoadMetadata is called, so we need to set the duration
-// value when the component is mounted
 onMounted(() => {
-  const d = audioPlayer.value?.duration;
-  if (Number.isFinite(d)) duration.value = d;
-  audioPlayer.value.playbackRate = playbackSpeed.value;
+  if (attachment.dataUrl) {
+    loadWithRetry(attachment.dataUrl);
+  }
 });
 
 // Listen for global audio play events and pause if it's not this audio
@@ -162,82 +166,94 @@ const downloadAudio = async () => {
 </script>
 
 <template>
-  <audio
-    ref="audioPlayer"
-    controls
-    class="hidden"
-    playsinline
-    @loadedmetadata="onLoadedMetadata"
-    @timeupdate="onTimeUpdate"
-    @ended="onEnd"
-  >
-    <source :src="timeStampURL" />
-  </audio>
   <div
+    v-if="hasError"
     v-bind="$attrs"
-    class="rounded-xl w-full gap-2 p-1.5 bg-n-alpha-white flex flex-col items-center border border-n-container shadow-[0px_2px_8px_0px_rgba(94,94,94,0.06)]"
+    class="flex items-center gap-1 text-center rounded-lg p-2 bg-n-alpha-white border border-n-container"
   >
-    <div class="flex gap-1 w-full flex-1 items-center justify-start">
-      <button class="p-0 border-0 size-8" @click="playOrPause">
-        <Icon
-          v-if="isPlaying"
-          class="size-8"
-          icon="i-teenyicons-pause-small-solid"
-        />
-        <Icon v-else class="size-8" icon="i-teenyicons-play-small-solid" />
-      </button>
-      <div class="tabular-nums text-xs">
-        {{ formatTime(currentTime) }} / {{ formatTime(duration) }}
-      </div>
-      <div class="flex-1 items-center flex px-2">
-        <input
-          type="range"
-          min="0"
-          :max="duration"
-          :value="currentTime"
-          class="w-full h-1 bg-n-slate-12/40 rounded-lg appearance-none cursor-pointer accent-current"
-          @input="seek"
-        />
-      </div>
-      <button
-        class="border-0 w-10 h-6 grid place-content-center bg-n-alpha-2 hover:bg-alpha-3 rounded-2xl"
-        @click="changePlaybackSpeed"
-      >
-        <span class="text-xs text-n-slate-11 font-medium">
-          {{ playbackSpeedLabel }}
-        </span>
-      </button>
-      <button
-        class="p-0 border-0 size-8 grid place-content-center"
-        @click="toggleMute"
-      >
-        <Icon v-if="isMuted" class="size-4" icon="i-lucide-volume-off" />
-        <Icon v-else class="size-4" icon="i-lucide-volume-2" />
-      </button>
-      <button
-        class="p-0 border-0 size-8 grid place-content-center"
-        @click="downloadAudio"
-      >
-        <Icon class="size-4" icon="i-lucide-download" />
-      </button>
-    </div>
-
-    <div
-      v-if="attachment.transcribedText && showTranscribedText"
-      class="text-n-slate-12 p-3 text-sm bg-n-alpha-1 rounded-lg w-full break-words"
-    >
-      {{ displayedTranscript }}
-      <button
-        v-if="isTranscriptLong"
-        class="block mt-1 p-0 border-0 bg-transparent text-n-slate-11 hover:text-n-slate-12 font-medium"
-        @click="isTranscriptExpanded = !isTranscriptExpanded"
-      >
-        {{
-          isTranscriptExpanded
-            ? $t('CONVERSATION.VOICE_CALL.TRANSCRIPT_SHOW_LESS')
-            : $t('CONVERSATION.VOICE_CALL.TRANSCRIPT_SHOW_MORE')
-        }}
-      </button>
-    </div>
+    <Icon icon="i-lucide-circle-off" class="text-n-slate-11" />
+    <p class="mb-0 text-n-slate-11 text-sm">
+      {{ $t('COMPONENTS.MEDIA.AUDIO_UNAVAILABLE') }}
+    </p>
   </div>
+  <template v-else-if="isLoaded">
+    <audio
+      ref="audioPlayer"
+      controls
+      class="hidden"
+      playsinline
+      @loadedmetadata="onLoadedMetadata"
+      @timeupdate="onTimeUpdate"
+      @ended="onEnd"
+    >
+      <source :src="timeStampURL" />
+    </audio>
+    <div
+      v-bind="$attrs"
+      class="rounded-xl w-full gap-2 p-1.5 bg-n-alpha-white flex flex-col items-center border border-n-container shadow-[0px_2px_8px_0px_rgba(94,94,94,0.06)]"
+    >
+      <div class="flex gap-1 w-full flex-1 items-center justify-start">
+        <button class="p-0 border-0 size-8" @click="playOrPause">
+          <Icon
+            v-if="isPlaying"
+            class="size-8"
+            icon="i-teenyicons-pause-small-solid"
+          />
+          <Icon v-else class="size-8" icon="i-teenyicons-play-small-solid" />
+        </button>
+        <div class="tabular-nums text-xs">
+          {{ formatTime(currentTime) }} / {{ formatTime(duration) }}
+        </div>
+        <div class="flex-1 items-center flex px-2">
+          <input
+            type="range"
+            min="0"
+            :max="duration"
+            :value="currentTime"
+            class="w-full h-1 bg-n-slate-12/40 rounded-lg appearance-none cursor-pointer accent-current"
+            @input="seek"
+          />
+        </div>
+        <button
+          class="border-0 w-10 h-6 grid place-content-center bg-n-alpha-2 hover:bg-alpha-3 rounded-2xl"
+          @click="changePlaybackSpeed"
+        >
+          <span class="text-xs text-n-slate-11 font-medium">
+            {{ playbackSpeedLabel }}
+          </span>
+        </button>
+        <button
+          class="p-0 border-0 size-8 grid place-content-center"
+          @click="toggleMute"
+        >
+          <Icon v-if="isMuted" class="size-4" icon="i-lucide-volume-off" />
+          <Icon v-else class="size-4" icon="i-lucide-volume-2" />
+        </button>
+        <button
+          class="p-0 border-0 size-8 grid place-content-center"
+          @click="downloadAudio"
+        >
+          <Icon class="size-4" icon="i-lucide-download" />
+        </button>
+      </div>
+
+      <div
+        v-if="attachment.transcribedText && showTranscribedText"
+        class="text-n-slate-12 p-3 text-sm bg-n-alpha-1 rounded-lg w-full break-words"
+      >
+        {{ displayedTranscript }}
+        <button
+          v-if="isTranscriptLong"
+          class="block mt-1 p-0 border-0 bg-transparent text-n-slate-11 hover:text-n-slate-12 font-medium"
+          @click="isTranscriptExpanded = !isTranscriptExpanded"
+        >
+          {{
+            isTranscriptExpanded
+              ? $t('CONVERSATION.VOICE_CALL.TRANSCRIPT_SHOW_LESS')
+              : $t('CONVERSATION.VOICE_CALL.TRANSCRIPT_SHOW_MORE')
+          }}
+        </button>
+      </div>
+    </div>
+  </template>
 </template>

--- a/app/javascript/dashboard/components-next/message/chips/Image.vue
+++ b/app/javascript/dashboard/components-next/message/chips/Image.vue
@@ -1,21 +1,32 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import Icon from 'next/icon/Icon.vue';
+import { useLoadWithRetry } from 'dashboard/composables/loadWithRetry';
 import { useSnakeCase } from 'dashboard/composables/useTransformKeys';
 import { useMessageContext } from '../provider.js';
 
 import GalleryView from 'dashboard/components/widgets/conversation/components/GalleryView.vue';
 
-defineProps({
+const { attachment } = defineProps({
   attachment: {
     type: Object,
     required: true,
   },
 });
-const hasError = ref(false);
+
 const showGallery = ref(false);
 
 const { filteredCurrentChatAttachments } = useMessageContext();
+
+const { isLoaded, hasError, loadWithRetry } = useLoadWithRetry({
+  mediaType: 'image',
+});
+
+onMounted(() => {
+  if (attachment.dataUrl) {
+    loadWithRetry(attachment.dataUrl);
+  }
+});
 
 const handleError = () => {
   hasError.value = true;
@@ -35,10 +46,9 @@ const handleError = () => {
       {{ $t('COMPONENTS.MEDIA.LOADING_FAILED') }}
     </div>
     <img
-      v-else
+      v-else-if="isLoaded"
       class="object-cover w-full h-full skip-context-menu"
       :src="attachment.dataUrl"
-      @error="handleError"
     />
   </div>
   <GalleryView

--- a/app/javascript/dashboard/components-next/message/chips/Video.vue
+++ b/app/javascript/dashboard/components-next/message/chips/Video.vue
@@ -1,11 +1,12 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import Icon from 'next/icon/Icon.vue';
+import { useLoadWithRetry } from 'dashboard/composables/loadWithRetry';
 import { useSnakeCase } from 'dashboard/composables/useTransformKeys';
 import { useMessageContext } from '../provider.js';
 import GalleryView from 'dashboard/components/widgets/conversation/components/GalleryView.vue';
 
-defineProps({
+const { attachment } = defineProps({
   attachment: {
     type: Object,
     required: true,
@@ -15,6 +16,20 @@ defineProps({
 const showGallery = ref(false);
 
 const { filteredCurrentChatAttachments } = useMessageContext();
+
+const { isLoaded, hasError, loadWithRetry } = useLoadWithRetry({
+  mediaType: 'video',
+});
+
+onMounted(() => {
+  if (attachment.dataUrl) {
+    loadWithRetry(attachment.dataUrl);
+  }
+});
+
+const handleError = () => {
+  hasError.value = true;
+};
 </script>
 
 <template>
@@ -22,31 +37,40 @@ const { filteredCurrentChatAttachments } = useMessageContext();
     class="size-[72px] overflow-hidden contain-content rounded-xl cursor-pointer relative group"
     @click="showGallery = true"
   >
-    <video
-      :src="attachment.dataUrl"
-      class="w-full h-full object-cover"
-      muted
-      playsInline
-    />
     <div
-      class="absolute w-full h-full inset-0 p-1 flex items-center justify-center"
+      v-if="hasError"
+      class="flex flex-col items-center justify-center gap-1 text-xs text-center rounded-lg size-full bg-n-alpha-1 text-n-slate-11"
     >
-      <div
-        class="size-7 bg-n-slate-1/60 backdrop-blur-sm rounded-full overflow-hidden shadow-[0_5px_15px_rgba(0,0,0,0.4)]"
-      >
-        <Icon
-          icon="i-teenyicons-play-small-solid"
-          class="size-7 text-n-slate-12/80 backdrop-blur"
-        />
-      </div>
+      <Icon icon="i-lucide-circle-off" class="text-n-slate-11" />
+      {{ $t('COMPONENTS.MEDIA.LOADING_FAILED') }}
     </div>
+    <template v-else-if="isLoaded">
+      <video
+        :src="attachment.dataUrl"
+        class="w-full h-full object-cover"
+        muted
+        playsInline
+      />
+      <div
+        class="absolute w-full h-full inset-0 p-1 flex items-center justify-center"
+      >
+        <div
+          class="size-7 bg-n-slate-1/60 backdrop-blur-sm rounded-full overflow-hidden shadow-[0_5px_15px_rgba(0,0,0,0.4)]"
+        >
+          <Icon
+            icon="i-teenyicons-play-small-solid"
+            class="size-7 text-n-slate-12/80 backdrop-blur"
+          />
+        </div>
+      </div>
+    </template>
   </div>
   <GalleryView
     v-if="showGallery"
     v-model:show="showGallery"
     :attachment="useSnakeCase(attachment)"
     :all-attachments="filteredCurrentChatAttachments"
-    @error="onError"
+    @error="handleError"
     @close="() => (showGallery = false)"
   />
 </template>

--- a/app/javascript/dashboard/composables/loadWithRetry.js
+++ b/app/javascript/dashboard/composables/loadWithRetry.js
@@ -22,6 +22,10 @@ export const useLoadWithRetry = (config = {}) => {
           element = new Audio();
           element.preload = 'metadata';
           element.onloadedmetadata = onSuccess;
+        } else if (mediaType === 'video') {
+          element = document.createElement('video');
+          element.preload = 'metadata';
+          element.onloadedmetadata = onSuccess;
         } else {
           element = new Image();
           element.onload = onSuccess;

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -297,6 +297,7 @@
     "MEDIA": {
       "IMAGE_UNAVAILABLE": "This image is no longer available.",
       "AUDIO_UNAVAILABLE": "This audio is no longer available.",
+      "VIDEO_UNAVAILABLE": "This video is no longer available.",
       "LOADING_FAILED": "Loading failed"
     }
   },


### PR DESCRIPTION
## Description

Follow-up to #12873 (load-with-retry for standalone images) and stacked on top of #13675 (audio retry on the standalone bubble). Those cover media rendered as a standalone bubble, but media sent **with a caption** renders through the attachment chips (`chips/Image.vue`, `chips/Audio.vue`, `chips/Video.vue`), which mount a plain element with no retry. So a captioned attachment that races ahead of the object storage upload stays broken until the page is refreshed — the remaining part of CW-4112 / #11013. Standalone video had no retry at all either.

This PR reuses the generic `useLoadWithRetry` composable from #13675 and fills the remaining gaps.

**Key changes**

- Add a `video` media type to `useLoadWithRetry` (metadata preload via a detached `<video>` element).
- Apply the retry to the captioned-attachment chips: `chips/Image.vue`, `chips/Audio.vue`, `chips/Video.vue` (the audio chip is the with-caption counterpart of #13675's bubble).
- Apply the retry to the standalone `bubbles/Video.vue`.
- Fix the `GalleryView` `@error` handler in both video components (it referenced an undefined `onError`).
- Add the `VIDEO_UNAVAILABLE` copy.

Kept aligned with the existing pattern (#12873 / #13675): the element is gated behind `isLoaded`, the failure state shows only after retries are exhausted, with no loading placeholder and no redundant per-element `@error`.

With #13675 + this PR, image, audio and video all retry whether or not they carry a caption. Supersedes #12977 (audio chip), which can be closed in favor of #13675 + this PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. With object storage (MinIO/S3/R2), send or receive an image, audio and video — each **with a caption** — plus a standalone video, while the upload is still propagating.
2. Before: the attachment is broken (404) until a manual refresh.
3. After: the media resolves on its own once the upload completes; after exhausting retries it shows the unavailable state.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
