### PR TITLE
fix: resolve `{{conversation.id}}` to `display_id`

### DIFF
--- a/app/drops/conversation_drop.rb
+++ b/app/drops/conversation_drop.rb
@@ -1,6 +1,10 @@
 class ConversationDrop < BaseDrop
   include MessageFormatHelper
 
+  def id
+    @obj.try(:display_id)
+  end
+
   def display_id
     @obj.try(:display_id)
   end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the `{{conversation.id}}` variable so it renders the visible conversation ID (display_id) instead of the internal database ID.
- Added an `id` override to `ConversationDrop` that returns `display_id`.

Fixes https://linear.app/chatwoot/issue/CW-7609/conversationid-resolves-to-internal-database-id-instead-of-display-id

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Screenshot**
<img width="732" height="479" alt="image" src="https://github.com/user-attachments/assets/29725a33-7e5a-47b3-9117-dc9729181c08" />


**Steps**
1. Open any conversation.
2. Send a reply containing 
```
This is the {{conversation.id}} you see.
```
3. Before: it renders the internal database ID (e.g. 3933509).
4. After: it renders the visible conversation ID (e.g. 30270).


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
