### PR TITLE
feat(captain): enable V2 for all paid plans

### DIFF
--- a/enterprise/app/models/enterprise/account.rb
+++ b/enterprise/app/models/enterprise/account.rb
@@ -1,9 +1,4 @@
 module Enterprise::Account
-  # Transitional marker for the Captain V1 to V2 rollout. New cloud accounts get
-  # this marker so plan reconciliation can enable V2 for them without upgrading
-  # existing paid accounts. Remove once every account is migrated to V2.
-  CAPTAIN_V2_DEFAULT_ELIGIBLE = 'captain_v2_default_eligible'.freeze
-
   class << self
     def captain_document_sync_intervals
       parse_captain_document_sync_intervals(InstallationConfig.find_by(name: 'CAPTAIN_DOCUMENT_AUTO_SYNC_INTERVALS')&.value)
@@ -107,11 +102,7 @@ module Enterprise::Account
 
   def enable_default_features
     super
-    if ChatwootApp.self_hosted_enterprise?
-      enable_features('captain_integration', 'captain_integration_v2')
-    elsif ChatwootApp.chatwoot_cloud?
-      internal_attributes[CAPTAIN_V2_DEFAULT_ELIGIBLE] = true
-    end
+    enable_features('captain_integration', 'captain_integration_v2') if ChatwootApp.self_hosted_enterprise?
   end
 
   def sync_assignment_features

--- a/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
+++ b/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
@@ -13,6 +13,7 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
     channel_instagram
     channel_tiktok
     captain_integration
+    captain_integration_v2
     captain_document_auto_sync
     advanced_search_indexing
     advanced_search
@@ -37,9 +38,7 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
 
   def perform
     account.disable_features(*PREMIUM_PLAN_FEATURES)
-    account.disable_features('captain_integration_v2') if default_plan?
     account.enable_features(*current_plan_features)
-    account.enable_features('captain_integration_v2') if captain_v2_default_eligible?
     account.enable_features(*manually_managed_features)
     account.save!
   end
@@ -71,9 +70,5 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
 
   def manually_managed_features
     @manually_managed_features ||= Internal::Accounts::InternalAttributesService.new(account).manually_managed_features
-  end
-
-  def captain_v2_default_eligible?
-    !default_plan? && account.internal_attributes[Enterprise::Account::CAPTAIN_V2_DEFAULT_ELIGIBLE] == true
   end
 end

--- a/spec/enterprise/models/account_spec.rb
+++ b/spec/enterprise/models/account_spec.rb
@@ -284,13 +284,11 @@ RSpec.describe Account, type: :model do
       expect(account.captain_models).to be_nil
     end
 
-    it 'marks new cloud accounts as eligible for the Captain V2 paid-plan default' do
+    it 'does not enable Captain for new cloud accounts before plan reconciliation' do
       allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(false)
-      allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
 
       account = create(:account)
 
-      expect(account.internal_attributes[Enterprise::Account::CAPTAIN_V2_DEFAULT_ELIGIBLE]).to be true
       expect(account).not_to be_feature_enabled('captain_integration')
       expect(account).not_to be_feature_enabled('captain_integration_v2')
     end

--- a/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
@@ -221,21 +221,7 @@ describe Enterprise::Billing::HandleStripeEventService do
         end
       end
 
-      it 'does not enable Captain V2 for existing paid accounts during reconciliation' do
-        allow(subscription).to receive(:[]).with('plan')
-                                           .and_return({ 'id' => 'test', 'product' => 'plan_id_startups', 'name' => 'Startups' })
-
-        stripe_event_service.new.perform(event: event)
-
-        expect(account.reload).not_to be_feature_enabled('captain_integration_v2')
-      end
-
-      it 'enables Captain V2 for new cloud accounts marked as default eligible' do
-        account.update!(
-          internal_attributes: account.internal_attributes.merge(
-            Enterprise::Account::CAPTAIN_V2_DEFAULT_ELIGIBLE => true
-          )
-        )
+      it 'enables Captain V2 for paid accounts during reconciliation' do
         allow(subscription).to receive(:[]).with('plan')
                                            .and_return({ 'id' => 'test', 'product' => 'plan_id_startups', 'name' => 'Startups' })
 


### PR DESCRIPTION
Paid Chatwoot Cloud accounts now use Captain V2 by default. When billing reconciles a Startups, Business, or Enterprise plan, it enables Captain V2 together with Captain. Free Hacker accounts remain unchanged.

## Closes

No linked issue.

## How to test

1. Reconcile a cloud account on the Hacker plan and confirm that Captain and Captain V2 are disabled.
2. Upgrade the account to Startups, Business, or Enterprise and reconcile the plan.
3. Create an assistant and confirm that playground messages and conversation replies use Captain V2.

## What changed

1. Added Captain V2 to the paid plan feature set.
2. Removed the temporary eligibility marker for new cloud accounts.
3. Updated the existing account and billing reconciliation specs.