### PR TITLE
feat(reply-box): add a pinnable formatting toolbar

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -95,6 +95,9 @@ const props = defineProps({
   conversationId: { type: Number, default: null },
   medium: { type: String, default: '' },
   focusOnMount: { type: Boolean, default: true },
+  // Render the formatting menu as a bubble over the current selection instead
+  // of a menubar pinned above the editor.
+  popoverMenu: { type: Boolean, default: false },
 });
 
 const emit = defineEmits([
@@ -208,10 +211,7 @@ const editorRoot = useTemplateRef('editorRoot');
 const imageUpload = useTemplateRef('imageUpload');
 const editor = useTemplateRef('editor');
 
-const isEditorMenuPopover = computed(
-  () =>
-    editorRoot.value?.classList.contains('popover-prosemirror-menu') ?? false
-);
+const isEditorMenuPopover = computed(() => props.popoverMenu);
 
 const handleCopilotAction = actionKey => {
   if (actionKey === 'improve_selection' && editorView?.state) {
@@ -875,6 +875,7 @@ useEmitter(BUS_EVENTS.INSERT_INTO_RICH_EDITOR, insertContentIntoEditor);
     class="relative w-full"
     :class="{
       'opacity-50 cursor-not-allowed pointer-events-none': disabled,
+      'popover-prosemirror-menu': popoverMenu,
     }"
   >
     <TagAgents

--- a/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
@@ -121,6 +121,14 @@ export default {
       type: Boolean,
       default: false,
     },
+    showFormattingToolbarToggle: {
+      type: Boolean,
+      default: false,
+    },
+    formattingToolbarEnabled: {
+      type: Boolean,
+      default: false,
+    },
     isEditorDisabled: {
       type: Boolean,
       default: false,
@@ -131,6 +139,7 @@ export default {
     'selectWhatsappTemplate',
     'selectContentTemplate',
     'toggleQuotedReply',
+    'toggleFormattingToolbar',
   ],
   setup(props) {
     const { setSignatureFlagForInbox, fetchSignatureFlagFromUISettings } =
@@ -260,6 +269,11 @@ export default {
         ? this.$t('CONVERSATION.REPLYBOX.QUOTED_REPLY.DISABLE_TOOLTIP')
         : this.$t('CONVERSATION.REPLYBOX.QUOTED_REPLY.ENABLE_TOOLTIP');
     },
+    formattingToolbarToggleTooltip() {
+      return this.formattingToolbarEnabled
+        ? this.$t('CONVERSATION.REPLYBOX.FORMATTING_TOOLBAR.DISABLE_TOOLTIP')
+        : this.$t('CONVERSATION.REPLYBOX.FORMATTING_TOOLBAR.ENABLE_TOOLTIP');
+    },
   },
   mounted() {
     ActiveStorage.start();
@@ -338,6 +352,16 @@ export default {
         faded
         sm
         @click="toggleMessageSignature"
+      />
+      <NextButton
+        v-if="showFormattingToolbarToggle"
+        v-tooltip.top-end="formattingToolbarToggleTooltip"
+        icon="i-ph-text-aa"
+        :variant="formattingToolbarEnabled ? 'solid' : 'faded'"
+        color="slate"
+        sm
+        :aria-pressed="formattingToolbarEnabled"
+        @click="$emit('toggleFormattingToolbar')"
       />
       <NextButton
         v-if="showQuotedReplyToggle"

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -48,6 +48,7 @@ import {
   appendSignature,
   removeSignature,
   getEffectiveChannelType,
+  getFormattingForEditor,
   getAgentVariables,
   getContactVariables,
 } from 'dashboard/helper/editorHelper';
@@ -87,6 +88,7 @@ export default {
   setup() {
     const {
       uiSettings,
+      updateUISettings,
       isEditorHotKeyEnabled,
       fetchSignatureFlagFromUISettings,
       setQuotedReplyFlagForInbox,
@@ -100,6 +102,7 @@ export default {
 
     return {
       uiSettings,
+      updateUISettings,
       isEditorHotKeyEnabled,
       fetchSignatureFlagFromUISettings,
       setQuotedReplyFlagForInbox,
@@ -436,6 +439,19 @@ export default {
     shouldShowQuotedReplyToggle() {
       return this.isAnEmailChannel && !this.isOnPrivateNote;
     },
+    editorFormattingMenu() {
+      const formatType = this.isPrivate
+        ? 'Context::PrivateNote'
+        : getEffectiveChannelType(this.channelType, this.inbox?.medium || '');
+
+      return getFormattingForEditor(formatType).menu;
+    },
+    shouldShowFormattingToolbarToggle() {
+      return !this.isEditorDisabled && this.editorFormattingMenu.length > 0;
+    },
+    isFormattingToolbarPinned() {
+      return !!this.uiSettings.formatting_toolbar_enabled;
+    },
     shouldShowQuotedPreview() {
       return (
         this.shouldShowQuotedReplyToggle &&
@@ -580,6 +596,11 @@ export default {
       );
 
       useTrack(CONVERSATION_EVENTS.INSERT_ARTICLE_LINK);
+    },
+    toggleFormattingToolbar() {
+      this.updateUISettings({
+        formatting_toolbar_enabled: !this.isFormattingToolbarPinned,
+      });
     },
     toggleQuotedReply() {
       if (!this.isAnEmailChannel) {
@@ -1338,7 +1359,8 @@ export default {
           v-model="message"
           :conversation-id="conversationId"
           :editor-id="editorStateId"
-          class="input popover-prosemirror-menu"
+          class="input"
+          :popover-menu="!isFormattingToolbarPinned"
           :is-private="isOnPrivateNote"
           :placeholder="messagePlaceHolder"
           :update-selection-with="updateEditorSelectionWith"
@@ -1431,6 +1453,8 @@ export default {
         :show-file-upload="showFileUpload"
         :show-quoted-reply-toggle="shouldShowQuotedReplyToggle"
         :quoted-reply-enabled="quotedReplyPreference"
+        :show-formatting-toolbar-toggle="shouldShowFormattingToolbarToggle"
+        :formatting-toolbar-enabled="isFormattingToolbarPinned"
         :toggle-audio-recorder-play-pause="toggleAudioRecorderPlayPause"
         :toggle-audio-recorder="toggleAudioRecorder"
         :toggle-emoji-picker="toggleEmojiPicker"
@@ -1441,6 +1465,7 @@ export default {
         @select-content-template="openContentTemplateModal"
         @toggle-insert-article="toggleInsertArticle"
         @toggle-quoted-reply="toggleQuotedReply"
+        @toggle-formatting-toolbar="toggleFormattingToolbar"
       />
     </Transition>
 

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -275,6 +275,10 @@
           "CANCEL": "Cancel"
         }
       },
+      "FORMATTING_TOOLBAR": {
+        "ENABLE_TOOLTIP": "Show formatting toolbar",
+        "DISABLE_TOOLTIP": "Hide formatting toolbar"
+      },
       "QUOTED_REPLY": {
         "ENABLE_TOOLTIP": "Include quoted email thread",
         "DISABLE_TOOLTIP": "Don't include quoted email thread",


### PR DESCRIPTION
The reply box now has a formatting toolbar an agent can pin open. Until now formatting there was a bubble that only appeared over selected text, which meant an agent could not start a bullet list on an empty line, could not turn on bold before typing, and had no visible sign that the reply box supports formatting at all. The compose window, running the very same editor, has always shown a toolbar — so the two places you write an email behaved differently.

A new button in the reply footer pins the toolbar above the composer. The choice is stored in the agent's UI settings, so it stays put across conversations and sessions. The selection bubble remains the default for anyone who prefers it.

## Closes

Closes #15182

## How to test

1. Open any conversation and look at the reply footer. There is a new **Aa** button next to emoji and attach.
2. Click it. The formatting toolbar appears above the composer and the button shows as pressed.
3. On an empty line, click the bulleted list button. The list starts — this was not reachable before, since there was no text to select.
4. Move to a different conversation and reload the page. The toolbar is still pinned.
5. Click the button again to unpin. Select some text: the bubble menu still appears as it always did.
6. Open a conversation on an SMS or X inbox. The button is absent, because those channels have no formatting options.
7. Switch to **Private Note**. The toolbar follows the private-note formatting set, which includes strikethrough.

## What changed

- `ReplyBottomPanel.vue` gains the toggle, mirroring the existing quoted-reply button including `aria-pressed`. It is hidden when the channel's formatting menu is empty or the editor is disabled.
- `ReplyBox.vue` stores the preference under `formatting_toolbar_enabled` in UI settings.
- `Editor.vue` previously decided between bubble and menubar by reading its own root element's `classList` inside a `computed`. That has no reactive dependency, so the value froze after mount and would never have seen a runtime toggle. It is now driven by a `popoverMenu` prop, and the editor applies the class itself, so the CSS and the JS read from one source.

### On tables

The issue also raises tables in email replies. That one cannot be fixed from this repository: `buildMessageSchema` in `@chatwoot/prosemirror-schema` builds no table nodes, `messageParser.js` disables the markdown `table` rule, and `messageSerializer.js` has no table serialization — only `fullSchema`, used by the Help Center editor, pulls in `prosemirror-tables`. It needs a change and a release in that package first. Happy to take it on if maintainers want it; I left it out here to keep this reviewable.
