### PR TITLE
feat(data-imports): resume Freshdesk imports after rate limits (2/3)

### DIFF
--- a/app/jobs/data_imports/freshdesk/base_job.rb
+++ b/app/jobs/data_imports/freshdesk/base_job.rb
@@ -9,6 +9,8 @@ class DataImports::Freshdesk::BaseJob < DataImports::BaseJob
     job.fail_import!(error)
   end
 
+  discard_on CustomExceptions::DataImport::FreshdeskTicketLimitError
+
   def retry_job(options = {})
     error = options[:error]
     options = options.merge(wait: rate_limit_wait(error)) if error.is_a?(DataImports::Freshdesk::Client::RateLimitError)

--- a/app/jobs/data_imports/freshdesk/base_job.rb
+++ b/app/jobs/data_imports/freshdesk/base_job.rb
@@ -1,9 +1,24 @@
 class DataImports::Freshdesk::BaseJob < DataImports::BaseJob
+  DEFAULT_RATE_LIMIT_WAIT = 1.minute
+
   retry_on DataImports::Freshdesk::Client::Error, wait: 1.minute, attempts: 3 do |job, error|
     job.fail_import!(error)
   end
 
-  retry_on DataImports::Freshdesk::Client::RateLimitError, wait: 1.minute, attempts: 5 do |job, error|
+  retry_on DataImports::Freshdesk::Client::RateLimitError, wait: DEFAULT_RATE_LIMIT_WAIT, attempts: 5 do |job, error|
     job.fail_import!(error)
+  end
+
+  def retry_job(options = {})
+    error = options[:error]
+    options = options.merge(wait: rate_limit_wait(error)) if error.is_a?(DataImports::Freshdesk::Client::RateLimitError)
+    super(options)
+  end
+
+  private
+
+  def rate_limit_wait(error)
+    retry_after = error.retry_after.to_i
+    retry_after.positive? ? retry_after.seconds : DEFAULT_RATE_LIMIT_WAIT
   end
 end

--- a/app/services/data_imports/freshdesk/client.rb
+++ b/app/services/data_imports/freshdesk/client.rb
@@ -25,6 +25,7 @@ class DataImports::Freshdesk::Client
   Page = Struct.new(:data, :next_page, keyword_init: true)
 
   DEFAULT_PER_PAGE = 100
+  MAX_TICKET_PAGES = 300
   EARLIEST_TICKET_TIMESTAMP = '1970-01-01T00:00:00Z'.freeze
   FRESHDESK_DOMAIN_REGEX = /\A[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.freshdesk\.com\z/i
 

--- a/app/services/data_imports/freshdesk/importer.rb
+++ b/app/services/data_imports/freshdesk/importer.rb
@@ -13,6 +13,7 @@ class DataImports::Freshdesk::Importer < DataImports::Importer
     return PageResult.new(next_cursor: nil) if import_stopped?
 
     reconcile_dirty_stats
+    verify_ticket_history_complete!(response)
     next_cursor = response.dig('pages', 'next', 'starting_after')
     next_cursor = update_cursor('conversations', next_cursor)
     PageResult.new(next_cursor: next_cursor)
@@ -32,6 +33,10 @@ class DataImports::Freshdesk::Importer < DataImports::Importer
       starting_after: cursor_for('conversations').presence || starting_after,
       per_page: @source.conversations_per_page
     )
+  end
+
+  def verify_ticket_history_complete!(response)
+    raise CustomExceptions::DataImport::FreshdeskTicketLimitError if response.dig('pages', 'limit_reached')
   end
 
   def import_conversation_summaries(response)

--- a/app/services/data_imports/freshdesk/importer.rb
+++ b/app/services/data_imports/freshdesk/importer.rb
@@ -3,4 +3,45 @@ class DataImports::Freshdesk::Importer < DataImports::Importer
   ALREADY_IMPORTED_ERROR_CODE = DataImports::Freshdesk::Source::ALREADY_IMPORTED_ERROR_CODE
   SKIPPED_MESSAGE_ERROR_CODE = DataImports::Freshdesk::Source::SKIPPED_MESSAGE_ERROR_CODE
   TRUNCATED_PARTS_ERROR_CODE = DataImports::Freshdesk::Source::TRUNCATED_PARTS_ERROR_CODE
