### PR TITLE
chore: Support Elastic Searchkick client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ gem 'redis-namespace'
 gem 'activerecord-import'
 
 gem 'searchkick'
+gem 'elasticsearch', '>= 7', '< 10'
 gem 'opensearch-ruby'
 gem 'faraday_middleware-aws-sigv4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,6 +288,15 @@ GEM
       concurrent-ruby (~> 1.0)
       http (>= 3.0)
       ruby2_keywords
+    elastic-transport (8.5.3)
+      faraday (< 3)
+      multi_json
+    elasticsearch (9.4.3)
+      elastic-transport (~> 8.3)
+      elasticsearch-api (= 9.4.3)
+    elasticsearch-api (9.4.3)
+      base64
+      multi_json
     email-provider-info (0.0.1)
     email_reply_trimmer (0.1.13)
     erubi (1.13.0)
@@ -1088,6 +1097,7 @@ DEPENDENCIES
   dotenv-rails (>= 3.0.0)
   down
   elastic-apm
+  elasticsearch (>= 7, < 10)
   email-provider-info
   email_reply_trimmer
   facebook-messenger

--- a/config/initializers/searchkick.rb
+++ b/config/initializers/searchkick.rb
@@ -1,8 +1,19 @@
-Searchkick.queue_name = :async_database_migration if ENV.fetch('OPENSEARCH_URL', '').present?
+opensearch_url = ENV.fetch('OPENSEARCH_URL', '').presence
+elasticsearch_url = ENV.fetch('ELASTICSEARCH_URL', '').presence
 
-api_key = ENV.fetch('OPENSEARCH_API_KEY', '').presence || ENV.fetch('ELASTICSEARCH_API_KEY', '').presence
+opensearch_api_key = ENV.fetch('OPENSEARCH_API_KEY', '').presence
+elasticsearch_api_key = ENV.fetch('ELASTICSEARCH_API_KEY', '').presence
+api_key = opensearch_api_key || elasticsearch_api_key
 access_key_id = ENV.fetch('OPENSEARCH_AWS_ACCESS_KEY_ID', '')
 secret_access_key = ENV.fetch('OPENSEARCH_AWS_SECRET_ACCESS_KEY', '')
+use_elasticsearch_client = elasticsearch_url.present? || (elasticsearch_api_key.present? && opensearch_api_key.blank?)
+search_url = use_elasticsearch_client ? (elasticsearch_url || opensearch_url) : opensearch_url
+
+if search_url.present?
+  Searchkick.queue_name = :async_database_migration
+  Searchkick.client_type = use_elasticsearch_client ? :elasticsearch : :opensearch
+  Searchkick.client_options = Searchkick.client_options.deep_merge(url: search_url) if use_elasticsearch_client
+end
 
 if api_key.present?
   Searchkick.client_options = Searchkick.client_options.deep_merge(
@@ -21,3 +32,86 @@ elsif access_key_id.present? && secret_access_key.present?
     region: region
   }
 end
+
+module SearchkickServerlessCompatibility
+  unless const_defined?(:SERVERLESS_UNSUPPORTED_ANALYZERS, false)
+    SERVERLESS_UNSUPPORTED_ANALYZERS = %i[
+      searchkick_suggest_index
+      searchkick_text_start_index
+      searchkick_text_middle_index
+      searchkick_text_end_index
+      searchkick_word_start_index
+      searchkick_word_middle_index
+      searchkick_word_end_index
+    ].freeze
+  end
+
+  unless const_defined?(:SERVERLESS_UNSUPPORTED_FILTERS, false)
+    SERVERLESS_UNSUPPORTED_FILTERS = %w[
+      searchkick_index_shingle
+      searchkick_search_shingle
+      searchkick_suggest_shingle
+      searchkick_edge_ngram
+      searchkick_ngram
+    ].freeze
+  end
+
+  def index_options
+    super.tap do |body|
+      remove_serverless_unsupported_index_options(body) if elasticsearch_serverless?
+    end
+  end
+
+  private
+
+  def elasticsearch_serverless?
+    return false unless Searchkick.client_type == :elasticsearch
+
+    server_info = Searchkick.server_info
+    server_info = server_info.to_h if server_info.respond_to?(:to_h)
+    version = server_info['version'] || server_info[:version] || {}
+    (version['build_flavor'] || version[:build_flavor]).to_s == 'serverless'
+  rescue StandardError
+    false
+  end
+
+  def remove_serverless_unsupported_index_options(body)
+    settings = body[:settings]
+    settings.delete(:number_of_shards)
+    settings.delete(:number_of_replicas)
+
+    index_settings = settings[:index] || settings['index']
+    index_settings&.delete(:max_ngram_diff)
+    index_settings&.delete(:max_shingle_diff)
+    remove_serverless_unsupported_analysis(settings)
+  end
+
+  def remove_serverless_unsupported_analysis(settings)
+    analysis = settings[:analysis] || settings['analysis']
+    return if analysis.blank?
+
+    remove_serverless_unsupported_analyzers(analysis[:analyzer] || analysis['analyzer'] || {})
+    remove_serverless_unsupported_filters(analysis[:filter] || analysis['filter'] || {})
+  end
+
+  def remove_serverless_unsupported_analyzers(analyzers)
+    SERVERLESS_UNSUPPORTED_ANALYZERS.each { |name| analyzers.delete(name) }
+    analyzers.each_value do |config|
+      remove_serverless_unsupported_filter_references(config[:filter])
+      remove_serverless_unsupported_filter_references(config['filter'])
+    end
+  end
+
+  def remove_serverless_unsupported_filter_references(filters)
+    filters&.reject! { |filter| SERVERLESS_UNSUPPORTED_FILTERS.include?(filter) }
+  end
+
+  def remove_serverless_unsupported_filters(filters)
+    SERVERLESS_UNSUPPORTED_FILTERS.each do |name|
+      filters.delete(name.to_sym)
+      filters.delete(name)
+    end
+  end
+end
+
+Searchkick::IndexOptions.prepend(SearchkickServerlessCompatibility) unless Searchkick::IndexOptions < SearchkickServerlessCompatibility

