### PR TITLE
feat: derive Captain overview metrics from conversation outcomes

### DIFF
--- a/app/dispatchers/sync_dispatcher.rb
+++ b/app/dispatchers/sync_dispatcher.rb
@@ -8,3 +8,5 @@ class SyncDispatcher < BaseDispatcher
     [ActionCableListener.instance, AgentBotListener.instance]
   end
 end
+
+SyncDispatcher.prepend_mod_with('SyncDispatcher')

--- a/app/listeners/reporting_event_listener.rb
+++ b/app/listeners/reporting_event_listener.rb
@@ -98,14 +98,6 @@ class ReportingEventListener < BaseListener
     safe_rollup(reporting_event)
   end
 
-  def conversation_captain_inference_resolved(event)
-    create_captain_inference_event(event, 'conversation_captain_inference_resolved')
-  end
-
-  def conversation_captain_inference_handoff(event)
-    create_captain_inference_event(event, 'conversation_captain_inference_handoff')
-  end
-
   def conversation_opened(event)
     conversation = extract_conversation_and_account(event)[0]
     event_end_time = event.timestamp
@@ -148,22 +140,6 @@ class ReportingEventListener < BaseListener
     reporting_event.save!
   end
 
-  def create_captain_inference_event(event, event_name)
-    conversation = extract_conversation_and_account(event)[0]
-    time_to_event = event.timestamp.to_i - conversation.created_at.to_i
-
-    ReportingEvent.create!(
-      name: event_name,
-      value: time_to_event,
-      account_id: conversation.account_id,
-      inbox_id: conversation.inbox_id,
-      user_id: conversation.assignee_id,
-      conversation_id: conversation.id,
-      event_start_time: conversation.created_at,
-      event_end_time: event.timestamp
-    )
-  end
-
   def create_bot_resolved_event(conversation, reporting_event)
     return unless conversation.inbox.active_bot?
     # We don't want to create a bot_resolved event if there is user interaction on the conversation
@@ -185,5 +161,3 @@ class ReportingEventListener < BaseListener
     ChatwootExceptionTracker.new(e, account: reporting_event.account).capture_exception
   end
 end
-
-ReportingEventListener.prepend_mod_with('ReportingEventListener')

--- a/app/listeners/reporting_event_listener.rb
+++ b/app/listeners/reporting_event_listener.rb
@@ -185,3 +185,5 @@ class ReportingEventListener < BaseListener
     ChatwootExceptionTracker.new(e, account: reporting_event.account).capture_exception
   end
 end
+
+ReportingEventListener.prepend_mod_with('ReportingEventListener')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
               member do
                 post :playground
                 get :metrics
+                get :outcome_metrics
                 get :faq_stats
                 get :summary
                 get :drilldown

--- a/db/migrate/20260729094838_create_captain_conversation_outcomes.rb
+++ b/db/migrate/20260729094838_create_captain_conversation_outcomes.rb
@@ -1,0 +1,40 @@
+class CreateCaptainConversationOutcomes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :captain_conversation_outcomes do |t|
+      t.references :account, null: false
+      t.references :assistant, null: false
+      t.references :conversation, null: false
+      t.references :inbox, null: false
+
+      t.datetime :first_captain_reply_at
+      t.datetime :last_captain_reply_at
+      t.integer :captain_reply_count, null: false, default: 0
+      t.datetime :first_human_reply_at
+
+      t.datetime :handoff_at
+      t.string :handoff_reason_category
+
+      t.datetime :resolved_at
+      t.datetime :last_reopened_at
+      t.integer :reopen_count, null: false, default: 0
+
+      t.integer :csat_rating
+      t.datetime :csat_received_at
+
+      t.timestamps
+    end
+
+    add_reporting_indexes
+  end
+
+  private
+
+  def add_reporting_indexes
+    add_index :captain_conversation_outcomes, [:account_id, :assistant_id, :conversation_id],
+              unique: true, name: 'idx_captain_outcomes_unique_conversation'
+    add_index :captain_conversation_outcomes, [:account_id, :assistant_id, :resolved_at],
+              name: 'idx_captain_outcomes_on_assistant_resolved_at'
+    add_index :captain_conversation_outcomes, [:account_id, :assistant_id, :handoff_at],
+              name: 'idx_captain_outcomes_on_assistant_handoff_at'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_18_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_29_094838) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -377,6 +377,33 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_18_000000) do
     t.jsonb "response_guidelines", default: []
     t.jsonb "guardrails", default: []
     t.index ["account_id"], name: "index_captain_assistants_on_account_id"
+  end
+
+  create_table "captain_conversation_outcomes", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "assistant_id", null: false
+    t.bigint "conversation_id", null: false
+    t.bigint "inbox_id", null: false
+    t.datetime "first_captain_reply_at"
+    t.datetime "last_captain_reply_at"
+    t.integer "captain_reply_count", default: 0, null: false
+    t.datetime "first_human_reply_at"
+    t.datetime "handoff_at"
+    t.string "handoff_reason_category"
+    t.datetime "resolved_at"
+    t.datetime "last_reopened_at"
+    t.integer "reopen_count", default: 0, null: false
+    t.integer "csat_rating"
+    t.datetime "csat_received_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "assistant_id", "conversation_id"], name: "idx_captain_outcomes_unique_conversation", unique: true
+    t.index ["account_id", "assistant_id", "handoff_at"], name: "idx_captain_outcomes_on_assistant_handoff_at"
+    t.index ["account_id", "assistant_id", "resolved_at"], name: "idx_captain_outcomes_on_assistant_resolved_at"
+    t.index ["account_id"], name: "index_captain_conversation_outcomes_on_account_id"
+    t.index ["assistant_id"], name: "index_captain_conversation_outcomes_on_assistant_id"
+    t.index ["conversation_id"], name: "index_captain_conversation_outcomes_on_conversation_id"
+    t.index ["inbox_id"], name: "index_captain_conversation_outcomes_on_inbox_id"
   end
 
   create_table "captain_custom_tools", force: :cascade do |t|

--- a/enterprise/app/builders/captain/assistant_drilldown_builder.rb
+++ b/enterprise/app/builders/captain/assistant_drilldown_builder.rb
@@ -3,14 +3,11 @@
 # conversations that produced it.
 #
 # The window is resolved by Captain::AssistantStatsWindow from the same `range`
-# and `timezone_offset` the stat card used, so the drilldown covers precisely the
-# rows the card counted. Records are serialized with the shared reports drilldown
+# and `timezone_offset` the stat card used, and each metric reuses the outcome
+# model's classification scopes, so the drilldown covers precisely the rows the
+# card counted. Records are serialized with the shared reports drilldown
 # serializer, so the existing frontend drilldown drawer/card can render them.
 class Captain::AssistantDrilldownBuilder
-  ASSISTANT_SENDER_TYPE = 'Captain::Assistant'.freeze
-  RESOLVED_EVENT_NAMES = Captain::AssistantStatsBuilder::RESOLVED_EVENT_NAMES
-  HANDOFF_EVENT_NAMES = Captain::AssistantStatsBuilder::HANDOFF_EVENT_NAMES
-
   SUPPORTED_METRICS = %w[
     conversations_handled auto_resolution_rate handoff_rate reopen_rate
   ].freeze
@@ -54,61 +51,25 @@ class Captain::AssistantDrilldownBuilder
   end
 
   def drilldown_scope
+    conversations_for(metric_outcomes.select(:conversation_id))
+  end
+
+  # Outcome rows behind the requested stat card, mirroring the cohort and
+  # classification AssistantStatsBuilder counted for the same window.
+  def metric_outcomes
     case metric
-    when 'conversations_handled' then handled_conversations
-    when 'auto_resolution_rate' then conversations_for(resolved_events.select(:conversation_id))
-    when 'handoff_rate' then event_conversations(HANDOFF_EVENT_NAMES)
-    when 'reopen_rate' then reopened_conversations
+    when 'conversations_handled' then window_outcomes.involved
+    when 'auto_resolution_rate' then window_outcomes.autonomous_resolved
+    when 'handoff_rate' then window_outcomes.involved.where.not(handoff_at: nil)
+    when 'reopen_rate' then window_outcomes.autonomous_resolved.reopened
     else
       raise ArgumentError, "Unsupported assistant drilldown metric: #{metric}"
     end
   end
 
-  # Messages the assistant authored in the window; the cohort every metric derives from.
-  def handled_messages
-    account.messages.where(sender_type: ASSISTANT_SENDER_TYPE, sender_id: assistant.id, created_at: range)
-  end
-
-  def handled_conversation_ids
-    handled_messages.select(:conversation_id)
-  end
-
-  def handled_conversations
-    conversations_for(handled_conversation_ids)
-  end
-
-  # Conversations in the handled cohort that recorded one of the given reporting
-  # events in the window (resolved or handed-off).
-  def event_conversations(event_names)
-    ids = account.reporting_events
-                 .where(name: event_names, created_at: range, conversation_id: handled_conversation_ids)
-                 .select(:conversation_id)
-    conversations_for(ids)
-  end
-
-  # Captain resolves in the window, excluding bot-resolved rows whose conversation
-  # was also handed off, mirroring AssistantStatsBuilder#resolved_clause so the
-  # drilldown lists exactly the conversations the auto-resolution card counted.
-  def resolved_events
-    handoff_ids = account.reporting_events.where(name: HANDOFF_EVENT_NAMES, created_at: range).select(:conversation_id)
-    account.reporting_events
-           .where(name: RESOLVED_EVENT_NAMES, created_at: range, conversation_id: handled_conversation_ids)
-           .where("NOT (name = ? AND conversation_id IN (#{handoff_ids.to_sql}))",
-                  Captain::AssistantStatsBuilder::BOT_RESOLVED_EVENT_NAME)
-  end
-
-  # Auto-resolved conversations that reopened at/after their Captain resolve,
-  # mirroring AssistantStatsBuilder#reopen_rate's numerator cohort.
-  def reopened_conversations
-    ids = account.reporting_events
-                 .where(name: 'conversation_opened')
-                 .where('reporting_events.value > 0')
-                 .where('reporting_events.event_end_time <= ?', range.last)
-                 .joins("INNER JOIN (#{resolved_events.to_sql}) resolves " \
-                        'ON resolves.conversation_id = reporting_events.conversation_id ' \
-                        'AND reporting_events.event_end_time >= resolves.event_end_time')
-                 .select('reporting_events.conversation_id')
-    conversations_for(ids)
+  # The demand cohort that entered the window (see AssistantStatsBuilder).
+  def window_outcomes
+    assistant.conversation_outcomes.where(created_at: range)
   end
 
   def conversations_for(conversation_ids)

--- a/enterprise/app/builders/captain/assistant_outcome_stats_builder.rb
+++ b/enterprise/app/builders/captain/assistant_outcome_stats_builder.rb
@@ -13,22 +13,12 @@ class Captain::AssistantOutcomeStatsBuilder
   # rather than counted as durable-so-far.
   DURABLE_RESOLUTION_WINDOW = 7.days
 
-  # Captain participated: replied publicly, or handed off for a real reason.
-  # A usage-limit handoff is blocked demand, not participation.
-  INVOLVED_SQL = "(first_captain_reply_at IS NOT NULL OR (handoff_at IS NOT NULL AND handoff_reason_category != 'usage_limit'))".freeze
-
-  # Resolved by Captain alone: no handoff and no public human reply before the
-  # resolution that stuck.
-  AUTONOMOUS_SQL = '(resolved_at IS NOT NULL AND first_captain_reply_at IS NOT NULL AND handoff_at IS NULL ' \
-                   'AND (first_human_reply_at IS NULL OR first_human_reply_at > resolved_at))'.freeze
-
-  # Resolved with Captain participation but a human in the loop.
-  ASSISTED_SQL = "(resolved_at IS NOT NULL AND #{INVOLVED_SQL} AND NOT #{AUTONOMOUS_SQL})".freeze
-
-  # The tracker only records reopens that happen after the current resolution,
-  # so a reopen timestamp at or before resolved_at belongs to an earlier,
-  # superseded resolution.
-  NOT_REOPENED_SQL = '(last_reopened_at IS NULL OR last_reopened_at <= resolved_at)'.freeze
+  # Classification predicates live on the model so every builder counts the
+  # same rows (see Captain::ConversationOutcome).
+  INVOLVED_SQL = Captain::ConversationOutcome::INVOLVED_SQL
+  AUTONOMOUS_SQL = Captain::ConversationOutcome::AUTONOMOUS_SQL
+  ASSISTED_SQL = Captain::ConversationOutcome::ASSISTED_SQL
+  NOT_REOPENED_SQL = Captain::ConversationOutcome::NOT_REOPENED_SQL
 
   attr_reader :assistant, :account
 

--- a/enterprise/app/builders/captain/assistant_outcome_stats_builder.rb
+++ b/enterprise/app/builders/captain/assistant_outcome_stats_builder.rb
@@ -1,0 +1,170 @@
+# Computes per-assistant outcome metrics for the Captain value report from
+# captain_conversation_outcomes. The cohort for a window is the demand that
+# entered it (rows created inside the window), so every rate shares one
+# denominator and a conversation never migrates between windows as it
+# progresses.
+#
+# The table stores only facts (see Captain::ConversationOutcome); every
+# classification here is a query-time expression, computed for the current and
+# previous window in a single scan via conditional FILTER aggregation.
+class Captain::AssistantOutcomeStatsBuilder
+  # How long an autonomous resolution must stay closed to count as durable.
+  # Resolutions younger than this are excluded from the durability denominator
+  # rather than counted as durable-so-far.
+  DURABLE_RESOLUTION_WINDOW = 7.days
+
+  # Captain participated: replied publicly, or handed off for a real reason.
+  # A usage-limit handoff is blocked demand, not participation.
+  INVOLVED_SQL = "(first_captain_reply_at IS NOT NULL OR (handoff_at IS NOT NULL AND handoff_reason_category != 'usage_limit'))".freeze
+
+  # Resolved by Captain alone: no handoff and no public human reply before the
+  # resolution that stuck.
+  AUTONOMOUS_SQL = '(resolved_at IS NOT NULL AND first_captain_reply_at IS NOT NULL AND handoff_at IS NULL ' \
+                   'AND (first_human_reply_at IS NULL OR first_human_reply_at > resolved_at))'.freeze
+
+  # Resolved with Captain participation but a human in the loop.
+  ASSISTED_SQL = "(resolved_at IS NOT NULL AND #{INVOLVED_SQL} AND NOT #{AUTONOMOUS_SQL})".freeze
+
+  # The tracker only records reopens that happen after the current resolution,
+  # so a reopen timestamp at or before resolved_at belongs to an earlier,
+  # superseded resolution.
+  NOT_REOPENED_SQL = '(last_reopened_at IS NULL OR last_reopened_at <= resolved_at)'.freeze
+
+  attr_reader :assistant, :account
+
+  delegate :range, :period, to: :window
+
+  def initialize(assistant, range = Captain::AssistantStatsWindow::DEFAULT_RANGE, timezone_offset = nil)
+    @assistant = assistant
+    @account = assistant.account
+    @window = Captain::AssistantStatsWindow.new(range, timezone_offset)
+  end
+
+  # Metric key => [window_metrics key, trend mode].
+  PACKED_METRICS = {
+    eligible_conversations: %i[eligible percent],
+    coverage_rate: %i[coverage point],
+    autonomous_resolutions: %i[autonomous percent],
+    autonomous_resolution_rate: %i[autonomous_rate point],
+    assisted_resolutions: %i[assisted percent],
+    durable_resolution_rate: %i[durable_rate point],
+    csat_score: %i[csat absolute],
+    median_first_response_seconds: %i[median_first_response absolute],
+    median_resolution_seconds: %i[median_resolution absolute]
+  }.freeze
+
+  def metrics
+    rows = window_rows
+    current = window_metrics(rows[:current])
+    previous = window_metrics(rows[:previous])
+
+    packed = PACKED_METRICS.transform_values { |(key, mode)| pack(current[key], previous[key], mode) }
+    packed.merge(
+      human_only_csat_score: pack(human_only_csat(window.current), human_only_csat(window.previous), :absolute),
+      handoff_reasons: handoff_reasons
+    )
+  end
+
+  private
+
+  attr_reader :window
+
+  def window_metrics(row)
+    eligible, involved, autonomous, assisted, assessable, durable, csat, first_response, resolution = row
+
+    {
+      eligible: eligible,
+      coverage: rate(involved, eligible),
+      autonomous: autonomous,
+      autonomous_rate: rate(autonomous, eligible),
+      assisted: assisted,
+      durable_rate: rate(durable, assessable),
+      csat: csat&.to_f&.round(2) || 0,
+      median_first_response: first_response.to_i,
+      median_resolution: resolution.to_i
+    }
+  end
+
+  # One scan over the full span computes all aggregates for both windows.
+  def window_rows
+    per_window = window_aggregates(window_clause(window.current)) + window_aggregates(window_clause(window.previous))
+    row = outcomes_scope(full_span).reorder(nil).pick(*per_window.map { |sql| Arel.sql(sql) })
+
+    { current: row[0..8], previous: row[9..17] }
+  end
+
+  def window_aggregates(clause)
+    assessable = "#{AUTONOMOUS_SQL} AND resolved_at <= #{quote(durable_cutoff)}"
+
+    [
+      "COUNT(*) FILTER (WHERE #{clause})",
+      "COUNT(*) FILTER (WHERE #{clause} AND #{INVOLVED_SQL})",
+      "COUNT(*) FILTER (WHERE #{clause} AND #{AUTONOMOUS_SQL})",
+      "COUNT(*) FILTER (WHERE #{clause} AND #{ASSISTED_SQL})",
+      "COUNT(*) FILTER (WHERE #{clause} AND #{assessable})",
+      "COUNT(*) FILTER (WHERE #{clause} AND #{assessable} AND #{NOT_REOPENED_SQL})",
+      "AVG(csat_rating) FILTER (WHERE #{clause} AND #{INVOLVED_SQL} AND csat_rating IS NOT NULL)",
+      'percentile_cont(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (first_captain_reply_at - created_at))) ' \
+      "FILTER (WHERE #{clause} AND first_captain_reply_at IS NOT NULL)",
+      'percentile_cont(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (resolved_at - created_at))) ' \
+      "FILTER (WHERE #{clause} AND #{INVOLVED_SQL} AND resolved_at IS NOT NULL)"
+    ]
+  end
+
+  def handoff_reasons
+    outcomes_scope(window.current).where.not(handoff_reason_category: nil).group(:handoff_reason_category).count
+  end
+
+  # CSAT for conversations no Captain assistant participated in, as the
+  # baseline the Captain CSAT is compared against.
+  def human_only_csat(range)
+    involved_conversations = Captain::ConversationOutcome
+                             .where(account_id: account.id)
+                             .where(INVOLVED_SQL)
+                             .select(:conversation_id)
+    score = account.csat_survey_responses
+                   .where(created_at: range)
+                   .where.not(conversation_id: involved_conversations)
+                   .average(:rating)
+    score&.to_f&.round(2) || 0
+  end
+
+  def outcomes_scope(range)
+    assistant.conversation_outcomes.where(created_at: range)
+  end
+
+  def full_span
+    [window.current.first, window.previous.first].min..window.current.last
+  end
+
+  def durable_cutoff
+    @durable_cutoff ||= Time.current - DURABLE_RESOLUTION_WINDOW
+  end
+
+  def window_clause(range)
+    "created_at >= #{quote(range.first)} AND created_at <= #{quote(range.last)}"
+  end
+
+  def quote(value)
+    account.class.connection.quote(value)
+  end
+
+  def rate(numerator, denominator)
+    return 0 if denominator.zero?
+
+    (numerator.to_f / denominator * 100).round(1)
+  end
+
+  def pack(current, previous, mode)
+    { current: current, previous: previous, trend: trend(current, previous, mode) }
+  end
+
+  def trend(current, previous, mode)
+    case mode
+    when :percent
+      previous.zero? ? 0 : ((current - previous).to_f / previous * 100).round(1)
+    else # :point and :absolute are both current - previous
+      (current - previous).round(1)
+    end
+  end
+end

