### PR TITLE
chore(ci): update bundler-audit ignore list

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -21,3 +21,6 @@ ignore:
   - CVE-2026-33176
   - CVE-2026-33195
   - CVE-2026-33202
+  # No Rails 7.1 patch for this Active Storage advisory; mitigated locally.
+  # Remove once on Rails 7.2.3.1+.
+  - CVE-2026-66066


### PR DESCRIPTION
`bundle-audit` in CI flags an Active Storage advisory with no patched release on the Rails 7.1 line, failing lint on every open PR. Adds it to the existing `.bundler-audit.yml` ignore list. Mitigated locally; remove once on Rails 7.2.3.1+.

Related to https://linear.app/chatwoot/issue/INF-92

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
