### PR TITLE
fix: apply installation name to sender name preview

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import Avatar from 'next/avatar/Avatar.vue';
 import RadioCard from 'dashboard/components-next/radioCard/RadioCard.vue';
+import { useBranding } from 'shared/composables/useBranding';
 
 const props = defineProps({
   senderNameType: {
@@ -22,6 +23,7 @@ const props = defineProps({
 const emit = defineEmits(['update']);
 
 const { t } = useI18n();
+const { replaceInstallationName } = useBranding();
 
 const senderNameKeyOptions = computed(() => [
   {
@@ -51,7 +53,9 @@ const isKeyOptionFriendly = key => key === 'friendly';
 const userName = keyOption =>
   isKeyOptionFriendly(keyOption.key)
     ? keyOption.preview.senderName
-    : keyOption.preview.businessName;
+    : replaceInstallationName(
+        props.businessName || keyOption.preview.businessName || ''
+      );
 
 const toggleSenderNameType = key => {
   emit('update', key);
@@ -92,7 +96,11 @@ const toggleSenderNameType = key => {
               {{ t('INBOX_MGMT.EDIT.SENDER_NAME_SECTION.FRIENDLY.FROM') }}
             </span>
             <span class="text-body-main text-n-slate-12">
-              {{ props.businessName || keyOption.preview.businessName }}
+              {{
+                replaceInstallationName(
+                  props.businessName || keyOption.preview.businessName || ''
+                )
+              }}
             </span>
           </div>
           <span class="text-label-small text-n-slate-11">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/SenderNameExamplePreview.vue
@@ -32,7 +32,7 @@ const senderNameKeyOptions = computed(() => [
     content: t('INBOX_MGMT.EDIT.SENDER_NAME_SECTION.FRIENDLY.SUBTITLE'),
     preview: {
       senderName: 'Smith',
-      businessName: 'Chatwoot',
+      businessName: replaceInstallationName('Chatwoot'),
       email: '<support@yourbusiness.com>',
     },
   },
@@ -42,7 +42,7 @@ const senderNameKeyOptions = computed(() => [
     content: t('INBOX_MGMT.EDIT.SENDER_NAME_SECTION.PROFESSIONAL.SUBTITLE'),
     preview: {
       senderName: '',
-      businessName: 'Chatwoot',
+      businessName: replaceInstallationName('Chatwoot'),
       email: '<support@yourbusiness.com>',
     },
   },
@@ -53,9 +53,7 @@ const isKeyOptionFriendly = key => key === 'friendly';
 const userName = keyOption =>
   isKeyOptionFriendly(keyOption.key)
     ? keyOption.preview.senderName
-    : replaceInstallationName(
-        props.businessName || keyOption.preview.businessName || ''
-      );
+    : props.businessName || keyOption.preview.businessName;
 
 const toggleSenderNameType = key => {
   emit('update', key);
@@ -96,11 +94,7 @@ const toggleSenderNameType = key => {
               {{ t('INBOX_MGMT.EDIT.SENDER_NAME_SECTION.FRIENDLY.FROM') }}
             </span>
             <span class="text-body-main text-n-slate-12">
-              {{
-                replaceInstallationName(
-                  props.businessName || keyOption.preview.businessName || ''
-                )
-              }}
+              {{ props.businessName || keyOption.preview.businessName }}
             </span>
           </div>
           <span class="text-label-small text-n-slate-11">

--- a/app/javascript/shared/composables/specs/useBranding.spec.js
+++ b/app/javascript/shared/composables/specs/useBranding.spec.js
@@ -73,13 +73,13 @@ describe('useBranding', () => {
       expect(result).toBe('Welcome to our platform');
     });
 
-    it('should be case-sensitive for "Chatwoot"', () => {
+    it('should replace "Chatwoot" regardless of casing', () => {
       const { replaceInstallationName } = useBranding();
       const result = replaceInstallationName(
-        'Welcome to chatwoot and CHATWOOT'
+        'Welcome to chatwoot, Chatwoot and CHATWOOT'
       );
 
-      expect(result).toBe('Welcome to chatwoot and CHATWOOT');
+      expect(result).toBe('Welcome to MyCompany, MyCompany and MyCompany');
     });
 
     it('should handle special characters in installation name', () => {

--- a/app/javascript/shared/composables/useBranding.js
+++ b/app/javascript/shared/composables/useBranding.js
@@ -7,7 +7,8 @@ import { useMapGetter } from 'dashboard/composables/store.js';
 export function useBranding() {
   const globalConfig = useMapGetter('globalConfig/get');
   /**
-   * Replaces "Chatwoot" in text with the installation name from global config
+   * Replaces "Chatwoot" (any casing) in text with the installation name from
+   * global config
    * @param {string} text - The text to process
    * @returns {string} - Text with "Chatwoot" replaced by installation name
    */
@@ -17,7 +18,7 @@ export function useBranding() {
     const installationName = globalConfig.value?.installationName;
     if (!installationName) return text;
 
-    return text.replace(/Chatwoot/g, installationName);
+    return text.replace(/chatwoot/gi, installationName);
   };
 
   return {


### PR DESCRIPTION
# Pull Request Template

## Description

This PR ensures the configured installation name is used everywhere the "Chatwoot" brand appeared in the sender name preview on self-hosted usages.

Fixes https://linear.app/chatwoot/issue/CW-7633/installation-name-not-applied-to-inbox-sender-name-preview

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="1306" height="396" alt="image" src="https://github.com/user-attachments/assets/61fc6484-fa9d-4c05-a7a2-bf04ab2f3978" />



**After**
<img width="1306" height="396" alt="image" src="https://github.com/user-attachments/assets/040e25c5-b04d-4427-8cef-075817782e14" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
