### PR TITLE
feat(captain): pass reasoning effort to v2 agents

### DIFF
--- a/enterprise/app/models/concerns/agentable.rb
+++ b/enterprise/app/models/concerns/agentable.rb
@@ -10,7 +10,8 @@ module Concerns::Agentable
       tools: agent_tools,
       model: agent_model,
       temperature: temperature.presence&.to_f || DEFAULT_TEMPERATURE,
-      response_schema: agent_response_schema
+      response_schema: agent_response_schema,
+      params: agent_params
     )
   end
 
@@ -50,6 +51,13 @@ module Concerns::Agentable
     return route[:model] if route[:source] == :account_override || account&.feature_enabled?('captain_integration_v2')
 
     installation_model.presence || route[:model]
+  end
+
+  def agent_params
+    route = Llm::FeatureRouter.resolve(feature: 'assistant', account: account)
+    return {} if route[:reasoning_effort].blank?
+
+    { reasoning_effort: route[:reasoning_effort] }
   end
 
   def installation_model

--- a/spec/enterprise/models/concerns/agentable_spec.rb
+++ b/spec/enterprise/models/concerns/agentable_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Concerns::Agentable do
         tools: [],
         model: Llm::Models.default_model_for('assistant'),
         temperature: 0.8,
-        response_schema: Captain::ResponseSchema
+        response_schema: Captain::ResponseSchema,
+        params: { reasoning_effort: Llm::Models.reasoning_effort_for('assistant') }
       )
 
       dummy_instance.agent
@@ -191,6 +192,14 @@ RSpec.describe Concerns::Agentable do
       agent = dummy_class.new(account: nil)
 
       expect(agent.send(:agent_model)).to eq(Llm::Models.default_model_for('assistant'))
+    end
+  end
+
+  describe '#agent_params' do
+    it 'returns reasoning effort for the assistant feature' do
+      expect(dummy_instance.send(:agent_params)).to eq(
+        reasoning_effort: Llm::Models.reasoning_effort_for('assistant')
+      )
     end
   end
 


### PR DESCRIPTION
Passes the configured assistant reasoning effort into Captain V2 agent construction so the AI Agents SDK path follows the same feature routing as the rest of Captain.

Closes
N/A

How to test
- Trigger a Captain V2 assistant response from an assistant with scenarios enabled.
- Verify the agent is created with the configured model and reasoning effort while handoff/tool behavior remains unchanged.

What changed
- Resolves the assistant feature route in `Agentable`.
- Passes `reasoning_effort` through agent provider params.
- Leaves legacy Captain V1 paths untouched.