--- a/enterprise/app/builders/captain/assistant_stats_builder.rb
+++ b/enterprise/app/builders/captain/assistant_stats_builder.rb
@@ -2,14 +2,13 @@
 # Each metric is returned for the current window and the previous equal-length
 # window, plus a derived trend.
 #
-# Queries are batched to cut round trips: the message-derived counts (handled,
-# public replies, depth) are computed for both windows in a single scan via
-# conditional FILTER aggregation.
+# Handled, resolution, handoff, and reopen metrics come from
+# captain_conversation_outcomes: the cohort for a window is the demand that
+# entered it (rows created inside the window), and classifications are the
+# model's query-time predicates. The reply-derived metrics (hours saved, depth)
+# stay on the messages table, which is the only per-message activity ledger.
+# Both sources compute the two windows in a single scan via FILTER aggregation.
 class Captain::AssistantStatsBuilder
-  RESOLVED_EVENT_NAMES = %w[conversation_captain_inference_resolved conversation_bot_resolved].freeze
-  HANDOFF_EVENT_NAMES = %w[conversation_captain_inference_handoff conversation_bot_handoff].freeze
-  BOT_RESOLVED_EVENT_NAME = 'conversation_bot_resolved'.freeze
-
   # Assumed agent effort displaced by each public assistant reply. Reporting data
   # only captures reply latency (customer wait time), not handling effort, so hours
   # saved is a count-times-assumed-effort estimate rather than a measured duration.
@@ -32,8 +31,9 @@ class Captain::AssistantStatsBuilder
 
   def metrics
     messages = message_window_metrics
-    current = window_metrics(current_range, messages[:current])
-    previous = window_metrics(previous_range, messages[:previous])
+    outcomes = outcome_window_metrics
+    current = window_metrics(outcomes[:current], messages[:current])
+    previous = window_metrics(outcomes[:previous], messages[:previous])
 
     build_metrics(current, previous)
   end
@@ -78,33 +78,54 @@ class Captain::AssistantStatsBuilder
     }
   end
 
-  # Combines the per-window message counts with the reporting-event metrics for one window.
-  def window_metrics(range, message_counts)
-    handled = message_counts[:handled]
+  # Combines the per-window outcome counts with the message-derived metrics for one window.
+  def window_metrics(outcome_counts, message_counts)
+    handled = outcome_counts[:handled]
     public_count = message_counts[:public_count]
     depth_conversations = message_counts[:depth_conversations]
-    resolution = resolution_counts(range)
 
     {
       handled: handled,
-      auto_resolution: rate(resolution[:resolved], handled),
-      handoff: rate(resolution[:handoff], handled),
+      auto_resolution: rate(outcome_counts[:autonomous], handled),
+      handoff: rate(outcome_counts[:handoff], handled),
       hours_saved: (public_count * SECONDS_SAVED_PER_REPLY / 3600.0).round,
-      reopen: reopen_rate(range, resolution[:resolved]),
+      reopen: rate(outcome_counts[:reopened], outcome_counts[:autonomous]),
       depth: depth_conversations.zero? ? 0 : (public_count.to_f / depth_conversations).round(1)
     }
   end
 
-  # One scan over the assistant's messages computes handled, public-reply count,
-  # and depth-conversation count for both windows via conditional aggregation.
+  # One scan over the assistant's outcome rows counts the involved cohort and its
+  # resolution states for both windows.
+  def outcome_window_metrics
+    per_window = [current_range, previous_range].flat_map { |range| outcome_aggregates(window_clause(range)) }
+    row = assistant.conversation_outcomes.where(created_at: full_span).reorder(nil).pick(*per_window.map { |sql| Arel.sql(sql) })
+
+    {
+      current: { handled: row[0], autonomous: row[1], handoff: row[2], reopened: row[3] },
+      previous: { handled: row[4], autonomous: row[5], handoff: row[6], reopened: row[7] }
+    }
+  end
+
+  def outcome_aggregates(clause)
+    involved = Captain::ConversationOutcome::INVOLVED_SQL
+    autonomous = Captain::ConversationOutcome::AUTONOMOUS_SQL
+
+    [
+      "COUNT(*) FILTER (WHERE #{clause} AND #{involved})",
+      "COUNT(*) FILTER (WHERE #{clause} AND #{autonomous})",
+      "COUNT(*) FILTER (WHERE #{clause} AND #{involved} AND handoff_at IS NOT NULL)",
+      "COUNT(*) FILTER (WHERE #{clause} AND #{autonomous} AND reopen_count > 0)"
+    ]
+  end
+
+  # One scan over the assistant's messages computes the public-reply count and
+  # depth-conversation count for both windows via conditional aggregation.
   def message_window_metrics
     public_clause = "message_type = #{Message.message_types[:outgoing]} AND private = false"
     cur = window_clause(current_range)
     prev = window_clause(previous_range)
 
-    row = handled_scope(full_span).reorder(nil).pick(
-      Arel.sql("COUNT(DISTINCT conversation_id) FILTER (WHERE #{cur})"),
-      Arel.sql("COUNT(DISTINCT conversation_id) FILTER (WHERE #{prev})"),
+    row = assistant_messages(full_span).reorder(nil).pick(
       Arel.sql("COUNT(*) FILTER (WHERE #{cur} AND #{public_clause})"),
       Arel.sql("COUNT(*) FILTER (WHERE #{prev} AND #{public_clause})"),
       Arel.sql("COUNT(DISTINCT conversation_id) FILTER (WHERE #{cur} AND #{public_clause})"),
@@ -112,45 +133,12 @@ class Captain::AssistantStatsBuilder
     )
 
     {
-      current: { handled: row[0], public_count: row[2], depth_conversations: row[4] },
-      previous: { handled: row[1], public_count: row[3], depth_conversations: row[5] }
+      current: { public_count: row[0], depth_conversations: row[2] },
+      previous: { public_count: row[1], depth_conversations: row[3] }
     }
   end
 
-  # Resolved and handed-off conversation counts for one window, in a single scan
-  # of the handled set's reporting events.
-  def resolution_counts(range)
-    row = account.reporting_events
-                 .where(name: RESOLVED_EVENT_NAMES + HANDOFF_EVENT_NAMES,
-                        created_at: range,
-                        conversation_id: handled_scope(range).select(:conversation_id))
-                 .reorder(nil)
-                 .pick(
-                   Arel.sql("COUNT(DISTINCT conversation_id) FILTER (WHERE #{resolved_clause(range)})"),
-                   Arel.sql("COUNT(DISTINCT conversation_id) FILTER (WHERE name IN (#{quoted(HANDOFF_EVENT_NAMES)}))")
-                 )
-    { resolved: row[0], handoff: row[1] }
-  end
-
-  # A countable resolve is any inference resolve, or a bot resolve on a conversation
-  # with no handoff in the window. conversation_bot_resolved fires on any resolve
-  # without an agent message (reporting_event_listener), so a handed-off conversation
-  # that goes quiet and gets closed would otherwise count as an auto-resolution too;
-  # the reports bot_resolutions metric applies the same exclusion (:exclude_bot_handoffs).
-  def resolved_clause(range)
-    "name IN (#{quoted(RESOLVED_EVENT_NAMES)}) AND #{bot_resolve_handoff_exclusion(range)}"
-  end
-
-  def bot_resolve_handoff_exclusion(range)
-    "NOT (name = #{quote(BOT_RESOLVED_EVENT_NAME)} AND conversation_id IN (#{handoff_conversation_ids(range).to_sql}))"
-  end
-
-  def handoff_conversation_ids(range)
-    account.reporting_events.where(name: HANDOFF_EVENT_NAMES, created_at: range).select(:conversation_id)
-  end
-
-  # Conversations the assistant participated in (authored any message).
-  def handled_scope(range)
+  def assistant_messages(range)
     account.messages.where(sender_type: 'Captain::Assistant', sender_id: assistant.id, created_at: range)
   end
 
@@ -165,39 +153,6 @@ class Captain::AssistantStatsBuilder
 
   def quote(value)
     account.class.connection.quote(value)
-  end
-
-  def quoted(values)
-    values.map { |value| quote(value) }.join(', ')
-  end
-
-  # Of the conversations Captain auto-resolved, the share reopened afterwards. The cohort is
-  # derived from the assistant's handled conversations (not current inbox membership) so a later
-  # inbox reassignment doesn't drop historical resolves, and covers both the evaluated (inference)
-  # and time-based (bot) resolve paths so the denominator matches auto_resolution_rate.
-  def reopen_rate(range, resolved_count)
-    return 0 if resolved_count.zero?
-
-    resolved_scope = account.reporting_events
-                            .where(name: RESOLVED_EVENT_NAMES, created_at: range,
-                                   conversation_id: handled_scope(range).select(:conversation_id))
-                            .where(bot_resolve_handoff_exclusion(range))
-    # event_end_time on a reopen is when it actually reopened. Join it to the conversation's own
-    # Captain resolves and keep only reopens at/after one of them, so a human resolve/reopen earlier
-    # in the same window isn't mistaken for a reopen-after-Captain-resolve. (Comparing the reopen's
-    # start time instead would misfire: the inference event is dispatched just after the generic
-    # conversation_resolved that seeds event_start_time, so it can land after the reopen's start.)
-    # The reopen itself must also fall inside the window, so a completed range (last_month, the
-    # previous window) doesn't count reopens that happened after it ended.
-    reopened = account.reporting_events
-                      .where(name: 'conversation_opened')
-                      .where('reporting_events.value > 0')
-                      .where('reporting_events.event_end_time <= ?', range.last)
-                      .joins("INNER JOIN (#{resolved_scope.to_sql}) resolves " \
-                             'ON resolves.conversation_id = reporting_events.conversation_id ' \
-                             'AND reporting_events.event_end_time >= resolves.event_end_time')
-                      .distinct.count('reporting_events.conversation_id')
-    rate(reopened, resolved_count)
   end
 
   def open_suggestion_count_sql

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::Accounts::Captain::AssistantsController < Api::V1::Accounts::BaseController
   before_action -> { check_authorization(Captain::Assistant) }
 
-  before_action :set_assistant, only: [:show, :update, :destroy, :playground, :metrics, :faq_stats, :summary, :drilldown]
+  before_action :set_assistant, only: [:show, :update, :destroy, :playground, :metrics, :outcome_metrics, :faq_stats, :summary, :drilldown]
 
   def index
     @assistants = account_assistants.ordered
@@ -44,6 +44,10 @@ class Api::V1::Accounts::Captain::AssistantsController < Api::V1::Accounts::Base
 
   def metrics
     render json: Captain::AssistantStatsBuilder.new(@assistant, params[:range], params[:timezone_offset]).metrics
+  end
+
+  def outcome_metrics
+    render json: Captain::AssistantOutcomeStatsBuilder.new(@assistant, params[:range], params[:timezone_offset]).metrics
   end
 
   def faq_stats

--- a/enterprise/app/dispatchers/enterprise/async_dispatcher.rb
+++ b/enterprise/app/dispatchers/enterprise/async_dispatcher.rb
@@ -1,7 +1,8 @@
 module Enterprise::AsyncDispatcher
   def listeners
     super + [
-      CaptainListener.instance
+      CaptainListener.instance,
+      Captain::ReportingEventListener.instance
     ]
   end
 end

--- a/enterprise/app/dispatchers/enterprise/sync_dispatcher.rb
+++ b/enterprise/app/dispatchers/enterprise/sync_dispatcher.rb
@@ -1,0 +1,7 @@
+module Enterprise::SyncDispatcher
+  def listeners
+    super + [
+      Captain::ConversationOutcomeEventListener.instance
+    ]
+  end
+end

--- a/enterprise/app/jobs/captain/conversation/response_builder_job.rb
+++ b/enterprise/app/jobs/captain/conversation/response_builder_job.rb
@@ -67,6 +67,10 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
         # HandoffTool flipped the flag without committing — its perform returned a
         # failure string (e.g. "Conversation not found") before bot_handoff! ran. Fall
         # back to a full V1 handoff so the customer still ends up with a human.
+        # Known gap, accepted for now: this repaired handoff emits no
+        # captain.conversation.handed_off event (the tool emits only after a successful
+        # bot_handoff!). If outcome data ever needs it, emit here with a distinct
+        # source such as 'tool_fallback'.
         process_v1_handoff
       else
         # HandoffTool already opened the conversation inside the agent loop. All that's

--- a/enterprise/app/jobs/captain/conversation/response_builder_job.rb
+++ b/enterprise/app/jobs/captain/conversation/response_builder_job.rb
@@ -54,6 +54,11 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
   end
 
   def process_response
+    # The V2 runner rescues its own generation errors and signals them via an error
+    # response instead of raising, so the failure event must be emitted here — the
+    # top-level handle_error path only sees exceptions raised outside the runner.
+    record_v2_response_failure(@response['error_reason']) if v2_generation_errored?
+
     # Check V2 before V1: error_response can set both signals at once when HandoffTool
     # fired before the runner errored. V2 must win — running V1 on top would duplicate
     # OOO and re-dispatch the bot_handoff event.
@@ -70,15 +75,20 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
       end
       capture_assistant_session(result_message: @handoff_message, credits_consumed: 0.0)
     elsif v1_handoff_requested?
-      # V1 only signals via the response string — no state has been touched yet. If
-      # the conversation isn't pending anymore, a human took over mid-run; bail out
-      # rather than posting a stale handoff message on top of their reply.
-      return unless conversation_pending?
-
-      process_v1_handoff
+      process_v1_handoff_request
     elsif conversation_pending?
       deliver_generated_response
     end
+  end
+
+  def process_v1_handoff_request
+    # V1 only signals via the response string — no state has been touched yet. If
+    # the conversation isn't pending anymore, a human took over mid-run; bail out
+    # rather than posting a stale handoff message on top of their reply.
+    return unless conversation_pending?
+
+    process_v1_handoff
+    record_v2_failure_handoff if v2_generation_errored?
   end
 
   def deliver_generated_response
@@ -166,7 +176,7 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
     @response ||= {}
     @response['action_source'] ||= 'error'
     @response['action_reason'] ||= error_action_reason(error)
-    record_v2_response_failure(error) if captain_v2_enabled?
+    record_v2_response_failure(error_action_reason(error)) if captain_v2_enabled?
     if conversation_pending?
       process_v1_handoff
       record_v2_failure_handoff if captain_v2_enabled?
@@ -174,13 +184,17 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
     true
   end
 
-  def record_v2_response_failure(error)
+  def record_v2_response_failure(reason)
     Captain::ConversationEvents.response_failed(
       conversation: @conversation,
       assistant: @assistant,
-      reason: error_action_reason(error),
+      reason: reason,
       at: Time.current
     )
+  end
+
+  def v2_generation_errored?
+    captain_v2_enabled? && @response['error'].present?
   end
 
   def record_v2_failure_handoff

--- a/enterprise/app/jobs/captain/conversation/response_builder_job.rb
+++ b/enterprise/app/jobs/captain/conversation/response_builder_job.rb
@@ -185,12 +185,7 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
   end
 
   def record_v2_response_failure(reason)
-    Captain::ConversationEvents.response_failed(
-      conversation: @conversation,
-      assistant: @assistant,
-      reason: reason,
-      at: Time.current
-    )
+    Captain::ConversationEvents.response_failed(conversation: @conversation, assistant: @assistant, reason: reason, at: Time.current)
   end
 
   def v2_generation_errored?

--- a/enterprise/app/jobs/captain/conversation/response_builder_job.rb
+++ b/enterprise/app/jobs/captain/conversation/response_builder_job.rb
@@ -77,14 +77,28 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
 
       process_v1_handoff
     elsif conversation_pending?
-      message = nil
-      ActiveRecord::Base.transaction do
-        message = create_messages
-        Rails.logger.info("[CAPTAIN][ResponseBuilderJob] Incrementing response usage for #{account.id}")
-        account.increment_response_usage
-      end
-      capture_assistant_session(result_message: message, credits_consumed: 1.0)
+      deliver_generated_response
     end
+  end
+
+  def deliver_generated_response
+    message = nil
+    ActiveRecord::Base.transaction do
+      message = create_messages
+      Rails.logger.info("[CAPTAIN][ResponseBuilderJob] Incrementing response usage for #{account.id}")
+      account.increment_response_usage
+    end
+    capture_assistant_session(result_message: message, credits_consumed: 1.0)
+    record_v2_response_completed(message) if captain_v2_enabled?
+  end
+
+  def record_v2_response_completed(message)
+    Captain::ConversationEvents.response_completed(
+      conversation: @conversation,
+      assistant: @assistant,
+      message: message,
+      at: Time.current
+    )
   end
 
   def v1_handoff_requested?
@@ -152,8 +166,31 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
     @response ||= {}
     @response['action_source'] ||= 'error'
     @response['action_reason'] ||= error_action_reason(error)
-    process_v1_handoff if conversation_pending?
+    record_v2_response_failure(error) if captain_v2_enabled?
+    if conversation_pending?
+      process_v1_handoff
+      record_v2_failure_handoff if captain_v2_enabled?
+    end
     true
+  end
+
+  def record_v2_response_failure(error)
+    Captain::ConversationEvents.response_failed(
+      conversation: @conversation,
+      assistant: @assistant,
+      reason: error_action_reason(error),
+      at: Time.current
+    )
+  end
+
+  def record_v2_failure_handoff
+    Captain::ConversationEvents.handed_off(
+      conversation: @conversation,
+      assistant: @assistant,
+      source: 'generation_failure',
+      reason_category: :tool_failure,
+      at: Time.current
+    )
   end
 
   def log_error(error)

--- a/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
+++ b/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
@@ -77,7 +77,12 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
       reason: CAPTAIN_INFERENCE_RESOLVE_ACTIVITY_REASON,
       reason_type: :inference
     ) { conversation.resolved! }
