### PR TITLE
fix: assign outbound voice call conversation to the calling agent

### DIFF
--- a/enterprise/app/controllers/api/v1/accounts/whatsapp_calls_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/whatsapp_calls_controller.rb
@@ -108,6 +108,8 @@ class Api::V1::Accounts::WhatsappCallsController < Api::V1::Accounts::BaseContro
     result = provider_service.initiate_call(contact_phone, params[:sdp_offer])
     provider_call_id = result.dig('calls', 0, 'id') || result['call_id']
 
+    @conversation.update!(assignee: Current.user) if @conversation.assignee_id.nil?
+
     Current.account.calls.create!(
       provider: :whatsapp, inbox: @conversation.inbox, conversation: @conversation, contact: @conversation.contact,
       provider_call_id: provider_call_id, direction: :outgoing, status: 'ringing',

--- a/enterprise/app/controllers/api/v1/accounts/whatsapp_calls_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/whatsapp_calls_controller.rb
@@ -105,14 +105,13 @@ class Api::V1::Accounts::WhatsappCallsController < Api::V1::Accounts::BaseContro
 
   def create_outbound_call
     contact_phone = @conversation.contact.phone_number.delete('+')
+    # Claim for the caller only if unassigned at trigger time (before the round-trip); wins over auto-assignment.
+    claim_for_caller = @conversation.assignee_id.nil?
+
     result = provider_service.initiate_call(contact_phone, params[:sdp_offer])
     provider_call_id = result.dig('calls', 0, 'id') || result['call_id']
 
-    # Re-read under a row lock: @conversation was loaded before the Meta round-trip above,
-    # so a concurrent assignment during it must not be clobbered by this claim.
-    @conversation.with_lock do
-      @conversation.update!(assignee: Current.user) if @conversation.assignee_id.nil?
-    end
+    @conversation.with_lock { @conversation.update!(assignee: Current.user) } if claim_for_caller
 
     Current.account.calls.create!(
       provider: :whatsapp, inbox: @conversation.inbox, conversation: @conversation, contact: @conversation.contact,

--- a/enterprise/app/controllers/api/v1/accounts/whatsapp_calls_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/whatsapp_calls_controller.rb
@@ -108,7 +108,11 @@ class Api::V1::Accounts::WhatsappCallsController < Api::V1::Accounts::BaseContro
     result = provider_service.initiate_call(contact_phone, params[:sdp_offer])
     provider_call_id = result.dig('calls', 0, 'id') || result['call_id']
 
-    @conversation.update!(assignee: Current.user) if @conversation.assignee_id.nil?
+    # Re-read under a row lock: @conversation was loaded before the Meta round-trip above,
+    # so a concurrent assignment during it must not be clobbered by this claim.
+    @conversation.with_lock do
+      @conversation.update!(assignee: Current.user) if @conversation.assignee_id.nil?
+    end
 
     Current.account.calls.create!(
       provider: :whatsapp, inbox: @conversation.inbox, conversation: @conversation, contact: @conversation.contact,

--- a/enterprise/app/services/voice/outbound_call_builder.rb
+++ b/enterprise/app/services/voice/outbound_call_builder.rb
@@ -20,12 +20,13 @@ class Voice::OutboundCallBuilder
     ActiveRecord::Base.transaction do
       contact_inbox = ensure_contact_inbox!
       conversation = @existing_conversation || create_conversation!(contact_inbox)
+      # Dial before locking so the Twilio round-trip doesn't hold the conversation row lock.
+      call_sid = initiate_call!
       # New conversations set assignee at creation (see create_conversation!) to win over the
       # auto-assignment after_save. A reused conversation is locked + re-read so a concurrent
       # assignment isn't clobbered; only claim it while still unassigned.
       @existing_conversation&.lock!
       conversation.update!(assignee: user) if conversation.assignee_id.nil?
-      call_sid = initiate_call!
       call = create_call!(conversation, call_sid)
       message = Voice::CallMessageBuilder.new(call).perform!
       call.update!(message_id: message.id)

--- a/enterprise/app/services/voice/outbound_call_builder.rb
+++ b/enterprise/app/services/voice/outbound_call_builder.rb
@@ -17,16 +17,19 @@ class Voice::OutboundCallBuilder
     raise ArgumentError, 'Contact phone number required' if contact.phone_number.blank?
     raise ArgumentError, 'Agent required' if user.blank?
 
+    # Claim for the caller if a reused conversation is unassigned at trigger time; wins over auto-assignment.
+    # New conversations set the assignee at creation instead (see create_conversation!).
+    claim_for_caller = @existing_conversation && @existing_conversation.assignee_id.nil?
+
     ActiveRecord::Base.transaction do
       contact_inbox = ensure_contact_inbox!
       conversation = @existing_conversation || create_conversation!(contact_inbox)
       # Dial before locking so the Twilio round-trip doesn't hold the conversation row lock.
       call_sid = initiate_call!
-      # New conversations set assignee at creation (see create_conversation!) to win over the
-      # auto-assignment after_save. A reused conversation is locked + re-read so a concurrent
-      # assignment isn't clobbered; only claim it while still unassigned.
-      @existing_conversation&.lock!
-      conversation.update!(assignee: user) if conversation.assignee_id.nil?
+      if claim_for_caller
+        @existing_conversation.lock!
+        @existing_conversation.update!(assignee: user)
+      end
       call = create_call!(conversation, call_sid)
       message = Voice::CallMessageBuilder.new(call).perform!
       call.update!(message_id: message.id)

--- a/enterprise/app/services/voice/outbound_call_builder.rb
+++ b/enterprise/app/services/voice/outbound_call_builder.rb
@@ -44,6 +44,7 @@ class Voice::OutboundCallBuilder
       contact_inbox_id: contact_inbox.id,
       inbox_id: inbox.id,
       contact_id: contact.id,
+      assignee_id: user.id,
       status: :open
     )
   end

--- a/enterprise/app/services/voice/outbound_call_builder.rb
+++ b/enterprise/app/services/voice/outbound_call_builder.rb
@@ -20,6 +20,8 @@ class Voice::OutboundCallBuilder
     ActiveRecord::Base.transaction do
       contact_inbox = ensure_contact_inbox!
       conversation = @existing_conversation || create_conversation!(contact_inbox)
+      # New conversations set assignee at creation (see create_conversation!) to win over the
+      # auto-assignment after_save; here we only claim a reused conversation that's still unassigned.
       conversation.update!(assignee: user) if conversation.assignee_id.nil?
       call_sid = initiate_call!
       call = create_call!(conversation, call_sid)
@@ -45,6 +47,7 @@ class Voice::OutboundCallBuilder
       contact_inbox_id: contact_inbox.id,
       inbox_id: inbox.id,
       contact_id: contact.id,
+      assignee_id: user.id,
       status: :open
     )
   end

--- a/enterprise/app/services/voice/outbound_call_builder.rb
+++ b/enterprise/app/services/voice/outbound_call_builder.rb
@@ -21,7 +21,9 @@ class Voice::OutboundCallBuilder
       contact_inbox = ensure_contact_inbox!
       conversation = @existing_conversation || create_conversation!(contact_inbox)
       # New conversations set assignee at creation (see create_conversation!) to win over the
-      # auto-assignment after_save; here we only claim a reused conversation that's still unassigned.
+      # auto-assignment after_save. A reused conversation is locked + re-read so a concurrent
+      # assignment isn't clobbered; only claim it while still unassigned.
+      @existing_conversation&.lock!
       conversation.update!(assignee: user) if conversation.assignee_id.nil?
       call_sid = initiate_call!
       call = create_call!(conversation, call_sid)

--- a/enterprise/app/services/voice/outbound_call_builder.rb
+++ b/enterprise/app/services/voice/outbound_call_builder.rb
@@ -20,6 +20,7 @@ class Voice::OutboundCallBuilder
     ActiveRecord::Base.transaction do
       contact_inbox = ensure_contact_inbox!
       conversation = @existing_conversation || create_conversation!(contact_inbox)
+      conversation.update!(assignee: user) if conversation.assignee_id.nil?
       call_sid = initiate_call!
       call = create_call!(conversation, call_sid)
       message = Voice::CallMessageBuilder.new(call).perform!
@@ -44,7 +45,6 @@ class Voice::OutboundCallBuilder
       contact_inbox_id: contact_inbox.id,
       inbox_id: inbox.id,
       contact_id: contact.id,
-      assignee_id: user.id,
       status: :open
     )
   end

