### PR TITLE
fix(whatsapp): run embedded signup webhook setup asynchronously

### DIFF
--- a/app/jobs/whatsapp/setup_webhooks_job.rb
+++ b/app/jobs/whatsapp/setup_webhooks_job.rb
@@ -1,0 +1,32 @@
+class Whatsapp::SetupWebhooksJob < ApplicationJob
+  queue_as :medium
+
+  # Runs the post-creation webhook setup and health check outside the web request.
+  # These hit the Meta Graph API and can be slow enough to exceed the request timeout,
+  # so the embedded signup controller returns as soon as the channel is persisted and
+  # this job finishes the setup asynchronously.
+  def perform(channel, run_health_check: true)
+    channel.setup_webhooks
+    check_channel_health_and_prompt_reauth(channel) if run_health_check
+  end
+
+  private
+
+  def check_channel_health_and_prompt_reauth(channel)
+    health_data = Whatsapp::HealthService.new(channel).fetch_health_status
+    return unless health_data
+
+    if channel_in_pending_state?(health_data)
+      channel.prompt_reauthorization!
+    else
+      Rails.logger.info "[WHATSAPP] Channel #{channel.phone_number} health check passed"
+    end
+  rescue StandardError => e
+    Rails.logger.error "[WHATSAPP] Health check failed for channel #{channel.phone_number}: #{e.message}"
+  end
+
+  def channel_in_pending_state?(health_data)
+    health_data[:platform_type] == 'NOT_APPLICABLE' ||
+      health_data.dig(:throughput, 'level') == 'NOT_APPLICABLE'
+  end
+end

--- a/app/services/whatsapp/embedded_signup_service.rb
+++ b/app/services/whatsapp/embedded_signup_service.rb
@@ -15,17 +15,15 @@ class Whatsapp::EmbeddedSignupService
     phone_info = fetch_phone_info(access_token)
 
     channel = create_or_reauthorize_channel(access_token, phone_info)
-    # NOTE: We call setup_webhooks explicitly here instead of relying on after_commit callback because:
-    # 1. Reauthorization flow updates an existing channel (not a create), so after_commit on: :create won't trigger
-    # 2. We need to run check_channel_health_and_prompt_reauth after webhook setup completes
-    # 3. The channel is marked with source: 'embedded_signup' to skip the after_commit callback
-    channel.setup_webhooks
-    # Skip health check during reauthorization — phone numbers in pending provisioning state
-    # (platform_type: NOT_APPLICABLE) would incorrectly trigger a disconnect email right after
-    # a successful reauth. Only run health check for new channel creation.
-    check_channel_health_and_prompt_reauth(channel) if @inbox_id.blank?
+    # Webhook setup + health check hit the Meta Graph API and can be slow enough to blow past the
+    # web request timeout (the channel is already persisted by this point, so the inbox exists even
+    # when the request 500s). Run them in a background job so the controller can return immediately.
+    # We enqueue explicitly instead of relying on the after_commit callback because the channel is
+    # marked source: 'embedded_signup' (which skips that callback) and reauthorization updates an
+    # existing channel rather than creating one. Skip the health check during reauthorization —
+    # phone numbers in a pending provisioning state would otherwise trigger a false disconnect email.
+    Whatsapp::SetupWebhooksJob.perform_later(channel, run_health_check: @inbox_id.blank?)
     channel
-
   rescue StandardError => e
     Rails.logger.error("[WHATSAPP] Embedded signup failed: #{e.message}")
     raise e
@@ -53,24 +51,6 @@ class Whatsapp::EmbeddedSignupService
       waba_info = { waba_id: @waba_id, business_name: phone_info[:business_name] }
       Whatsapp::ChannelCreationService.new(@account, waba_info, phone_info, access_token).perform
     end
-  end
-
-  def check_channel_health_and_prompt_reauth(channel)
-    health_data = Whatsapp::HealthService.new(channel).fetch_health_status
-    return unless health_data
-
-    if channel_in_pending_state?(health_data)
-      channel.prompt_reauthorization!
-    else
-      Rails.logger.info "[WHATSAPP] Channel #{channel.phone_number} health check passed"
-    end
-  rescue StandardError => e
-    Rails.logger.error "[WHATSAPP] Health check failed for channel #{channel.phone_number}: #{e.message}"
-  end
-
-  def channel_in_pending_state?(health_data)
-    health_data[:platform_type] == 'NOT_APPLICABLE' ||
-      health_data.dig(:throughput, 'level') == 'NOT_APPLICABLE'
   end
 
   def validate_parameters!