-    conversation.dispatch_captain_inference_resolved_event
+    Captain::ConversationEvents.resolved(
+      conversation: conversation,
+      assistant: inbox.captain_assistant,
+      source: 'inference',
+      at: Time.current
+    )
   end
 
   def handoff_conversation(conversation, inbox, reason)
@@ -87,7 +92,13 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
       reason: CAPTAIN_INFERENCE_HANDOFF_ACTIVITY_REASON,
       reason_type: :inference
     ) { conversation.bot_handoff! }
-    conversation.dispatch_captain_inference_handoff_event
+    Captain::ConversationEvents.handed_off(
+      conversation: conversation,
+      assistant: inbox.captain_assistant,
+      source: 'inference',
+      reason_category: :pending_clarification,
+      at: Time.current
+    )
     send_out_of_office_message_if_applicable(conversation.reload)
   end
 

--- a/enterprise/app/listeners/captain/conversation_outcome_event_listener.rb
+++ b/enterprise/app/listeners/captain/conversation_outcome_event_listener.rb
@@ -1,0 +1,22 @@
+class Captain::ConversationOutcomeEventListener < BaseListener
+  def captain_conversation_eligible(event)
+    tracker(event).record_eligibility
+  end
+
+  def captain_conversation_handed_off(event)
+    outcome_tracker = tracker(event)
+    # Self-heal: a handoff implies the conversation was eligible, even if the
+    # eligible event was lost, so the outcome row is created here if missing.
+    outcome_tracker.record_eligibility
+    outcome_tracker.record_handoff(at: event.timestamp, reason_category: event.data[:reason_category])
+  end
+
+  private
+
+  def tracker(event)
+    Captain::ConversationOutcomeTracker.new(
+      conversation: event.data[:conversation],
+      assistant: event.data[:assistant]
+    )
+  end
+end

--- a/enterprise/app/listeners/captain/reporting_event_listener.rb
+++ b/enterprise/app/listeners/captain/reporting_event_listener.rb
@@ -1,0 +1,27 @@
+class Captain::ReportingEventListener < BaseListener
+  def captain_conversation_handed_off(event)
+    create_captain_inference_event(event, 'conversation_captain_inference_handoff') if event.data[:source] == 'inference'
+  end
+
+  def captain_conversation_resolved(event)
+    create_captain_inference_event(event, 'conversation_captain_inference_resolved') if event.data[:source] == 'inference'
+  end
+
+  private
+
+  def create_captain_inference_event(event, event_name)
+    conversation = extract_conversation_and_account(event)[0]
+    time_to_event = event.timestamp.to_i - conversation.created_at.to_i
+
+    ReportingEvent.create!(
+      name: event_name,
+      value: time_to_event,
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      user_id: conversation.assignee_id,
+      conversation_id: conversation.id,
+      event_start_time: conversation.created_at,
+      event_end_time: event.timestamp
+    )
+  end
+end

--- a/enterprise/app/listeners/captain_listener.rb
+++ b/enterprise/app/listeners/captain_listener.rb
@@ -1,13 +1,53 @@
 class CaptainListener < BaseListener
   include ::Events::Types
 
+  def message_created(event)
+    message = event.data[:message]
+    return unless message.outgoing? && !message.private?
+
+    if message.sender_type == 'Captain::Assistant'
+      Captain::ConversationOutcomeTracker.new(conversation: message.conversation, assistant: message.sender)
+                                         .record_captain_reply(message: message)
+    else
+      outcome_trackers(message.conversation).each { |tracker| tracker.record_human_reply(message: message) }
+    end
+  end
+
+  def message_updated(event)
+    message = event.data[:message]
+    return unless message.input_csat?
+
+    response = CsatSurveyResponse.find_by(message: message)
+    return unless response
+
+    outcome_trackers(message.conversation).each { |tracker| tracker.record_csat(response: response) }
+  end
+
   def conversation_resolved(event)
     conversation = extract_conversation_and_account(event)[0]
+    outcome_trackers(conversation).each { |tracker| tracker.record_resolution(at: event.timestamp) }
+
     assistant = conversation.inbox.captain_assistant
 
     return unless conversation.inbox.captain_active?
 
     Captain::Llm::ContactNotesService.new(assistant, conversation).generate_and_update_notes if assistant.config['feature_memory'].present?
     Captain::Llm::ConversationFaqJob.perform_later(conversation, assistant) if assistant.config['feature_faq'].present?
+  end
+
+  def conversation_opened(event)
+    conversation = extract_conversation_and_account(event)[0]
+    outcome_trackers(conversation).each { |tracker| tracker.record_reopen(at: event.timestamp) }
+  end
+
+  private
+
+  def outcome_trackers(conversation)
+    Captain::ConversationOutcome.where(
+      account_id: conversation.account_id,
+      conversation_id: conversation.id
+    ).includes(:assistant).map do |outcome|
+      Captain::ConversationOutcomeTracker.new(conversation: conversation, assistant: outcome.assistant)
+    end
   end
 end

--- a/enterprise/app/listeners/enterprise/reporting_event_listener.rb
+++ b/enterprise/app/listeners/enterprise/reporting_event_listener.rb
@@ -1,9 +1,0 @@
-module Enterprise::ReportingEventListener
-  def captain_conversation_handed_off(event)
-    conversation_captain_inference_handoff(event) if event.data[:source] == 'inference'
-  end
-
-  def captain_conversation_resolved(event)
-    conversation_captain_inference_resolved(event) if event.data[:source] == 'inference'
-  end
-end

--- a/enterprise/app/listeners/enterprise/reporting_event_listener.rb
+++ b/enterprise/app/listeners/enterprise/reporting_event_listener.rb
@@ -1,0 +1,9 @@
+module Enterprise::ReportingEventListener
+  def captain_conversation_handed_off(event)
+    conversation_captain_inference_handoff(event) if event.data[:source] == 'inference'
+  end
+
+  def captain_conversation_resolved(event)
+    conversation_captain_inference_resolved(event) if event.data[:source] == 'inference'
+  end
+end

--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -39,6 +39,7 @@ class Captain::Assistant < ApplicationRecord
   has_many :copilot_threads, dependent: :destroy_async
   has_many :scenarios, class_name: 'Captain::Scenario', dependent: :destroy_async
   has_many :agent_sessions, class_name: 'Captain::AgentSession', dependent: :destroy_async
+  has_many :conversation_outcomes, class_name: 'Captain::ConversationOutcome', dependent: :destroy_async
 
   store_accessor :config, :temperature, :feature_faq, :feature_memory, :feature_contact_attributes, :product_name
 

--- a/enterprise/app/models/captain/conversation_outcome.rb
+++ b/enterprise/app/models/captain/conversation_outcome.rb
@@ -21,6 +21,16 @@
 #  conversation_id         :bigint           not null
 #  inbox_id                :bigint           not null
 #
+# Indexes
+#
+#  idx_captain_outcomes_on_assistant_handoff_at            (account_id,assistant_id,handoff_at)
+#  idx_captain_outcomes_on_assistant_resolved_at           (account_id,assistant_id,resolved_at)
+#  idx_captain_outcomes_unique_conversation                (account_id,assistant_id,conversation_id) UNIQUE
+#  index_captain_conversation_outcomes_on_account_id       (account_id)
+#  index_captain_conversation_outcomes_on_assistant_id     (assistant_id)
+#  index_captain_conversation_outcomes_on_conversation_id  (conversation_id)
+#  index_captain_conversation_outcomes_on_inbox_id         (inbox_id)
+#
 class Captain::ConversationOutcome < ApplicationRecord
   HANDOFF_REASON_CATEGORIES = %w[
     customer_request

--- a/enterprise/app/models/captain/conversation_outcome.rb
+++ b/enterprise/app/models/captain/conversation_outcome.rb
@@ -1,0 +1,49 @@
+# == Schema Information
+#
+# Table name: captain_conversation_outcomes
+#
+#  id                      :bigint           not null, primary key
+#  captain_reply_count     :integer          default(0), not null
+#  csat_rating             :integer
+#  csat_received_at        :datetime
+#  first_captain_reply_at  :datetime
+#  first_human_reply_at    :datetime
+#  handoff_at              :datetime
+#  handoff_reason_category :string
+#  last_captain_reply_at   :datetime
+#  last_reopened_at        :datetime
+#  reopen_count            :integer          default(0), not null
+#  resolved_at             :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  account_id              :bigint           not null
+#  assistant_id            :bigint           not null
+#  conversation_id         :bigint           not null
+#  inbox_id                :bigint           not null
+#
+class Captain::ConversationOutcome < ApplicationRecord
+  HANDOFF_REASON_CATEGORIES = %w[
+    customer_request
+    missing_knowledge
+    unsupported_request
+    policy_restriction
+    tool_failure
+    pending_clarification
+    usage_limit
+  ].freeze
+
+  self.table_name = 'captain_conversation_outcomes'
+
+  belongs_to :account
+  belongs_to :assistant, class_name: 'Captain::Assistant'
+  belongs_to :conversation, class_name: '::Conversation'
+  belongs_to :inbox
+
+  enum :handoff_reason_category,
+       HANDOFF_REASON_CATEGORIES.index_by(&:itself),
+       prefix: :handoff_reason,
+       validate: { allow_nil: true }
+
+  validates :conversation_id, uniqueness: { scope: [:account_id, :assistant_id] }
+  validates :handoff_reason_category, presence: true, if: :handoff_at?
+end

--- a/enterprise/app/models/captain/conversation_outcome.rb
+++ b/enterprise/app/models/captain/conversation_outcome.rb
@@ -42,6 +42,29 @@ class Captain::ConversationOutcome < ApplicationRecord
     usage_limit
   ].freeze
 
+  # Query-time classification predicates: the table stores only facts, and every
+  # judgment is derived from them. Shared by the stats and drilldown builders so
+  # a stat card and its drilldown always count the same rows.
+  #
+  # Involved: Captain replied publicly, or handed off for a real reason. A
+  # usage-limit handoff is blocked demand, not participation.
+  INVOLVED_SQL = "(first_captain_reply_at IS NOT NULL OR (handoff_at IS NOT NULL AND handoff_reason_category != 'usage_limit'))".freeze
+  # Autonomous: resolved by Captain alone, with no handoff and no public human
+  # reply before the resolution that stuck.
+  AUTONOMOUS_SQL = '(resolved_at IS NOT NULL AND first_captain_reply_at IS NOT NULL AND handoff_at IS NULL ' \
+                   'AND (first_human_reply_at IS NULL OR first_human_reply_at > resolved_at))'.freeze
+  # Assisted: resolved with Captain participation and a human in the loop.
+  ASSISTED_SQL = "(resolved_at IS NOT NULL AND #{INVOLVED_SQL} AND NOT #{AUTONOMOUS_SQL})".freeze
+  # The tracker only records reopens that happen after the current resolution,
+  # so a reopen timestamp at or before resolved_at belongs to an earlier,
+  # superseded resolution.
+  NOT_REOPENED_SQL = '(last_reopened_at IS NULL OR last_reopened_at <= resolved_at)'.freeze
+
+  scope :involved, -> { where(INVOLVED_SQL) }
+  scope :autonomous_resolved, -> { where(AUTONOMOUS_SQL) }
+  scope :assisted_resolved, -> { where(ASSISTED_SQL) }
+  scope :reopened, -> { where('reopen_count > 0') }
+
   self.table_name = 'captain_conversation_outcomes'
 
   belongs_to :account

--- a/enterprise/app/models/enterprise/concerns/account.rb
+++ b/enterprise/app/models/enterprise/concerns/account.rb
@@ -16,6 +16,7 @@ module Enterprise::Concerns::Account
     has_many :captain_documents, dependent: :destroy_async, class_name: 'Captain::Document'
     has_many :captain_custom_tools, dependent: :destroy_async, class_name: 'Captain::CustomTool'
     has_many :captain_agent_sessions, dependent: :destroy_async, class_name: 'Captain::AgentSession'
+    has_many :captain_conversation_outcomes, dependent: :destroy_async, class_name: 'Captain::ConversationOutcome'
 
     has_many :copilot_threads, dependent: :destroy_async
     has_many :companies, dependent: :destroy_async

