### PR TITLE
feat(compose): allow multiple To recipients on email inboxes

### DIFF
--- a/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
@@ -49,6 +49,7 @@ const isSearching = ref(false);
 const formState = reactive({
   message: '',
   subject: '',
+  toEmails: '',
   ccEmails: '',
   bccEmails: '',
   attachedFiles: [],
@@ -57,6 +58,7 @@ const formState = reactive({
 const clearFormState = () => {
   Object.assign(formState, {
     subject: '',
+    toEmails: '',
     ccEmails: '',
     bccEmails: '',
     attachedFiles: [],

--- a/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue
@@ -60,6 +60,7 @@ const copilot = useCopilotReply();
 
 const showContactsDropdown = ref(false);
 const showInboxesDropdown = ref(false);
+const showToEmailsDropdown = ref(false);
 const showCcEmailsDropdown = ref(false);
 const showBccEmailsDropdown = ref(false);
 
@@ -68,6 +69,7 @@ const isCreating = computed(() => props.contactConversationsUiFlags.isCreating);
 const state = props.formState || {
   message: '',
   subject: '',
+  toEmails: '',
   ccEmails: '',
   bccEmails: '',
   attachedFiles: [],
@@ -129,12 +131,14 @@ const validationStates = computed(() => ({
 }));
 
 const newMessagePayload = () => {
-  const { message, subject, ccEmails, bccEmails, attachedFiles } = state;
+  const { message, subject, toEmails, ccEmails, bccEmails, attachedFiles } =
+    state;
   return prepareNewMessagePayload({
     targetInbox: props.targetInbox,
     selectedContact: props.selectedContact,
     message,
     subject,
+    toEmails,
     ccEmails,
     bccEmails,
     currentUser: props.currentUser,
@@ -160,6 +164,7 @@ const isAnyDropdownActive = computed(() => {
   return (
     showContactsDropdown.value ||
     showInboxesDropdown.value ||
+    showToEmailsDropdown.value ||
     showCcEmailsDropdown.value ||
     showBccEmailsDropdown.value
   );
@@ -171,7 +176,9 @@ const handleContactSearch = value => {
 };
 
 const handleDropdownUpdate = (type, value) => {
-  if (type === 'cc') {
+  if (type === 'to') {
+    showToEmailsDropdown.value = value;
+  } else if (type === 'cc') {
     showCcEmailsDropdown.value = value;
   } else if (type === 'bcc') {
     showBccEmailsDropdown.value = value;
@@ -180,7 +187,16 @@ const handleDropdownUpdate = (type, value) => {
   }
 };
 
+const searchToEmails = value => {
+  showCcEmailsDropdown.value = false;
+  showBccEmailsDropdown.value = false;
+  emit('resetContactSearch');
+  showToEmailsDropdown.value = value.trim().length >= 2;
+  emit('searchContacts', value);
+};
+
 const searchCcEmails = value => {
+  showToEmailsDropdown.value = false;
   showBccEmailsDropdown.value = false;
   emit('resetContactSearch');
   showCcEmailsDropdown.value = value.trim().length >= 2;
@@ -188,6 +204,7 @@ const searchCcEmails = value => {
 };
 
 const searchBccEmails = value => {
+  showToEmailsDropdown.value = false;
   showCcEmailsDropdown.value = false;
   emit('resetContactSearch');
   showBccEmailsDropdown.value = value.trim().length >= 2;
@@ -282,6 +299,7 @@ const clearForm = () => {
   Object.assign(state, {
     message: '',
     subject: '',
+    toEmails: '',
     ccEmails: '',
     bccEmails: '',
     attachedFiles: [],
@@ -367,6 +385,7 @@ useKeyboardEvents({
   >
     <div class="flex-1 overflow-y-auto divide-y divide-n-strong">
       <ContactSelector
+        v-model:to-emails="state.toEmails"
         :contacts="contacts"
         :selected-contact="selectedContact"
         :show-contacts-dropdown="showContactsDropdown"
@@ -376,7 +395,10 @@ useKeyboardEvents({
         :contactable-inboxes-list="contactableInboxesList"
         :show-inboxes-dropdown="showInboxesDropdown"
         :has-errors="validationStates.isContactInvalid"
+        :allow-additional-recipients="inboxTypes.isEmail"
+        :show-to-emails-dropdown="showToEmailsDropdown"
         @search-contacts="handleContactSearch"
+        @search-to-emails="searchToEmails"
         @set-selected-contact="setSelectedContact"
         @clear-selected-contact="clearSelectedContact"
         @update-dropdown="handleDropdownUpdate"

--- a/app/javascript/dashboard/components-next/NewConversation/components/ContactSelector.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ContactSelector.vue
@@ -43,10 +43,21 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  // Additional To recipients are only supported on email inboxes, where the
+  // channel can deliver a single message to more than one address.
+  allowAdditionalRecipients: {
+    type: Boolean,
+    default: false,
+  },
+  showToEmailsDropdown: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits([
   'searchContacts',
+  'searchToEmails',
   'setSelectedContact',
   'clearSelectedContact',
   'updateDropdown',
@@ -56,6 +67,16 @@ const i18nPrefix = 'COMPOSE_NEW_CONVERSATION.FORM.CONTACT_SELECTOR';
 const { t } = useI18n();
 
 const inputType = ref(INPUT_TYPES.EMAIL);
+
+const toEmails = defineModel('toEmails', { type: String, default: '' });
+
+const toEmailsArray = computed(() =>
+  toEmails.value ? toEmails.value.split(',').map(email => email.trim()) : []
+);
+
+const handleToEmailsUpdate = value => {
+  toEmails.value = value.join(',');
+};
 
 const contactsList = computed(() => {
   return props.contacts?.map(({ name, id, thumbnail, email, ...rest }) => ({
@@ -69,6 +90,19 @@ const contactsList = computed(() => {
     action: 'contact',
   }));
 });
+
+const contactEmailsList = computed(() =>
+  props.contacts
+    ?.filter(({ email }) => email && email !== props.selectedContact?.email)
+    .map(({ name, id, email }) => ({
+      id,
+      label: email,
+      email,
+      thumbnail: { name, src: '' },
+      value: id,
+      action: 'email',
+    }))
+);
 
 const selectedContactLabel = computed(() => {
   const { name, email = '', phoneNumber = '' } = props.selectedContact || {};
@@ -98,7 +132,7 @@ const handleInput = value => {
 
 <template>
   <div class="relative flex-1 px-4 py-3 overflow-y-visible">
-    <div class="flex items-baseline w-full gap-3 min-h-7">
+    <div class="flex flex-wrap items-baseline w-full gap-3 min-h-7">
       <label class="text-sm font-medium text-n-slate-11 whitespace-nowrap">
         {{ t(`${i18nPrefix}.LABEL`) }}
       </label>
@@ -150,6 +184,20 @@ const handleInput = value => {
         @on-click-outside="emit('updateDropdown', 'contacts', false)"
         @add="emit('setSelectedContact', $event)"
         @remove="emit('clearSelectedContact')"
+      />
+      <TagInput
+        v-if="selectedContact && allowAdditionalRecipients"
+        :model-value="toEmailsArray"
+        :placeholder="t(`${i18nPrefix}.ADDITIONAL_RECIPIENTS_PLACEHOLDER`)"
+        :menu-items="contactEmailsList"
+        :show-dropdown="showToEmailsDropdown"
+        :is-loading="isLoading"
+        type="email"
+        allow-create
+        class="flex-1 min-h-7"
+        @input="emit('searchToEmails', $event)"
+        @on-click-outside="emit('updateDropdown', 'to', false)"
+        @update:model-value="handleToEmailsUpdate"
       />
     </div>
   </div>

--- a/app/javascript/dashboard/components-next/NewConversation/helpers/composeConversationHelper.js
+++ b/app/javascript/dashboard/components-next/NewConversation/helpers/composeConversationHelper.js
@@ -126,6 +126,7 @@ export const prepareNewMessagePayload = ({
   selectedContact,
   message,
   subject,
+  toEmails,
   ccEmails,
   bccEmails,
   currentUser,
@@ -149,6 +150,15 @@ export const prepareNewMessagePayload = ({
 
   if (subject) {
     payload.mailSubject = subject;
+  }
+
+  // to_emails replaces the contact address on the outgoing mail, so the primary
+  // contact has to be part of the list whenever extra recipients are added.
+  if (toEmails) {
+    const recipients = [selectedContact.email, ...toEmails.split(',')]
+      .map(email => email?.trim())
+      .filter(Boolean);
+    payload.message.to_emails = [...new Set(recipients)].join(',');
   }
 
   if (ccEmails) {

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -622,7 +622,8 @@
       "CONTACT_SELECTOR": {
         "LABEL": "To:",
         "TAG_INPUT_PLACEHOLDER": "Enter at least 2 characters to search by name, email, or phone number",
-        "CONTACT_CREATING": "Creating contact..."
+        "CONTACT_CREATING": "Creating contact...",
+        "ADDITIONAL_RECIPIENTS_PLACEHOLDER": "Add another recipient"
       },
       "INBOX_SELECTOR": {
         "LABEL": "Via:",

--- a/app/javascript/dashboard/store/modules/contactConversations.js
+++ b/app/javascript/dashboard/store/modules/contactConversations.js
@@ -4,8 +4,9 @@ import ConversationApi from '../../api/conversations';
 import camelcaseKeys from 'camelcase-keys';
 
 export const createMessagePayload = (payload, message) => {
-  const { content, cc_emails, bcc_emails } = message;
+  const { content, to_emails, cc_emails, bcc_emails } = message;
   payload.append('message[content]', content);
+  if (to_emails) payload.append('message[to_emails]', to_emails);
   if (cc_emails) payload.append('message[cc_emails]', cc_emails);
   if (bcc_emails) payload.append('message[bcc_emails]', bcc_emails);
 };


### PR DESCRIPTION
Agents can now address a new email thread to more than one person. Until now the compose window's `To:` field took exactly one contact, so anyone else on the thread had to be pushed into `Cc` — which reads differently to the recipients and is not what the agent meant. Pick the contact as before, choose the email inbox, and then keep adding recipients right next to it, with the same contact suggestions that `Cc` already offers.

The conversation still belongs to one contact. The extra addresses ride along as additional `To` recipients on that first outgoing email, exactly as the reply box already does on an existing conversation.

## Closes

Closes #15181

## How to test

1. Open the compose (new conversation) window.
2. Pick a contact in `To:` and select an **Email** inbox in `Via:`.
3. A second input appears next to the contact chip. Type two or more characters — matching contacts are suggested, and an address that matches nothing can still be typed in full.
4. Add a subject and a message, and send.
5. Open the created conversation. The first outgoing email lists every address in its `To` header, and the contact you picked first is the conversation contact.
6. Switch `Via:` to a non-email inbox: the extra recipient input is not offered, since no other channel can deliver one message to several addresses.

## What changed

- `ContactSelector.vue` keeps the single-contact chip that drives inbox selection, and renders a multi-value `TagInput` beside it when the target inbox is email. Suggestions come from the contact search already wired into the compose window.
- `prepareNewMessagePayload` sends `message[to_emails]`. The primary contact's address is prepended and the list de-duplicated, because `content_attributes[:to_emails]` replaces rather than extends the contact address in `ConversationReplyMailer#to_emails`.
- `contactConversations.js` forwards `to_emails` on the multipart create payload.

No backend change: `Messages::MessageBuilder#process_emails` already reads `to_emails`, validates the addresses, and stores them.
