### PR TITLE
fix: add (conversation_id, created_at) index to messages

### DIFF
--- a/db/migrate/20260728000000_add_conversation_created_index_to_messages.rb
+++ b/db/migrate/20260728000000_add_conversation_created_index_to_messages.rb
@@ -10,13 +10,21 @@ class AddConversationCreatedIndexToMessages < ActiveRecord::Migration[7.1]
   # existing index_messages_on_conversation_account_type_created can't serve the
   # ORDER BY because account_id / message_type sit between the two columns.
   def up
+    # CREATE INDEX CONCURRENTLY on a large table can take minutes; disable the
+    # session statement_timeout so the build is not cancelled mid-run.
+    execute 'SET statement_timeout TO 0'
     add_index :messages, [:conversation_id, :created_at],
               name: 'index_messages_on_conversation_id_and_created_at',
               algorithm: :concurrently, if_not_exists: true
+  ensure
+    execute 'RESET statement_timeout'
   end
 
   def down
+    execute 'SET statement_timeout TO 0'
     remove_index :messages, name: 'index_messages_on_conversation_id_and_created_at',
                             algorithm: :concurrently, if_exists: true
+  ensure
+    execute 'RESET statement_timeout'
   end
 end

--- a/db/migrate/20260728000000_add_conversation_created_index_to_messages.rb
+++ b/db/migrate/20260728000000_add_conversation_created_index_to_messages.rb
@@ -1,0 +1,22 @@
+class AddConversationCreatedIndexToMessages < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  # Message pagination (MessageFinder#messages_before) and the per-conversation
+  # last-message lookup in api/v1/conversations/partials/_conversation.json.jbuilder
+  # both filter by conversation_id and order by created_at, but no index covers
+  # that shape. For old/inactive conversations Postgres falls back to an
+  # Index Scan Backward on the global index_messages_on_created_at, which on a
+  # large messages table crosses statement_timeout (default 14s) and 500s. The
+  # existing index_messages_on_conversation_account_type_created can't serve the
+  # ORDER BY because account_id / message_type sit between the two columns.
+  def up
+    add_index :messages, [:conversation_id, :created_at],
+              name: 'index_messages_on_conversation_id_and_created_at',
+              algorithm: :concurrently, if_not_exists: true
+  end
+
+  def down
+    remove_index :messages, name: 'index_messages_on_conversation_id_and_created_at',
+                            algorithm: :concurrently, if_exists: true
+  end
+end

--- a/db/migrate/20260728000000_add_conversation_created_index_to_messages.rb
+++ b/db/migrate/20260728000000_add_conversation_created_index_to_messages.rb
@@ -37,7 +37,7 @@ class AddConversationCreatedIndexToMessages < ActiveRecord::Migration[7.1]
   INDEX_NAME = 'index_messages_on_conversation_id_and_created_at'.freeze
 
   def drop_invalid_index_if_present
-    result = execute(<<~SQL)
+    result = execute(<<~SQL.squish)
       SELECT indisvalid
       FROM pg_class
       JOIN pg_index ON pg_index.indexrelid = pg_class.oid

--- a/db/migrate/20260728000000_add_conversation_created_index_to_messages.rb
+++ b/db/migrate/20260728000000_add_conversation_created_index_to_messages.rb
@@ -10,6 +10,10 @@ class AddConversationCreatedIndexToMessages < ActiveRecord::Migration[7.1]
   # existing index_messages_on_conversation_account_type_created can't serve the
   # ORDER BY because account_id / message_type sit between the two columns.
   def up
+    # A previous failed CONCURRENTLY build may have left an invalid index stub.
+    # Drop it so the build below does not silently skip over a broken index.
+    drop_invalid_index_if_present
+
     # CREATE INDEX CONCURRENTLY on a large table can take minutes; disable the
     # session statement_timeout so the build is not cancelled mid-run.
     execute 'SET statement_timeout TO 0'
@@ -24,6 +28,25 @@ class AddConversationCreatedIndexToMessages < ActiveRecord::Migration[7.1]
     execute 'SET statement_timeout TO 0'
     remove_index :messages, name: 'index_messages_on_conversation_id_and_created_at',
                             algorithm: :concurrently, if_exists: true
+  ensure
+    execute 'RESET statement_timeout'
+  end
+
+  private
+
+  INDEX_NAME = 'index_messages_on_conversation_id_and_created_at'
+
+  def drop_invalid_index_if_present
+    result = execute(<<~SQL)
+      SELECT indisvalid
+      FROM pg_class
+      JOIN pg_index ON pg_index.indexrelid = pg_class.oid
+      WHERE pg_class.relname = '#{INDEX_NAME}'
+    SQL
+    return if result.none? || result.first['indisvalid'] == 't'
+
+    execute 'SET statement_timeout TO 0'
+    remove_index :messages, name: INDEX_NAME, algorithm: :concurrently
   ensure
     execute 'RESET statement_timeout'
   end