--- a/enterprise/app/models/enterprise/concerns/conversation.rb
+++ b/enterprise/app/models/enterprise/concerns/conversation.rb
@@ -8,6 +8,7 @@ module Enterprise::Concerns::Conversation
     has_many :calls, dependent: :destroy_async
     has_many :captain_responses, class_name: 'Captain::AssistantResponse', dependent: :nullify, as: :documentable
     has_many :captain_faq_observations, class_name: 'Captain::FaqObservation', dependent: :delete_all
+    has_many :captain_conversation_outcomes, class_name: 'Captain::ConversationOutcome', dependent: :destroy_async
     scope :with_sla_applicable_contact, -> { left_joins(:contact).where(contacts: { blocked: [false, nil] }) }
 
     before_validation :validate_sla_policy, if: -> { sla_policy_id_changed? }

--- a/enterprise/app/models/enterprise/concerns/inbox.rb
+++ b/enterprise/app/models/enterprise/concerns/inbox.rb
@@ -8,6 +8,7 @@ module Enterprise::Concerns::Inbox
             class_name: 'Captain::Assistant'
     has_many :inbox_capacity_limits, dependent: :destroy
     has_many :calls, dependent: :destroy_async
+    has_many :captain_conversation_outcomes, class_name: 'Captain::ConversationOutcome', dependent: :destroy_async
 
     before_create :ensure_create_permitted
   end

--- a/enterprise/app/models/enterprise/conversation.rb
+++ b/enterprise/app/models/enterprise/conversation.rb
@@ -1,14 +1,6 @@
 module Enterprise::Conversation
   attr_accessor :captain_activity_reason, :captain_activity_reason_type
 
-  def dispatch_captain_inference_resolved_event
-    dispatch_captain_inference_event(Events::Types::CONVERSATION_CAPTAIN_INFERENCE_RESOLVED)
-  end
-
-  def dispatch_captain_inference_handoff_event
-    dispatch_captain_inference_event(Events::Types::CONVERSATION_CAPTAIN_INFERENCE_HANDOFF)
-  end
-
   def list_of_keys
     super + %w[sla_policy_id]
   end
@@ -32,10 +24,6 @@ module Enterprise::Conversation
   end
 
   private
-
-  def dispatch_captain_inference_event(event_name)
-    dispatcher_dispatch(event_name)
-  end
 
   def call_attributes_changed?
     return false if previous_changes['additional_attributes'].blank?

--- a/enterprise/app/policies/captain/assistant_policy.rb
+++ b/enterprise/app/policies/captain/assistant_policy.rb
@@ -11,6 +11,10 @@ class Captain::AssistantPolicy < ApplicationPolicy
     true
   end
 
+  def outcome_metrics?
+    true
+  end
+
   def faq_stats?
     true
   end

--- a/enterprise/app/services/captain/assistant/agent_runner_service.rb
+++ b/enterprise/app/services/captain/assistant/agent_runner_service.rb
@@ -28,7 +28,7 @@ class Captain::Assistant::AgentRunnerService
     Rails.logger.error "[Captain V2] AgentRunnerService error: #{e.message}"
     Rails.logger.error e.backtrace.join("\n")
 
-    error_response(e.message)
+    error_response(e)
   end
 
   private
@@ -93,10 +93,12 @@ class Captain::Assistant::AgentRunnerService
     response
   end
 
-  def error_response(error_message)
+  def error_response(error)
     {
       'response' => 'conversation_handoff',
-      'reasoning' => "Error occurred: #{error_message}",
+      'reasoning' => "Error occurred: #{error.message}",
+      'error' => true,
+      'error_reason' => error.class.name.underscore.tr('/', '_'),
       'handoff_tool_called' => @handoff_tool_called
     }
   end

--- a/enterprise/app/services/captain/conversation_events.rb
+++ b/enterprise/app/services/captain/conversation_events.rb
@@ -52,8 +52,13 @@ class Captain::ConversationEvents
 
     private
 
+    # Lifecycle events are secondary effects: a dispatch failure must never alter
+    # the customer-facing Captain flow (blocking a response from being scheduled,
+    # or turning an already-delivered reply into a spurious handoff).
     def dispatch(event_name, at:, **data)
       Rails.configuration.dispatcher.dispatch(event_name, at, data)
+    rescue StandardError => e
+      ChatwootExceptionTracker.new(e, account: data[:conversation]&.account).capture_exception
     end
   end
 end

--- a/enterprise/app/services/captain/conversation_events.rb
+++ b/enterprise/app/services/captain/conversation_events.rb
@@ -1,0 +1,59 @@
+class Captain::ConversationEvents
+  class << self
+    def engaged(conversation:, assistant:, at:)
+      dispatch(
+        Events::Types::CAPTAIN_CONVERSATION_ENGAGED,
+        at: at,
+        conversation: conversation,
+        assistant: assistant
+      )
+    end
+
+    def handed_off(conversation:, assistant:, source:, at:, reason_category: nil)
+      dispatch(
+        Events::Types::CAPTAIN_CONVERSATION_HANDED_OFF,
+        at: at,
+        conversation: conversation,
+        assistant: assistant,
+        source: source,
+        reason_category: reason_category
+      )
+    end
+
+    def resolved(conversation:, assistant:, source:, at:)
+      dispatch(
+        Events::Types::CAPTAIN_CONVERSATION_RESOLVED,
+        at: at,
+        conversation: conversation,
+        assistant: assistant,
+        source: source
+      )
+    end
+
+    def response_completed(conversation:, assistant:, message:, at:)
+      dispatch(
+        Events::Types::CAPTAIN_RESPONSE_COMPLETED,
+        at: at,
+        conversation: conversation,
+        assistant: assistant,
+        message: message
+      )
+    end
+
+    def response_failed(conversation:, assistant:, reason:, at:)
+      dispatch(
+        Events::Types::CAPTAIN_RESPONSE_FAILED,
+        at: at,
+        conversation: conversation,
+        assistant: assistant,
+        reason: reason
+      )
+    end
+
+    private
+
+    def dispatch(event_name, at:, **data)
+      Rails.configuration.dispatcher.dispatch(event_name, at, data)
+    end
+  end
+end

--- a/enterprise/app/services/captain/conversation_events.rb
+++ b/enterprise/app/services/captain/conversation_events.rb
@@ -1,8 +1,8 @@
 class Captain::ConversationEvents
   class << self
-    def engaged(conversation:, assistant:, at:)
+    def eligible(conversation:, assistant:, at:)
       dispatch(
-        Events::Types::CAPTAIN_CONVERSATION_ENGAGED,
+        Events::Types::CAPTAIN_CONVERSATION_ELIGIBLE,
         at: at,
         conversation: conversation,
         assistant: assistant

--- a/enterprise/app/services/captain/conversation_outcome_tracker.rb
+++ b/enterprise/app/services/captain/conversation_outcome_tracker.rb
@@ -1,0 +1,162 @@
+class Captain::ConversationOutcomeTracker
+  pattr_initialize [:conversation!, :assistant!]
+
+  def record_eligibility
+    safely_track(:eligibility) do
+      next unless account.feature_enabled?('captain_integration_v2')
+
+      find_or_create_outcome
+    end
+  end
+
+  def record_captain_reply(message:)
+    return unless public_captain_reply?(message)
+
+    track_existing_outcome(:captain_reply) do |outcome|
+      outcome.with_lock do
+        outcome.first_captain_reply_at = earliest(outcome.first_captain_reply_at, message.created_at)
+        outcome.last_captain_reply_at = latest(outcome.last_captain_reply_at, message.created_at)
+        outcome.captain_reply_count = public_captain_replies.count
+        outcome.save!
+      end
+    end
+  end
+
+  def record_handoff(at:, reason_category:)
+    track_existing_outcome(:handoff) do |outcome|
+      outcome.with_lock do
+        # First handoff wins: re-delivered or later handoff events must not
+        # overwrite the reason the conversation originally left Captain.
+        next outcome if outcome.handoff_at.present? && outcome.handoff_at <= at
+
+        outcome.handoff_at = at
+        outcome.handoff_reason_category = reason_category
+        outcome.save!
+      end
+    end
+  end
+
+  def record_human_reply(message:)
+    return unless public_human_reply?(message)
+
+    track_existing_outcome(:human_reply) do |outcome|
+      outcome.with_lock do
+        outcome.first_human_reply_at = earliest(outcome.first_human_reply_at, message.created_at)
+        outcome.save! if outcome.changed?
+      end
+    end
+  end
+
+  def record_resolution(at:)
+    track_existing_outcome(:resolution) do |outcome|
+      outcome.with_lock do
+        # Latest resolution wins: after a reopen the final resolution is the one
+        # that counts, and out-of-order events must not roll it back.
+        next outcome if outcome.resolved_at.present? && at < outcome.resolved_at
+
+        outcome.resolved_at = at
+        outcome.save!
+      end
+    end
+  end
+
+  def record_reopen(at:)
+    track_existing_outcome(:reopen) do |outcome|
+      outcome.with_lock do
+        next outcome if outcome.resolved_at.blank? || at <= outcome.resolved_at
+        next outcome if outcome.last_reopened_at == at
+
+        outcome.last_reopened_at = latest(outcome.last_reopened_at, at)
+        outcome.reopen_count += 1
+        outcome.save!
+      end
+    end
+  end
+
+  def record_csat(response:)
+    track_existing_outcome(:csat) do |outcome|
+      outcome.with_lock do
+        outcome.update!(csat_rating: response.rating, csat_received_at: response.created_at)
+      end
+    end
+  end
+
+  private
+
+  def account
+    conversation.account
+  end
+
+  def conversation_outcome
+    Captain::ConversationOutcome.find_by(
+      account: account,
+      assistant: assistant,
+      conversation: conversation
+    )
+  end
+
+  def find_or_create_outcome
+    conversation_outcome || Captain::ConversationOutcome.create!(
+      account: account,
+      assistant: assistant,
+      conversation: conversation,
+      inbox: conversation.inbox
+    )
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+    conversation_outcome || raise
+  end
+
+  def public_captain_reply?(message)
+    message.conversation_id == conversation.id &&
+      message.sender == assistant &&
+      message.outgoing? &&
+      !message.private?
+  end
+
+  def public_human_reply?(message)
+    return false unless message.conversation_id == conversation.id && message.outgoing? && !message.private?
+    return false if message.content_attributes['automation_rule_id'].present?
+    return false if message.additional_attributes['campaign_id'].present?
+
+    message.sender.is_a?(User) || message.content_attributes['external_echo'].present?
+  end
+
+  def public_captain_replies
+    conversation.messages.where(
+      sender_type: 'Captain::Assistant',
+      sender_id: assistant.id,
+      message_type: :outgoing,
+      private: false
+    )
+  end
+
+  def earliest(existing, candidate)
+    [existing, candidate].compact.min
+  end
+
+  def latest(existing, candidate)
+    [existing, candidate].compact.max
+  end
+
+  def track_existing_outcome(action)
+    safely_track(action) do
+      outcome = conversation_outcome
+      next unless outcome
+
+      yield outcome
+      outcome
+    end
+  end
+
+  # Outcome tracking is reporting, not product behavior: a tracking bug must
+  # never break message delivery or conversation state transitions.
+  def safely_track(action)
+    yield
+  rescue StandardError => e
+    ChatwootExceptionTracker.new(e, account: account).capture_exception
+    Rails.logger.error(
+      "[CAPTAIN][ConversationOutcomeTracker] Failed to record #{action} for conversation=#{conversation.display_id}: #{e.message}"
+    )
+    nil
+  end
+end

--- a/enterprise/app/services/enterprise/message_templates/hook_execution_service.rb
+++ b/enterprise/app/services/enterprise/message_templates/hook_execution_service.rb
@@ -3,10 +3,17 @@ module Enterprise::MessageTemplates::HookExecutionService
 
   def trigger_templates
     super
-    return unless should_process_captain_response?
+    return unless captain_conversation_message?
+
+    # Eligibility is demand-level: every inbound customer message in a
+    # Captain-connected inbox counts, including conversations a human grabbed
+    # first or that arrive while the account is over its usage limit —
+    # otherwise the coverage denominator only ever contains conversations
+    # Captain was already about to answer.
+    track_captain_eligibility
+    return unless conversation.pending?
     return perform_handoff unless inbox.captain_active?
 
-    track_captain_engagement
     schedule_captain_response
   end
 
@@ -30,18 +37,12 @@ module Enterprise::MessageTemplates::HookExecutionService
 
   private
 
-  def track_captain_engagement
-    return unless captain_v2_enabled?
-
-    Captain::ConversationEvents.engaged(
+  def track_captain_eligibility
+    Captain::ConversationEvents.eligible(
       conversation: conversation,
       assistant: inbox.captain_assistant,
       at: message.created_at
     )
-  end
-
-  def captain_v2_enabled?
-    conversation.account.feature_enabled?('captain_integration_v2')
   end
 
   def schedule_captain_response
@@ -64,8 +65,8 @@ module Enterprise::MessageTemplates::HookExecutionService
     base_wait + additional_wait
   end
 
-  def should_process_captain_response?
-    conversation.pending? && message.incoming? && inbox.captain_assistant.present?
+  def captain_conversation_message?
+    message.incoming? && inbox.captain_assistant.present?
   end
 
   def perform_handoff
@@ -79,15 +80,13 @@ module Enterprise::MessageTemplates::HookExecutionService
       content: 'Transferring to another agent for further assistance.'
     )
     conversation.bot_handoff!
-    if captain_v2_enabled?
-      Captain::ConversationEvents.handed_off(
-        conversation: conversation,
-        assistant: inbox.captain_assistant,
-        source: 'usage_limit',
-        reason_category: :usage_limit,
-        at: Time.current
-      )
-    end
+    Captain::ConversationEvents.handed_off(
+      conversation: conversation,
+      assistant: inbox.captain_assistant,
+      source: 'usage_limit',
+      reason_category: :usage_limit,
+      at: Time.current
+    )
     send_out_of_office_message_after_handoff
   end
 

--- a/enterprise/app/services/enterprise/message_templates/hook_execution_service.rb
+++ b/enterprise/app/services/enterprise/message_templates/hook_execution_service.rb
@@ -6,6 +6,7 @@ module Enterprise::MessageTemplates::HookExecutionService
     return unless should_process_captain_response?
     return perform_handoff unless inbox.captain_active?
 
+    track_captain_engagement
     schedule_captain_response
   end
 
@@ -28,6 +29,20 @@ module Enterprise::MessageTemplates::HookExecutionService
   end
 
   private
+
+  def track_captain_engagement
+    return unless captain_v2_enabled?
+
+    Captain::ConversationEvents.engaged(
+      conversation: conversation,
+      assistant: inbox.captain_assistant,
+      at: message.created_at
+    )
+  end
+
+  def captain_v2_enabled?
+    conversation.account.feature_enabled?('captain_integration_v2')
+  end
 
   def schedule_captain_response
     job_args = [conversation, conversation.inbox.captain_assistant]
@@ -64,6 +79,15 @@ module Enterprise::MessageTemplates::HookExecutionService
       content: 'Transferring to another agent for further assistance.'
     )
     conversation.bot_handoff!
+    if captain_v2_enabled?
+      Captain::ConversationEvents.handed_off(
+        conversation: conversation,
+        assistant: inbox.captain_assistant,
+        source: 'usage_limit',
+        reason_category: :usage_limit,
+        at: Time.current
+      )
+    end
     send_out_of_office_message_after_handoff
   end
 

--- a/enterprise/lib/captain/tools/handoff_tool.rb
+++ b/enterprise/lib/captain/tools/handoff_tool.rb
@@ -45,6 +45,7 @@ class Captain::Tools::HandoffTool < Captain::Tools::BasePublicTool
 
     # Trigger the bot handoff (sets status to open + dispatches events)
     conversation.bot_handoff!
+    Captain::ConversationEvents.handed_off(conversation: conversation, assistant: @assistant, source: 'tool', at: Time.current)
 
     # Send out of office message if applicable (since template messages were suppressed while Captain was handling)
     send_out_of_office_message_if_applicable(conversation)

--- a/enterprise/lib/captain/tools/handoff_tool.rb
+++ b/enterprise/lib/captain/tools/handoff_tool.rb
@@ -1,8 +1,12 @@
 class Captain::Tools::HandoffTool < Captain::Tools::BasePublicTool
   description 'Hand off the conversation to a human agent when unable to assist further'
   param :reason, type: 'string', desc: 'The reason why handoff is needed (optional)', required: false
+  param :reason_category,
+        type: 'string',
+        desc: 'Reporting category: customer_request, missing_knowledge, unsupported_request, policy_restriction, or tool_failure',
+        required: true
 
-  def perform(tool_context, reason: nil)
+  def perform(tool_context, reason: nil, reason_category: nil)
     conversation = find_conversation(tool_context.state)
     return 'Conversation not found' unless conversation
 
