### PR TITLE
chore: add context to Captain embedding traces

### DIFF
--- a/enterprise/app/jobs/captain/llm/update_embedding_job.rb
+++ b/enterprise/app/jobs/captain/llm/update_embedding_job.rb
@@ -2,8 +2,24 @@ class Captain::Llm::UpdateEmbeddingJob < ApplicationJob
   queue_as :low
 
   def perform(record, content)
-    account_id = record.account_id
-    embedding = Captain::Llm::EmbeddingService.new(account_id: account_id).get_embedding(content)
+    source, metadata = case record
+                       when Captain::AssistantResponse
+                         ['assistant_response', { assistant_id: record.assistant_id }]
+                       when Captain::FaqSuggestion
+                         ['faq_suggestion', { assistant_id: record.assistant_id, language: record.language }]
+                       when ArticleEmbedding
+                         ['help_center_article', { language: record.article.locale, article_id: record.article_id }]
+                       else
+                         raise ArgumentError, "Unsupported embedding record: #{record.class.name}"
+                       end
+    metadata[:record_type] = record.class.name
+    metadata[:record_id] = record.id
+    embedding = Captain::Llm::EmbeddingService.new(account_id: record.account_id).get_embedding(
+      content,
+      purpose: 'indexing',
+      source: source,
+      metadata: metadata
+    )
     record.update!(embedding: embedding)
   end
 end

--- a/enterprise/app/models/captain/assistant_response.rb
+++ b/enterprise/app/models/captain/assistant_response.rb
@@ -46,8 +46,13 @@ class Captain::AssistantResponse < ApplicationRecord
 
   enum status: { approved: 1 }
 
-  def self.search(query, account_id: nil)
-    embedding = Captain::Llm::EmbeddingService.new(account_id: account_id).get_embedding(query)
+  def self.search(query, embedding_source:, account_id: nil, embedding_metadata: {})
+    embedding = Captain::Llm::EmbeddingService.new(account_id: account_id).get_embedding(
+      query,
+      purpose: 'search',
+      source: embedding_source,
+      metadata: embedding_metadata
+    )
     nearest_neighbors(:embedding, embedding, distance: 'cosine').limit(5)
   end
 

--- a/enterprise/app/models/enterprise/concerns/article.rb
+++ b/enterprise/app/models/enterprise/concerns/article.rb
@@ -11,7 +11,7 @@ module Enterprise::Concerns::Article
     add_article_embedding_association
 
     def self.vector_search(params)
