### PR TITLE
fix: create email inbox when Microsoft id_token has no email claim

### DIFF
--- a/app/controllers/microsoft/callbacks_controller.rb
+++ b/app/controllers/microsoft/callbacks_controller.rb
@@ -21,4 +21,11 @@ class Microsoft::CallbacksController < OauthCallbackController
   def imap_login_identity
     users_data['preferred_username'] || users_data['upn'] || super
   end
+
+  # Prefer the actual `email` claim. Microsoft work/school accounts without a mailbox
+  # omit it, returning only `preferred_username`/`upn`; fall back to those so inbox
+  # creation does not fail on a null email.
+  def email_address
+    super || users_data['preferred_username'] || users_data['upn']
+  end
 end

--- a/app/controllers/oauth_callback_controller.rb
+++ b/app/controllers/oauth_callback_controller.rb
@@ -41,7 +41,7 @@ class OauthCallbackController < ApplicationController
   end
 
   def find_channel_by_email
-    Channel::Email.find_by(email: users_data['email'], account: account)
+    Channel::Email.find_by(email: email_address, account: account)
   end
 
   def update_channel(channel_email)
@@ -64,6 +64,13 @@ class OauthCallbackController < ApplicationController
     users_data['email']
   end
 
+  # Email address stored on the Channel::Email record and used to match an existing
+  # channel. Defaults to the id_token's `email` claim; providers override when that
+  # claim can be absent and a different one carries the address.
+  def email_address
+    users_data['email']
+  end
+
   def provider_name
     raise NotImplementedError
   end
@@ -74,7 +81,7 @@ class OauthCallbackController < ApplicationController
 
   def create_channel_with_inbox
     ActiveRecord::Base.transaction do
-      channel_email = Channel::Email.create!(email: users_data['email'], account: account)
+      channel_email = Channel::Email.create!(email: email_address, account: account)
 
       account.inboxes.create!(
         account: account,
@@ -119,7 +126,7 @@ class OauthCallbackController < ApplicationController
 
   # Fallback name, for when name field is missing from users_data
   def fallback_name
-    users_data['email'].split('@').first.parameterize.titleize
+    email_address.to_s.split('@').first.parameterize.titleize
   end
 
   def oauth_code

--- a/spec/controllers/microsoft/callbacks_controller_spec.rb
+++ b/spec/controllers/microsoft/callbacks_controller_spec.rb
@@ -53,6 +53,26 @@ RSpec.describe 'Microsoft::CallbacksController', type: :request do
       expect(channel.email).to eq mailbox
     end
 
+    it 'falls back to preferred_username for the channel email when the id_token has no email claim' do
+      upn = 'testaccount@primary-domain.example'
+      response_body = {
+        id_token: JWT.encode({ preferred_username: upn, name: 'test' }, nil, 'none'),
+        access_token: SecureRandom.hex(10), token_type: 'Bearer', refresh_token: SecureRandom.hex(10)
+      }
+      stub_request(:post, 'https://login.microsoftonline.com/common/oauth2/v2.0/token')
+        .with(body: { 'code' => code, 'grant_type' => 'authorization_code',
+                      'redirect_uri' => "#{ENV.fetch('FRONTEND_URL', 'http://localhost:3000')}/microsoft/callback" })
+        .to_return(status: 200, body: response_body.to_json, headers: { 'Content-Type' => 'application/json' })
+
+      get microsoft_callback_url, params: { code: code, state: state }
+
+      expect(response).to redirect_to app_email_inbox_agents_url(account_id: account.id, inbox_id: account.inboxes.last.id)
+      expect(account.inboxes.count).to be 1
+      channel = account.inboxes.last.channel
+      expect(channel.email).to eq upn
+      expect(channel.imap_login).to eq upn
+    end
+
     it 'creates updates inbox channel config if inbox exists and authentication is successful' do
       inbox = create(:channel_email, account: account, email: email)&.inbox
       expect(inbox.channel.provider_config).to eq({})


### PR DESCRIPTION
## Description

Adding a Microsoft email inbox via OAuth can fail at the final step when the returned `id_token` does not include an `email` claim. Some Microsoft work/school accounts (for example accounts without a mailbox, where the directory `mail` attribute is not populated) return `preferred_username`/`upn` but no `email`. The callback then runs `Channel::Email.create!(email: nil)`, which violates the `NOT NULL` constraint on `channel_email.email` and raises `PG::NotNullViolation`. The error is rescued and the user is redirected to `/`, so inbox creation fails silently and the screen drops back to the dashboard.

This adds an `email_address` resolver on `OauthCallbackController` (defaulting to the `email` claim) and overrides it for Microsoft to fall back to `preferred_username`/`upn` when the `email` claim is absent. The `email` claim is still preferred when present, so existing behaviour is unchanged. The fallback mirrors how `imap_login_identity` already resolves the SMTP login identity.

Ref: https://linear.app/chatwoot/issue/INF-76

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Added a request spec asserting that when the Microsoft `id_token` contains only `preferred_username` and no `email` claim, the inbox is created and the channel `email` is set to the `preferred_username`. The existing spec asserting the `email` claim is preferred when both are present continues to pass.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
