### PR TITLE
fix: calls dashboard load race

### DIFF
--- a/app/javascript/dashboard/components-next/Calls/CallListItem.vue
+++ b/app/javascript/dashboard/components-next/Calls/CallListItem.vue
@@ -25,8 +25,11 @@ const route = useRoute();
 
 const kind = computed(() => getCallKind(props.call));
 
-const contactName = computed(
-  () => props.call.contact.name || props.call.contact.phoneNumber
+const contactName = computed(() =>
+  (props.call.contact.name || props.call.contact.phoneNumber || '').replace(
+    /^\+/,
+    ''
+  )
 );
 
 const agentActionLabel = computed(() => {

--- a/app/javascript/dashboard/routes/dashboard/calls/pages/CallsIndex.vue
+++ b/app/javascript/dashboard/routes/dashboard/calls/pages/CallsIndex.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { computed, ref, watch } from 'vue';
+import { computed, ref, watch, onMounted } from 'vue';
+import { until } from '@vueuse/core';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import { useMapGetter, useStore } from 'dashboard/composables/store';
@@ -49,7 +50,9 @@ const isVoiceEnabled = computed(
 const calls = computed(() => callHistoryStore.records);
 const meta = computed(() => callHistoryStore.meta);
 const isFetching = computed(() => callHistoryStore.uiFlags.isFetching);
-const inboxesUiFlags = useMapGetter('inboxes/getUIFlags');
+const accountUiFlags = useMapGetter('accounts/getUIFlags');
+
+const isInitializing = ref(true);
 
 // Filters are seeded from the URL so a shared link restores the same view.
 const activity = ref(
@@ -98,20 +101,25 @@ const onPageChange = page => {
   fetchCalls();
 };
 
-// inboxes/get flips isFetching true synchronously, so the spinner shows on the
-// first render and the setup CTA never flashes; hit the calls endpoint only
-// once inboxes confirm voice is on.
-store.dispatch('inboxes/get').then(() => {
-  if (!isVoiceEnabled.value) return;
-  // Only admins see the assignee filter, so only they need the agent list.
-  if (isAdmin.value) store.dispatch('agents/get');
-  fetchCalls();
+onMounted(async () => {
+  try {
+    await Promise.all([
+      store.dispatch('inboxes/get'),
+      until(() => accountUiFlags.value.isFetchingItem).toBe(false),
+    ]);
+    if (!isVoiceEnabled.value) return;
+    // Only admins see the assignee filter, so only they need the agent list.
+    if (isAdmin.value) store.dispatch('agents/get');
+    await fetchCalls();
+  } finally {
+    isInitializing.value = false;
+  }
 });
 </script>
 
 <template>
   <div
-    v-if="inboxesUiFlags.isFetching"
+    v-if="isInitializing"
     class="flex items-center justify-center w-full h-full bg-n-surface-1"
   >
     <Spinner :size="24" />


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes two issues on the Calls dashboard.

1. On a hard refresh, the page could briefly (or persistently) show "No calls found" even when calls existed. Navigating away and back fixed it. The page now waits for both the account feature flag and inboxes to load before determining whether voice is enabled, and keeps the loader visible throughout the initial load so the list renders reliably without an empty-state flash.

2. Phone-only contacts (those without a name) displayed with a leading `+` in both the row label and avatar initial. The leading `+` is now stripped for a cleaner display.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Steps to reproduce

**Empty-state flash:**

1. Open the Calls page and hard refresh (⌘/Ctrl+R).
2. Before the fix: "No calls found" briefly appears (intermittently, depending on load timing) even though calls exist. Navigating to Conversations and back shows them correctly.
3. After the fix: the loader stays visible until everything is ready and the calls list renders without flashing the empty state.

**Leading `+`:**

1. Have a call from a contact without a name (phone number only).
2. Before the fix: the row label and avatar display `+9199…`.
3. After the fix: the number is displayed without the leading `+`.



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