+
+  def import_conversations_page(starting_after: cursor_for('conversations'))
+    response = conversations_page(starting_after)
+    checkpoint_ticket_page(response)
+    update_stat_total('conversations', response['total_count']) if response['total_count'].present?
+    import_conversation_summaries(response)
+    return PageResult.new(next_cursor: nil) if import_stopped?
+
+    reconcile_dirty_stats
+    next_cursor = response.dig('pages', 'next', 'starting_after')
+    update_cursor('conversations', next_cursor)
+    PageResult.new(next_cursor: next_cursor)
+  end
+
+  private
+
+  def checkpoint_ticket_page(response)
+    current_cursor = response.dig('pages', 'current', 'starting_after')
+    update_cursor('conversations', current_cursor) unless current_cursor == cursor_for('conversations')
+  end
+
+  def conversations_page(starting_after)
+    @source.list_conversations(
+      starting_after: cursor_for('conversations').presence || starting_after,
+      per_page: @source.conversations_per_page
+    )
+  end
+
+  def import_conversation_summaries(response)
+    summaries = Array(response['data'] || response['conversations'])
+    checkpoints = Array(response.dig('pages', 'checkpoints'))
+
+    summaries.each_with_index do |conversation_summary, index|
+      break if import_stopped?
+
+      import_conversation_from_summary(conversation_summary)
+      break if import_stopped?
+
+      update_cursor('conversations', checkpoints.fetch(index)) if index < summaries.length - 1
+    end
+  end
 end

--- a/app/services/data_imports/freshdesk/importer.rb
+++ b/app/services/data_imports/freshdesk/importer.rb
@@ -6,14 +6,15 @@ class DataImports::Freshdesk::Importer < DataImports::Importer
 
   def import_conversations_page(starting_after: cursor_for('conversations'))
     response = conversations_page(starting_after)
-    checkpoint_ticket_page(response)
+    return PageResult.new(next_cursor: cursor_for('conversations')) unless checkpoint_ticket_page(response)
+
     update_stat_total('conversations', response['total_count']) if response['total_count'].present?
-    import_conversation_summaries(response)
+    return PageResult.new(next_cursor: cursor_for('conversations')) unless import_conversation_summaries(response)
     return PageResult.new(next_cursor: nil) if import_stopped?
 
     reconcile_dirty_stats
     next_cursor = response.dig('pages', 'next', 'starting_after')
-    update_cursor('conversations', next_cursor)
+    next_cursor = update_cursor('conversations', next_cursor)
     PageResult.new(next_cursor: next_cursor)
   end
 
@@ -21,7 +22,9 @@ class DataImports::Freshdesk::Importer < DataImports::Importer
 
   def checkpoint_ticket_page(response)
     current_cursor = response.dig('pages', 'current', 'starting_after')
-    update_cursor('conversations', current_cursor) unless current_cursor == cursor_for('conversations')
+    return true if current_cursor == cursor_for('conversations')
+
+    update_cursor('conversations', current_cursor) == current_cursor
   end
 
   def conversations_page(starting_after)
@@ -41,7 +44,11 @@ class DataImports::Freshdesk::Importer < DataImports::Importer
       import_conversation_from_summary(conversation_summary)
       break if import_stopped?
 
-      update_cursor('conversations', checkpoints.fetch(index)) if index < summaries.length - 1
+      next if index == summaries.length - 1
+
+      checkpoint = checkpoints.fetch(index)
+      return false unless update_cursor('conversations', checkpoint) == checkpoint
     end
+    true
   end
 end

--- a/app/services/data_imports/freshdesk/source.rb
+++ b/app/services/data_imports/freshdesk/source.rb
@@ -81,7 +81,8 @@ class DataImports::Freshdesk::Source
       'pages' => {
         'current' => { 'starting_after' => page.current_cursor },
         'next' => page.next_cursor.present? ? { 'starting_after' => page.next_cursor } : nil,
-        'checkpoints' => page.checkpoints
+        'checkpoints' => page.checkpoints,
+        'limit_reached' => page.limit_reached?
       }
     }
   end

--- a/app/services/data_imports/freshdesk/source.rb
+++ b/app/services/data_imports/freshdesk/source.rb
@@ -69,14 +69,21 @@ class DataImports::Freshdesk::Source
   end
 
   def list_conversations(starting_after:, per_page:)
