### PR TITLE
feat: seed Captain conversation outcomes in the reports seeder

### DIFF
--- a/lib/seeders/reports/assistant_conversation_creator.rb
+++ b/lib/seeders/reports/assistant_conversation_creator.rb
@@ -14,11 +14,20 @@ require 'active_support/testing/time_helpers'
 #   - :resolved_and_reopened  Captain resolves, then the conversation reopens
 #
 # Reporting events are fired through ReportingEventListener directly (mirroring
-# ConversationCreator) so the same rows the builder reads from get populated.
-class Seeders::Reports::AssistantConversationCreator
+# ConversationCreator), and outcome facts are folded through
+# Captain::ConversationOutcomeTracker at the same frozen timestamps, so both the
+# event-backed and outcome-backed overview metrics get populated the same way
+# production would populate them.
+class Seeders::Reports::AssistantConversationCreator # rubocop:disable Metrics/ClassLength
   include ActiveSupport::Testing::TimeHelpers
 
   OUTCOMES = %i[resolved_by_assistant handled_by_both handed_off resolved_and_reopened].freeze
+  HANDOFF_REASON_CATEGORIES = %w[
+    customer_request missing_knowledge unsupported_request policy_restriction tool_failure pending_clarification
+  ].freeze
+  # Rating distribution skews positive, mirroring typical CSAT response shapes.
+  CSAT_RATINGS = [5, 5, 5, 4, 4, 3, 2].freeze
+  CSAT_RESPONSE_CHANCE = 0.45
 
   def initialize(account:, assistant:, inbox:, resources:)
     @account = account
@@ -62,6 +71,7 @@ class Seeders::Reports::AssistantConversationCreator
   # handled set; some outcomes add a human reply or a handoff.
   def seed_dialogue(conversation, outcome)
     customer_message = incoming_message(conversation)
+    tracker(conversation).record_eligibility
 
     travel(rand((20.seconds)..(5.minutes)))
     assistant_reply(conversation, waiting_since: customer_message.created_at)
@@ -131,6 +141,7 @@ class Seeders::Reports::AssistantConversationCreator
       sender: @assistant
     )
     trigger_reply_time(message, waiting_since)
+    tracker(conversation).record_captain_reply(message: message)
     message
   end
 
@@ -138,7 +149,7 @@ class Seeders::Reports::AssistantConversationCreator
     agent = @agents.sample
     conversation.update_column(:assignee_id, agent.id) if conversation.assignee_id.nil? # rubocop:disable Rails/SkipsModelValidations
 
