### PR TITLE
docs: add branded email layout API reference

### DIFF
--- a/swagger/definitions/index.yml
+++ b/swagger/definitions/index.yml
@@ -46,6 +46,8 @@ agent:
   $ref: ./resource/agent.yml
 inbox:
   $ref: ./resource/inbox.yml
+branded_email_layout:
+  $ref: ./resource/branded_email_layout.yml
 inbox_contact:
   $ref: ./resource/inbox_contact.yml
 agent_bot:
@@ -145,6 +147,8 @@ inbox_create_payload:
   $ref: ./request/inbox/create_payload.yml
 inbox_update_payload:
   $ref: ./request/inbox/update_payload.yml
+account_branded_email_layout_payload:
+  $ref: ./request/account/branded_email_layout_payload.yml
 inbox_create_web_widget_channel_payload:
   $ref: ./request/inbox/channels/create_web_widget_channel_payload.yml
 inbox_create_api_channel_payload:

--- a/swagger/definitions/request/account/branded_email_layout_payload.yml
+++ b/swagger/definitions/request/account/branded_email_layout_payload.yml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  branded_email_layout:
+    type:
+      - string
+      - 'null'
+    description: Account-scoped Liquid HTML layout for branded email replies. Blank or null removes the account override.
+    example: '<html><body>{{ content_for_layout }}</body></html>'

--- a/swagger/definitions/request/inbox/update_payload.yml
+++ b/swagger/definitions/request/inbox/update_payload.yml
@@ -109,6 +109,15 @@ properties:
 
       Available for: `Website` `Email`
     example: 'My Business'
+  branded_email_layout:
+    type:
+      - string
+      - 'null'
+    description: |
+      Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}`.
+
+      Available for: `Email`
+    example: '<html><body>{{ content_for_layout }}</body></html>'
   channel:
     anyOf:
       - $ref: '#/components/schemas/inbox_update_web_widget_channel_payload'

--- a/swagger/definitions/resource/branded_email_layout.yml
+++ b/swagger/definitions/resource/branded_email_layout.yml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  branded_email_layout:
+    type:
+      - string
+      - 'null'
+    description: Account-scoped Liquid HTML layout for branded email replies.
+    example: '<html><body>{{ content_for_layout }}</body></html>'

--- a/swagger/definitions/resource/inbox.yml
+++ b/swagger/definitions/resource/inbox.yml
@@ -122,6 +122,11 @@ properties:
       - string
       - 'null'
     description: Business name associated with the inbox
+  branded_email_layout:
+    type:
+      - string
+      - 'null'
+    description: Liquid HTML layout for branded email replies. Available to administrators for Email inbox show/update responses.
   hmac_mandatory:
     type: boolean
     description: Whether HMAC verification is mandatory

--- a/swagger/paths/application/branded_email_layout.yml
+++ b/swagger/paths/application/branded_email_layout.yml
@@ -1,0 +1,58 @@
+get:
+  tags:
+    - Inboxes
+  operationId: getAccountBrandedEmailLayout
+  summary: Get account branded email layout
+  security:
+    - userApiKey: []
+  description: Get the account-scoped Liquid HTML layout used as the fallback for branded email replies.
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+  responses:
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/branded_email_layout'
+    '403':
+      description: Access denied
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/bad_request_error'
+patch:
+  tags:
+    - Inboxes
+  operationId: updateAccountBrandedEmailLayout
+  summary: Update account branded email layout
+  security:
+    - userApiKey: []
+  description: Update or clear the account-scoped Liquid HTML layout used as the fallback for branded email replies.
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/account_branded_email_layout_payload'
+  responses:
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/branded_email_layout'
+    '403':
+      description: Access denied
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/bad_request_error'
+    '422':
+      description: Validation failed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/application/branded_email_layout.yml
+++ b/swagger/paths/application/branded_email_layout.yml
@@ -15,8 +15,8 @@ get:
         application/json:
           schema:
             $ref: '#/components/schemas/branded_email_layout'
-    '403':
-      description: Access denied
+    '401':
+      description: Unauthorized
       content:
         application/json:
           schema:
@@ -44,8 +44,8 @@ patch:
         application/json:
           schema:
             $ref: '#/components/schemas/branded_email_layout'
-    '403':
-      description: Access denied
+    '401':
+      description: Unauthorized
       content:
         application/json:
           schema:

--- a/swagger/paths/index.yml
+++ b/swagger/paths/index.yml
@@ -411,6 +411,8 @@
     $ref: ./application/conversation/reporting_events.yml
 
 # Inboxes
+/api/v1/accounts/{account_id}/branded_email_layout:
+  $ref: ./application/branded_email_layout.yml
 /api/v1/accounts/{account_id}/inboxes:
   $ref: ./application/inboxes/index.yml
 /api/v1/accounts/{account_id}/inboxes/{id}:

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -5403,8 +5403,8 @@
               }
             }
           },
-          "403": {
-            "description": "Access denied",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {
@@ -5453,8 +5453,8 @@
               }
             }
           },
-          "403": {
-            "description": "Access denied",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -5374,6 +5374,108 @@
         }
       }
     },
+    "/api/v1/accounts/{account_id}/branded_email_layout": {
+      "get": {
+        "tags": [
+          "Inboxes"
+        ],
+        "operationId": "getAccountBrandedEmailLayout",
+        "summary": "Get account branded email layout",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Get the account-scoped Liquid HTML layout used as the fallback for branded email replies.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/account_id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/branded_email_layout"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Inboxes"
+        ],
+        "operationId": "updateAccountBrandedEmailLayout",
+        "summary": "Update account branded email layout",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Update or clear the account-scoped Liquid HTML layout used as the fallback for branded email replies.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/account_id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/account_branded_email_layout_payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/branded_email_layout"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/accounts/{account_id}/inboxes": {
       "get": {
         "tags": [
@@ -10465,6 +10567,13 @@
             ],
             "description": "Business name associated with the inbox"
           },
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Liquid HTML layout for branded email replies. Available to administrators for Email inbox show/update responses."
+          },
           "hmac_mandatory": {
             "type": "boolean",
             "description": "Whether HMAC verification is mandatory"
@@ -10507,6 +10616,19 @@
               "null"
             ],
             "description": "Provider of the channel"
+          }
+        }
+      },
+      "branded_email_layout": {
+        "type": "object",
+        "properties": {
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Account-scoped Liquid HTML layout for branded email replies.",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }
       },
@@ -12677,6 +12799,14 @@
             "description": "Business name for outbound email replies.\n\nAvailable for: `Website` `Email`\n",
             "example": "My Business"
           },
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}`.\n\nAvailable for: `Email`\n",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
+          },
           "channel": {
             "anyOf": [
               {
@@ -12701,6 +12831,19 @@
                 "$ref": "#/components/schemas/inbox_update_sms_channel_payload"
               }
             ]
+          }
+        }
+      },
+      "account_branded_email_layout_payload": {
+        "type": "object",
+        "properties": {
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Account-scoped Liquid HTML layout for branded email replies. Blank or null removes the account override.",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }
       },

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -3917,6 +3917,108 @@
         }
       }
     },