@@ -13,7 +17,7 @@ class Captain::Tools::HandoffTool < Captain::Tools::BasePublicTool
                    })
 
     # Use existing handoff mechanism from ResponseBuilderJob
-    trigger_handoff(tool_context, conversation, reason)
+    trigger_handoff(tool_context, conversation, reason, reason_category)
 
     "Conversation handed off to human support team#{" (Reason: #{reason})" if reason}"
   rescue StandardError => e
@@ -23,7 +27,7 @@ class Captain::Tools::HandoffTool < Captain::Tools::BasePublicTool
 
   private
 
-  def trigger_handoff(tool_context, conversation, reason)
+  def trigger_handoff(tool_context, conversation, reason, reason_category)
     # post the reason as a private note
     note = conversation.messages.create!(
       message_type: :outgoing,
@@ -45,7 +49,8 @@ class Captain::Tools::HandoffTool < Captain::Tools::BasePublicTool
 
     # Trigger the bot handoff (sets status to open + dispatches events)
     conversation.bot_handoff!
-    Captain::ConversationEvents.handed_off(conversation: conversation, assistant: @assistant, source: 'tool', at: Time.current)
+    Captain::ConversationEvents.handed_off(conversation: conversation, assistant: @assistant, source: 'tool', reason_category: reason_category,
+                                           at: Time.current)
 
     # Send out of office message if applicable (since template messages were suppressed while Captain was handling)
     send_out_of_office_message_if_applicable(conversation)

--- a/enterprise/lib/captain/tools/resolve_conversation_tool.rb
+++ b/enterprise/lib/captain/tools/resolve_conversation_tool.rb
@@ -11,6 +11,7 @@ class Captain::Tools::ResolveConversationTool < Captain::Tools::BasePublicTool
     log_tool_usage('resolve_conversation', { conversation_id: conversation.id, reason: reason })
 
     conversation.with_captain_activity_context(reason: reason, reason_type: :tool) { conversation.resolved! }
+    Captain::ConversationEvents.resolved(conversation: conversation, assistant: @assistant, source: 'tool', at: Time.current)
 
     "Conversation ##{conversation.display_id} resolved#{" (Reason: #{reason})" if reason}"
   end

--- a/lib/events/types.rb
+++ b/lib/events/types.rb
@@ -22,8 +22,11 @@ module Events::Types
   # FIXME: deprecate the opened and resolved events in future in favor of status changed event.
   CONVERSATION_OPENED = 'conversation.opened'
   CONVERSATION_RESOLVED = 'conversation.resolved'
-  CONVERSATION_CAPTAIN_INFERENCE_RESOLVED = 'conversation.captain_inference_resolved'
-  CONVERSATION_CAPTAIN_INFERENCE_HANDOFF = 'conversation.captain_inference_handoff'
+  CAPTAIN_CONVERSATION_ENGAGED = 'captain.conversation.engaged'
+  CAPTAIN_CONVERSATION_HANDED_OFF = 'captain.conversation.handed_off'
+  CAPTAIN_CONVERSATION_RESOLVED = 'captain.conversation.resolved'
+  CAPTAIN_RESPONSE_COMPLETED = 'captain.response.completed'
+  CAPTAIN_RESPONSE_FAILED = 'captain.response.failed'
 
   CONVERSATION_STATUS_CHANGED = 'conversation.status_changed'
   CONVERSATION_CONTACT_CHANGED = 'conversation.contact_changed'

--- a/lib/events/types.rb
+++ b/lib/events/types.rb
@@ -22,7 +22,7 @@ module Events::Types
   # FIXME: deprecate the opened and resolved events in future in favor of status changed event.
   CONVERSATION_OPENED = 'conversation.opened'
   CONVERSATION_RESOLVED = 'conversation.resolved'
-  CAPTAIN_CONVERSATION_ENGAGED = 'captain.conversation.engaged'
+  CAPTAIN_CONVERSATION_ELIGIBLE = 'captain.conversation.eligible'
   CAPTAIN_CONVERSATION_HANDED_OFF = 'captain.conversation.handed_off'
   CAPTAIN_CONVERSATION_RESOLVED = 'captain.conversation.resolved'
   CAPTAIN_RESPONSE_COMPLETED = 'captain.response.completed'

--- a/lib/seeders/reports/assistant_conversation_creator.rb
+++ b/lib/seeders/reports/assistant_conversation_creator.rb
@@ -152,7 +152,7 @@ class Seeders::Reports::AssistantConversationCreator
     mark_resolved(conversation, resolved_at)
     travel_to(resolved_at) do
       trigger_event('conversation_resolved', conversation)
-      trigger_event('conversation_captain_inference_resolved', conversation)
+      trigger_captain_event(Events::Types::CAPTAIN_CONVERSATION_RESOLVED, conversation)
     end
     travel_back
   end
@@ -178,7 +178,7 @@ class Seeders::Reports::AssistantConversationCreator
   end
 
   def handoff_to_human(conversation)
-    trigger_event('conversation_captain_inference_handoff', conversation)
+    trigger_captain_event(Events::Types::CAPTAIN_CONVERSATION_HANDED_OFF, conversation)
   end
 
   def mark_resolved(conversation, resolved_at)
@@ -192,6 +192,11 @@ class Seeders::Reports::AssistantConversationCreator
     ReportingEventListener.instance.public_send(
       name, Events::Base.new(name, Time.current, { conversation: conversation })
     )
+  end
+
+  def trigger_captain_event(name, conversation)
+    event = Events::Base.new(name, Time.current, { conversation: conversation, source: 'inference' })
+    Captain::ReportingEventListener.instance.public_send(event.method_name, event)
   end
 
   def trigger_reply_time(message, waiting_since)

--- a/spec/enterprise/builders/captain/assistant_outcome_stats_builder_spec.rb
+++ b/spec/enterprise/builders/captain/assistant_outcome_stats_builder_spec.rb
@@ -1,0 +1,147 @@
+require 'rails_helper'
+
+RSpec.describe Captain::AssistantOutcomeStatsBuilder do
+  subject(:metrics) { described_class.new(assistant, '30').metrics }
+
+  let(:account) { create(:account) }
+  let(:assistant) { create(:captain_assistant, account: account) }
+  let(:inbox) { create(:inbox, account: account) }
+
+  def create_outcome(created_at:, **attributes)
+    conversation = create(:conversation, account: account, inbox: inbox)
+    create(
+      :captain_conversation_outcome,
+      account: account,
+      assistant: assistant,
+      conversation: conversation,
+      inbox: inbox,
+      created_at: created_at,
+      **attributes
+    )
+  end
+
+  context 'with no outcomes' do
+    it 'returns zeroed metrics' do
+      expect(metrics[:eligible_conversations]).to eq(current: 0, previous: 0, trend: 0)
+      expect(metrics[:coverage_rate][:current]).to eq(0)
+      expect(metrics[:durable_resolution_rate][:current]).to eq(0)
+      expect(metrics[:handoff_reasons]).to eq({})
+    end
+  end
+
+  context 'with a demand cohort in the current window' do
+    before do
+      # Autonomous and durable: resolved 20 days ago, never reopened.
+      demand_start = 20.days.ago
+      create_outcome(
+        created_at: demand_start,
+        first_captain_reply_at: demand_start + 30.seconds,
+        captain_reply_count: 1,
+        resolved_at: demand_start + 100.seconds,
+        csat_rating: 5
+      )
+
+      # Autonomous but reopened after resolution: assessable, not durable.
+      demand_start = 20.days.ago
+      create_outcome(
+        created_at: demand_start,
+        first_captain_reply_at: demand_start + 60.seconds,
+        captain_reply_count: 1,
+        resolved_at: demand_start + 200.seconds,
+        last_reopened_at: demand_start + 200.seconds + 1.day,
+        reopen_count: 1
+      )
+
+      # Autonomous but resolved too recently to judge durability.
+      demand_start = 6.days.ago
+      create_outcome(
+        created_at: demand_start,
+        first_captain_reply_at: demand_start + 90.seconds,
+        captain_reply_count: 1,
+        resolved_at: demand_start + 300.seconds
+      )
+
+      # Assisted: Captain replied, then handed off, human closed it out.
+      demand_start = 10.days.ago
+      create_outcome(
+        created_at: demand_start,
+        first_captain_reply_at: demand_start + 120.seconds,
+        captain_reply_count: 2,
+        handoff_at: demand_start + 150.seconds,
+        handoff_reason_category: 'missing_knowledge',
+        first_human_reply_at: demand_start + 250.seconds,
+        resolved_at: demand_start + 400.seconds,
+        csat_rating: 4
+      )
+
+      # Blocked by the usage limit: eligible demand, not involvement.
+      create_outcome(
+        created_at: 5.days.ago,
+        handoff_at: 5.days.ago,
+        handoff_reason_category: 'usage_limit'
+      )
+
+      # Demand Captain never touched.
+      create_outcome(created_at: 4.days.ago)
+
+      # Previous-window demand: one involved, autonomous resolution.
+      demand_start = 45.days.ago
+      create_outcome(
+        created_at: demand_start,
+        first_captain_reply_at: demand_start + 45.seconds,
+        captain_reply_count: 1,
+        resolved_at: demand_start + 500.seconds
+      )
+    end
+
+    it 'counts eligible demand per window with a trend' do
+      expect(metrics[:eligible_conversations]).to eq(current: 6, previous: 1, trend: 500.0)
+    end
+
+    it 'computes coverage as involved over eligible, excluding usage-limit handoffs' do
+      expect(metrics[:coverage_rate][:current]).to eq(66.7)
+      expect(metrics[:coverage_rate][:previous]).to eq(100.0)
+    end
+
+    it 'classifies autonomous and assisted resolutions' do
+      expect(metrics[:autonomous_resolutions][:current]).to eq(3)
+      expect(metrics[:autonomous_resolution_rate][:current]).to eq(50.0)
+      expect(metrics[:assisted_resolutions][:current]).to eq(1)
+    end
+
+    it 'computes durability only over resolutions old enough to judge' do
+      expect(metrics[:durable_resolution_rate][:current]).to eq(50.0)
+    end
+
+    it 'averages CSAT over involved conversations' do
+      expect(metrics[:csat_score][:current]).to eq(4.5)
+    end
+
+    it 'computes median first response and resolution times from the row timestamps' do
+      expect(metrics[:median_first_response_seconds][:current]).to eq(75)
+      expect(metrics[:median_resolution_seconds][:current]).to eq(250)
+    end
+
+    it 'returns the current-window handoff reason distribution' do
+      expect(metrics[:handoff_reasons]).to eq('missing_knowledge' => 1, 'usage_limit' => 1)
+    end
+  end
+
+  describe 'human-only CSAT baseline' do
+    it 'averages CSAT for conversations without Captain involvement' do
+      create(:csat_survey_response, account: account, rating: 3, created_at: 5.days.ago)
+
+      involved = create_outcome(created_at: 5.days.ago, first_captain_reply_at: 5.days.ago, csat_rating: 5)
+      create(
+        :csat_survey_response,
+        account: account,
+        conversation: involved.conversation,
+        contact: involved.conversation.contact,
+        rating: 5,
+        created_at: 5.days.ago
+      )
+
+      expect(metrics[:human_only_csat_score][:current]).to eq(3.0)
+    end
+  end
+end

--- a/spec/enterprise/builders/captain/assistant_stats_builder_spec.rb
+++ b/spec/enterprise/builders/captain/assistant_stats_builder_spec.rb
@@ -7,19 +7,41 @@ RSpec.describe Captain::AssistantStatsBuilder do
 
   before { create(:captain_inbox, captain_assistant: assistant, inbox: inbox) }
 
+  def create_outcome(created_at:, **attributes)
+    conversation = create(:conversation, account: account, inbox: inbox)
+    create(
+      :captain_conversation_outcome,
+      account: account,
+      assistant: assistant,
+      conversation: conversation,
+      inbox: inbox,
+      created_at: created_at,
+      **attributes
+    )
+  end
+
   describe '#metrics' do
     # Two conversations handled in the current 30-day window, one in the previous.
-    let(:current_convo_a) { create(:conversation, account: account, inbox: inbox) }
-    let(:current_convo_b) { create(:conversation, account: account, inbox: inbox) }
-    let(:previous_convo) { create(:conversation, account: account, inbox: inbox) }
+    # convo_a resolved autonomously; convo_b was handed off.
+    let!(:current_outcome_a) do
+      create_outcome(created_at: 5.days.ago, first_captain_reply_at: 5.days.ago, resolved_at: 4.days.ago)
+    end
+    let!(:current_outcome_b) do
+      create_outcome(
+        created_at: 5.days.ago,
+        first_captain_reply_at: 5.days.ago,
+        handoff_at: 5.days.ago,
+        handoff_reason_category: 'missing_knowledge'
+      )
+    end
 
     before do
-      [current_convo_a, current_convo_b].each do |conversation|
-        create(:message, account: account, inbox: inbox, conversation: conversation,
+      create_outcome(created_at: 45.days.ago, first_captain_reply_at: 45.days.ago)
+
+      [current_outcome_a, current_outcome_b].each do |outcome|
+        create(:message, account: account, inbox: inbox, conversation: outcome.conversation,
                          sender: assistant, message_type: :outgoing, private: false, created_at: 5.days.ago)
       end
-      create(:message, account: account, inbox: inbox, conversation: previous_convo,
-                       sender: assistant, message_type: :outgoing, private: false, created_at: 45.days.ago)
     end
 
     it 'returns every metric for the current and previous window' do
@@ -32,7 +54,7 @@ RSpec.describe Captain::AssistantStatsBuilder do
       expect(metrics[:conversations_handled]).to include(:current, :previous, :trend)
     end
 
-    it 'counts distinct handled conversations per window and the percent trend' do
+    it 'counts involved conversations per window and the percent trend' do
       handled = described_class.new(assistant, '30').metrics[:conversations_handled]
 
       expect(handled[:current]).to eq(2)
@@ -40,56 +62,29 @@ RSpec.describe Captain::AssistantStatsBuilder do
       expect(handled[:trend]).to eq(100.0)
     end
 
-    it 'derives auto-resolution and handoff rates from reporting events on the handled set' do
-      create(:reporting_event, account: account, conversation: current_convo_a,
-                               name: 'conversation_captain_inference_resolved')
-      create(:reporting_event, account: account, conversation: current_convo_b,
-                               name: 'conversation_captain_inference_handoff')
-
+    it 'derives auto-resolution and handoff rates from the outcome rows' do
       metrics = described_class.new(assistant, '30').metrics
 
       expect(metrics[:auto_resolution_rate][:current]).to eq(50.0)
       expect(metrics[:handoff_rate][:current]).to eq(50.0)
     end
 
-    it 'does not count a bot resolve as an auto-resolution when the conversation was handed off' do
-      # convo_a: handoff, customer goes quiet, resolve lands without an agent message, so the
-      # listener still emits conversation_bot_resolved for the handed-off conversation. It must
-      # not count as an auto-resolution, but still counts as a handoff.
-      create(:reporting_event, account: account, conversation: current_convo_a,
-                               name: 'conversation_bot_handoff')
-      create(:reporting_event, account: account, conversation: current_convo_a,
-                               name: 'conversation_bot_resolved')
-      # convo_b: a clean bot resolve with no handoff still counts, so the exclusion is scoped
-      # to handed-off conversations and doesn't drop every bot resolve.
-      create(:reporting_event, account: account, conversation: current_convo_b,
-                               name: 'conversation_bot_resolved')
+    it 'does not count untouched or usage-limit-blocked demand as handled' do
+      create_outcome(created_at: 4.days.ago)
+      create_outcome(created_at: 4.days.ago, handoff_at: 4.days.ago, handoff_reason_category: 'usage_limit')
 
-      metrics = described_class.new(assistant, '30').metrics
-
-      expect(metrics[:auto_resolution_rate][:current]).to eq(50.0)
-      expect(metrics[:handoff_rate][:current]).to eq(50.0)
+      expect(described_class.new(assistant, '30').metrics[:conversations_handled][:current]).to eq(2)
     end
 
-    it 'still counts an inference resolve when the conversation was also handed off' do
-      create(:reporting_event, account: account, conversation: current_convo_a,
-                               name: 'conversation_captain_inference_handoff')
-      create(:reporting_event, account: account, conversation: current_convo_a,
-                               name: 'conversation_captain_inference_resolved')
+    it 'does not count a resolution as autonomous when a human replied before it' do
+      current_outcome_a.update!(first_human_reply_at: 5.days.ago)
 
-      metrics = described_class.new(assistant, '30').metrics
-
-      expect(metrics[:auto_resolution_rate][:current]).to eq(50.0)
-      expect(metrics[:handoff_rate][:current]).to eq(50.0)
+      expect(described_class.new(assistant, '30').metrics[:auto_resolution_rate][:current]).to eq(0.0)
     end
 
-    it 'excludes resolution events that fall outside the current window' do
-      create(:reporting_event, account: account, conversation: current_convo_a,
-                               name: 'conversation_captain_inference_resolved', created_at: 60.days.ago)
-
-      metrics = described_class.new(assistant, '30').metrics
-
-      expect(metrics[:auto_resolution_rate][:current]).to eq(0.0)
+    it 'excludes demand that entered outside the current window' do
+      expect(described_class.new(assistant, '7').metrics[:conversations_handled][:current]).to eq(2)
+      expect(described_class.new(assistant, '7').metrics[:conversations_handled][:previous]).to eq(0)
     end
 
     it 'computes conversation depth as public replies per handled conversation' do
@@ -100,7 +95,7 @@ RSpec.describe Captain::AssistantStatsBuilder do
     end
 
     it 'ignores private notes and incoming messages when counting public replies' do
-      create(:message, account: account, inbox: inbox, conversation: current_convo_a,
+      create(:message, account: account, inbox: inbox, conversation: current_outcome_a.conversation,
                        sender: assistant, message_type: :outgoing, private: true, created_at: 5.days.ago)
 
       depth = described_class.new(assistant, '30').metrics[:conversation_depth]
@@ -124,88 +119,32 @@ RSpec.describe Captain::AssistantStatsBuilder do
   end
 
   describe '#metrics reopen_rate' do
-    # A conversation the assistant handled (messaged) inside the current 30-day window.
-    let(:conversation) { create(:conversation, account: account, inbox: inbox) }
-
-    before do
-      create(:message, account: account, inbox: inbox, conversation: conversation,
-                       sender: assistant, message_type: :outgoing, private: false, created_at: 8.days.ago)
-    end
-
-    it 'counts a reopen that happened after the captain resolve' do
-      create(:reporting_event, account: account, inbox: inbox, conversation: conversation,
-                               name: 'conversation_bot_resolved', event_start_time: 6.days.ago, event_end_time: 6.days.ago)
-      create(:reporting_event, account: account, inbox: inbox, conversation: conversation,
-                               name: 'conversation_opened', value: 120, event_start_time: 6.days.ago, event_end_time: 4.days.ago)
-
-      expect(described_class.new(assistant, '30').metrics[:reopen_rate][:current]).to eq(100.0)
-    end
-
-    it 'ignores a human resolve/reopen that happened before the captain resolve' do
-      # Earlier resolve/reopen cycle, then Captain resolves later in the same window.
-      create(:reporting_event, account: account, inbox: inbox, conversation: conversation,
-                               name: 'conversation_opened', value: 120, event_start_time: 20.days.ago, event_end_time: 18.days.ago)
-      create(:reporting_event, account: account, inbox: inbox, conversation: conversation,
-                               name: 'conversation_bot_resolved', event_start_time: 5.days.ago, event_end_time: 5.days.ago)
-
-      expect(described_class.new(assistant, '30').metrics[:reopen_rate][:current]).to eq(0.0)
-    end
-
-    it 'counts an evaluated-path reopen when bot_resolved is skipped and the inference event is newer' do
-      # Prior human reply => create_bot_resolved_event skips conversation_bot_resolved, so the cohort
-      # only holds the inference event, which is dispatched a moment after the generic conversation_resolved
-      # that seeds the reopen's event_start_time. The match must use the reopen's actual reopen time.
-      create(:reporting_event, account: account, inbox: inbox, conversation: conversation,
-                               name: 'conversation_captain_inference_resolved',
-                               event_start_time: 6.days.ago, event_end_time: 6.days.ago + 1.second)
-      create(:reporting_event, account: account, inbox: inbox, conversation: conversation,
-                               name: 'conversation_opened', value: 120, event_start_time: 6.days.ago, event_end_time: 3.days.ago)
-
-      expect(described_class.new(assistant, '30').metrics[:reopen_rate][:current]).to eq(100.0)
-    end
-
-    it 'counts both inference and time-based bot resolves in the denominator' do
-      # conversation: inference-resolved and reopened
-      create(:reporting_event, account: account, inbox: inbox, conversation: conversation,
-                               name: 'conversation_captain_inference_resolved', event_start_time: 6.days.ago, event_end_time: 6.days.ago)
-      create(:reporting_event, account: account, inbox: inbox, conversation: conversation,
-                               name: 'conversation_opened', value: 120, event_start_time: 6.days.ago, event_end_time: 4.days.ago)
-      # other: time-based bot-resolved, never reopened
-      other = create(:conversation, account: account, inbox: inbox)
-      create(:message, account: account, inbox: inbox, conversation: other,
-                       sender: assistant, message_type: :outgoing, private: false, created_at: 8.days.ago)
-      create(:reporting_event, account: account, inbox: inbox, conversation: other,
-                               name: 'conversation_bot_resolved', event_start_time: 6.days.ago, event_end_time: 6.days.ago)
+    it 'counts autonomously resolved conversations that reopened afterwards' do
+      create_outcome(
+        created_at: 8.days.ago,
+        first_captain_reply_at: 8.days.ago,
+        resolved_at: 6.days.ago,
+        last_reopened_at: 4.days.ago,
+        reopen_count: 1
+      )
+      create_outcome(created_at: 8.days.ago, first_captain_reply_at: 8.days.ago, resolved_at: 6.days.ago)
 
       expect(described_class.new(assistant, '30').metrics[:reopen_rate][:current]).to eq(50.0)
     end
 
-    it 'ignores a reopen that landed after a completed window ended' do
-      travel_to(Time.utc(2026, 7, 15)) do
-        convo = create(:conversation, account: account, inbox: inbox)
-        create(:message, account: account, inbox: inbox, conversation: convo,
-                         sender: assistant, message_type: :outgoing, private: false, created_at: Time.utc(2026, 6, 10))
-        create(:reporting_event, account: account, inbox: inbox, conversation: convo,
-                                 name: 'conversation_bot_resolved', created_at: Time.utc(2026, 6, 12),
-                                 event_start_time: Time.utc(2026, 6, 12), event_end_time: Time.utc(2026, 6, 12))
-        # Reopened on July 1, after the June window closed; June's rate must not count it.
-        create(:reporting_event, account: account, inbox: inbox, conversation: convo,
-                                 name: 'conversation_opened', value: 120,
-                                 event_start_time: Time.utc(2026, 6, 12), event_end_time: Time.utc(2026, 7, 1))
+    it 'scopes the denominator to autonomous resolutions' do
+      # Handed off then resolved: assisted, so it joins neither side of the rate.
+      create_outcome(
+        created_at: 8.days.ago,
+        first_captain_reply_at: 8.days.ago,
+        handoff_at: 7.days.ago,
+        handoff_reason_category: 'customer_request',
+        resolved_at: 6.days.ago,
+        last_reopened_at: 4.days.ago,
+        reopen_count: 1
+      )
 
-        expect(described_class.new(assistant, 'last_month').metrics[:reopen_rate][:current]).to eq(0.0)
-      end
-    end
-
-    it 'derives the cohort from handled conversations, not current inbox membership' do
-      create(:reporting_event, account: account, inbox: inbox, conversation: conversation,
-                               name: 'conversation_captain_inference_resolved', event_start_time: 6.days.ago, event_end_time: 6.days.ago)
-      create(:reporting_event, account: account, inbox: inbox, conversation: conversation,
-                               name: 'conversation_opened', value: 120, event_start_time: 6.days.ago, event_end_time: 4.days.ago)
-      # The assistant is later removed from the inbox; the cohort must still resolve via handled messages.
-      CaptainInbox.where(captain_assistant: assistant).delete_all
-
-      expect(described_class.new(assistant, '30').metrics[:reopen_rate][:current]).to eq(100.0)
+      expect(described_class.new(assistant, '30').metrics[:reopen_rate][:current]).to eq(0)
     end
   end
 

--- a/spec/enterprise/controllers/api/v1/accounts/captain/assistants_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/assistants_controller_spec.rb
@@ -252,6 +252,33 @@ RSpec.describe 'Api::V1::Accounts::Captain::Assistants', type: :request do
     end
   end
 
+  describe 'GET /api/v1/accounts/{account.id}/captain/assistants/{id}/outcome_metrics' do
+    let(:assistant) { create(:captain_assistant, account: account) }
+    let(:inbox) { create(:inbox, account: account) }
+
+    it 'returns the outcome metrics for the assistant' do
+      conversation = create(:conversation, account: account, inbox: inbox)
+      create(
+        :captain_conversation_outcome,
+        account: account,
+        assistant: assistant,
+        conversation: conversation,
+        inbox: inbox,
+        first_captain_reply_at: 1.day.ago,
+        resolved_at: 1.day.ago
+      )
+
+      get "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/outcome_metrics",
+          headers: admin.create_new_auth_token,
+          as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(json_response[:eligible_conversations]).to include(current: 1)
+      expect(json_response[:coverage_rate]).to include(current: 100.0)
+      expect(json_response).to have_key(:handoff_reasons)
+    end
+  end
+
   describe 'GET /api/v1/accounts/{account.id}/captain/assistants/{id}/faq_stats' do
     let(:assistant) { create(:captain_assistant, account: account) }
 

--- a/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
+++ b/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe Captain::Conversation::ResponseBuilderJob, type: :job do
         expect(conversation.messages.last.content).to eq('Hey, welcome to Captain Specs')
       end
 
+      it 'does not emit captain lifecycle events' do
+        expect(Captain::ConversationEvents).not_to receive(:response_completed)
+
+        described_class.perform_now(conversation, assistant)
+      end
+
       it 'keeps the default message history limited to public chat messages' do
         create(
           :message,
@@ -410,6 +416,24 @@ RSpec.describe Captain::Conversation::ResponseBuilderJob, type: :job do
         described_class.perform_now(conversation, assistant)
         account.reload
         expect(account.usage_limits[:captain][:responses][:consumed]).to eq(1)
+      end
+
+      it 'emits a response completed event' do
+        expect(Captain::ConversationEvents).to receive(:response_completed)
+          .with(conversation: conversation, assistant: assistant, message: kind_of(Message), at: kind_of(Time))
+
+        described_class.perform_now(conversation, assistant)
+      end
+
+      it 'emits response failed and generation failure handoff events when generation errors' do
+        allow(mock_agent_runner_service).to receive(:generate_response).and_raise(StandardError, 'llm down')
+
+        expect(Captain::ConversationEvents).to receive(:response_failed)
+          .with(conversation: conversation, assistant: assistant, reason: 'standard_error', at: kind_of(Time))
+        expect(Captain::ConversationEvents).to receive(:handed_off)
+          .with(conversation: conversation, assistant: assistant, source: 'generation_failure', reason_category: :tool_failure, at: kind_of(Time))
+
+        described_class.perform_now(conversation, assistant)
       end
     end
 

--- a/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
+++ b/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
@@ -425,7 +425,21 @@ RSpec.describe Captain::Conversation::ResponseBuilderJob, type: :job do
         described_class.perform_now(conversation, assistant)
       end
 
-      it 'emits response failed and generation failure handoff events when generation errors' do
+      it 'emits response failed and generation failure handoff events when the runner returns an error response' do
+        allow(mock_agent_runner_service).to receive(:generate_response).and_return(
+          { 'response' => 'conversation_handoff', 'reasoning' => 'Error occurred: llm down', 'error' => true,
+            'error_reason' => 'standard_error', 'handoff_tool_called' => false }
+        )
+
+        expect(Captain::ConversationEvents).to receive(:response_failed)
+          .with(conversation: conversation, assistant: assistant, reason: 'standard_error', at: kind_of(Time))
+        expect(Captain::ConversationEvents).to receive(:handed_off)
+          .with(conversation: conversation, assistant: assistant, source: 'generation_failure', reason_category: :tool_failure, at: kind_of(Time))
+
+        described_class.perform_now(conversation, assistant)
+      end
+
+      it 'emits response failed and generation failure handoff events when generation raises' do
         allow(mock_agent_runner_service).to receive(:generate_response).and_raise(StandardError, 'llm down')
 
         expect(Captain::ConversationEvents).to receive(:response_failed)

--- a/spec/enterprise/lib/captain/tools/handoff_tool_spec.rb
+++ b/spec/enterprise/lib/captain/tools/handoff_tool_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Captain::Tools::HandoffTool, type: :model do
       expect(tool.parameters[:reason].type).to eq('string')
       expect(tool.parameters[:reason].description).to eq('The reason why handoff is needed (optional)')
       expect(tool.parameters[:reason].required).to be false
+      expect(tool.parameters[:reason_category].required).to be true
     end
   end
 
@@ -63,11 +64,33 @@ RSpec.describe Captain::Tools::HandoffTool, type: :model do
           tool.perform(tool_context, reason: 'Test reason')
         end
 
-        it 'emits a captain handoff event with the tool source' do
+        it 'emits a captain handoff event with the tool source and reason category' do
           expect(Captain::ConversationEvents).to receive(:handed_off)
-            .with(conversation: conversation, assistant: assistant, source: 'tool', at: kind_of(Time))
+            .with(conversation: conversation, assistant: assistant, source: 'tool', reason_category: 'unsupported_request', at: kind_of(Time))
 
-          tool.perform(tool_context, reason: 'Test reason')
+          tool.perform(tool_context, reason: 'Test reason', reason_category: 'unsupported_request')
+        end
+
+        it 'records the handoff on an existing V2 outcome' do
+          account.enable_features!('captain_integration_v2')
+          create(
+            :captain_conversation_outcome,
+            account: account,
+            assistant: assistant,
+            conversation: conversation,
+            inbox: inbox
+          )
+
+          tool.perform(
+            tool_context,
+            reason: 'Customer needs specialized support',
+            reason_category: 'unsupported_request'
+          )
+
+          expect(Captain::ConversationOutcome.last).to have_attributes(
+            handoff_reason_category: 'unsupported_request',
+            handoff_at: be_present
+          )
         end
 
         it 'creates a conversation_bot_handoff reporting event' do

--- a/spec/enterprise/lib/captain/tools/handoff_tool_spec.rb
+++ b/spec/enterprise/lib/captain/tools/handoff_tool_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe Captain::Tools::HandoffTool, type: :model do
           tool.perform(tool_context, reason: 'Test reason')
         end
 
+        it 'emits a captain handoff event with the tool source' do
+          expect(Captain::ConversationEvents).to receive(:handed_off)
+            .with(conversation: conversation, assistant: assistant, source: 'tool', at: kind_of(Time))
+
+          tool.perform(tool_context, reason: 'Test reason')
+        end
+
         it 'creates a conversation_bot_handoff reporting event' do
           create(:captain_inbox, captain_assistant: assistant, inbox: inbox)
           Current.executed_by = assistant

--- a/spec/enterprise/lib/captain/tools/resolve_conversation_tool_spec.rb
+++ b/spec/enterprise/lib/captain/tools/resolve_conversation_tool_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe Captain::Tools::ResolveConversationTool do
       )
     end
 
+    it 'emits a captain resolution event with the tool source' do
+      expect(Captain::ConversationEvents).to receive(:resolved)
+        .with(conversation: conversation, assistant: assistant, source: 'tool', at: kind_of(Time))
+
+      tool.perform(tool_context, reason: 'Possible spam')
+    end
+
     it 'creates a conversation_resolved reporting event' do
       create(:captain_inbox, captain_assistant: assistant, inbox: inbox)
 
@@ -64,6 +71,12 @@ RSpec.describe Captain::Tools::ResolveConversationTool do
 
   describe 'resolving an already resolved conversation' do
     let(:conversation) { create(:conversation, account: account, inbox: inbox, status: :resolved) }
+
+    it 'does not emit a captain resolution event' do
+      expect(Captain::ConversationEvents).not_to receive(:resolved)
+
+      tool.perform(tool_context, reason: 'Possible spam')
+    end
 
     it 'does not re-resolve and returns an already resolved message' do
       queue_adapter = ActiveJob::Base.queue_adapter

--- a/spec/enterprise/listeners/captain/reporting_event_listener_spec.rb
+++ b/spec/enterprise/listeners/captain/reporting_event_listener_spec.rb
@@ -1,39 +1,48 @@
 require 'rails_helper'
 
-RSpec.describe ReportingEventListener do
+RSpec.describe Captain::ReportingEventListener do
   let(:listener) { described_class.instance }
   let(:account) { create(:account) }
   let(:inbox) { create(:inbox, account: account) }
   let(:conversation) { create(:conversation, account: account, inbox: inbox) }
   let(:assistant) { create(:captain_assistant, account: account) }
-  let(:decision_time) { Time.zone.now }
 
   describe '#captain_conversation_resolved' do
     it 'creates a captain inference resolved reporting event for inference resolutions' do
+      decision_time = conversation.created_at + 60.seconds
       event = Events::Base.new(
         Events::Types::CAPTAIN_CONVERSATION_RESOLVED, decision_time,
         conversation: conversation, assistant: assistant, source: 'inference'
       )
 
-      expect { listener.captain_conversation_resolved(event) }
-        .to change { account.reporting_events.where(name: 'conversation_captain_inference_resolved').count }.by(1)
+      listener.captain_conversation_resolved(event)
+
+      reporting_event = account.reporting_events.where(name: 'conversation_captain_inference_resolved').first
+      expect(reporting_event).to be_present
+      expect(reporting_event.value).to eq 60
+      expect(reporting_event.event_end_time).to be_within(1.second).of(decision_time)
     end
   end
 
   describe '#captain_conversation_handed_off' do
     it 'creates a captain inference handoff reporting event for inference handoffs' do
+      decision_time = conversation.created_at + 90.seconds
       event = Events::Base.new(
         Events::Types::CAPTAIN_CONVERSATION_HANDED_OFF, decision_time,
         conversation: conversation, assistant: assistant, source: 'inference', reason_category: :pending_clarification
       )
 
-      expect { listener.captain_conversation_handed_off(event) }
-        .to change { account.reporting_events.where(name: 'conversation_captain_inference_handoff').count }.by(1)
+      listener.captain_conversation_handed_off(event)
+
+      reporting_event = account.reporting_events.where(name: 'conversation_captain_inference_handoff').first
+      expect(reporting_event).to be_present
+      expect(reporting_event.value).to eq 90
+      expect(reporting_event.event_end_time).to be_within(1.second).of(decision_time)
     end
 
     it 'does not create a reporting event for non-inference handoffs' do
       event = Events::Base.new(
-        Events::Types::CAPTAIN_CONVERSATION_HANDED_OFF, decision_time,
+        Events::Types::CAPTAIN_CONVERSATION_HANDED_OFF, Time.zone.now,
         conversation: conversation, assistant: assistant, source: 'tool', reason_category: nil
       )
 

--- a/spec/enterprise/listeners/captain_listener_spec.rb
+++ b/spec/enterprise/listeners/captain_listener_spec.rb
@@ -49,5 +49,153 @@ describe CaptainListener do
         listener.conversation_resolved(event)
       end
     end
+
+    it 'records the resolution on an existing V2 outcome' do
+      assistant.update!(config: {})
+      outcome = create(
+        :captain_conversation_outcome,
+        account: account,
+        assistant: assistant,
+        conversation: conversation,
+        inbox: inbox
+      )
+
+      listener.conversation_resolved(event)
+
+      expect(outcome.reload.resolved_at).to eq(event.timestamp)
+    end
+  end
+
+  describe '#message_created' do
+    let(:conversation) { create(:conversation, account: account, inbox: inbox, status: :pending) }
+
+    before do
+      account.enable_features!('captain_integration_v2')
+      create(:captain_inbox, captain_assistant: assistant, inbox: inbox)
+      create(
+        :captain_conversation_outcome,
+        account: account,
+        assistant: assistant,
+        conversation: conversation,
+        inbox: inbox
+      )
+    end
+
+    it 'records public Captain replies' do
+      message = create(
+        :message,
+        account: account,
+        inbox: inbox,
+        conversation: conversation,
+        sender: assistant,
+        message_type: :outgoing
+      )
+      event = Events::Base.new(:message_created, message.created_at, message: message)
+
+      listener.message_created(event)
+
+      expect(Captain::ConversationOutcome.last).to have_attributes(
+        first_captain_reply_at: message.created_at,
+        captain_reply_count: 1
+      )
+    end
+
+    it 'ignores Captain messages without an existing V2 outcome' do
+      Captain::ConversationOutcome.delete_all
+      message = create(
+        :message,
+        account: account,
+        inbox: inbox,
+        conversation: conversation,
+        sender: assistant,
+        message_type: :outgoing
+      )
+      event = Events::Base.new(:message_created, message.created_at, message: message)
+
+      expect do
+        listener.message_created(event)
+      end.not_to change(Captain::ConversationOutcome, :count)
+    end
+
+    it 'records public human replies on the existing outcome' do
+      message = create(
+        :message,
+        account: account,
+        inbox: inbox,
+        conversation: conversation,
+        sender: user,
+        message_type: :outgoing
+      )
+      event = Events::Base.new(:message_created, message.created_at, message: message)
+
+      listener.message_created(event)
+
+      expect(Captain::ConversationOutcome.last.first_human_reply_at).to eq(message.created_at)
+    end
+  end
+
+  describe '#conversation_opened' do
+    let(:conversation) { create(:conversation, account: account, inbox: inbox, status: :open) }
+    let!(:outcome) do
+      create(
+        :captain_conversation_outcome,
+        account: account,
+        assistant: assistant,
+        conversation: conversation,
+        inbox: inbox,
+        resolved_at: 2.minutes.ago
+      )
+    end
+
+    it 'records a reopening after a Captain outcome was resolved' do
+      event = Events::Base.new(:conversation_opened, Time.current, conversation: conversation)
+
+      listener.conversation_opened(event)
+
+      expect(outcome.reload).to have_attributes(
+        reopen_count: 1,
+        last_reopened_at: event.timestamp
+      )
+    end
+  end
+
+  describe '#message_updated' do
+    let(:conversation) { create(:conversation, account: account, inbox: inbox) }
+    let!(:outcome) do
+      create(
+        :captain_conversation_outcome,
+        account: account,
+        assistant: assistant,
+        conversation: conversation,
+        inbox: inbox
+      )
+    end
+
+    it 'records a submitted CSAT response' do
+      message = create(
+        :message,
+        account: account,
+        inbox: inbox,
+        conversation: conversation,
+        content_type: :input_csat,
+        message_type: :outgoing
+      )
+      response = create(
+        :csat_survey_response,
+        account: account,
+        conversation: conversation,
+        contact: conversation.contact,
+        message: message,
+        rating: 5
+      )
+      event = Events::Base.new(:message_updated, Time.current, message: message)
+
+      listener.message_updated(event)
+
+      expect(outcome.reload).to have_attributes(
+        csat_rating: 5,
+        csat_received_at: response.created_at
+      )
+    end
   end
 end

--- a/spec/enterprise/listeners/enterprise/reporting_event_listener_spec.rb
+++ b/spec/enterprise/listeners/enterprise/reporting_event_listener_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe ReportingEventListener do
+  let(:listener) { described_class.instance }
+  let(:account) { create(:account) }
+  let(:inbox) { create(:inbox, account: account) }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox) }
+  let(:assistant) { create(:captain_assistant, account: account) }
+  let(:decision_time) { Time.zone.now }
+
+  describe '#captain_conversation_resolved' do
+    it 'creates a captain inference resolved reporting event for inference resolutions' do
+      event = Events::Base.new(
+        Events::Types::CAPTAIN_CONVERSATION_RESOLVED, decision_time,
+        conversation: conversation, assistant: assistant, source: 'inference'
+      )
+
+      expect { listener.captain_conversation_resolved(event) }
+        .to change { account.reporting_events.where(name: 'conversation_captain_inference_resolved').count }.by(1)
+    end
+  end
+
+  describe '#captain_conversation_handed_off' do
+    it 'creates a captain inference handoff reporting event for inference handoffs' do
+      event = Events::Base.new(
+        Events::Types::CAPTAIN_CONVERSATION_HANDED_OFF, decision_time,
+        conversation: conversation, assistant: assistant, source: 'inference', reason_category: :pending_clarification
+      )
+
+      expect { listener.captain_conversation_handed_off(event) }
+        .to change { account.reporting_events.where(name: 'conversation_captain_inference_handoff').count }.by(1)
+    end
+
+    it 'does not create a reporting event for non-inference handoffs' do
+      event = Events::Base.new(
+        Events::Types::CAPTAIN_CONVERSATION_HANDED_OFF, decision_time,
+        conversation: conversation, assistant: assistant, source: 'tool', reason_category: nil
+      )
+
+      expect { listener.captain_conversation_handed_off(event) }
+        .not_to(change { account.reporting_events.count })
+    end
+  end
+end

--- a/spec/enterprise/models/captain/conversation_outcome_spec.rb
+++ b/spec/enterprise/models/captain/conversation_outcome_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Captain::ConversationOutcome, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:account) }
+    it { is_expected.to belong_to(:assistant).class_name('Captain::Assistant') }
+    it { is_expected.to belong_to(:conversation).class_name('::Conversation') }
+    it { is_expected.to belong_to(:inbox) }
+  end
+
+  describe 'enums' do
+    it {
+      expect(subject).to define_enum_for(:handoff_reason_category)
+        .with_values(described_class::HANDOFF_REASON_CATEGORIES.index_by(&:itself))
+        .backed_by_column_of_type(:string)
+        .with_prefix(:handoff_reason)
+    }
+  end
+
+  describe 'validations' do
+    it 'requires a reason category when a handoff is recorded' do
+      outcome = build(:captain_conversation_outcome, handoff_at: Time.current)
+
+      expect(outcome).not_to be_valid
+      expect(outcome.errors[:handoff_reason_category]).to be_present
+    end
+
+    it 'requires unique conversations per assistant and account' do
+      existing = create(:captain_conversation_outcome)
+      duplicate = build(
+        :captain_conversation_outcome,
+        account: existing.account,
+        assistant: existing.assistant,
+        conversation: existing.conversation,
+        inbox: existing.inbox
+      )
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:conversation_id]).to be_present
+    end
+  end
+
+  it 'builds a valid outcome' do
+    expect(build(:captain_conversation_outcome)).to be_valid
+  end
+end

