### PR TITLE
fix: default Captain overview to last 7 days

### DIFF
--- a/app/javascript/dashboard/components-next/captain/pageComponents/overview/RangeSelector.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/overview/RangeSelector.vue
@@ -6,7 +6,7 @@ import { vOnClickOutside } from '@vueuse/components';
 import Button from 'dashboard/components-next/button/Button.vue';
 import DropdownMenu from 'dashboard/components-next/dropdown-menu/DropdownMenu.vue';
 
-const modelValue = defineModel({ type: String, default: '30' });
+const modelValue = defineModel({ type: String, default: '7' });
 
 const { t } = useI18n();
 const [showDropdown, toggleDropdown] = useToggle();

--- a/app/javascript/dashboard/components-next/captain/pageComponents/overview/WelcomeCard.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/overview/WelcomeCard.vue
@@ -7,7 +7,7 @@ import MessageFormatter from 'shared/helpers/MessageFormatter.js';
 const props = defineProps({
   range: {
     type: String,
-    default: '30',
+    default: '7',
   },
   stats: {
     type: Object,

--- a/app/javascript/dashboard/routes/dashboard/captain/assistants/overview/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/assistants/overview/Index.vue
@@ -23,7 +23,7 @@ const route = useRoute();
 const { checkPermissions } = usePolicy();
 const canDrilldown = computed(() => checkPermissions(['administrator']));
 
-const selectedRange = ref('this_month');
+const selectedRange = ref('7');
 
 const assistantId = computed(() => route.params.assistantId);
 const metricStats = ref(null);

--- a/enterprise/app/builders/captain/assistant_stats_window.rb
+++ b/enterprise/app/builders/captain/assistant_stats_window.rb
@@ -11,7 +11,7 @@
 class Captain::AssistantStatsWindow
   include TimezoneHelper
 
-  DEFAULT_RANGE = '30'.freeze
+  DEFAULT_RANGE = '7'.freeze
   ALLOWED_RANGES = %w[7 30 90 this_month last_month].freeze
 
   attr_reader :range

--- a/spec/enterprise/builders/captain/assistant_stats_builder_spec.rb
+++ b/spec/enterprise/builders/captain/assistant_stats_builder_spec.rb
@@ -117,9 +117,9 @@ RSpec.describe Captain::AssistantStatsBuilder do
     end
 
     it 'falls back to the default range for values outside the allowed set' do
-      expect(described_class.new(assistant, '365000').range).to eq('30')
-      expect(described_class.new(assistant, 'bogus').range).to eq('30')
-      expect(described_class.new(assistant, nil).range).to eq('30')
+      expect(described_class.new(assistant, '365000').range).to eq('7')
+      expect(described_class.new(assistant, 'bogus').range).to eq('7')
+      expect(described_class.new(assistant, nil).range).to eq('7')
     end
   end
 


### PR DESCRIPTION
The Captain agents overview now defaults to the last 7 days instead of this month, so the page opens on a more recent and actionable window.

## What changed

- Overview page, range selector, and welcome card default to `7`.
- Backend `Captain::AssistantStatsWindow::DEFAULT_RANGE` changed from `30` to `7`, so requests without a `range` param (or with invalid values) also resolve to the last 7 days.

## How to test

- Open Captain → Overview: the range selector should show "Last 7 days" by default and metrics should reflect that window. Other ranges continue to work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)