### PR TITLE
fix: resolve Firefox input issues and persist advanced filters

### DIFF
--- a/app/javascript/dashboard/modules/search/components/SearchHeader.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchHeader.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch, useTemplateRef } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import { INSTALLATION_TYPES } from 'dashboard/constants/installationTypes';
 import { ROLES } from 'dashboard/constants/permissions';
@@ -30,16 +30,6 @@ const onSelectRecentSearch = query => {
   searchQuery.value = query;
   onSearch(query);
 };
-
-watch(
-  () => props.initialQuery,
-  newValue => {
-    if (searchQuery.value !== newValue) {
-      searchQuery.value = newValue;
-    }
-  },
-  { immediate: true }
-);
 </script>
 
 <template>

--- a/app/javascript/dashboard/modules/search/components/SearchInput.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchInput.vue
@@ -30,10 +30,13 @@ const debouncedEmit = debounce(
   500
 );
 
-const onInput = () => {
-  debouncedEmit(searchQuery.value);
+const onInput = e => {
+  // Use the DOM value, not searchQuery.value: the defineModel ref updates a tick
+  // later, so reading it back here lags one character behind.
+  const value = e.target.value;
+  debouncedEmit(value);
 
-  if (searchQuery.value.trim()) {
+  if (value.trim()) {
     showRecentSearches.value = false;
   } else if (isInputFocused.value) {
     showRecentSearches.value = true;

--- a/app/javascript/dashboard/modules/search/components/SearchTabs.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchTabs.vue
@@ -1,8 +1,6 @@
 <script setup>
 import { computed, watch, ref } from 'vue';
-import { useI18n } from 'vue-i18n';
 import TabBar from 'dashboard/components-next/tabbar/TabBar.vue';
-import Button from 'dashboard/components-next/button/Button.vue';
 
 const props = defineProps({
   tabs: {
@@ -16,8 +14,6 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['tabChange']);
-
-const { t } = useI18n();
 
 const activeTab = ref(props.selectedTab);
 
@@ -50,15 +46,6 @@ const onTabChange = selectedTab => {
       :tabs="tabBarTabs"
       :initial-active-tab="activeTab"
       @tab-changed="onTabChange"
-    />
-
-    <Button
-      :label="t('SEARCH.SORT_BY.RELEVANCE')"
-      sm
-      link
-      slate
-      class="hover:!no-underline pointer-events-none lg:inline-flex hidden"
-      icon="i-lucide-arrow-up-down"
     />
   </div>
 </template>

--- a/app/javascript/dashboard/modules/search/components/SearchView.vue
+++ b/app/javascript/dashboard/modules/search/components/SearchView.vue
@@ -1,8 +1,9 @@
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { useMapGetter, useStore } from 'dashboard/composables/store.js';
 import { useRouter, useRoute } from 'vue-router';
 import { useTrack } from 'dashboard/composables';
+import { useAccount } from 'dashboard/composables/useAccount';
 import { useI18n } from 'vue-i18n';
 import { useCamelCase } from 'dashboard/composables/useTransformKeys';
 import { generateURLParams, parseURLParams } from '../helpers/searchHelper';
@@ -28,6 +29,7 @@ import SearchResultArticlesList from './SearchResultArticlesList.vue';
 const router = useRouter();
 const route = useRoute();
 const store = useStore();
+const { currentAccount } = useAccount();
 const { t } = useI18n();
 
 const PER_PAGE = 15; // Results per page
@@ -338,18 +340,25 @@ const onTabChange = tab => {
 onMounted(() => {
   store.dispatch('conversationSearch/clearSearchResults');
   store.dispatch('agents/get');
-
-  const parsedFilters = parseURLParams(
-    route.query,
-    isFeatureFlagEnabled(FEATURE_FLAGS.ADVANCED_SEARCH)
-  );
-  filters.value = parsedFilters;
-
-  // Auto-execute search if query parameter exists
-  if (route.query.q) {
-    onSearch(route.query.q);
-  }
 });
+
+// Wait for the account before restoring URL filters: the ADVANCED_SEARCH flag
+// derives from account.features (loaded async), and reading it too early strips
+// the filter params from the URL. `immediate` covers the already-loaded case.
+watch(
+  () => currentAccount.value?.id,
+  id => {
+    if (!id) return;
+    filters.value = parseURLParams(
+      route.query,
+      isFeatureFlagEnabled(FEATURE_FLAGS.ADVANCED_SEARCH)
+    );
+    if (route.query.q) {
+      onSearch(route.query.q);
+    }
+  },
+  { immediate: true }
+);
 
 onUnmounted(() => {
   query.value = '';


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes a few issues in Global Search and removes a non-functional control.

* Fixes an issue in Firefox where characters could be dropped while typing in the search input. The search now uses the latest input value directly, preventing searches from running one character behind.

* Removes a stale query sync in `SearchHeader` that could overwrite recently typed characters during the debounce window, causing the input to appear out of sync.

* Fixes advanced search filters being removed from the URL on page reload. The search page now waits for account data to load before parsing URL parameters, ensuring agent, inbox, and date range filters are preserved.

* Removes the non-functional "Sort by relevance" button from the search tabs bar, as it was disabled and had no effect.


Fixes https://github.com/chatwoot/chatwoot/issues/14684 [CW-7305](https://linear.app/chatwoot/issue/CW-7305/global-search-drops-characters-while-typing-in-firefox-query-truncated)  [CW-7370](https://linear.app/chatwoot/issue/CW-7370/remove-non-functional-relevance-placeholder-button-from-global-search) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screencast

**Before**

https://github.com/user-attachments/assets/48d72a4e-20f4-4f24-91f4-2c9a9c065eba




**After**

https://github.com/user-attachments/assets/0e41a803-b4fd-410d-a739-549f72d418d6





## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
