### PR TITLE
feat: hide delete option on channels without delete support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -570,7 +570,7 @@ GEM
     minitest (5.25.5)
     mock_redis (0.36.0)
       ruby2_keywords
-    msgpack (1.8.0)
+    msgpack (1.8.2)
     multi_json (1.15.0)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -374,6 +374,16 @@ const payloadForContextMenu = computed(() => {
   };
 });
 
+// Only Chatwoot-native channels support real message deletion at this moment.
+const CHANNELS_WITH_DELETE_SUPPORT = ['Channel::WebWidget', 'Channel::Api'];
+
+const canDeleteOnChannel = computed(() => {
+  if (props.private) return true;
+  const channelType = inbox.value?.channel_type;
+  if (!channelType) return true;
+  return CHANNELS_WITH_DELETE_SUPPORT.includes(channelType);
+});
+
 const contextMenuEnabledOptions = computed(() => {
   const hasText = !!props.content;
   const hasAttachments = !!(props.attachments && props.attachments.length > 0);
@@ -591,6 +601,7 @@ provideMessageContext({
         :is-open="showContextMenu"
         :enabled-options="contextMenuEnabledOptions"
         :message="payloadForContextMenu"
+        :can-delete-on-channel="canDeleteOnChannel"
         hide-button
         @open="openContextMenu"
         @close="closeContextMenu"

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -380,7 +380,6 @@ const CHANNELS_WITH_DELETE_SUPPORT = ['Channel::WebWidget', 'Channel::Api'];
 const canDeleteOnChannel = computed(() => {
   if (props.private) return true;
   const channelType = inbox.value?.channel_type;
-  if (!channelType) return true;
   return CHANNELS_WITH_DELETE_SUPPORT.includes(channelType);
 });
 

--- a/app/javascript/dashboard/modules/conversations/components/MessageContextMenu.vue
+++ b/app/javascript/dashboard/modules/conversations/components/MessageContextMenu.vue
@@ -45,6 +45,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    canDeleteOnChannel: {
+      type: Boolean,
+      default: true,
+    },
   },
   emits: ['open', 'close', 'replyTo'],
   setup() {
@@ -259,9 +263,9 @@ export default {
           variant="icon"
           @click.stop="openReportDialog"
         />
-        <hr v-if="enabledOptions['delete']" />
+        <hr v-if="enabledOptions['delete'] && canDeleteOnChannel" />
         <MenuItem
-          v-if="enabledOptions['delete']"
+          v-if="enabledOptions['delete'] && canDeleteOnChannel"
           :option="{
             icon: 'delete',
             label: $t('CONVERSATION.CONTEXT_MENU.DELETE'),


### PR DESCRIPTION
Currently, the "Delete message" button in Chatwoot performs a soft-delete — it only removes the message from the Chatwoot interface but does not delete it on the external platform (e.g., WhatsApp, Telegram, Facebook). This causes confusion for agents who lose visibility of the conversation, while the customer retains the full chat history on their end.

This change hides the delete option in the message context menu on channels that don't support real deletion via their external API. Only Chatwoot-native channels (Web Widget and API) show the delete option, since the soft-delete effectively removes the message for the end user. Private notes can always be deleted regardless of channel.

Supersedes #13685 (closed without merge; branch was deleted).

Closes #13684

## How to test

- Open a Web Widget conversation → right-click a message → Delete option is available in the context menu
- Open a WhatsApp/Telegram/Email conversation → right-click a message → Delete option is not shown
- Open any conversation → right-click a private note → Delete option is available