### PR TITLE
perf(captain): add cosine FAQ search index

### DIFF
--- a/db/migrate/20260714230000_replace_captain_assistant_response_embedding_index_with_cosine.rb
+++ b/db/migrate/20260714230000_replace_captain_assistant_response_embedding_index_with_cosine.rb
@@ -3,8 +3,11 @@ class ReplaceCaptainAssistantResponseEmbeddingIndexWithCosine < ActiveRecord::Mi
 
   OLD_INDEX_NAME = 'vector_idx_knowledge_entries_embedding'.freeze
   NEW_INDEX_NAME = 'vector_idx_captain_assistant_responses_embedding_cosine'.freeze
+  MINIMUM_PGVECTOR_VERSION = Gem::Version.new('0.8.0')
 
   def up
+    ensure_iterative_scans_supported!
+
     add_index :captain_assistant_responses,
               :embedding,
               using: :ivfflat,
@@ -22,5 +25,14 @@ class ReplaceCaptainAssistantResponseEmbeddingIndexWithCosine < ActiveRecord::Mi
               name: OLD_INDEX_NAME,
               algorithm: :concurrently
     remove_index :captain_assistant_responses, name: NEW_INDEX_NAME, algorithm: :concurrently
+  end
+
+  private
+
+  def ensure_iterative_scans_supported!
+    installed_version = Gem::Version.new(select_value("SELECT extversion FROM pg_extension WHERE extname = 'vector'"))
+    return if installed_version >= MINIMUM_PGVECTOR_VERSION
+
+    raise StandardError, "pgvector #{MINIMUM_PGVECTOR_VERSION} or newer is required for filtered FAQ search"
   end
 end

--- a/db/migrate/20260714230000_replace_captain_assistant_response_embedding_index_with_cosine.rb
+++ b/db/migrate/20260714230000_replace_captain_assistant_response_embedding_index_with_cosine.rb
@@ -1,0 +1,26 @@
+class ReplaceCaptainAssistantResponseEmbeddingIndexWithCosine < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  OLD_INDEX_NAME = 'vector_idx_knowledge_entries_embedding'.freeze
+  NEW_INDEX_NAME = 'vector_idx_captain_assistant_responses_embedding_cosine'.freeze
+
+  def up
+    add_index :captain_assistant_responses,
+              :embedding,
+              using: :ivfflat,
+              opclass: :vector_cosine_ops,
+              name: NEW_INDEX_NAME,
+              algorithm: :concurrently
+    remove_index :captain_assistant_responses, name: OLD_INDEX_NAME, algorithm: :concurrently
+  end
+
+  def down
+    add_index :captain_assistant_responses,
+              :embedding,
+              using: :ivfflat,
+              opclass: :vector_l2_ops,
+              name: OLD_INDEX_NAME,
+              algorithm: :concurrently
+    remove_index :captain_assistant_responses, name: NEW_INDEX_NAME, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_13_184351) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_14_230000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -361,7 +361,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_13_184351) do
     t.index ["account_id"], name: "index_captain_assistant_responses_on_account_id"
     t.index ["assistant_id"], name: "index_captain_assistant_responses_on_assistant_id"
     t.index ["documentable_id", "documentable_type"], name: "idx_cap_asst_resp_on_documentable"
-    t.index ["embedding"], name: "vector_idx_knowledge_entries_embedding", using: :ivfflat
+    t.index ["embedding"], name: "vector_idx_captain_assistant_responses_embedding_cosine", opclass: :vector_cosine_ops, using: :ivfflat
     t.index ["status"], name: "index_captain_assistant_responses_on_status"
   end
 

--- a/enterprise/app/models/captain/assistant_response.rb
+++ b/enterprise/app/models/captain/assistant_response.rb
@@ -17,11 +17,11 @@
 #
 # Indexes
 #
-#  idx_cap_asst_resp_on_documentable                  (documentable_id,documentable_type)
-#  index_captain_assistant_responses_on_account_id    (account_id)
-#  index_captain_assistant_responses_on_assistant_id  (assistant_id)
-#  index_captain_assistant_responses_on_status        (status)
-#  vector_idx_knowledge_entries_embedding             (embedding) USING ivfflat
+#  idx_cap_asst_resp_on_documentable                        (documentable_id,documentable_type)
+#  index_captain_assistant_responses_on_account_id          (account_id)
+#  index_captain_assistant_responses_on_assistant_id        (assistant_id)
+#  index_captain_assistant_responses_on_status              (status)
+#  vector_idx_captain_assistant_responses_embedding_cosine  (embedding) USING ivfflat
 #
 class Captain::AssistantResponse < ApplicationRecord
   self.table_name = 'captain_assistant_responses'
@@ -48,7 +48,11 @@ class Captain::AssistantResponse < ApplicationRecord
 
   def self.search(query, account_id: nil)
     embedding = Captain::Llm::EmbeddingService.new(account_id: account_id).get_embedding(query)
-    nearest_neighbors(:embedding, embedding, distance: 'cosine').limit(5)
+
+    transaction do
+      connection.execute("SET LOCAL ivfflat.iterative_scan = 'relaxed_order'")
+      nearest_neighbors(:embedding, embedding, distance: 'cosine').limit(5).load
+    end
   end
 
   private


### PR DESCRIPTION
This draft is future work and must not be merged as part of the first FAQ suggestion rollout.

Production currently runs pgvector 0.4.1. Filtered iterative vector scans require pgvector 0.8.0 or newer. The first rollout will use an exact cosine search instead.

Keep this draft for the pgvector upgrade discussion. After production and supported self hosted installations can run pgvector 0.8.0 or newer, this change can replace the unused L2 index with a cosine index.

## Closes

Part of [CW-7495](https://linear.app/chatwoot/issue/CW-7495/backend-llm-changes-to-make-conversation-faqs-as-signalssuggestions).

## How to reproduce

1. Upgrade pgvector to 0.8.0 or newer.
2. Use an assistant with a large FAQ library.
3. Search within that assistant's approved FAQs.
4. Confirm that the search returns five matching rows from the assistant scope.
5. Confirm that PostgreSQL uses the cosine vector index.

## What changed

The migration replaces the old L2 IVFFlat index with a cosine IVFFlat index. It creates and removes both indexes concurrently. FAQ search enables relaxed iterative scans so account, assistant, and status filters do not hide valid matches. The migration stops when pgvector is older than 0.8.0.