--- a/spec/jobs/whatsapp/setup_webhooks_job_spec.rb
+++ b/spec/jobs/whatsapp/setup_webhooks_job_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::SetupWebhooksJob do
+  subject(:job) { described_class.new }
+
+  let(:account) { create(:account) }
+  let(:channel) do
+    create(:channel_whatsapp, account: account, phone_number: '+1234567890',
+                              validate_provider_config: false, sync_templates: false)
+  end
+  let(:health_service) { instance_double(Whatsapp::HealthService) }
+  let(:healthy_status) do
+    { platform_type: 'CLOUD_API', throughput: { 'level' => 'STANDARD' }, messaging_limit_tier: 'TIER_1000' }
+  end
+
+  before do
+    allow(channel).to receive(:setup_webhooks)
+    allow(Whatsapp::HealthService).to receive(:new).with(channel).and_return(health_service)
+    allow(health_service).to receive(:fetch_health_status).and_return(healthy_status)
+  end
+
+  it 'sets up the channel webhooks' do
+    expect(channel).to receive(:setup_webhooks)
+    job.perform(channel)
+  end
+
+  it 'checks health status after webhook setup' do
+    expect(health_service).to receive(:fetch_health_status)
+    job.perform(channel)
+  end
+
+  context 'when the channel is healthy' do
+    it 'does not prompt reauthorization' do
+      expect(channel).not_to receive(:prompt_reauthorization!)
+      job.perform(channel)
+    end
+  end
+
+  context 'when the channel is in a pending state' do
+    it 'prompts reauthorization for a NOT_APPLICABLE platform type' do
+      allow(health_service).to receive(:fetch_health_status)
+        .and_return(healthy_status.merge(platform_type: 'NOT_APPLICABLE'))
+
+      expect(channel).to receive(:prompt_reauthorization!)
+      job.perform(channel)
+    end
+
+    it 'prompts reauthorization when throughput level is NOT_APPLICABLE' do
+      allow(health_service).to receive(:fetch_health_status)
+        .and_return(healthy_status.merge(throughput: { 'level' => 'NOT_APPLICABLE' }))
+
+      expect(channel).to receive(:prompt_reauthorization!)
+      job.perform(channel)
+    end
+  end
+
+  context 'when run_health_check is false' do
+    it 'skips the health check' do
+      expect(Whatsapp::HealthService).not_to receive(:new)
+      job.perform(channel, run_health_check: false)
+    end
+  end
+
+  context 'when the health check raises' do
+    it 'rescues the error without raising' do
+      allow(health_service).to receive(:fetch_health_status).and_raise('Health error')
+
+      expect { job.perform(channel) }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/whatsapp/embedded_signup_service_spec.rb
+++ b/spec/services/whatsapp/embedded_signup_service_spec.rb
@@ -42,66 +42,20 @@ describe Whatsapp::EmbeddedSignupService do
         .and_return(channel_creation)
       allow(channel_creation).to receive(:perform).and_return(channel)
 
-      allow(channel).to receive(:setup_webhooks)
       allow(channel).to receive(:phone_number).and_return('+1234567890')
 
-      health_service = instance_double(Whatsapp::HealthService)
-      allow(Whatsapp::HealthService).to receive(:new).and_return(health_service)
-      allow(health_service).to receive(:fetch_health_status).and_return({
-                                                                          platform_type: 'CLOUD_API',
-                                                                          throughput: { 'level' => 'STANDARD' },
-                                                                          messaging_limit_tier: 'TIER_1000'
-                                                                        })
+      # Webhook setup + health check run asynchronously; the slow Meta calls must stay off the request path.
+      allow(Whatsapp::SetupWebhooksJob).to receive(:perform_later)
     end
 
