### PR TITLE
fix: add if_not_exists to conversations.created_at index migration

### DIFF
--- a/db/migrate/20260724000100_add_index_to_conversations_created_at.rb
+++ b/db/migrate/20260724000100_add_index_to_conversations_created_at.rb
@@ -2,6 +2,6 @@ class AddIndexToConversationsCreatedAt < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def change
-    add_index :conversations, :created_at, algorithm: :concurrently
+    add_index :conversations, :created_at, algorithm: :concurrently, if_not_exists: true
   end
 end


### PR DESCRIPTION
## Description

Follow-up to #15147. The migration missed `if_not_exists`, so it fails with `index already exists` on a re-run or when the index is pre-built. Makes it idempotent, matching recent concurrent-index migrations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)