### PR TITLE
feat(instagram): support post/reel comment management

### DIFF
--- a/app/builders/messages/instagram/comment_builder.rb
+++ b/app/builders/messages/instagram/comment_builder.rb
@@ -1,0 +1,94 @@
+class Messages::Instagram::CommentBuilder
+  def initialize(comment, inbox)
+    @comment = comment.with_indifferent_access
+    @inbox = inbox
+  end
+
+  def perform
+    return if @inbox.channel.reauthorization_required?
+    return if message_already_exists?
+
+    ActiveRecord::Base.transaction do
+      conversation.messages.create!(message_params)
+    end
+  rescue StandardError => e
+    ChatwootExceptionTracker.new(e, account: @inbox.account).capture_exception
+  end
+
+  private
+
+  def contact
+    @contact ||= contact_inbox&.contact
+  end
+
+  def contact_inbox
+    @contact_inbox ||= @inbox.contact_inboxes.find_by(source_id: commenter_id)
+  end
+
+  def conversation
+    @conversation ||= find_open_conversation || build_conversation
+  end
+
+  # Group all comments from the same media + contact into a single conversation,
+  # keeping comment threads separate from direct-message conversations.
+  # additional_attributes is a `json` column, so we match in Ruby instead of
+  # relying on the Postgres `->>` operator (unreliable here).
+  def find_open_conversation
+    @inbox.conversations
+          .where(contact_id: contact.id)
+          .where.not(status: :resolved)
+          .order(created_at: :desc)
+          .find { |conv| conv.additional_attributes['instagram_media_id'] == media_id }
+  end
+
+  def build_conversation
+    Conversation.create!(
+      account_id: @inbox.account_id,
+      inbox_id: @inbox.id,
+      contact_id: contact.id,
+      contact_inbox_id: contact_inbox.id,
+      additional_attributes: {
+        type: 'instagram_comment',
+        instagram_media_id: media_id
+      }
+    )
+  end
+
+  def message_params
+    {
+      account_id: @inbox.account_id,
+      inbox_id: @inbox.id,
+      message_type: :incoming,
+      status: :sent,
+      source_id: comment_id,
+      content: comment_text,
+      sender: contact,
+      content_attributes: {
+        type: 'instagram_comment',
+        instagram_comment_id: comment_id,
+        instagram_media_id: media_id,
+        instagram_parent_comment_id: @comment[:parent_id]
+      }
+    }
+  end
+
+  def message_already_exists?
+    Message.find_by(source_id: comment_id).present?
+  end
+
+  def commenter_id
+    @comment.dig(:from, :id).to_s
+  end
+
+  def comment_id
+    @comment[:id]
+  end
+
+  def media_id
+    @comment.dig(:media, :id)
+  end
+
+  def comment_text
+    @comment[:text]
+  end
+end

--- a/app/controllers/instagram/callbacks_controller.rb
+++ b/app/controllers/instagram/callbacks_controller.rb
@@ -96,6 +96,9 @@ class Instagram::CallbacksController < ApplicationController
 
     if channel_instagram
       update_channel(channel_instagram, user_details)
+      # Re-subscribe so newly granted scopes (e.g. comments) take effect on the
+      # refreshed token; new channels already subscribe via after_create_commit.
+      channel_instagram.subscribe
     else
       channel_instagram = create_channel_with_inbox(user_details)
     end

--- a/app/controllers/webhooks/instagram_controller.rb
+++ b/app/controllers/webhooks/instagram_controller.rb
@@ -67,7 +67,12 @@ class Webhooks::InstagramController < ActionController::API
 
   def instagram_ids_from_entry(entry)
     messages = entry[:messaging].presence || entry[:standby] || []
-    messages.filter_map { |messaging| instagram_id_from_messaging(messaging.with_indifferent_access) }
+    messaging_ids = messages.filter_map { |messaging| instagram_id_from_messaging(messaging.with_indifferent_access) }
+
+    # Comment webhooks arrive as `changes` (field: comments); the business account is entry[:id].
+    comment_ids = entry[:changes].present? ? [entry[:id]] : []
+
+    (messaging_ids + comment_ids).compact.uniq
   end
 
   def instagram_id_from_messaging(messaging)

