### PR TITLE
fix: do not merge into an identified contact without a matching identifier

### DIFF
--- a/app/actions/contact_identify_action.rb
+++ b/app/actions/contact_identify_action.rb
@@ -72,9 +72,11 @@ class ContactIdentifyAction
   def merge_contacts?(existing_contact, key)
     return if existing_contact.blank?
 
-    return true if params[:identifier].blank?
-
-    # we want to prevent merging contacts with different identifiers
+    # Never merge into a contact that already owns an identifier unless the request
+    # supplies the matching one. This also covers the blank-identifier case: an
+    # unverified/anonymous request must not take over an identified contact just by
+    # matching its email or phone_number. Merges into non-identified contacts
+    # (anonymous dedup) are still allowed.
     if existing_contact.identifier.present? && existing_contact.identifier != params[:identifier]
       # we will remove attribute from update list
       @attributes_to_update.delete(key)

--- a/spec/actions/contact_identify_action_spec.rb
+++ b/spec/actions/contact_identify_action_spec.rb
@@ -107,6 +107,24 @@ describe ContactIdentifyAction do
       end
     end
 
+    context 'when a request without an identifier matches an already identified contact' do
+      it 'does not merge into the identified contact via a matching email' do
+        victim = create(:contact, account: account, identifier: 'victim_id', email: 'victim@test.com', name: 'Victim')
+        params = { email: 'victim@test.com', name: 'Attacker' }
+        result = described_class.new(contact: contact, params: params).perform
+        expect(result.id).not_to eq victim.id
+        expect(victim.reload.name).to eq 'Victim'
+      end
+
+      it 'does not merge into the identified contact via a matching phone_number' do
+        victim = create(:contact, account: account, identifier: 'victim_id', phone_number: '+919999888877', name: 'Victim')
+        params = { phone_number: '+919999888877', name: 'Attacker' }
+        result = described_class.new(contact: contact, params: params).perform
+        expect(result.id).not_to eq victim.id
+        expect(victim.reload.name).to eq 'Victim'
+      end
+    end
+
     context 'when contacts with blank identifiers exist and identify action is called with blank identifier' do
       it 'updates the attributes of contact passed in to identify action' do
         create(:contact, account: account, identifier: '')


### PR DESCRIPTION
## Description

`ContactIdentifyAction` resolves an incoming contact against existing ones by `identifier`, `email`, and `phone_number`, and merges when a match is found. `merge_contacts?` returned `true` whenever the request carried no `identifier`, short-circuiting before the guard that prevents merging contacts with mismatched identifiers. Because of that, a request without an `identifier` could merge into (and overwrite) a contact that is already identified, purely by matching its `email` or `phone_number`.

This change removes the blank-identifier short-circuit so the existing identifier-mismatch guard also runs in that case: a contact that already owns an `identifier` is only merged into when the request supplies the same identifier. Merges into non-identified contacts (the normal anonymous de-duplication by email/phone) are unchanged.

Scope note: this hardens the merge behaviour in `ContactIdentifyAction` only. Endpoint-level identity validation (widget/public contact controllers) is tracked separately.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `ContactIdentifyAction` specs: a request with no `identifier` that matches an already-identified contact by `email` or by `phone_number` no longer merges into it, and the identified contact is left unchanged. Existing merge/dedup specs (merge into a non-identified email/phone contact, mismatched-identifier cases, blank-identifier update) continue to pass. Also ran the dependent widget contacts/conversations/messages controller specs, `ContactMergeAction`, and `ContactInboxWithContactBuilder` specs (66 examples, 0 failures). RuboCop clean.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
