### PR TITLE
fix: Enforce authorization in direct uploads controller

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/direct_uploads_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/direct_uploads_controller.rb
@@ -3,6 +3,7 @@ class Api::V1::Accounts::Conversations::DirectUploadsController < ActiveStorage:
   include RequestExceptionHandler
   include AccessTokenAuthHelper
   include EnsureCurrentAccountHelper
+  include Pundit::Authorization
 
   skip_before_action :verify_authenticity_token, if: :authenticate_by_access_token?
 
@@ -22,6 +23,14 @@ class Api::V1::Accounts::Conversations::DirectUploadsController < ActiveStorage:
 
   private
 
+  def pundit_user
+    {
+      user: Current.user,
+      account: Current.account,
+      account_user: Current.account_user
+    }
+  end
+
   def authenticate_by_access_token?
     request.headers[:api_access_token].present? || request.headers[:HTTP_API_ACCESS_TOKEN].present?
   end
@@ -33,6 +42,7 @@ class Api::V1::Accounts::Conversations::DirectUploadsController < ActiveStorage:
   end
 
   def conversation
-    @conversation ||= Current.account.conversations.find_by(display_id: params[:conversation_id])
+    @conversation ||= Current.account.conversations.find_by!(display_id: params[:conversation_id])
+    authorize @conversation, :show?
   end
 end

--- a/app/controllers/api/v1/accounts/conversations/direct_uploads_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/direct_uploads_controller.rb
@@ -11,6 +11,7 @@ class Api::V1::Accounts::Conversations::DirectUploadsController < ActiveStorage:
   before_action :authenticate_access_token!, if: :authenticate_by_access_token?
   before_action :validate_bot_access_token!, if: :authenticate_by_access_token?
   before_action :authenticate_user!, unless: :authenticate_by_access_token?
+  before_action :set_current_user, unless: :authenticate_by_access_token?
   before_action :current_account
   before_action :validate_token_api_access, if: :authenticate_by_access_token?
   before_action :conversation
@@ -22,6 +23,11 @@ class Api::V1::Accounts::Conversations::DirectUploadsController < ActiveStorage:
   end
 
   private
+
+  def set_current_user
+    @user ||= current_user
+    Current.user = @user
+  end
 
   def pundit_user
     {

--- a/spec/controllers/api/v1/accounts/conversations/direct_uploads_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/direct_uploads_controller_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe '/api/v1/accounts/:account_id/conversations/:conversation_id/dire
          as: :json
   end
 
+  before do
+    create(:inbox_member, user: agent, inbox: web_widget.inbox)
+  end
+
   describe 'POST /api/v1/accounts/:account_id/conversations/:conversation_id/direct_uploads' do
     context 'when it is an unauthenticated request' do
       it 'returns unauthorized without any credentials' do


### PR DESCRIPTION
Users were able to attach files to any conversations if they have a valid conversation_id due to a missing pundit authorization check. This commit includes Pundit::Authorization and explicitly authorizes the conversation before proceeding. It also implements pundit_user to provide the proper authorization context for the controller. Fixes #15072