### PR TITLE
feat(voice): add in-call DTMF keypad

### DIFF
--- a/app/javascript/dashboard/api/channel/voice/specs/twilioVoiceClient.spec.js
+++ b/app/javascript/dashboard/api/channel/voice/specs/twilioVoiceClient.spec.js
@@ -1,0 +1,34 @@
+import TwilioVoiceClient from '../twilioVoiceClient';
+
+describe('TwilioVoiceClient#sendDigits', () => {
+  afterEach(() => {
+    TwilioVoiceClient.activeConnection = null;
+  });
+
+  it('returns false when there is no active connection', () => {
+    expect(TwilioVoiceClient.sendDigits('9')).toBe(false);
+  });
+
+  it('returns false without sending when the connection is not open', () => {
+    const sendDigits = vi.fn();
+    TwilioVoiceClient.activeConnection = {
+      status: vi.fn(() => 'reconnecting'),
+      sendDigits,
+    };
+
+    expect(TwilioVoiceClient.sendDigits('9')).toBe(false);
+    expect(sendDigits).not.toHaveBeenCalled();
+  });
+
+  it('sends one digit through an open connection', () => {
+    const sendDigits = vi.fn();
+    TwilioVoiceClient.activeConnection = {
+      status: vi.fn(() => 'open'),
+      sendDigits,
+    };
+
+    expect(TwilioVoiceClient.sendDigits('#')).toBe(true);
+    expect(sendDigits).toHaveBeenCalledOnce();
+    expect(sendDigits).toHaveBeenCalledWith('#');
+  });
+});

--- a/app/javascript/dashboard/api/channel/voice/twilioVoiceClient.js
+++ b/app/javascript/dashboard/api/channel/voice/twilioVoiceClient.js
@@ -1,4 +1,4 @@
-import { Device } from '@twilio/voice-sdk';
+import { Call, Device } from '@twilio/voice-sdk';
 import VoiceAPI from './voiceAPIClient';
 
 const createCallDisconnectedEvent = () => new CustomEvent('call:disconnected');
@@ -52,6 +52,18 @@ class TwilioVoiceClient extends EventTarget {
     if (!this.activeConnection) return false;
     this.activeConnection.mute(shouldMute);
     return shouldMute;
+  }
+
+  sendDigits(digit) {
+    if (
+      !this.activeConnection ||
+      this.activeConnection.status() !== Call.State.Open
+    ) {
+      return false;
+    }
+
+    this.activeConnection.sendDigits(digit);
+    return true;
   }
 
   endClientCall() {

--- a/app/javascript/dashboard/components-next/Contacts/VoiceCallButton.vue
+++ b/app/javascript/dashboard/components-next/Contacts/VoiceCallButton.vue
@@ -171,6 +171,7 @@ const startCall = async (inboxId, conversationIdHint = null) => {
       conversationId,
       inboxId,
       callDirection: VOICE_CALL_DIRECTION.OUTBOUND,
+      provider: VOICE_CALL_PROVIDERS.TWILIO,
     });
 
     useAlert(t('CONTACT_PANEL.CALL_INITIATED'));

--- a/app/javascript/dashboard/components-next/call/CallCard.story.vue
+++ b/app/javascript/dashboard/components-next/call/CallCard.story.vue
@@ -131,6 +131,21 @@ const log =
       />
     </Variant>
 
+    <Variant title="Ongoing · WhatsApp with keypad">
+      <CallCard
+        :call="whatsappCall"
+        :call-info="richCallInfo"
+        :state="VOICE_CALL_DIRECTION.ONGOING"
+        duration="03:47"
+        show-mute
+        show-keypad
+        @end="log('end')"
+        @toggle-mute="log('toggleMute')"
+        @send-digit="log('sendDigit')"
+        @go-to-conversation="log('goToConversation')"
+      />
+    </Variant>
+
     <Variant title="Ongoing · Twilio (no mute control)">
       <CallCard
         :call="twilioCall"
@@ -138,6 +153,21 @@ const log =
         :state="VOICE_CALL_DIRECTION.ONGOING"
         duration="00:42"
         @end="log('end')"
+        @go-to-conversation="log('goToConversation')"
+      />
+    </Variant>
+
+    <Variant title="Ongoing · Twilio with keypad">
+      <CallCard
+        :call="twilioCall"
+        :call-info="richCallInfo"
+        :state="VOICE_CALL_DIRECTION.ONGOING"
+        duration="00:42"
+        show-mute
+        show-keypad
+        @end="log('end')"
+        @toggle-mute="log('toggleMute')"
+        @send-digit="log('sendDigit')"
         @go-to-conversation="log('goToConversation')"
       />
     </Variant>

--- a/app/javascript/dashboard/components-next/call/CallCard.vue
+++ b/app/javascript/dashboard/components-next/call/CallCard.vue
@@ -1,11 +1,12 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { VOICE_CALL_DIRECTION } from 'dashboard/components-next/message/constants';
 import { VOICE_CALL_PROVIDERS } from 'dashboard/helper/inbox';
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
 import NextButton from 'dashboard/components-next/button/Button.vue';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
