### PR TITLE
feat(whatsapp): unify embedded signup feature gating

### DIFF
--- a/app/controllers/api/v1/accounts/whatsapp/authorizations_controller.rb
+++ b/app/controllers/api/v1/accounts/whatsapp/authorizations_controller.rb
@@ -50,7 +50,12 @@ class Api::V1::Accounts::Whatsapp::AuthorizationsController < Api::V1::Accounts:
   end
 
   def can_reconfigure_channel?
-    @inbox.channel.provider == 'whatsapp_cloud'
+    channel = @inbox.channel
+    return false unless channel.provider == 'whatsapp_cloud'
+    return true if ChatwootApp.chatwoot_cloud?
+    return Current.account.feature_enabled?('whatsapp_reconfigure') if channel.provider_config['source'] == 'embedded_signup'
+
+    true
   end
 
   def render_success_response(inbox)

--- a/app/controllers/api/v1/accounts/whatsapp/authorizations_controller.rb
+++ b/app/controllers/api/v1/accounts/whatsapp/authorizations_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::Accounts::Whatsapp::AuthorizationsController < Api::V1::Accounts::BaseController
+  before_action :ensure_embedded_signup_enabled
   # Reconfiguring/reauthorizing a live inbox swaps its credentials, so restrict it to admins.
   before_action :check_admin_authorization?, if: -> { params[:inbox_id].present? }
   before_action :fetch_and_validate_inbox, if: -> { params[:inbox_id].present? }
@@ -17,6 +18,13 @@ class Api::V1::Accounts::Whatsapp::AuthorizationsController < Api::V1::Accounts:
   end
 
   private
