### PR TITLE
fix(security): Update crass to 1.0.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     cronex (0.15.0)
       tzinfo
       unicode (>= 0.4.4.5)


### PR DESCRIPTION
## Description

Updates the transitive `crass` dependency from `1.0.6` to `1.0.7` so the bundle-audit security check no longer flags the Crass denial-of-service advisories published on June 25, 2026. `crass` is pulled in through `rails-html-sanitizer -> loofah`, and this change only updates the resolved lockfile version.

Fixes # N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `bundle exec bundle audit update && bundle exec bundle audit check -v`
- `bundle exec rspec spec/mailboxes/mailbox_helper_spec.rb spec/mailboxes/reply_mailbox_spec.rb spec/mailboxes/imap/imap_mailbox_spec.rb spec/models/channel/telegram_spec.rb spec/lib/integrations/slack/send_on_slack_service_spec.rb spec/lib/integrations/slack/update_slack_message_service_spec.rb spec/presenters/html_parser_spec.rb`
- `bundle exec rubocop Gemfile`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
