### PR TITLE
fix: stabilize Intercom client error spec

### DIFF
--- a/spec/services/data_imports/intercom/client_spec.rb
+++ b/spec/services/data_imports/intercom/client_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe DataImports::Intercom::Client do
     it 'wraps transport failures in a retryable client error', :aggregate_failures do
       allow(HTTParty).to receive(:get).and_raise(SocketError, 'getaddrinfo failed')
 
-      expect { client.list_contacts }.to raise_error(DataImports::Intercom::Client::Error) do |error|
+      expect { client.list_contacts }.to raise_error do |error|
+        expect(error.class.name).to eq('DataImports::Intercom::Client::Error')
         expect(error.message).to eq('Intercom API request failed before receiving a response: getaddrinfo failed')
         expect(error.body).to include(transport_error_class: 'SocketError')
       end


### PR DESCRIPTION
Stabilizes the Intercom transport-error spec when Rails reloads application constants during the full backend suite. The production client behavior is unchanged; the expectation now compares the exception class name while continuing to verify its message and metadata.

## Closes

- Follow-up to [CW-7615](https://linear.app/chatwoot/issue/CW-7615/optimize-intercom-import-reliability-and-bulk-message-ingestion)
- Follow-up to #15050

## How to reproduce

1. Run the backend shard containing the Intercom client spec after specs that trigger Rails constant reloading.
2. Observe that the old matcher can reject an exception whose printed class is still `DataImports::Intercom::Client::Error` because it references a different class object.
3. Confirm the updated expectation accepts the reloaded class by name and still verifies the transport error message and body.

## What changed

- Compare the raised Intercom client error using `error.class.name`.
- Preserve assertions for the user-facing error message and transport error metadata.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing focused unit tests pass locally with my changes