### PR TITLE
fix(security): route every Captain API through the premium feature guard

### DIFF
--- a/app/controllers/api/v1/accounts/captain/preferences_controller.rb
+++ b/app/controllers/api/v1/accounts/captain/preferences_controller.rb
@@ -81,3 +81,5 @@ class Api::V1::Accounts::Captain::PreferencesController < Api::V1::Accounts::Bas
     Llm::Models.default_model_for(feature_key)
   end
 end
+
+Api::V1::Accounts::Captain::PreferencesController.prepend_mod_with('Api::V1::Accounts::Captain::PreferencesController')

--- a/enterprise/app/controllers/api/v1/accounts/captain/agent_sessions_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/agent_sessions_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Accounts::Captain::AgentSessionsController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::Captain::AgentSessionsController < Api::V1::Accounts::Captain::BaseController
   before_action :set_message
   before_action :authorize_conversation
 

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistant_responses_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistant_responses_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Accounts::Captain::AssistantResponsesController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::Captain::AssistantResponsesController < Api::V1::Accounts::Captain::BaseController
   before_action -> { check_authorization(Captain::Assistant) }
 
   before_action :set_current_page, only: [:index]

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Accounts::Captain::AssistantsController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::Captain::AssistantsController < Api::V1::Accounts::Captain::BaseController
   before_action -> { check_authorization(Captain::Assistant) }
 
   before_action :set_assistant, only: [:show, :update, :destroy, :playground, :metrics, :faq_stats, :summary, :drilldown]

--- a/enterprise/app/controllers/api/v1/accounts/captain/base_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/base_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Accounts::Captain::BaseController < Api::V1::Accounts::BaseController
+  include Enterprise::Concerns::CaptainFeatureGuard
+
+  before_action :ensure_captain_enabled
+end

--- a/enterprise/app/controllers/api/v1/accounts/captain/bulk_actions_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/bulk_actions_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Accounts::Captain::BulkActionsController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::Captain::BulkActionsController < Api::V1::Accounts::Captain::BaseController
   before_action -> { check_authorization(Captain::Assistant) }
   before_action :validate_params
   before_action :type_matches?

--- a/enterprise/app/controllers/api/v1/accounts/captain/copilot_messages_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/copilot_messages_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Accounts::Captain::CopilotMessagesController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::Captain::CopilotMessagesController < Api::V1::Accounts::Captain::BaseController
   before_action :set_copilot_thread
 
   def index

--- a/enterprise/app/controllers/api/v1/accounts/captain/copilot_threads_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/copilot_threads_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Accounts::Captain::CopilotThreadsController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::Captain::CopilotThreadsController < Api::V1::Accounts::Captain::BaseController
   before_action :ensure_message, only: :create
 
   def index

--- a/enterprise/app/controllers/api/v1/accounts/captain/custom_tools_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/custom_tools_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Accounts::Captain::CustomToolsController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::Captain::CustomToolsController < Api::V1::Accounts::Captain::BaseController
   before_action :ensure_custom_tools_enabled
   before_action -> { check_authorization(Captain::CustomTool) }
   before_action :set_custom_tool, only: [:show, :update, :destroy]

--- a/enterprise/app/controllers/api/v1/accounts/captain/documents_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/documents_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Accounts::Captain::DocumentsController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::Captain::DocumentsController < Api::V1::Accounts::Captain::BaseController
   before_action -> { check_authorization(Captain::Assistant) }
 
   before_action :set_current_page, only: [:index]

--- a/enterprise/app/controllers/api/v1/accounts/captain/faq_suggestions_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/faq_suggestions_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Accounts::Captain::FaqSuggestionsController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::Captain::FaqSuggestionsController < Api::V1::Accounts::Captain::BaseController
   before_action :current_account
   before_action -> { check_authorization(Captain::FaqSuggestion) }
   before_action :set_accessible_suggestions

--- a/enterprise/app/controllers/api/v1/accounts/captain/inboxes_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/inboxes_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Accounts::Captain::InboxesController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::Captain::InboxesController < Api::V1::Accounts::Captain::BaseController
   before_action -> { check_authorization(Captain::Assistant) }
 
   before_action :set_assistant

