### PR TITLE
feat(captain): apply migrated FAQs as approved

### DIFF
--- a/enterprise/app/services/captain/assistant_migration/draft_applier.rb
+++ b/enterprise/app/services/captain/assistant_migration/draft_applier.rb
@@ -24,13 +24,15 @@ class Captain::AssistantMigration::DraftApplier
       description: description_change,
       response_guidelines: array_change(:response_guidelines, response_guidelines),
       guardrails: array_change(:guardrails, guardrails),
-      config: config_change
+      config: config_change,
+      faq_responses: faq_responses_change
     }.compact
   end
 
   def apply_changes(changes)
     assistant.transaction do
       assistant.update!(assistant_update_attributes(changes)) if assistant_update_attributes(changes).present?
+      apply_faq_response_changes(changes[:faq_responses]) if changes[:faq_responses].present?
     end
   end
 
@@ -142,6 +144,21 @@ class Captain::AssistantMigration::DraftApplier
 
   def scenario_response_guidelines
     scenario_candidates.filter_map { |candidate| candidate[:response_guideline].presence }
+  end
+
+  def faq_responses_change
+    faq_materializer.changes
+  end
+
+  def apply_faq_response_changes(changes)
+    faq_materializer.apply(changes)
+  end
+
+  def faq_materializer
+    @faq_materializer ||= Captain::AssistantMigration::FaqMaterializer.new(
+      assistant: assistant,
+      candidates: normalized_faq_document_candidates
+    )
   end
 
   def scenario_tool_ids(tool_ids)

--- a/enterprise/app/services/captain/assistant_migration/draft_applier.rb
+++ b/enterprise/app/services/captain/assistant_migration/draft_applier.rb
@@ -147,15 +147,15 @@ class Captain::AssistantMigration::DraftApplier
   end
 
   def faq_responses_change
-    faq_materializer.changes
+    faq_applier.changes
   end
 
   def apply_faq_response_changes(changes)
-    faq_materializer.apply(changes)
+    faq_applier.apply(changes)
   end
 