--- a/spec/enterprise/services/captain/assistant/agent_runner_service_spec.rb
+++ b/spec/enterprise/services/captain/assistant/agent_runner_service_spec.rb
@@ -241,6 +241,8 @@ RSpec.describe Captain::Assistant::AgentRunnerService do
         expect(result).to eq({
                                'response' => 'conversation_handoff',
                                'reasoning' => 'Error occurred: Test error',
+                               'error' => true,
+                               'error_reason' => 'standard_error',
                                'handoff_tool_called' => false
                              })
       end
@@ -269,6 +271,8 @@ RSpec.describe Captain::Assistant::AgentRunnerService do
           expect(result).to eq({
                                  'response' => 'conversation_handoff',
                                  'reasoning' => 'Error occurred: Test error',
+                                 'error' => true,
+                                 'error_reason' => 'standard_error',
                                  'handoff_tool_called' => false
                                })
         end
@@ -293,6 +297,8 @@ RSpec.describe Captain::Assistant::AgentRunnerService do
           expect(result).to eq({
                                  'response' => 'conversation_handoff',
                                  'reasoning' => 'Error occurred: Test error',
+                                 'error' => true,
+                                 'error_reason' => 'standard_error',
                                  'handoff_tool_called' => true
                                })
         end

--- a/spec/enterprise/services/captain/conversation_events_spec.rb
+++ b/spec/enterprise/services/captain/conversation_events_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Captain::ConversationEvents do
+  let(:account) { create(:account) }
+  let(:conversation) { create(:conversation, account: account) }
+  let(:assistant) { create(:captain_assistant, account: account) }
+  let(:timestamp) { Time.zone.now }
+
+  describe '.engaged' do
+    it 'dispatches the engagement event with normalized context' do
+      expect(Rails.configuration.dispatcher).to receive(:dispatch).with(
+        Events::Types::CAPTAIN_CONVERSATION_ENGAGED,
+        timestamp,
+        { conversation: conversation, assistant: assistant }
+      )
+
+      described_class.engaged(conversation: conversation, assistant: assistant, at: timestamp)
+    end
+  end
+
+  describe '.handed_off' do
+    it 'dispatches the handoff event with source and reason category' do
+      expect(Rails.configuration.dispatcher).to receive(:dispatch).with(
+        Events::Types::CAPTAIN_CONVERSATION_HANDED_OFF,
+        timestamp,
+        { conversation: conversation, assistant: assistant, source: 'inference', reason_category: :pending_clarification }
+      )
+
+      described_class.handed_off(
+        conversation: conversation, assistant: assistant, source: 'inference', reason_category: :pending_clarification, at: timestamp
+      )
+    end
+  end
+
+  describe '.resolved' do
+    it 'dispatches the resolution event with source' do
+      expect(Rails.configuration.dispatcher).to receive(:dispatch).with(
+        Events::Types::CAPTAIN_CONVERSATION_RESOLVED,
+        timestamp,
+        { conversation: conversation, assistant: assistant, source: 'inference' }
+      )
+
+      described_class.resolved(conversation: conversation, assistant: assistant, source: 'inference', at: timestamp)
+    end
+  end
+
+  describe '.response_completed' do
+    it 'dispatches the response completed event with the result message' do
+      message = create(:message, conversation: conversation, account: account)
+
+      expect(Rails.configuration.dispatcher).to receive(:dispatch).with(
+        Events::Types::CAPTAIN_RESPONSE_COMPLETED,
+        timestamp,
+        { conversation: conversation, assistant: assistant, message: message }
+      )
+
+      described_class.response_completed(conversation: conversation, assistant: assistant, message: message, at: timestamp)
+    end
+  end
+
+  describe '.response_failed' do
+    it 'dispatches the response failed event with the failure reason' do
+      expect(Rails.configuration.dispatcher).to receive(:dispatch).with(
+        Events::Types::CAPTAIN_RESPONSE_FAILED,
+        timestamp,
+        { conversation: conversation, assistant: assistant, reason: 'faraday_bad_request_error' }
+      )
+
+      described_class.response_failed(conversation: conversation, assistant: assistant, reason: 'faraday_bad_request_error', at: timestamp)
+    end
+  end
+end

