### PR TITLE
fix(email): allow larger email templates

### DIFF
--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -22,6 +22,7 @@
 class EmailTemplate < ApplicationRecord
   BRANDED_LAYOUT_NAME = 'base'.freeze
   DEFAULT_LOCALE = 'en'.freeze
+  MAX_BODY_LENGTH = 256.kilobytes
   CONTENT_FOR_LAYOUT_PATTERN = /\{\{\s*content_for_layout\s*\}\}/
 
   enum :locale, LANGUAGES_CONFIG.map { |key, val| [val[:iso_639_1_code], key] }.to_h, prefix: true
@@ -34,6 +35,7 @@ class EmailTemplate < ApplicationRecord
             if: :installation_scoped?
   validates :name, uniqueness: { scope: %i[account_id template_type locale], conditions: -> { where(inbox_id: nil) } }, if: :account_scoped?
   validates :name, uniqueness: { scope: %i[inbox_id template_type locale] }, if: :inbox_scoped?
+  validates :body, length: { maximum: MAX_BODY_LENGTH }
   validate :validate_inbox_account
   validate :validate_liquid_body
   validate :validate_layout_slot, if: :layout?

--- a/spec/controllers/api/v1/accounts/branded_email_layouts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/branded_email_layouts_controller_spec.rb
@@ -85,6 +85,20 @@ RSpec.describe 'Branded Email Layout API', type: :request do
         expect(response.parsed_body['branded_email_layout']).to eq(layout)
       end
 
+      it 'updates account-scoped branded email layouts up to 100 KiB' do
+        account.enable_features!(:branded_email_templates)
+        slot = '{{ content_for_layout }}'
+        large_layout = "#{'a' * (100.kilobytes - slot.length)}#{slot}"
+
+        patch "/api/v1/accounts/#{account.id}/branded_email_layout",
+              headers: admin.create_new_auth_token,
+              params: { branded_email_layout: large_layout },
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(EmailTemplate.account_branded_layout_template_for(account).body.length).to eq(100.kilobytes)
+      end
+
       it 'clears account-scoped branded email layout when blank value is passed' do
         account.enable_features!(:branded_email_templates)
         create(:email_template, :layout, account: account, body: layout)

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -636,6 +636,22 @@ RSpec.describe 'Inboxes API', type: :request do
         expect(response.parsed_body['branded_email_layout']).to eq(layout)
       end
 
+      it 'rejects branded email layouts larger than 256 KiB' do
+        account.enable_features!(:branded_email_templates)
+        email_channel = create(:channel_email, account: account)
+        email_inbox = create(:inbox, channel: email_channel, account: account)
+        slot = '{{ content_for_layout }}'
+        large_layout = "#{'a' * (EmailTemplate::MAX_BODY_LENGTH - slot.length + 1)}#{slot}"
+
+        patch "/api/v1/accounts/#{account.id}/inboxes/#{email_inbox.id}",
+              headers: admin.create_new_auth_token,
+              params: { branded_email_layout: large_layout },
+              as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to include('is too long (maximum is 262144 characters)')
+      end
+
       it 'rolls back branded email layout when inbox update fails' do
         account.enable_features!(:branded_email_templates)
         email_channel = create(:channel_email, account: account)

--- a/spec/models/email_template_spec.rb
+++ b/spec/models/email_template_spec.rb
@@ -68,6 +68,23 @@ RSpec.describe EmailTemplate do
       expect(template.errors[:body]).to include('must include {{ content_for_layout }}')
     end
 
+    it 'allows email templates up to 262,144 characters' do
+      slot = '{{ content_for_layout }}'
+      body = "#{'a' * (described_class::MAX_BODY_LENGTH - slot.length)}#{slot}"
+      template = build(:email_template, :layout, account: create(:account), body: body)
+
+      expect(template).to be_valid
+    end
+
+    it 'rejects email templates larger than 262,144 characters' do
+      slot = '{{ content_for_layout }}'
+      body = "#{'a' * (described_class::MAX_BODY_LENGTH - slot.length + 1)}#{slot}"
+      template = build(:email_template, :layout, account: create(:account), body: body)
+
+      expect(template).not_to be_valid
+      expect(template.errors[:body]).to include('is too long (maximum is 262144 characters)')
+    end
+
     it 'validates liquid syntax' do
       template = build(:email_template, body: '{{ broken ')
 

--- a/swagger/definitions/request/account/branded_email_layout_payload.yml
+++ b/swagger/definitions/request/account/branded_email_layout_payload.yml
@@ -4,5 +4,6 @@ properties:
     type:
       - string
       - 'null'
-    description: Account-scoped Liquid HTML layout for branded email replies. Blank or null removes the account override.
+    maxLength: 262144
+    description: Account-scoped Liquid HTML layout for branded email replies. Maximum length is 262,144 characters. Blank or null removes the account override.
     example: '<html><body>{{ content_for_layout }}</body></html>'

