### PR TITLE
fix(whatsapp): skip template sync for suspended accounts

### DIFF
--- a/app/jobs/channels/whatsapp/templates_sync_scheduler_job.rb
+++ b/app/jobs/channels/whatsapp/templates_sync_scheduler_job.rb
@@ -2,7 +2,9 @@ class Channels::Whatsapp::TemplatesSyncSchedulerJob < ApplicationJob
   queue_as :low
 
   def perform
-    Channel::Whatsapp.order(Arel.sql('message_templates_last_updated IS NULL DESC, message_templates_last_updated ASC'))
+    Channel::Whatsapp.joins(:account)
+                     .merge(Account.active)
+                     .order(Arel.sql('message_templates_last_updated IS NULL DESC, message_templates_last_updated ASC'))
                      .where('message_templates_last_updated <= ? OR message_templates_last_updated IS NULL', 3.hours.ago)
                      .limit(Limits::BULK_EXTERNAL_HTTP_CALLS_LIMIT)
                      .each do |channel|

--- a/spec/jobs/channels/whatsapp/templates_sync_scheduler_job_spec.rb
+++ b/spec/jobs/channels/whatsapp/templates_sync_scheduler_job_spec.rb
@@ -24,6 +24,23 @@ RSpec.describe Channels::Whatsapp::TemplatesSyncSchedulerJob do
       )
     end
 
+    it 'does not schedule templates_sync_jobs for suspended accounts' do
+      stub_request(:post, 'https://waba.360dialog.io/v1/configs/webhook')
+      suspended_account = create(:account, status: :suspended)
+      suspended_channel = create(
+        :channel_whatsapp,
+        account: suspended_account,
+        sync_templates: false,
+        message_templates_last_updated: nil
+      )
+
+      described_class.perform_now
+
+      expect(Channels::Whatsapp::TemplatesSyncJob).not_to(
+        have_been_enqueued.with(suspended_channel).on_queue('low')
+      )
+    end
+
     it 'schedules templates_sync_job for oldest synced channels first' do
       stub_const('Limits::BULK_EXTERNAL_HTTP_CALLS_LIMIT', 2)
       stub_request(:post, 'https://waba.360dialog.io/v1/configs/webhook')


### PR DESCRIPTION
Suspended accounts no longer participate in scheduled WhatsApp template syncs. This avoids unnecessary external API calls while keeping the existing refresh behavior unchanged for active accounts.