--- a/spec/enterprise/controllers/api/v1/accounts/whatsapp_calls_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/whatsapp_calls_controller_spec.rb
@@ -104,6 +104,31 @@ RSpec.describe 'WhatsApp Calls API', type: :request do
       expect(Call.find_by(provider_call_id: 'wacid_outbound')).to have_attributes(direction: 'outgoing', status: 'ringing')
     end
 
+    it 'assigns the conversation to the agent placing the call when it is unassigned' do
+      allow(provider_service).to receive(:initiate_call).and_return({ 'calls' => [{ 'id' => 'wacid_outbound' }] })
+
+      post "/api/v1/accounts/#{account.id}/whatsapp_calls/initiate",
+           params: { conversation_id: initiate_conversation.display_id, sdp_offer: 'sdp_offer' },
+           headers: agent.create_new_auth_token
+
+      expect(response).to have_http_status(:ok)
+      expect(initiate_conversation.reload.assignee_id).to eq(agent.id)
+    end
+
+    it 'keeps the existing assignee when the conversation is already assigned' do
+      other_agent = create(:user, account: account, role: :agent)
+      create(:inbox_member, user: other_agent, inbox: inbox)
+      initiate_conversation.update!(assignee: other_agent)
+      allow(provider_service).to receive(:initiate_call).and_return({ 'calls' => [{ 'id' => 'wacid_outbound' }] })
+
+      post "/api/v1/accounts/#{account.id}/whatsapp_calls/initiate",
+           params: { conversation_id: initiate_conversation.display_id, sdp_offer: 'sdp_offer' },
+           headers: agent.create_new_auth_token
+
+      expect(response).to have_http_status(:ok)
+      expect(initiate_conversation.reload.assignee_id).to eq(other_agent.id)
+    end
+
     it 'sends a permission request and records the wamid when Meta returns NoCallPermission' do
       allow(provider_service).to receive(:initiate_call).and_raise(Voice::CallErrors::NoCallPermission)
       allow(provider_service).to receive(:send_call_permission_request).and_return({ 'messages' => [{ 'id' => 'wamid.req_xyz' }] })

