### PR TITLE
fix: harden conversation participant api

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/participants_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/participants_controller.rb
@@ -1,6 +1,8 @@
 class Api::V1::Accounts::Conversations::ParticipantsController < Api::V1::Accounts::Conversations::BaseController
   include Events::Types
 
+  before_action :validate_participant_ids, only: [:create, :update]
+
   def show
     @participants = @conversation.conversation_participants
   end
@@ -9,7 +11,7 @@ class Api::V1::Accounts::Conversations::ParticipantsController < Api::V1::Accoun
     participant_ids_to_add = participants_to_be_added_ids
 
     ActiveRecord::Base.transaction do
-      @participants = participant_ids_to_add.map { |user_id| @conversation.conversation_participants.find_or_create_by(user_id: user_id) }
+      @participants = participant_ids_to_add.map { |user_id| @conversation.conversation_participants.find_or_create_by!(user_id: user_id) }
     end
     notify_unread_count_change if participant_ids_to_add.any?
   end
@@ -20,11 +22,11 @@ class Api::V1::Accounts::Conversations::ParticipantsController < Api::V1::Accoun
     changed_participant_ids = participant_ids_to_add + participant_ids_to_remove
 
     ActiveRecord::Base.transaction do
-      participant_ids_to_add.each { |user_id| @conversation.conversation_participants.find_or_create_by(user_id: user_id) }
+      participant_ids_to_add.each { |user_id| @conversation.conversation_participants.find_or_create_by!(user_id: user_id) }
       participant_ids_to_remove.each { |user_id| @conversation.conversation_participants.find_by(user_id: user_id)&.destroy }
     end
     notify_unread_count_change if changed_participant_ids.any?
-    @participants = @conversation.conversation_participants
+    @participants = @conversation.conversation_participants.reload
     render action: 'show'
   end
 
@@ -41,15 +43,26 @@ class Api::V1::Accounts::Conversations::ParticipantsController < Api::V1::Accoun
   private
 
   def participants_to_be_added_ids
-    params[:user_ids] - current_participant_ids
+    participant_ids - current_participant_ids
   end
 
   def participants_to_be_removed_ids
-    current_participant_ids - params[:user_ids]
+    current_participant_ids - participant_ids
   end
 
   def current_participant_ids
     @current_participant_ids ||= @conversation.conversation_participants.pluck(:user_id)
+  end
+
+  def participant_ids
+    @participant_ids ||= params[:user_ids].map(&:to_i)
+  end
+
+  def validate_participant_ids
+    invalid_ids = participants_to_be_added_ids - @conversation.inbox.assignable_agents.map(&:id)
+    return if invalid_ids.empty?
+
+    render json: { error: 'Invalid participant IDs' }, status: :unprocessable_entity
   end
 
   def notify_unread_count_change

--- a/spec/controllers/api/v1/accounts/conversations/participants_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/participants_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Conversation Participants API', type: :request do
   let(:account) { create(:account) }
   let(:conversation) { create(:conversation, account: account) }
   let(:agent) { create(:user, account: account, role: :agent) }
+  let(:foreign_participant) { create(:user, account: create(:account), role: :agent) }
 
   before do
     create(:inbox_member, inbox: conversation.inbox, user: agent)
@@ -69,6 +70,20 @@ RSpec.describe 'Conversation Participants API', type: :request do
         expect(conversation.conversation_participants.count).to eq(1)
       end
 
+      it 'rejects foreign participant ids without exposing user details' do
+        params = { user_ids: [participant.id, foreign_participant.id] }
+
+        post api_v1_account_conversation_participants_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: params,
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body).to eq('error' => 'Invalid participant IDs')
+        expect(response.body).not_to include(foreign_participant.email)
+        expect(conversation.conversation_participants).to be_empty
+      end
+
       it 'notifies unread counts when a participant is added' do
         account.enable_features!(:conversation_unread_counts, :unread_count_for_filters)
         allow(Rails.configuration.dispatcher).to receive(:dispatch)
@@ -122,6 +137,21 @@ RSpec.describe 'Conversation Participants API', type: :request do
         expect(response.body).to include(participant.email)
         expect(response.body).to include(participant_to_be_added.email)
         expect(conversation.conversation_participants.count).to eq(2)
+      end
+
+      it 'rejects foreign participant ids without changing existing participants' do
+        create(:conversation_participant, conversation: conversation, user: participant)
+        params = { user_ids: [participant_to_be_added.id, foreign_participant.id] }
+
+        patch api_v1_account_conversation_participants_url(account_id: account.id, conversation_id: conversation.display_id),
+              params: params,
+              headers: agent.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body).to eq('error' => 'Invalid participant IDs')
+        expect(response.body).not_to include(foreign_participant.email)
+        expect(conversation.conversation_participants.reload.pluck(:user_id)).to eq([participant.id])
       end
 
       it 'notifies unread counts when participant membership changes' do


### PR DESCRIPTION
## Description

Prevents the conversation participants endpoints from returning profile details for users who cannot be assigned to the conversation's inbox. Invalid participant IDs are now rejected before any participant records are changed, so mixed valid and cross-account payloads fail atomically without exposing user data.

## Closes

- [CW-7746](https://linear.app/chatwoot/issue/CW-7746/ghsa-chmg-8qj2-4pp6-cross-tenant-pii-disclosure-via-conversation)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How to reproduce

1. Create two accounts with separate agents and inboxes.
2. Authenticate as an agent in account 1 and send a `POST` or `PATCH` request to an account-1 conversation with an account-2 user ID.
3. Confirm the response is `422` with `Invalid participant IDs`, contains no foreign user profile fields, and leaves the conversation's participants unchanged.

## What changed

- Validates newly requested participant IDs against agents assignable to the conversation inbox.
- Uses raising participant writes so unexpected validation failures roll back the transaction.
- Reloads persisted participants before rendering the update response.
- Adds regression coverage for cross-account `POST` and `PATCH` payloads.

## How Has This Been Tested?

- Request coverage verifies valid participant creation and updates continue to work.
- Cross-account `POST` and `PATCH` requests return a generic validation error without exposing user details.
- A two-account endpoint probe confirms no participant is persisted and a follow-up participants request remains empty.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
