### PR TITLE
fix(enterprise): show participant conversations on dashboard All tab for custom roles

### DIFF
--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -209,7 +209,8 @@ class ConversationFinder
 
   def conversations_base_query
     @conversations.includes(
-      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox
+      :taggings, :inbox, :conversation_participants,
+      { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox
     )
   end
 

--- a/app/javascript/dashboard/store/modules/conversations/helpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers.js
@@ -101,7 +101,7 @@ export const applyRoleFilter = (
 
   // Check participating conversation management permission
   if (permissions.includes('conversation_participating_manage')) {
-    return isAssignedToUser;
+    return isAssignedToUser || conversation.meta?.is_participant;
   }
 
   return false;

--- a/app/javascript/dashboard/store/modules/conversations/helpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers.js
@@ -101,7 +101,7 @@ export const applyRoleFilter = (
 
   // Check participating conversation management permission
   if (permissions.includes('conversation_participating_manage')) {
-    return isAssignedToUser || conversation.meta?.is_participant;
+    return isAssignedToUser || Boolean(conversation.meta?.is_participant);
   }
 
   return false;

--- a/app/javascript/dashboard/store/modules/conversations/specs/helpers.spec.js
+++ b/app/javascript/dashboard/store/modules/conversations/specs/helpers.spec.js
@@ -200,6 +200,24 @@ describe('Conversation Helpers', () => {
           )
         ).toBe(false);
       });
+
+      it('returns true when the user is a participant but not the assignee', () => {
+        const conversationWithParticipant = {
+          meta: {
+            assignee: { id: 2 },
+            is_participant: true,
+          },
+        };
+
+        expect(
+          applyRoleFilter(
+            conversationWithParticipant,
+            role,
+            permissions,
+            currentUserId
+          )
+        ).toBe(true);
+      });
     });
 
     // Test for user with no relevant permissions

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -24,7 +24,7 @@ json.meta do
     end
   end
   json.hmac_verified conversation.contact_inbox&.hmac_verified
-  json.is_participant conversation.conversation_participants.any? { |cp| cp.user_id == Current.user&.id }
+  json.is_participant(conversation.conversation_participants.any? { |cp| cp.user_id == Current.user&.id })
 end
 
 json.id conversation.display_id

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -24,6 +24,7 @@ json.meta do
     end
   end
   json.hmac_verified conversation.contact_inbox&.hmac_verified
+  json.is_participant conversation.conversation_participants.any? { |cp| cp.user_id == Current.user&.id }
 end
 
 json.id conversation.display_id

--- a/enterprise/app/services/enterprise/conversations/permission_filter_service.rb
+++ b/enterprise/app/services/enterprise/conversations/permission_filter_service.rb
@@ -23,7 +23,7 @@ module Enterprise::Conversations::PermissionFilterService
     elsif permissions.include?('conversation_unassigned_manage')
       filter_unassigned_and_mine
     elsif permissions.include?('conversation_participating_manage')
-      accessible_conversations.assigned_to(user)
+      filter_participating_and_mine
     else
       Conversation.none
     end
@@ -34,6 +34,16 @@ module Enterprise::Conversations::PermissionFilterService
     unassigned = accessible_conversations.unassigned
 
     Conversation.from("(#{mine.to_sql} UNION #{unassigned.to_sql}) as conversations")
+                .where(account_id: account.id)
+  end
+
+  def filter_participating_and_mine
+    mine = accessible_conversations.assigned_to(user)
+    participating = accessible_conversations
+                    .joins(:conversation_participants)
+                    .where(conversation_participants: { user_id: user.id })
+
+    Conversation.from("(#{mine.to_sql} UNION #{participating.to_sql}) as conversations")
                 .where(account_id: account.id)
   end
 end

--- a/spec/enterprise/services/enterprise/conversations/permission_filter_service_spec.rb
+++ b/spec/enterprise/services/enterprise/conversations/permission_filter_service_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Enterprise::Conversations::PermissionFilterService do
     end
 
     context 'when user has conversation_participating_manage permission' do
