### PR TITLE
docs: fix grammar in API docs

### DIFF
--- a/swagger/definitions/resource/message.yml
+++ b/swagger/definitions/resource/message.yml
@@ -86,7 +86,7 @@ properties:
     type:
       - object
       - 'null'
-    description: The file object attached to the image
+    description: The file object attached to the message
   sender:
     type: object
     description: User/Agent/AgentBot object


### PR DESCRIPTION
Fixes grammar in Chatwoot API documentation. Changed 'attached to the image' to 'attached to the message' in the message resource schema description (swagger/definitions/resource/message.yml).