--- a/app/helpers/instagram/integration_helper.rb
+++ b/app/helpers/instagram/integration_helper.rb
@@ -1,5 +1,9 @@
 module Instagram::IntegrationHelper
-  REQUIRED_SCOPES = %w[instagram_business_basic instagram_business_manage_messages].freeze
+  REQUIRED_SCOPES = %w[
+    instagram_business_basic
+    instagram_business_manage_messages
+    instagram_business_manage_comments
+  ].freeze
 
   # Generates a signed JWT token for Instagram integration
   #

--- a/app/jobs/webhooks/instagram_events_job.rb
+++ b/app/jobs/webhooks/instagram_events_job.rb
@@ -40,12 +40,38 @@ class Webhooks::InstagramEventsJob < MutexApplicationJob
   private
 
   def process_single_entry(entry)
+    return process_comments(entry) if instagram_comment_event?(entry)
+
     if test_event?(entry)
       process_test_event(entry)
       return
     end
 
     process_messages(entry)
+  end
+
+  # Comment webhooks usually arrive as `changes` with field `comments` (the
+  # test-event path also uses `changes`, field `messages`, so we route by field).
+  # Some Instagram Login payloads carry `field`/`value` directly on the entry, so
+  # we support that shape too.
+  def instagram_comment_event?(entry)
+    comment_values(entry).any?
+  end
+
+  def process_comments(entry)
+    channel = Channel::Instagram.find_by(instagram_id: entry[:id])
+    return if channel.blank?
+
+    comment_values(entry).each do |value|
+      Rails.logger.info("Instagram Events Job Comment: #{value}")
+      ::Instagram::CommentText.new(value, channel).perform
+    end
+  end
+
+  def comment_values(entry)
+    values = Array(entry[:changes]).select { |change| change[:field] == 'comments' }.pluck(:value)
+    values << entry[:value] if entry[:field] == 'comments'
+    values.compact
   end
 
   def process_messages(entry)

--- a/app/models/channel/instagram.rb
+++ b/app/models/channel/instagram.rb
@@ -47,7 +47,7 @@ class Channel::Instagram < ApplicationRecord
     HTTParty.post(
       "https://graph.instagram.com/v22.0/#{instagram_id}/subscribed_apps",
       query: {
-        subscribed_fields: %w[messages message_reactions messaging_seen],
+        subscribed_fields: %w[messages message_reactions messaging_seen comments],
         access_token: access_token
       }
     )

--- a/app/services/conversations/message_window_service.rb
+++ b/app/services/conversations/message_window_service.rb
@@ -7,12 +7,19 @@ class Conversations::MessageWindowService
   end
 
   def can_reply?
+    return true if instagram_comment_conversation?
     return true if messaging_window.blank?
 
     last_message_in_messaging_window?(messaging_window)
   end
 
   private
+
+  # Instagram post/reel comment replies go through the Comments API, which has no
+  # 24h/7d messaging window, so they are not bound by the DM reply window.
+  def instagram_comment_conversation?
+    @conversation.additional_attributes['type'] == 'instagram_comment'
+  end
 
   def messaging_window
     case @conversation.inbox.channel_type

--- a/app/services/instagram/comment_text.rb
+++ b/app/services/instagram/comment_text.rb
@@ -1,0 +1,48 @@
+class Instagram::CommentText < Instagram::WebhooksBaseService
+  attr_reader :comment
+
+  def initialize(comment, channel)
+    @comment = comment.with_indifferent_access
+    super(channel)
+  end
+
+  def perform
+    inbox_channel(@channel.instagram_id)
+    return if @inbox.blank?
+
+    if @inbox.channel.reauthorization_required?
+      Rails.logger.info("Skipping comment; reauthorization required for inbox #{@inbox.id}")
+      return
+    end
+
+    # Ignore comments authored by the connected account itself (our own replies / echoes)
+    # to avoid feedback loops.
+    return if own_comment?
+
+    find_or_create_contact(commenter_user)
+    return if @contact_inbox.blank?
+
+    Messages::Instagram::CommentBuilder.new(@comment, @inbox).perform
+  end
+
+  private
+
+  def own_comment?
+    commenter_id == @channel.instagram_id.to_s
+  end
+
+  def commenter_id
+    @comment.dig(:from, :id).to_s
+  end
+
+  # Build the user hash expected by WebhooksBaseService#find_or_create_contact.
+  # The comments webhook already provides the commenter's username, so a Graph API
+  # profile fetch is not required for the base flow.
+  def commenter_user
+    {
+      'id' => commenter_id,
+      'name' => @comment.dig(:from, :username).presence || "IG User #{commenter_id}",
+      'username' => @comment.dig(:from, :username)
+    }.with_indifferent_access
+  end
+end

