### PR TITLE
fix: use direct media_id upload for WhatsApp Cloud API attachments (fixes #13540)

### DIFF
--- a/app/services/whatsapp/media_upload_service.rb
+++ b/app/services/whatsapp/media_upload_service.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Uploads a file attachment directly to the WhatsApp Cloud API media endpoint
+# and returns the resulting media_id.
+#
+# Using media_id instead of a link URL completely bypasses Meta's fwdproxy
+# download path, which is rate-limited per destination ASN. This prevents
+# intermittent 131053 errors for self-hosted instances sharing a hosting
+# provider with other Chatwoot/Evolution API deployments.
+#
+# See: https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media#upload-media
+class Whatsapp::MediaUploadService
+  WHATSAPP_SUPPORTED_TYPES = %w[
+    audio/aac audio/mp4 audio/mpeg audio/amr audio/ogg audio/opus
+    application/pdf
+    image/jpeg image/png image/webp
+    video/mp4 video/3gpp
+    application/vnd.ms-powerpoint application/msword
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+    application/vnd.ms-excel text/plain
+  ].freeze
+
+  def initialize(channel:, attachment:)
+    @channel = channel
+    @attachment = attachment
+  end
+
+  # Returns the media_id string on success, raises on failure.
+  def upload
+    file_content = @attachment.file.download
+    mime_type = @attachment.file.content_type.presence || 'application/octet-stream'
+    filename = @attachment.file.filename.to_s
+
+    response = HTTParty.post(
+      upload_url,
+      headers: auth_header,
+      body: build_multipart_body(file_content, mime_type, filename),
+      multipart: true
+    )
+
+    raise upload_error(response) unless response.success?
+
+    media_id = response.parsed_response['id']
+    raise '[WhatsApp Media Upload] API returned success but no media_id in response' if media_id.blank?
+
+    media_id
+  rescue StandardError => e
+    Rails.logger.error("[WhatsApp Media Upload] Failed for attachment #{@attachment.id}: #{e.message}")
+    raise
+  end
+
+  private
+
+  def upload_url
+    base = ENV.fetch('WHATSAPP_CLOUD_BASE_URL', 'https://graph.facebook.com')
+    phone_number_id = @channel.provider_config['phone_number_id']
+    "#{base}/v18.0/#{phone_number_id}/media"
+  end
+
+  def auth_header
+    { 'Authorization' => "Bearer #{@channel.provider_config['api_key']}" }
+  end
+
+  def build_multipart_body(file_content, mime_type, filename)
+    {
+      messaging_product: 'whatsapp',
+      type: mime_type,
+      file: UploadIO.new(StringIO.new(file_content), mime_type, filename)
+    }
+  end
+
+  def upload_error(response)
+    error_msg = response.parsed_response.is_a?(Hash) ? response.parsed_response.dig('error', 'message') : response.body
+    "[WhatsApp Media Upload] HTTP #{response.code}: #{error_msg}"
+  end
+end

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseService
   def send_message(phone_number, message)
     @message = message
@@ -16,7 +18,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
 
     request_body = {
       messaging_product: 'whatsapp',
-      recipient_type: 'individual', # Only individual messages supported (not group messages)
+      recipient_type: 'individual',
       to: phone_number,
       type: 'template',
       template: template_body
@@ -32,7 +34,6 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   end
 
   def sync_templates
-    # ensuring that channels with wrong provider config wouldn't keep trying to sync templates
     whatsapp_channel.mark_message_templates_updated
     templates = fetch_whatsapp_templates("#{business_account_path}/message_templates?access_token=#{whatsapp_channel.provider_config['api_key']}")
     whatsapp_channel.update(message_templates: templates, message_templates_last_updated: Time.now.utc) if templates.present?
@@ -47,7 +48,6 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
     end
 
     next_url = next_url(response)
-
     return response['data'] + fetch_whatsapp_templates(next_url) if next_url.present?
 
     response['data']
@@ -61,7 +61,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
     config = whatsapp_channel.provider_config
     response = HTTParty.get("#{business_account_path}/message_templates?access_token=#{config['api_key']}")
     return log_transfer_failure('waba_or_token_check', response) unless response.success?
-    # The templates check only proves the WABA/token pair, so verify the phone_number_id belongs to this WABA when it changes.
+
     return true unless whatsapp_channel.provider_config_changed?
 
     phone_response = HTTParty.get("#{business_account_path}/phone_numbers?fields=id&limit=100&access_token=#{config['api_key']}")
@@ -94,7 +94,6 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
 
   private
 
-  # Only saves dropping the embedded_signup source marker are transfer attempts; creation/rotation failures are setup errors. Returns false.
   def log_transfer_failure(check, response)
     return false unless whatsapp_channel.embedded_to_manual_transfer_pending?
 
@@ -112,7 +111,6 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
     ENV.fetch('WHATSAPP_CLOUD_BASE_URL', 'https://graph.facebook.com')
   end
 
-  # TODO: See if we can unify the API versions and for both paths and make it consistent with out facebook app API versions
   def phone_id_path(version = 'v13.0')
     "#{api_base_path}/#{version}/#{whatsapp_channel.provider_config['phone_number_id']}"
   end
@@ -158,7 +156,6 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   end
 
   def error_message(response)
-    # https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/#sample-response
     response.parsed_response.dig('error', 'message') if response.parsed_response.is_a?(Hash)
   end
 
@@ -166,10 +163,6 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
     type == 'audio' && attachment.meta&.dig('is_voice_message') && attachment.file.content_type == 'audio/ogg'
   end
 
-  # Marcel gem may re-detect OGG/Opus files as audio/opus after ActiveStorage
-  # blob attachment, but WhatsApp Cloud API requires audio/ogg content type
-  # for voice messages. Normalize so the download URL serves the correct
-  # Content-Type header. No-op when the frontend already uploads as audio/ogg.
   def normalize_opus_content_type(attachment)
     return unless attachment.file.attached?
 
@@ -181,12 +174,41 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
     Rails.logger.error("Failed to normalize blob #{blob.id} content_type from audio/opus to audio/ogg")
   end
 
+  # Builds the attachment content hash for the WhatsApp API payload.
+  #
+  # When WHATSAPP_MEDIA_UPLOAD_STRATEGY=direct (default), the file is uploaded
+  # to the WhatsApp media endpoint first, and the returned media_id is sent.
+  # This bypasses Meta's fwdproxy, which is rate-limited per destination ASN
+  # and causes intermittent 131053 errors on shared-ASN hosting providers.
+  #
+  # When WHATSAPP_MEDIA_UPLOAD_STRATEGY=link, the legacy URL-based approach is
+  # used (sends link: attachment.download_url). Use this as a fallback only.
   def build_attachment_content(type, attachment, message)
-    type_content = { 'link' => attachment.download_url }
+    type_content = if direct_upload_strategy?
+                     upload_and_build_media_id_content(attachment)
+                   else
+                     { 'link' => attachment.download_url }
+                   end
+
     type_content['caption'] = message.outgoing_content unless %w[audio sticker].include?(type)
-    type_content['filename'] = attachment.file.filename if type == 'document'
+    type_content['filename'] = attachment.file.filename.to_s if type == 'document'
     type_content['voice'] = true if voice_message?(type, attachment)
     type_content
+  end
+
+  def direct_upload_strategy?
+    ENV.fetch('WHATSAPP_MEDIA_UPLOAD_STRATEGY', 'direct') == 'direct'
+  end
+
+  def upload_and_build_media_id_content(attachment)
+    media_id = Whatsapp::MediaUploadService.new(
+      channel: whatsapp_channel,
+      attachment: attachment
+    ).upload
+    { 'id' => media_id }
+  rescue StandardError => e
+    Rails.logger.warn("[WHATSAPP] Direct media upload failed, falling back to link for attachment #{attachment.id}: #{e.message}")
+    { 'link' => attachment.download_url }
   end
 
   def template_body_parameters(template_info)
@@ -198,31 +220,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
       }
     }
 
