### PR TITLE
fix(i18n): localize email-collect template messages to account locale

### DIFF
--- a/app/services/message_templates/template/email_collect.rb
+++ b/app/services/message_templates/template/email_collect.rb
@@ -17,8 +17,9 @@ class MessageTemplates::Template::EmailCollect
   delegate :inbox, to: :message
 
   def ways_to_reach_you_message_params
-    content = I18n.t('conversations.templates.ways_to_reach_you_message_body',
-                     account_name: account.name)
+    content = I18n.with_locale(account.locale) do
+      I18n.t('conversations.templates.ways_to_reach_you_message_body', account_name: account.name)
+    end
 
     {
       account_id: @conversation.account_id,
@@ -29,8 +30,9 @@ class MessageTemplates::Template::EmailCollect
   end
 
   def email_input_box_template_message_params
-    content = I18n.t('conversations.templates.email_input_box_message_body',
-                     account_name: account.name)
+    content = I18n.with_locale(account.locale) do
+      I18n.t('conversations.templates.email_input_box_message_body', account_name: account.name)
+    end
 
     {
       account_id: @conversation.account_id,


### PR DESCRIPTION
## Pull Request Description

The email-collect template (`MessageTemplates::Template::EmailCollect`) builds its message content with `I18n.t`, but it runs from the message-templates hook (an event/job context) where `I18n.locale` is the application default (`en`) rather than the account's locale. As a result, accounts configured for a non-English locale receive the "Give the team a way to reach you." / "Get notified by email" prompts in English, even though translations exist for those keys.

This wraps both lookups in `I18n.with_locale(account.locale)` so the stored content matches the account locale — consistent with how locale-aware content is rendered elsewhere.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- `spec/services/message_templates/template/email_collect_spec.rb` passes (message creation unchanged).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