-    it 'creates channel and sets up webhooks' do
-      expect(channel).to receive(:setup_webhooks)
-
+    it 'creates the channel and returns it' do
       result = service.perform
       expect(result).to eq(channel)
     end
 
-    it 'checks health status after channel creation' do
-      health_service = instance_double(Whatsapp::HealthService)
-      allow(Whatsapp::HealthService).to receive(:new).and_return(health_service)
-      expect(health_service).to receive(:fetch_health_status)
-
+    it 'enqueues webhook setup with a health check for new channels' do
+      expect(Whatsapp::SetupWebhooksJob).to receive(:perform_later).with(channel, run_health_check: true)
       service.perform
-    end
-
-    context 'when channel is in pending state' do
-      it 'prompts reauthorization for pending channel' do
-        health_service = instance_double(Whatsapp::HealthService)
-        allow(Whatsapp::HealthService).to receive(:new).and_return(health_service)
-        allow(health_service).to receive(:fetch_health_status).and_return({
-                                                                            platform_type: 'NOT_APPLICABLE',
-                                                                            throughput: { 'level' => 'STANDARD' },
-                                                                            messaging_limit_tier: 'TIER_1000'
-                                                                          })
-
-        expect(channel).to receive(:prompt_reauthorization!)
-        service.perform
-      end
-
-      it 'prompts reauthorization when throughput level is NOT_APPLICABLE' do
-        health_service = instance_double(Whatsapp::HealthService)
-        allow(Whatsapp::HealthService).to receive(:new).and_return(health_service)
-        allow(health_service).to receive(:fetch_health_status).and_return({
-                                                                            platform_type: 'CLOUD_API',
-                                                                            throughput: { 'level' => 'NOT_APPLICABLE' },
-                                                                            messaging_limit_tier: 'TIER_1000'
-                                                                          })
-
-        expect(channel).to receive(:prompt_reauthorization!)
-        service.perform
-      end
-    end
-
-    context 'when channel is healthy' do
-      it 'does not prompt reauthorization for healthy channel' do
-        expect(channel).not_to receive(:prompt_reauthorization!)
-        service.perform
-      end
     end
 
     context 'when parameters are invalid' do
@@ -120,30 +74,6 @@ describe Whatsapp::EmbeddedSignupService do
         expect(Rails.logger).to receive(:error).with('[WHATSAPP] Embedded signup failed: Token error')
         expect { service.perform }.to raise_error('Token error')
       end
-
-      it 'prompts reauthorization when webhook setup fails' do
-        # Create a real channel to test the actual webhook failure behavior
-        real_channel = create(:channel_whatsapp, account: account, phone_number: '+1234567890',
-                                                 validate_provider_config: false, sync_templates: false)
-
-        # Mock the channel creation to return our real channel
-        channel_creation = instance_double(Whatsapp::ChannelCreationService)
-        allow(Whatsapp::ChannelCreationService).to receive(:new).and_return(channel_creation)
-        allow(channel_creation).to receive(:perform).and_return(real_channel)
-
-        # Mock webhook setup to fail
-        allow(real_channel).to receive(:perform_webhook_setup).and_raise('Webhook setup error')
-
-        # Verify channel is not marked for reauthorization initially
-        expect(real_channel.reauthorization_required?).to be false
-
-        # The service completes successfully even if webhook fails (webhook error is rescued in setup_webhooks)
-        result = service.perform
-        expect(result).to eq(real_channel)
-
-        # Verify the channel is now marked for reauthorization
-        expect(real_channel.reauthorization_required?).to be true
-      end
     end
 
     context 'with reauthorization flow' do
@@ -161,77 +91,14 @@ describe Whatsapp::EmbeddedSignupService do
           business_id: params[:business_id]
         ).and_return(reauth_service)
         allow(reauth_service).to receive(:perform).with(access_token, phone_info).and_return(channel)
-
-        allow(channel).to receive(:phone_number).and_return('+1234567890')
-
-        health_service = instance_double(Whatsapp::HealthService)
-        allow(Whatsapp::HealthService).to receive(:new).and_return(health_service)
-        allow(health_service).to receive(:fetch_health_status).and_return({
-                                                                            platform_type: 'CLOUD_API',
-                                                                            throughput: { 'level' => 'STANDARD' },
-                                                                            messaging_limit_tier: 'TIER_1000'
-                                                                          })
       end
 