-    page = @client.list_tickets(page: starting_after.presence || 1, per_page: per_page)
-    tickets = Array(page.data).map do |ticket|
+    page = DataImports::Freshdesk::TicketPage.new(client: @client, starting_after: starting_after, per_page: per_page)
+    summaries = page.chunk.map do |ticket|
       {
         'id' => ticket['id'].to_s,
         'source' => { 'type' => DataImports::Freshdesk::SourceBucket.source_type(ticket['source']) }
       }
     end
-    paginated_response(page, tickets)
+    {
+      'data' => summaries,
+      'pages' => {
+        'current' => { 'starting_after' => page.current_cursor },
+        'next' => page.next_cursor.present? ? { 'starting_after' => page.next_cursor } : nil,
+        'checkpoints' => page.checkpoints
+      }
+    }
   end
 
   def retrieve_conversation(id)

--- a/app/services/data_imports/freshdesk/ticket_page.rb
+++ b/app/services/data_imports/freshdesk/ticket_page.rb
@@ -5,8 +5,11 @@ class DataImports::Freshdesk::TicketPage
 
   def initialize(client:, starting_after:, per_page:)
     @client = client
+    @per_page = per_page
     @cursor = normalize_cursor(starting_after)
     @tickets, next_page = ticket_page(per_page)
+    @page_limit_reached = page_limit_reached?
+    next_page = nil if @page_limit_reached
     @current_cursor = @cursor.merge('tickets' => @tickets, 'next_page' => next_page)
   end
 
@@ -22,6 +25,10 @@ class DataImports::Freshdesk::TicketPage
     return checkpoints.last if chunk.present?
 
     cursor_after(0)
+  end
+
+  def limit_reached?
+    @page_limit_reached && next_cursor.nil?
   end
 
   private
@@ -47,5 +54,9 @@ class DataImports::Freshdesk::TicketPage
     return { 'page' => current_cursor['next_page'], 'offset' => 0 } if current_cursor['next_page'].present?
 
     nil
+  end
+
+  def page_limit_reached?
+    @cursor['page'].to_i >= DataImports::Freshdesk::Client::MAX_TICKET_PAGES && @tickets.size >= @per_page
   end
 end

--- a/app/services/data_imports/freshdesk/ticket_page.rb
+++ b/app/services/data_imports/freshdesk/ticket_page.rb
@@ -1,0 +1,51 @@
+class DataImports::Freshdesk::TicketPage
+  TICKETS_PER_CHUNK = 10
+
+  attr_reader :current_cursor
+
+  def initialize(client:, starting_after:, per_page:)
+    @client = client
+    @cursor = normalize_cursor(starting_after)
+    @tickets, next_page = ticket_page(per_page)
+    @current_cursor = @cursor.merge('tickets' => @tickets, 'next_page' => next_page)
+  end
+
+  def chunk
+    @chunk ||= @tickets.slice(@cursor['offset'], TICKETS_PER_CHUNK) || []
+  end
+
+  def checkpoints
+    @checkpoints ||= chunk.each_index.map { |index| cursor_after(index + 1) }
+  end
+
+  def next_cursor
+    return checkpoints.last if chunk.present?
+
+    cursor_after(0)
+  end
+
+  private
+
+  def normalize_cursor(starting_after)
+    return { 'page' => starting_after.presence || 1, 'offset' => 0 } unless starting_after.is_a?(Hash)
+
+    cursor = starting_after.deep_stringify_keys.slice('page', 'offset', 'tickets', 'next_page')
+    cursor.merge('page' => cursor['page'] || 1, 'offset' => cursor['offset'].to_i)
+  end
+
+  def ticket_page(per_page)
+    return [Array(@cursor['tickets']), @cursor['next_page']] if @cursor.key?('tickets')
+
+    page = @client.list_tickets(page: @cursor['page'], per_page: per_page)
+    tickets = Array(page.data).map { |ticket| ticket.slice('id', 'source') }
+    [tickets, page.next_page]
+  end
+
+  def cursor_after(processed_count)
+    next_offset = @cursor['offset'] + processed_count
+    return current_cursor.merge('offset' => next_offset) if next_offset < @tickets.size
+    return { 'page' => current_cursor['next_page'], 'offset' => 0 } if current_cursor['next_page'].present?
+
+    nil
+  end
+end

