### PR TITLE
fix: respect companies feature flag for auto-association

### DIFF
--- a/enterprise/app/models/enterprise/concerns/contact.rb
+++ b/enterprise/app/models/enterprise/concerns/contact.rb
@@ -14,16 +14,18 @@ module Enterprise::Concerns::Contact
 
   def should_associate_company?
     # Only trigger if:
-    # 1. The account has the Companies feature enabled
-    # 2. Contact has an email
-    # 3. Contact doesn't have a company yet
-    # 4. Email was just set/changed
-    # 5. Email was previously nil (first time getting email)
-    account.feature_enabled?('companies') &&
-      email.present? &&
+    # 1. Contact has an email
+    # 2. Contact doesn't have a company yet
+    # 3. Email was just set/changed
+    # 4. Email was previously nil (first time getting email)
+    # 5. The account has the Companies feature enabled
+    # Feature check is last so unrelated contact updates short-circuit on the
+    # cheap in-memory guards before touching the account (hot message-ingest path).
+    email.present? &&
       company_id.nil? &&
       saved_change_to_email? &&
-      saved_change_to_email.first.nil?
+      saved_change_to_email.first.nil? &&
+      account.feature_enabled?('companies')
   end
 
   def associate_company_from_email

--- a/enterprise/app/models/enterprise/concerns/contact.rb
+++ b/enterprise/app/models/enterprise/concerns/contact.rb
@@ -14,11 +14,13 @@ module Enterprise::Concerns::Contact
 
   def should_associate_company?
     # Only trigger if:
-    # 1. Contact has an email
-    # 2. Contact doesn't have a compan yet
-    # 3. Email was just set/changed
-    # 4. Email was previously nil (first time getting email)
-    email.present? &&
+    # 1. The account has the Companies feature enabled
+    # 2. Contact has an email
+    # 3. Contact doesn't have a company yet
+    # 4. Email was just set/changed
+    # 5. Email was previously nil (first time getting email)
+    account.feature_enabled?('companies') &&
+      email.present? &&
       company_id.nil? &&
       saved_change_to_email? &&
       saved_change_to_email.first.nil?

--- a/spec/enterprise/models/contact_company_association_spec.rb
+++ b/spec/enterprise/models/contact_company_association_spec.rb
@@ -4,6 +4,26 @@ RSpec.describe Contact, type: :model do
   describe 'company auto-association' do
     let(:account) { create(:account) }
 
+    before { account.enable_features!(:companies) }
+
+    context 'when the companies feature is disabled' do
+      before { account.disable_features!(:companies) }
+
+      it 'does not create or associate a company' do
+        expect do
+          create(:contact, email: 'john@acme.com', account: account)
+        end.not_to change(Company, :count)
+        expect(described_class.last.company).to be_nil
+      end
+
+      it 'preserves a contact-supplied company_name' do
+        contact = create(:contact, email: 'john@acme.com', account: account,
+                                   additional_attributes: { 'company_name' => 'John Personal Co' })
+
+        expect(contact.reload.additional_attributes['company_name']).to eq('John Personal Co')
+      end
+    end
+
     context 'when creating a new contact with business email' do
       it 'automatically creates and associates a company' do
         expect do


### PR DESCRIPTION
# Pull Request Template

## Description

This PR stops new contacts from getting an auto-assigned company name when the Companies feature is disabled.

Since #14496, email-domain company auto-association also updates a contact's `company_name`. However, the callback isn't gated behind the Companies feature flag, so accounts without the feature enabled still auto-create companies and overwrite any `company_name` provided via the SDK/`setUser`.

This PR gates `should_associate_company?` behind `account.feature_enabled?('companies')`, so auto-association only runs when the Companies feature is enabled.

Fixes https://linear.app/chatwoot/issue/CW-7462/setuser-overwrites-contact-company-name-for-accounts-that-dont-use

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
