### PR TITLE
fix: guard Message#reindex_for_search when searchkick is not loaded

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -452,6 +452,12 @@ class Message < ApplicationRecord
   end
 
   def reindex_for_search
+    # `reindex` is only mixed in by searchkick when `advanced_search_allowed?`
+    # is true at class-load time. That guard can disagree with the runtime
+    # `should_index?` check (for example when the flag is stubbed in specs),
+    # so make sure the method is available before calling it.
+    return unless respond_to?(:reindex)
+
     reindex(mode: :async)
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -835,6 +835,12 @@ RSpec.describe Message do
         message.save!
       end
 
+      it 'does not raise when searchkick reindex is not mixed in' do
+        message = create(:message, conversation: conversation, account: account, message_type: :incoming)
+        allow(message).to receive(:respond_to?).with(:reindex).and_return(false)
+        expect { message.send(:reindex_for_search) }.not_to raise_error
+      end
+
       it 'calls reindex_for_search for outgoing message on update' do
         # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(described_class).to receive(:reindex_for_search).and_return(true)


### PR DESCRIPTION
## Description

`Message#reindex_for_search` calls `reindex(mode: :async)` unconditionally, but `reindex` is only mixed into the model by the `searchkick` macro, which is guarded by `if ChatwootApp.advanced_search_allowed?` at class-load time. When advanced search is not available (the default for the test environment and self-hosted installs without OpenSearch), `reindex` is never defined, yet the runtime `should_index?` guard on the `after_commit` callback can still be satisfied, e.g. when specs stub `advanced_search_allowed?` to `true`. Saving an indexable message then raises `NoMethodError: undefined method 'reindex' for an instance of Message`.

This guards `reindex_for_search` so it only calls `reindex` when the method is actually available, which resolves the failing `spec/models/message_spec.rb` examples referenced in #15064.

Fixes #15064

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added a spec in the existing `#reindex_for_search callback` block that stubs the model to not respond to `reindex` and asserts the callback no longer raises. The rest of the `message_spec.rb` search examples continue to exercise the indexed/not-indexed paths.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