--- a/lib/custom_exceptions/data_import/freshdesk_ticket_limit_error.rb
+++ b/lib/custom_exceptions/data_import/freshdesk_ticket_limit_error.rb
@@ -1,0 +1,13 @@
+class CustomExceptions::DataImport::FreshdeskTicketLimitError < CustomExceptions::Base
+  MESSAGE = 'Freshdesk limits ticket listing to 300 pages. This import stopped after 30,000 tickets because the API cannot ' \
+            'confirm that the ticket history is complete. A Freshdesk admin Account Export is required for any remaining history, ' \
+            'but this importer does not support account exports yet.'.freeze
+
+  def initialize
+    super({})
+  end
+
+  def message
+    MESSAGE
+  end
+end

--- a/spec/jobs/data_imports/freshdesk/import_jobs_spec.rb
+++ b/spec/jobs/data_imports/freshdesk/import_jobs_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe DataImports::Freshdesk::ImportJob do
     it 'checks rate limit retry before the generic client retry' do
       expect(described_class.rescue_handlers.last.first).to eq('DataImports::Freshdesk::Client::RateLimitError')
     end
+
+    it 'schedules a rate-limit retry using the Freshdesk Retry-After header' do
+      error = DataImports::Freshdesk::Client::RateLimitError.new('Rate limited', retry_after: '42')
+      allow(importer).to receive(:start!).and_raise(error)
+
+      travel_to(Time.zone.parse('2026-07-30 12:00:00 UTC')) do
+        expect do
+          DataImports::Freshdesk::ImportJob.perform_now(data_import, run_id)
+        end.to have_enqueued_job(DataImports::Freshdesk::ImportJob).at(42.seconds.from_now)
+      end
+    end
   end
 
   describe DataImports::Freshdesk::ImportJob do

--- a/spec/jobs/data_imports/freshdesk/import_jobs_spec.rb
+++ b/spec/jobs/data_imports/freshdesk/import_jobs_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe DataImports::Freshdesk::ImportJob do
 
   describe DataImports::Freshdesk::BaseJob do
     it 'checks rate limit retry before the generic client retry' do
-      expect(described_class.rescue_handlers.last.first).to eq('DataImports::Freshdesk::Client::RateLimitError')
+      handlers = described_class.rescue_handlers.map(&:first)
+
+      expect(handlers.index('DataImports::Freshdesk::Client::RateLimitError')).to be > handlers.index('DataImports::Freshdesk::Client::Error')
     end
 
     it 'schedules a rate-limit retry using the Freshdesk Retry-After header' do
@@ -26,6 +28,18 @@ RSpec.describe DataImports::Freshdesk::ImportJob do
           DataImports::Freshdesk::ImportJob.perform_now(data_import, run_id)
         end.to have_enqueued_job(DataImports::Freshdesk::ImportJob).at(42.seconds.from_now)
       end
+    end
+
+    it 'discards a terminal ticket-limit error after recording the failed import' do
+      error = CustomExceptions::DataImport::FreshdeskTicketLimitError.new
+      allow(importer).to receive_messages(conversations_completed?: false, fail!: true)
+      allow(importer).to receive(:import_conversations_page).with(starting_after: nil).and_raise(error)
+
+      expect do
+        DataImports::Freshdesk::ConversationsPageJob.perform_now(data_import, nil, run_id)
+      end.not_to have_enqueued_job
+
+      expect(importer).to have_received(:fail!).with(error)
     end
   end
 

--- a/spec/services/data_imports/freshdesk/importer_spec.rb
+++ b/spec/services/data_imports/freshdesk/importer_spec.rb
@@ -269,4 +269,34 @@ RSpec.describe DataImports::Freshdesk::Importer do
     expect(result.next_cursor).to eq(newer_cursor)
     expect(data_import.reload.cursor.dig('conversations', 'starting_after')).to eq(newer_cursor)
   end
