### PR TITLE
fix(search): include contact thumbnails in contact results

### DIFF
--- a/app/views/api/v1/accounts/search/_contact.json.jbuilder
+++ b/app/views/api/v1/accounts/search/_contact.json.jbuilder
@@ -3,5 +3,6 @@ json.id contact.id
 json.name contact.name
 json.phone_number contact.phone_number
 json.identifier contact.identifier
+json.thumbnail contact.avatar_url
 json.additional_attributes contact.additional_attributes
 json.last_activity_at contact.last_activity_at&.to_i

--- a/spec/controllers/api/v1/accounts/search_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/search_controller_spec.rb
@@ -86,6 +86,21 @@ RSpec.describe 'Search', type: :request do
         expect(contact_result).not_to have_key(:created_at)
       end
 
+      it 'returns thumbnail in contact search results' do
+        contact = create(:contact, :with_avatar, email: 'avatar@test.com', account: account)
+
+        get "/api/v1/accounts/#{account.id}/search/contacts",
+            headers: agent.create_new_auth_token,
+            params: { q: 'avatar' },
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        response_data = JSON.parse(response.body, symbolize_names: true)
+
+        contact_result = response_data[:payload][:contacts].first
+        expect(contact_result[:thumbnail]).to eq(contact.avatar_url)
+      end
+
       context 'with advanced_search feature enabled', :opensearch do
         before do
           account.enable_features!('advanced_search')


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes #14965

Contact search results currently render fallback initials for contacts that already have avatars because the contact search JSON response does not include a `thumbnail` field. The contact detail endpoint already exposes the thumbnail, so the UI can show the avatar after opening the contact but not in the search listing.

This change adds `thumbnail` to the contact search serializer and covers it with a request spec.

Fixed listing proof from the local patched Docker setup, with identifying text blurred:

![Contact search listing renders existing avatars after the fix](https://raw.githubusercontent.com/KevinAsher/chatwoot/9344c3251e7a3c759a2c363a230ae434e98c06c5/docs/proof/search-contact-thumbnail-fixed-listing.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Added a request spec covering `thumbnail` in `/api/v1/accounts/:account_id/search/contacts` results.
- Manually validated in a local self-hosted Docker setup by building/running the patched Chatwoot image and confirming contact search listings render existing avatars.
- Local RSpec was not run from this checkout because the host Ruby environment is missing Bundler `2.5.16` required by `Gemfile.lock`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