-  def faq_materializer
-    @faq_materializer ||= Captain::AssistantMigration::FaqMaterializer.new(
+  def faq_applier
+    @faq_applier ||= Captain::AssistantMigration::FaqApplier.new(
       assistant: assistant,
       candidates: normalized_faq_document_candidates
     )

--- a/enterprise/app/services/captain/assistant_migration/draft_applier.rb
+++ b/enterprise/app/services/captain/assistant_migration/draft_applier.rb
@@ -203,7 +203,7 @@ class Captain::AssistantMigration::DraftApplier
 
       candidate = candidate.deep_symbolize_keys
       question = candidate[:question].to_s.squish
-      answer = candidate[:answer].to_s.squish
+      answer = candidate[:answer].to_s.strip
       raise ArgumentError, 'FAQ document candidates must include a question and answer' if question.blank? || answer.blank?
 
       { 'question' => question, 'answer' => answer }

--- a/enterprise/app/services/captain/assistant_migration/faq_applier.rb
+++ b/enterprise/app/services/captain/assistant_migration/faq_applier.rb
@@ -16,16 +16,20 @@ class Captain::AssistantMigration::FaqApplier
   private
 
   def categorize(candidate, result)
-    existing_responses = assistant.responses.approved.where(question: candidate['question']).to_a
-    ensure_no_conflict!(candidate, existing_responses)
+    existing_answers = assistant.responses.approved.where(question: candidate['question']).pluck(:answer)
+    planned_answers = result[:create].filter_map do |response|
+      response['answer'] if response['question'] == candidate['question']
+    end
+    answers = existing_answers + planned_answers
 
-    return if existing_responses.any? { |response| response.answer == candidate['answer'] }
+    ensure_no_conflict!(candidate, answers)
+    return if answers.include?(candidate['answer'])
 
     result[:create] << candidate.merge('status' => 'approved')
   end
 
-  def ensure_no_conflict!(candidate, existing_responses)
-    return if existing_responses.all? { |response| response.answer == candidate['answer'] }
+  def ensure_no_conflict!(candidate, answers)
+    return if answers.all?(candidate['answer'])
 
     raise ArgumentError, "FAQ candidate conflicts with an existing FAQ: #{candidate['question']}"
   end

--- a/enterprise/app/services/captain/assistant_migration/faq_applier.rb
+++ b/enterprise/app/services/captain/assistant_migration/faq_applier.rb
@@ -2,16 +2,12 @@ class Captain::AssistantMigration::FaqApplier
   pattr_initialize [:assistant!, :candidates!]
 
   def changes
-    @changes ||= candidates.each_with_object({ create: [], approve: [] }) do |candidate, result|
+    @changes ||= candidates.each_with_object({ create: [] }) do |candidate, result|
       categorize(candidate, result)
     end.compact_blank.presence
   end
 
   def apply(changes)
-    Array(changes[:approve]).each do |candidate|
-      assistant.responses.find(candidate[:id]).update!(status: :approved)
-    end
-
     Array(changes[:create]).each do |candidate|
       assistant.responses.create!(candidate.slice('question', 'answer', 'status'))
     end
@@ -20,12 +16,10 @@ class Captain::AssistantMigration::FaqApplier
   private
 
   def categorize(candidate, result)
-    existing_responses = assistant.responses.where(question: candidate['question']).to_a
+    existing_responses = assistant.responses.approved.where(question: candidate['question']).to_a
     ensure_no_conflict!(candidate, existing_responses)
 
-    existing_response = existing_responses.find { |response| response.answer == candidate['answer'] }
-    return result[:approve] << approval_change(existing_response) if existing_response&.pending?
-    return if existing_response
+    return if existing_responses.any? { |response| response.answer == candidate['answer'] }
 
     result[:create] << candidate.merge('status' => 'approved')
   end
@@ -34,9 +28,5 @@ class Captain::AssistantMigration::FaqApplier
     return if existing_responses.all? { |response| response.answer == candidate['answer'] }
 
     raise ArgumentError, "FAQ candidate conflicts with an existing FAQ: #{candidate['question']}"
-  end
-
-  def approval_change(response)
-    { id: response.id, question: response.question, answer: response.answer }
   end
 end

--- a/enterprise/app/services/captain/assistant_migration/faq_applier.rb
+++ b/enterprise/app/services/captain/assistant_migration/faq_applier.rb
@@ -1,4 +1,4 @@
-class Captain::AssistantMigration::FaqMaterializer
+class Captain::AssistantMigration::FaqApplier
   pattr_initialize [:assistant!, :candidates!]
 
   def changes

--- a/enterprise/app/services/captain/assistant_migration/faq_materializer.rb
+++ b/enterprise/app/services/captain/assistant_migration/faq_materializer.rb
@@ -1,0 +1,42 @@
+class Captain::AssistantMigration::FaqMaterializer
+  pattr_initialize [:assistant!, :candidates!]
+
+  def changes
+    @changes ||= candidates.each_with_object({ create: [], approve: [] }) do |candidate, result|
+      categorize(candidate, result)
+    end.compact_blank.presence
+  end
+
+  def apply(changes)
+    Array(changes[:approve]).each do |candidate|
+      assistant.responses.find(candidate[:id]).update!(status: :approved)
+    end
+
+    Array(changes[:create]).each do |candidate|
+      assistant.responses.create!(candidate.slice('question', 'answer', 'status'))
+    end
+  end
+
+  private
+
+  def categorize(candidate, result)
+    existing_responses = assistant.responses.where(question: candidate['question']).to_a
+    ensure_no_conflict!(candidate, existing_responses)
+
+    existing_response = existing_responses.find { |response| response.answer == candidate['answer'] }
+    return result[:approve] << approval_change(existing_response) if existing_response&.pending?
+    return if existing_response
+
+    result[:create] << candidate.merge('status' => 'approved')
+  end
+
+  def ensure_no_conflict!(candidate, existing_responses)
+    return if existing_responses.all? { |response| response.answer == candidate['answer'] }
+
+    raise ArgumentError, "FAQ candidate conflicts with an existing FAQ: #{candidate['question']}"
+  end
+
+  def approval_change(response)
+    { id: response.id, question: response.question, answer: response.answer }
+  end
+end

--- a/enterprise/app/services/captain/assistant_migration/instruction_classifier_schema.rb
+++ b/enterprise/app/services/captain/assistant_migration/instruction_classifier_schema.rb
@@ -68,8 +68,8 @@ class Captain::AssistantMigration::InstructionClassifierSchema < RubyLLM::Schema
   end
 
   array :faq_document_candidates,
-        description: 'Pending FAQ candidates for factual or product-specific knowledge such as pricing, policy, setup, troubleshooting, ' \
-                     'or operational details. These candidates remain inactive until reviewed and approved.',
+        description: 'FAQ candidates for reusable query-dependent facts such as pricing, policy, setup, troubleshooting, ' \
+                     'or operational details.',
         max_items: 25 do
     object do
       string :question,

--- a/enterprise/lib/captain/prompts/instruction_auditor.liquid
+++ b/enterprise/lib/captain/prompts/instruction_auditor.liquid
@@ -26,7 +26,8 @@ Review source.instructions clause by clause against all fields in generated_draf
    - Add every source-required action, prohibition, language rule, verification, trigger, exception, ordering rule, escalation condition,
      or workflow that is not already active in generated response_guidelines, guardrails, or scenario response_guidelines.
    - Words such as always, immediately, never, only, before, after, unless, and except are mandatory.
-   - FAQ candidates and needs_review are inactive. If mandatory behavior appears only there, add the missing active guideline or guardrail.
+   - FAQ question and answer text is active factual knowledge, but it does not preserve mandatory behavior.
+     If mandatory behavior appears only there, add the missing active guideline or guardrail. needs_review is inactive.
    - Keep the minimum factual trigger, threshold, allowlist, or exception needed to execute the action or enforce the prohibition.
    - When factual policy contains a mandatory boundary, add the boundary as an active guardrail while leaving the full policy in FAQ.
      Examples include never promising refunds outside a stated window and never recommending cooking a product that must remain raw.

--- a/enterprise/lib/captain/prompts/instruction_classifier.liquid
+++ b/enterprise/lib/captain/prompts/instruction_classifier.liquid
@@ -7,7 +7,7 @@ The original custom instructions remain stored unchanged. Your job is only to de
 3. Guardrails
 4. Scenario Candidates with flattened Response Guidelines
 5. Conversation Messages
-6. Pending FAQ Candidates
+6. FAQ Candidates
 7. Needs Review Notes
 
 ## Core Rules
@@ -86,10 +86,9 @@ The original custom instructions remain stored unchanged. Your job is only to de
 - Existing config messages remain active and are preserved. If source wording has the same intent, keep the existing config message.
 - Migration applies extracted copy only when the corresponding existing config field is blank.
 
-## Pending FAQ Candidates
+## FAQ Candidates
 
 - Convert reusable query-dependent facts into natural customer questions with self-contained answers.
-- FAQ candidates are pending review metadata. They are not active and are not automatically approved by this migration.
 - Use only facts stated in the custom instructions. Preserve exact prices, limits, dates, links, conditions, exceptions, and product names.
 - Keep related conditions together; split unrelated facts. Do not duplicate a full FAQ answer in active guidelines or guardrails;
   repeat only the minimal condition, threshold, or exception required to enforce mandatory behavior.

--- a/spec/enterprise/services/captain/assistant_migration/draft_applier_spec.rb
+++ b/spec/enterprise/services/captain/assistant_migration/draft_applier_spec.rb
@@ -98,6 +98,25 @@ RSpec.describe Captain::AssistantMigration::DraftApplier do
       )
     end
 