+
+  it 'fails with an actionable error instead of completing at the REST ticket limit', :aggregate_failures do
+    tickets = Array.new(100) { |index| { 'id' => index + 1, 'source' => 1 } }
+    allow(client).to receive(:list_tickets).with(page: 300, per_page: 100).and_return(
+      DataImports::Freshdesk::Client::Page.new(data: tickets, next_page: nil)
+    )
+    importer = described_class.new(data_import: data_import)
+    processed_ticket_ids = []
+    allow(importer).to receive(:import_conversation_from_summary) { |summary| processed_ticket_ids << summary['id'] }
+    limit_error = nil
+
+    expect { importer.import_conversations_page(starting_after: { 'page' => 300, 'offset' => 90 }) }.to raise_error do |error|
+      expect(error.class.name).to eq('CustomExceptions::DataImport::FreshdeskTicketLimitError')
+      limit_error = error
+    end
+    importer.fail!(limit_error)
+
+    expect(processed_ticket_ids).to eq((91..100).map(&:to_s))
+    expect(data_import.reload).to be_failed
+    expect(data_import.cursor.dig('conversations', 'starting_after')).to include('page' => 300, 'offset' => 99)
+    expect(data_import.import_errors.last).to have_attributes(
+      error_code: 'CustomExceptions::DataImport::FreshdeskTicketLimitError',
+      message: limit_error.message
+    )
+    expect(data_import.import_errors.last.details).to include(
+      'kind' => 'run_error',
+      'source_provider' => 'freshdesk',
+      'error_class' => 'CustomExceptions::DataImport::FreshdeskTicketLimitError'
+    )
+  end
 end

--- a/spec/services/data_imports/freshdesk/importer_spec.rb
+++ b/spec/services/data_imports/freshdesk/importer_spec.rb
@@ -233,4 +233,38 @@ RSpec.describe DataImports::Freshdesk::Importer do
     expect(data_import.reload.cursor['conversations']).to include('starting_after' => nil, 'completed' => true)
     expect(client).to have_received(:list_tickets).once
   end
+
+  it 'stops a delayed worker when a newer per-ticket checkpoint is observed', :aggregate_failures do
+    current_cursor = { 'page' => 1, 'offset' => 0, 'tickets' => [], 'next_page' => 2 }
+    newer_cursor = current_cursor.merge('offset' => 3)
+    summaries = Array.new(3) { |index| { 'id' => (index + 2001).to_s } }
+    response = {
+      'data' => summaries,
+      'pages' => {
+        'current' => { 'starting_after' => current_cursor },
+        'next' => { 'starting_after' => { 'page' => 2, 'offset' => 0 } },
+        'checkpoints' => Array.new(3) { |index| current_cursor.merge('offset' => index + 1) }
+      }
+    }
+    importer = described_class.new(data_import: DataImport.find(data_import.id))
+    processed_ticket_ids = []
+    allow(importer).to receive(:conversations_page).and_return(response)
+    allow(importer).to receive(:import_conversation_from_summary) do |summary|
+      processed_ticket_ids << summary['id']
+      next unless summary['id'] == '2001'
+
+      concurrent_import = DataImport.find(data_import.id)
+      concurrent_import.update!(
+        cursor: concurrent_import.cursor.to_h.deep_merge(
+          'conversations' => { 'starting_after' => newer_cursor, 'completed' => false }
+        )
+      )
+    end
+
+    result = importer.import_conversations_page(starting_after: current_cursor)
+
+    expect(processed_ticket_ids).to eq(%w[2001])
+    expect(result.next_cursor).to eq(newer_cursor)
+    expect(data_import.reload.cursor.dig('conversations', 'starting_after')).to eq(newer_cursor)
+  end
 end

--- a/spec/services/data_imports/freshdesk/importer_spec.rb
+++ b/spec/services/data_imports/freshdesk/importer_spec.rb
@@ -247,12 +247,13 @@ RSpec.describe DataImports::Freshdesk::Importer do
       }
     }
     importer = described_class.new(data_import: DataImport.find(data_import.id))
-    processed_ticket_ids = []
     allow(importer).to receive(:conversations_page).and_return(response)
-    allow(importer).to receive(:import_conversation_from_summary) do |summary|
-      processed_ticket_ids << summary['id']
-      next unless summary['id'] == '2001'
+    cursor_advanced = false
+    allow(importer).to receive(:persist_stats).and_wrap_original do |method, *args|
+      method.call(*args)
+      next if cursor_advanced
 
