### PR TITLE
fix: correct report drilldown drawer position in RTL/LTR

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportDrilldownCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportDrilldownCard.vue
@@ -225,7 +225,7 @@ const openRecord = () => {
         </div>
       </div>
       <div
-        class="ml-2 flex shrink-0 items-center justify-end gap-1 text-right text-xs leading-4 text-n-slate-10"
+        class="ms-2 flex shrink-0 items-center justify-end gap-1 text-end text-xs leading-4 text-n-slate-10"
       >
         <span
           v-if="isMessageRecord"

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportDrilldownDrawer.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportDrilldownDrawer.vue
@@ -241,6 +241,7 @@ onBeforeUnmount(() => {
                 slate
                 size="sm"
                 icon="i-ph-caret-left"
+                class="rtl:rotate-180"
                 :disabled="!canPrev"
                 :aria-label="$t('REPORT.DRILLDOWN.PREVIOUS_BUCKET')"
                 @click="navigate(-1)"
@@ -250,6 +251,7 @@ onBeforeUnmount(() => {
                 slate
                 size="sm"
                 icon="i-ph-caret-right"
+                class="rtl:rotate-180"
                 :disabled="!canNext"
                 :aria-label="$t('REPORT.DRILLDOWN.NEXT_BUCKET')"
                 @click="navigate(1)"

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportDrilldownDrawer.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/ReportDrilldownDrawer.vue
@@ -5,6 +5,7 @@ import { useI18n } from 'vue-i18n';
 import { formatTime } from '@chatwoot/utils';
 import Button from 'dashboard/components-next/button/Button.vue';
 import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
+import TeleportWithDirection from 'dashboard/components-next/TeleportWithDirection.vue';
 import { useReportDrilldown } from '../composables/useReportDrilldown';
 import ReportDrilldownCard from './ReportDrilldownCard.vue';
 
@@ -195,7 +196,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <Teleport to="body">
+  <TeleportWithDirection to="body">
     <Transition name="report-drilldown-fade">
       <div
         v-if="isOpen"
@@ -205,7 +206,7 @@ onBeforeUnmount(() => {
       >
         <aside
           ref="drawerRef"
-          class="fixed inset-y-0 right-0 flex w-full max-w-xl flex-col bg-n-solid-1 shadow-xl outline outline-1 outline-n-container"
+          class="fixed inset-y-0 end-0 flex w-full max-w-xl flex-col bg-n-solid-1 shadow-xl outline outline-1 outline-n-container"
           role="dialog"
           aria-modal="true"
           :aria-label="title"
@@ -308,5 +309,5 @@ onBeforeUnmount(() => {
         </aside>
       </div>
     </Transition>
-  </Teleport>
+  </TeleportWithDirection>
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/ReportDrilldownDrawer.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/ReportDrilldownDrawer.spec.js
@@ -79,7 +79,9 @@ describe('ReportDrilldownDrawer.vue', () => {
       attachTo: options?.attachTo,
       global: {
         stubs: {
-          Teleport: true,
+          TeleportWithDirection: {
+            template: '<div><slot /></div>',
+          },
           Transition: false,
           Spinner: true,
           Button: {
@@ -246,6 +248,27 @@ describe('ReportDrilldownDrawer.vue', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('5 conversations');
+  });
+
+  it('anchors the drawer to the inline-end edge so it flips in RTL', async () => {
+    const wrapper = mountDrawer();
+    await flushPromises();
+
+    const drawer = wrapper.get('[role="dialog"]');
+    expect(drawer.classes()).toContain('end-0');
+    expect(drawer.classes()).not.toContain('right-0');
+  });
+
+  it('flips the navigation caret icons in RTL', async () => {
+    const wrapper = mountDrawer({ props: { canPrev: true, canNext: true } });
+    await flushPromises();
+
+    expect(
+      wrapper.get('[aria-label="REPORT.DRILLDOWN.PREVIOUS_BUCKET"]').classes()
+    ).toContain('rtl:rotate-180');
+    expect(
+      wrapper.get('[aria-label="REPORT.DRILLDOWN.NEXT_BUCKET"]').classes()
+    ).toContain('rtl:rotate-180');
   });
 
   it('emits close when the drawer close button is clicked', async () => {


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the report drilldown drawer opening from the wrong side in RTL/LTR. It now respects text direction and opens from the correct edge with properly aligned timestamps.

https://github.com/chatwoot/chatwoot/pull/14626

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="1650" height="1176" alt="image" src="https://github.com/user-attachments/assets/7e04a0fb-e703-4c4e-815a-bce3fe6d4c85" />


**After**
<img width="1650" height="1176" alt="image" src="https://github.com/user-attachments/assets/ae263f52-8b5c-4b2d-a836-413a7afd5586" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
