### PR TITLE
fix: Show a clear error when message translation fails

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -52,9 +52,9 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
     end
 
     render json: { content: translated_content }
-  rescue StandardError => e
-    # Google::Cloud errors expose a clean human message via `details`; `message` includes gRPC debug noise
-    render_could_not_create_error(e.try(:details).presence || e.message)
+  rescue Google::Cloud::Error => e
+    # `details` carries the clean human message; `message` includes gRPC debug noise
+    render_could_not_create_error(e.details.presence || e.message)
   end
 
   private

--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -52,6 +52,9 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
     end
 
     render json: { content: translated_content }
+  rescue StandardError => e
+    # Google::Cloud errors expose a clean human message via `details`; `message` includes gRPC debug noise
+    render_could_not_create_error(e.try(:details).presence || e.message)
   end
 
   private

--- a/app/javascript/dashboard/modules/conversations/components/MessageContextMenu.vue
+++ b/app/javascript/dashboard/modules/conversations/components/MessageContextMenu.vue
@@ -6,6 +6,7 @@ import ContextMenu from 'dashboard/components/ui/ContextMenu.vue';
 import AddCannedModal from 'dashboard/routes/dashboard/settings/canned/AddCanned.vue';
 import { useSnakeCase } from 'dashboard/composables/useTransformKeys';
 import { copyTextToClipboard } from 'shared/helpers/clipboard';
+import { parseAPIErrorResponse } from 'dashboard/store/utils/api';
 import { conversationUrl, frontendURL } from '../../../helper/URLHelper';
 import {
   ACCOUNT_EVENTS,
@@ -119,16 +120,20 @@ export default {
     handleClose(e) {
       this.$emit('close', e);
     },
-    handleTranslate() {
+    async handleTranslate() {
       const { locale: accountLocale } = this.getAccount(this.currentAccountId);
       const agentLocale = this.getUISettings?.locale;
       const targetLanguage = agentLocale || accountLocale || 'en';
-      this.$store.dispatch('translateMessage', {
-        conversationId: this.conversationId,
-        messageId: this.messageId,
-        targetLanguage,
-      });
-      useTrack(CONVERSATION_EVENTS.TRANSLATE_A_MESSAGE);
+      try {
+        await this.$store.dispatch('translateMessage', {
+          conversationId: this.conversationId,
+          messageId: this.messageId,
+          targetLanguage,
+        });
+        useTrack(CONVERSATION_EVENTS.TRANSLATE_A_MESSAGE);
+      } catch (error) {
+        useAlert(parseAPIErrorResponse(error));
+      }
       this.handleClose();
     },
     handleReplyTo() {

--- a/app/javascript/dashboard/store/modules/conversations/actions/messageTranslateActions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions/messageTranslateActions.js
@@ -2,14 +2,10 @@ import MessageApi from '../../../../api/inbox/message';
 
 export default {
   async translateMessage(_, { conversationId, messageId, targetLanguage }) {
-    try {
-      await MessageApi.translateMessage(
-        conversationId,
-        messageId,
-        targetLanguage
-      );
-    } catch (error) {
-      // ignore error
-    }
+    await MessageApi.translateMessage(
+      conversationId,
+      messageId,
+      targetLanguage
+    );
   },
 };


### PR DESCRIPTION
# Pull Request Template

## Description


Translating a message previously failed with a generic `500 Internal Server Error`, leaving agents with no indication of what went wrong. This change surfaces the actual translation error (for example, "Cloud Translation API is disabled" or "Text is too long") so the issue can be understood and resolved.

**What changed**

* Backend now rescues translation errors and returns the actual error message instead of a generic `500`, while stripping gRPC debug information.
* Frontend no longer swallows translation errors and displays the returned message as a toast.

Fixes https://linear.app/chatwoot/issue/CW-7487/message-translation-returns-opaque-500-instead-of-a-meaningful-error

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="1351" height="456" alt="image" src="https://github.com/user-attachments/assets/3252b1f5-30ba-4a85-b648-5411312eebc0" />


**After**
<img width="1052" height="481" alt="image" src="https://github.com/user-attachments/assets/60541451-cbe8-419d-a372-fb7933626971" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