--- a/spec/enterprise/services/captain/conversation_events_spec.rb
+++ b/spec/enterprise/services/captain/conversation_events_spec.rb
@@ -58,6 +58,22 @@ RSpec.describe Captain::ConversationEvents do
     end
   end
 
+  describe 'when dispatch fails' do
+    it 'captures the exception instead of raising into the Captain flow' do
+      conversation
+      assistant
+      error = StandardError.new('redis down')
+      allow(Rails.configuration.dispatcher).to receive(:dispatch).and_raise(error)
+      expect(ChatwootExceptionTracker).to receive(:new)
+        .with(error, account: account)
+        .and_return(instance_double(ChatwootExceptionTracker, capture_exception: true))
+
+      expect do
+        described_class.engaged(conversation: conversation, assistant: assistant, at: timestamp)
+      end.not_to raise_error
+    end
+  end
+
   describe '.response_failed' do
     it 'dispatches the response failed event with the failure reason' do
       expect(Rails.configuration.dispatcher).to receive(:dispatch).with(

--- a/spec/enterprise/services/captain/conversation_events_spec.rb
+++ b/spec/enterprise/services/captain/conversation_events_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe Captain::ConversationEvents do
   let(:assistant) { create(:captain_assistant, account: account) }
   let(:timestamp) { Time.zone.now }
 
-  describe '.engaged' do
-    it 'dispatches the engagement event with normalized context' do
+  describe '.eligible' do
+    it 'dispatches the eligibility event with normalized context' do
       expect(Rails.configuration.dispatcher).to receive(:dispatch).with(
-        Events::Types::CAPTAIN_CONVERSATION_ENGAGED,
+        Events::Types::CAPTAIN_CONVERSATION_ELIGIBLE,
         timestamp,
         { conversation: conversation, assistant: assistant }
       )
 
-      described_class.engaged(conversation: conversation, assistant: assistant, at: timestamp)
+      described_class.eligible(conversation: conversation, assistant: assistant, at: timestamp)
     end
   end
 
@@ -69,7 +69,7 @@ RSpec.describe Captain::ConversationEvents do
         .and_return(instance_double(ChatwootExceptionTracker, capture_exception: true))
 
       expect do
-        described_class.engaged(conversation: conversation, assistant: assistant, at: timestamp)
+        described_class.eligible(conversation: conversation, assistant: assistant, at: timestamp)
       end.not_to raise_error
     end
   end

--- a/spec/enterprise/services/captain/conversation_outcome_tracker_spec.rb
+++ b/spec/enterprise/services/captain/conversation_outcome_tracker_spec.rb
@@ -1,0 +1,257 @@
+require 'rails_helper'
+
+RSpec.describe Captain::ConversationOutcomeTracker do
+  let(:account) { create(:account) }
+  let(:assistant) { create(:captain_assistant, account: account) }
+  let(:inbox) { create(:inbox, account: account) }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox, status: :pending) }
+  let(:tracker) { described_class.new(conversation: conversation, assistant: assistant) }
+
+  before do
+    account.enable_features!('captain_integration_v2')
+    create(:captain_inbox, captain_assistant: assistant, inbox: inbox)
+  end
+
+  describe '#record_eligibility' do
+    it 'creates the V2 conversation outcome' do
+      outcome = tracker.record_eligibility
+
+      expect(outcome).to have_attributes(
+        account: account,
+        assistant: assistant,
+        conversation: conversation,
+        inbox: inbox
+      )
+    end
+
+    it 'is idempotent' do
+      tracker.record_eligibility
+
+      expect do
+        tracker.record_eligibility
+      end.not_to change(Captain::ConversationOutcome, :count)
+    end
+
+    it 'does not create outcomes for Captain V1' do
+      account.disable_features!('captain_integration_v2')
+
+      expect do
+        tracker.record_eligibility
+      end.not_to change(Captain::ConversationOutcome, :count)
+    end
+  end
+
+  describe '#record_captain_reply' do
+    let!(:outcome) { tracker.record_eligibility }
+
+    it 'records the reply timestamps and the public reply count' do
+      message = create(
+        :message,
+        account: account,
+        inbox: inbox,
+        conversation: conversation,
+        sender: assistant,
+        message_type: :outgoing,
+        created_at: 1.minute.ago
+      )
+
+      tracker.record_captain_reply(message: message)
+
+      expect(outcome.reload).to have_attributes(
+        first_captain_reply_at: message.created_at,
+        last_captain_reply_at: message.created_at,
+        captain_reply_count: 1
+      )
+    end
+
+    it 'is idempotent and keeps the first and last reply timestamps' do
+      first_message = create(
+        :message,
+        account: account,
+        inbox: inbox,
+        conversation: conversation,
+        sender: assistant,
+        message_type: :outgoing,
+        created_at: 90.seconds.ago
+      )
+      second_message = create(
+        :message,
+        account: account,
+        inbox: inbox,
+        conversation: conversation,
+        sender: assistant,
+        message_type: :outgoing,
+        created_at: 30.seconds.ago
+      )
+
+      tracker.record_captain_reply(message: second_message)
+      tracker.record_captain_reply(message: first_message)
+      tracker.record_captain_reply(message: second_message)
+
+      expect(outcome.reload).to have_attributes(
+        first_captain_reply_at: first_message.created_at,
+        last_captain_reply_at: second_message.created_at,
+        captain_reply_count: 2
+      )
+    end
+
+    it 'ignores private Captain messages' do
+      message = create(
+        :message,
+        account: account,
+        inbox: inbox,
+        conversation: conversation,
+        sender: assistant,
+        message_type: :outgoing,
+        private: true
+      )
+
+      tracker.record_captain_reply(message: message)
+
+      expect(outcome.reload.first_captain_reply_at).to be_nil
+    end
+  end
+
+  describe '#record_handoff' do
+    let!(:outcome) { tracker.record_eligibility }
+
+    it 'records the handoff details' do
+      handed_off_at = Time.current
+
+      tracker.record_handoff(at: handed_off_at, reason_category: 'unsupported_request')
+
+      expect(outcome.reload).to have_attributes(
+        handoff_at: handed_off_at,
+        handoff_reason_category: 'unsupported_request'
+      )
+    end
+
+    it 'preserves the first handoff and its reason category' do
+      first_handoff_at = 1.minute.ago
+      tracker.record_handoff(at: first_handoff_at, reason_category: 'missing_knowledge')
+
+      tracker.record_handoff(at: Time.current, reason_category: 'unsupported_request')
+
+      expect(outcome.reload).to have_attributes(
+        handoff_at: first_handoff_at,
+        handoff_reason_category: 'missing_knowledge'
+      )
+    end
+  end
+
+  describe '#record_human_reply' do
+    let!(:outcome) { tracker.record_eligibility }
+
+    it 'records the first public human reply' do
+      agent = create(:user, account: account)
+      message = create(
+        :message,
+        account: account,
+        inbox: inbox,
+        conversation: conversation,
+        sender: agent,
+        message_type: :outgoing,
+        created_at: 1.minute.ago
+      )
+
+      tracker.record_human_reply(message: message)
+
+      expect(outcome.reload.first_human_reply_at).to eq(message.created_at)
+    end
+
+    it 'ignores private notes from agents' do
+      agent = create(:user, account: account)
+      message = create(
+        :message,
+        account: account,
+        inbox: inbox,
+        conversation: conversation,
+        sender: agent,
+        message_type: :outgoing,
+        private: true
+      )
+
+      tracker.record_human_reply(message: message)
+
+      expect(outcome.reload.first_human_reply_at).to be_nil
+    end
+  end
+
+  describe '#record_resolution' do
+    let!(:outcome) { tracker.record_eligibility }
+
+    it 'records the resolution time' do
+      resolved_at = Time.current
+
+      tracker.record_resolution(at: resolved_at)
+
+      expect(outcome.reload.resolved_at).to eq(resolved_at)
+    end
+
+    it 'preserves the latest resolution when events arrive out of order' do
+      latest_resolution_at = Time.current
+      tracker.record_resolution(at: latest_resolution_at)
+
+      tracker.record_resolution(at: 1.minute.ago)
+
+      expect(outcome.reload.resolved_at).to eq(latest_resolution_at)
+    end
+  end
+
+  describe '#record_reopen' do
+    let!(:outcome) { tracker.record_eligibility }
+
+    before do
+      tracker.record_resolution(at: 2.minutes.ago)
+    end
+
+    it 'records reopenings after the latest resolution once' do
+      reopened_at = Time.current
+
+      tracker.record_reopen(at: reopened_at)
+      tracker.record_reopen(at: reopened_at)
+
+      expect(outcome.reload).to have_attributes(
+        last_reopened_at: reopened_at,
+        reopen_count: 1
+      )
+    end
+
+    it 'ignores an opening that predates the latest resolution' do
+      expect do
+        tracker.record_reopen(at: 3.minutes.ago)
+      end.not_to(change { outcome.reload.reopen_count })
+    end
+
+    it 'ignores openings on an unresolved outcome' do
+      outcome.reload.update!(resolved_at: nil)
+
+      expect do
+        tracker.record_reopen(at: Time.current)
+      end.not_to(change { outcome.reload.reopen_count })
+    end
+  end
+
+  describe '#record_csat' do
+    let!(:outcome) { tracker.record_eligibility }
+
+    it 'records the latest CSAT response' do
+      message = create(:message, account: account, inbox: inbox, conversation: conversation)
+      response = create(
+        :csat_survey_response,
+        account: account,
+        conversation: conversation,
+        contact: conversation.contact,
+        message: message,
+        rating: 5
+      )
+
+      tracker.record_csat(response: response)
+
+      expect(outcome.reload).to have_attributes(
+        csat_rating: 5,
+        csat_received_at: response.created_at
+      )
+    end
+  end
+end

