### PR TITLE
fix(conversation): remove deprecated style block

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyToMessage.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyToMessage.vue
@@ -38,12 +38,4 @@ const emit = defineEmits(['dismiss']);
   </div>
 </template>
 
-<style lang="scss">
-// TODO: Remove this
-// override for dashboard/assets/scss/widgets/_reply-box.scss
-.reply-editor {
-  .icon {
-    margin-right: 0px !important;
-  }
-}
-</style>
+

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyToMessage.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyToMessage.vue
@@ -14,7 +14,7 @@ const emit = defineEmits(['dismiss']);
 
 <template>
   <div
-    class="reply-editor bg-n-slate-9/10 rounded-md py-1 pl-2 pr-1 text-xs tracking-wide mt-2 flex items-center gap-1.5"
+    class="reply-editor bg-n-slate-9/10 rounded-md py-1 ps-2 pe-1 text-xs tracking-wide mt-2 flex items-center gap-1.5"
   >
     <fluent-icon class="flex-shrink-0 icon" icon="arrow-reply" size="14" />
     <div class="flex-grow gap-1 mt-px text-xs truncate">

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyToMessage.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyToMessage.vue
@@ -37,5 +37,3 @@ const emit = defineEmits(['dismiss']);
     />
   </div>
 </template>
-
-


### PR DESCRIPTION
## Summary
## Overview
Cleaned up the frontend UI by stripping out an obsolete SCSS override block that was corrupting the styling of the conversation reply box.

## Technical Details
- **The Problem**: A legacy, hacky style injection in `ReplyToMessage.vue` was forcibly overriding the margin on the reply icon with `!important`, fighting the core design system and leaving an open `// TODO: Remove this`.
- **The Solution**: Completely eradicated the deprecated style block, restoring the design system's natural alignment and permanently eliminating the localized technical debt.
