### PR TITLE
fix: restrict libvips to trusted image loaders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,11 @@ ACTION_MAILBOX_SES_SNS_TOPIC=
 # Storage
 ACTIVE_STORAGE_SERVICE=local
 
+# Restrict libvips to its trusted, well-tested image loaders when Active Storage
+# generates variants. Hardens image processing against untrusted uploads.
+# Requires libvips >= 8.13 (ignored on older versions).
+VIPS_BLOCK_UNTRUSTED=1
+
 # Amazon S3
 # documentation: https://www.chatwoot.com/docs/configuring-s3-bucket-as-cloud-storage
 S3_BUCKET_NAME=

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -130,6 +130,9 @@ RUN apk update && apk add --no-cache \
   vips \
   && gem install bundler -v "$BUNDLER_VERSION"
 
+# Restrict libvips to its trusted image loaders when generating variants
+ENV VIPS_BLOCK_UNTRUSTED=1
+
 COPY --from=node /usr/local/bin/node /usr/local/bin/
 COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 


### PR DESCRIPTION
## Description

Adds `VIPS_BLOCK_UNTRUSTED=1` to `.env.example`. This tells libvips to only use its trusted, well-tested loaders when Active Storage generates image variants, hardening image processing against untrusted uploads. The setting requires libvips >= 8.13 and is silently ignored on older versions.

Related to https://linear.app/chatwoot/issue/INF-92

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified locally that thumbnail/variant generation for the common raster formats (JPEG, PNG, GIF, WebP, TIFF, HEIC) is unaffected with the flag enabled.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
