### PR TITLE
fix(meta): disable Instagram replies on Cloud during restriction

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -146,6 +146,7 @@ export default {
       currentUser: 'getCurrentUser',
       lastEmail: 'getLastEmailInSelectedChat',
       globalConfig: 'globalConfig/get',
+      isOnChatwootCloud: 'globalConfig/isOnChatwootCloud',
     }),
     currentContact() {
       const senderId = this.currentChat?.meta?.sender?.id;
@@ -173,6 +174,9 @@ export default {
       return this.isATwilioWhatsAppChannel && !this.isPrivate;
     },
     isPrivate() {
+      if (this.isInstagramReplyRestricted) {
+        return true;
+      }
       if (
         this.currentChat.can_reply ||
         this.isAWhatsAppChannel ||
@@ -197,10 +201,16 @@ export default {
       );
       return !!stripped.trim();
     },
+    // Instagram replies are disabled on Chatwoot Cloud during the temporary
+    // Meta platform restriction; private notes remain available.
+    isInstagramReplyRestricted() {
+      return this.isOnChatwootCloud && this.isAnInstagramChannel;
+    },
     isReplyRestricted() {
       return (
-        !this.currentChat?.can_reply &&
-        !(this.isAWhatsAppChannel || this.isAPIInbox)
+        this.isInstagramReplyRestricted ||
+        (!this.currentChat?.can_reply &&
+          !(this.isAWhatsAppChannel || this.isAPIInbox))
       );
     },
     inboxId() {
@@ -470,7 +480,10 @@ export default {
         return;
       }
 
-      if (canReply || this.isAWhatsAppChannel || this.isAPIInbox) {
+      if (
+        !this.isInstagramReplyRestricted &&
+        (canReply || this.isAWhatsAppChannel || this.isAPIInbox)
+      ) {
         this.replyType = REPLY_EDITOR_MODES.REPLY;
       } else {
         this.replyType = REPLY_EDITOR_MODES.NOTE;
@@ -937,7 +950,10 @@ export default {
       this.$store.dispatch('draftMessages/setReplyEditorMode', {
         mode,
       });
-      if (canReply || this.isAWhatsAppChannel || this.isAPIInbox)
+      if (
+        !this.isInstagramReplyRestricted &&
+        (canReply || this.isAWhatsAppChannel || this.isAPIInbox)
+      )
         this.replyType = mode;
       if (this.isRecordingAudio) {
         this.toggleAudioRecorder();


### PR DESCRIPTION
Agents can no longer send replies in Instagram conversations on Chatwoot Cloud while the temporary Meta platform restriction is active. The reply box locks into Private Note mode — the same behavior as an expired 24-hour reply window — so teams can still collaborate internally, with the existing amber restriction banner above the conversation explaining why. Self-hosted installations are unaffected.

Follow-up to #14974.


## How to test

1. On a Chatwoot Cloud environment (`isOnChatwootCloud` true), open any Instagram conversation.
2. The composer should be locked to Private Note mode: the Reply/Private Note toggle is disabled, and sending creates a private note — even for conversations within the 24-hour reply window.
3. Switching between conversations should keep the composer in Private Note mode for Instagram conversations.
4. On a self-hosted environment, Instagram conversations should behave as before (reply allowed within the messaging window).