### PR TITLE
fix: Pin pnpm 11.10.0 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,8 @@ jobs:
 
       - node/install:
           node-version: '24.13'
-      - node/install-pnpm
+      - node/install-pnpm:
+          version: '11.10.0'
       - node/install-packages:
           pkg-manager: pnpm
           override-ci-command: pnpm i
@@ -118,7 +119,8 @@ jobs:
       - checkout
       - node/install:
           node-version: '24.13'
-      - node/install-pnpm
+      - node/install-pnpm:
+          version: '11.10.0'
       - node/install-packages:
           pkg-manager: pnpm
           override-ci-command: pnpm i
@@ -149,7 +151,8 @@ jobs:
       - checkout
       - node/install:
           node-version: '24.13'
-      - node/install-pnpm
+      - node/install-pnpm:
+          version: '11.10.0'
       - node/install-packages:
           pkg-manager: pnpm
           override-ci-command: pnpm i


### PR DESCRIPTION
## Description

Pins pnpm 11.10.0 explicitly in the CircleCI lint, frontend test, and backend test jobs. This bypasses the `circleci/node` orb's broken latest-version parsing, which combines pnpm 11.12.0 with the internal `@pnpm/engine.runtime.system-version` dependency version and fails before dependencies or tests can run.

Related upstream issue: https://github.com/CircleCI-Public/node-orb/issues/262
Reported in PNPM repo: https://github.com/pnpm/pnpm/issues/12955

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How to reproduce

1. Run any CircleCI workflow job that calls `node/install-pnpm` without a pinned version.
2. Observe npm fail with `ETARGET` while trying to install the combined `11.12.0` and `1100.0.3` value.
3. Confirm the jobs install pnpm 11.10.0 after applying this change.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