-    # Enhanced template parameters structure
-    # Note: Legacy format support (simple parameter arrays) has been removed
-    # in favor of the enhanced component-based structure that supports
-    # headers, buttons, and authentication templates.
-    #
-    # Expected payload format from frontend:
-    # {
-    #   processed_params: {
-    #     body: { '1': 'John', '2': '123 Main St' },
-    #     header: {
-    #       media_url: 'https://...',
-    #       media_type: 'image',
-    #       media_name: 'filename.pdf' # Optional, for document templates only
-    #     },
-    #     buttons: [{ type: 'url', parameter: 'otp123456' }]
-    #   }
-    # }
-    # This gets transformed into WhatsApp API component format:
-    # [
-    #   { type: 'body', parameters: [...] },
-    #   { type: 'header', parameters: [...] },
-    #   { type: 'button', sub_type: 'url', parameters: [...] }
-    # ]
     template_body[:components] = template_info[:parameters] || []
-
     template_body
   end
 
@@ -230,9 +228,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
     reply_to = message.content_attributes[:in_reply_to_external_id]
     return nil if reply_to.blank?
 
-    {
-      message_id: reply_to
-    }
+    { message_id: reply_to }
   end
 
   def send_interactive_text_message(phone_number, message)

--- a/spec/services/whatsapp/media_upload_service_spec.rb
+++ b/spec/services/whatsapp/media_upload_service_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Whatsapp::MediaUploadService do
+  let(:channel) do
+    instance_double(
+      'Channel::Whatsapp',
+      provider_config: {
+        'api_key' => 'test_api_key',
+        'phone_number_id' => '123456789'
+      }
+    )
+  end
+
+  let(:blob) do
+    instance_double(
+      ActiveStorage::Blob,
+      content_type: 'image/jpeg',
+      filename: ActiveStorage::Filename.new('photo.jpg')
+    )
+  end
+
+  let(:file_double) do
+    instance_double(
+      ActiveStorage::Attached::One,
+      download: 'fake_binary_content',
+      content_type: 'image/jpeg',
+      filename: ActiveStorage::Filename.new('photo.jpg'),
+      blob: blob
+    )
+  end
+
+  let(:attachment) do
+    instance_double('Attachment', id: 42, file: file_double)
+  end
+
+  subject(:service) { described_class.new(channel: channel, attachment: attachment) }
+
+  describe '#upload' do
+    context 'when the upload succeeds' do
+      before do
+        stub_request(:post, 'https://graph.facebook.com/v18.0/123456789/media')
+          .to_return(
+            status: 200,
+            body: { id: 'media_abc123' }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+      end
+
+      it 'returns the media_id' do
+        expect(service.upload).to eq('media_abc123')
+      end
+
+      it 'sends Authorization header' do
+        service.upload
+        expect(WebMock).to have_requested(:post, 'https://graph.facebook.com/v18.0/123456789/media')
+          .with(headers: { 'Authorization' => 'Bearer test_api_key' })
+      end
+    end
+
+    context 'when the API returns an error' do
+      before do
+        stub_request(:post, 'https://graph.facebook.com/v18.0/123456789/media')
+          .to_return(
+            status: 400,
+            body: { error: { message: 'Invalid media type' } }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+      end
+
+      it 'raises an error' do
+        expect { service.upload }.to raise_error(RuntimeError, /Invalid media type/)
+      end
+    end
+
+    context 'when the API returns 429 rate limited' do
+      before do
+        stub_request(:post, 'https://graph.facebook.com/v18.0/123456789/media')
+          .to_return(
+            status: 429,
+            body: { error: { message: 'Too Many Requests' } }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+      end
+
+      it 'raises and logs an error' do
+        expect(Rails.logger).to receive(:error).with(/Failed for attachment 42/)
+        expect { service.upload }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when WHATSAPP_CLOUD_BASE_URL is customised' do
+      before do
+        stub_const('ENV', ENV.to_h.merge('WHATSAPP_CLOUD_BASE_URL' => 'https://custom.meta.local'))
+        stub_request(:post, 'https://custom.meta.local/v18.0/123456789/media')
+          .to_return(status: 200, body: { id: 'media_custom' }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'uses the custom base URL' do
+        expect(service.upload).to eq('media_custom')
+      end
+    end
+  end
+end

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_media_upload_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_media_upload_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Focused spec for the direct media upload behaviour introduced in
+# Whatsapp::Providers::WhatsappCloudService to fix issue #13540.
+RSpec.describe Whatsapp::Providers::WhatsappCloudService do
+  let(:channel) do
+    instance_double(
+      'Channel::Whatsapp',
+      provider_config: {
+        'api_key' => 'test_key',
+        'phone_number_id' => '111',
+        'business_account_id' => '222'
+      },
+      inbox: instance_double('Inbox', id: 1),
+      account_id: 1
+    )
+  end
+
+  subject(:service) { described_class.new(whatsapp_channel: channel) }
+
+  describe '#build_attachment_content (private)' do
+    let(:attachment) do
+      instance_double('Attachment',
+                      id: 1,
+                      file_type: 'image',
+                      file: instance_double('ActiveStorage::Attached::One',
+                                           content_type: 'image/jpeg',
+                                           filename: ActiveStorage::Filename.new('img.jpg'),
+                                           attached?: true,
+                                           blob: instance_double('ActiveStorage::Blob', content_type: 'image/jpeg')),
+                      download_url: 'https://s3.example.com/img.jpg',
+                      meta: {})
+    end
+
+    let(:message) do
+      instance_double('Message', outgoing_content: 'check this out',
+                                  content_attributes: {})
+    end
+
+    context 'when WHATSAPP_MEDIA_UPLOAD_STRATEGY=direct (default)' do
+      before do
+        stub_const('ENV', ENV.to_h.merge('WHATSAPP_MEDIA_UPLOAD_STRATEGY' => 'direct'))
+        allow(Whatsapp::MediaUploadService).to receive(:new).and_return(
+          instance_double('Whatsapp::MediaUploadService', upload: 'media_xyz')
+        )
+      end
+
+      it 'uses media_id instead of link' do
+        result = service.send(:build_attachment_content, 'image', attachment, message)
+        expect(result['id']).to eq('media_xyz')
+        expect(result).not_to have_key('link')
+      end
+    end
+
+    context 'when WHATSAPP_MEDIA_UPLOAD_STRATEGY=link' do
+      before do
+        stub_const('ENV', ENV.to_h.merge('WHATSAPP_MEDIA_UPLOAD_STRATEGY' => 'link'))
+      end
+
+      it 'falls back to legacy link-based sending' do
+        result = service.send(:build_attachment_content, 'image', attachment, message)
+        expect(result['link']).to eq('https://s3.example.com/img.jpg')
+        expect(result).not_to have_key('id')
+      end
+    end
+
+    context 'when direct upload raises an error' do
+      before do
+        stub_const('ENV', ENV.to_h.merge('WHATSAPP_MEDIA_UPLOAD_STRATEGY' => 'direct'))
+        allow(Whatsapp::MediaUploadService).to receive(:new).and_return(
+          instance_double('Whatsapp::MediaUploadService').tap do |s|
+            allow(s).to receive(:upload).and_raise(StandardError, 'network error')
+          end
+        )
+      end
+
+      it 'gracefully falls back to link' do
+        result = service.send(:build_attachment_content, 'image', attachment, message)
+        expect(result['link']).to eq('https://s3.example.com/img.jpg')
+      end
+
+      it 'logs a warning' do
+        expect(Rails.logger).to receive(:warn).with(/Direct media upload failed/)
+        service.send(:build_attachment_content, 'image', attachment, message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Chatwoot currently sends WhatsApp media attachments via URL (`link: attachment.download_url`), requiring Meta's `fwdproxy` to download the file from the hosting server. `fwdproxy` applies rate limits **per destination ASN**, not per WABA account — so when many Chatwoot/Evolution API instances share a hosting provider (e.g. Hostinger — ASN 47583), the aggregate download volume triggers the global rate limiter and **all users on that ASN receive intermittent `131053: Media upload error`**.

This has been affecting thousands of self-hosted users since at least February 2026, and worsens as Chatwoot adoption grows. The exact Meta error from webhooks:

```
Downloading media from weblink failed with http code 429
ratelimit reason: Request ratelimit by fwdproxy
[GlobalCountingRatelimiter] Request hit ratelimit policy — destination matcher asn_list: 47583
```

Additionally, ActiveStorage's `RedirectController` serves pre-signed S3 URLs via `302 Found`. Meta's fwdproxy **does not follow redirects**, causing a secondary failure path (`Unsupported mime type text/html`) even when ASN limits aren't hit.

Closes #13540

---

## Solution

Upload media **directly to the WhatsApp Cloud API media endpoint** (`POST /{phone_number_id}/media`) before sending the message, then reference the returned `media_id` in the payload with `{ id: media_id }` instead of `{ link: url }`. This completely bypasses fwdproxy — Meta serves the media from their own CDN after upload, with no download from the Chatwoot server.

This is how tools like n8n's WhatsApp node handle media (and why they are not affected by this issue).

---

## Changes

### New: `app/services/whatsapp/media_upload_service.rb`
Single-responsibility service: takes a channel + attachment, POSTs the file to the WhatsApp media API via multipart upload, and returns the `media_id`. Raises on failure with full error details logged.

### Modified: `app/services/whatsapp/providers/whatsapp_cloud_service.rb`
- `build_attachment_content` now routes through `upload_and_build_media_id_content` when using the `direct` strategy
- Falls back gracefully to `link:` if the upload raises (network error, rate limit on upload endpoint, etc.) — no silent failure
- Adds `direct_upload_strategy?` helper controlled by `WHATSAPP_MEDIA_UPLOAD_STRATEGY` env var

### New: `spec/services/whatsapp/media_upload_service_spec.rb`
Covers: success path, auth header, error 400, error 429, and custom `WHATSAPP_CLOUD_BASE_URL`.

### New: `spec/services/whatsapp/providers/whatsapp_cloud_service_media_upload_spec.rb`
Covers: `direct` strategy uses `media_id`, `link` strategy uses URL, upload failure falls back to link with warning log.

---

## Configuration

| Env var | Default | Description |
|---|---|---|
| `WHATSAPP_MEDIA_UPLOAD_STRATEGY` | `direct` | Set to `link` to revert to URL-based sending |
| `WHATSAPP_CLOUD_BASE_URL` | `https://graph.facebook.com` | Existing var, respected by the upload service |

No database migrations required. No breaking changes for operators — existing deployments get the fix automatically on upgrade. Operators who want to revert temporarily can set `WHATSAPP_MEDIA_UPLOAD_STRATEGY=link`.

---

## Testing

```bash
bundle exec rspec spec/services/whatsapp/media_upload_service_spec.rb
bundle exec rspec spec/services/whatsapp/providers/whatsapp_cloud_service_media_upload_spec.rb
```

---

## References
- Issue: #13540
- Meta docs — Upload Media: https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media#upload-media
- Meta docs — Send Media Messages: https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-messages#media-messages