+    it 'rejects conflicting FAQ answers within the same draft' do
+      conflicting_draft = draft.merge(
+        faq_document_candidates: [
+          faq_document_candidate,
+          {
+            'question' => "When is support\navailable?",
+            'answer' => 'Support is available every day.'
+          }
+        ]
+      )
+
+      expect do
+        described_class.new(assistant: assistant, draft: conflicting_draft, dry_run: true).perform
+      end.to raise_error(ArgumentError, 'FAQ candidate conflicts with an existing FAQ: When is support available?')
+
+      expect(assistant.responses.count).to eq(0)
+      expect(assistant.config).not_to have_key('assistant_migration')
+    end
+
     it 'rejects stale drafts whose FAQ candidates use the old string format' do
       stale_draft = draft.merge(faq_document_candidates: ['Support is available Monday to Friday.'])
 

--- a/spec/enterprise/services/captain/assistant_migration/draft_applier_spec.rb
+++ b/spec/enterprise/services/captain/assistant_migration/draft_applier_spec.rb
@@ -46,11 +46,15 @@ RSpec.describe Captain::AssistantMigration::DraftApplier do
       expect(result.dig(:changes, :response_guidelines, :to)).to include(
         'For account-specific billing issues, collect the invoice number and summarize the issue before escalating.'
       )
+      expect(result.dig(:changes, :faq_responses, :create)).to contain_exactly(
+        faq_document_candidate.merge('status' => 'approved')
+      )
       expect(assistant.reload.config).not_to have_key('assistant_migration')
+      expect(assistant.responses.count).to eq(0)
       expect(assistant.scenarios.count).to eq(0)
     end
 
-    it 'stores scenario candidates in assistant config and flattens them into response guidelines' do
+    it 'stores scenario and FAQ candidates and creates approved FAQ responses' do
       described_class.new(assistant: assistant, draft: draft, dry_run: false).perform
 
       assistant.reload
