### PR TITLE
fix(firecrawl): get url in case sourceUrl is not available

### DIFF
--- a/enterprise/app/jobs/captain/tools/firecrawl_parser_job.rb
+++ b/enterprise/app/jobs/captain/tools/firecrawl_parser_job.rb
@@ -5,7 +5,7 @@ class Captain::Tools::FirecrawlParserJob < ApplicationJob
     assistant = Captain::Assistant.find(assistant_id)
     metadata = payload[:metadata]
 
-    canonical_url = normalize_link(metadata['url'])
+    canonical_url = normalize_link(metadata['sourceURL'].presence || metadata['url'])
     document = assistant.documents.find_or_initialize_by(
       external_link: canonical_url
     )

--- a/spec/enterprise/jobs/captain/tools/firecrawl_parser_job_spec.rb
+++ b/spec/enterprise/jobs/captain/tools/firecrawl_parser_job_spec.rb
@@ -71,6 +71,28 @@ RSpec.describe Captain::Tools::FirecrawlParserJob, type: :job do
       expect(assistant.documents.last.external_link.length).to be > 255
     end
 
+    it 'uses sourceURL when Firecrawl payload does not include url metadata' do
+      payload[:metadata].delete('url')
+      payload[:metadata]['sourceURL'] = 'https://www.firecrawl.dev/docs/'
+
+      described_class.perform_now(assistant_id: assistant.id, payload: payload)
+
+      expect(assistant.documents.last).to have_attributes(
+        external_link: 'https://www.firecrawl.dev/docs',
+        status: 'available',
+        sync_status: 'synced'
+      )
+    end
+
+    it 'prefers sourceURL when Firecrawl payload includes both URL metadata fields' do
+      payload[:metadata]['url'] = 'https://www.firecrawl.dev/canonical'
+      payload[:metadata]['sourceURL'] = 'https://www.firecrawl.dev/source/'
+
+      described_class.perform_now(assistant_id: assistant.id, payload: payload)
+
+      expect(assistant.documents.last.external_link).to eq('https://www.firecrawl.dev/source')
+    end
+
     context 'when an error occurs' do
       it 'raises an error with a descriptive message' do
         allow(Captain::Assistant).to receive(:find).and_raise(ActiveRecord::RecordNotFound)


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes inconsistency by adding a fallback to use `url` instead of `sourceUrl` when Firecrawl returns empty `sourceUrl` in production.

We switched to v2 endpoints of Firecrawl in https://github.com/chatwoot/chatwoot/pull/14624 and it worked locally, but seems to fail for some cases in production.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
locally


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