--- a/spec/config/searchkick_spec.rb
+++ b/spec/config/searchkick_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe Searchkick do
     original_queue_name = described_class.queue_name
     original_aws_credentials = described_class.aws_credentials
     original_client = described_class.instance_variable_get(:@client)
+    original_client_type = described_class.client_type
 
     example.run
   ensure
     described_class.client_options = original_client_options
     described_class.queue_name = original_queue_name
+    described_class.client_type = original_client_type
     described_class.instance_variable_set(:@aws_credentials, original_aws_credentials)
     described_class.instance_variable_set(:@client, original_client)
   end
@@ -20,7 +22,8 @@ RSpec.describe Searchkick do
   it 'configures API key authorization from OPENSEARCH_API_KEY' do
     described_class.client_options = {}
 
-    with_modified_env OPENSEARCH_API_KEY: 'opensearch-api-key', ELASTICSEARCH_API_KEY: nil,
+    with_modified_env OPENSEARCH_URL: nil, ELASTICSEARCH_URL: nil,
+                      OPENSEARCH_API_KEY: 'opensearch-api-key', ELASTICSEARCH_API_KEY: nil,
                       OPENSEARCH_AWS_ACCESS_KEY_ID: nil, OPENSEARCH_AWS_SECRET_ACCESS_KEY: nil do
       load initializer_path
     end
@@ -34,10 +37,63 @@ RSpec.describe Searchkick do
     )
   end
 
+  it 'uses the OpenSearch client for OPENSEARCH_URL' do
+    described_class.client_options = {}
+    described_class.client_type = nil
+
+    with_modified_env OPENSEARCH_URL: 'http://localhost:9200', ELASTICSEARCH_URL: nil,
+                      OPENSEARCH_API_KEY: nil, ELASTICSEARCH_API_KEY: nil,
+                      OPENSEARCH_AWS_ACCESS_KEY_ID: nil, OPENSEARCH_AWS_SECRET_ACCESS_KEY: nil do
+      load initializer_path
+    end
+
+    expect(described_class.queue_name).to eq(:async_database_migration)
+    expect(described_class.client_type).to eq(:opensearch)
+    expect(described_class.client_options).to eq({})
+  end
+
+  it 'uses the Elasticsearch client for ELASTICSEARCH_URL' do
+    described_class.client_options = {}
+    described_class.client_type = nil
+
+    with_modified_env ELASTICSEARCH_URL: 'https://elastic.example.com', OPENSEARCH_URL: nil,
+                      OPENSEARCH_API_KEY: nil, ELASTICSEARCH_API_KEY: nil,
+                      OPENSEARCH_AWS_ACCESS_KEY_ID: nil, OPENSEARCH_AWS_SECRET_ACCESS_KEY: nil do
+      load initializer_path
+    end
+
+    expect(described_class.queue_name).to eq(:async_database_migration)
+    expect(described_class.client_type).to eq(:elasticsearch)
+    expect(described_class.client_options).to eq(url: 'https://elastic.example.com')
+  end
+
+  it 'uses the Elasticsearch client when Elastic API key credentials reuse OPENSEARCH_URL' do
+    described_class.client_options = {}
+    described_class.client_type = nil
+
+    with_modified_env OPENSEARCH_URL: 'https://elastic.example.com', ELASTICSEARCH_URL: nil,
+                      OPENSEARCH_API_KEY: nil, ELASTICSEARCH_API_KEY: 'elastic-api-key',
+                      OPENSEARCH_AWS_ACCESS_KEY_ID: nil, OPENSEARCH_AWS_SECRET_ACCESS_KEY: nil do
+      load initializer_path
+    end
+
+    expect(described_class.queue_name).to eq(:async_database_migration)
+    expect(described_class.client_type).to eq(:elasticsearch)
+    expect(described_class.client_options).to eq(
+      url: 'https://elastic.example.com',
+      transport_options: {
+        headers: {
+          'Authorization' => 'ApiKey elastic-api-key'
+        }
+      }
+    )
+  end
+
   it 'supports ELASTICSEARCH_API_KEY for Elastic Cloud credentials' do
     described_class.client_options = {}
 