--- a/enterprise/app/controllers/api/v1/accounts/captain/message_reports_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/message_reports_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Accounts::Captain::MessageReportsController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::Captain::MessageReportsController < Api::V1::Accounts::Captain::BaseController
   before_action :ensure_cloud_installation
   before_action :set_message
   before_action :authorize_conversation

--- a/enterprise/app/controllers/api/v1/accounts/captain/scenarios_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/scenarios_controller.rb
@@ -1,4 +1,5 @@
-class Api::V1::Accounts::Captain::ScenariosController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::Captain::ScenariosController < Api::V1::Accounts::Captain::BaseController
+  before_action :ensure_captain_v2_enabled
   before_action -> { check_authorization(Captain::Scenario) }
   before_action :set_assistant
   before_action :set_scenario, only: [:show, :update, :destroy]
@@ -23,6 +24,13 @@ class Api::V1::Accounts::Captain::ScenariosController < Api::V1::Accounts::BaseC
   end
 
   private
+
+  # Scenarios are a Captain v2-only feature; the shared base guard allows either flag, so require v2 here.
+  def ensure_captain_v2_enabled
+    return if current_account.feature_enabled?('captain_integration_v2')
+
+    render json: { error: 'Captain is not enabled for this account' }, status: :forbidden
+  end
 
   def set_assistant
     @assistant = account_assistants.find(params[:assistant_id])

--- a/enterprise/app/controllers/enterprise/api/v1/accounts/captain/preferences_controller.rb
+++ b/enterprise/app/controllers/enterprise/api/v1/accounts/captain/preferences_controller.rb
@@ -1,0 +1,9 @@
+module Enterprise::Api::V1::Accounts::Captain::PreferencesController
+  extend ActiveSupport::Concern
+
+  prepended do
+    include Enterprise::Concerns::CaptainFeatureGuard
+
+    before_action :ensure_captain_enabled
+  end
+end

--- a/enterprise/app/controllers/enterprise/api/v1/accounts/captain/tasks_controller.rb
+++ b/enterprise/app/controllers/enterprise/api/v1/accounts/captain/tasks_controller.rb
@@ -1,0 +1,9 @@
+module Enterprise::Api::V1::Accounts::Captain::TasksController
+  extend ActiveSupport::Concern
+
+  prepended do
+    include Enterprise::Concerns::CaptainFeatureGuard
+
+    before_action :ensure_captain_enabled
+  end
+end

--- a/enterprise/app/controllers/enterprise/concerns/captain_feature_guard.rb
+++ b/enterprise/app/controllers/enterprise/concerns/captain_feature_guard.rb
@@ -1,0 +1,13 @@
+module Enterprise::Concerns::CaptainFeatureGuard
+  extend ActiveSupport::Concern
+
+  private
+
+  # Captain is a premium feature; block API access when neither the v1 nor v2 flag is enabled for the account.
+  # `current_account` resolves and memoizes the account, so this does not depend on before_action ordering.
+  def ensure_captain_enabled
+    return if current_account.feature_enabled?('captain_integration') || current_account.feature_enabled?('captain_integration_v2')
+
+    render json: { error: 'Captain is not enabled for this account' }, status: :forbidden
+  end
+end

--- a/enterprise/app/services/enterprise/message_templates/hook_execution_service.rb
+++ b/enterprise/app/services/enterprise/message_templates/hook_execution_service.rb
@@ -50,7 +50,14 @@ module Enterprise::MessageTemplates::HookExecutionService
   end
 
   def should_process_captain_response?
-    conversation.pending? && message.incoming? && inbox.captain_assistant.present?
+    conversation.pending? && message.incoming? && inbox.captain_assistant.present? && captain_feature_enabled?
+  end
+
+  # Captain is a premium feature; stop the runtime responder when it has been revoked, even if an
+  # assistant is still linked to the inbox.
+  def captain_feature_enabled?
+    account = conversation.account
+    account.feature_enabled?('captain_integration') || account.feature_enabled?('captain_integration_v2')
   end
 
   def perform_handoff
