### PR TITLE
fix: don't show the self-hosted upgrade banner on chatwoot cloud

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -18,7 +18,8 @@ class Api::V1::AccountsController < Api::BaseController
               with: :render_error_response
 
   def show
-    @latest_chatwoot_version = ::Redis::Alfred.get(::Redis::Alfred::LATEST_CHATWOOT_VERSION)
+    # The upgrade banner is a self-hosted nudge; the managed instance is always current.
+    @latest_chatwoot_version = ::Redis::Alfred.get(::Redis::Alfred::LATEST_CHATWOOT_VERSION) unless ChatwootApp.chatwoot_cloud?
     render 'api/v1/accounts/show', format: :json
   end
 

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -18,8 +18,7 @@ class Api::V1::AccountsController < Api::BaseController
               with: :render_error_response
 
   def show
-    # The upgrade banner is a self-hosted nudge; the managed instance is always current.
-    @latest_chatwoot_version = ::Redis::Alfred.get(::Redis::Alfred::LATEST_CHATWOOT_VERSION) unless ChatwootApp.chatwoot_cloud?
+    @latest_chatwoot_version = latest_chatwoot_version
     render 'api/v1/accounts/show', format: :json
   end
 
@@ -71,6 +70,10 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   private
+
+  def latest_chatwoot_version
+    Redis::Alfred.get(Redis::Alfred::LATEST_CHATWOOT_VERSION)
+  end
 
   def enqueue_branding_enrichment
     email = account_params[:email].presence || @user&.email

--- a/enterprise/app/controllers/enterprise/api/v1/accounts_settings.rb
+++ b/enterprise/app/controllers/enterprise/api/v1/accounts_settings.rb
@@ -6,6 +6,13 @@ module Enterprise::Api::V1::AccountsSettings
 
   private
 
+  # The upgrade banner is a self-hosted nudge; the managed cloud instance is always current.
+  def latest_chatwoot_version
+    return if ChatwootApp.chatwoot_cloud?
+
+    super
+  end
+
   def record_marketing_attribution
     return if current_user.present?
     return if @account.blank?

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe 'Accounts API', type: :request do
         expect(response.body).to include(account.locale)
       end
 
-      it 'exposes the latest chatwoot version on self-hosted' do
+      it 'exposes the latest chatwoot version' do
         Redis::Alfred.set(Redis::Alfred::LATEST_CHATWOOT_VERSION, '4.16.1')
 
         get "/api/v1/accounts/#{account.id}",
@@ -207,17 +207,6 @@ RSpec.describe 'Accounts API', type: :request do
             as: :json
 
         expect(response.parsed_body['latest_chatwoot_version']).to eq('4.16.1')
-      end
-
-      it 'does not expose the latest chatwoot version on cloud' do
-        Redis::Alfred.set(Redis::Alfred::LATEST_CHATWOOT_VERSION, '4.16.1')
-        allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
-
-        get "/api/v1/accounts/#{account.id}",
-            headers: admin.create_new_auth_token,
-            as: :json
-
-        expect(response.parsed_body['latest_chatwoot_version']).to be_nil
       end
     end
 

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe 'Accounts API', type: :request do
       end
 
       it 'exposes the latest chatwoot version on self-hosted' do
-        ::Redis::Alfred.set(::Redis::Alfred::LATEST_CHATWOOT_VERSION, '4.16.1')
+        Redis::Alfred.set(Redis::Alfred::LATEST_CHATWOOT_VERSION, '4.16.1')
 
         get "/api/v1/accounts/#{account.id}",
             headers: admin.create_new_auth_token,
@@ -210,7 +210,7 @@ RSpec.describe 'Accounts API', type: :request do
       end
 
       it 'does not expose the latest chatwoot version on cloud' do
-        ::Redis::Alfred.set(::Redis::Alfred::LATEST_CHATWOOT_VERSION, '4.16.1')
+        Redis::Alfred.set(Redis::Alfred::LATEST_CHATWOOT_VERSION, '4.16.1')
         allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
 
         get "/api/v1/accounts/#{account.id}",

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -198,6 +198,27 @@ RSpec.describe 'Accounts API', type: :request do
         expect(response.body).to include(account.support_email)
         expect(response.body).to include(account.locale)
       end
+
+      it 'exposes the latest chatwoot version on self-hosted' do
+        ::Redis::Alfred.set(::Redis::Alfred::LATEST_CHATWOOT_VERSION, '4.16.1')
+
+        get "/api/v1/accounts/#{account.id}",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response.parsed_body['latest_chatwoot_version']).to eq('4.16.1')
+      end
+
+      it 'does not expose the latest chatwoot version on cloud' do
+        ::Redis::Alfred.set(::Redis::Alfred::LATEST_CHATWOOT_VERSION, '4.16.1')
+        allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
+
+        get "/api/v1/accounts/#{account.id}",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response.parsed_body['latest_chatwoot_version']).to be_nil
+      end
     end
 
     context 'when API and webhook access is disabled for the account' do

--- a/spec/enterprise/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts_controller_spec.rb
@@ -68,4 +68,33 @@ RSpec.describe 'Enterprise Accounts API', type: :request do
       expect(account.internal_attributes).not_to include('marketing_attribution')
     end
   end
+
+  describe 'GET /api/v1/accounts/{account.id}' do
+    let(:account) { create(:account) }
+    let(:admin) { create(:user, account: account, role: :administrator) }
+
+    before do
+      Redis::Alfred.set(Redis::Alfred::LATEST_CHATWOOT_VERSION, '4.16.1')
+    end
+
+    it 'hides the latest chatwoot version on cloud' do
+      allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
+
+      get "/api/v1/accounts/#{account.id}",
+          headers: admin.create_new_auth_token,
+          as: :json
+
+      expect(response.parsed_body['latest_chatwoot_version']).to be_nil
+    end
+
+    it 'exposes the latest chatwoot version on self-hosted enterprise' do
+      allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(false)
+
+      get "/api/v1/accounts/#{account.id}",
+          headers: admin.create_new_auth_token,
+          as: :json
+
+      expect(response.parsed_body['latest_chatwoot_version']).to eq('4.16.1')
+    end
+  end
 end


### PR DESCRIPTION
## Description

The dashboard "update to vX.Y.Z is available" banner is a self-hosted upgrade nudge, but nothing gates it to self-hosted installs. On a managed cloud instance the banner can still appear: `latest_chatwoot_version` is populated in Redis from the hub's advertised latest stable release, and the frontend compares it (`semver.lt`) against the per-request `appVersion` baked into the dashboard HTML. When a browser session is holding HTML rendered before the current deploy, `appVersion` lags the hub's advertised version and the banner fires, even though the managed instance is already on the newest build.

This gates the value at the source: `api/v1/accounts#show` no longer sets `latest_chatwoot_version` when running on cloud, so `hasAnUpdateAvailable` short-circuits (`semver.valid(null)` is false) and the banner never renders there. Self-hosted behaviour is unchanged.

Fixes https://linear.app/chatwoot/issue/CW-7763

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added request specs on `GET /api/v1/accounts/{id}`: `latest_chatwoot_version` is exposed on self-hosted and is `nil` when `ChatwootApp.chatwoot_cloud?` is true. `bundle exec rspec spec/controllers/api/v1/accounts_controller_spec.rb` -> 13 examples, 0 failures.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