+      cursor_advanced = true
       concurrent_import = DataImport.find(data_import.id)
       concurrent_import.update!(
         cursor: concurrent_import.cursor.to_h.deep_merge(
@@ -263,7 +264,8 @@ RSpec.describe DataImports::Freshdesk::Importer do
 
     result = importer.import_conversations_page(starting_after: current_cursor)
 
-    expect(processed_ticket_ids).to eq(%w[2001])
+    expect(account.conversations.where(identifier: 'freshdesk:2001').count).to eq(1)
+    expect(client).not_to have_received(:retrieve_ticket).with('2002')
     expect(result.next_cursor).to eq(newer_cursor)
     expect(data_import.reload.cursor.dig('conversations', 'starting_after')).to eq(newer_cursor)
   end

--- a/spec/services/data_imports/freshdesk/importer_spec.rb
+++ b/spec/services/data_imports/freshdesk/importer_spec.rb
@@ -202,4 +202,35 @@ RSpec.describe DataImports::Freshdesk::Importer do
 
     expect(data_import.reload.cursor['conversations']).to include('starting_after' => nil, 'completed' => true)
   end
+
+  it 'resumes a rate-limited ticket chunk from the last persisted checkpoint', :aggregate_failures do
+    tickets = Array.new(3) { |index| { 'id' => index + 2001, 'source' => 1 } }
+    allow(client).to receive(:list_tickets).with(page: 1, per_page: 100).and_return(
+      DataImports::Freshdesk::Client::Page.new(data: tickets, next_page: nil)
+    )
+    importer = described_class.new(data_import: data_import)
+    processed_ticket_ids = []
+    rate_limited = true
+    allow(importer).to receive(:import_conversation_from_summary) do |summary|
+      processed_ticket_ids << summary['id']
+      if summary['id'] == '2003' && rate_limited
+        rate_limited = false
+        raise DataImports::Freshdesk::Client::RateLimitError.new('Rate limited', retry_after: '42')
+      end
+    end
+
+    expect do
+      importer.import_conversations_page(starting_after: { 'page' => 1, 'offset' => 0 })
+    end.to raise_error(DataImports::Freshdesk::Client::RateLimitError)
+    expect(processed_ticket_ids).to eq(%w[2001 2002 2003])
+    expect(data_import.reload.cursor.dig('conversations', 'starting_after')).to include('page' => 1, 'offset' => 2)
+
+    processed_ticket_ids.clear
+    result = importer.import_conversations_page(starting_after: { 'page' => 1, 'offset' => 0 })
+
+    expect(processed_ticket_ids).to eq(%w[2003])
+    expect(result).to be_done
+    expect(data_import.reload.cursor['conversations']).to include('starting_after' => nil, 'completed' => true)
+    expect(client).to have_received(:list_tickets).once
+  end
 end

--- a/spec/services/data_imports/freshdesk/source_spec.rb
+++ b/spec/services/data_imports/freshdesk/source_spec.rb
@@ -77,6 +77,34 @@ RSpec.describe DataImports::Freshdesk::Source do
       expect(response.dig('pages', 'checkpoints').last).to eq('page' => 3, 'offset' => 0)
       expect(response.dig('pages', 'next', 'starting_after')).to eq('page' => 3, 'offset' => 0)
     end
+
+    it 'reports the REST ticket limit only after the final chunk of a full page 300', :aggregate_failures do
+      tickets = Array.new(100) { |index| { 'id' => index + 1, 'source' => 1 } }
+      expect(client).to receive(:list_tickets).with(page: 300, per_page: 100).once.and_return(
+        DataImports::Freshdesk::Client::Page.new(data: tickets, next_page: nil)
+      )
+
+      first_chunk = source.list_conversations(starting_after: { 'page' => 300, 'offset' => 0 }, per_page: 100)
+      final_cursor = first_chunk.dig('pages', 'current', 'starting_after').merge('offset' => 90)
+      final_chunk = source.list_conversations(starting_after: final_cursor, per_page: 100)
+
+      expect(first_chunk.dig('pages', 'limit_reached')).to be(false)
+      expect(final_chunk['data'].pluck('id')).to eq((91..100).map(&:to_s))
+      expect(final_chunk.dig('pages', 'next')).to be_nil
+      expect(final_chunk.dig('pages', 'limit_reached')).to be(true)
+    end
+
+    it 'completes a partial page 300 without reporting the ticket limit' do
+      tickets = Array.new(99) { |index| { 'id' => index + 1, 'source' => 1 } }
+      allow(client).to receive(:list_tickets).with(page: 300, per_page: 100).and_return(
+        DataImports::Freshdesk::Client::Page.new(data: tickets, next_page: nil)
+      )
+
+      response = source.list_conversations(starting_after: { 'page' => 300, 'offset' => 90 }, per_page: 100)
+
+      expect(response.dig('pages', 'next')).to be_nil
+      expect(response.dig('pages', 'limit_reached')).to be(false)
+    end
   end
 
   describe '#retrieve_conversation' do

--- a/spec/services/data_imports/freshdesk/source_spec.rb
+++ b/spec/services/data_imports/freshdesk/source_spec.rb
@@ -43,6 +43,42 @@ RSpec.describe DataImports::Freshdesk::Source do
     end
   end
 
+  describe '#list_conversations' do
+    it 'returns a resumable ticket chunk with a cursor after every ticket', :aggregate_failures do
+      tickets = Array.new(25) { |index| { 'id' => index + 1, 'source' => 1 } }
+      allow(client).to receive(:list_tickets).with(page: 2, per_page: 100).and_return(
+        DataImports::Freshdesk::Client::Page.new(data: tickets, next_page: 3)
+      )
+
+      response = source.list_conversations(
+        starting_after: { 'page' => 2, 'offset' => 10 },
+        per_page: 100
+      )
+
+      expect(response['data'].pluck('id')).to eq((11..20).map(&:to_s))
+      expect(response.dig('pages', 'checkpoints').first).to include('page' => 2, 'offset' => 11, 'next_page' => 3)
+      expect(response.dig('pages', 'checkpoints').last).to include('page' => 2, 'offset' => 20, 'next_page' => 3)
+      expect(response.dig('pages', 'next', 'starting_after')).to include('page' => 2, 'offset' => 20, 'next_page' => 3)
+    end
+
+    it 'reuses the cached ticket page before advancing to the next Freshdesk page', :aggregate_failures do
+      tickets = Array.new(25) { |index| { 'id' => index + 1, 'source' => 1 } }
+      expect(client).to receive(:list_tickets).with(page: 2, per_page: 100).once.and_return(
+        DataImports::Freshdesk::Client::Page.new(data: tickets, next_page: 3)
+      )
+
+      first_chunk = source.list_conversations(
+        starting_after: { 'page' => 2, 'offset' => 10 },
+        per_page: 100
+      )
+      response = source.list_conversations(starting_after: first_chunk.dig('pages', 'next', 'starting_after'), per_page: 100)
+
+      expect(response['data'].pluck('id')).to eq((21..25).map(&:to_s))
+      expect(response.dig('pages', 'checkpoints').last).to eq('page' => 3, 'offset' => 0)
+      expect(response.dig('pages', 'next', 'starting_after')).to eq('page' => 3, 'offset' => 0)
+    end
+  end
+
   describe '#retrieve_conversation' do
     it 'retrieves every conversation page and normalizes the ticket', :aggregate_failures do
       conversations = ticket_fixture.fetch('conversations')


### PR DESCRIPTION
Freshdesk migrations now process historical tickets in small resumable chunks and honor the retry window returned by Freshdesk, avoiding repeated API work when an account reaches its rate limit.

This is a stacked follow-up to #15261.

## Closes

- [CW-7639](https://linear.app/chatwoot/issue/CW-7639/freshdesk-freshworks-migration)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What changed

- Fetch up to 100 ticket summaries once, retain only their IDs and source values in the import cursor, and process ten tickets per job.
- Checkpoint the page and ticket offset after each successfully imported ticket.
- Resume retries from the persisted checkpoint instead of the stale job argument, preventing completed tickets from being fetched again.
- Schedule rate-limit retries using Freshdesk's `Retry-After` seconds, with the existing one-minute fallback when the header is unavailable.

## How to test

1. Start a Freshdesk migration with ticket import enabled and enough historical tickets to span multiple ten-ticket chunks.
2. Confirm the import continues across chunks and completes without duplicate conversations or messages.
3. Return a `429` response with a `Retry-After` header during ticket processing.
4. Confirm the import remains retryable, waits for the requested interval, and resumes at the interrupted ticket.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