-    with_modified_env OPENSEARCH_API_KEY: nil, ELASTICSEARCH_API_KEY: 'elastic-api-key',
+    with_modified_env OPENSEARCH_URL: nil, ELASTICSEARCH_URL: nil,
+                      OPENSEARCH_API_KEY: nil, ELASTICSEARCH_API_KEY: 'elastic-api-key',
                       OPENSEARCH_AWS_ACCESS_KEY_ID: nil, OPENSEARCH_AWS_SECRET_ACCESS_KEY: nil do
       load initializer_path
     end
@@ -48,6 +104,58 @@ RSpec.describe Searchkick do
           'Authorization' => 'ApiKey elastic-api-key'
         }
       }
+    )
+  end
+
+  it 'removes index settings unsupported by Elastic serverless' do
+    described_class.client_type = :elasticsearch
+    allow(described_class).to receive(:server_info).and_return('version' => { 'build_flavor' => 'serverless' })
+
+    index_options = Searchkick::Index.new('serverless_test').index_options
+
+    expect(index_options.dig(:settings, :index)).not_to include(:max_ngram_diff, :max_shingle_diff)
+    expect(index_options[:settings]).not_to include(:number_of_shards, :number_of_replicas)
+    expect(index_options.dig(:settings, :analysis, :filter)).not_to include(
+      :searchkick_index_shingle,
+      :searchkick_search_shingle,
+      :searchkick_suggest_shingle,
+      :searchkick_edge_ngram,
+      :searchkick_ngram
+    )
+    expect(index_options.dig(:settings, :analysis, :analyzer)).not_to include(
+      :searchkick_suggest_index,
+      :searchkick_text_start_index,
+      :searchkick_text_middle_index,
+      :searchkick_text_end_index,
+      :searchkick_word_start_index,
+      :searchkick_word_middle_index,
+      :searchkick_word_end_index
+    )
+    index_options.dig(:settings, :analysis, :analyzer).each_value do |analyzer|
+      expect(analyzer[:filter]).not_to include(
+        'searchkick_index_shingle',
+        'searchkick_search_shingle',
+        'searchkick_suggest_shingle',
+        'searchkick_edge_ngram',
+        'searchkick_ngram'
+      )
+    end
+  end
+
+  it 'keeps Searchkick index settings for non-serverless clusters' do
+    described_class.client_type = :elasticsearch
+    allow(described_class).to receive(:server_info).and_return('version' => { 'build_flavor' => 'default' })
+
+    index_options = Searchkick::Index.new('non_serverless_test').index_options
+
+    expect(index_options.dig(:settings, :index)).to include(
+      max_ngram_diff: 49,
+      max_shingle_diff: 4
+    )
+    expect(index_options.dig(:settings, :analysis, :filter)).to include(
+      :searchkick_index_shingle,
+      :searchkick_edge_ngram,
+      :searchkick_ngram
     )
   end
 end


### PR DESCRIPTION
# Pull Request Template

## Description

Configures Searchkick to use the official Elasticsearch client when Elastic Cloud credentials are provided, while preserving the existing OpenSearch path for OpenSearch credentials.

Elastic serverless rejects Searchkick's generated ngram/shingle index settings, so this also strips those unsupported index options only when Searchkick is connected to an Elasticsearch serverless cluster.

Fixes https://linear.app/chatwoot/issue/CW-7511/populate-test-data-set-and-run-experiments

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `bundle exec rspec spec/config/searchkick_spec.rb`
- `bundle exec rubocop config/initializers/searchkick.rb spec/config/searchkick_spec.rb`
- `git diff --check`
- Verified a live Elastic Cloud serverless Searchkick smoke test by creating and deleting a temporary `messages_development_*` index with `Elasticsearch::Client`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