-      embedding = Captain::Llm::EmbeddingService.new(account_id: params[:account_id]).get_embedding(params['query'])
+      embedding = help_center_search_embedding(params)
       records = joins(
         :category
       ).search_by_category_slug(
@@ -36,6 +36,13 @@ module Enterprise::Concerns::Article
       # Fetch the articles by the IDs obtained from the nearest neighbors search
       where(id: article_ids).in_order_of(:id, article_ids)
     end
+
+    def self.help_center_search_embedding(params)
+      Captain::Llm::EmbeddingService.new(account_id: params[:account_id]).get_embedding(
+        params['query'], purpose: 'search', source: 'help_center_search', metadata: { language: params[:locale] }.compact
+      )
+    end
+    private_class_method :help_center_search_embedding
   end
 
   def add_article_embedding

--- a/enterprise/app/services/captain/llm/conversation_faq_service.rb
+++ b/enterprise/app/services/captain/llm/conversation_faq_service.rb
@@ -41,7 +41,10 @@ class Captain::Llm::ConversationFaqService < Llm::BaseAiService
   end
 
   def route_candidate(faq)
-    embedding = embedding_service.get_embedding(candidate_text(faq))
+    embedding = embedding_service.get_embedding(
+      candidate_text(faq), purpose: 'candidate_grouping', source: 'conversation_faq',
+                           metadata: { assistant_id: assistant.id, conversation_id: conversation.display_id, language: faq_language }
+    )
 
     return discard_observation(faq) if matching_record(approved_faqs, faq, embedding)
     return discard_observation(faq) if matching_record(dismissed_suggestions_for_language, faq, embedding)

--- a/enterprise/app/services/captain/llm/embedding_service.rb
+++ b/enterprise/app/services/captain/llm/embedding_service.rb
@@ -13,10 +13,10 @@ class Captain::Llm::EmbeddingService
     InstallationConfig.find_by(name: 'CAPTAIN_EMBEDDING_MODEL')&.value.presence || LlmConstants::DEFAULT_EMBEDDING_MODEL
   end
 
-  def get_embedding(content, model: @embedding_model)
+  def get_embedding(content, purpose:, source:, metadata: {}, model: @embedding_model)
     return [] if content.blank?
 
-    instrument_embedding_call(instrumentation_params(content, model)) do
+    instrument_embedding_call(instrumentation_params(content, model, purpose, source, metadata)) do
       RubyLLM.embed(content, model: model).vectors
     end
   rescue RubyLLM::Error => e
@@ -26,13 +26,14 @@ class Captain::Llm::EmbeddingService
 
   private
 
-  def instrumentation_params(content, model)
+  def instrumentation_params(content, model, purpose, source, metadata)
     {
       span_name: 'llm.captain.embedding',
       model: model,
       input: content,
       feature_name: 'embedding',
-      account_id: @account_id
+      account_id: @account_id,
+      metadata: metadata.merge(embedding_purpose: purpose, embedding_source: source)
     }
   end
 end

--- a/enterprise/app/services/captain/tools/search_documentation_service.rb
+++ b/enterprise/app/services/captain/tools/search_documentation_service.rb
@@ -13,7 +13,12 @@ class Captain::Tools::SearchDocumentationService < Captain::Tools::BaseTool
                        .new(account: assistant.account)
                        .translate(query, target_language: assistant.account.locale_english_name)
 
-    responses = assistant.responses.approved.search(translated_query)
+    responses = assistant.responses.approved.search(
+      translated_query,
+      account_id: assistant.account_id,
+      embedding_source: 'search_documentation',
+      embedding_metadata: { assistant_id: assistant.id }
+    )
 
     return 'No FAQs found for the given query' if responses.empty?
 

--- a/enterprise/app/services/captain/tools/search_reply_documentation_service.rb
+++ b/enterprise/app/services/captain/tools/search_reply_documentation_service.rb
@@ -31,10 +31,22 @@ class Captain::Tools::SearchReplyDocumentationService < RubyLLM::Tool
   private
 
   def search_responses(query)
+    embedding_metadata = { assistant_id: @assistant&.id }.compact
+
     if @assistant.present?
-      @assistant.responses.approved.search(query, account_id: @account.id)
+      @assistant.responses.approved.search(
+        query,
+        account_id: @account.id,
+        embedding_source: 'reply_suggestion',
+        embedding_metadata: embedding_metadata
+      )
     else
-      @account.captain_assistant_responses.approved.search(query, account_id: @account.id)
+      @account.captain_assistant_responses.approved.search(
+        query,
+        account_id: @account.id,
+        embedding_source: 'reply_suggestion',
+        embedding_metadata: embedding_metadata
+      )
     end
   end
 

--- a/enterprise/lib/captain/tools/faq_lookup_tool.rb
+++ b/enterprise/lib/captain/tools/faq_lookup_tool.rb
@@ -6,7 +6,15 @@ class Captain::Tools::FaqLookupTool < Captain::Tools::BasePublicTool
     log_tool_usage('searching', { query: query })
 
     # Use existing vector search on approved responses
-    responses = @assistant.responses.approved.search(query).to_a
+    responses = @assistant.responses.approved.search(
+      query,
+      account_id: @assistant.account_id,
+      embedding_source: 'faq_lookup',
+      embedding_metadata: {
+        assistant_id: @assistant.id,
+        conversation_id: tool_context.state&.dig(:conversation, :display_id)
+      }.compact
+    ).to_a
     record_retrieved_sources(tool_context, responses)
 
     if responses.empty?

--- a/spec/enterprise/jobs/captain/llm/update_embedding_job_spec.rb
+++ b/spec/enterprise/jobs/captain/llm/update_embedding_job_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe Captain::Llm::UpdateEmbeddingJob do
+  let(:account) { build_stubbed(:account) }
+  let(:assistant) { build_stubbed(:captain_assistant, account: account) }
+  let(:embedding_service) { instance_double(Captain::Llm::EmbeddingService) }
+  let(:embedding) { Array.new(1536, 0.1) }
+
+  before do
+    allow(Captain::Llm::EmbeddingService).to receive(:new).with(account_id: account.id).and_return(embedding_service)
+    allow(embedding_service).to receive(:get_embedding).and_return(embedding)
+  end
+
+  it 'identifies approved assistant response indexing' do
+    record = build_stubbed(:captain_assistant_response, account: account, assistant: assistant)
+    allow(record).to receive(:update!)
+
+    described_class.perform_now(record, 'question: answer')
+
+    expect(embedding_service).to have_received(:get_embedding).with(
+      'question: answer',
+      purpose: 'indexing',
+      source: 'assistant_response',
+      metadata: {
+        assistant_id: assistant.id,
+        record_type: 'Captain::AssistantResponse',
+        record_id: record.id
+      }
+    )
+  end
+
+  it 'identifies FAQ suggestion indexing and includes its language' do
+    record = Captain::FaqSuggestion.new(
+      id: 11,
+      account: account,
+      assistant: assistant,
+      question: 'Question',
+      answer: 'Answer',
+      language: 'fr'
+    )
+    allow(record).to receive(:update!)
+
+    described_class.perform_now(record, 'question: answer')
+
+    expect(embedding_service).to have_received(:get_embedding).with(
+      'question: answer',
+      purpose: 'indexing',
+      source: 'faq_suggestion',
+      metadata: {
+        assistant_id: assistant.id,
+        language: 'fr',
+        record_type: 'Captain::FaqSuggestion',
+        record_id: record.id
+      }
+    )
+  end
+
+  it 'identifies help center article indexing and includes its language' do
+    article = build_stubbed(:article, account: account, locale: 'pt')
+    record = ArticleEmbedding.new(id: 12, article: article, term: 'search term')
+    allow(record).to receive(:update!)
+
+    described_class.perform_now(record, 'search term')
+
+    expect(embedding_service).to have_received(:get_embedding).with(
+      'search term',
+      purpose: 'indexing',
+      source: 'help_center_article',
+      metadata: {
+        language: 'pt',
+        article_id: article.id,
+        record_type: 'ArticleEmbedding',
+        record_id: record.id
+      }
+    )
+  end
+end

--- a/spec/enterprise/lib/captain/tools/faq_lookup_tool_spec.rb
+++ b/spec/enterprise/lib/captain/tools/faq_lookup_tool_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Captain::Tools::FaqLookupTool, type: :model do
   let(:account) { create(:account) }
   let(:assistant) { create(:captain_assistant, account: account) }
   let(:tool) { described_class.new(assistant) }
-  let(:tool_context) { Struct.new(:state).new({}) }
+  let(:tool_context) { Struct.new(:state).new({ conversation: { display_id: 321 } }) }
+  let(:embedding_service) { instance_double(Captain::Llm::EmbeddingService) }
 
   before do
     # Create installation config for OpenAI API key to avoid errors
     create(:installation_config, name: 'CAPTAIN_OPEN_AI_API_KEY', value: 'test-key')
 
     # Mock embedding service to avoid actual API calls
-    embedding_service = instance_double(Captain::Llm::EmbeddingService)
     allow(Captain::Llm::EmbeddingService).to receive(:new).and_return(embedding_service)
     allow(embedding_service).to receive(:get_embedding).and_return(Array.new(1536, 0.1))
   end
@@ -60,6 +60,13 @@ RSpec.describe Captain::Tools::FaqLookupTool, type: :model do
       it 'searches FAQs and returns formatted responses' do
         result = tool.perform(tool_context, query: 'password reset')
 
+        expect(Captain::Llm::EmbeddingService).to have_received(:new).with(account_id: account.id)
+        expect(embedding_service).to have_received(:get_embedding).with(
+          'password reset',
+          purpose: 'search',
+          source: 'faq_lookup',
+          metadata: { assistant_id: assistant.id, conversation_id: 321 }
+        )
         expect(result).to include('Question: How to reset password?')
         expect(result).to include('Answer: Click on forgot password link')
         expect(result).to include('Question: How to change email?')
@@ -118,7 +125,7 @@ RSpec.describe Captain::Tools::FaqLookupTool, type: :model do
       it 'leaves shared state untouched' do
         tool.perform(tool_context, query: 'nonexistent topic')
 
-        expect(tool_context.state).to eq({})
+        expect(tool_context.state).to eq(conversation: { display_id: 321 })
       end
     end
 

--- a/spec/enterprise/models/captain/assistant_response_spec.rb
+++ b/spec/enterprise/models/captain/assistant_response_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Captain::AssistantResponse do
+  describe '.search' do
+    let(:embedding_service) { instance_double(Captain::Llm::EmbeddingService) }
+    let(:embedding) { Array.new(1536, 0.1) }
+
+    it 'passes the search path and available metadata to the embedding service' do
+      allow(Captain::Llm::EmbeddingService).to receive(:new).with(account_id: 1).and_return(embedding_service)
+      allow(embedding_service).to receive(:get_embedding).and_return(embedding)
+      allow(described_class).to receive(:nearest_neighbors).and_return(described_class.none)
+
+      described_class.search(
+        'reset password',
+        account_id: 1,
+        embedding_source: 'faq_lookup',
+        embedding_metadata: { assistant_id: 2 }
+      ).to_a
+
+      expect(embedding_service).to have_received(:get_embedding).with(
+        'reset password',
+        purpose: 'search',
+        source: 'faq_lookup',
+        metadata: { assistant_id: 2 }
+      )
+    end
+  end
+end

--- a/spec/enterprise/models/enterprise/concerns/article_spec.rb
+++ b/spec/enterprise/models/enterprise/concerns/article_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Enterprise::Concerns::Article do
+  describe '.vector_search' do
+    let(:embedding_service) { instance_double(Captain::Llm::EmbeddingService) }
+
+    it 'identifies help center searches and includes the language' do
+      allow(Captain::Llm::EmbeddingService).to receive(:new).with(account_id: 1).and_return(embedding_service)
+      allow(embedding_service).to receive(:get_embedding).and_return(Array.new(1536, 0.1))
+      allow(ArticleEmbedding).to receive(:where).and_return(ArticleEmbedding.none)
+
+      params = { 'query' => 'reset password' }.merge(account_id: 1, locale: 'es')
+      Article.vector_search(params).to_a
+
+      expect(embedding_service).to have_received(:get_embedding).with(
+        'reset password',
+        purpose: 'search',
+        source: 'help_center_search',
+        metadata: { language: 'es' }
+      )
+    end
+  end
+end

--- a/spec/enterprise/services/captain/llm/conversation_faq_service_spec.rb
+++ b/spec/enterprise/services/captain/llm/conversation_faq_service_spec.rb
@@ -70,6 +70,21 @@ RSpec.describe Captain::Llm::ConversationFaqService do
         described_class.new(captain_assistant, conversation).generate_suggestions
       end
 
+      it 'adds grouping context to each candidate embedding' do
+        expect(embedding_service).to receive(:get_embedding).with(
+          kind_of(String),
+          purpose: 'candidate_grouping',
+          source: 'conversation_faq',
+          metadata: {
+            assistant_id: captain_assistant.id,
+            conversation_id: conversation.display_id,
+            language: 'en'
+          }
+        ).twice.and_return(embedding_one, embedding_two)
+
+        service.generate_suggestions
+      end
+
       it 'sends only customer and human support agent messages to the LLM' do
         create(:message, conversation: conversation, account: conversation.account, inbox: conversation.inbox,
                          sender: create(:contact, account: conversation.account), message_type: :incoming,

--- a/spec/enterprise/services/captain/llm/embedding_service_spec.rb
+++ b/spec/enterprise/services/captain/llm/embedding_service_spec.rb
@@ -32,7 +32,40 @@ RSpec.describe Captain::Llm::EmbeddingService, type: :service do
 
       expect(RubyLLM).to receive(:embed).with('search text', model: 'custom-embedding-model').and_return(embedding_response)
 
-      expect(described_class.new(account_id: account.id).get_embedding('search text')).to eq([0.1, 0.2])
+      expect(
+        described_class.new(account_id: account.id).get_embedding(
+          'search text',
+          purpose: 'search',
+          source: 'faq_lookup'
+        )
+      ).to eq([0.1, 0.2])
+    end
+
+    it 'keeps the embedding observation contract and adds embedding context metadata' do
+      service = described_class.new(account_id: account.id)
+      allow(RubyLLM).to receive(:embed).and_return(embedding_response)
+
+      expect(service).to receive(:instrument_embedding_call).with(
+        {
+          span_name: 'llm.captain.embedding',
+          model: LlmConstants::DEFAULT_EMBEDDING_MODEL,
+          input: 'search text',
+          feature_name: 'embedding',
+          account_id: account.id,
+          metadata: {
+            assistant_id: 42,
+            embedding_purpose: 'search',
+            embedding_source: 'faq_lookup'
+          }
+        }
+      ).and_yield
+
+      service.get_embedding(
+        'search text',
+        purpose: 'search',
+        source: 'faq_lookup',
+        metadata: { assistant_id: 42 }
+      )
     end
   end
 end

--- a/spec/enterprise/services/captain/tools/search_documentation_service_spec.rb
+++ b/spec/enterprise/services/captain/tools/search_documentation_service_spec.rb
@@ -41,7 +41,12 @@ RSpec.describe Captain::Tools::SearchDocumentationService do
     context 'when matching responses exist' do
       before do
         response.update(documentable: documentable)
-        allow(Captain::AssistantResponse).to receive(:search).with(question).and_return([response])
+        allow(Captain::AssistantResponse).to receive(:search).with(
+          question,
+          account_id: assistant.account_id,
+          embedding_source: 'search_documentation',
+          embedding_metadata: { assistant_id: assistant.id }
+        ).and_return([response])
       end
 
       it 'returns formatted responses for the search query' do
@@ -55,7 +60,12 @@ RSpec.describe Captain::Tools::SearchDocumentationService do
 
     context 'when no matching responses exist' do
       before do
-        allow(Captain::AssistantResponse).to receive(:search).with(question).and_return([])
+        allow(Captain::AssistantResponse).to receive(:search).with(
+          question,
+          account_id: assistant.account_id,
+          embedding_source: 'search_documentation',
+          embedding_metadata: { assistant_id: assistant.id }
+        ).and_return([])
       end
 
       it 'returns an empty string' do

--- a/spec/enterprise/services/captain/tools/search_reply_documentation_service_spec.rb
+++ b/spec/enterprise/services/captain/tools/search_reply_documentation_service_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Captain::Tools::SearchReplyDocumentationService do
+  let(:account) { create(:account) }
+  let(:assistant) { create(:captain_assistant, account: account) }
+  let(:service) { described_class.new(account: account, assistant: assistant) }
+  let(:translator) { instance_double(Captain::Llm::TranslateQueryService, translate: 'reset password') }
+
+  before do
+    allow(Captain::Llm::TranslateQueryService).to receive(:new).with(account: account).and_return(translator)
+  end
+
+  it 'identifies reply suggestion searches and includes the assistant' do
+    expect(Captain::AssistantResponse).to receive(:search).with(
+      'reset password',
+      account_id: account.id,
+      embedding_source: 'reply_suggestion',
+      embedding_metadata: { assistant_id: assistant.id }
+    ).and_return([])
+
+    expect(service.execute(query: 'password help')).to eq('No FAQs found for the given query')
+  end
+end

--- a/spec/lib/integrations/llm_instrumentation_spec.rb
+++ b/spec/lib/integrations/llm_instrumentation_spec.rb
@@ -307,7 +307,12 @@ RSpec.describe Integrations::LlmInstrumentation do
             account_id: 123,
             feature_name: 'embedding',
             model: 'text-embedding-3-small',
-            input: 'search result'
+            input: 'search result',
+            metadata: {
+              embedding_purpose: 'search',
+              embedding_source: 'faq_lookup',
+              assistant_id: 789
+            }
           }
           allow(root_span).to receive(:set_attribute)
           allow(embedding_span).to receive(:set_attribute)
@@ -324,6 +329,9 @@ RSpec.describe Integrations::LlmInstrumentation do
           expect(embedding_span).to have_received(:set_attribute).with('langfuse.trace.tags', ['embedding'])
           expect(embedding_span).to have_received(:set_attribute).with('langfuse.observation.metadata.session_id', '123_456')
           expect(embedding_span).to have_received(:set_attribute).with('langfuse.observation.metadata.feature_name', 'embedding')
+          expect(embedding_span).to have_received(:set_attribute).with('langfuse.observation.metadata.embedding_purpose', 'search')
+          expect(embedding_span).to have_received(:set_attribute).with('langfuse.observation.metadata.embedding_source', 'faq_lookup')
+          expect(embedding_span).to have_received(:set_attribute).with('langfuse.observation.metadata.assistant_id', '789')
         end
 
         # Regression test for Langfuse double-counting bug.


### PR DESCRIPTION
Captain embedding traces now show why an embedding was requested and which product path requested it. The existing `llm.captain.embedding` observation name and `embedding` tag stay unchanged, so current searches and dashboards continue to work.

## What changed

- Added separate `embedding_purpose` and `embedding_source` metadata.
- Added assistant, conversation, language, article, record type, and record IDs when the caller has them.
- Kept account and session inheritance for nested FAQ lookup calls.
- Covered FAQ search, help center search, conversation FAQ grouping, and record indexing.

## How to test

1. Trigger a Captain FAQ lookup inside a conversation.
2. Generate a conversation FAQ candidate.
3. Index an assistant response, FAQ suggestion, or help center article.
4. Search local Langfuse for the `llm.captain.embedding` observation and the `embedding` tag.
5. Confirm the purpose, source, account, session, and available record metadata.