### PR TITLE
feat: update sidekiq and mutex lock timeout for fetch imap

### DIFF
--- a/app/jobs/inboxes/fetch_imap_emails_job.rb
+++ b/app/jobs/inboxes/fetch_imap_emails_job.rb
@@ -7,7 +7,7 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
     return unless should_fetch_email?(channel)
 
     key = format(::Redis::Alfred::EMAIL_MESSAGE_MUTEX, inbox_id: channel.inbox.id)
-    with_lock(key, 24.minutes) do
+    with_lock(key, 30.minutes) do
       process_email_for_channel(channel, interval)
     end
   rescue *ExceptionList::IMAP_EXCEPTIONS => e

--- a/app/jobs/inboxes/fetch_imap_emails_job.rb
+++ b/app/jobs/inboxes/fetch_imap_emails_job.rb
@@ -7,8 +7,7 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
     return unless should_fetch_email?(channel)
 
     key = format(::Redis::Alfred::EMAIL_MESSAGE_MUTEX, inbox_id: channel.inbox.id)
-
-    with_lock(key, 5.minutes) do
+    with_lock(key, 24.minutes) do
       process_email_for_channel(channel, interval)
     end
   rescue *ExceptionList::IMAP_EXCEPTIONS => e


### PR DESCRIPTION
This PR has the following changes

1.  Update lock timeout for IMAP fetching to 24 minutes to avoid overlapping of simultaneous imap connections

Ref: https://linear.app/chatwoot/issue/CW-7681/add-expiry-to-email-sync-lock