+    "/api/v1/accounts/{account_id}/branded_email_layout": {
+      "get": {
+        "tags": [
+          "Inboxes"
+        ],
+        "operationId": "getAccountBrandedEmailLayout",
+        "summary": "Get account branded email layout",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Get the account-scoped Liquid HTML layout used as the fallback for branded email replies.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/account_id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/branded_email_layout"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Inboxes"
+        ],
+        "operationId": "updateAccountBrandedEmailLayout",
+        "summary": "Update account branded email layout",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Update or clear the account-scoped Liquid HTML layout used as the fallback for branded email replies.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/account_id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/account_branded_email_layout_payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/branded_email_layout"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/accounts/{account_id}/inboxes": {
       "get": {
         "tags": [
@@ -8972,6 +9074,13 @@
             ],
             "description": "Business name associated with the inbox"
           },
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Liquid HTML layout for branded email replies. Available to administrators for Email inbox show/update responses."
+          },
           "hmac_mandatory": {
             "type": "boolean",
             "description": "Whether HMAC verification is mandatory"
@@ -9014,6 +9123,19 @@
               "null"
             ],
             "description": "Provider of the channel"
+          }
+        }
+      },
+      "branded_email_layout": {
+        "type": "object",
+        "properties": {
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Account-scoped Liquid HTML layout for branded email replies.",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }
       },
@@ -11184,6 +11306,14 @@
             "description": "Business name for outbound email replies.\n\nAvailable for: `Website` `Email`\n",
             "example": "My Business"
           },
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}`.\n\nAvailable for: `Email`\n",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
+          },
           "channel": {
             "anyOf": [
               {
@@ -11208,6 +11338,19 @@
                 "$ref": "#/components/schemas/inbox_update_sms_channel_payload"
               }
             ]
+          }
+        }
+      },
+      "account_branded_email_layout_payload": {
+        "type": "object",
+        "properties": {
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Account-scoped Liquid HTML layout for branded email replies. Blank or null removes the account override.",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }
       },

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -3946,8 +3946,8 @@
               }
             }
           },
-          "403": {
-            "description": "Access denied",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {
@@ -3996,8 +3996,8 @@
               }
             }
           },
-          "403": {
-            "description": "Access denied",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -1882,6 +1882,13 @@
             ],
             "description": "Business name associated with the inbox"
           },
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Liquid HTML layout for branded email replies. Available to administrators for Email inbox show/update responses."
+          },
           "hmac_mandatory": {
             "type": "boolean",
             "description": "Whether HMAC verification is mandatory"
@@ -1924,6 +1931,19 @@
               "null"
             ],
             "description": "Provider of the channel"
+          }
+        }
+      },
+      "branded_email_layout": {
+        "type": "object",
+        "properties": {
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Account-scoped Liquid HTML layout for branded email replies.",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }
       },
@@ -4094,6 +4114,14 @@
             "description": "Business name for outbound email replies.\n\nAvailable for: `Website` `Email`\n",
             "example": "My Business"
           },
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}`.\n\nAvailable for: `Email`\n",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
+          },
           "channel": {
             "anyOf": [
               {
@@ -4118,6 +4146,19 @@
                 "$ref": "#/components/schemas/inbox_update_sms_channel_payload"
               }
             ]
+          }
+        }
+      },
+      "account_branded_email_layout_payload": {
+        "type": "object",
+        "properties": {
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Account-scoped Liquid HTML layout for branded email replies. Blank or null removes the account override.",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }
       },

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -1297,6 +1297,13 @@
             ],
             "description": "Business name associated with the inbox"
           },
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Liquid HTML layout for branded email replies. Available to administrators for Email inbox show/update responses."
+          },
           "hmac_mandatory": {
             "type": "boolean",
             "description": "Whether HMAC verification is mandatory"
@@ -1339,6 +1346,19 @@
               "null"
             ],
             "description": "Provider of the channel"
