### PR TITLE
feat: add support action to suspended account page

### DIFF
--- a/app/javascript/dashboard/components-next/sidebar/SidebarProfileMenu.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarProfileMenu.vue
@@ -44,6 +44,12 @@ const showChatSupport = computed(() => {
   );
 });
 
+const toggleChatSupport = () => {
+  if (window.$chatwoot) {
+    window.$chatwoot.toggle();
+  }
+};
+
 const menuItems = computed(() => {
   return [
     {
@@ -51,9 +57,7 @@ const menuItems = computed(() => {
       showOnCustomBrandedInstance: false,
       label: t('SIDEBAR_ITEMS.CONTACT_SUPPORT'),
       icon: 'i-lucide-life-buoy',
-      click: () => {
-        window.$chatwoot.toggle();
-      },
+      click: toggleChatSupport,
     },
     {
       show: true,

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -263,7 +263,7 @@
     "EMAIL_VERIFICATION_SENT": "Verification email has been sent. Please check your inbox.",
     "ACCOUNT_SUSPENDED": {
       "TITLE": "Account Suspended",
-      "MESSAGE": "Your account has been suspended after we detected activity that may violate our policies or put other users at risk. If you believe this is a mistake, please contact our support team."
+      "MESSAGE": "Your account has been suspended due to activity that may violate our policies. If you believe this is a mistake, please contact our support team."
     },
     "NO_ACCOUNTS": {
       "TITLE": "No account found",

--- a/app/javascript/dashboard/routes/dashboard/suspended/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/suspended/Index.vue
@@ -1,10 +1,17 @@
 <script setup>
 import EmptyState from 'dashboard/components/widgets/EmptyState.vue';
+import NextButton from 'dashboard/components-next/button/Button.vue';
 import { onMounted } from 'vue';
 
 const toggleSupportWidgetVisibility = () => {
   if (window.$chatwoot) {
     window.$chatwoot.toggleBubbleVisibility('show');
+  }
+};
+
+const toggleSupportWidget = () => {
+  if (window.$chatwoot) {
+    window.$chatwoot.toggle();
   }
 };
 
@@ -25,6 +32,14 @@ onMounted(() => {
     <EmptyState
       :title="$t('APP_GLOBAL.ACCOUNT_SUSPENDED.TITLE')"
       :message="$t('APP_GLOBAL.ACCOUNT_SUSPENDED.MESSAGE')"
-    />
+    >
+      <div class="flex justify-center">
+        <NextButton
+          icon="i-lucide-life-buoy"
+          :label="$t('SIDEBAR_ITEMS.CONTACT_SUPPORT')"
+          @click="toggleSupportWidget"
+        />
+      </div>
+    </EmptyState>
   </div>
 </template>


### PR DESCRIPTION
Updates the suspended account page with the revised policy copy and adds a visible Contact support action that opens the embedded Chatwoot support widget.