### PR TITLE
fix: unread notification dot and unread preview sizing

### DIFF
--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -53,6 +53,12 @@ export const SDK_CSS = `
   z-index: 2147483000 !important;
 }
 
+.woot-widget-bubble:focus-visible {
+  outline: 2px solid AccentColor;
+  outline: 2px solid -webkit-focus-ring-color;
+  outline-offset: 2px;
+}
+
 .woot-widget-bubble.woot-widget-bubble--flat {
   border-radius: 0;
 }

--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -54,9 +54,9 @@ export const SDK_CSS = `
 }
 
 .woot-widget-bubble:focus-visible {
-  outline: 2px solid AccentColor;
-  outline: 2px solid -webkit-focus-ring-color;
-  outline-offset: 2px;
+  outline: 2px solid AccentColor !important;
+  outline: 2px solid -webkit-focus-ring-color !important;
+  outline-offset: 2px !important;
 }
 
 .woot-widget-bubble.woot-widget-bubble--flat {

--- a/app/javascript/sdk/sdk.js
+++ b/app/javascript/sdk/sdk.js
@@ -51,7 +51,6 @@ export const SDK_CSS = `
   user-select: none;
   width: 64px;
   z-index: 2147483000 !important;
-  overflow: hidden;
 }
 
 .woot-widget-bubble.woot-widget-bubble--flat {
@@ -68,7 +67,7 @@ export const SDK_CSS = `
 }
 
 .woot-widget-bubble.woot-widget-bubble--flat svg {
-  margin: 16px;
+  margin: 16px !important;
 }
 
 .woot-widget-bubble.woot-widget-bubble--flat.woot--close::before,
@@ -115,9 +114,9 @@ export const SDK_CSS = `
 }
 
 .woot-widget-bubble.woot-widget--expanded svg {
-  height: 20px;
-  margin: 14px 8px 14px 16px;
-  width: 20px;
+  height: 20px !important;
+  margin: 14px 8px 14px 16px !important;
+  width: 20px !important;
 }
 
 .woot-widget-bubble.woot-elements--left {
@@ -135,9 +134,10 @@ export const SDK_CSS = `
 
 .woot-widget-bubble svg {
   all: revert;
-  height: 24px;
-  margin: 20px;
-  width: 24px;
+  height: 24px !important;
+  margin: 20px !important;
+  padding: 0 !important;
+  width: 24px !important;
 }
 
 .woot-widget-bubble.woot-widget-bubble-color--lighter path{

--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -74,6 +74,14 @@ export default {
     activeCampaign() {
       this.setCampaignView();
     },
+    // Keep the notification dot in sync with the unread count. The SDK ignores
+    // dot updates while the bubble is hidden, so refresh it when it is back.
+    unreadMessageCount() {
+      this.handleUnreadNotificationDot();
+    },
+    hideMessageBubble() {
+      this.handleUnreadNotificationDot();
+    },
     isRTL: {
       immediate: true,
       handler(value) {
@@ -217,25 +225,26 @@ export default {
     },
     setUnreadView() {
       const { unreadMessageCount } = this;
-      if (!this.showUnreadMessagesDialog) {
-        this.handleUnreadNotificationDot();
-      } else if (
-        this.isIFrame &&
-        unreadMessageCount > 0 &&
-        !this.isWidgetOpen
-      ) {
+      if (!this.showUnreadMessagesDialog || !this.isIFrame) return;
+
+      // The unread view marks the widget as open, so only the route tells us it
+      // is already on screen. Resize it, else the new message gets cut off.
+      if (this.$route.name === 'unread-messages') {
+        this.setIframeHeight(true);
+        return;
+      }
+
+      if (unreadMessageCount > 0 && !this.isWidgetOpen) {
         this.router.replace({ name: 'unread-messages' }).then(() => {
           this.setIframeHeight(true);
           IFrameHelper.sendMessage({ event: 'setUnreadMode' });
         });
-        this.handleUnreadNotificationDot();
       }
     },
     unsetUnreadView() {
       if (this.isIFrame) {
         IFrameHelper.sendMessage({ event: 'resetUnreadMode' });
         this.setIframeHeight(false);
-        this.handleUnreadNotificationDot();
       }
     },
     handleUnreadNotificationDot() {


### PR DESCRIPTION
# Pull Request Template

## Description

This fixes a few issues with the unread notification in the widget launcher.

The unread notification dot was rendered as a clipped red sliver instead of a full dot. It also remained visible after all unread messages were read when `showUnreadMessagesDialog` was disabled. Additionally, the unread preview only resized for the first unread message, causing later messages to be cut off instead of expanding the preview.

Fixes https://linear.app/chatwoot/issue/CW-7772/widget-unread-notification-dot-is-clipped-does-not-clear-after-reading

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**1. Unread notification dot is clipped**

**Before**
<img width="98" height="102" alt="image" src="https://github.com/user-attachments/assets/c888ed95-3e69-4a8d-a80d-c983d3b3df9b" />
<img width="201" height="102" alt="image" src="https://github.com/user-attachments/assets/4e3984eb-4542-47c5-afd9-06797bc06211" />



**After**
<img width="109" height="114" alt="image" src="https://github.com/user-attachments/assets/d9bc1376-3cf6-44dd-bccd-c76410174e69" />
<img width="203" height="97" alt="image" src="https://github.com/user-attachments/assets/44e8b805-becf-41db-80d7-dcb0bf02fc73" />


**2. Unread notification dot does not clear after reading**

**Before**

https://github.com/user-attachments/assets/cebcb8cd-0452-4f6c-a8d6-f61eae0d7e8d



**After**

https://github.com/user-attachments/assets/907032f8-ff2b-4800-9c28-22b4f8cb8cbc



**3. Unread preview is not resized for new messages**

**Before**

https://github.com/user-attachments/assets/f749d0c5-66fb-40c1-963d-0cb70b40e683



**After**

https://github.com/user-attachments/assets/f2d8271c-39a4-43b2-a97d-184cc028ea63



### Steps to reproduce

1. Open the widget on a page and close it.
2. Reply to the conversation as an agent.
   * The unread dot on the launcher appears as a clipped sliver instead of a full dot.
5. Send two more replies while the unread preview is visible.
   * The new messages are cut off instead of expanding the preview.
6. Set `showUnreadMessagesDialog: false`.
7. Open the widget to read the messages, then close it.
   * The unread notification dot is still visible even though there are no unread messages.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