-      it 'returns only conversations assigned to the agent' do
+      it 'returns conversations assigned to the agent or where the agent is a participant' do
         # Create a new isolated test environment
         test_account = create(:account)
         test_inbox = create(:inbox, account: test_account)
@@ -114,12 +114,38 @@ RSpec.describe Enterprise::Conversations::PermissionFilterService do
           test_account
         ).perform
 
-        # Should only see conversations assigned to this agent
+        # Should see conversations assigned to this agent
         expect(result.count).to eq(1)
         expect(result.first.assignee).to eq(test_agent)
         expect(result).to include(assigned_conversation)
         expect(result).not_to include(other_conversation)
         expect(result).not_to include(other_inbox_conversation)
+      end
+
+      it 'returns conversations where the agent is a participant but not the assignee' do
+        test_account = create(:account)
+        test_inbox = create(:inbox, account: test_account)
+        test_agent = create(:user, account: test_account, role: :agent)
+        create(:inbox_member, user: test_agent, inbox: test_inbox)
+
+        test_custom_role = create(:custom_role, account: test_account, permissions: %w[conversation_participating_manage])
+        AccountUser.find_by(user: test_agent, account: test_account)
+                   .update!(role: :agent, custom_role: test_custom_role)
+
+        other_agent = create(:user, account: test_account, role: :agent)
+        participant_conversation = create(:conversation, account: test_account, inbox: test_inbox, assignee: other_agent)
+        create(:conversation_participant, conversation: participant_conversation, account: test_account, user: test_agent)
+
+        unrelated_conversation = create(:conversation, account: test_account, inbox: test_inbox, assignee: other_agent)
+
+        result = Conversations::PermissionFilterService.new(
+          test_account.conversations,
+          test_agent,
+          test_account
+        ).perform
+
+        expect(result).to include(participant_conversation)
+        expect(result).not_to include(unrelated_conversation)
       end
     end
 


### PR DESCRIPTION
Closes [#14786](https://github.com/chatwoot/chatwoot/issues/14786)
Agents with a custom role granting `conversation_participating_manage` could open a conversation when added as a participant, and the conversation appeared on `/participating/conversations`, but it did not appear on the dashboard **All** tab. This aligns list filtering with the existing `ConversationPolicy` behavior.

## How to reproduce

1. Create an agent with a custom role that includes only `conversation_participating_manage`.
2. Add the agent to an inbox/queue.
3. Open a conversation assigned to another agent (or unassigned).
4. Add the agent as a conversation participant via the participants API.
5. Observe the conversation on `/participating/conversations` but not on `/dashboard` → **All**.

## What changed

- **Backend:** `PermissionFilterService` now returns assigned **or** participating conversations for `conversation_participating_manage` (UNION query, same pattern as unassigned filtering).
- **API:** Conversation list payload includes `meta.is_participant` for the current user, with `conversation_participants` preloaded to avoid N+1 queries.
- **Frontend:** `applyRoleFilter` allows conversations where `meta.is_participant` is true on the **All** tab (Mine tab unchanged).
- **Tests:** Added/updated RSpec and Vitest coverage for the participant-only case.

## Closes

[#14786](https://github.com/chatwoot/chatwoot/issues/14786)

## How to test

1. Repeat the reproduction steps above.
2. Confirm the conversation appears on:
   - `/app/accounts/:id/participating/conversations`
   - `/app/accounts/:id/dashboard` → **All** tab
3. Confirm it does **not** appear on dashboard **Mine** when the agent is only a participant.
4. Run:
   - `bundle exec rspec spec/enterprise/services/enterprise/conversations/permission_filter_service_spec.rb spec/enterprise/policies/conversation_policy_spec.rb`
   - `pnpm test app/javascript/dashboard/store/modules/conversations/specs/helpers.spec.js`