@@ -62,8 +66,18 @@ RSpec.describe Captain::AssistantMigration::DraftApplier do
       expect(assistant.response_guidelines).to include(
         'For account-specific billing issues, collect the invoice number and summarize the issue before escalating.'
       )
-      expect(assistant.response_guidelines).not_to include(faq_document_candidate['answer'])
+      expect(assistant.responses).to contain_exactly(
+        have_attributes(
+          question: faq_document_candidate['question'],
+          answer: faq_document_candidate['answer'],
+          status: 'approved'
+        )
+      )
       expect(assistant.scenarios.count).to eq(0)
+
+      expect do
+        described_class.new(assistant: assistant, draft: draft, dry_run: false).perform
+      end.not_to(change { assistant.responses.count })
     end
 
     it 'rejects stale drafts whose FAQ candidates use the old string format' do

--- a/spec/enterprise/services/captain/assistant_migration/draft_applier_spec.rb
+++ b/spec/enterprise/services/captain/assistant_migration/draft_applier_spec.rb
@@ -80,6 +80,24 @@ RSpec.describe Captain::AssistantMigration::DraftApplier do
       end.not_to(change { assistant.responses.count })
     end
 
+    it 'leaves pending FAQ responses untouched' do
+      pending_response = assistant.responses.create!(
+        question: faq_document_candidate['question'],
+        answer: faq_document_candidate['answer'],
+        status: :pending
+      )
+
+      described_class.new(assistant: assistant, draft: draft, dry_run: false).perform
+
+      expect(pending_response.reload).to be_pending
+      expect(assistant.responses.approved).to contain_exactly(
+        have_attributes(
+          question: faq_document_candidate['question'],
+          answer: faq_document_candidate['answer']
+        )
+      )
+    end
+
     it 'rejects stale drafts whose FAQ candidates use the old string format' do
       stale_draft = draft.merge(faq_document_candidates: ['Support is available Monday to Friday.'])
 

--- a/spec/enterprise/services/captain/assistant_migration/draft_applier_spec.rb
+++ b/spec/enterprise/services/captain/assistant_migration/draft_applier_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Captain::AssistantMigration::DraftApplier do
   let(:faq_document_candidate) do
     {
       'question' => 'When is support available?',
-      'answer' => 'Support is available Monday to Friday.'
+      'answer' => "Support is available Monday to Friday.\n\nUrgent requests are handled by the on-call team."
     }
   end
   let(:draft) do

--- a/spec/enterprise/services/captain/assistant_migration/instruction_classifier_spec.rb
+++ b/spec/enterprise/services/captain/assistant_migration/instruction_classifier_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe Captain::AssistantMigration::InstructionClassifier do
   end
 
   describe 'classifier prompt' do
-    it 'keeps the model focused on active behavior and pending FAQ candidates' do
+    it 'keeps the model focused on active behavior and approved FAQ candidates' do
       prompt = Captain::PromptRenderer.render('instruction_classifier')
 
       expect(prompt).to include(
         'The original custom instructions remain stored unchanged',
         'A FAQ cannot implicitly preserve an action',
         'Scenario candidates remain pending metadata',
-        'FAQ candidates are pending review metadata',
+        'Convert reusable query-dependent facts into natural customer questions',
         'an error code that requires immediate',
         'actively require specialist-name verification',
         'Mandatory prohibitions are not FAQ-only',


### PR DESCRIPTION
Captain migrations now add generated FAQ candidates as approved FAQs when a draft is applied. Captain can use the migrated facts instead of leaving them unused in the migration config.

## What changed

The draft applier leaves pending FAQs unchanged. It creates a new approved FAQ unless an identical approved FAQ already exists. It stops if an approved FAQ has the same question with a different answer, so the migration does not overwrite or add conflicting information.

The dry run also stops if one draft contains the same normalized question with different answers.

The dry run lists each FAQ that the apply step would create. It does not change the assistant. Applying the same draft again does not create duplicate approved FAQs.

FAQ answers keep their paragraph breaks, lists, and other internal formatting when applied.

The classifier keeps the existing question and answer format. Its prompt only explains which facts belong in FAQs. The draft applier handles database records in code.

The change adds no database column. It keeps each FAQ candidate in the assistant migration config and does not change the JSONL format.

## How to test

1. Generate a migration draft that contains an FAQ candidate.
2. Run the apply task as a dry run and confirm that `changes.faq_responses.create` contains the FAQ with an approved status.
3. Apply the draft and confirm that Captain shows the FAQ as approved.
4. Apply the same draft again and confirm that Captain does not create a duplicate.

The focused migration service specs pass with 10 examples and no failures. RuboCop passes for the changed Ruby files.
