### PR TITLE
Add custom_title field to agents

### DIFF
--- a/app/controllers/api/v1/accounts/agents_controller.rb
+++ b/app/controllers/api/v1/accounts/agents_controller.rb
@@ -68,11 +68,11 @@ class Api::V1::Accounts::AgentsController < Api::V1::Accounts::BaseController
   end
 
   def account_user_attributes
-    [:role, :availability, :auto_offline]
+    [:role, :availability, :auto_offline, :custom_title]
   end
 
   def allowed_agent_params
-    [:name, :email, :role, :availability, :auto_offline]
+    [:name, :email, :role, :availability, :auto_offline, :custom_title]
   end
 
   def agent_params

--- a/app/javascript/dashboard/routes/dashboard/settings/agents/EditAgent.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agents/EditAgent.vue
@@ -38,6 +38,10 @@ const props = defineProps({
     type: Number,
     default: null,
   },
+  customTitle: {
+    type: String,
+    default: '',
+  },
 });
 
 const emit = defineEmits(['close']);
@@ -50,6 +54,7 @@ const { t } = useI18n();
 const agentName = ref(props.name);
 const agentAvailability = ref(props.availability);
 const selectedRoleId = ref(props.customRoleId || props.type);
+const customTitle = ref(props.customTitle);
 const agentCredentials = ref({ email: props.email });
 
 const rules = {
@@ -126,6 +131,7 @@ const editAgent = async () => {
       id: props.id,
       name: agentName.value,
       availability: agentAvailability.value,
+      custom_title: customTitle.value,
     };
 
     if (selectedRole.value.name.startsWith('custom_')) {
@@ -201,6 +207,17 @@ const resetPassword = async () => {
           <span v-if="v$.agentAvailability.$error" class="message">
             {{ $t('AGENT_MGMT.EDIT.FORM.AGENT_AVAILABILITY.ERROR') }}
           </span>
+        </label>
+      </div>
+
+      <div class="w-full">
+        <label>
+          Custom Title
+          <input
+            v-model="customTitle"
+            type="text"
+            placeholder="e.g., Senior Support Agent"
+          />
         </label>
       </div>
 

--- a/app/javascript/dashboard/routes/dashboard/settings/agents/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agents/Index.vue
@@ -196,9 +196,17 @@ const confirmDeletion = () => {
               hide-offline-status
             />
             <div class="flex flex-col gap-1.5 items-start">
-              <span class="block text-heading-3 text-n-slate-12 capitalize">
-                {{ agent.name }}
-              </span>
+              <div class="flex items-center gap-2">
+                <span class="block text-heading-3 text-n-slate-12 capitalize">
+                  {{ agent.name }}
+                </span>
+                <span
+                  v-if="agent.custom_title"
+                  class="text-body-main text-n-slate-10 italic"
+                >
+                  ({{ agent.custom_title }})
+                </span>
+              </div>
               <div class="flex items-center gap-2">
                 <span class="text-body-main text-n-slate-11">
                   {{ agent.email }}
@@ -291,6 +299,7 @@ const confirmDeletion = () => {
         :email="currentAgent.email"
         :availability="currentAgent.availability_status"
         :custom-role-id="currentAgent.custom_role_id"
+        :custom-title="currentAgent.custom_title"
         @close="hideEditPopup"
       />
     </woot-modal>

--- a/app/views/api/v1/models/_agent.json.jbuilder
+++ b/app/views/api/v1/models/_agent.json.jbuilder
@@ -10,5 +10,6 @@ json.available_name resource.available_name
 json.custom_attributes resource.custom_attributes if resource.custom_attributes.present?
 json.name resource.name
 json.role resource.role
+json.custom_title resource.current_account_user&.custom_title
 json.thumbnail resource.avatar_url
 json.custom_role_id resource.current_account_user&.custom_role_id if ChatwootApp.enterprise?

--- a/db/migrate/20260708225021_add_custom_title_to_account_users.rb
+++ b/db/migrate/20260708225021_add_custom_title_to_account_users.rb
@@ -1,0 +1,5 @@
+class AddCustomTitleToAccountUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :account_users, :custom_title, :string, default: nil
+  end
+end


### PR DESCRIPTION
Add a new optional custom_title field to agent profiles

Changes:
- Database: Added custom_title column to account_users table
- Backend: Updated AgentsController to accept and return custom_title
- API: Added custom_title to agent JSON response
- Frontend: EditAgent component with custom title input field