--- a/swagger/definitions/request/inbox/update_payload.yml
+++ b/swagger/definitions/request/inbox/update_payload.yml
@@ -113,8 +113,9 @@ properties:
     type:
       - string
       - 'null'
+    maxLength: 262144
     description: |
-      Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}`.
+      Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}` and be 262,144 characters or shorter.
 
       Available for: `Email`
     example: '<html><body>{{ content_for_layout }}</body></html>'

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -12804,7 +12804,8 @@
               "string",
               "null"
             ],
-            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}`.\n\nAvailable for: `Email`\n",
+            "maxLength": 262144,
+            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}` and be 262,144 characters or shorter.\n\nAvailable for: `Email`\n",
             "example": "<html><body>{{ content_for_layout }}</body></html>"
           },
           "channel": {
@@ -12842,7 +12843,8 @@
               "string",
               "null"
             ],
-            "description": "Account-scoped Liquid HTML layout for branded email replies. Blank or null removes the account override.",
+            "maxLength": 262144,
+            "description": "Account-scoped Liquid HTML layout for branded email replies. Maximum length is 262,144 characters. Blank or null removes the account override.",
             "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -11311,7 +11311,8 @@
               "string",
               "null"
             ],
-            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}`.\n\nAvailable for: `Email`\n",
+            "maxLength": 262144,
+            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}` and be 262,144 characters or shorter.\n\nAvailable for: `Email`\n",
             "example": "<html><body>{{ content_for_layout }}</body></html>"
           },
           "channel": {
@@ -11349,7 +11350,8 @@
               "string",
               "null"
             ],
-            "description": "Account-scoped Liquid HTML layout for branded email replies. Blank or null removes the account override.",
+            "maxLength": 262144,
+            "description": "Account-scoped Liquid HTML layout for branded email replies. Maximum length is 262,144 characters. Blank or null removes the account override.",
             "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -4119,7 +4119,8 @@
               "string",
               "null"
             ],
-            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}`.\n\nAvailable for: `Email`\n",
+            "maxLength": 262144,
+            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}` and be 262,144 characters or shorter.\n\nAvailable for: `Email`\n",
             "example": "<html><body>{{ content_for_layout }}</body></html>"
           },
           "channel": {
@@ -4157,7 +4158,8 @@
               "string",
               "null"
             ],
-            "description": "Account-scoped Liquid HTML layout for branded email replies. Blank or null removes the account override.",
+            "maxLength": 262144,
+            "description": "Account-scoped Liquid HTML layout for branded email replies. Maximum length is 262,144 characters. Blank or null removes the account override.",
             "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -3534,7 +3534,8 @@
               "string",
               "null"
             ],
-            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}`.\n\nAvailable for: `Email`\n",
+            "maxLength": 262144,
+            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}` and be 262,144 characters or shorter.\n\nAvailable for: `Email`\n",
             "example": "<html><body>{{ content_for_layout }}</body></html>"
           },
           "channel": {
@@ -3572,7 +3573,8 @@
               "string",
               "null"
             ],
-            "description": "Account-scoped Liquid HTML layout for branded email replies. Blank or null removes the account override.",
+            "maxLength": 262144,
+            "description": "Account-scoped Liquid HTML layout for branded email replies. Maximum length is 262,144 characters. Blank or null removes the account override.",
             "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -4295,7 +4295,8 @@
               "string",
               "null"
             ],
-            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}`.\n\nAvailable for: `Email`\n",
+            "maxLength": 262144,
+            "description": "Liquid HTML layout for outbound email replies. Must include `{{ content_for_layout }}` and be 262,144 characters or shorter.\n\nAvailable for: `Email`\n",
             "example": "<html><body>{{ content_for_layout }}</body></html>"
           },
           "channel": {
@@ -4333,7 +4334,8 @@
               "string",
               "null"
             ],
-            "description": "Account-scoped Liquid HTML layout for branded email replies. Blank or null removes the account override.",
+            "maxLength": 262144,
+            "description": "Account-scoped Liquid HTML layout for branded email replies. Maximum length is 262,144 characters. Blank or null removes the account override.",
             "example": "<html><body>{{ content_for_layout }}</body></html>"
           }
         }


### PR DESCRIPTION
## Description

Branded email layouts and other email templates can now contain up to 262,144 characters instead of the generic 20,000-character text limit. This supports customer layouts around 41 KB and 100 KB while retaining a defined application-level ceiling. The account and inbox API schemas now expose the same maximum.

## Closes

[CW-7682](https://linear.app/chatwoot/issue/CW-7682/allow-larger-branded-email-templates)

Related: [CW-7514](https://linear.app/chatwoot/issue/CW-7514/branded-html-email-templates-per-inboxbrand)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

1. As an administrator with `branded_email_templates` enabled, update an account branded layout with a 100 KB Liquid layout containing `{{ content_for_layout }}` and confirm the request succeeds.
2. Update an Email inbox layout with more than 262,144 characters and confirm the API returns `422`.
3. Confirm a layout at exactly 262,144 characters remains valid.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules