### PR TITLE
fix: preserve link URLs on channels without hyperlink support

### DIFF
--- a/app/javascript/dashboard/components/Modal.vue
+++ b/app/javascript/dashboard/components/Modal.vue
@@ -124,8 +124,6 @@ onMounted(() => {
         @apply p-4;
       }
 
-      // Links rendered inside the rich-text editor (e.g. canned response
-      // content) are real anchors and must not inherit the modal's link padding.
       .ProseMirror a {
         @apply p-0;
       }

--- a/app/javascript/dashboard/components/Modal.vue
+++ b/app/javascript/dashboard/components/Modal.vue
@@ -123,6 +123,12 @@ onMounted(() => {
       a {
         @apply p-4;
       }
+
+      // Links rendered inside the rich-text editor (e.g. canned response
+      // content) are real anchors and must not inherit the modal's link padding.
+      .ProseMirror a {
+        @apply p-0;
+      }
     }
   }
 }

--- a/app/javascript/dashboard/constants/editor.js
+++ b/app/javascript/dashboard/constants/editor.js
@@ -265,14 +265,15 @@ export const MARKDOWN_PATTERNS = [
     type: 'link', // PM: link
     patterns: [
       // [text](url) -> "text: url" (drop label if it equals the URL).
-      // Strips the hidden title and unwraps an <angle-bracketed> destination.
+      // URL capture is escape-aware so it spans the \( \) the serializer stores.
       {
-        pattern: /\[([^\]]+)\]\(([^)]+)\)/g,
+        pattern: /\[([^\]]+)\]\(((?:\\.|[^)\\])*)\)/g,
         replacement: (_match, text, url) => {
           const cleanUrl = url
             .trim()
             .replace(/\s+["'(].*$/, '') // drop the hidden CommonMark title
-            .replace(/^<|>$/g, ''); // unwrap an <angle-bracketed> destination
+            .replace(/^<|>$/g, '') // unwrap an <angle-bracketed> destination
+            .replace(/\\(.)/g, '$1'); // unescape \( \) \_ etc from the serializer
           return text === cleanUrl ? cleanUrl : `${text}: ${cleanUrl}`;
         },
       },

--- a/app/javascript/dashboard/constants/editor.js
+++ b/app/javascript/dashboard/constants/editor.js
@@ -264,10 +264,10 @@ export const MARKDOWN_PATTERNS = [
   {
     type: 'link', // PM: link
     patterns: [
-      // [text](url) -> "text: url" (keep the URL; drop label if it is the URL).
-      // Drop the hidden CommonMark title and unwrap an <angle-bracketed> destination.
+      // [text](url) -> "text: url" (drop label if it equals the URL).
+      // Strips the hidden title, unwraps <url>, and allows parens inside the URL.
       {
-        pattern: /\[([^\]]+)\]\(([^)]+)\)/g,
+        pattern: /\[([^\]]+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)/g,
         replacement: (_match, text, url) => {
           const cleanUrl = url
             .trim()

--- a/app/javascript/dashboard/constants/editor.js
+++ b/app/javascript/dashboard/constants/editor.js
@@ -264,11 +264,12 @@ export const MARKDOWN_PATTERNS = [
   {
     type: 'link', // PM: link
     patterns: [
-      // [text](url) -> "text: url" (keep the URL; drop label if it is the URL)
+      // [text](url) -> "text: url" (keep the URL; drop label if it is the URL).
+      // Unwrap an <angle-bracketed> destination while keeping any link title.
       {
         pattern: /\[([^\]]+)\]\(([^)]+)\)/g,
         replacement: (_match, text, url) => {
-          const cleanUrl = url.replace(/^<|>$/g, '').trim();
+          const cleanUrl = url.trim().replace(/^<([^>]*)>/, '$1');
           return text === cleanUrl ? cleanUrl : `${text}: ${cleanUrl}`;
         },
       },

--- a/app/javascript/dashboard/constants/editor.js
+++ b/app/javascript/dashboard/constants/editor.js
@@ -264,7 +264,14 @@ export const MARKDOWN_PATTERNS = [
   {
     type: 'link', // PM: link
     patterns: [
-      { pattern: /\[([^\]]+)\]\([^)]+\)/g, replacement: '$1' }, // [text](url) -> text
+      // [text](url) -> "text: url" (keep the URL; drop label if it is the URL)
+      {
+        pattern: /\[([^\]]+)\]\(([^)]+)\)/g,
+        replacement: (_match, text, url) => {
+          const cleanUrl = url.replace(/^<|>$/g, '').trim();
+          return text === cleanUrl ? cleanUrl : `${text}: ${cleanUrl}`;
+        },
+      },
       { pattern: /<([a-zA-Z][a-zA-Z0-9+.-]*:[^\s>]+)>/g, replacement: '$1' }, // <https://...>, <mailto:...>, <tel:...>, <ftp://...>, etc
       { pattern: /<([^\s@]+@[^\s@>]+)>/g, replacement: '$1' }, // <user@example.com> -> user@example.com
     ],

--- a/app/javascript/dashboard/constants/editor.js
+++ b/app/javascript/dashboard/constants/editor.js
@@ -265,11 +265,14 @@ export const MARKDOWN_PATTERNS = [
     type: 'link', // PM: link
     patterns: [
       // [text](url) -> "text: url" (keep the URL; drop label if it is the URL).
-      // Unwrap an <angle-bracketed> destination while keeping any link title.
+      // Drop the hidden CommonMark title and unwrap an <angle-bracketed> destination.
       {
         pattern: /\[([^\]]+)\]\(([^)]+)\)/g,
         replacement: (_match, text, url) => {
-          const cleanUrl = url.trim().replace(/^<([^>]*)>/, '$1');
+          const cleanUrl = url
+            .trim()
+            .replace(/\s+["'(].*$/, '') // drop hidden CommonMark title
+            .replace(/^<|>$/g, ''); // unwrap <angle-bracketed> destination
           return text === cleanUrl ? cleanUrl : `${text}: ${cleanUrl}`;
         },
       },

--- a/app/javascript/dashboard/constants/editor.js
+++ b/app/javascript/dashboard/constants/editor.js
@@ -265,14 +265,14 @@ export const MARKDOWN_PATTERNS = [
     type: 'link', // PM: link
     patterns: [
       // [text](url) -> "text: url" (drop label if it equals the URL).
-      // Strips the hidden title, unwraps <url>, and allows parens inside the URL.
+      // Strips the hidden title and unwraps an <angle-bracketed> destination.
       {
-        pattern: /\[([^\]]+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)/g,
+        pattern: /\[([^\]]+)\]\(([^)]+)\)/g,
         replacement: (_match, text, url) => {
           const cleanUrl = url
             .trim()
-            .replace(/\s+["'(].*$/, '') // drop hidden CommonMark title
-            .replace(/^<|>$/g, ''); // unwrap <angle-bracketed> destination
+            .replace(/\s+["'(].*$/, '') // drop the hidden CommonMark title
+            .replace(/^<|>$/g, ''); // unwrap an <angle-bracketed> destination
           return text === cleanUrl ? cleanUrl : `${text}: ${cleanUrl}`;
         },
       },

--- a/app/javascript/dashboard/constants/editor.js
+++ b/app/javascript/dashboard/constants/editor.js
@@ -188,19 +188,14 @@ export const ARTICLE_EDITOR_MENU_OPTIONS = [
   'insertTable',
 ];
 
-// [text](url) -> "text: url" for channels without links (drop label if it
-// equals the URL). Undoes the backslash escapes the serializer adds (\( \) \_),
-// strips the hidden CommonMark title and unwraps an <angle-bracketed> URL.
+// [text](url) -> "text: url" (drop label if it equals the URL). Keep serializer
+// escapes; the re-parse renders them literally, unescaping would crash it.
 const flattenLink = (_match, text, url) => {
-  const unescape = str => str.replace(/\\(.)/g, '$1');
-  const cleanText = unescape(text);
-  const cleanUrl = unescape(
-    url
-      .trim()
-      .replace(/\s+["'(].*$/, '')
-      .replace(/^<|>$/g, '')
-  );
-  return cleanText === cleanUrl ? cleanUrl : `${cleanText}: ${cleanUrl}`;
+  const cleanUrl = url
+    .trim()
+    .replace(/\s+["'(].*$/, '')
+    .replace(/^<|>$/g, '');
+  return text === cleanUrl ? cleanUrl : `${text}: ${cleanUrl}`;
 };
 
 /**
@@ -279,9 +274,10 @@ export const MARKDOWN_PATTERNS = [
   {
     type: 'link', // PM: link
     patterns: [
-      // URL capture is escape-aware so it spans the \( \) the serializer stores.
+      // Escape-aware label + URL captures so a \] or \) can't cut the match
+      // short and leave link markup that crashes the re-parse.
       {
-        pattern: /\[([^\]]+)\]\(((?:\\.|[^)\\])*)\)/g,
+        pattern: /\[((?:\\.|[^\]\\])*)\]\(((?:\\.|[^)\\])*)\)/g,
         replacement: flattenLink,
       },
       { pattern: /<([a-zA-Z][a-zA-Z0-9+.-]*:[^\s>]+)>/g, replacement: '$1' }, // <https://...>, <mailto:...>, <tel:...>, <ftp://...>, etc

--- a/app/javascript/dashboard/constants/editor.js
+++ b/app/javascript/dashboard/constants/editor.js
@@ -188,6 +188,21 @@ export const ARTICLE_EDITOR_MENU_OPTIONS = [
   'insertTable',
 ];
 
+// [text](url) -> "text: url" for channels without links (drop label if it
+// equals the URL). Undoes the backslash escapes the serializer adds (\( \) \_),
+// strips the hidden CommonMark title and unwraps an <angle-bracketed> URL.
+const flattenLink = (_match, text, url) => {
+  const unescape = str => str.replace(/\\(.)/g, '$1');
+  const cleanText = unescape(text);
+  const cleanUrl = unescape(
+    url
+      .trim()
+      .replace(/\s+["'(].*$/, '')
+      .replace(/^<|>$/g, '')
+  );
+  return cleanText === cleanUrl ? cleanUrl : `${cleanText}: ${cleanUrl}`;
+};
+
 /**
  * Markdown formatting patterns for stripping unsupported formatting.
  *
@@ -264,18 +279,10 @@ export const MARKDOWN_PATTERNS = [
   {
     type: 'link', // PM: link
     patterns: [
-      // [text](url) -> "text: url" (drop label if it equals the URL).
       // URL capture is escape-aware so it spans the \( \) the serializer stores.
       {
         pattern: /\[([^\]]+)\]\(((?:\\.|[^)\\])*)\)/g,
-        replacement: (_match, text, url) => {
-          const cleanUrl = url
-            .trim()
-            .replace(/\s+["'(].*$/, '') // drop the hidden CommonMark title
-            .replace(/^<|>$/g, '') // unwrap an <angle-bracketed> destination
-            .replace(/\\(.)/g, '$1'); // unescape \( \) \_ etc from the serializer
-          return text === cleanUrl ? cleanUrl : `${text}: ${cleanUrl}`;
-        },
+        replacement: flattenLink,
       },
       { pattern: /<([a-zA-Z][a-zA-Z0-9+.-]*:[^\s>]+)>/g, replacement: '$1' }, // <https://...>, <mailto:...>, <tel:...>, <ftp://...>, etc
       { pattern: /<([^\s@]+@[^\s@>]+)>/g, replacement: '$1' }, // <user@example.com> -> user@example.com

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -987,13 +987,20 @@ describe('stripUnsupportedFormatting', () => {
       ).toBe('Check this link: https://example.com');
     });
 
-    it('keeps the link title while preserving the URL', () => {
+    it('drops the hidden link title when preserving the URL', () => {
       expect(
         stripUnsupportedFormatting(
           'Check [docs](https://example.com "Docs")',
           emptySchema
         )
-      ).toBe('Check docs: https://example.com "Docs"');
+      ).toBe('Check docs: https://example.com');
+
+      expect(
+        stripUnsupportedFormatting(
+          'Check [docs](<https://example.com> "Docs")',
+          emptySchema
+        )
+      ).toBe('Check docs: https://example.com');
     });
 
     it('leaves bare URLs untouched so channels can auto-link them', () => {

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -987,6 +987,24 @@ describe('stripUnsupportedFormatting', () => {
       ).toBe('Check this link: https://example.com');
     });
 
+    it('keeps the link title while preserving the URL', () => {
+      expect(
+        stripUnsupportedFormatting(
+          'Check [docs](https://example.com "Docs")',
+          emptySchema
+        )
+      ).toBe('Check docs: https://example.com "Docs"');
+    });
+
+    it('leaves bare URLs untouched so channels can auto-link them', () => {
+      expect(
+        stripUnsupportedFormatting('Visit www.example.com now', emptySchema)
+      ).toBe('Visit www.example.com now');
+      expect(
+        stripUnsupportedFormatting('Visit <https://example.com>', emptySchema)
+      ).toBe('Visit https://example.com');
+    });
+
     it('converts autolinks to plain URLs when schema does not support links', () => {
       const content = 'Visit <https://cegrafic.com/catalogo/> for more info';
       const expected = 'Visit https://cegrafic.com/catalogo/ for more info';

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -1012,6 +1012,16 @@ describe('stripUnsupportedFormatting', () => {
       ).toBe('See wiki: https://en.wikipedia.org/wiki/Foo_(bar)');
     });
 
+    it('unescapes the backslash-escaped URL the serializer stores', () => {
+      // Editor-created links serialize parens/underscores as \( \) \_
+      expect(
+        stripUnsupportedFormatting(
+          'See [wiki](https://en.wikipedia.org/wiki/Foo\\_\\(bar\\))',
+          emptySchema
+        )
+      ).toBe('See wiki: https://en.wikipedia.org/wiki/Foo_(bar)');
+    });
+
     it('leaves bare URLs untouched so channels can auto-link them', () => {
       expect(
         stripUnsupportedFormatting('Visit www.example.com now', emptySchema)

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -1022,6 +1022,16 @@ describe('stripUnsupportedFormatting', () => {
       ).toBe('See wiki: https://en.wikipedia.org/wiki/Foo_(bar)');
     });
 
+    it('drops the label when it equals the URL even when escaped', () => {
+      // Both label and URL are escaped; must collapse to a single bare URL
+      expect(
+        stripUnsupportedFormatting(
+          '[www.example.com/Foo\\_\\(bar\\)](www.example.com/Foo\\_\\(bar\\))',
+          emptySchema
+        )
+      ).toBe('www.example.com/Foo_(bar)');
+    });
+
     it('leaves bare URLs untouched so channels can auto-link them', () => {
       expect(
         stripUnsupportedFormatting('Visit www.example.com now', emptySchema)

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -1,4 +1,9 @@
-import { EditorState, EditorView } from '@chatwoot/prosemirror-schema';
+import {
+  EditorState,
+  EditorView,
+  buildMessageSchema,
+  MessageMarkdownTransformer,
+} from '@chatwoot/prosemirror-schema';
 import { FORMATTING } from 'dashboard/constants/editor';
 import { Schema } from 'prosemirror-model';
 import {
@@ -1003,31 +1008,43 @@ describe('stripUnsupportedFormatting', () => {
       ).toBe('Check docs: https://example.com');
     });
 
-    it('unescapes the backslash-escaped URL the serializer stores', () => {
-      // Editor-created links serialize parens/underscores as \( \) \_,
-      // including parens mid-URL with more text after them.
-      expect(
-        stripUnsupportedFormatting(
-          'See [wiki](https://en.wikipedia.org/wiki/Foo\\_\\(bar\\))',
-          emptySchema
-        )
-      ).toBe('See wiki: https://en.wikipedia.org/wiki/Foo_(bar)');
-      expect(
-        stripUnsupportedFormatting(
-          'See [wiki](https://host/a\\_\\(b\\)c)',
-          emptySchema
-        )
-      ).toBe('See wiki: https://host/a_(b)c');
-    });
+    // Output is re-parsed before sending, so assert the final text
+    // (strip + re-parse); the re-parse turns serializer escapes into literals.
+    describe('links round-trip through re-parse without crashing', () => {
+      const smsSchema = buildMessageSchema([], []); // no marks, no nodes
+      const sendAs = md =>
+        new MessageMarkdownTransformer(smsSchema).parse(
+          stripUnsupportedFormatting(md, smsSchema)
+        ).textContent;
 
-    it('drops the label when it equals the URL even when escaped', () => {
-      // Both label and URL are escaped; must collapse to a single bare URL
-      expect(
-        stripUnsupportedFormatting(
-          '[www.example.com/Foo\\_\\(bar\\)](www.example.com/Foo\\_\\(bar\\))',
-          emptySchema
-        )
-      ).toBe('www.example.com/Foo_(bar)');
+      it('keeps escaped parens/underscores anywhere in the URL', () => {
+        expect(
+          sendAs('See [wiki](https://en.wikipedia.org/wiki/Foo\\_\\(bar\\))')
+        ).toBe('See wiki: https://en.wikipedia.org/wiki/Foo_(bar)');
+        expect(sendAs('See [wiki](https://host/a\\_\\(b\\)c)')).toBe(
+          'See wiki: https://host/a_(b)c'
+        );
+      });
+
+      it('drops the label when it equals the URL even when escaped', () => {
+        expect(
+          sendAs(
+            '[www.example.com/Foo\\_\\(bar\\)](www.example.com/Foo\\_\\(bar\\))'
+          )
+        ).toBe('www.example.com/Foo_(bar)');
+      });
+
+      it('does not reintroduce emphasis from an escaped label', () => {
+        expect(sendAs('[Use \\_id\\_](https://example.com)')).toBe(
+          'Use _id_: https://example.com'
+        );
+      });
+
+      it('flattens a label containing an escaped closing bracket', () => {
+        expect(sendAs('[FAQ \\[v2\\]](https://example.com)')).toBe(
+          'FAQ [v2]: https://example.com'
+        );
+      });
     });
 
     it('leaves bare URLs untouched so channels can auto-link them', () => {

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -1003,23 +1003,21 @@ describe('stripUnsupportedFormatting', () => {
       ).toBe('Check docs: https://example.com');
     });
 
-    it('keeps parentheses that belong to the URL', () => {
-      expect(
-        stripUnsupportedFormatting(
-          'See [wiki](https://en.wikipedia.org/wiki/Foo_(bar))',
-          emptySchema
-        )
-      ).toBe('See wiki: https://en.wikipedia.org/wiki/Foo_(bar)');
-    });
-
     it('unescapes the backslash-escaped URL the serializer stores', () => {
-      // Editor-created links serialize parens/underscores as \( \) \_
+      // Editor-created links serialize parens/underscores as \( \) \_,
+      // including parens mid-URL with more text after them.
       expect(
         stripUnsupportedFormatting(
           'See [wiki](https://en.wikipedia.org/wiki/Foo\\_\\(bar\\))',
           emptySchema
         )
       ).toBe('See wiki: https://en.wikipedia.org/wiki/Foo_(bar)');
+      expect(
+        stripUnsupportedFormatting(
+          'See [wiki](https://host/a\\_\\(b\\)c)',
+          emptySchema
+        )
+      ).toBe('See wiki: https://host/a_(b)c');
     });
 
     it('drops the label when it equals the URL even when escaped', () => {

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -1001,13 +1001,6 @@ describe('stripUnsupportedFormatting', () => {
           emptySchema
         )
       ).toBe('Check docs: https://example.com');
-
-      expect(
-        stripUnsupportedFormatting(
-          'Check [docs](https://example.com (Docs))',
-          emptySchema
-        )
-      ).toBe('Check docs: https://example.com');
     });
 
     it('keeps parentheses that belong to the URL', () => {

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -1001,6 +1001,22 @@ describe('stripUnsupportedFormatting', () => {
           emptySchema
         )
       ).toBe('Check docs: https://example.com');
+
+      expect(
+        stripUnsupportedFormatting(
+          'Check [docs](https://example.com (Docs))',
+          emptySchema
+        )
+      ).toBe('Check docs: https://example.com');
+    });
+
+    it('keeps parentheses that belong to the URL', () => {
+      expect(
+        stripUnsupportedFormatting(
+          'See [wiki](https://en.wikipedia.org/wiki/Foo_(bar))',
+          emptySchema
+        )
+      ).toBe('See wiki: https://en.wikipedia.org/wiki/Foo_(bar)');
     });
 
     it('leaves bare URLs untouched so channels can auto-link them', () => {

--- a/app/javascript/dashboard/helper/specs/editorHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/editorHelper.spec.js
@@ -978,13 +978,13 @@ describe('stripUnsupportedFormatting', () => {
       );
     });
 
-    it('strips links but keeps text', () => {
+    it('keeps link text and URL when schema does not support links', () => {
       expect(
         stripUnsupportedFormatting(
           'Check [this link](https://example.com)',
           emptySchema
         )
-      ).toBe('Check this link');
+      ).toBe('Check this link: https://example.com');
     });
 
     it('converts autolinks to plain URLs when schema does not support links', () => {
@@ -1049,7 +1049,7 @@ describe('stripUnsupportedFormatting', () => {
     it('handles complex content with multiple formatting types', () => {
       const content =
         '**Bold** and *italic* with `code` and [link](url)\n- list item';
-      const expected = 'Bold and italic with code and link\nlist item';
+      const expected = 'Bold and italic with code and link: url\nlist item';
       expect(stripUnsupportedFormatting(content, emptySchema)).toBe(expected);
     });
   });

--- a/app/javascript/dashboard/routes/dashboard/settings/canned/AddCanned.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/canned/AddCanned.vue
@@ -149,9 +149,5 @@ export default {
 
 :deep(.ProseMirror-woot-style) {
   @apply min-h-[12.5rem];
-
-  p {
-    @apply text-base;
-  }
 }
 </style>

--- a/app/javascript/dashboard/routes/dashboard/settings/canned/EditCanned.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/canned/EditCanned.vue
@@ -153,9 +153,5 @@ export default {
 
 :deep(.ProseMirror-woot-style) {
   @apply min-h-[12.5rem];
-
-  p {
-    @apply text-base;
-  }
 }
 </style>


### PR DESCRIPTION
# Pull Request Template

## Description

Some channels (Meta, SMS, and API) don't support Markdown hyperlinks. Previously, sending a message like `[text](url)` on these channels stripped the URL and sent only the link text, making the link unusable.

This PR preserves the URL by converting Markdown links into a plain-text format (`text: url`) before sending. Since these channels automatically detect and linkify bare URLs, the link remains clickable. If the link text is already the URL, it simply sends the URL to avoid duplication.

This PR also fixes a couple of small UI issues in the canned response editor:
 * Removes the extra padding around links inside modals.
 * Makes link text use the same font size as regular paragraph text, keeping it consistent with the rest of the app.


**Before**

```
here link example
```

The URL is removed, so the recipient can't access the link.

**After**

```
here link example: https://example.com/1
```

The URL is preserved, allowing the channel to automatically turn it into a clickable link.

Fixes https://linear.app/chatwoot/issue/CW-7521/canned-response-hyperlinks-strips-in-meta-channel

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Steps

1. Create a canned response containing:
   ```
   here [link example](https://example.com/1)
   ```
2. Use the canned response in a reply on Facebook, WhatsApp, Instagram, SMS, or another channel without hyperlink support.


### Loom video

https://www.loom.com/share/66502d87512141db9798aa2d07fdf469

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
