### PR TITLE
feat(facebook): show ad referral card above first client message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ CLAUDE.local.md
 .pnpm-store/*
 local/
 Procfile.worktree
+
+# Local simulation / test scripts — not for production
+simulation/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,61 @@
-AGENTS.md
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+See [AGENTS.md](./AGENTS.md) for build commands, code style, styling rules, commit conventions, and project-specific guidelines. The rules there apply equally here.
+
+## Architecture Overview
+
+Chatwoot is an omnichannel customer support platform. The primary stack is **Rails 7** (API + server-rendered auth/admin pages) with a **Vue 3** SPA frontend, **Sidekiq** for background jobs, **Action Cable** (WebSockets) for real-time updates, and **Redis** for caching and pub/sub.
+
+### Backend structure
+
+All customer-facing APIs live under `app/controllers/api/v1/accounts/` and are scoped by `account_id`. The key domain models are:
+
+- **Account** — top-level tenant; nearly every model has `account_id`
+- **Inbox** — a communication channel instance (email inbox, WhatsApp number, web widget, etc.). It owns a polymorphic `channel` (`Channel::WebWidget`, `Channel::Email`, `Channel::FacebookPage`, etc. in `app/models/channel/`)
+- **Conversation** — a thread between a contact and agents, always tied to an inbox
+- **Message** — individual messages within a conversation
+- **Contact** / **ContactInbox** — a customer and their identity within a specific inbox
+
+Business logic lives in `app/services/` (organized by domain). Heavy lifting that must not block the request goes through `app/jobs/`. Reusable pieces used across jobs/services that are not Rails-conventional live in `lib/`.
+
+**Event system**: Model callbacks and controller actions call `Dispatcher.dispatch(event_name, ...)`. `app/listeners/` subscribe to these events (sync or async) and fan out to jobs, webhooks, Action Cable broadcasts, and notifications.
+
+### Frontend structure
+
+The frontend is built with Vite (`vite-plugin-ruby`) and has multiple independent entrypoints in `app/javascript/entrypoints/`:
+
+| Entrypoint | Path | Purpose |
+|---|---|---|
+| `dashboard.js` | `app/javascript/dashboard/` | Main agent workspace (the core app) |
+| `v3app.js` | `app/javascript/v3/` | Auth / onboarding flows |
+| `widget.js` | `app/javascript/widget/` | Embeddable customer chat widget |
+| `portal.js` | `app/javascript/portal/` | Customer-facing help center |
+| `survey.js` | `app/javascript/survey/` | CSAT survey page |
+| `superadmin.js` | `app/javascript/superadmin_pages/` | Super-admin UI |
+
+`app/javascript/shared/` contains utilities, composables, and components used across all entrypoints.
+
+**Import aliases** (defined in `vite.shared.ts`):
+- `dashboard` → `app/javascript/dashboard`
+- `next` → `app/javascript/dashboard/components-next`
+- `shared` → `app/javascript/shared`
+- `v3` → `app/javascript/v3`
+- `widget` → `app/javascript/widget`
+
+### Frontend state management
+
+The dashboard uses **Vuex** (`dashboard/store/`) for most global state. A migration to **Pinia** (`dashboard/stores/`) is in progress — new features should prefer Pinia. The Captain AI stores are already on Pinia.
+
+### Component system
+
+`dashboard/components-next/` is the active design system used for all new UI work (message bubbles, sidebar, dialogs, etc.). `dashboard/components/` is legacy and being deprecated — do not add new components there.
+
+### Captain (AI features)
+
+Captain is Chatwoot's AI layer. OSS tooling lives in `lib/captain/` and `app/services/captain/`; enterprise-specific services (LLM connectors, copilot, voice) live under `enterprise/`. Config for LLM providers is in `config/llm.yml` and `config/llm_models.json`.
+
+### Enterprise Edition
+
+`enterprise/` mirrors the OSS directory layout and extends it via Ruby's `prepend_mod_with` / `include_mod_with` hooks. When modifying OSS code that has enterprise equivalents, always check and update `enterprise/` in the same change. Enterprise-only models, controllers, and services live exclusively under `enterprise/app/`.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,90 @@ Publish help articles, FAQs, and guides through the built-in Help Center Portal.
 - Downloadable Reports for offline analysis and reporting.
 
 
+---
+
+## Switchable Fork — Custom Features
+
+This repository is a fork of Chatwoot with isolated, portable custom features. Each feature is self-contained and can be copied into any other Chatwoot installation without touching upstream files beyond a minimum.
+
+---
+
+### Feature: Facebook Messenger Ad Referral Card
+
+When a contact starts a conversation by clicking a Facebook ad, Chatwoot now displays the ad content (thumbnail + title) above their first message in the chat.
+
+#### How it works
+
+Facebook sends a `referral` object alongside the message webhook event. This fork captures it and stores it in `content_attributes.referral`. The frontend reads that data and renders an ad card at the top of the text bubble.
+
+#### Files added by this feature
+
+| File | Purpose |
+|---|---|
+| `config/initializers/facebook_ad_referral.rb` | Wires the extensions (the only file that references upstream classes) |
+| `lib/integrations/facebook/ad_referral/message_parser_extension.rb` | Extracts `referral` from the webhook payload |
+| `lib/integrations/facebook/ad_referral/message_builder_extension.rb` | Stores referral in `content_attributes` |
+| `app/javascript/dashboard/components-next/message/ad-referral/AdReferralCard.vue` | Vue component that renders the ad card |
+
+#### Minimal changes to upstream files
+
+| File | Change |
+|---|---|
+| `app/javascript/dashboard/components-next/message/bubbles/Text/Index.vue` | 1 import line + 3 template lines |
+| `app/javascript/dashboard/i18n/locale/en/conversation.json` | `AD_REFERRAL.SPONSORED` translation key |
+
+#### Deploying to an existing Chatwoot installation
+
+1. **Copy the new files** into the target Chatwoot repo:
+   ```
+   config/initializers/facebook_ad_referral.rb
+   lib/integrations/facebook/ad_referral/
+   app/javascript/dashboard/components-next/message/ad-referral/
+   ```
+
+2. **Edit `app/javascript/dashboard/components-next/message/bubbles/Text/Index.vue`** — add after the existing imports:
+   ```js
+   import AdReferralCard from 'next/message/ad-referral/AdReferralCard.vue';
+   ```
+   Then inside the template's `<div class="gap-3 flex flex-col">`, before `<span v-if="isEmpty">`:
+   ```vue
+   <AdReferralCard
+     v-if="contentAttributes.referral"
+     :referral="contentAttributes.referral"
+   />
+   ```
+
+3. **Add the translation key** to `app/javascript/dashboard/i18n/locale/en/conversation.json` inside the top-level `CONVERSATION` object:
+   ```json
+   "AD_REFERRAL": {
+     "SPONSORED": "Sponsored"
+   },
+   ```
+
+4. **Rebuild the frontend assets:**
+   ```bash
+   pnpm install
+   pnpm build
+   ```
+
+5. **Restart Rails** (the initializer loads automatically on boot — no migrations required):
+   ```bash
+   bundle exec rails server
+   # or in production: restart your Rails process / Sidekiq workers
+   ```
+
+#### Removing the feature
+
+Delete these files and restart Rails:
+```
+config/initializers/facebook_ad_referral.rb
+lib/integrations/facebook/ad_referral/
+app/javascript/dashboard/components-next/message/ad-referral/
+```
+Then revert the 4 lines in `Text/Index.vue` and the i18n key.
+
+---
+
 ## Documentation
 
 Detailed documentation is available at [chatwoot.com/help-center](https://www.chatwoot.com/help-center).

--- a/app/javascript/dashboard/components-next/message/ad-referral/AdReferralCard.spec.js
+++ b/app/javascript/dashboard/components-next/message/ad-referral/AdReferralCard.spec.js
@@ -1,0 +1,85 @@
+import { mount } from '@vue/test-utils';
+import AdReferralCard from './AdReferralCard.vue';
+
+const adReferral = {
+  ref: 'sim_ref_abc123',
+  source: 'ADS',
+  type: 'OPEN_THREAD',
+  adId: '6089986171001',
+  adsContextData: {
+    adTitle: 'Summer Sale – 30% Off All Items',
+    photoUrl: 'https://picsum.photos/seed/simad/800/400',
+    videoUrl: null,
+    postId: '123456789_987654321',
+    productId: null,
+  },
+};
+
+const mountCard = referral =>
+  mount(AdReferralCard, {
+    props: { referral },
+    global: { mocks: { $t: key => key } },
+  });
+
+describe('AdReferralCard', () => {
+  it('renders the card when source is ADS and has content', () => {
+    const wrapper = mountCard(adReferral);
+    expect(wrapper.find('div').exists()).toBe(true);
+  });
+
+  it('shows the ad thumbnail image', () => {
+    const wrapper = mountCard(adReferral);
+    const img = wrapper.find('img');
+    expect(img.exists()).toBe(true);
+    expect(img.attributes('src')).toBe(adReferral.adsContextData.photoUrl);
+  });
+
+  it('shows the Sponsored label', () => {
+    const wrapper = mountCard(adReferral);
+    expect(wrapper.find('span').text()).toBe(
+      'CONVERSATION.AD_REFERRAL.SPONSORED'
+    );
+  });
+
+  it('shows the ad title', () => {
+    const wrapper = mountCard(adReferral);
+    expect(wrapper.find('p').text()).toBe(adReferral.adsContextData.adTitle);
+  });
+
+  it('renders without image when photoUrl is empty', () => {
+    const noImage = {
+      ...adReferral,
+      adsContextData: { ...adReferral.adsContextData, photoUrl: '' },
+    };
+    const wrapper = mountCard(noImage);
+    expect(wrapper.find('img').exists()).toBe(false);
+    expect(wrapper.find('p').text()).toBe(adReferral.adsContextData.adTitle);
+  });
+
+  it('does NOT render when source is not ADS', () => {
+    const shortlink = {
+      ref: 'some_link',
+      source: 'SHORTLINK',
+      type: 'OPEN_THREAD',
+      adId: null,
+      adsContextData: null,
+    };
+    const wrapper = mountCard(shortlink);
+    expect(wrapper.find('div').exists()).toBe(false);
+  });
+
+  it('does NOT render when adsContextData has no content', () => {
+    const emptyAd = {
+      ...adReferral,
+      adsContextData: { adTitle: '', photoUrl: '' },
+    };
+    const wrapper = mountCard(emptyAd);
+    expect(wrapper.find('div').exists()).toBe(false);
+  });
+
+  it('does NOT render when adsContextData is null', () => {
+    const nullData = { ...adReferral, adsContextData: null };
+    const wrapper = mountCard(nullData);
+    expect(wrapper.find('div').exists()).toBe(false);
+  });
+});

--- a/app/javascript/dashboard/components-next/message/ad-referral/AdReferralCard.vue
+++ b/app/javascript/dashboard/components-next/message/ad-referral/AdReferralCard.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  referral: {
+    type: Object,
+    required: true,
+  },
+});
+
+const adData = computed(() => props.referral.adsContextData ?? {});
+const thumbnailUrl = computed(() => adData.value.photoUrl ?? '');
+const adTitle = computed(() => adData.value.adTitle ?? '');
+const hasContent = computed(() => !!(thumbnailUrl.value || adTitle.value));
+</script>
+
+<template>
+  <div
+    v-if="referral.source === 'ADS' && hasContent"
+    class="rounded-lg overflow-hidden border border-n-slate-4 bg-n-alpha-1 -mx-1"
+  >
+    <img
+      v-if="thumbnailUrl"
+      :src="thumbnailUrl"
+      class="w-full object-cover max-h-48 skip-context-menu"
+      alt=""
+    />
+    <div class="px-3 py-2 flex flex-col gap-0.5">
+      <span class="text-xs font-medium text-n-slate-9 uppercase tracking-wide">
+        {{ $t('CONVERSATION.AD_REFERRAL.SPONSORED') }}
+      </span>
+      <p v-if="adTitle" class="m-0 text-sm font-semibold text-n-slate-12">
+        {{ adTitle }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/app/javascript/dashboard/components-next/message/bubbles/Text/Index.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Text/Index.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, ref } from 'vue';
 import BaseBubble from 'next/message/bubbles/Base.vue';
+import AdReferralCard from 'next/message/ad-referral/AdReferralCard.vue';
 import FormattedContent from './FormattedContent.vue';
 import AttachmentChips from 'next/message/chips/AttachmentChips.vue';
 import TranslationToggle from 'dashboard/components-next/message/TranslationToggle.vue';
@@ -44,6 +45,10 @@ const handleSeeOriginal = () => {
 <template>
   <BaseBubble class="px-4 py-3" data-bubble-name="text">
     <div class="gap-3 flex flex-col">
+      <AdReferralCard
+        v-if="contentAttributes.referral"
+        :referral="contentAttributes.referral"
+      />
       <span v-if="isEmpty" class="text-n-slate-11">
         {{ $t('CONVERSATION.NO_CONTENT') }}
       </span>

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -97,6 +97,9 @@
       "TRANSCRIPT_SHOW_MORE": "Show more",
       "TRANSCRIPT_SHOW_LESS": "Show less"
     },
+    "AD_REFERRAL": {
+      "SPONSORED": "Sponsored"
+    },
     "HEADER": {
       "RESOLVE_ACTION": "Resolve",
       "REOPEN_ACTION": "Reopen",

--- a/config/initializers/facebook_ad_referral.rb
+++ b/config/initializers/facebook_ad_referral.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Facebook Messenger ad referral feature.
+# To remove: delete this file and lib/integrations/facebook/ad_referral/
+Rails.application.config.to_prepare do
+  Integrations::Facebook::MessageParser.prepend(
+    Integrations::Facebook::AdReferral::MessageParserExtension
+  )
+  Messages::Facebook::MessageBuilder.prepend(
+    Integrations::Facebook::AdReferral::MessageBuilderExtension
+  )
+end

--- a/lib/integrations/facebook/ad_referral/message_builder_extension.rb
+++ b/lib/integrations/facebook/ad_referral/message_builder_extension.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Integrations::Facebook::AdReferral
+  module MessageBuilderExtension
+    private
+
+    def message_params
+      params = super
+      referral = response.referral
+      params[:content_attributes][:referral] = referral if !@outgoing_echo && referral.present?
+      params
+    end
+  end
+end

--- a/lib/integrations/facebook/ad_referral/message_parser_extension.rb
+++ b/lib/integrations/facebook/ad_referral/message_parser_extension.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Integrations::Facebook::AdReferral
+  module MessageParserExtension
+    def referral
+      @messaging['referral']&.deep_stringify_keys
+    end
+  end
+end


### PR DESCRIPTION
When a contact starts a conversation via a Facebook Messenger ad, capture the referral object from the webhook and render an ad card (thumbnail + title) above the client's message in the chat bubble.

Feature is fully isolated — remove by deleting the initializer, lib/integrations/facebook/ad_referral/, and the ad-referral component.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