--- a/spec/enterprise/services/enterprise/message_templates/hook_execution_service_spec.rb
+++ b/spec/enterprise/services/enterprise/message_templates/hook_execution_service_spec.rb
@@ -79,19 +79,30 @@ RSpec.describe MessageTemplates::HookExecutionService do
         create(:message, conversation: conversation, message_type: :incoming, account: account)
       end
 
-      it 'emits the engagement event when captain V2 is enabled' do
-        account.enable_features!('captain_integration_v2')
-
-        expect(Captain::ConversationEvents).to receive(:engaged)
+      it 'emits the eligibility event for inbound messages' do
+        expect(Captain::ConversationEvents).to receive(:eligible)
           .with(conversation: conversation, assistant: assistant, at: kind_of(Time))
 
         create(:message, conversation: conversation, message_type: :incoming, account: account)
       end
 
-      it 'does not emit the engagement event when captain V2 is disabled' do
-        expect(Captain::ConversationEvents).not_to receive(:engaged)
+      it 'records a conversation outcome when captain V2 is enabled' do
+        account.enable_features!('captain_integration_v2')
 
-        create(:message, conversation: conversation, message_type: :incoming, account: account)
+        expect do
+          create(:message, conversation: conversation, message_type: :incoming, account: account)
+        end.to change(Captain::ConversationOutcome, :count).by(1)
+
+        expect(Captain::ConversationOutcome.last).to have_attributes(
+          assistant: assistant,
+          conversation: conversation
+        )
+      end
+
+      it 'does not record a conversation outcome when captain V2 is disabled' do
+        expect do
+          create(:message, conversation: conversation, message_type: :incoming, account: account)
+        end.not_to change(Captain::ConversationOutcome, :count)
       end
     end
 
@@ -115,19 +126,30 @@ RSpec.describe MessageTemplates::HookExecutionService do
         expect(conversation.reload.status).to eq('open')
       end
 
-      it 'emits a usage limit handoff event when captain V2 is enabled' do
-        account.enable_features!('captain_integration_v2')
-
+      it 'emits a usage limit handoff event' do
         expect(Captain::ConversationEvents).to receive(:handed_off)
           .with(conversation: conversation, assistant: assistant, source: 'usage_limit', reason_category: :usage_limit, at: kind_of(Time))
 
         create(:message, conversation: conversation, message_type: :incoming, account: account)
       end
 
-      it 'does not emit a handoff event when captain V2 is disabled' do
-        expect(Captain::ConversationEvents).not_to receive(:handed_off)
+      it 'records the handoff on the outcome when captain V2 is enabled' do
+        account.enable_features!('captain_integration_v2')
 
-        create(:message, conversation: conversation, message_type: :incoming, account: account)
+        expect do
+          create(:message, conversation: conversation, message_type: :incoming, account: account)
+        end.to change(Captain::ConversationOutcome, :count).by(1)
+
+        expect(Captain::ConversationOutcome.last).to have_attributes(
+          handoff_reason_category: 'usage_limit',
+          handoff_at: be_present
+        )
+      end
+
+      it 'does not record an outcome when captain V2 is disabled' do
+        expect do
+          create(:message, conversation: conversation, message_type: :incoming, account: account)
+        end.not_to change(Captain::ConversationOutcome, :count)
       end
     end
   end
@@ -153,6 +175,14 @@ RSpec.describe MessageTemplates::HookExecutionService do
       expect(Captain::Conversation::ResponseBuilderJob).not_to receive(:perform_later)
 
       create(:message, conversation: conversation, message_type: :incoming, account: account)
+    end
+
+    it 'still records the conversation as eligible demand when captain V2 is enabled' do
+      account.enable_features!('captain_integration_v2')
+
+      expect do
+        create(:message, conversation: conversation, message_type: :incoming, account: account)
+      end.to change(Captain::ConversationOutcome, :count).by(1)
     end
   end
 

--- a/spec/enterprise/services/enterprise/message_templates/hook_execution_service_spec.rb
+++ b/spec/enterprise/services/enterprise/message_templates/hook_execution_service_spec.rb
@@ -78,6 +78,21 @@ RSpec.describe MessageTemplates::HookExecutionService do
 
         create(:message, conversation: conversation, message_type: :incoming, account: account)
       end
+
+      it 'emits the engagement event when captain V2 is enabled' do
+        account.enable_features!('captain_integration_v2')
+
+        expect(Captain::ConversationEvents).to receive(:engaged)
+          .with(conversation: conversation, assistant: assistant, at: kind_of(Time))
+
+        create(:message, conversation: conversation, message_type: :incoming, account: account)
+      end
+
+      it 'does not emit the engagement event when captain V2 is disabled' do
+        expect(Captain::ConversationEvents).not_to receive(:engaged)
+
+        create(:message, conversation: conversation, message_type: :incoming, account: account)
+      end
     end
 
     context 'when captain quota is exceeded within business hours' do
@@ -98,6 +113,21 @@ RSpec.describe MessageTemplates::HookExecutionService do
         create(:message, conversation: conversation, message_type: :incoming, account: account)
 
         expect(conversation.reload.status).to eq('open')
+      end
+
+      it 'emits a usage limit handoff event when captain V2 is enabled' do
+        account.enable_features!('captain_integration_v2')
+
+        expect(Captain::ConversationEvents).to receive(:handed_off)
+          .with(conversation: conversation, assistant: assistant, source: 'usage_limit', reason_category: :usage_limit, at: kind_of(Time))
+
+        create(:message, conversation: conversation, message_type: :incoming, account: account)
+      end
+
+      it 'does not emit a handoff event when captain V2 is disabled' do
+        expect(Captain::ConversationEvents).not_to receive(:handed_off)
+
+        create(:message, conversation: conversation, message_type: :incoming, account: account)
       end
     end
   end

--- a/spec/factories/captain/conversation_outcome.rb
+++ b/spec/factories/captain/conversation_outcome.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :captain_conversation_outcome, class: 'Captain::ConversationOutcome' do
+    account { create(:account) }
+
+    after(:build) do |outcome|
+      outcome.assistant ||= create(:captain_assistant, account: outcome.account)
+      outcome.inbox ||= create(:inbox, account: outcome.account)
+      outcome.conversation ||= create(:conversation, account: outcome.account, inbox: outcome.inbox)
+    end
+  end
+end

--- a/spec/listeners/reporting_event_listener_spec.rb
+++ b/spec/listeners/reporting_event_listener_spec.rb
@@ -309,38 +309,6 @@ describe ReportingEventListener do
     end
   end
 
-  describe '#conversation_captain_inference_resolved' do
-    it 'creates conversation_captain_inference_resolved event' do
-      expect(account.reporting_events.where(name: 'conversation_captain_inference_resolved').count).to be 0
-      decision_time = conversation.created_at + 60.seconds
-      event = Events::Base.new('conversation.captain_inference_resolved', decision_time, conversation: conversation)
-      allow(conversation).to receive(:updated_at).and_return(decision_time + 5.minutes)
-
-      listener.conversation_captain_inference_resolved(event)
-
-      reporting_event = account.reporting_events.where(name: 'conversation_captain_inference_resolved').first
-      expect(reporting_event).to be_present
-      expect(reporting_event.value).to eq 60
-      expect(reporting_event.event_end_time).to be_within(1.second).of(decision_time)
-    end
-  end
-
-  describe '#conversation_captain_inference_handoff' do
-    it 'creates conversation_captain_inference_handoff event' do
-      expect(account.reporting_events.where(name: 'conversation_captain_inference_handoff').count).to be 0
-      decision_time = conversation.created_at + 90.seconds
-      event = Events::Base.new('conversation.captain_inference_handoff', decision_time, conversation: conversation)
-      allow(conversation).to receive(:updated_at).and_return(decision_time + 5.minutes)
-
-      listener.conversation_captain_inference_handoff(event)
-
-      reporting_event = account.reporting_events.where(name: 'conversation_captain_inference_handoff').first
-      expect(reporting_event).to be_present
-      expect(reporting_event.value).to eq 90
-      expect(reporting_event.event_end_time).to be_within(1.second).of(decision_time)
-    end
-  end
-
   describe '#conversation_opened' do
     context 'when conversation is opened for the first time' do
       let(:new_conversation) { create(:conversation, account: account, inbox: inbox, assignee: user) }


### PR DESCRIPTION
Migrates the Captain Overview metrics to `captain_conversation_outcomes`. Conversations handled, auto-resolution rate, handoff rate, and reopen rate now read from the outcome table instead of message scans joined with reporting events; hours saved and conversation depth stay on the messages table since they need per-window reply counts that a one-row-per-conversation fact table cannot provide. Net: 153 insertions, 285 deletions, with the reopen rate's `event_end_time` join logic deleted outright because the tracker only records reopens that follow a resolution.

The classification predicates now live on `Captain::ConversationOutcome` as shared constants and scopes, used by both stats builders and the drilldown builder, so a stat card and its drilldown count exactly the same rows by construction rather than by mirrored queries. Semantics shift with the source: a window owns the demand cohort that entered it, handled means involved (usage-limit blocks excluded), and the reopen denominator is autonomous resolutions. The Overview page is V2-only and the table has no backfill, so windows reaching before deployment undercount until the data ages in.

| Metric | Old source | New source |
| --- | --- | --- |
| `conversations_handled` | Distinct conversations with an assistant message | Involved outcome rows in the window's demand cohort |
| `auto_resolution_rate` | Resolved/bot-resolved reporting events with handoff exclusion | Autonomous predicate over involved rows |
| `handoff_rate` | Handoff reporting events on the handled set | Involved rows with `handoff_at` |
| `reopen_rate` | `conversation_opened` events joined on `event_end_time` | Reopened autonomous resolutions over autonomous resolutions |
| `hours_saved` | Public assistant replies × assumed effort | Unchanged (messages table) |
| `conversation_depth` | Public replies per conversation | Unchanged (messages table) |
| `faq_stats` | Knowledge tables | Unchanged (out of scope) |