--- a/app/services/instagram/send_on_instagram_service.rb
+++ b/app/services/instagram/send_on_instagram_service.rb
@@ -1,6 +1,65 @@
 class Instagram::SendOnInstagramService < Instagram::BaseSendService
   private
 
+  # Instagram comment conversations reply publicly via the Comments API,
+  # while DMs continue through the parent (messaging) flow.
+  def perform_reply
+    return send_comment_reply if instagram_comment_conversation?
+
+    super
+  end
+
+  def instagram_comment_conversation?
+    message.conversation.additional_attributes['type'] == 'instagram_comment'
+  end
+
+  def send_comment_reply
+    # The Comments API only accepts text; attachment-only replies are unsupported.
+    return mark_comment_reply_unsupported if message.content.blank?
+
+    comment_id = reply_target_comment_id
+    return if comment_id.blank?
+
+    response = HTTParty.post(
+      "https://graph.instagram.com/v22.0/#{comment_id}/replies",
+      query: { access_token: channel.access_token },
+      body: { message: message.outgoing_content }
+    )
+    process_comment_response(response)
+  end
+
+  def mark_comment_reply_unsupported
+    Messages::StatusUpdateService.new(
+      message, 'failed', 'Instagram comment replies support text only; attachments are not supported.'
+    ).perform
+  end
+
+  # Reply to the latest incoming comment that already existed when this reply was
+  # composed. Filtering by created_at avoids posting under a newer comment that
+  # arrived while the reply sat in the SendReplyJob queue.
+  # `reorder` (not `order`) is required to override Message's default_scope
+  # `order(created_at: :asc)`, otherwise the newest comment is not picked first.
+  # content_attributes is a `json` column, so Postgres `->>` is unreliable;
+  # read the attributes in Ruby instead (works for both json and jsonb).
+  def reply_target_comment_id
+    comment = message.conversation.messages.incoming
+                     .where(created_at: ..message.created_at)
+                     .reorder(created_at: :desc)
+                     .find { |msg| msg.content_attributes['type'] == 'instagram_comment' }
+    comment&.content_attributes&.dig('instagram_comment_id')
+  end
+
+  def process_comment_response(response)
+    parsed = response.parsed_response
+    if response.success? && parsed['error'].blank?
+      message.update!(source_id: parsed['id'])
+    else
+      error = external_error(parsed)
+      Rails.logger.error("Instagram comment reply error: #{error} : message ##{message.id}")
+      Messages::StatusUpdateService.new(message, 'failed', error).perform
+    end
+  end
+
   def channel_class
     Channel::Instagram
   end

--- a/lib/tasks/instagram_comments.rake
+++ b/lib/tasks/instagram_comments.rake
@@ -1,0 +1,25 @@
+namespace :instagram do
+  desc 'Re-subscribe existing Instagram Login channels so the comments webhook field is enabled'
+  task resubscribe_comments: :environment do
+    resubscribed = 0
+    needs_reauth = 0
+
+    Channel::Instagram.find_each do |channel|
+      response = channel.subscribe
+
+      if response.respond_to?(:success?) && response.success?
+        resubscribed += 1
+        Rails.logger.info("Re-subscribed Instagram channel ##{channel.id} (#{channel.instagram_id})")
+      else
+        # Channels connected before comments support was added may hold a token minted
+        # without `instagram_business_manage_comments`; flag them for reauthorization
+        # instead of reporting a false success.
+        channel.prompt_reauthorization!
+        needs_reauth += 1
+        Rails.logger.warn("Instagram channel ##{channel.id} (#{channel.instagram_id}) needs reauthorization to receive comments")
+      end
+    end
+
+    Rails.logger.info("Done. Re-subscribed #{resubscribed} Instagram channel(s); #{needs_reauth} need reauthorization.")
+  end
+end

