### PR TITLE
chore: register Slovenian (sl) locale in survey

### DIFF
--- a/app/javascript/survey/i18n/index.js
+++ b/app/javascript/survey/i18n/index.js
@@ -29,6 +29,7 @@ import pt_BR from './locale/pt_BR.json';
 import ro from './locale/ro.json';
 import ru from './locale/ru.json';
 import sk from './locale/sk.json';
+import sl from './locale/sl.json';
 import sr from './locale/sr.json';
 import sv from './locale/sv.json';
 import ta from './locale/ta.json';
@@ -72,6 +73,7 @@ export default {
   ro,
   ru,
   sk,
+  sl,
   sr,
   sv,
   ta,


### PR DESCRIPTION
# Pull Request Template

## Description

The CSAT survey page now renders in Slovenian for accounts using that language. The Slovenian survey copy already ships in the repo via Crowdin, but the locale was never registered with the survey i18n loader, so those accounts fell back to English.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
