### PR TITLE
feat: register Slovenian (sl) locale in the live-chat widget

### DIFF
--- a/app/javascript/dashboard/i18n/index.js
+++ b/app/javascript/dashboard/i18n/index.js
@@ -28,6 +28,7 @@ import pt_BR from './locale/pt_BR';
 import ro from './locale/ro';
 import ru from './locale/ru';
 import sk from './locale/sk';
+import sl from './locale/sl';
 import sr from './locale/sr';
 import sv from './locale/sv';
 import ta from './locale/ta';
@@ -72,6 +73,7 @@ export default {
   ro,
   ru,
   sk,
+  sl,
   sr,
   sv,
   ta,

--- a/app/javascript/widget/i18n/index.js
+++ b/app/javascript/widget/i18n/index.js
@@ -29,6 +29,7 @@ import pt_BR from './locale/pt_BR.json';
 import ro from './locale/ro.json';
 import ru from './locale/ru.json';
 import sk from './locale/sk.json';
+import sl from './locale/sl.json';
 import sr from './locale/sr.json';
 import sv from './locale/sv.json';
 import ta from './locale/ta.json';

--- a/app/javascript/widget/i18n/index.js
+++ b/app/javascript/widget/i18n/index.js
@@ -73,6 +73,7 @@ export default {
   ro,
   ru,
   sk,
+  sl,
   sr,
   sv,
   ta,

--- a/config/initializers/languages.rb
+++ b/config/initializers/languages.rb
@@ -44,7 +44,8 @@ LANGUAGES_CONFIG = {
   39 => { name: 'Српски (sr)', iso_639_3_code: 'srp', iso_639_1_code: 'sr', enabled: true },
   40 => { name: 'български (bg)', iso_639_3_code: 'bul', iso_639_1_code: 'bg', enabled: true },
   41 => { name: 'Eesti keel (et)', iso_639_3_code: 'est', iso_639_1_code: 'et', enabled: true },
-  42 => { name: 'Oʻzbekcha (uz)', iso_639_3_code: 'uzb', iso_639_1_code: 'uz', enabled: true }
+  42 => { name: 'Oʻzbekcha (uz)', iso_639_3_code: 'uzb', iso_639_1_code: 'uz', enabled: true },
+  43 => { name: 'slovenščina (sl)', iso_639_3_code: 'slv', iso_639_1_code: 'sl', enabled: true }
 }.filter { |_key, val| val[:enabled] }.freeze
 
 Rails.configuration.i18n.available_locales = LANGUAGES_CONFIG.map { |_index, lang| lang[:iso_639_1_code].to_sym }


### PR DESCRIPTION
The widget is translated and should be imported. If anything is missing on the widget part, I am happy to translate it and reopen, just please let me know. I tried translating yesterday, but there was 131 pages...

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I haven't tested it; it didn't seem necessary for the change I am proposing. I tested locally by simulating a language on my instance. 