### PR TITLE
fix: dedupe API messages by source_id on bridge retries

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -21,6 +21,10 @@ class Messages::MessageBuilder
   end
 
   def perform
+    # Bridges (Evolution/Baileys) may retry the same webhook; return existing message when source_id matches.
+    existing = existing_message_with_source_id
+    return existing if existing
+
     @message = @conversation.messages.build(message_params)
     process_attachments
     process_emails
@@ -32,6 +36,13 @@ class Messages::MessageBuilder
   end
 
   private
+
+  def existing_message_with_source_id
+    source_id = @params[:source_id]
+    return if source_id.blank?
+
+    @conversation.messages.find_by(source_id: source_id)
+  end
 
   # Extracts content attributes from the given params.
   # - Converts ActionController::Parameters to a regular hash if needed.

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -26,9 +26,10 @@ class Whatsapp::IncomingMessageBaseService
     # Multiple webhook event can be received against the same message due to misconfigurations in the Meta
     # business manager account. While we have not found the core reason yet, the following line ensure that
     # there are no duplicate messages created.
-    return if find_message_by_source_id(@processed_params[:messages].first[:id]) || message_under_process?
+    return if find_message_by_source_id(@processed_params[:messages].first[:id])
+    # Atomic SET NX avoids check-then-set races when Meta delivers the same webhook concurrently.
+    return unless cache_message_source_id_in_redis
 
-    cache_message_source_id_in_redis
     set_contact
     return unless @contact
 

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -69,16 +69,12 @@ module Whatsapp::IncomingMessageServiceHelpers
     @message = Message.find_by(source_id: source_id)
   end
 
-  def message_under_process?
-    key = format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: @processed_params[:messages].first[:id])
-    Redis::Alfred.get(key)
-  end
-
   def cache_message_source_id_in_redis
-    return if @processed_params.try(:[], :messages).blank?
+    return false if @processed_params.try(:[], :messages).blank?
 
     key = format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: @processed_params[:messages].first[:id])
-    ::Redis::Alfred.setex(key, true)
+    # SET NX: only the first concurrent webhook acquires the lock
+    ::Redis::Alfred.set(key, true, nx: true, ex: 1.day.to_i)
   end
 
   def clear_message_source_id_from_redis


### PR DESCRIPTION
## Summary
- Deduplicate incoming API messages when `source_id` already exists (Evolution/Baileys webhook retries were creating spam in Chatwoot while WhatsApp showed the message once).
- Harden native WhatsApp webhook locking to atomic Redis `SET NX` to avoid concurrent duplicate inserts.

## Test plan
- [ ] On prod, confirm conversation #2411 inbox is `Channel::Api` and inspect the 4 spam rows' `source_id` values
- [ ] Confirm the bridge maps WhatsApp `key.id` → Chatwoot `source_id`
- [ ] Replay/retry the same incoming webhook twice and verify only one message is created
- [ ] Smoke-test a normal new incoming message still creates correctly


Made with [Cursor](https://cursor.com)