--- a/spec/enterprise/services/voice/outbound_call_builder_spec.rb
+++ b/spec/enterprise/services/voice/outbound_call_builder_spec.rb
@@ -55,11 +55,15 @@ RSpec.describe Voice::OutboundCallBuilder do
       expect(call.conversation.assignee_id).to eq(user.id)
     end
 
-    it 'keeps the calling agent assigned even when inbox auto-assignment is enabled' do
+    it 'keeps the calling agent assigned even when auto-assignment would pick an online agent' do
       other_agent = create(:user, account: account)
       create(:inbox_member, inbox: inbox, user: other_agent)
       create(:inbox_member, inbox: inbox, user: user)
       inbox.update!(enable_auto_assignment: true)
+      # Only other_agent is online, so round-robin would claim the new conversation for them
+      # in the after_save callback unless the caller is assigned at creation time.
+      OnlineStatusTracker.update_presence(account.id, 'User', other_agent.id)
+      OnlineStatusTracker.set_status(account.id, other_agent.id, 'online')
 
       call = described_class.perform!(
         account: account,

--- a/spec/enterprise/services/voice/outbound_call_builder_spec.rb
+++ b/spec/enterprise/services/voice/outbound_call_builder_spec.rb
@@ -60,8 +60,7 @@ RSpec.describe Voice::OutboundCallBuilder do
       create(:inbox_member, inbox: inbox, user: other_agent)
       create(:inbox_member, inbox: inbox, user: user)
       inbox.update!(enable_auto_assignment: true)
-      # Only other_agent is online, so round-robin would claim the new conversation for them
-      # in the after_save callback unless the caller is assigned at creation time.
+      # Only other_agent is online, so round-robin would claim the conversation unless the caller wins at creation.
       OnlineStatusTracker.update_presence(account.id, 'User', other_agent.id)
       OnlineStatusTracker.set_status(account.id, other_agent.id, 'online')
 
@@ -73,6 +72,24 @@ RSpec.describe Voice::OutboundCallBuilder do
       )
 
       expect(call.conversation.assignee_id).to eq(user.id)
