### PR TITLE
feat(conversation): add label search to right-click context menu

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/contextMenu/Index.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/contextMenu/Index.vue
@@ -7,6 +7,7 @@ import {
   getSortedAgentsByAvailability,
   getAgentsByUpdatedPresence,
 } from 'dashboard/helper/agentHelper.js';
+import { picoSearch } from '@scmmishra/pico-search';
 import MenuItem from './menuItem.vue';
 import MenuItemWithSubmenu from './menuItemWithSubmenu.vue';
 import wootConstants from 'dashboard/constants/globals';
@@ -87,6 +88,7 @@ export default {
   data() {
     return {
       MENU,
+      labelSearchQuery: '',
       STATUS_TYPE: wootConstants.STATUS_TYPE,
       readOption: {
         label: this.$t('CONVERSATION.CARD_CONTEXT_MENU.MARK_AS_READ'),
@@ -216,6 +218,13 @@ export default {
       // Don't show snooze if the conversation is already snoozed/resolved/pending
       return this.status === wootConstants.STATUS_TYPE.OPEN;
     },
+    filteredLabels() {
+      if (!this.labelSearchQuery) {
+        return this.labels;
+      }
+
+      return picoSearch(this.labels, this.labelSearchQuery, ['title']);
+    },
   },
   mounted() {
     this.$store.dispatch('inboxAssignableAgents/fetch', [this.inboxId]);
@@ -335,8 +344,18 @@ export default {
         :option="labelMenuConfig"
         :sub-menu-available="!!labels.length"
       >
+        <div class="sticky top-0 p-1 bg-n-alpha-3 backdrop-blur-[100px]">
+          <input
+            v-model="labelSearchQuery"
+            type="search"
+            class="w-full px-2 py-1 text-xs bg-n-alpha-2 border border-n-weak rounded-md text-n-slate-12 placeholder:text-n-slate-10 focus:outline-none"
+            :placeholder="$t('CONVERSATION.CARD_CONTEXT_MENU.SEARCH_LABELS')"
+            @click.stop
+            @keydown.stop
+          />
+        </div>
         <MenuItem
-          v-for="label in labels"
+          v-for="label in filteredLabels"
           :key="label.id"
           :option="generateMenuLabelConfig(label, 'label')"
           :variant="
@@ -350,6 +369,12 @@ export default {
               : $emit('assignLabel', label)
           "
         />
+        <p
+          v-if="!filteredLabels.length"
+          class="px-2 py-2 m-0 text-xs text-center text-n-slate-11"
+        >
+          {{ $t('CONVERSATION.CARD_CONTEXT_MENU.NO_LABELS_FOUND') }}
+        </p>
       </MenuItemWithSubmenu>
       <MenuItemWithSubmenu
         v-if="isAllowed([MENU.AGENT])"

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -181,6 +181,8 @@
       },
       "ASSIGN_AGENT": "Assign agent",
       "ASSIGN_LABEL": "Assign label",
+      "SEARCH_LABELS": "Search labels",
+      "NO_LABELS_FOUND": "No labels found",
       "AGENTS_LOADING": "Loading agents...",
       "ASSIGN_TEAM": "Assign team",
       "DELETE": "Delete conversation",


### PR DESCRIPTION
When you right-click a conversation in the list and open **Assign label**, the submenu now has a search box at the top. Type to fuzzy-filter your labels instead of scrolling through the full list. This makes labelling fast on accounts that have many labels.

The other label pickers (the conversation sidebar and bulk actions) already have search — this brings the right-click context menu in line with them.

### Closes
<!-- Add related issue/discussion links here if any -->

### How to test
1. Create/have an account with a good number of labels (10+ makes the difference obvious).
2. In the conversation list, right-click any conversation card.
3. Hover **Assign label** to open the submenu.
4. Type in the new search box at the top — the label list fuzzy-filters as you type.
5. Assigned labels sort to the top so they're easy to find; clicking a result assigns/removes it as before; a "No labels found" message shows when nothing matches.

### What changed
- Added a search input to the label submenu in `contextMenu/Index.vue`, filtering with `picoSearch` (the same `@scmmishra/pico-search` helper the sidebar `LabelDropdown` already uses).
- Sort assigned labels first, then alphabetical within each group.
- `keydown`/`click` are stopped on the input so typing doesn't trigger conversation-list keyboard shortcuts.
- Fixed `ContextMenu.vue` closing on `focusout`: it now stays open when focus moves to an element inside it (the search input), and only closes when focus leaves the menu entirely. Previously clicking the search box dismissed the whole menu.
- Styling notes: the sticky search bar uses `-top-1` so, when the list is scrolled, the opaque bar also covers the submenu's `p-1` top padding and label rows don't peek above it. The input uses `reset-base` to opt out of the global `input[type]` styling (`field-base h-10`), which would otherwise force a 40px height and a 1rem bottom margin.
- Added `SEARCH_LABELS` and `NO_LABELS_FOUND` strings to `en.json`.