--- a/db/migrate/20260728000000_add_conversation_created_index_to_messages.rb
+++ b/db/migrate/20260728000000_add_conversation_created_index_to_messages.rb
@@ -34,7 +34,7 @@ class AddConversationCreatedIndexToMessages < ActiveRecord::Migration[7.1]
 
   private
 
-  INDEX_NAME = 'index_messages_on_conversation_id_and_created_at'
+  INDEX_NAME = 'index_messages_on_conversation_id_and_created_at'.freeze
 
   def drop_invalid_index_if_present
     result = execute(<<~SQL)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1226,6 +1226,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_04_000003) do
     t.index ["account_id"], name: "index_messages_on_account_id"
     t.index ["content"], name: "index_messages_on_content", opclass: :gin_trgm_ops, using: :gin
     t.index ["conversation_id", "account_id", "message_type", "created_at"], name: "index_messages_on_conversation_account_type_created"
+    t.index ["conversation_id", "created_at"], name: "index_messages_on_conversation_id_and_created_at"
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["created_at"], name: "index_messages_on_created_at"
     t.index ["inbox_id"], name: "index_messages_on_inbox_id"


### PR DESCRIPTION
## Description

Message endpoints that paginate/inspect a conversation's messages can return **HTTP 500** (`ActiveRecord::QueryCanceled` / `PG::QueryCanceled: canceling statement due to statement timeout`) on instances with a large `messages` table, even for conversations that are themselves small (~1k messages).

**Root cause is a missing index, not conversation size.** Two hot paths filter by `conversation_id` and order by `created_at`:

- `MessageFinder#messages_before` → `... WHERE conversation_id = ? AND id < ? ORDER BY created_at DESC LIMIT 20` (the `GET /api/v1/accounts/:id/conversations/:id/messages?before=` cursor).
- `app/views/api/v1/conversations/partials/_conversation.json.jbuilder` → `conversation.messages.where(account_id: …).last` (and `.non_activity_messages.first`), i.e. `... WHERE conversation_id = ? [AND account_id = ?] ORDER BY created_at DESC LIMIT 1`, rendered once **per conversation** in `Contacts::ConversationsController#index`.

No index covers `(conversation_id, created_at)`. The existing `index_messages_on_conversation_account_type_created` can't serve the ordering because `account_id` and `message_type` sit between `conversation_id` and `created_at`. So the planner falls back to an **`Index Scan Backward` on the global `index_messages_on_created_at`**, filtering by `conversation_id`. For **old/inactive** conversations the matching rows live at the far (oldest) end of that global index, so Postgres walks a huge fraction of the table before collecting the 20 (or 1) rows — crossing `statement_timeout` (default `14s`) and returning 500.

This complements #14933 (which sanitizes the error message but does not prevent the timeout). This PR removes the timeout at the source by adding a dedicated composite index; both the API pagination and the agent-facing conversation list benefit, with no query/logic changes.

Fixes #15225

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Validated locally against a clean PostgreSQL 16 database loaded from `develop`'s `db:schema:load`:

- `bundle exec rails db:migrate` → applied `AddConversationCreatedIndexToMessages`, creating `CREATE INDEX index_messages_on_conversation_id_and_created_at ON public.messages USING btree (conversation_id, created_at)`.
- `bundle exec rails db:rollback STEP=1` → `remove_index` ran, index dropped cleanly (fully reversible).
- `bundle exec rails db:schema:dump` confirms the `db/schema.rb` entry and its placement in this PR match the canonical dump.
- `bundle exec rubocop db/migrate/20260728000000_add_conversation_created_index_to_messages.rb` → `1 file inspected, no offenses detected`.

Effectiveness measured on a production instance (~358k rows in `messages`; sample conversation has only 1,668 messages), with `EXPLAIN ANALYZE` before and after creating the index concurrently.

**`messages_before` — before:**

```
Limit  (cost=0.42..954.50 rows=20)
  ->  Index Scan Backward using index_messages_on_created_at on messages
        Filter: ((id < 208128) AND (conversation_id = 10278))
```
→ 14,013 ms in ActiveRecord → statement timeout → 500.

**`messages_before` — after:**

```
Limit  (actual time=495.568..503.417 rows=20)
  ->  Index Scan Backward using index_messages_on_conversation_id_and_created_at
        Index Cond: (conversation_id = 10278)
        Filter: (id < 208128)
 Execution Time: 503.484 ms
```

**`.last` (jbuilder) — before:** same global-index scan → ~14,000 ms → 500.
**`.last` (jbuilder) — after:**

```
Limit  (actual time=0.019..0.020 rows=1)
  ->  Index Scan Backward using index_messages_on_conversation_id_and_created_at
        Index Cond: (conversation_id = 10278)
        Filter: (account_id = 2)
 Execution Time: 0.044 ms
```

The index was also created concurrently on that production instance (`indisvalid = t`), confirming the statement is valid and non-blocking at scale.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
