### PR TITLE
Fix/15091 distinguish my chat messages from that of other support users

### DIFF
--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -503,6 +503,12 @@ const avatarTooltip = computed(() => {
   return `${t('CONVERSATION.SENT_BY')} ${avatarInfo.value.name}`;
 });
 
+// for checking if the message was sent by current user
+const isMyMessage = computed(() => {
+  const effectiveSenderId = props.senderId ?? props.sender?.id;
+  return effectiveSenderId === props.currentUserId;
+});
+
 const setupHighlightTimer = () => {
   if (Number(route.query.messageId) !== Number(props.id)) {
     return;
@@ -523,6 +529,7 @@ provideMessageContext({
   variant,
   orientation,
   isBotOrAgentMessage,
+  isMyMessage,
   shouldGroupWithNext,
 });
 </script>
@@ -567,13 +574,25 @@ provideMessageContext({
         <Avatar v-bind="avatarInfo" :size="24" />
       </div>
       <div
-        class="[grid-area:bubble] flex min-w-0"
+        class="[grid-area:bubble] flex flex-col min-w-0"
         :class="{
-          'ltr:ml-8 rtl:mr-8 justify-end': orientation === ORIENTATION.RIGHT,
-          'ltr:mr-8 rtl:ml-8': orientation === ORIENTATION.LEFT,
+          'ltr:ml-8 rtl:mr-8 items-end': orientation === ORIENTATION.RIGHT,
+          'ltr:mr-8 rtl:ml-8 items-start': orientation === ORIENTATION.LEFT,
         }"
         @contextmenu="openContextMenu($event)"
       >
+        <!-- Sender Name Header -->
+        <span
+          v-if="
+            isBotOrAgentMessage &&
+            !shouldGroupWithNext &&
+            avatarInfo.name?.trim()
+          "
+          class="text-xs mb-1 font-medium text-n-slate-11 dark:text-n-slate-11 px-1"
+        >
+          {{ isMyMessage ? `${avatarInfo.name} (You)` : avatarInfo.name }}
+        </span>
+
         <Component :is="componentToRender" />
       </div>
       <MessageError

--- a/app/javascript/dashboard/components-next/message/specs/Message.spec.js
+++ b/app/javascript/dashboard/components-next/message/specs/Message.spec.js
@@ -1,0 +1,80 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import Message from '../Message.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: key => key,
+  }),
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    query: {},
+  }),
+}));
+
+vi.mock('dashboard/composables/store', () => ({
+  useMapGetter: () => () => ({}),
+  useStoreGetters: () => ({
+    getUISettings: { value: {} },
+  }),
+  useStore: () => ({
+    dispatch: vi.fn(),
+  }),
+}));
+
+vi.mock('dashboard/composables', () => ({
+  useTrack: vi.fn(),
+}));
+
+describe('Message.vue Sender Name Header', () => {
+  const defaultProps = {
+    id: 1,
+    messageType: 1,
+    status: 'sent',
+    content: 'hello world',
+    conversationId: 100,
+    createdAt: 123456789,
+    currentUserId: 10,
+    sender: { id: 10, name: 'John', type: 'user' },
+    senderId: 10,
+    senderType: 'user',
+  };
+
+  it('renders sender name with (You) tag for current user message', () => {
+    const wrapper = mount(Message, {
+      props: defaultProps,
+      global: {
+        stubs: {
+          Avatar: true,
+          MessageError: true,
+          ContextMenu: true,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('John (You)');
+  });
+
+  it('renders only sender name when message is from another agent', () => {
+    const wrapper = mount(Message, {
+      props: {
+        ...defaultProps,
+        currentUserId: 10,
+        sender: { id: 20, name: 'Samantha', type: 'user' },
+        senderId: 20,
+      },
+      global: {
+        stubs: {
+          Avatar: true,
+          MessageError: true,
+          ContextMenu: true,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Samantha');
+    expect(wrapper.text()).not.toContain('Samantha (You)');
+  });
+});


### PR DESCRIPTION
## Description

This PR improves message readability in the chat dashboard by displaying the sender's name above agent/bot message bubbles and appending a `(You)` tag for messages sent by the active dashboard user.

* Displays sender name headers on outgoing agent/bot message bubbles.
* Appends `(You)` dynamically to the current user's messages.
* Hides headers for incoming customer messages and consecutive grouped messages.

Fixes chatwoot/chatwoot#15091

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

* Added unit tests for `Message.vue` to verify sender name and `(You)` tag rendering.
* Tested locally inside Docker via Vitest (`pnpm vitest run app/javascript/dashboard/components-next/message/specs/Message.spec.js`).
* Verified visual behavior manually across light/dark modes and different user sessions.

### UI Preview

<img src="https://github.com/user-attachments/assets/ab29802b-587f-444d-8c15-6660fe26ef59 " alt="Screenshot From 2026-07-22 02-19-00" width="1191" data-linear-height="623" />

<img src="https://github.com/user-attachments/assets/0a4cf437-ab20-4896-ab8f-3127fe3c6f66 " alt="Screenshot From 2026-07-22 02-19-36" width="363" data-linear-height="440" />

<img src="https://github.com/user-attachments/assets/aa0d0337-89d4-4e74-8e70-da921ca57602 " alt="Screenshot From 2026-07-22 02-20-26" width="1122" data-linear-height="693" />

<img src="https://github.com/user-attachments/assets/3ef25fe3-6bf3-46b8-bb01-3c78f6f53113 " alt="Screenshot From 2026-07-22 02-21-14" width="1156" data-linear-height="692" />

## Checklist:

* \[✓\] My code follows the style guidelines of this project
* \[✓\] My changes generate no new warnings
* \[✓\] I have added tests that prove my fix is effective or that my feature works
* \[✓\] New and existing unit tests pass locally with my changes