@@ -75,7 +82,9 @@ module Enterprise::MessageTemplates::HookExecutionService
     ::MessageTemplates::Template::OutOfOffice.perform_if_applicable(conversation)
   end
 
+  # Only let Captain suppress the fallback templates when it can actually reply; otherwise a revoked
+  # feature would leave the contact with neither a Captain response nor a greeting/OOO/email-collect.
   def captain_handling_conversation?
-    conversation.pending? && inbox.respond_to?(:captain_assistant) && inbox.captain_assistant.present?
+    conversation.pending? && inbox.respond_to?(:captain_assistant) && inbox.captain_assistant.present? && captain_feature_enabled?
   end
 end

--- a/spec/controllers/api/v1/accounts/captain/preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/captain/preferences_controller_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe 'Api::V1::Accounts::Captain::Preferences', type: :request do
   let(:admin) { create(:user, account: account, role: :administrator) }
   let(:agent) { create(:user, account: account, role: :agent) }
 
+  before { account.enable_features!('captain_integration') }
+
   def json_response
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/spec/enterprise/controllers/api/v1/accounts/captain/agent_sessions_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/agent_sessions_controller_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe 'Api::V1::Accounts::Captain::AgentSessions', type: :request do
     create(:message, account: account, conversation: conversation, message_type: :outgoing, sender: assistant)
   end
 
-  before { create(:inbox_member, user: agent, inbox: inbox) }
+  before do
+    account.enable_features!('captain_integration')
+    create(:inbox_member, user: agent, inbox: inbox)
+  end
 
   def json_response
     JSON.parse(response.body, symbolize_names: true)

--- a/spec/enterprise/controllers/api/v1/accounts/captain/assistant_responses_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/assistant_responses_controller_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Api::V1::Accounts::Captain::AssistantResponses', type: :request 
   let(:another_assistant) { create(:captain_assistant, account: account) }
   let(:another_document) { create(:captain_document, account: account, assistant: assistant) }
 
+  before { account.enable_features!('captain_integration') }
+
   def json_response
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/spec/enterprise/controllers/api/v1/accounts/captain/assistants_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/assistants_controller_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe 'Api::V1::Accounts::Captain::Assistants', type: :request do
   let(:admin) { create(:user, account: account, role: :administrator) }
   let(:agent) { create(:user, account: account, role: :agent) }
 
+  before { account.enable_features!('captain_integration') }
+
   def json_response
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/spec/enterprise/controllers/api/v1/accounts/captain/bulk_actions_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/bulk_actions_controller_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe 'Api::V1::Accounts::Captain::BulkActions', type: :request do
     )
   end
 
+  before { account.enable_features!('captain_integration') }
+
   def json_response
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/spec/enterprise/controllers/api/v1/accounts/captain/copilot_messages_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/copilot_messages_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'Api::V1::Accounts::Captain::CopilotMessagesController', type: :r
   let(:copilot_thread) { create(:captain_copilot_thread, account: account, user: user) }
   let!(:copilot_message) { create(:captain_copilot_message, copilot_thread: copilot_thread, account: account) }
 
+  before { account.enable_features!('captain_integration') }
+
   describe 'GET /api/v1/accounts/{account.id}/captain/copilot_threads/{thread.id}/copilot_messages' do
     context 'when it is an authenticated user' do
       it 'returns all messages' do

--- a/spec/enterprise/controllers/api/v1/accounts/captain/copilot_threads_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/copilot_threads_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'Api::V1::Accounts::Captain::CopilotThreads', type: :request do
   let(:agent) { create(:user, account: account, role: :agent) }
   let(:conversation) { create(:conversation, account: account) }
 
+  before { account.enable_features!('captain_integration') }
+
   def json_response
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/spec/enterprise/controllers/api/v1/accounts/captain/custom_tools_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/custom_tools_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Api::V1::Accounts::Captain::CustomTools', type: :request do
   let(:admin) { create(:user, account: account, role: :administrator) }
   let(:agent) { create(:user, account: account, role: :agent) }
 