--- a/spec/controllers/instagram/callbacks_controller_spec.rb
+++ b/spec/controllers/instagram/callbacks_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Instagram::CallbacksController do
     allow(exception_tracker).to receive(:capture_exception)
 
     # Stub the exact request format that's being made
-    stub_request(:post, 'https://graph.instagram.com/v22.0/12345/subscribed_apps?access_token=long_lived_test_token&subscribed_fields%5B%5D=messages&subscribed_fields%5B%5D=message_reactions&subscribed_fields%5B%5D=messaging_seen')
+    stub_request(:post, 'https://graph.instagram.com/v22.0/12345/subscribed_apps?access_token=long_lived_test_token&subscribed_fields%5B%5D=messages&subscribed_fields%5B%5D=message_reactions&subscribed_fields%5B%5D=messaging_seen&subscribed_fields%5B%5D=comments')
       .with(
         headers: {
           'Accept' => '*/*',

--- a/spec/factories/channel/channel_instagram.rb
+++ b/spec/factories/channel/channel_instagram.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
       WebMock::API.stub_request(:post, "https://graph.instagram.com/v22.0/#{channel.instagram_id}/subscribed_apps")
                   .with(query: {
                           access_token: channel.access_token,
-                          subscribed_fields: %w[messages message_reactions messaging_seen]
+                          subscribed_fields: %w[messages message_reactions messaging_seen comments]
                         })
                   .to_return(status: 200, body: '', headers: {})
 

--- a/spec/services/conversations/message_window_service_spec.rb
+++ b/spec/services/conversations/message_window_service_spec.rb
@@ -203,6 +203,16 @@ RSpec.describe Conversations::MessageWindowService do
     let!(:instagram_inbox) { create(:inbox, channel: instagram_channel, account: instagram_channel.account) }
     let!(:conversation) { create(:conversation, inbox: instagram_inbox, account: instagram_channel.account) }
 
+    context 'when the conversation is an Instagram comment thread' do
+      it 'can always reply, ignoring the DM messaging window' do
+        conversation.update!(additional_attributes: { 'type' => 'instagram_comment' })
+        create(:message, account: conversation.account, inbox: instagram_inbox,
+                         conversation: conversation, created_at: 30.days.ago)
+
+        expect(described_class.new(conversation).can_reply?).to be true
+      end
+    end
+
     context 'when the HUMAN_AGENT is enabled' do
       it 'return false if the last message is outgoing' do
         with_modified_env ENABLE_INSTAGRAM_CHANNEL_HUMAN_AGENT: 'true' do

--- a/spec/services/instagram/comment_text_spec.rb
+++ b/spec/services/instagram/comment_text_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+describe Instagram::CommentText do
+  let!(:account) { create(:account) }
+  let!(:channel) { create(:channel_instagram, account: account, instagram_id: 'connected-ig-account-id') }
+  let(:inbox) { channel.inbox }
+
+  def comment_value(overrides = {})
+    {
+      'from' => { 'id' => '999888777', 'username' => 'cliente_teste' },
+      'media' => { 'id' => 'media-1', 'media_product_type' => 'FEED' },
+      'id' => 'comment-1',
+      'text' => 'Que produto lindo!'
+    }.merge(overrides).with_indifferent_access
+  end
+
+  describe '#perform' do
+    context 'with a new comment' do
+      before { described_class.new(comment_value, channel).perform }
+
+      it 'creates the commenter contact' do
+        expect(inbox.contacts.count).to eq 1
+        expect(inbox.contacts.last.additional_attributes['social_instagram_user_name']).to eq 'cliente_teste'
+      end
+
+      it 'creates a single comment conversation grouped by media' do
+        conversation = inbox.conversations.last
+        expect(inbox.conversations.count).to eq 1
+        expect(conversation.additional_attributes['type']).to eq 'instagram_comment'
+        expect(conversation.additional_attributes['instagram_media_id']).to eq 'media-1'
+      end
+
+      it 'creates an incoming comment message' do
+        message = inbox.messages.last
+        expect(message.message_type).to eq 'incoming'
+        expect(message.content).to eq 'Que produto lindo!'
+        expect(message.source_id).to eq 'comment-1'
+        expect(message.content_attributes['type']).to eq 'instagram_comment'
+        expect(message.content_attributes['instagram_comment_id']).to eq 'comment-1'
+      end
+    end
+
+    it 'ignores comments authored by the connected account itself' do
+      described_class.new(comment_value('from' => { 'id' => channel.instagram_id, 'username' => 'self' }), channel).perform
+
+      expect(inbox.conversations.count).to eq 0
+      expect(inbox.messages.count).to eq 0
+    end
+
+    it 'is idempotent for the same comment id' do
+      2.times { described_class.new(comment_value, channel).perform }
+
+      expect(inbox.messages.count).to eq 1
+    end
+
+    it 'groups multiple comments on the same media into one conversation' do
+      described_class.new(comment_value('id' => 'c1', 'text' => 'primeiro'), channel).perform
+      described_class.new(comment_value('id' => 'c2', 'text' => 'segundo'), channel).perform
+
+      expect(inbox.conversations.count).to eq 1
+      expect(inbox.messages.count).to eq 2
+    end
+  end
+
+  describe 'routing via Webhooks::InstagramEventsJob' do
+    let(:comment_entry) do
+      [{ 'id' => channel.instagram_id, 'time' => 1,
+         'changes' => [{ 'field' => 'comments', 'value' => comment_value }] }]
+    end
+
+    it 'routes comment change events to Instagram::CommentText' do
+      expect(described_class).to receive(:new).with(kind_of(Hash), kind_of(Channel::Instagram)).and_call_original
+      Webhooks::InstagramEventsJob.perform_now(comment_entry)
+    end
+
+    it 'does not treat a real comment change as a test event' do
+      expect(Instagram::TestEventService).not_to receive(:new)
+      Webhooks::InstagramEventsJob.perform_now(comment_entry)
+    end
+
+    it 'also handles entry-level comment payloads (field/value on the entry)' do
+      entry_level = [{ 'id' => channel.instagram_id, 'time' => 1, 'field' => 'comments', 'value' => comment_value }]
+      expect(described_class).to receive(:new).with(kind_of(Hash), kind_of(Channel::Instagram)).and_call_original
+      Webhooks::InstagramEventsJob.perform_now(entry_level)
+    end
+  end
+end

--- a/spec/services/instagram/send_on_instagram_service_comment_spec.rb
+++ b/spec/services/instagram/send_on_instagram_service_comment_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+# Covers the Instagram comment-reply path of Instagram::SendOnInstagramService.
+# Direct-message replies are covered in send_on_instagram_service_spec.rb.
+describe Instagram::SendOnInstagramService do
+  let!(:account) { create(:account) }
+  let!(:channel) { create(:channel_instagram, account: account, instagram_id: 'connected-ig-account-id') }
+  let!(:inbox) { create(:inbox, channel: channel, account: account, greeting_enabled: false) }
+  let!(:contact) { create(:contact, account: account) }
+  let!(:contact_inbox) { create(:contact_inbox, contact: contact, inbox: inbox) }
+  let!(:conversation) do
+    create(:conversation, contact: contact, inbox: inbox, contact_inbox: contact_inbox,
+                          additional_attributes: { 'type' => 'instagram_comment', 'instagram_media_id' => 'media-1' })
+  end
+
+  before do
+    # The incoming comment we are replying to.
+    create(:message, message_type: 'incoming', inbox: inbox, account: account, conversation: conversation,
+                     source_id: 'comment-1',
+                     content_attributes: { 'type' => 'instagram_comment', 'instagram_comment_id' => 'comment-1' })
+  end
+
+  describe '#perform on a comment conversation' do
+    it 'replies publicly to the latest comment via the Comments API' do
+      reply_response = instance_double(
+        HTTParty::Response,
+        :success? => true,
+        :parsed_response => { 'id' => 'reply-comment-id' }
+      )
+      allow(HTTParty).to receive(:post).and_return(reply_response)
+
+      outgoing = create(:message, message_type: 'outgoing', content: 'Obrigado pelo comentário!',
+                                  inbox: inbox, account: account, conversation: conversation)
+      described_class.new(message: outgoing).perform
+
+      expect(HTTParty).to have_received(:post)
+        .with('https://graph.instagram.com/v22.0/comment-1/replies', hash_including(:body))
+      expect(outgoing.reload.source_id).to eq 'reply-comment-id'
+    end
+
+    it 'marks the message as failed when the Comments API returns an error' do
+      error_body = { 'error' => { 'message' => 'Invalid comment', 'code' => 100 } }
+      error_response = instance_double(
+        HTTParty::Response,
+        :success? => false,
+        :parsed_response => error_body
+      )
+      allow(HTTParty).to receive(:post).and_return(error_response)
+
+      outgoing = create(:message, message_type: 'outgoing', content: 'Obrigado!',
+                                  inbox: inbox, account: account, conversation: conversation)
+      described_class.new(message: outgoing).perform
+
+      expect(outgoing.reload.status).to eq 'failed'
+    end
+
+    it 'marks an attachment-only reply (blank content) as failed without calling the API' do
+      allow(HTTParty).to receive(:post)
+
+      outgoing = create(:message, message_type: 'outgoing', content: nil,
+                                  inbox: inbox, account: account, conversation: conversation)
+      described_class.new(message: outgoing).perform
+
+      expect(HTTParty).not_to have_received(:post)
+      expect(outgoing.reload.status).to eq 'failed'
+    end
+
+    it 'replies to the latest comment that existed when composed, ignoring older and newer ones' do
+      reply_response = instance_double(HTTParty::Response, :success? => true, :parsed_response => { 'id' => 'reply-id' })
+      allow(HTTParty).to receive(:post).and_return(reply_response)
+
+      # An older comment in the same grouped conversation (must not win over comment-1).
+      create(:message, message_type: 'incoming', inbox: inbox, account: account, conversation: conversation,
+                       source_id: 'comment-0', created_at: 2.minutes.ago,
+                       content_attributes: { 'type' => 'instagram_comment', 'instagram_comment_id' => 'comment-0' })
+
+      outgoing = create(:message, message_type: 'outgoing', content: 'Resposta',
+                                  inbox: inbox, account: account, conversation: conversation)
+      # A newer comment arrives while the reply sits in the SendReplyJob queue.
+      create(:message, message_type: 'incoming', inbox: inbox, account: account, conversation: conversation,
+                       source_id: 'comment-2', created_at: outgoing.created_at + 1.minute,
+                       content_attributes: { 'type' => 'instagram_comment', 'instagram_comment_id' => 'comment-2' })
+
+      described_class.new(message: outgoing).perform
+
+      expect(HTTParty).to have_received(:post).with('https://graph.instagram.com/v22.0/comment-1/replies', hash_including(:body))
+    end
+  end
+end


### PR DESCRIPTION
## Describe your changes

The Instagram channel (Instagram API with Instagram Login) currently handles
**direct messages only** (`SUPPORTED_EVENTS = [:message, :read]`). This PR adds
ingestion of **post/reel comments** and **public replies** via the Comments API.

When someone comments on a connected professional account's post or reel, the
comment becomes a conversation in the agent inbox; an agent (or automation) can
reply, and the reply is posted **publicly** on the comment thread.

### What changed
- Subscribe to the `comments` webhook field on the IG account
- Route comment change events by `field` (avoids colliding with the IG
  test-event path and with direct messages)
- `Instagram::CommentText` + `Messages::Instagram::CommentBuilder` create the
  comment conversation/message, grouped per media
- `Instagram::SendOnInstagramService` replies via `POST /{comment-id}/replies`
- Robust webhook signature verification for comment entries
- Add `instagram_business_manage_comments` to `REQUIRED_SCOPES`
- Read `content_attributes` / `additional_attributes` in Ruby (these `json`
  columns make the Postgres `->>` operator unreliable)
- `rake instagram:resubscribe_comments` to migrate already-connected channels

### Tested
Validated end-to-end on a self-hosted instance: an Instagram comment on a
connected professional account's post created a conversation in Chatwoot, and an
agent reply was posted back as a **public comment reply** on Instagram.

Specs added: `comment_text_spec`, `send_on_instagram_service_comment_spec`.

### Note
Production use requires `instagram_business_manage_comments` approved in App Review.

## Type of change
- [x] New feature (non-breaking change which adds functionality)