-      it 'uses ReauthorizationService and sets up webhooks' do
+      it 'uses ReauthorizationService and enqueues webhook setup without a health check' do
         expect(reauth_service).to receive(:perform)
-        expect(channel).to receive(:setup_webhooks)
+        expect(Whatsapp::SetupWebhooksJob).to receive(:perform_later).with(channel, run_health_check: false)
 
         result = service_with_inbox.perform
         expect(result).to eq(channel)
-      end
-
-      context 'with real channel requiring reauthorization' do
-        let(:inbox) { create(:inbox, account: account) }
-        let(:whatsapp_channel) do
-          create(:channel_whatsapp, account: account, phone_number: '+1234567890',
-                                    validate_provider_config: false, sync_templates: false)
-        end
-        let(:service_with_real_inbox) { described_class.new(account: account, params: params, inbox_id: inbox.id) }
-
-        before do
-          inbox.update!(channel: whatsapp_channel)
-          whatsapp_channel.prompt_reauthorization!
-
-          setup_reauthorization_mocks
-          setup_health_service_mock
-        end
-
-        it 'clears reauthorization flag when reauthorization completes' do
-          expect(whatsapp_channel.reauthorization_required?).to be true
-          result = service_with_real_inbox.perform
-          expect(result).to eq(whatsapp_channel)
-          expect(whatsapp_channel.reauthorization_required?).to be false
-        end
-
-        private
-
-        def setup_reauthorization_mocks
-          reauth_service = instance_double(Whatsapp::ReauthorizationService)
-          allow(Whatsapp::ReauthorizationService).to receive(:new).with(
-            account: account,
-            inbox_id: inbox.id,
-            phone_number_id: params[:phone_number_id],
-            business_id: params[:business_id]
-          ).and_return(reauth_service)
-
-          allow(reauth_service).to receive(:perform) do
-            whatsapp_channel.reauthorized!
-            whatsapp_channel
-          end
-
-          allow(whatsapp_channel).to receive(:setup_webhooks).and_return(true)
-        end
-
-        def setup_health_service_mock
-          health_service = instance_double(Whatsapp::HealthService)
-          allow(Whatsapp::HealthService).to receive(:new).and_return(health_service)
-          allow(health_service).to receive(:fetch_health_status).and_return({
-                                                                              platform_type: 'CLOUD_API',
-                                                                              throughput: { 'level' => 'STANDARD' },
-                                                                              messaging_limit_tier: 'TIER_1000'
-                                                                            })
-        end
       end
     end
   end


### PR DESCRIPTION
## Pull Request Description

WhatsApp Embedded Signup runs `channel.setup_webhooks` (and a health check) inline in the `POST /api/v1/accounts/:id/whatsapp/authorization` request. Both hit the Meta Graph API (`subscribe_app_to_waba`, phone registration, health status) and can be slow enough to exceed the request timeout. When that happens the request returns a 500 to the dashboard **even though the channel/inbox was already persisted earlier in the request** — so the inbox exists and works, but the user sees an error.

This moves the post-persistence work into a background job (`Whatsapp::SetupWebhooksJob`) so the controller returns as soon as the channel is created. The webhook subscription and health check then run asynchronously (and benefit from Sidekiq retries if Meta is slow/unavailable).

### Observed in production logs
```
[WHATSAPP] Phone registration failed but continuing: ... (rescued)
source=rack-timeout ... timeout=15000ms state=timed_out
Completed 500 Internal Server Error in 14996ms
Rack::Timeout::RequestTimeoutException
  facebook_api_client.rb subscribe_app_to_waba
  webhook_setup_service.rb setup_webhook
  channel/whatsapp.rb setup_webhooks
  embedded_signup_service.rb#perform
  authorizations_controller.rb#create
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Updated `spec/services/whatsapp/embedded_signup_service_spec.rb` to assert the job is enqueued (with the health check skipped during reauthorization).
- Added `spec/jobs/whatsapp/setup_webhooks_job_spec.rb` covering webhook setup, the health check, the pending-state reauthorization prompt, and rescue behavior.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