-  before { account.enable_features!('custom_tools') }
+  before { account.enable_features!('custom_tools', 'captain_integration') }
 
   def json_response
     JSON.parse(response.body, symbolize_names: true)

--- a/spec/enterprise/controllers/api/v1/accounts/captain/documents_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/documents_controller_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'Api::V1::Accounts::Captain::Documents', type: :request do
     }.with_indifferent_access
   end
 
+  before { account.enable_features!('captain_integration') }
+
   def json_response
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/spec/enterprise/controllers/api/v1/accounts/captain/faq_suggestions_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/faq_suggestions_controller_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Api::V1::Accounts::Captain::FaqSuggestions', type: :request do
   end
 
   before do
+    account.enable_features!('captain_integration')
     suggestion.observations.create!(
       conversation: conversation,
       generated_question: suggestion.question,

--- a/spec/enterprise/controllers/api/v1/accounts/captain/feature_guard_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/feature_guard_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe 'Captain API premium feature guard', type: :request do
       expect(response).to have_http_status(:forbidden)
     end
 
+    it 'blocks captain faq suggestions' do
+      get "/api/v1/accounts/#{account.id}/captain/faq_suggestions", headers: admin.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
     it 'blocks captain custom tools' do
       account.enable_features!('custom_tools')
 

--- a/spec/enterprise/controllers/api/v1/accounts/captain/feature_guard_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/feature_guard_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe 'Captain API premium feature guard', type: :request do
+  let(:account) { create(:account) }
+  let(:admin) { create(:user, account: account, role: :administrator) }
+  let(:inbox) { create(:inbox, account: account) }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox) }
+  let(:assistant) { create(:captain_assistant, account: account) }
+  let(:message) { create(:message, account: account, conversation: conversation, message_type: :outgoing, sender: assistant) }
+
+  describe 'when neither captain feature is enabled' do
+    before { account.disable_features!('captain_integration', 'captain_integration_v2') }
+
+    it 'blocks captain preferences' do
+      get "/api/v1/accounts/#{account.id}/captain/preferences", headers: admin.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'blocks captain tasks' do
+      post "/api/v1/accounts/#{account.id}/captain/tasks/summarize",
+           params: { conversation_display_id: conversation.display_id },
+           headers: admin.create_new_auth_token,
+           as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'blocks captain agent sessions' do
+      get "/api/v1/accounts/#{account.id}/captain/agent_sessions/#{message.id}", headers: admin.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'blocks captain message reports' do
+      post "/api/v1/accounts/#{account.id}/captain/message_reports",
+           params: { message_id: message.id, report_reason: 'incorrect_information' },
+           headers: admin.create_new_auth_token,
+           as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'blocks captain custom tools' do
+      account.enable_features!('custom_tools')
+
+      get "/api/v1/accounts/#{account.id}/captain/custom_tools", headers: admin.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'when the captain feature is enabled' do
+    before { account.enable_features!('captain_integration') }
+
+    it 'allows captain preferences' do
+      get "/api/v1/accounts/#{account.id}/captain/preferences", headers: admin.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/enterprise/controllers/api/v1/accounts/captain/inboxes_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/inboxes_controller_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Api::V1::Accounts::Captain::Inboxes', type: :request do
   let(:admin) { create(:user, account: account, role: :administrator) }
   let(:agent) { create(:user, account: account, role: :agent) }
 
+  before { account.enable_features!('captain_integration') }
+
   def json_response
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/spec/enterprise/controllers/api/v1/accounts/captain/message_reports_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/message_reports_controller_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe 'Api::V1::Accounts::Captain::MessageReports', type: :request do
     create(:message, account: account, conversation: conversation, message_type: :outgoing, sender: assistant)
   end
 
-  before { create(:inbox_member, user: agent, inbox: inbox) }
+  before do
+    account.enable_features!('captain_integration')
+    create(:inbox_member, user: agent, inbox: inbox)
+  end
 
   def json_response
     JSON.parse(response.body, symbolize_names: true)

--- a/spec/enterprise/controllers/api/v1/accounts/captain/scenarios_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/scenarios_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'Api::V1::Accounts::Captain::Scenarios', type: :request do
   let(:agent) { create(:user, account: account, role: :agent) }
   let(:assistant) { create(:captain_assistant, account: account) }
 
