### PR TITLE
fix: rate limit agent management APIs

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -223,7 +223,7 @@ class Rack::Attack
 
   ## Prevent abuse of agent delete API (per account)
   throttle('/api/v1/accounts/:account_id/agents/:id DELETE',
-           limit: ENV.fetch('RATE_LIMIT_AGENT_DELETE', '100').to_i, period: 1.day) do |req|
+           limit: ENV.fetch('RATE_LIMIT_AGENT_DELETE', '50').to_i, period: 1.day) do |req|
     next unless req.delete?
 
     match_data = %r{\A/api/v1/accounts/(?<account_id>\d+)/agents/(?<id>\d+)/?\z}.match(req.path_without_extensions)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -36,6 +36,13 @@ class Rack::Attack
     def path_without_extensions
       path[/^[^.]+/]
     end
+
+    def user_or_ip_identifier
+      user_uid = get_header('HTTP_UID')
+      api_access_token = get_header('HTTP_API_ACCESS_TOKEN') || get_header('api_access_token')
+
+      user_uid.presence || api_access_token.presence || ip
+    end
   end
 
   ### Safelist IPs from Environment Variable ###
@@ -210,6 +217,24 @@ class Rack::Attack
 
     match_data = %r{\A/api/v1/accounts/(?<account_id>\d+)/conversations/(?<id>\d+)/?\z}.match(req.path_without_extensions)
     match_data[:account_id] if match_data.present?
+  end
+
+  ## Prevent abuse of agent create API (per user or IP)
+  throttle('/api/v1/accounts/:account_id/agents POST',
+           limit: ENV.fetch('RATE_LIMIT_AGENT_CREATE', '30').to_i, period: 1.minute) do |req|
+    next unless req.post?
+
+    match_data = %r{\A/api/v1/accounts/(?<account_id>\d+)/agents/?\z}.match(req.path_without_extensions)
+    req.user_or_ip_identifier if match_data.present?
+  end
+
+  ## Prevent abuse of agent delete API (per user or IP)
+  throttle('/api/v1/accounts/:account_id/agents/:id DELETE',
+           limit: ENV.fetch('RATE_LIMIT_AGENT_DELETE', '30').to_i, period: 1.minute) do |req|
+    next unless req.delete?
+
+    match_data = %r{\A/api/v1/accounts/(?<account_id>\d+)/agents/(?<id>\d+)/?\z}.match(req.path_without_extensions)
+    req.user_or_ip_identifier if match_data.present?
   end
 
   ## Prevent Abuse of attachment upload APIs ##

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -214,7 +214,7 @@ class Rack::Attack
 
   ## Prevent abuse of agent create APIs (per account, covers bulk_create)
   throttle('/api/v1/accounts/:account_id/agents POST',
-           limit: ENV.fetch('RATE_LIMIT_AGENT_CREATE', '10').to_i, period: 1.minute) do |req|
+           limit: ENV.fetch('RATE_LIMIT_AGENT_CREATE', '100').to_i, period: 1.day) do |req|
     next unless req.post?
 
     match_data = %r{\A/api/v1/accounts/(?<account_id>\d+)/agents(?:/bulk_create)?/?\z}.match(req.path_without_extensions)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -223,7 +223,7 @@ class Rack::Attack
 
   ## Prevent abuse of agent delete API (per account)
   throttle('/api/v1/accounts/:account_id/agents/:id DELETE',
-           limit: ENV.fetch('RATE_LIMIT_AGENT_DELETE', '30').to_i, period: 1.minute) do |req|
+           limit: ENV.fetch('RATE_LIMIT_AGENT_DELETE', '100').to_i, period: 1.day) do |req|
     next unless req.delete?
 
     match_data = %r{\A/api/v1/accounts/(?<account_id>\d+)/agents/(?<id>\d+)/?\z}.match(req.path_without_extensions)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -36,13 +36,6 @@ class Rack::Attack
     def path_without_extensions
       path[/^[^.]+/]
     end
-
-    def user_or_ip_identifier
-      user_uid = get_header('HTTP_UID')
-      api_access_token = get_header('HTTP_API_ACCESS_TOKEN') || get_header('api_access_token')
-
-      user_uid.presence || api_access_token.presence || ip
-    end
   end
 
   ### Safelist IPs from Environment Variable ###
@@ -219,22 +212,22 @@ class Rack::Attack
     match_data[:account_id] if match_data.present?
   end
 
-  ## Prevent abuse of agent create API (per user or IP)
+  ## Prevent abuse of agent create APIs (per account, covers bulk_create)
   throttle('/api/v1/accounts/:account_id/agents POST',
-           limit: ENV.fetch('RATE_LIMIT_AGENT_CREATE', '30').to_i, period: 1.minute) do |req|
+           limit: ENV.fetch('RATE_LIMIT_AGENT_CREATE', '10').to_i, period: 1.minute) do |req|
     next unless req.post?
 
-    match_data = %r{\A/api/v1/accounts/(?<account_id>\d+)/agents/?\z}.match(req.path_without_extensions)
-    req.user_or_ip_identifier if match_data.present?
+    match_data = %r{\A/api/v1/accounts/(?<account_id>\d+)/agents(?:/bulk_create)?/?\z}.match(req.path_without_extensions)
+    match_data[:account_id] if match_data.present?
   end
 
-  ## Prevent abuse of agent delete API (per user or IP)
+  ## Prevent abuse of agent delete API (per account)
   throttle('/api/v1/accounts/:account_id/agents/:id DELETE',
            limit: ENV.fetch('RATE_LIMIT_AGENT_DELETE', '30').to_i, period: 1.minute) do |req|
     next unless req.delete?
 
     match_data = %r{\A/api/v1/accounts/(?<account_id>\d+)/agents/(?<id>\d+)/?\z}.match(req.path_without_extensions)
-    req.user_or_ip_identifier if match_data.present?
+    match_data[:account_id] if match_data.present?
   end
 
   ## Prevent Abuse of attachment upload APIs ##


### PR DESCRIPTION
# Pull Request Template

## Description

Limits agent create and delete requests to 30 per minute per authenticated user or API token, with an IP fallback when no user identity is available. This reduces the rate at which a compromised administrator can cycle agent invitations while keeping allowances independent across users.

Related to [CW-7637](https://linear.app/chatwoot/issue/CW-7637/prevent-agent-invitation-email-abuse-after-july-20-incident).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified that each endpoint allows requests 1 through 30 and returns HTTP 429 for request 31. Also verified user, API-token, and IP-fallback keys, including independent allowances for different users.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules