### PR TITLE
fix(whatsapp): surface webhook registration errors

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -627,7 +627,8 @@ export default {
         await this.fetchHealthData();
       } catch (error) {
         useAlert(
-          error.message ||
+          error.response?.data?.error ||
+            error.message ||
             this.$t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.REGISTER_ERROR')
         );
       } finally {


### PR DESCRIPTION
When webhook registration fails from WhatsApp Account Health, the settings page currently shows Axios's generic HTTP 422 message and hides the actionable error returned by Chatwoot. This change surfaces the backend error first so users can see the actual Meta setup failure.

The existing Axios message and translated generic error remain as fallbacks. Successful registration and the API contract are unchanged.

### Things to know

This only changes the alert shown after a failed webhook-registration request. It does not change webhook setup, WABA subscriptions, or phone-level callback configuration.

### How to test

1. Open Account Health for a WhatsApp Cloud API inbox.
2. Trigger **Register webhook** with a configuration that causes the API to return a descriptive `error` response.
3. Confirm the alert shows the API-provided error instead of `Request failed with status code 422`.
4. Confirm the existing Axios and translated messages remain the fallback when the response contains no API error.