-    conversation.messages.create!(
+    message = conversation.messages.create!(
       account: @account,
       inbox: @inbox,
       message_type: :outgoing,
@@ -146,6 +157,8 @@ class Seeders::Reports::AssistantConversationCreator
       content: Faker::Lorem.paragraph(sentence_count: rand(1..4)),
       sender: agent
     )
+    tracker(conversation).record_human_reply(message: message)
+    message
   end
 
   def resolve_by_captain(conversation, resolved_at)
@@ -153,16 +166,20 @@ class Seeders::Reports::AssistantConversationCreator
     travel_to(resolved_at) do
       trigger_event('conversation_resolved', conversation)
       trigger_captain_event(Events::Types::CAPTAIN_CONVERSATION_RESOLVED, conversation)
+      tracker(conversation).record_resolution(at: Time.current)
     end
     travel_back
+    seed_csat_response(conversation, resolved_at) if rand < CSAT_RESPONSE_CHANCE
   end
 
   def resolve_by_human(conversation, resolved_at)
     mark_resolved(conversation, resolved_at)
     travel_to(resolved_at) do
       trigger_event('conversation_resolved', conversation)
+      tracker(conversation).record_resolution(at: Time.current)
     end
     travel_back
+    seed_csat_response(conversation, resolved_at) if rand < CSAT_RESPONSE_CHANCE
   end
 
   def reopen(conversation, reopened_at)
@@ -173,12 +190,43 @@ class Seeders::Reports::AssistantConversationCreator
 
     travel_to(reopened_at) do
       trigger_event('conversation_opened', conversation)
+      tracker(conversation).record_reopen(at: Time.current)
     end
     travel_back
   end
 
   def handoff_to_human(conversation)
     trigger_captain_event(Events::Types::CAPTAIN_CONVERSATION_HANDED_OFF, conversation)
+    tracker(conversation).record_handoff(at: Time.current, reason_category: HANDOFF_REASON_CATEGORIES.sample)
+  end
+
+  # A share of resolved conversations gets a CSAT response so the experience
+  # metrics have data. The survey message carries no sender so the reply
+  # folding never mistakes it for a Captain or human reply.
+  def seed_csat_response(conversation, resolved_at)
+    travel_to(resolved_at + rand((5.minutes)..(2.hours))) do
+      message = conversation.messages.create!(
+        account: @account,
+        inbox: @inbox,
+        message_type: :outgoing,
+        content_type: :input_csat,
+        content: 'Please rate this conversation',
+        private: false
+      )
+      response = CsatSurveyResponse.create!(
+        account: @account,
+        conversation: conversation,
+        contact: conversation.contact,
+        message: message,
+        rating: CSAT_RATINGS.sample
+      )
+      tracker(conversation).record_csat(response: response)
+    end
+    travel_back
+  end
+
+  def tracker(conversation)
+    Captain::ConversationOutcomeTracker.new(conversation: conversation, assistant: @assistant)
   end
 
   def mark_resolved(conversation, resolved_at)

--- a/lib/seeders/reports/report_data_seeder.rb
+++ b/lib/seeders/reports/report_data_seeder.rb
@@ -94,14 +94,14 @@ class Seeders::Reports::ReportDataSeeder
     @account.reporting_events.destroy_all
   end
 
-  # Delete Captain records directly (assistant associations are destroy_async, which
-  # would leave rows around mid-reseed); order respects foreign keys.
+  # Delete Captain activity records directly (the associations are destroy_async,
+  # which would leave rows around mid-reseed). Assistants and their knowledge are
+  # preserved so an account's existing Captain setup is reused across reseeds;
+  # inbox bindings are cleared because the inboxes themselves get recreated.
   def clear_assistant_data
     assistant_ids = Captain::Assistant.for_account(@account.id).select(:id)
-    Captain::AssistantResponse.by_account(@account.id).delete_all
-    Captain::Document.for_account(@account.id).delete_all
+    Captain::ConversationOutcome.where(account_id: @account.id).delete_all
     CaptainInbox.where(captain_assistant_id: assistant_ids).delete_all
-    Captain::Assistant.for_account(@account.id).delete_all
   end
 
   def create_teams
@@ -232,20 +232,28 @@ class Seeders::Reports::ReportDataSeeder
     print "\n"
   end
 
-  # One assistant, bound to a single web inbox (the first one), as the overview page expects.
+  # One assistant, bound to a single web inbox (the first one), as the overview
+  # page expects. An account's existing assistant is reused (keeping its name and
+  # knowledge); one is only created when the account has none.
   def create_assistant
     @account.enable_features!('captain_integration', 'captain_integration_v2')
     @assistant_inbox = @inboxes.first
-    @assistant = Captain::Assistant.create!(
-      account: @account,
-      name: "#{Faker::Company.name} Copilot",
-      description: 'Captain assistant handling website support conversations.',
-      config: { feature_faq: true, feature_memory: true, product_name: @account.name }
-    )
-    CaptainInbox.create!(captain_assistant: @assistant, inbox: @assistant_inbox)
-    create_assistant_knowledge
+    @assistant = Captain::Assistant.for_account(@account.id).first
 
-    puts "Created assistant '#{@assistant.name}' for inbox '#{@assistant_inbox.name}'"
+    if @assistant
+      puts "Reusing assistant '#{@assistant.name}' for inbox '#{@assistant_inbox.name}'"
+    else
+      @assistant = Captain::Assistant.create!(
+        account: @account,
+        name: "#{Faker::Company.name} Copilot",
+        description: 'Captain assistant handling website support conversations.',
+        config: { feature_faq: true, feature_memory: true, product_name: @account.name }
+      )
+      create_assistant_knowledge
+      puts "Created assistant '#{@assistant.name}' for inbox '#{@assistant_inbox.name}'"
+    end
+
+    CaptainInbox.create!(captain_assistant: @assistant, inbox: @assistant_inbox)
   end
 
   def create_assistant_knowledge


### PR DESCRIPTION
Makes the reports seeder populate `captain_conversation_outcomes`, so the outcome-backed overview metrics (#15239) and the new value-report sections (#15247) show realistic data on seeded accounts. Every seeded assistant conversation is folded through the real `Captain::ConversationOutcomeTracker` at the same frozen timestamps the seeder already uses for messages and reporting events: eligibility on the first customer message, Captain and human reply folds, handoffs with a sampled reason category, resolutions, reopens, and a CSAT response on roughly half of resolved conversations. Because the production tracker does the folding, seeded rows are shaped exactly like real ones rather than hand-inserted approximations.

The seeder also reuses an account's existing Captain assistant, keeping its name and knowledge, and only creates a fresh assistant (with seeded FAQs and documents) when the account has none. Clearing between reseeds now removes outcome rows and inbox bindings instead of deleting the assistant, and the binding is recreated against the newly seeded inbox.

## How to test

Run `ACCOUNT_ID=<id> ENABLE_ACCOUNT_SEEDING=true bundle exec rake db:seed:reports_data` twice. Both runs should complete, the second should log "Reusing assistant", and Captain → Assistant → Overview should show populated Reach/Resolution/Experience sections including the handoff reason breakdown and CSAT.