+  before { account.enable_features!('captain_integration_v2') }
+
   def json_response
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/spec/enterprise/services/enterprise/message_templates/hook_execution_service_spec.rb
+++ b/spec/enterprise/services/enterprise/message_templates/hook_execution_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe MessageTemplates::HookExecutionService do
   let(:assistant) { create(:captain_assistant, account: account) }
 
   before do
+    account.enable_features!('captain_integration')
     create(:captain_inbox, captain_assistant: assistant, inbox: inbox)
   end
 
@@ -199,6 +200,29 @@ RSpec.describe MessageTemplates::HookExecutionService do
         out_of_office_message = conversation.reload.messages.template.last
         expect(out_of_office_message.content).to eq('We are currently closed')
       end
+    end
+  end
+
+  context 'when the Captain feature is disabled but an assistant is still linked' do
+    before do
+      account.disable_features!('captain_integration', 'captain_integration_v2')
+      conversation.update!(status: :pending)
+    end
+
+    it 'does not schedule captain response job' do
+      expect(Captain::Conversation::ResponseBuilderJob).not_to receive(:perform_later)
+
+      create(:message, conversation: conversation, message_type: :incoming, account: account)
+    end
+
+    it 'falls back to the greeting message instead of leaving the contact without a reply' do
+      inbox.update!(greeting_enabled: true, greeting_message: 'Hello! How can we help you?', enable_email_collect: false)
+
+      expect do
+        create(:message, conversation: conversation, message_type: :incoming, account: account)
+      end.to change { conversation.reload.messages.template.count }.by(1)
+
+      expect(conversation.reload.messages.template.last.content).to eq('Hello! How can we help you?')
     end
   end
 


### PR DESCRIPTION
Captain is a premium feature, but the account's `captain_integration` / `captain_integration_v2` flags were never checked by the Captain APIs. An account on a plan without Captain — or one whose plan was downgraded and had the flags revoked — could still reach every Captain endpoint: assistants, documents, copilot, scenarios, custom tools, agent sessions, preferences, and the Captain task endpoints that consume response credits. All Captain routes now require the feature.

This also fixes a related side effect: an inbox with a Captain assistant suppressed the greeting / out-of-office / email-collect fallback templates even when Captain could no longer reply, so contacts on a revoked account got no response at all.

## How to reproduce

1. Disable `captain_integration` and `captain_integration_v2` for an account that has a Captain assistant.
2. `GET /api/v1/accounts/{id}/captain/assistants` — returns 200 with the assistants instead of denying. The same holds for `documents`, `copilot_threads`, `scenarios`, `custom_tools`, `agent_sessions`, `message_reports` and `preferences`.
3. `POST /api/v1/accounts/{id}/captain/tasks/summarize` — runs the Captain task service and consumes a response credit.
4. Assign the assistant to an inbox and message that inbox as a contact — no Captain reply arrives, and no greeting or out-of-office message is sent either.

## What changed

- New `Api::V1::Accounts::Captain::BaseController` enforces the guard, and every Captain controller under `enterprise/` now inherits it.
- `preferences` and `tasks` live in OSS `app/`, so they cannot inherit an enterprise class — CE builds ship without `enterprise/`. They get the guard through `prepend_mod_with` overlays instead, which keeps Captain tasks working on CE installs where the flags do not apply.
- The check itself lives in `Enterprise::Concerns::CaptainFeatureGuard` so the base controller and the two overlays share one definition.
- Scenarios are Captain v2 only, so that controller additionally requires `captain_integration_v2`.
- `Enterprise::MessageTemplates::HookExecutionService#captain_handling_conversation?` now also requires the feature, so fallback templates resume when Captain is revoked.

Gating Captain tasks on the Captain flags rather than the default-enabled `captain_tasks` flag does not cut off ordinary free accounts: cloud accounts are stamped `captain_v2_default_eligible`, and `ReconcilePlanFeaturesService` keeps `captain_integration_v2` enabled for them. Only genuinely revoked accounts lose access.
