### PR TITLE
fix(inboxes): guide users through meta api incident

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -33,7 +33,10 @@ import {
 // constants
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import { REPLY_POLICY } from 'shared/constants/links';
-import wootConstants from 'dashboard/constants/globals';
+import wootConstants, {
+  IS_META_INBOX_CREATION_DISABLED,
+  META_RESTRICTION_STATUS_URL,
+} from 'dashboard/constants/globals';
 import { LOCAL_STORAGE_KEYS } from 'dashboard/constants/localStorage';
 import { INBOX_TYPES } from 'dashboard/helper/inbox';
 
@@ -93,6 +96,7 @@ export default {
       currentUserId: 'getCurrentUserID',
       listLoadingStatus: 'getAllMessagesLoaded',
       currentAccountId: 'getCurrentAccountId',
+      isOnChatwootCloud: 'globalConfig/isOnChatwootCloud',
     }),
     isOpen() {
       return this.currentChat?.status === wootConstants.STATUS_TYPE.OPEN;
@@ -169,6 +173,16 @@ export default {
         additionalAttributes.type === 'instagram_direct_message' &&
         instagramInbox
       );
+    },
+    isInstagramRestrictionBannerVisible() {
+      return (
+        this.isOnChatwootCloud &&
+        IS_META_INBOX_CREATION_DISABLED &&
+        this.isAnInstagramChannel
+      );
+    },
+    instagramRestrictionStatusUrl() {
+      return META_RESTRICTION_STATUS_URL;
     },
     replyWindowBannerMessage() {
       if (this.isAWhatsAppChannel) {
@@ -454,6 +468,14 @@ export default {
   >
     <div ref="topBannerRef">
       <Banner
+        v-if="isInstagramRestrictionBannerVisible"
+        color-scheme="warning"
+        class="mx-2 mt-2 overflow-hidden rounded-lg"
+        :banner-message="$t('CONVERSATION.INSTAGRAM_RESTRICTION_BANNER')"
+        :href-link="instagramRestrictionStatusUrl"
+        :href-link-text="$t('CONVERSATION.INSTAGRAM_RESTRICTION_STATUS_LINK')"
+      />
+      <Banner
         v-if="!currentChat.can_reply"
         color-scheme="alert"
         class="mx-2 mt-2 overflow-hidden rounded-lg"
@@ -462,7 +484,7 @@ export default {
         :href-link-text="replyWindowLinkText"
       />
       <Banner
-        v-else-if="hasDuplicateInstagramInbox"
+        v-if="hasDuplicateInstagramInbox"
         color-scheme="alert"
         class="mx-2 mt-2 overflow-hidden rounded-lg"
         :banner-message="$t('CONVERSATION.OLD_INSTAGRAM_INBOX_REPLY_BANNER')"

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -470,7 +470,7 @@ export default {
       <Banner
         v-if="isInstagramRestrictionBannerVisible"
         color-scheme="warning"
-        class="mx-2 mt-2 overflow-hidden rounded-lg"
+        class="mx-2 mt-2 min-h-12 !h-auto rounded-lg"
         :banner-message="$t('CONVERSATION.INSTAGRAM_RESTRICTION_BANNER')"
         :href-link="instagramRestrictionStatusUrl"
         :href-link-text="$t('CONVERSATION.INSTAGRAM_RESTRICTION_STATUS_LINK')"

--- a/app/javascript/dashboard/constants/globals.js
+++ b/app/javascript/dashboard/constants/globals.js
@@ -79,4 +79,5 @@ export default {
 };
 export const DEFAULT_REDIRECT_URL = '/app/';
 export const IS_META_INBOX_CREATION_DISABLED = true;
-export const META_RESTRICTION_STATUS_URL = 'https://status.chatwoot.com';
+export const META_RESTRICTION_STATUS_URL =
+  'https://status.chatwoot.com/incident/976975';

--- a/app/javascript/dashboard/constants/globals.js
+++ b/app/javascript/dashboard/constants/globals.js
@@ -80,4 +80,4 @@ export default {
 export const DEFAULT_REDIRECT_URL = '/app/';
 export const IS_META_INBOX_CREATION_DISABLED = true;
 export const META_RESTRICTION_STATUS_URL =
-  'https://status.chatwoot.com/incident/976975';
+  'https://status.chatwoot.com/incidents';

--- a/app/javascript/dashboard/constants/globals.js
+++ b/app/javascript/dashboard/constants/globals.js
@@ -78,3 +78,5 @@ export default {
   },
 };
 export const DEFAULT_REDIRECT_URL = '/app/';
+export const IS_META_INBOX_CREATION_DISABLED = true;
+export const META_RESTRICTION_STATUS_URL = 'https://status.chatwoot.com';

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -44,6 +44,8 @@
     "TWILIO_WHATSAPP_CAN_REPLY": "You can only reply to this conversation using a template message due to",
     "TWILIO_WHATSAPP_24_HOURS_WINDOW": "24 hour message window restriction",
     "OLD_INSTAGRAM_INBOX_REPLY_BANNER": "This Instagram account was migrated to the new Instagram channel inbox. All new messages will show up there. You won’t be able to send messages from this conversation anymore.",
+    "INSTAGRAM_RESTRICTION_BANNER": "Instagram is currently affected by a Meta account restriction. Some messages or actions may be delayed or unavailable.",
+    "INSTAGRAM_RESTRICTION_STATUS_LINK": "View status updates",
     "REPLYING_TO": "You are replying to:",
     "REMOVE_SELECTION": "Remove Selection",
     "DOWNLOAD": "Download",

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -44,7 +44,7 @@
     "TWILIO_WHATSAPP_CAN_REPLY": "You can only reply to this conversation using a template message due to",
     "TWILIO_WHATSAPP_24_HOURS_WINDOW": "24 hour message window restriction",
     "OLD_INSTAGRAM_INBOX_REPLY_BANNER": "This Instagram account was migrated to the new Instagram channel inbox. All new messages will show up there. You won’t be able to send messages from this conversation anymore.",
-    "INSTAGRAM_RESTRICTION_BANNER": "Instagram is currently affected by a Meta account restriction. Some messages or actions may be delayed or unavailable.",
+    "INSTAGRAM_RESTRICTION_BANNER": "Instagram messaging is currently affected by an API-level issue on Meta’s side, not a problem with Chatwoot. Some messages or actions may be delayed or unavailable. We’re working closely with Meta to resolve it as quickly as possible.",
     "INSTAGRAM_RESTRICTION_STATUS_LINK": "View status updates",
     "REPLYING_TO": "You are replying to:",
     "REMOVE_SELECTION": "Remove Selection",

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -258,7 +258,8 @@
         },
         "SELECT_PROVIDER": {
           "TITLE": "Select your API provider",
-          "DESCRIPTION": "Choose your WhatsApp provider. You can connect directly through Meta which requires no setup, or connect through Twilio using your account credentials."
+          "DESCRIPTION": "Choose your WhatsApp provider. You can connect directly through Meta which requires no setup, or connect through Twilio using your account credentials.",
+          "RESTRICTION_DESCRIPTION": "Choose your WhatsApp provider. You can connect WhatsApp Cloud manually using your Cloud API credentials, or connect through Twilio using your account credentials."
         },
         "INBOX_NAME": {
           "LABEL": "Inbox Name",

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -49,7 +49,9 @@
         "ADD_NAME": "Add a name for your inbox",
         "PICK_NAME": "Pick a Name for your Inbox",
         "PICK_A_VALUE": "Pick a value",
-        "CREATE_INBOX": "Create Inbox"
+        "CREATE_INBOX": "Create Inbox",
+        "RESTRICTED_WARNING": "Facebook inbox creation is temporarily unavailable while we resolve a Meta account restriction.",
+        "STATUS_LINK": "View status updates"
       },
       "INSTAGRAM": {
         "CONTINUE_WITH_INSTAGRAM": "Continue with Instagram",
@@ -58,7 +60,10 @@
         "ERROR_MESSAGE": "There was an error connecting to Instagram, please try again",
         "ERROR_AUTH": "There was an error connecting to Instagram, please try again",
         "NEW_INBOX_SUGGESTION": "This Instagram account was previously linked to a different inbox and has now been migrated here. All new messages will appear here. The old inbox will no longer be able to send or receive messages for this account.",
-        "DUPLICATE_INBOX_BANNER": "This Instagram account was migrated to the new Instagram channel inbox. You won’t be able to send/receive Instagram messages from this inbox anymore."
+        "DUPLICATE_INBOX_BANNER": "This Instagram account was migrated to the new Instagram channel inbox. You won’t be able to send/receive Instagram messages from this inbox anymore.",
+        "RESTRICTED_WARNING": "Instagram inbox creation is temporarily unavailable while we resolve a Meta account restriction.",
+        "SETTINGS_RESTRICTED_WARNING": "Instagram is currently affected by a Meta account restriction. Some messages or actions may be delayed or unavailable.",
+        "STATUS_LINK": "View status updates"
       },
       "TIKTOK": {
         "CONTINUE_WITH_TIKTOK": "Continue with TikTok",
@@ -320,6 +325,8 @@
           "SUCCESS_FALLBACK": "WhatsApp Business Account has been successfully configured",
           "MANUAL_FALLBACK": "If your number is already connected to the WhatsApp Business Platform (API), or if you’re a tech provider onboarding your own number, please use the {link} flow",
           "MANUAL_LINK_TEXT": "manual setup flow",
+          "RESTRICTED_WARNING": "WhatsApp Embedded Signup is temporarily unavailable while we resolve a Meta account restriction. You can use manual setup instead.",
+          "STATUS_LINK": "View status updates",
           "CALLING_ENABLE_FAILED": "Your WhatsApp inbox is ready, but voice calling couldn't be turned on — this number isn't enrolled in the WhatsApp Business Calling API yet. Reach out to Meta or your WhatsApp Business Solution Provider to onboard it, then turn calling on from the inbox's Calls settings."
         },
         "API": {

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -50,7 +50,7 @@
         "PICK_NAME": "Pick a Name for your Inbox",
         "PICK_A_VALUE": "Pick a value",
         "CREATE_INBOX": "Create Inbox",
-        "RESTRICTED_WARNING": "Facebook inbox creation is temporarily unavailable while we resolve a Meta account restriction.",
+        "RESTRICTED_WARNING": "Facebook inbox creation is temporarily unavailable due to an API-level issue on Meta’s side, not a problem with Chatwoot. We’re working closely with Meta to resolve it as quickly as possible.",
         "STATUS_LINK": "View status updates"
       },
       "INSTAGRAM": {
@@ -61,8 +61,8 @@
         "ERROR_AUTH": "There was an error connecting to Instagram, please try again",
         "NEW_INBOX_SUGGESTION": "This Instagram account was previously linked to a different inbox and has now been migrated here. All new messages will appear here. The old inbox will no longer be able to send or receive messages for this account.",
         "DUPLICATE_INBOX_BANNER": "This Instagram account was migrated to the new Instagram channel inbox. You won’t be able to send/receive Instagram messages from this inbox anymore.",
-        "RESTRICTED_WARNING": "Instagram inbox creation is temporarily unavailable while we resolve a Meta account restriction.",
-        "SETTINGS_RESTRICTED_WARNING": "Instagram is currently affected by a Meta account restriction. Some messages or actions may be delayed or unavailable.",
+        "RESTRICTED_WARNING": "Instagram inbox creation is temporarily unavailable due to an API-level issue on Meta’s side, not a problem with Chatwoot. We’re working closely with Meta to resolve it as quickly as possible.",
+        "SETTINGS_RESTRICTED_WARNING": "Instagram messaging is currently affected by an API-level issue on Meta’s side, not a problem with Chatwoot. Some messages or actions may be delayed or unavailable. We’re working closely with Meta to resolve it as quickly as possible.",
         "STATUS_LINK": "View status updates"
       },
       "TIKTOK": {
@@ -252,6 +252,7 @@
           "TWILIO": "Twilio",
           "WHATSAPP_CLOUD": "WhatsApp Cloud",
           "WHATSAPP_CLOUD_DESC": "Quick setup through Meta",
+          "WHATSAPP_CLOUD_MANUAL_SETUP_DESC": "Manual setup with Cloud API credentials",
           "TWILIO_DESC": "Connect via Twilio credentials",
           "360_DIALOG": "360Dialog"
         },
@@ -325,12 +326,14 @@
           "SUCCESS_FALLBACK": "WhatsApp Business Account has been successfully configured",
           "MANUAL_FALLBACK": "If your number is already connected to the WhatsApp Business Platform (API), or if you’re a tech provider onboarding your own number, please use the {link} flow",
           "MANUAL_LINK_TEXT": "manual setup flow",
-          "RESTRICTED_WARNING": "WhatsApp Embedded Signup is temporarily unavailable while we resolve a Meta account restriction. You can use manual setup instead.",
+          "RESTRICTED_WARNING": "WhatsApp Embedded Signup is temporarily unavailable due to an API-level issue on Meta’s side, not a problem with Chatwoot. You can use manual setup for eligible Cloud API numbers. We’re working closely with Meta to resolve it as quickly as possible.",
           "STATUS_LINK": "View status updates",
           "CALLING_ENABLE_FAILED": "Your WhatsApp inbox is ready, but voice calling couldn't be turned on — this number isn't enrolled in the WhatsApp Business Calling API yet. Reach out to Meta or your WhatsApp Business Solution Provider to onboard it, then turn calling on from the inbox's Calls settings."
         },
         "API": {
-          "ERROR_MESSAGE": "We were not able to save the WhatsApp channel"
+          "ERROR_MESSAGE": "We were not able to save the WhatsApp channel",
+          "MANUAL_RESTRICTION_WARNING": "WhatsApp Embedded Signup is temporarily unavailable due to an API-level issue on Meta’s side, not a problem with Chatwoot. Manual setup works only for numbers already connected to WhatsApp Cloud API. Numbers using WhatsApp Business app coexistence are not supported in this flow yet. We’re working closely with Meta to resolve the issue as quickly as possible. Thanks for your patience.",
+          "STATUS_LINK": "View status updates"
         }
       },
       "VOICE": {

--- a/app/javascript/dashboard/i18n/locale/en/onboarding.json
+++ b/app/javascript/dashboard/i18n/locale/en/onboarding.json
@@ -39,6 +39,10 @@
     "ERROR": "Something went wrong. Please try again.",
     "WHATSAPP_CONNECTED": "WhatsApp connected successfully",
     "FACEBOOK_CONNECTED": "Facebook connected successfully",
+    "META_RESTRICTION": {
+      "MESSAGE": "Instagram and WhatsApp inbox creation through Meta is temporarily unavailable. You can continue setup later from your dashboard.",
+      "STATUS_LINK": "View status updates"
+    },
     "CREATED_FOR_YOU": {
       "TITLE": "We've created the following for you",
       "LIVE_CHAT": "Live Chat widget",

--- a/app/javascript/dashboard/i18n/locale/en/onboarding.json
+++ b/app/javascript/dashboard/i18n/locale/en/onboarding.json
@@ -40,7 +40,7 @@
     "WHATSAPP_CONNECTED": "WhatsApp connected successfully",
     "FACEBOOK_CONNECTED": "Facebook connected successfully",
     "META_RESTRICTION": {
-      "MESSAGE": "Instagram and WhatsApp inbox creation through Meta is temporarily unavailable. You can continue setup later from your dashboard.",
+      "MESSAGE": "Inbox setup for Facebook, Instagram, and WhatsApp is temporarily unavailable due to an API-level issue on Meta’s side, not a problem with Chatwoot. We’re working closely with Meta to resolve it as quickly as possible.",
       "STATUS_LINK": "View status updates"
     },
     "CREATED_FOR_YOU": {

--- a/app/javascript/dashboard/routes/dashboard/onboarding/InboxSetup.vue
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/InboxSetup.vue
@@ -19,11 +19,17 @@ import { CHANNEL_TYPES } from 'dashboard/helper/inbox';
 import { useChannelConnect } from './inbox-setup/useChannelConnect';
 import { useDetectedChannels } from './inbox-setup/useDetectedChannels';
 import { DIALOG_CHANNELS } from './inbox-setup/constants';
+import Banner from 'dashboard/components-next/banner/Banner.vue';
+import {
+  IS_META_INBOX_CREATION_DISABLED,
+  META_RESTRICTION_STATUS_URL,
+} from 'dashboard/constants/globals';
 
 const { t } = useI18n();
 const store = useStore();
 const router = useRouter();
-const { accountId, currentAccount, finishOnboarding } = useAccount();
+const { accountId, currentAccount, finishOnboarding, isOnChatwootCloud } =
+  useAccount();
 const { isEnterprise } = useConfig();
 const { connectViaOAuth, connectWhatsapp } = useChannelConnect();
 
@@ -43,6 +49,9 @@ const {
 } = useDetectedChannels();
 
 const channelsDialogRef = ref(null);
+const showMetaRestrictionBanner = computed(
+  () => isOnChatwootCloud.value && IS_META_INBOX_CREATION_DISABLED
+);
 
 // The initial inboxes fetch happens in WebWidgetCreationStatus, which polls
 // `inboxes/get` from its own mount — no need to dispatch it here too.
@@ -124,6 +133,25 @@ const connectChannel = channel => {
         :title="t('ONBOARDING_INBOX_SETUP.CHANNELS.TITLE')"
         icon="i-lucide-inbox"
       >
+        <Banner v-if="showMetaRestrictionBanner" color="amber" class="m-3">
+          <div class="flex items-start gap-3 text-start">
+            <Icon
+              icon="i-lucide-triangle-alert"
+              class="flex-shrink-0 size-4 mt-0.5"
+            />
+            <span>
+              {{ t('ONBOARDING_INBOX_SETUP.META_RESTRICTION.MESSAGE') }}
+              <a
+                :href="META_RESTRICTION_STATUS_URL"
+                class="link underline"
+                rel="noopener noreferrer nofollow"
+                target="_blank"
+              >
+                {{ t('ONBOARDING_INBOX_SETUP.META_RESTRICTION.STATUS_LINK') }}
+              </a>
+            </span>
+          </div>
+        </Banner>
         <div
           v-if="hasDetectedChannels"
           class="flex items-center gap-2 p-3 border-b border-dashed border-n-strong"

--- a/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
@@ -1,6 +1,7 @@
 import { useMapGetter } from 'dashboard/composables/store';
 import { useAccount } from 'dashboard/composables/useAccount';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
+import { IS_META_INBOX_CREATION_DISABLED } from 'dashboard/constants/globals';
 
 // OAuth/SDK channels need installation-level app credentials to be usable. When
 // the credential is missing the channel is "not configured" and is hidden from
@@ -12,18 +13,23 @@ export function useChannelConfig() {
   const isOnChatwootCloud = useMapGetter('globalConfig/isOnChatwootCloud');
   const { isCloudFeatureEnabled } = useAccount();
   const installationConfig = window.chatwootConfig || {};
+  const isMetaInboxCreationDisabled = () =>
+    isOnChatwootCloud.value && IS_META_INBOX_CREATION_DISABLED;
 
   const CHANNEL_CONFIGURED = {
     // WhatsApp is onboarded only via Meta embedded signup, which needs both the
     // app id (not the 'none' sentinel) and the signup configuration id.
     whatsapp: () =>
+      !isMetaInboxCreationDisabled() &&
       (!isOnChatwootCloud.value ||
         isCloudFeatureEnabled(FEATURE_FLAGS.WHATSAPP_EMBEDDED_SIGNUP_FLOW)) &&
       Boolean(installationConfig.whatsappAppId) &&
       installationConfig.whatsappAppId !== 'none' &&
       Boolean(installationConfig.whatsappConfigurationId),
-    facebook: () => Boolean(installationConfig.fbAppId),
+    facebook: () =>
+      !isMetaInboxCreationDisabled() && Boolean(installationConfig.fbAppId),
     instagram: () =>
+      !isMetaInboxCreationDisabled() &&
       Boolean(installationConfig.instagramAppId) &&
       isCloudFeatureEnabled(FEATURE_FLAGS.CHANNEL_INSTAGRAM),
     tiktok: () => Boolean(installationConfig.tiktokAppId),

--- a/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConnect.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConnect.js
@@ -1,7 +1,9 @@
 import { useI18n } from 'vue-i18n';
 import { useAlert } from 'dashboard/composables';
 import { useStore } from 'dashboard/composables/store';
+import { useAccount } from 'dashboard/composables/useAccount';
 import { useWhatsappEmbeddedSignup } from 'dashboard/composables/useWhatsappEmbeddedSignup';
+import { IS_META_INBOX_CREATION_DISABLED } from 'dashboard/constants/globals';
 import { parseAPIErrorResponse } from 'dashboard/store/utils/api';
 import googleClient from 'dashboard/api/channel/googleClient';
 import microsoftClient from 'dashboard/api/channel/microsoftClient';
@@ -22,11 +24,19 @@ const OAUTH_CLIENTS = {
 export function useChannelConnect() {
   const { t } = useI18n();
   const store = useStore();
+  const { isOnChatwootCloud } = useAccount();
   const { runEmbeddedSignup } = useWhatsappEmbeddedSignup();
+  const isMetaInboxCreationDisabled = () =>
+    isOnChatwootCloud.value && IS_META_INBOX_CREATION_DISABLED;
 
   const connectViaOAuth = async provider => {
     const client = OAUTH_CLIENTS[provider];
     if (!client) return;
+
+    if (provider === 'instagram' && isMetaInboxCreationDisabled()) {
+      useAlert(t('ONBOARDING_INBOX_SETUP.META_RESTRICTION.MESSAGE'));
+      return;
+    }
 
     try {
       const {
@@ -43,6 +53,11 @@ export function useChannelConnect() {
   // inbox, and surface the result inline — then refetch so the connected state
   // reflects the freshly created inbox (and renders its real channel icon).
   const connectWhatsapp = async () => {
+    if (isMetaInboxCreationDisabled()) {
+      useAlert(t('ONBOARDING_INBOX_SETUP.META_RESTRICTION.MESSAGE'));
+      return;
+    }
+
     let credentials;
     try {
       credentials = await runEmbeddedSignup();

--- a/app/javascript/dashboard/routes/dashboard/onboarding/specs/inbox-setup/InboxChannelsDialog.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/specs/inbox-setup/InboxChannelsDialog.spec.js
@@ -2,9 +2,16 @@ import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import InboxChannelsDialog from '../../inbox-setup/InboxChannelsDialog.vue';
 
+const { isOnChatwootCloud } = vi.hoisted(() => ({
+  isOnChatwootCloud: { value: false },
+}));
+
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: key => key }) }));
 vi.mock('dashboard/composables/store', () => ({
-  useMapGetter: () => ({ value: {} }),
+  useMapGetter: getter =>
+    getter === 'globalConfig/isOnChatwootCloud'
+      ? isOnChatwootCloud
+      : { value: {} },
 }));
 vi.mock('dashboard/composables/useAccount', () => ({
   useAccount: () => ({ isCloudFeatureEnabled: () => true }),
@@ -36,6 +43,7 @@ const mountDialog = () =>
 describe('InboxChannelsDialog Facebook gating', () => {
   afterEach(() => {
     delete window.chatwootConfig;
+    isOnChatwootCloud.value = false;
   });
 
   it('opens the Facebook page picker when fbAppId is configured', async () => {
@@ -57,6 +65,18 @@ describe('InboxChannelsDialog Facebook gating', () => {
 
     expect(wrapper.find('[data-test="fb-form"]').exists()).toBe(false);
     // The channel grid renders its cards instead.
+    expect(wrapper.find('button').exists()).toBe(true);
+  });
+
+  it('shows the grid when Meta inbox creation is disabled on Chatwoot Cloud', async () => {
+    isOnChatwootCloud.value = true;
+    window.chatwootConfig = { fbAppId: 'fb-app' };
+    const wrapper = mountDialog();
+
+    wrapper.vm.open('facebook');
+    await nextTick();
+
+    expect(wrapper.find('[data-test="fb-form"]').exists()).toBe(false);
     expect(wrapper.find('button').exists()).toBe(true);
   });
 });

--- a/app/javascript/dashboard/routes/dashboard/onboarding/specs/inbox-setup/useDetectedChannels.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/specs/inbox-setup/useDetectedChannels.spec.js
@@ -211,11 +211,17 @@ describe('useDetectedChannels', () => {
       ]);
     });
 
-    it('keeps Instagram available on Chatwoot Cloud when enabled for the account', () => {
+    it('hides Meta channels on Chatwoot Cloud during the Meta restriction', () => {
       const { displayedChannels } = mountComposable({
+        features: {
+          channel_instagram: true,
+          whatsapp_embedded_signup_inbox_creation: true,
+        },
         isOnChatwootCloud: true,
         brandInfo: {
           socials: [
+            { type: 'whatsapp', url: 'https://wa.me/14155552671' },
+            { type: 'facebook', url: 'https://facebook.com/acme' },
             { type: 'instagram', url: 'https://instagram.com/acme' },
             { type: 'tiktok', url: 'https://tiktok.com/@acme' },
           ],
@@ -223,7 +229,6 @@ describe('useDetectedChannels', () => {
       });
 
       expect(displayedChannels.value.map(channel => channel.type)).toEqual([
-        'instagram',
         'tiktok',
       ]);
     });

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -4,6 +4,8 @@ import { shouldBeUrl } from 'shared/helpers/Validators';
 import { useAlert } from 'dashboard/composables';
 import { useVuelidate } from '@vuelidate/core';
 import Avatar from 'next/avatar/Avatar.vue';
+import Banner from 'dashboard/components-next/banner/Banner.vue';
+import Icon from 'dashboard/components-next/icon/Icon.vue';
 import SettingIntroBanner from 'dashboard/components/widgets/SettingIntroBanner.vue';
 import SettingsToggleSection from 'dashboard/components-next/Settings/SettingsToggleSection.vue';
 import SettingsFieldSection from 'dashboard/components-next/Settings/SettingsFieldSection.vue';
@@ -44,9 +46,14 @@ import SelectInput from 'dashboard/components-next/select/Select.vue';
 import Widget from 'dashboard/modules/widget-preview/components/Widget.vue';
 import AccessToken from 'dashboard/routes/dashboard/settings/profile/AccessToken.vue';
 import { copyTextToClipboard } from 'shared/helpers/clipboard';
+import {
+  IS_META_INBOX_CREATION_DISABLED,
+  META_RESTRICTION_STATUS_URL,
+} from 'dashboard/constants/globals';
 
 export default {
   components: {
+    Banner,
     BotConfiguration,
     CollaboratorsPage,
     ConfigurationPage,
@@ -80,6 +87,7 @@ export default {
     WhatsappManualMigrationBanner,
     Widget,
     AccessToken,
+    Icon,
   },
   mixins: [inboxMixin],
   setup() {
@@ -346,6 +354,16 @@ export default {
     },
     instagramUnauthorized() {
       return this.isAnInstagramChannel && this.inbox.reauthorization_required;
+    },
+    showInstagramRestrictionSettingsBanner() {
+      return (
+        this.isOnChatwootCloud &&
+        IS_META_INBOX_CREATION_DISABLED &&
+        this.isAnInstagramChannel
+      );
+    },
+    metaRestrictionStatusUrl() {
+      return META_RESTRICTION_STATUS_URL;
     },
     tiktokUnauthorized() {
       return this.isATiktokChannel && this.inbox.reauthorization_required;
@@ -823,6 +841,29 @@ export default {
           class="mx-6 mb-4"
           :class="bannerMaxWidth"
         />
+        <Banner
+          v-if="showInstagramRestrictionSettingsBanner"
+          color="amber"
+          class="mx-6 mb-4 max-w-4xl"
+        >
+          <div class="flex items-start gap-3 text-start">
+            <Icon
+              icon="i-lucide-triangle-alert"
+              class="flex-shrink-0 size-4 mt-0.5"
+            />
+            <span>
+              {{ $t('INBOX_MGMT.ADD.INSTAGRAM.SETTINGS_RESTRICTED_WARNING') }}
+              <a
+                :href="metaRestrictionStatusUrl"
+                class="link underline"
+                rel="noopener noreferrer nofollow"
+                target="_blank"
+              >
+                {{ $t('INBOX_MGMT.ADD.INSTAGRAM.STATUS_LINK') }}
+              </a>
+            </span>
+          </div>
+        </Banner>
         <WhatsappManualMigrationBanner
           v-if="showWhatsAppManualMigration"
           class="mx-6 mb-6"

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Facebook.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Facebook.vue
@@ -4,12 +4,19 @@ import { useAlert } from 'dashboard/composables';
 import { useFacebookPageConnect } from 'dashboard/composables/useFacebookPageConnect';
 import { required } from '@vuelidate/validators';
 import LoadingState from 'dashboard/components/widgets/LoadingState.vue';
+import Banner from 'dashboard/components-next/banner/Banner.vue';
+import Icon from 'dashboard/components-next/icon/Icon.vue';
 
 import PageHeader from '../../SettingsSubPageHeader.vue';
 import router from '../../../../index';
 import { useBranding } from 'shared/composables/useBranding';
+import { useAccount } from 'dashboard/composables/useAccount';
 import NextButton from 'dashboard/components-next/button/Button.vue';
 import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
+import {
+  IS_META_INBOX_CREATION_DISABLED,
+  META_RESTRICTION_STATUS_URL,
+} from 'dashboard/constants/globals';
 
 import * as Sentry from '@sentry/vue';
 
@@ -19,14 +26,19 @@ export default {
     PageHeader,
     NextButton,
     ComboBox,
+    Banner,
+    Icon,
   },
   setup() {
     const { replaceInstallationName } = useBranding();
+    const { isOnChatwootCloud } = useAccount();
     const { preloadSdk, loginAndFetchPages } = useFacebookPageConnect();
     return {
       replaceInstallationName,
+      isOnChatwootCloud,
       preloadSdk,
       loginAndFetchPages,
+      META_RESTRICTION_STATUS_URL,
       v$: useVuelidate(),
     };
   },
@@ -70,16 +82,23 @@ export default {
         label: name,
       }));
     },
+    isFacebookConnectionDisabled() {
+      return this.isOnChatwootCloud && IS_META_INBOX_CREATION_DISABLED;
+    },
   },
 
   mounted() {
     // Warm the SDK so the login click opens its popup within the gesture's
     // activation window (see useFacebookPageConnect).
-    this.preloadSdk();
+    if (!this.isFacebookConnectionDisabled) {
+      this.preloadSdk();
+    }
   },
 
   methods: {
     async startLogin() {
+      if (this.isFacebookConnectionDisabled) return;
+
       this.hasLoginStarted = true;
       try {
         const result = await this.loginAndFetchPages();
@@ -151,16 +170,48 @@ export default {
       v-if="!hasLoginStarted"
       class="flex flex-col items-center justify-center h-full text-center"
     >
-      <a href="#" @click="startLogin()">
-        <img
-          class="w-auto h-10 rounded-md"
-          src="~dashboard/assets/images/channels/facebook_login.png"
-          alt="Facebook-logo"
-        />
-      </a>
-      <p class="py-6">
-        {{ replaceInstallationName($t('INBOX_MGMT.ADD.FB.HELP')) }}
-      </p>
+      <div class="flex flex-col items-center w-full max-w-2xl">
+        <button
+          type="button"
+          :disabled="isFacebookConnectionDisabled"
+          :class="{
+            'cursor-not-allowed opacity-50': isFacebookConnectionDisabled,
+          }"
+          @click="startLogin()"
+        >
+          <img
+            class="w-auto h-10 rounded-md"
+            src="~dashboard/assets/images/channels/facebook_login.png"
+            alt="Facebook-logo"
+          />
+        </button>
+        <p class="py-6">
+          {{ replaceInstallationName($t('INBOX_MGMT.ADD.FB.HELP')) }}
+        </p>
+        <Banner
+          v-if="isFacebookConnectionDisabled"
+          color="amber"
+          class="w-full"
+        >
+          <div class="flex items-start gap-3 text-start">
+            <Icon
+              icon="i-lucide-triangle-alert"
+              class="flex-shrink-0 size-4 mt-0.5"
+            />
+            <span>
+              {{ $t('INBOX_MGMT.ADD.FB.RESTRICTED_WARNING') }}
+              <a
+                :href="META_RESTRICTION_STATUS_URL"
+                class="link underline"
+                rel="noopener noreferrer nofollow"
+                target="_blank"
+              >
+                {{ $t('INBOX_MGMT.ADD.FB.STATUS_LINK') }}
+              </a>
+            </span>
+          </div>
+        </Banner>
+      </div>
     </div>
     <div v-else>
       <div v-if="hasError" class="max-w-lg mx-auto text-center">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Instagram.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Instagram.vue
@@ -1,15 +1,26 @@
 <script setup>
-import { ref, onMounted } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import instagramClient from 'dashboard/api/channel/instagramClient';
 import Button from 'dashboard/components-next/button/Button.vue';
+import Banner from 'dashboard/components-next/banner/Banner.vue';
+import Icon from 'dashboard/components-next/icon/Icon.vue';
+import { useAccount } from 'dashboard/composables/useAccount';
+import {
+  IS_META_INBOX_CREATION_DISABLED,
+  META_RESTRICTION_STATUS_URL,
+} from 'dashboard/constants/globals';
 
 const { t } = useI18n();
+const { isOnChatwootCloud } = useAccount();
 
 const hasError = ref(false);
 const errorStateMessage = ref('');
 const errorStateDescription = ref('');
 const isRequestingAuthorization = ref(false);
+const isInstagramConnectionDisabled = computed(
+  () => isOnChatwootCloud.value && IS_META_INBOX_CREATION_DISABLED
+);
 
 onMounted(() => {
   const urlParams = new URLSearchParams(window.location.search);
@@ -34,6 +45,8 @@ onMounted(() => {
 });
 
 const requestAuthorization = async () => {
+  if (isInstagramConnectionDisabled.value) return;
+
   isRequestingAuthorization.value = true;
   const response = await instagramClient.generateAuthorization();
   const {
@@ -58,21 +71,48 @@ const requestAuthorization = async () => {
         v-else
         class="flex flex-col items-center justify-center w-full px-8 py-10 text-center rounded-2xl outline outline-1 outline-n-weak"
       >
-        <h6 class="text-2xl font-medium">
-          {{ $t('INBOX_MGMT.ADD.INSTAGRAM.CONNECT_YOUR_INSTAGRAM_PROFILE') }}
-        </h6>
-        <p class="py-6 text-sm text-n-slate-11">
-          {{ $t('INBOX_MGMT.ADD.INSTAGRAM.HELP') }}
-        </p>
-        <Button
-          class="text-white !rounded-full !px-6 bg-gradient-to-r from-[#833AB4] via-[#FD1D1D] to-[#FCAF45]"
-          lg
-          icon="i-ri-instagram-line"
-          :disabled="isRequestingAuthorization"
-          :is-loading="isRequestingAuthorization"
-          :label="$t('INBOX_MGMT.ADD.INSTAGRAM.CONTINUE_WITH_INSTAGRAM')"
-          @click="requestAuthorization()"
-        />
+        <div class="flex flex-col items-center w-full max-w-2xl">
+          <h6 class="text-2xl font-medium">
+            {{ $t('INBOX_MGMT.ADD.INSTAGRAM.CONNECT_YOUR_INSTAGRAM_PROFILE') }}
+          </h6>
+          <p class="py-6 text-sm text-n-slate-11">
+            {{ $t('INBOX_MGMT.ADD.INSTAGRAM.HELP') }}
+          </p>
+          <Button
+            class="text-white !rounded-full !px-6 bg-gradient-to-r from-[#833AB4] via-[#FD1D1D] to-[#FCAF45]"
+            lg
+            icon="i-ri-instagram-line"
+            :disabled="
+              isRequestingAuthorization || isInstagramConnectionDisabled
+            "
+            :is-loading="isRequestingAuthorization"
+            :label="$t('INBOX_MGMT.ADD.INSTAGRAM.CONTINUE_WITH_INSTAGRAM')"
+            @click="requestAuthorization()"
+          />
+          <Banner
+            v-if="isInstagramConnectionDisabled"
+            color="amber"
+            class="w-full mt-6"
+          >
+            <div class="flex items-start gap-3 text-start">
+              <Icon
+                icon="i-lucide-triangle-alert"
+                class="flex-shrink-0 size-4 mt-0.5"
+              />
+              <span>
+                {{ $t('INBOX_MGMT.ADD.INSTAGRAM.RESTRICTED_WARNING') }}
+                <a
+                  :href="META_RESTRICTION_STATUS_URL"
+                  class="link underline"
+                  rel="noopener noreferrer nofollow"
+                  target="_blank"
+                >
+                  {{ $t('INBOX_MGMT.ADD.INSTAGRAM.STATUS_LINK') }}
+                </a>
+              </span>
+            </div>
+          </Banner>
+        </div>
       </div>
     </div>
   </div>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -9,6 +9,10 @@ import WhatsappEmbeddedSignup from './WhatsappEmbeddedSignup.vue';
 import ChannelSelector from 'dashboard/components/ChannelSelector.vue';
 import { useAccount } from 'dashboard/composables/useAccount';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
+import {
+  IS_META_INBOX_CREATION_DISABLED,
+  META_RESTRICTION_STATUS_URL,
+} from 'dashboard/constants/globals';
 
 const route = useRoute();
 const router = useRouter();
@@ -36,6 +40,9 @@ const selectedProvider = computed(() => route.query.provider);
 const showProviderSelection = computed(() => !selectedProvider.value);
 
 const showConfiguration = computed(() => Boolean(selectedProvider.value));
+const isWhatsappEmbeddedSignupDisabled = computed(
+  () => isOnChatwootCloud.value && IS_META_INBOX_CREATION_DISABLED
+);
 
 const shouldShowWhatsappEmbeddedSignup = computed(() => {
   return (
@@ -109,7 +116,11 @@ const handleManualLinkClick = () => {
     <div v-else-if="showConfiguration">
       <div class="px-6 py-5 rounded-2xl border border-n-weak">
         <div v-if="shouldShowWhatsappEmbeddedSignup">
-          <WhatsappEmbeddedSignup />
+          <WhatsappEmbeddedSignup
+            :is-disabled="isWhatsappEmbeddedSignupDisabled"
+            :show-restriction-alert="isWhatsappEmbeddedSignupDisabled"
+            :restriction-status-url="META_RESTRICTION_STATUS_URL"
+          />
 
           <!-- Manual setup fallback option -->
           <div class="pt-6 mt-6 border-t border-n-weak">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -7,6 +7,8 @@ import ThreeSixtyDialogWhatsapp from './360DialogWhatsapp.vue';
 import CloudWhatsapp from './CloudWhatsapp.vue';
 import WhatsappEmbeddedSignup from './WhatsappEmbeddedSignup.vue';
 import ChannelSelector from 'dashboard/components/ChannelSelector.vue';
+import Banner from 'dashboard/components-next/banner/Banner.vue';
+import Icon from 'dashboard/components-next/icon/Icon.vue';
 import { useAccount } from 'dashboard/composables/useAccount';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import {
@@ -57,7 +59,9 @@ const availableProviders = computed(() => [
   {
     key: PROVIDER_TYPES.WHATSAPP,
     title: t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.WHATSAPP_CLOUD'),
-    description: t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.WHATSAPP_CLOUD_DESC'),
+    description: isWhatsappEmbeddedSignupDisabled.value
+      ? t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.WHATSAPP_CLOUD_MANUAL_SETUP_DESC')
+      : t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.WHATSAPP_CLOUD_DESC'),
     icon: 'i-woot-whatsapp',
   },
   {
@@ -69,10 +73,16 @@ const availableProviders = computed(() => [
 ]);
 
 const selectProvider = providerValue => {
+  const targetProvider =
+    providerValue === PROVIDER_TYPES.WHATSAPP &&
+    isWhatsappEmbeddedSignupDisabled.value
+      ? PROVIDER_TYPES.WHATSAPP_MANUAL
+      : providerValue;
+
   router.push({
     name: route.name,
     params: route.params,
-    query: { provider: providerValue },
+    query: { provider: targetProvider },
   });
 };
 
@@ -147,7 +157,37 @@ const handleManualLinkClick = () => {
         </div>
 
         <!-- Show manual setup -->
-        <CloudWhatsapp v-else-if="shouldShowCloudWhatsapp(selectedProvider)" />
+        <div v-else-if="shouldShowCloudWhatsapp(selectedProvider)">
+          <Banner
+            v-if="
+              isWhatsappEmbeddedSignupDisabled &&
+              selectedProvider === PROVIDER_TYPES.WHATSAPP_MANUAL
+            "
+            color="amber"
+            class="w-full mb-6"
+          >
+            <div class="flex items-start gap-3 text-start">
+              <Icon
+                icon="i-lucide-triangle-alert"
+                class="flex-shrink-0 size-4 mt-0.5"
+              />
+              <span>
+                {{
+                  $t('INBOX_MGMT.ADD.WHATSAPP.API.MANUAL_RESTRICTION_WARNING')
+                }}
+                <a
+                  :href="META_RESTRICTION_STATUS_URL"
+                  class="link underline"
+                  rel="noopener noreferrer nofollow"
+                  target="_blank"
+                >
+                  {{ $t('INBOX_MGMT.ADD.WHATSAPP.API.STATUS_LINK') }}
+                </a>
+              </span>
+            </div>
+          </Banner>
+          <CloudWhatsapp />
+        </div>
 
         <!-- Other providers -->
         <Twilio

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -72,6 +72,12 @@ const availableProviders = computed(() => [
   },
 ]);
 
+const providerSelectionDescription = computed(() =>
+  isWhatsappEmbeddedSignupDisabled.value
+    ? t('INBOX_MGMT.ADD.WHATSAPP.SELECT_PROVIDER.RESTRICTION_DESCRIPTION')
+    : t('INBOX_MGMT.ADD.WHATSAPP.SELECT_PROVIDER.DESCRIPTION')
+);
+
 const selectProvider = providerValue => {
   const targetProvider =
     providerValue === PROVIDER_TYPES.WHATSAPP &&
@@ -107,7 +113,7 @@ const handleManualLinkClick = () => {
           {{ $t('INBOX_MGMT.ADD.WHATSAPP.SELECT_PROVIDER.TITLE') }}
         </h1>
         <p class="text-sm leading-relaxed text-n-slate-11">
-          {{ $t('INBOX_MGMT.ADD.WHATSAPP.SELECT_PROVIDER.DESCRIPTION') }}
+          {{ providerSelectionDescription }}
         </p>
       </div>
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/WhatsappEmbeddedSignup.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/WhatsappEmbeddedSignup.vue
@@ -7,6 +7,7 @@ import { useAlert } from 'dashboard/composables';
 import { useWhatsappEmbeddedSignup } from 'dashboard/composables/useWhatsappEmbeddedSignup';
 import Icon from 'next/icon/Icon.vue';
 import NextButton from 'next/button/Button.vue';
+import Banner from 'next/banner/Banner.vue';
 import LoadingState from 'dashboard/components/widgets/LoadingState.vue';
 import InboxesAPI from 'dashboard/api/inboxes';
 import { parseAPIErrorResponse } from 'dashboard/store/utils/api';
@@ -16,6 +17,18 @@ const props = defineProps({
   enableCallingOnComplete: {
     type: Boolean,
     default: false,
+  },
+  isDisabled: {
+    type: Boolean,
+    default: false,
+  },
+  showRestrictionAlert: {
+    type: Boolean,
+    default: false,
+  },
+  restrictionStatusUrl: {
+    type: String,
+    default: '',
   },
 });
 
@@ -81,6 +94,8 @@ const handleSignupSuccess = async inboxData => {
 };
 
 const launchEmbeddedSignup = async () => {
+  if (props.isDisabled) return;
+
   let credentials;
   try {
     credentials = await runEmbeddedSignup();
@@ -174,9 +189,32 @@ const launchEmbeddedSignup = async () => {
         </I18nT>
       </div>
 
+      <Banner v-if="showRestrictionAlert" color="amber" class="w-full mb-6">
+        <div class="flex items-start gap-3 text-start">
+          <Icon
+            icon="i-lucide-triangle-alert"
+            class="flex-shrink-0 size-4 mt-0.5"
+          />
+          <span>
+            {{
+              $t('INBOX_MGMT.ADD.WHATSAPP.EMBEDDED_SIGNUP.RESTRICTED_WARNING')
+            }}
+            <a
+              v-if="restrictionStatusUrl"
+              :href="restrictionStatusUrl"
+              class="link underline"
+              rel="noopener noreferrer nofollow"
+              target="_blank"
+            >
+              {{ $t('INBOX_MGMT.ADD.WHATSAPP.EMBEDDED_SIGNUP.STATUS_LINK') }}
+            </a>
+          </span>
+        </div>
+      </Banner>
+
       <div class="flex mt-4">
         <NextButton
-          :disabled="isAuthenticating"
+          :disabled="isAuthenticating || isDisabled"
           :is-loading="isAuthenticating"
           faded
           slate


### PR DESCRIPTION
An API-level issue on Meta’s side is preventing Chatwoot Cloud customers from completing some Meta inbox setup flows and can affect actions in existing Instagram conversations. This draft temporarily gates the affected Facebook, Instagram, and WhatsApp flows behind one incident flag and gives users clear guidance with a link to the current status incident.

Self-hosted installations remain unchanged. While WhatsApp Embedded Signup is unavailable, selecting WhatsApp Cloud takes eligible users directly to manual setup and explains the current limitations.

Related: https://status.chatwoot.com/incident/976975

Fixes https://linear.app/chatwoot/issue/CW-7771/guide-users-through-meta-api-incident

### Things to know

- `IS_META_INBOX_CREATION_DISABLED` is the single temporary rollout flag and is currently enabled.
- The incident behavior applies only to Chatwoot Cloud.
- Facebook, Instagram, and WhatsApp Embedded Signup are removed from the new onboarding suggestions while the incident is active.
- Existing Instagram inbox settings and conversations show incident guidance with a status link.
- The WhatsApp Cloud provider routes to manual setup while the flag is enabled.
- Manual setup works only for numbers already connected to WhatsApp Cloud API; numbers using WhatsApp Business app coexistence are not supported by this flow yet.
- The flag should be disabled or removed after the incident is resolved.

### How to test

1. Run Chatwoot with the Cloud installation configuration and open the new inbox flow.
2. Confirm Facebook and Instagram authentication actions are disabled and display the amber incident banner.
3. Open the WhatsApp provider selector and confirm WhatsApp Cloud is described as manual setup with Cloud API credentials.
4. Select WhatsApp Cloud and confirm it opens the manual setup form with the incident warning and links to the current status incident.
5. Open WhatsApp Embedded Signup directly and confirm the signup action is disabled while the eligible manual setup option remains available.
6. Open the initial account onboarding flow and confirm Meta channels are not offered while other configured channels remain available.
7. Open an existing Instagram inbox and conversation and confirm the incident guidance links to the current status incident.
8. Run the same flows as a self-hosted installation and confirm they remain available.
