### PR TITLE
chore(whatsapp): log warning when Cloud API template sync fails

### DIFF
--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -159,7 +159,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
 
   def error_message(response)
     # https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/#sample-response
-    response.parsed_response&.dig('error', 'message')
+    response.parsed_response.dig('error', 'message') if response.parsed_response.is_a?(Hash)
   end
 
   def voice_message?(type, attachment)

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -40,7 +40,11 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
 
   def fetch_whatsapp_templates(url)
     response = HTTParty.get(url)
-    return [] unless response.success?
+    unless response.success?
+      Rails.logger.warn "[WHATSAPP] Template sync failed for account #{whatsapp_channel.account_id} " \
+                        "inbox #{whatsapp_channel.inbox&.id}: #{response.code} #{error_message(response)}"
+      return []
+    end
 
     next_url = next_url(response)
 


### PR DESCRIPTION
WhatsApp Cloud API template sync currently fails silently — if the Graph API call errors (expired token, rate limit, permission issue), the channel simply keeps its stale templates with no trace in the logs. This adds a warning log when the template fetch fails, so failed syncs are visible and debuggable.

## What changed

- `Whatsapp::Providers::WhatsappCloudService#fetch_whatsapp_templates` now logs a warning with the account id, inbox id, HTTP status code, and Meta's error message when the response is not successful.
- The inbox id uses safe navigation since sync also runs from the channel's `after_create` callback, before the inbox record exists.
- The request URL is intentionally not logged, as it contains the access token as a query param.

## How to reproduce

1. Set up a WhatsApp Cloud inbox with an invalid/expired `api_key`.
2. Trigger a template sync (Inbox settings → sync templates, or wait for the scheduler).
3. Previously nothing was logged; now a `[WHATSAPP] Template sync failed for account ... inbox ...` warning appears in the Rails logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)