### PR TITLE
fix(captain): keep custom tools available in Captain V2

### DIFF
--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -98,7 +98,8 @@ class Captain::Assistant < ApplicationRecord
   def agent_tools
     [
       self.class.resolve_tool_class('faq_lookup').new(self),
-      self.class.resolve_tool_class('handoff').new(self)
+      self.class.resolve_tool_class('handoff').new(self),
+      *account.captain_custom_tools.enabled.map { |custom_tool| custom_tool.tool(self) }
     ]
   end
 

--- a/spec/enterprise/models/captain/assistant_spec.rb
+++ b/spec/enterprise/models/captain/assistant_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Captain::Assistant do
+  describe '#agent_tools' do
+    let(:account) { create(:account) }
+    let(:assistant) { create(:captain_assistant, account: account) }
+
+    it 'includes enabled custom tools from the assistant account' do
+      custom_tool = create(:captain_custom_tool, account: account)
+
+      tools = assistant.send(:agent_tools)
+
+      expect(tools.map(&:name)).to include(custom_tool.slug)
+      expect(tools.find { |tool| tool.name == custom_tool.slug }).to be_a(Captain::Tools::HttpTool)
+    end
+
+    it 'excludes disabled custom tools' do
+      custom_tool = create(:captain_custom_tool, :disabled, account: account)
+
+      tools = assistant.send(:agent_tools)
+
+      expect(tools.map(&:name)).not_to include(custom_tool.slug)
+    end
+
+    it 'excludes custom tools from other accounts' do
+      custom_tool = create(:captain_custom_tool)
+
+      tools = assistant.send(:agent_tools)
+
+      expect(tools.map(&:name)).not_to include(custom_tool.slug)
+    end
+
+    it 'keeps the built-in FAQ lookup and handoff tools' do
+      tools = assistant.send(:agent_tools)
+
+      expect(tools).to include(
+        an_instance_of(Captain::Tools::FaqLookupTool),
+        an_instance_of(Captain::Tools::HandoffTool)
+      )
+    end
+  end
+end


### PR DESCRIPTION
Captain V2 assistants can now use every enabled custom tool from their account through the main assistant. The change keeps existing custom tool access when an assistant has no migrated scenarios, so switching from V1 does not remove the capability without warning.

## How to reproduce

1. Create and enable an account custom tool.
2. Use an assistant with no custom instructions and no generated scenarios.
3. Enable Captain V2 for the account.
4. Before this change, the main assistant receives only FAQ lookup and handoff. After this change, it also receives the enabled account custom tool.

## What changed

The main V2 assistant now loads enabled custom tools through its account association. Scenario agents still load only the tools named in their scenario instructions. The account custom tool limit keeps the added tool count bounded.

Focused model coverage verifies enabled tools, disabled tools, account isolation, FAQ lookup, and handoff. Existing V1 assistant, V2 scenario, and V2 runner coverage passes. RuboCop passes.