### PR TITLE
feat: update status on agent bot assignment

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -113,6 +113,11 @@ export const mutations = {
     if (chat) {
       chat.meta.assignee = assignee;
       chat.meta.assignee_type = assigneeType;
+      if (assigneeType === 'AgentBot') {
+        chat.status = 'pending';
+      } else if (assignee) {
+        chat.status = 'open';
+      }
     }
   },
 

--- a/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
@@ -699,11 +699,11 @@ describe('#mutations', () => {
   });
 
   describe('#ASSIGN_AGENT', () => {
-    it('should assign agent to the correct conversation by ID', () => {
+    it('should assign agent bot to the correct conversation by ID', () => {
       const assignee = { id: 1, name: 'Agent' };
       const state = {
         allConversations: [
-          { id: 1, meta: {} },
+          { id: 1, meta: {}, status: 'open' },
           { id: 2, meta: {} },
         ],
         selectedChatId: 2,
@@ -716,7 +716,23 @@ describe('#mutations', () => {
       });
       expect(state.allConversations[0].meta.assignee).toEqual(assignee);
       expect(state.allConversations[0].meta.assignee_type).toEqual('AgentBot');
+      expect(state.allConversations[0].status).toEqual('pending');
       expect(state.allConversations[1].meta.assignee).toBeUndefined();
+    });
+
+    it('should open the conversation when assigning a user', () => {
+      const assignee = { id: 1, name: 'Agent' };
+      const state = {
+        allConversations: [{ id: 1, meta: {}, status: 'pending' }],
+      };
+
+      mutations[types.ASSIGN_AGENT](state, {
+        conversationId: 1,
+        assignee,
+        assigneeType: 'User',
+      });
+
+      expect(state.allConversations[0].status).toEqual('open');
     });
   });
 

--- a/app/services/conversations/assignment_service.rb
+++ b/app/services/conversations/assignment_service.rb
@@ -16,6 +16,7 @@ class Conversations::AssignmentService
   def assign_agent
     conversation.assignee = assignee
     conversation.assignee_agent_bot = nil
+    conversation.status = :open if assignee
     conversation.save!
     assignee
   end
@@ -25,6 +26,7 @@ class Conversations::AssignmentService
 
     conversation.assignee = nil
     conversation.assignee_agent_bot = agent_bot
+    conversation.status = :pending
     conversation.save!
     agent_bot
   end

--- a/spec/controllers/api/v1/accounts/conversations/assignments_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/assignments_controller_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'Conversation Assignment API', type: :request do
       end
 
       it 'assigns a user to the conversation' do
+        conversation.update!(status: :pending)
         params = { assignee_id: agent.id }
 
         post api_v1_account_conversation_assignments_url(account_id: account.id, conversation_id: conversation.display_id),
@@ -52,10 +53,13 @@ RSpec.describe 'Conversation Assignment API', type: :request do
              as: :json
 
         expect(response).to have_http_status(:success)
-        expect(conversation.reload.assignee).to eq(agent)
+        conversation.reload
+        expect(conversation.assignee).to eq(agent)
+        expect(conversation.status).to eq('open')
       end
 
       it 'assigns an agent bot to the conversation' do
+        conversation.update!(status: :open)
         params = { assignee_id: agent_bot.id, assignee_type: 'AgentBot' }
 
         expect(Conversations::AssignmentService).to receive(:new)
@@ -72,6 +76,7 @@ RSpec.describe 'Conversation Assignment API', type: :request do
         conversation.reload
         expect(conversation.assignee_agent_bot).to eq(agent_bot)
         expect(conversation.assignee).to be_nil
+        expect(conversation.status).to eq('pending')
       end
 
       it 'assigns a team to the conversation' do

--- a/spec/services/conversations/assignment_service_spec.rb
+++ b/spec/services/conversations/assignment_service_spec.rb
@@ -23,16 +23,17 @@ describe Conversations::AssignmentService do
 
     context 'when assigning a user' do
       before do
-        conversation.update!(assignee_agent_bot: agent_bot, assignee: nil)
+        conversation.update!(assignee_agent_bot: agent_bot, assignee: nil, status: :pending)
       end
 
-      it 'sets the agent and clears agent bot' do
+      it 'sets the agent, clears agent bot and opens the conversation' do
         result = described_class.new(conversation: conversation, assignee_id: agent.id).perform
 
         conversation.reload
         expect(result).to eq(agent)
         expect(conversation.assignee_id).to eq(agent.id)
         expect(conversation.assignee_agent_bot_id).to be_nil
+        expect(conversation.status).to eq('open')
       end
     end
 
@@ -45,8 +46,8 @@ describe Conversations::AssignmentService do
         )
       end
 
-      it 'sets the agent bot and clears human assignee' do
-        conversation.update!(assignee: agent, assignee_agent_bot: nil)
+      it 'sets the agent bot, clears human assignee and marks the conversation pending' do
+        conversation.update!(assignee: agent, assignee_agent_bot: nil, status: :open)
 
         result = service.perform
 
@@ -54,6 +55,7 @@ describe Conversations::AssignmentService do
         expect(result).to eq(agent_bot)
         expect(conversation.assignee_agent_bot_id).to eq(agent_bot.id)
         expect(conversation.assignee_id).to be_nil
+        expect(conversation.status).to eq('pending')
       end
     end
   end


### PR DESCRIPTION
Assigning a conversation to an Agent Bot now moves it to pending, and assigning it back to a human opens it again. This makes Agent Bot ownership behave like an AI handoff while keeping reply-locking and Captain support for follow-up PRs.

Closes: https://linear.app/chatwoot/issue/CW-7448/apply-agent-bot-assignment-behavior

## Why
Agent Bot assignment should remove conversations from the main open queue while the bot is handling them. Human takeover should bring the conversation back to the open queue and clear the bot owner.

## What changed
- Agent Bot assignment clears the human assignee and marks the conversation pending.
- Human assignment clears the Agent Bot owner and marks the conversation open.
- The conversation store mirrors the status change immediately after assignment.

## Validation
- Assign an open conversation to an Agent Bot and verify it becomes pending.
- Assign that conversation back to a human and verify it becomes open.
- Verify unassigning still clears ownership without forcing the conversation open.