### PR TITLE
fix: auto enable document auto-sync

### DIFF
--- a/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
+++ b/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
@@ -13,6 +13,7 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
     channel_instagram
     channel_tiktok
     captain_integration
+    captain_document_auto_sync
     advanced_search_indexing
     advanced_search
     linear_integration

--- a/enterprise/config/premium_features.yml
+++ b/enterprise/config/premium_features.yml
@@ -4,5 +4,6 @@
 - sla
 - custom_roles
 - captain_integration
+- captain_document_auto_sync
 - csat_review_notes
 - conversation_required_attributes


### PR DESCRIPTION
# Pull Request Template

## Description

Auto enables document auto-sync on paid plans

fixes: https://linear.app/chatwoot/issue/AI-186/captain-auto-sync-doesnt-turn-on-automatically-on-subscription

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