+    end
+
+    it 'claims a reused conversation for the caller when it is unassigned' do
+      # Reload so the builder gets a DB-fresh record, mirroring the controller's find_by load.
+      conversation = create(:conversation, account: account, inbox: inbox, contact: contact).reload
+
+      described_class.perform!(account: account, inbox: inbox, user: user, contact: contact, conversation: conversation)
+
+      expect(conversation.reload.assignee_id).to eq(user.id)
+    end
+
+    it 'keeps the existing assignee when a reused conversation is already assigned' do
+      other_agent = create(:user, account: account)
+      conversation = create(:conversation, account: account, inbox: inbox, contact: contact, assignee: other_agent).reload
+
+      described_class.perform!(account: account, inbox: inbox, user: user, contact: contact, conversation: conversation)
+
+      expect(conversation.reload.assignee_id).to eq(other_agent.id)
     end
 
     it 'does not set conversation.identifier or write call state to additional_attributes' do

--- a/spec/enterprise/services/voice/outbound_call_builder_spec.rb
+++ b/spec/enterprise/services/voice/outbound_call_builder_spec.rb
@@ -44,6 +44,33 @@ RSpec.describe Voice::OutboundCallBuilder do
       end
     end
 
+    it 'assigns the conversation to the agent placing the call' do
+      call = described_class.perform!(
+        account: account,
+        inbox: inbox,
+        user: user,
+        contact: contact
+      )
+
+      expect(call.conversation.assignee_id).to eq(user.id)
+    end
+
+    it 'keeps the calling agent assigned even when inbox auto-assignment is enabled' do
+      other_agent = create(:user, account: account)
+      create(:inbox_member, inbox: inbox, user: other_agent)
+      create(:inbox_member, inbox: inbox, user: user)
+      inbox.update!(enable_auto_assignment: true)
+
+      call = described_class.perform!(
+        account: account,
+        inbox: inbox,
+        user: user,
+        contact: contact
+      )
+
+      expect(call.conversation.assignee_id).to eq(user.id)
+    end
+
     it 'does not set conversation.identifier or write call state to additional_attributes' do
       call = described_class.perform!(
         account: account,


### PR DESCRIPTION
Outbound voice calls were being auto-assigned to the wrong agent. When an agent placed an outbound call, the conversation was created without an assignee, so inboxes with auto-assignment enabled would round-robin it to a different agent instead of keeping it with the person who actually made the call. This made it hard to tell which agent was on an active call.

## What changed

- Set the calling agent as the conversation's assignee when creating an outbound voice call conversation.
- This prevents the generic auto-assignment handler from treating the conversation as unassigned and reassigning it.
- Added specs covering the assignment, including a regression case with inbox auto-assignment enabled.

**Note:** this applies to newly placed calls; it does not retroactively fix conversations that were already mis-assigned.