+import CallKeypad from './CallKeypad.vue';
 
 const props = defineProps({
   call: {
@@ -33,6 +34,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  showKeypad: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 defineEmits([
@@ -42,9 +47,29 @@ defineEmits([
   'toggleMute',
   'goToConversation',
   'dismiss',
+  'sendDigit',
 ]);
 
 const { t } = useI18n();
+const isKeypadOpen = ref(false);
+
+const toggleKeypad = () => {
+  isKeypadOpen.value = !isKeypadOpen.value;
+};
+
+watch(
+  () => props.showKeypad,
+  showKeypad => {
+    if (!showKeypad) isKeypadOpen.value = false;
+  }
+);
+
+watch(
+  () => props.call?.callSid,
+  () => {
+    isKeypadOpen.value = false;
+  }
+);
 
 const isOngoing = computed(() => props.state === VOICE_CALL_DIRECTION.ONGOING);
 const isIncoming = computed(
@@ -190,6 +215,28 @@ const channelIcon = computed(() => {
             @click="$emit('accept')"
           />
 
+          <NextButton
+            v-if="isOngoing && showKeypad"
+            v-tooltip.top="
+              isKeypadOpen
+                ? $t('CONVERSATION.VOICE_WIDGET.HIDE_KEYPAD')
+                : $t('CONVERSATION.VOICE_WIDGET.SHOW_KEYPAD')
+            "
+            icon="i-ph-dots-nine-bold"
+            :variant="isKeypadOpen ? 'solid' : 'faded'"
+            color="teal"
+            class="!rounded-full"
+            aria-controls="voice-call-keypad"
+            :aria-expanded="isKeypadOpen"
+            :aria-label="
+              isKeypadOpen
+                ? $t('CONVERSATION.VOICE_WIDGET.HIDE_KEYPAD')
+                : $t('CONVERSATION.VOICE_WIDGET.SHOW_KEYPAD')
+            "
+            data-test-id="voice-call-keypad-toggle"
+            @click="toggleKeypad"
+          />
+
           <!-- Reject / end call (all states) -->
           <NextButton
             v-tooltip.top="
@@ -205,6 +252,8 @@ const channelIcon = computed(() => {
         </div>
       </div>
     </div>
+
+    <CallKeypad v-if="isKeypadOpen" @digit="$emit('sendDigit', $event)" />
 
     <!-- Footer: go to conversation thread -->
     <NextButton

--- a/app/javascript/dashboard/components-next/call/CallKeypad.vue
+++ b/app/javascript/dashboard/components-next/call/CallKeypad.vue
@@ -1,0 +1,55 @@
+<script setup>
+import { useI18n } from 'vue-i18n';
+
+const emit = defineEmits(['digit']);
+const { t } = useI18n();
+
+const KEYS = [
+  { digit: '1', letters: '' },
+  { digit: '2', letters: 'ABC' },
+  { digit: '3', letters: 'DEF' },
+  { digit: '4', letters: 'GHI' },
+  { digit: '5', letters: 'JKL' },
+  { digit: '6', letters: 'MNO' },
+  { digit: '7', letters: 'PQRS' },
+  { digit: '8', letters: 'TUV' },
+  { digit: '9', letters: 'WXYZ' },
+  { digit: '*', letters: '' },
+  { digit: '0', letters: '' },
+  { digit: '#', letters: '' },
+];
+
+const getKeyLabel = digit => {
+  if (digit === '*') return t('CONVERSATION.VOICE_WIDGET.STAR');
+  if (digit === '#') return t('CONVERSATION.VOICE_WIDGET.POUND');
+  return digit;
+};
+</script>
+
+<template>
+  <div
+    id="voice-call-keypad"
+    role="group"
+    :aria-label="$t('CONVERSATION.VOICE_WIDGET.KEYPAD')"
+    class="grid grid-cols-3 gap-2 px-16 py-4 border-b border-n-call-widget-border"
+  >
+    <button
+      v-for="key in KEYS"
+      :key="key.digit"
+      type="button"
+      :aria-label="getKeyLabel(key.digit)"
+      :data-digit="key.digit"
+      data-test-id="voice-call-keypad-key"
+      class="flex flex-col items-center justify-center h-12 rounded-xl bg-n-alpha-2 text-n-call-widget-text hover:bg-n-alpha-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-n-teal-8"
+      @click="emit('digit', key.digit)"
+    >
+      <span class="text-base font-medium leading-none">{{ key.digit }}</span>
+      <span
+        v-if="key.letters"
+        class="mt-1 text-[9px] leading-none tracking-widest text-n-call-widget-sub-text"
+      >
+        {{ key.letters }}
+      </span>
+    </button>
+  </div>
+</template>

--- a/app/javascript/dashboard/components-next/call/FloatingCallWidget.vue
+++ b/app/javascript/dashboard/components-next/call/FloatingCallWidget.vue
@@ -2,8 +2,13 @@
 import { computed, onBeforeUnmount, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useStore } from 'vuex';
+import { useI18n } from 'vue-i18n';
+import { useAlert } from 'dashboard/composables';
 import { useCallSession } from 'dashboard/composables/useCallSession';
-import { setWhatsappCallMuted } from 'dashboard/composables/useWhatsappCallSession';
+import {
+  sendWhatsappDigits,
+  setWhatsappCallMuted,
+} from 'dashboard/composables/useWhatsappCallSession';
 import TwilioVoiceClient from 'dashboard/api/channel/voice/twilioVoiceClient';
 import { frontendURL, conversationUrl } from 'dashboard/helper/URLHelper';
 import { VOICE_CALL_PROVIDERS } from 'dashboard/helper/inbox';
@@ -17,6 +22,7 @@ const RINGTONE_URL = '/audio/dashboard/ringtone.mp3';
 const route = useRoute();
 const router = useRouter();
 const store = useStore();
+const { t } = useI18n();
 
 const {
   activeCall,
@@ -36,6 +42,26 @@ const isMuted = ref(false);
 const isWhatsappActive = computed(
   () => activeCall.value?.provider === VOICE_CALL_PROVIDERS.WHATSAPP
 );
+const showKeypad = computed(
+  () =>
+    activeCall.value?.provider === VOICE_CALL_PROVIDERS.TWILIO ||
+    isWhatsappActive.value
+);
+
+const handleSendDigit = digit => {
+  let sent;
+  if (activeCall.value?.provider === VOICE_CALL_PROVIDERS.TWILIO) {
+    sent = TwilioVoiceClient.sendDigits(digit);
+  } else if (isWhatsappActive.value) {
+    sent = sendWhatsappDigits(digit);
+  } else {
+    return;
+  }
+
+  if (!sent) {
+    useAlert(t('CONVERSATION.VOICE_WIDGET.KEYPAD_SEND_FAILED'));
+  }
+};
 
 const primaryIncomingCall = computed(() =>
   hasActiveCall.value ? null : incomingCalls.value[0] || null
@@ -262,11 +288,13 @@ onBeforeUnmount(stopRingtone);
       :duration="hasActiveCall ? formattedCallDuration : ''"
       :is-muted="isMuted"
       :show-mute="hasActiveCall"
+      :show-keypad="showKeypad"
       @accept="handleJoinCall(primaryIncomingCall)"
       @reject="rejectIncomingCall(primaryIncomingCall?.callSid)"
       @dismiss="dismissCall(primaryIncomingCall?.callSid)"
       @end="handleEndCall"
       @toggle-mute="toggleMute"
+      @send-digit="handleSendDigit"
       @go-to-conversation="goToConversation(activeCall || primaryIncomingCall)"
     />
   </div>

--- a/app/javascript/dashboard/components-next/call/specs/CallCard.spec.js
+++ b/app/javascript/dashboard/components-next/call/specs/CallCard.spec.js
@@ -1,0 +1,91 @@
+import { mount } from '@vue/test-utils';
+import { VOICE_CALL_DIRECTION } from 'dashboard/components-next/message/constants';
+import CallCard from '../CallCard.vue';
+
+const callInfo = {
+  contactName: 'Apartment intercom',
+  phoneNumber: '+16045550198',
+  location: 'Vancouver, Canada',
+  countryFlag: '',
+  hasLocation: false,
+  avatar: '',
+};
+
+const mountCard = (props = {}) =>
+  mount(CallCard, {
+    props: {
+      call: { callSid: 'CA123', conversationId: 42, provider: 'twilio' },
+      callInfo,
+      state: VOICE_CALL_DIRECTION.ONGOING,
+      showKeypad: true,
+      ...props,
+    },
+    global: {
+      stubs: { Avatar: true, Icon: true },
+    },
+  });
+
+describe('CallCard keypad', () => {
+  it('starts collapsed and toggles the inline keypad', async () => {
+    const wrapper = mountCard();
+    const toggle = wrapper.find('[data-test-id="voice-call-keypad-toggle"]');
+
+    expect(toggle.exists()).toBe(true);
+    expect(toggle.attributes('aria-controls')).toBe('voice-call-keypad');
+    expect(toggle.attributes('aria-expanded')).toBe('false');
+    expect(toggle.attributes('aria-label')).toBe('Show keypad');
+    expect(wrapper.find('#voice-call-keypad').exists()).toBe(false);
+
+    await toggle.trigger('click');
+
+    expect(toggle.attributes('aria-expanded')).toBe('true');
+    expect(toggle.attributes('aria-label')).toBe('Hide keypad');
+    expect(wrapper.find('#voice-call-keypad').exists()).toBe(true);
+  });
+
+  it('forwards clicked digits', async () => {
+    const wrapper = mountCard();
+    await wrapper
+      .find('[data-test-id="voice-call-keypad-toggle"]')
+      .trigger('click');
+    await wrapper.find('[data-digit="9"]').trigger('click');
+
+    expect(wrapper.emitted('sendDigit')).toEqual([['9']]);
+  });
+
+  it('hides and resets the keypad when availability becomes false', async () => {
+    const wrapper = mountCard();
+    await wrapper
+      .find('[data-test-id="voice-call-keypad-toggle"]')
+      .trigger('click');
+
+    await wrapper.setProps({ showKeypad: false });
+    expect(
+      wrapper.find('[data-test-id="voice-call-keypad-toggle"]').exists()
+    ).toBe(false);
+
+    await wrapper.setProps({ showKeypad: true });
+    expect(wrapper.find('#voice-call-keypad').exists()).toBe(false);
+  });
+
+  it('resets the keypad when the call changes', async () => {
+    const wrapper = mountCard();
+    await wrapper
+      .find('[data-test-id="voice-call-keypad-toggle"]')
+      .trigger('click');
+
+    await wrapper.setProps({
+      call: { callSid: 'CA456', conversationId: 42, provider: 'twilio' },
+    });
+
+    expect(wrapper.find('#voice-call-keypad').exists()).toBe(false);
+  });
+
+  it('does not expose the keypad outside an ongoing call', () => {
+    const wrapper = mountCard({ state: VOICE_CALL_DIRECTION.INCOMING });
+
+    expect(
+      wrapper.find('[data-test-id="voice-call-keypad-toggle"]').exists()
+    ).toBe(false);
+  });
+});

--- a/app/javascript/dashboard/components-next/call/specs/CallKeypad.spec.js
+++ b/app/javascript/dashboard/components-next/call/specs/CallKeypad.spec.js
@@ -1,0 +1,61 @@
+import { mount } from '@vue/test-utils';
+import CallKeypad from '../CallKeypad.vue';
+
+const mountKeypad = () => mount(CallKeypad);
+
+describe('CallKeypad', () => {
+  it('renders the twelve telephone keys in standard order', () => {
+    const wrapper = mountKeypad();
+    const keys = wrapper.findAll('[data-test-id="voice-call-keypad-key"]');
+
+    expect(keys).toHaveLength(12);
+    expect(keys.map(key => key.attributes('data-digit'))).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '*',
+      '0',
+      '#',
+    ]);
+    keys.forEach(key => expect(key.element.tagName).toBe('BUTTON'));
+  });
+
+  it('emits one digit when a visible key is clicked', async () => {
+    const wrapper = mountKeypad();
+
+    await wrapper.find('[data-digit="9"]').trigger('click');
+    await wrapper.find('[data-digit="#"]').trigger('click');
+
+    expect(wrapper.emitted('digit')).toEqual([['9'], ['#']]);
+  });
+
+  it('provides accessible labels without changing button behavior', () => {
+    const wrapper = mountKeypad();
+    const keypad = wrapper.find('#voice-call-keypad');
+    const keys = wrapper.findAll('[data-test-id="voice-call-keypad-key"]');
+
+    expect(keypad.attributes('role')).toBe('group');
+    expect(keypad.attributes('aria-label')).toBe('Call keypad');
+    expect(wrapper.find('[data-digit="*"]').attributes('aria-label')).toBe(
+      'Star'
+    );
+    expect(wrapper.find('[data-digit="#"]').attributes('aria-label')).toBe(
+      'Pound'
+    );
+    keys.forEach(key => expect(key.attributes('type')).toBe('button'));
+  });
+
+  it('does not emit digits from keyboard events', async () => {
+    const wrapper = mountKeypad();
+
+    await wrapper.trigger('keydown', { key: '9' });
+
+    expect(wrapper.emitted('digit')).toBeUndefined();
+  });
+});

--- a/app/javascript/dashboard/components-next/call/specs/FloatingCallWidget.spec.js
+++ b/app/javascript/dashboard/components-next/call/specs/FloatingCallWidget.spec.js
@@ -1,0 +1,178 @@
+import { computed, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import { VOICE_CALL_PROVIDERS } from 'dashboard/helper/inbox';
+import CallCard from '../CallCard.vue';
+
+const mocks = vi.hoisted(() => ({
+  activeCall: null,
+  sendDigits: vi.fn(),
+  sendWhatsappDigits: vi.fn(),
+  useAlert: vi.fn(),
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { accountId: '1' } }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('vuex', () => ({
+  useStore: () => ({
+    getters: {
+      getConversationById: vi.fn(() => ({
+        inbox_id: 7,
+        meta: {
+          sender: {
+            name: 'Apartment intercom',
+            phone_number: '+16045550198',
+          },
+        },
+      })),
+      'inboxes/getInbox': vi.fn(() => ({ name: 'Voice' })),
+    },
+  }),
+}));
+
+vi.mock('dashboard/composables', () => ({
+  useAlert: mocks.useAlert,
+}));
+
+vi.mock('dashboard/composables/useCallSession', () => ({
+  useCallSession: () => ({
+    activeCall: computed(() => mocks.activeCall),
+    incomingCalls: ref([]),
+    hasActiveCall: computed(() => Boolean(mocks.activeCall)),
+    isJoining: ref(false),
+    joinCall: vi.fn(),
+    endCall: vi.fn(),
+    rejectIncomingCall: vi.fn(),
+    dismissCall: vi.fn(),
+    formattedCallDuration: ref('00:42'),
+  }),
+}));
+
+vi.mock('dashboard/composables/useWhatsappCallSession', () => ({
+  sendWhatsappDigits: mocks.sendWhatsappDigits,
+  setWhatsappCallMuted: vi.fn(),
+}));
+
+vi.mock('dashboard/api/channel/voice/twilioVoiceClient', () => ({
+  default: {
+    sendDigits: mocks.sendDigits,
+    setMuted: vi.fn(),
+  },
+}));
+
+import FloatingCallWidget from '../FloatingCallWidget.vue';
+
+const activeCall = provider => ({
+  callSid: 'CA123',
+  conversationId: 42,
+  inboxId: 7,
+  ...(provider ? { provider } : {}),
+  isActive: true,
+});
+
+const mountWidget = () =>
+  mount(FloatingCallWidget, {
+    global: {
+      stubs: { Avatar: true, Icon: true },
+    },
+  });
+
+describe('FloatingCallWidget keypad', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+    mocks.activeCall = activeCall(VOICE_CALL_PROVIDERS.TWILIO);
+    mocks.sendDigits.mockReturnValue(true);
+    mocks.sendWhatsappDigits.mockReturnValue(true);
+  });
+
+  it('exposes the keypad and routes digits only to Twilio for an active Twilio call', async () => {
+    const wrapper = mountWidget();
+    const keypadToggle = wrapper.find(
+      '[data-test-id="voice-call-keypad-toggle"]'
+    );
+
+    expect(keypadToggle.exists()).toBe(true);
+
+    await keypadToggle.trigger('click');
+    await wrapper.find('[data-digit="9"]').trigger('click');
+
+    expect(mocks.sendDigits).toHaveBeenCalledWith('9');
+    expect(mocks.sendWhatsappDigits).not.toHaveBeenCalled();
+  });
+
+  it('exposes the keypad and routes digits only to WhatsApp for an active WhatsApp call', async () => {
+    mocks.activeCall = activeCall(VOICE_CALL_PROVIDERS.WHATSAPP);
+    const wrapper = mountWidget();
+    const keypadToggle = wrapper.find(
+      '[data-test-id="voice-call-keypad-toggle"]'
+    );
+
+    expect(keypadToggle.exists()).toBe(true);
+
+    await keypadToggle.trigger('click');
+    await wrapper.find('[data-digit="3"]').trigger('click');
+
+    expect(mocks.sendWhatsappDigits).toHaveBeenCalledWith('3');
+    expect(mocks.sendDigits).not.toHaveBeenCalled();
+  });
+
+  it('does not expose the keypad for an unsupported provider', () => {
+    mocks.activeCall = activeCall('unsupported');
+    const wrapper = mountWidget();
+
+    expect(
+      wrapper.find('[data-test-id="voice-call-keypad-toggle"]').exists()
+    ).toBe(false);
+  });
+
+  it.each([
+    { providerName: 'unsupported', provider: 'unsupported' },
+    { providerName: 'missing', provider: undefined },
+  ])(
+    'does not route digits for a $providerName provider',
+    async ({ provider }) => {
+      mocks.activeCall = activeCall(provider);
+      const wrapper = mountWidget();
+
+      expect(
+        wrapper.find('[data-test-id="voice-call-keypad-toggle"]').exists()
+      ).toBe(false);
+
+      wrapper.findComponent(CallCard).vm.$emit('sendDigit', '5');
+      await wrapper.vm.$nextTick();
+
+      expect(mocks.sendDigits).not.toHaveBeenCalled();
+      expect(mocks.sendWhatsappDigits).not.toHaveBeenCalled();
+      expect(mocks.useAlert).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    {
+      providerName: 'Twilio',
+      provider: VOICE_CALL_PROVIDERS.TWILIO,
+      sendMethod: 'sendDigits',
+    },
+    {
+      providerName: 'WhatsApp',
+      provider: VOICE_CALL_PROVIDERS.WHATSAPP,
+      sendMethod: 'sendWhatsappDigits',
+    },
+  ])(
+    'alerts when the $providerName connection cannot send the digit',
+    async ({ provider, sendMethod }) => {
+      mocks.activeCall = activeCall(provider);
+      mocks[sendMethod].mockReturnValue(false);
+      const wrapper = mountWidget();
+      await wrapper
+        .find('[data-test-id="voice-call-keypad-toggle"]')
+        .trigger('click');
+      await wrapper.find('[data-digit="#"]').trigger('click');
+
+      expect(mocks.useAlert).toHaveBeenCalledOnce();
+      expect(mocks.useAlert).toHaveBeenCalledWith('Could not send keypad tone');
+    }
+  );
+});

--- a/app/javascript/dashboard/components-next/call/specs/TwilioCallProducers.spec.js
+++ b/app/javascript/dashboard/components-next/call/specs/TwilioCallProducers.spec.js
@@ -1,0 +1,176 @@
+import { ref } from 'vue';
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { VOICE_CALL_PROVIDERS, INBOX_TYPES } from 'dashboard/helper/inbox';
+import {
+  MESSAGE_TYPES,
+  VOICE_CALL_DIRECTION,
+  VOICE_CALL_STATUS,
+} from 'dashboard/components-next/message/constants';
+import { useCallsStore } from 'dashboard/stores/calls';
+import ConversationCallButton from 'dashboard/components/widgets/conversation/ConversationCallButton.vue';
+import VoiceCallButton from 'dashboard/components-next/Contacts/VoiceCallButton.vue';
+import VoiceCall from 'dashboard/components-next/message/bubbles/VoiceCall.vue';
+
+const mocks = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  inboxes: [],
+  messageContext: null,
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { accountId: '1' } }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('vuex', () => ({
+  useStore: () => ({
+    dispatch: mocks.dispatch,
+    getters: {
+      getConversationById: vi.fn(() => ({ meta: { assignee: null } })),
+      'agents/getAgentById': vi.fn(),
+    },
+  }),
+}));
+
+vi.mock('dashboard/composables/store', () => ({
+  useStore: () => ({
+    dispatch: mocks.dispatch,
+    getters: {
+      getConversationById: vi.fn(),
+    },
+  }),
+  useMapGetter: key => {
+    const values = {
+      'contacts/getUIFlags': {},
+      'inboxes/getInboxes': mocks.inboxes,
+    };
+    return { value: values[key] };
+  },
+}));
+
+vi.mock('dashboard/composables/useAccount', () => ({
+  useAccount: () => ({ isCloudFeatureEnabled: () => true }),
+}));
+
+vi.mock('dashboard/composables', () => ({ useAlert: vi.fn() }));
+
+vi.mock('dashboard/composables/useWhatsappCallSession', () => ({
+  cleanupWhatsappSession: vi.fn(),
+  useWhatsappCallSession: () => ({
+    isInitiating: ref(false),
+    initiateOutboundCall: vi.fn(),
+  }),
+}));
+
+vi.mock('dashboard/api/channel/voice/twilioVoiceClient', () => ({
+  default: { endClientCall: vi.fn() },
+}));
+
+vi.mock('dashboard/composables/useCallSession', () => ({
+  useCallActions: () => ({
+    activeCall: ref(null),
+    hasActiveCall: ref(false),
+    isJoining: ref(false),
+    joinCall: vi.fn(),
+    endCall: vi.fn(),
+  }),
+}));
+
+vi.mock('dashboard/components-next/message/provider.js', () => ({
+  useMessageContext: () => mocks.messageContext,
+}));
+
+const twilioInbox = {
+  id: 7,
+  name: 'Support line',
+  channel_type: INBOX_TYPES.TWILIO,
+  voice_enabled: true,
+  phone_number: '+16045550198',
+};
+
+const twilioResponse = {
+  call_sid: 'CA123',
+  conversation_id: 42,
+};
+
+const expectNormalizedTwilioCall = callsStore => {
+  callsStore.setCallActive(twilioResponse.call_sid);
+
+  expect(callsStore.activeCall).toEqual({
+    callSid: twilioResponse.call_sid,
+    conversationId: twilioResponse.conversation_id,
+    inboxId: twilioInbox.id,
+    callDirection: VOICE_CALL_DIRECTION.OUTBOUND,
+    provider: VOICE_CALL_PROVIDERS.TWILIO,
+    isActive: true,
+  });
+};
+
+describe('outbound Twilio call producers', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mocks.inboxes = [twilioInbox];
+    mocks.dispatch.mockResolvedValue(twilioResponse);
+    mocks.messageContext = {
+      call: ref({
+        status: VOICE_CALL_STATUS.NO_ANSWER,
+        direction: VOICE_CALL_DIRECTION.INCOMING,
+        provider: VOICE_CALL_PROVIDERS.TWILIO,
+      }),
+      attachments: ref([]),
+      contentAttributes: ref({}),
+      conversationId: ref(twilioResponse.conversation_id),
+      currentUserId: ref(1),
+      inboxId: ref(twilioInbox.id),
+      sender: ref({ id: 99 }),
+      messageType: ref(MESSAGE_TYPES.INCOMING),
+    };
+  });
+
+  it('retains the Twilio provider when started from the conversation header', async () => {
+    const callsStore = useCallsStore();
+    const wrapper = shallowMount(ConversationCallButton, {
+      props: {
+        inbox: twilioInbox,
+        chat: {
+          id: twilioResponse.conversation_id,
+          meta: { sender: { id: 99 } },
+        },
+      },
+    });
+
+    await wrapper.get('button').trigger('click');
+    await flushPromises();
+
+    expectNormalizedTwilioCall(callsStore);
+  });
+
+  it('retains the Twilio provider when started from a contact', async () => {
+    const callsStore = useCallsStore();
+    const wrapper = shallowMount(VoiceCallButton, {
+      props: { phone: '+16045550198', contactId: 99 },
+    });
+
+    await wrapper.findComponent({ name: 'Button' }).trigger('click');
+    await flushPromises();
+
+    expectNormalizedTwilioCall(callsStore);
+  });
+
+  it('retains the Twilio provider when calling back from a message bubble', async () => {
+    const callsStore = useCallsStore();
+    const wrapper = shallowMount(VoiceCall, {
+      global: {
+        stubs: {
+          BaseBubble: { template: '<div><slot /></div>' },
+        },
+      },
+    });
+
+    await wrapper.get('button').trigger('click');
+    await flushPromises();
+
+    expectNormalizedTwilioCall(callsStore);
+  });
+});

--- a/app/javascript/dashboard/components-next/message/bubbles/VoiceCall.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/VoiceCall.vue
@@ -297,6 +297,7 @@ const handleCallBack = async () => {
       conversationId: response?.conversation_id ?? conversationId.value,
       inboxId: inboxId.value,
       callDirection: VOICE_CALL_DIRECTION.OUTBOUND,
+      provider: VOICE_CALL_PROVIDERS.TWILIO,
     });
   } catch (error) {
     useAlert(error?.message || t('CONTACT_PANEL.CALL_FAILED'));

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationCallButton.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationCallButton.vue
@@ -116,6 +116,7 @@ const startTwilioCall = async () => {
       conversationId: response?.conversation_id ?? props.chat.id,
       inboxId: props.inbox?.id,
       callDirection: VOICE_CALL_DIRECTION.OUTBOUND,
+      provider: VOICE_CALL_PROVIDERS.TWILIO,
     });
   } catch (error) {
     useAlert(error?.message || t('CONVERSATION.HEADER.VOICE_CALL_FAILED'));

--- a/app/javascript/dashboard/composables/spec/useWhatsappCallSession.spec.js
+++ b/app/javascript/dashboard/composables/spec/useWhatsappCallSession.spec.js
@@ -1,0 +1,138 @@
+import {
+  cleanupWhatsappSession,
+  sendWhatsappDigits,
+  useWhatsappCallSession,
+} from '../useWhatsappCallSession';
+
+describe('sendWhatsappDigits', () => {
+  let peerConnection;
+
+  beforeEach(() => {
+    const localTrack = { stop: vi.fn() };
+    const localStream = {
+      getTracks: vi.fn(() => [localTrack]),
+    };
+    const remoteStream = {
+      addTrack: vi.fn(),
+      getAudioTracks: vi.fn(() => []),
+      getTracks: vi.fn(() => []),
+    };
+
+    peerConnection = {
+      addTrack: vi.fn(),
+      close: vi.fn(),
+      createOffer: vi.fn().mockResolvedValue({ type: 'offer', sdp: 'offer' }),
+      getSenders: vi.fn(() => []),
+      iceGatheringState: 'complete',
+      localDescription: null,
+      setLocalDescription: vi.fn(async description => {
+        peerConnection.localDescription = description;
+      }),
+    };
+
+    vi.stubGlobal(
+      'MediaStream',
+      vi.fn(() => remoteStream)
+    );
+    vi.stubGlobal(
+      'RTCPeerConnection',
+      vi.fn(() => peerConnection)
+    );
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(localStream),
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanupWhatsappSession();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns false when there is no peer connection', () => {
+    expect(sendWhatsappDigits('9')).toBe(false);
+  });
+
+  it('returns false when there is no audio sender and ignores video senders', async () => {
+    const insertDTMF = vi.fn();
+    peerConnection.getSenders.mockReturnValue([
+      {
+        track: { kind: 'video' },
+        dtmf: { canInsertDTMF: true, insertDTMF, toneBuffer: '' },
+      },
+    ]);
+    await useWhatsappCallSession().prepareOutboundOffer();
+
+    expect(sendWhatsappDigits('9')).toBe(false);
+    expect(insertDTMF).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the audio sender has no DTMF support', async () => {
+    peerConnection.getSenders.mockReturnValue([{ track: { kind: 'audio' } }]);
+    await useWhatsappCallSession().prepareOutboundOffer();
+
+    expect(sendWhatsappDigits('*')).toBe(false);
+  });
+
+  it('returns false when the audio sender cannot insert DTMF', async () => {
+    const insertDTMF = vi.fn();
+    peerConnection.getSenders.mockReturnValue([
+      {
+        track: { kind: 'audio' },
+        dtmf: { canInsertDTMF: false, insertDTMF },
+      },
+    ]);
+    await useWhatsappCallSession().prepareOutboundOffer();
+
+    expect(sendWhatsappDigits('*')).toBe(false);
+    expect(insertDTMF).not.toHaveBeenCalled();
+  });
+
+  it('appends a digit to buffered tones and inserts it once', async () => {
+    const insertDTMF = vi.fn();
+    peerConnection.getSenders.mockReturnValue([
+      {
+        track: { kind: 'audio' },
+        dtmf: { canInsertDTMF: true, insertDTMF, toneBuffer: '12' },
+      },
+    ]);
+    await useWhatsappCallSession().prepareOutboundOffer();
+
+    expect(sendWhatsappDigits('#')).toBe(true);
+    expect(insertDTMF).toHaveBeenCalledOnce();
+    expect(insertDTMF).toHaveBeenCalledWith('12#', 500, 100);
+  });
+
+  it('returns false when insertion loses the WebRTC state race', async () => {
+    const insertDTMF = vi.fn(() => {
+      throw new DOMException('Peer connection closed', 'InvalidStateError');
+    });
+    peerConnection.getSenders.mockReturnValue([
+      {
+        track: { kind: 'audio' },
+        dtmf: { canInsertDTMF: true, insertDTMF, toneBuffer: '' },
+      },
+    ]);
+    await useWhatsappCallSession().prepareOutboundOffer();
+
+    expect(sendWhatsappDigits('0')).toBe(false);
+    expect(insertDTMF).toHaveBeenCalledOnce();
+  });
+
+  it('rethrows unrelated insertion errors', async () => {
+    const insertionError = new Error('DTMF device failure');
+    const insertDTMF = vi.fn(() => {
+      throw insertionError;
+    });
+    peerConnection.getSenders.mockReturnValue([
+      {
+        track: { kind: 'audio' },
+        dtmf: { canInsertDTMF: true, insertDTMF, toneBuffer: '' },
+      },
+    ]);
+    await useWhatsappCallSession().prepareOutboundOffer();
+
+    expect(() => sendWhatsappDigits('5')).toThrow(insertionError);
+  });
+});

--- a/app/javascript/dashboard/composables/useWhatsappCallSession.js
+++ b/app/javascript/dashboard/composables/useWhatsappCallSession.js
@@ -445,6 +445,23 @@ export const setWhatsappCallMuted = muted => {
   return muted;
 };
 
+export const sendWhatsappDigits = digit => {
+  if (!pc) return false;
+  const audioSender = pc
+    .getSenders()
+    .find(sender => sender.track?.kind === 'audio');
+  const dtmf = audioSender?.dtmf;
+  if (!dtmf?.canInsertDTMF) return false;
+
+  try {
+    dtmf.insertDTMF(`${dtmf.toneBuffer}${digit}`, 500, 100);
+    return true;
+  } catch (error) {
+    if (error.name === 'InvalidStateError') return false;
+    throw error;
+  }
+};
+
 export const sendWhatsappTerminateBeacon = () => {
   // Always fire when there's a live callId. The beacon endpoint is idempotent,
   // so racing it with an in-flight Axios terminate (which unload may abort) is

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -343,6 +343,12 @@
       "END_CALL": "End call",
       "MUTE": "Mute mic",
       "UNMUTE": "Unmute mic",
+      "SHOW_KEYPAD": "Show keypad",
+      "HIDE_KEYPAD": "Hide keypad",
+      "KEYPAD": "Call keypad",
+      "STAR": "Star",
+      "POUND": "Pound",
+      "KEYPAD_SEND_FAILED": "Could not send keypad tone",
       "VIEW_CHAT_HISTORY": "View chat history",
       "GO_TO_CONVERSATION": "Go to conversation thread"
     }


### PR DESCRIPTION
Adds a collapsible in-call keypad to the floating call card so agents can navigate IVRs and enter digits during active Twilio and WhatsApp calls. The control appears only after a supported call is connected, stays collapsed by default, and keeps the existing call controls intact.

### Closes

- Closes https://github.com/chatwoot/chatwoot/issues/15012

### How to test

1. Start and connect an outbound Twilio call.
2. Confirm the keypad button appears only once the call is active and that the keypad is collapsed by default.
3. Expand the keypad and use it to send digits to an IVR, including `*` and `#`.
4. Repeat with an active WhatsApp call.
5. Confirm ringing calls and unsupported providers do not show the keypad.
6. End the call and confirm the existing caller, duration, mute, hang-up, and conversation controls continue to behave normally.

### What changed

- Added a shared accessible 3-by-4 keypad and provider-neutral call-card disclosure.
- Routed Twilio digits through the active Voice SDK call and WhatsApp digits through WebRTC DTMF.
- Normalized outbound Twilio call records so provider-aware routing is available immediately.
- Added focused coverage for transport guards, provider isolation, disclosure state, accessibility, and outbound call producers.

@tds-1, could you review this?