+
+  def ensure_embedded_signup_enabled
+    return unless ChatwootApp.chatwoot_cloud?
+    return if Current.account.feature_enabled?('whatsapp_embedded_signup_inbox_creation')
+
+    raise Pundit::NotAuthorizedError
+  end
 
   def process_embedded_signup
     service = Whatsapp::EmbeddedSignupService.new(
@@ -42,13 +50,7 @@ class Api::V1::Accounts::Whatsapp::AuthorizationsController < Api::V1::Accounts:
   end
 
   def can_reconfigure_channel?
-    channel = @inbox.channel
-    return false unless channel.provider == 'whatsapp_cloud'
-
-    # Reconfiguring a live embedded-signup channel requires the feature flag.
-    return Current.account.feature_enabled?('whatsapp_reconfigure') if channel.provider_config['source'] == 'embedded_signup'
-
-    true
+    @inbox.channel.provider == 'whatsapp_cloud'
   end
 
   def render_success_response(inbox)

--- a/app/javascript/dashboard/featureFlags.js
+++ b/app/javascript/dashboard/featureFlags.js
@@ -9,6 +9,7 @@ export const FEATURE_FLAGS = {
   WHATSAPP_CAMPAIGNS: 'whatsapp_campaign',
   WHATSAPP_EMBEDDED_SIGNUP_FLOW: 'whatsapp_embedded_signup_inbox_creation',
   WHATSAPP_MANUAL_TRANSFER: 'whatsapp_manual_transfer',
+  WHATSAPP_RECONFIGURE: 'whatsapp_reconfigure',
   CANNED_RESPONSES: 'canned_responses',
   CRM: 'crm',
   CUSTOM_ATTRIBUTES: 'custom_attributes',

--- a/app/javascript/dashboard/featureFlags.js
+++ b/app/javascript/dashboard/featureFlags.js
@@ -10,7 +10,6 @@ export const FEATURE_FLAGS = {
   WHATSAPP_EMBEDDED_SIGNUP_INBOX_CREATION:
     'whatsapp_embedded_signup_inbox_creation',
   WHATSAPP_MANUAL_TRANSFER: 'whatsapp_manual_transfer',
-  WHATSAPP_RECONFIGURE: 'whatsapp_reconfigure',
   CANNED_RESPONSES: 'canned_responses',
   CRM: 'crm',
   CUSTOM_ATTRIBUTES: 'custom_attributes',

--- a/app/javascript/dashboard/featureFlags.js
+++ b/app/javascript/dashboard/featureFlags.js
@@ -7,8 +7,7 @@ export const FEATURE_FLAGS = {
   AUTOMATIONS: 'automations',
   CAMPAIGNS: 'campaigns',
   WHATSAPP_CAMPAIGNS: 'whatsapp_campaign',
-  WHATSAPP_EMBEDDED_SIGNUP_INBOX_CREATION:
-    'whatsapp_embedded_signup_inbox_creation',
+  WHATSAPP_EMBEDDED_SIGNUP_FLOW: 'whatsapp_embedded_signup_inbox_creation',
   WHATSAPP_MANUAL_TRANSFER: 'whatsapp_manual_transfer',
   CANNED_RESPONSES: 'canned_responses',
   CRM: 'crm',

--- a/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
@@ -18,9 +18,7 @@ export function useChannelConfig() {
     // app id (not the 'none' sentinel) and the signup configuration id.
     whatsapp: () =>
       (!isOnChatwootCloud.value ||
-        isCloudFeatureEnabled(
-          FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_INBOX_CREATION
-        )) &&
+        isCloudFeatureEnabled(FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_FLOW)) &&
       Boolean(installationConfig.whatsappAppId) &&
       installationConfig.whatsappAppId !== 'none' &&
       Boolean(installationConfig.whatsappConfigurationId),

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -393,7 +393,7 @@ export default {
         (!this.isOnChatwootCloud ||
           this.isFeatureEnabledonAccount(
             this.accountId,
-            FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_INBOX_CREATION
+            FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_FLOW
           )) &&
         this.inbox.reauthorization_required
       );

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -390,6 +390,11 @@ export default {
       return (
         this.isAWhatsAppCloudChannel &&
         this.isEmbeddedSignupWhatsApp &&
+        (!this.isOnChatwootCloud ||
+          this.isFeatureEnabledonAccount(
+            this.accountId,
+            FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_INBOX_CREATION
+          )) &&
         this.inbox.reauthorization_required
       );
     },

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -42,9 +42,7 @@ const shouldShowWhatsappEmbeddedSignup = computed(() => {
     selectedProvider.value === PROVIDER_TYPES.WHATSAPP &&
     hasWhatsappAppId.value &&
     (!isOnChatwootCloud.value ||
-      isCloudFeatureEnabled(
-        FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_INBOX_CREATION
-      ))
+      isCloudFeatureEnabled(FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_FLOW))
   );
 });
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
@@ -64,11 +64,12 @@ export default {
     showWhatsAppReconfigure() {
       return (
         this.isEmbeddedSignupWhatsApp &&
-        (!this.isOnChatwootCloud ||
-          this.isFeatureEnabledonAccount(
-            this.accountId,
-            FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_FLOW
-          ))
+        this.isFeatureEnabledonAccount(
+          this.accountId,
+          this.isOnChatwootCloud
+            ? FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_FLOW
+            : FEATURE_FLAGS.WHATSAPP_RECONFIGURE
+        )
       );
     },
     isForwardingEnabled() {

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
@@ -56,6 +56,7 @@ export default {
     ...mapGetters({
       accountId: 'getCurrentAccountId',
       isFeatureEnabledonAccount: 'accounts/isFeatureEnabledonAccount',
+      isOnChatwootCloud: 'globalConfig/isOnChatwootCloud',
     }),
     isEmbeddedSignupWhatsApp() {
       return this.inbox.provider_config?.source === 'embedded_signup';
@@ -63,10 +64,11 @@ export default {
     showWhatsAppReconfigure() {
       return (
         this.isEmbeddedSignupWhatsApp &&
-        this.isFeatureEnabledonAccount(
-          this.accountId,
-          FEATURE_FLAGS.WHATSAPP_RECONFIGURE
-        )
+        (!this.isOnChatwootCloud ||
+          this.isFeatureEnabledonAccount(
+            this.accountId,
+            FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_INBOX_CREATION
+          ))
       );
     },
     isForwardingEnabled() {

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
@@ -67,7 +67,7 @@ export default {
         (!this.isOnChatwootCloud ||
           this.isFeatureEnabledonAccount(
             this.accountId,
-            FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_INBOX_CREATION
+            FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_FLOW
           ))
       );
     },

--- a/config/features.yml
+++ b/config/features.yml
@@ -265,6 +265,6 @@
   enabled: false
   column: feature_flags_ext_1
 - name: whatsapp_embedded_signup_inbox_creation
-  display_name: WhatsApp Embedded Signup Inbox Creation
+  display_name: WhatsApp Embedded Signup Flow
   enabled: false
   column: feature_flags_ext_1

--- a/config/features.yml
+++ b/config/features.yml
@@ -264,7 +264,6 @@
   display_name: WhatsApp Reconfigure
   enabled: false
   column: feature_flags_ext_1
-  deprecated: true
 - name: whatsapp_embedded_signup_inbox_creation
   display_name: WhatsApp Embedded Signup Flow
   enabled: false

--- a/config/features.yml
+++ b/config/features.yml
@@ -264,6 +264,7 @@
   display_name: WhatsApp Reconfigure
   enabled: false
   column: feature_flags_ext_1
+  deprecated: true
 - name: whatsapp_embedded_signup_inbox_creation
   display_name: WhatsApp Embedded Signup Flow
   enabled: false


### PR DESCRIPTION
WhatsApp embedded signup now uses `whatsapp_embedded_signup_inbox_creation` as the single Chatwoot Cloud rollout gate for inbox creation, proactive reconfiguration, and disconnected inbox reauthorization. The authorization endpoint enforces the same gate, so the UI and backend remain consistent.

Self-hosted installations keep their existing behavior.

## Things to know

- This reuses the existing feature flag; there is no migration or schema change.
- The feature is shown as “WhatsApp Embedded Signup Flow” in feature management.
- `whatsapp_reconfigure` remains visible and honored for self-hosted proactive reconfiguration to preserve existing accounts. It can be deprecated after the self-hosted dependency is removed or migrated.

## How to test

1. On Chatwoot Cloud, enable `whatsapp_embedded_signup_inbox_creation` for an account.
2. Confirm that new WhatsApp inbox creation, proactive reconfiguration, and disconnected inbox reauthorization are available.
3. Disable the flag and confirm those entry points are hidden and authorization requests are rejected.
4. On self-hosted, confirm proactive reconfiguration remains controlled by the existing `whatsapp_reconfigure` account setting.