+          }
+        }
+      },
+      "branded_email_layout": {
+        "type": "object",
+        "properties": {
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Account-scoped Liquid HTML layout for branded email replies.",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }
       },
@@ -3509,6 +3529,14 @@
             "description": "Business name for outbound email replies.\n\nAvailable for: `Website` `Email`\n",
             "example": "My Business"
           },
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}`.\n\nAvailable for: `Email`\n",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
+          },
           "channel": {
             "anyOf": [
               {
@@ -3533,6 +3561,19 @@
                 "$ref": "#/components/schemas/inbox_update_sms_channel_payload"
               }
             ]
+          }
+        }
+      },
+      "account_branded_email_layout_payload": {
+        "type": "object",
+        "properties": {
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Account-scoped Liquid HTML layout for branded email replies. Blank or null removes the account override.",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }
       },

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -2058,6 +2058,13 @@
             ],
             "description": "Business name associated with the inbox"
           },
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Liquid HTML layout for branded email replies. Available to administrators for Email inbox show/update responses."
+          },
           "hmac_mandatory": {
             "type": "boolean",
             "description": "Whether HMAC verification is mandatory"
@@ -2100,6 +2107,19 @@
               "null"
             ],
             "description": "Provider of the channel"
+          }
+        }
+      },
+      "branded_email_layout": {
+        "type": "object",
+        "properties": {
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Account-scoped Liquid HTML layout for branded email replies.",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }
       },
@@ -4270,6 +4290,14 @@
             "description": "Business name for outbound email replies.\n\nAvailable for: `Website` `Email`\n",
             "example": "My Business"
           },
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}`.\n\nAvailable for: `Email`\n",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
+          },
           "channel": {
             "anyOf": [
               {
@@ -4294,6 +4322,19 @@
                 "$ref": "#/components/schemas/inbox_update_sms_channel_payload"
               }
             ]
+          }
+        }
+      },
+      "account_branded_email_layout_payload": {
+        "type": "object",
+        "properties": {
+          "branded_email_layout": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Account-scoped Liquid HTML layout for branded email replies. Blank or null removes the account override.",
+            "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }
       },


### PR DESCRIPTION
## Description

Adds Swagger API documentation for branded email layouts, including the account-level layout endpoint, Email inbox update field, and generated API schemas. This stacked PR keeps the implementation review in #14936 focused on the product change.

Related: [CW-7514](https://linear.app/chatwoot/issue/CW-7514/branded-html-email-templates-per-inboxbrand)
Depends on #14936

## Type of change

- [x] This change requires a documentation update

## How to test

1. Run `bundle exec rake swagger:build`.
2. Start Chatwoot locally and open `http://localhost:3000/swagger`.
3. Verify the branded email layout account endpoint and Email inbox `branded_email_layout` field appear in the API reference.

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings