### PR TITLE
fix: append /v1 to openai_api_base in global RubyLLM config

### DIFF
--- a/lib/llm/config.rb
+++ b/lib/llm/config.rb
@@ -34,7 +34,7 @@ module Llm::Config
     def configure_ruby_llm
       RubyLLM.configure do |config|
         config.openai_api_key = system_api_key if system_api_key.present?
-        config.openai_api_base = "#{openai_endpoint.chomp('/')}/v1" if openai_endpoint.present?
+        config.openai_api_base = "#{openai_endpoint.chomp('/').delete_suffix('/v1')}/v1" if openai_endpoint.present?
         config.model_registry_file = Rails.root.join('config/llm_models.json').to_s
         config.logger = Rails.logger
       end

--- a/lib/llm/config.rb
+++ b/lib/llm/config.rb
@@ -34,7 +34,7 @@ module Llm::Config
     def configure_ruby_llm
       RubyLLM.configure do |config|
         config.openai_api_key = system_api_key if system_api_key.present?
-        config.openai_api_base = openai_endpoint.chomp('/') if openai_endpoint.present?
+        config.openai_api_base = "#{openai_endpoint.chomp('/')}/v1" if openai_endpoint.present?
         config.model_registry_file = Rails.root.join('config/llm_models.json').to_s
         config.logger = Rails.logger
       end


### PR DESCRIPTION
## Description

The global RubyLLM config in `lib/llm/config.rb` was missing the `/v1` <br>path suffix on `openai_api_base`, causing Captain V2 Copilot agent calls <br>to hit `/chat/completions` instead of `/v1/chat/completions` when a custom <br>OpenAI endpoint is configured.

`base_task_service` already appends `/v1` for its own scoped contexts via <br>`with_api_key`, but the global config used by the Captain V2 agent did not, <br>resulting in failed Copilot responses for self-hosted instances using a <br>custom `CAPTAIN_OPEN_AI_ENDPOINT`.

Fixes chatwoot/chatwoot#14789

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* Configured a custom `CAPTAIN_OPEN_AI_ENDPOINT` without trailing `/v1`
* Verified Copilot now correctly calls `/v1/chat/completions`
* Verified Playground continues to work as expected
* Verified no regression for instances using the default OpenAI endpoint

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] The change is minimal and focused on the bug fix