### PR TITLE
chore(inbox): temporarily disable Instagram and WhatsApp embedded signup inbox creation

### DIFF
--- a/app/javascript/dashboard/components/widgets/ChannelItem.vue
+++ b/app/javascript/dashboard/components/widgets/ChannelItem.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue';
 import ChannelSelector from '../ChannelSelector.vue';
+import { IS_INSTAGRAM_WHATSAPP_INBOX_CREATION_DISABLED } from 'dashboard/constants/globals';
 
 const props = defineProps({
   channel: {
@@ -20,7 +21,10 @@ const hasFbConfigured = computed(() => {
 });
 
 const hasInstagramConfigured = computed(() => {
-  return window.chatwootConfig?.instagramAppId;
+  return (
+    !IS_INSTAGRAM_WHATSAPP_INBOX_CREATION_DISABLED &&
+    window.chatwootConfig?.instagramAppId
+  );
 });
 
 const hasTiktokConfigured = computed(() => {
@@ -58,6 +62,7 @@ const isActive = computed(() => {
 
   if (key === 'whatsapp_call') {
     return (
+      !IS_INSTAGRAM_WHATSAPP_INBOX_CREATION_DISABLED &&
       props.enabledFeatures.channel_voice &&
       !!window.chatwootConfig?.whatsappAppId &&
       window.chatwootConfig.whatsappAppId !== 'none'

--- a/app/javascript/dashboard/constants/globals.js
+++ b/app/javascript/dashboard/constants/globals.js
@@ -78,3 +78,8 @@ export default {
   },
 };
 export const DEFAULT_REDIRECT_URL = '/app/';
+
+// Temporarily disables Instagram and WhatsApp inbox creation
+// (WhatsApp embedded signup popup, Instagram OAuth, WhatsApp Call).
+// Flip to false when the channels are brought back.
+export const IS_INSTAGRAM_WHATSAPP_INBOX_CREATION_DISABLED = true;

--- a/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
@@ -1,4 +1,5 @@
 import { useMapGetter } from 'dashboard/composables/store';
+import { IS_INSTAGRAM_WHATSAPP_INBOX_CREATION_DISABLED } from 'dashboard/constants/globals';
 
 // OAuth/SDK channels need installation-level app credentials to be usable. When
 // the credential is missing the channel is "not configured" and is hidden from
@@ -13,11 +14,14 @@ export function useChannelConfig() {
     // WhatsApp is onboarded only via Meta embedded signup, which needs both the
     // app id (not the 'none' sentinel) and the signup configuration id.
     whatsapp: () =>
+      !IS_INSTAGRAM_WHATSAPP_INBOX_CREATION_DISABLED &&
       Boolean(installationConfig.whatsappAppId) &&
       installationConfig.whatsappAppId !== 'none' &&
       Boolean(installationConfig.whatsappConfigurationId),
     facebook: () => Boolean(installationConfig.fbAppId),
-    instagram: () => Boolean(installationConfig.instagramAppId),
+    instagram: () =>
+      !IS_INSTAGRAM_WHATSAPP_INBOX_CREATION_DISABLED &&
+      Boolean(installationConfig.instagramAppId),
     tiktok: () => Boolean(installationConfig.tiktokAppId),
     gmail: () => Boolean(installationConfig.googleOAuthClientId),
     outlook: () => Boolean(globalConfig.value.azureAppId),

--- a/app/javascript/dashboard/routes/dashboard/onboarding/specs/inbox-setup/useDetectedChannels.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/specs/inbox-setup/useDetectedChannels.spec.js
@@ -6,6 +6,13 @@ import { useDetectedChannels } from '../../inbox-setup/useDetectedChannels';
 
 vi.mock('vue-router');
 
+// Neutralize the temporary Instagram/WhatsApp kill switch so these specs keep
+// covering the credential-based gating it currently short-circuits.
+vi.mock('dashboard/constants/globals', async importOriginal => ({
+  ...(await importOriginal()),
+  IS_INSTAGRAM_WHATSAPP_INBOX_CREATION_DISABLED: false,
+}));
+
 // Mounts the composable against a real store and the real useAccount (only
 // useRoute and the underlying getters are faked), so a change to how useAccount
 // resolves the current account is exercised here too. The real ./constants are

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -7,6 +7,7 @@ import ThreeSixtyDialogWhatsapp from './360DialogWhatsapp.vue';
 import CloudWhatsapp from './CloudWhatsapp.vue';
 import WhatsappEmbeddedSignup from './WhatsappEmbeddedSignup.vue';
 import ChannelSelector from 'dashboard/components/ChannelSelector.vue';
+import { IS_INSTAGRAM_WHATSAPP_INBOX_CREATION_DISABLED } from 'dashboard/constants/globals';
 
 const route = useRoute();
 const router = useRouter();
@@ -23,6 +24,7 @@ const PROVIDER_TYPES = {
 
 const hasWhatsappAppId = computed(() => {
   return (
+    !IS_INSTAGRAM_WHATSAPP_INBOX_CREATION_DISABLED &&
     window.chatwootConfig?.whatsappAppId &&
     window.chatwootConfig.whatsappAppId !== 'none'
   );


### PR DESCRIPTION
This temporarily turns off inbox creation for channels that rely on Meta's embedded signup — the WhatsApp Cloud signup popup, Instagram (OAuth-only), and WhatsApp Call. WhatsApp Cloud inbox creation now falls back to the manual API-key form, while the Instagram and WhatsApp Call tiles appear disabled. Both channels are also hidden from the new-account onboarding flow. Existing inboxes are not affected.