### PR TITLE
fix: default assignment age exclusion

### DIFF
--- a/app/models/assignment_policy.rb
+++ b/app/models/assignment_policy.rb
@@ -22,6 +22,8 @@
 #  index_assignment_policies_on_enabled              (enabled)
 #
 class AssignmentPolicy < ApplicationRecord
+  DEFAULT_EXCLUDE_OLDER_THAN_HOURS = 168
+
   belongs_to :account
   has_many :inbox_assignment_policies, dependent: :destroy
   has_many :inboxes, through: :inbox_assignment_policies

--- a/app/services/auto_assignment/assignment_service.rb
+++ b/app/services/auto_assignment/assignment_service.rb
@@ -35,9 +35,9 @@ class AutoAssignment::AssignmentService
   def unassigned_conversations(limit)
     scope = inbox.conversations.unassigned.open
 
-    # Skip stale backlog with no activity beyond the policy's age threshold (defaults to 7 days)
+    # Skip stale backlog with no activity beyond the age threshold
     policy = inbox.assignment_policy
-    scope = apply_age_exclusions(scope, policy&.exclude_older_than_hours)
+    scope = apply_age_exclusions(scope, age_exclusion_hours(policy))
 
     # Apply conversation priority using assignment policy if available
     scope = if policy&.longest_waiting?
@@ -47,6 +47,12 @@ class AutoAssignment::AssignmentService
             end
 
     scope.limit(limit)
+  end
+
+  def age_exclusion_hours(policy)
+    return policy.exclude_older_than_hours if policy
+
+    AssignmentPolicy::DEFAULT_EXCLUDE_OLDER_THAN_HOURS
   end
 
   def apply_age_exclusions(scope, hours_threshold)

--- a/enterprise/app/services/enterprise/auto_assignment/assignment_service.rb
+++ b/enterprise/app/services/enterprise/auto_assignment/assignment_service.rb
@@ -60,7 +60,7 @@ module Enterprise::AutoAssignment::AssignmentService
     scope = inbox.conversations.unassigned.open
 
     # First apply the assignment policy's age exclusion (defaults to 7 days)
-    scope = apply_age_exclusions(scope, policy&.exclude_older_than_hours)
+    scope = apply_age_exclusions(scope, age_exclusion_hours(policy))
 
     # Then apply the capacity policy's exclusion rules (labels and age)
     scope = apply_exclusion_rules(scope)

--- a/spec/services/auto_assignment/assignment_service_spec.rb
+++ b/spec/services/auto_assignment/assignment_service_spec.rb
@@ -239,6 +239,24 @@ RSpec.describe AutoAssignment::AssignmentService do
         expect(assigned_count).to eq(1)
         expect(old_conversation.reload.assignee).to eq(agent)
       end
+
+      context 'when the inbox has no assignment policy' do
+        before do
+          inbox.inbox_assignment_policy.destroy!
+          inbox.reload
+        end
+
+        it 'falls back to the default threshold and skips stale conversations' do
+          stale_conversation = create(:conversation, inbox: inbox, assignee: nil, last_activity_at: 8.days.ago)
+          recent_conversation = create(:conversation, inbox: inbox, assignee: nil, last_activity_at: 6.days.ago)
+
+          assigned_count = service.perform_bulk_assignment(limit: 10)
+
+          expect(assigned_count).to eq(1)
+          expect(stale_conversation.reload.assignee).to be_nil
+          expect(recent_conversation.reload.assignee).to eq(agent)
+        end
+      end
     end
 
     context 'with fair distribution' do


### PR DESCRIPTION
## Description
Auto-assignment was skipping the 7-day staleness check entirely for inboxes that don't have an assignment policy attached. Those inboxes would pull unassigned conversations of any age off the backlog and hand them to agents — including conversations untouched for months — while the activity log still credited "Default Policy" for the assignment. This makes the default behaviour match what that label implies: with no policy configured, conversations with no activity in the last 7 days are now excluded, the same window a freshly created policy uses.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
