### PR TITLE
feat(data-imports): detect Freshdesk ticket limit (3/3)

### DIFF
--- a/app/jobs/data_imports/freshdesk/base_job.rb
+++ b/app/jobs/data_imports/freshdesk/base_job.rb
@@ -9,7 +9,7 @@ class DataImports::Freshdesk::BaseJob < DataImports::BaseJob
     job.fail_import!(error)
   end
 
-  discard_on DataImports::Freshdesk::TicketLimitError
+  discard_on CustomExceptions::DataImport::FreshdeskTicketLimitError
 
   def retry_job(options = {})
     error = options[:error]

--- a/app/jobs/data_imports/freshdesk/base_job.rb
+++ b/app/jobs/data_imports/freshdesk/base_job.rb
@@ -9,6 +9,8 @@ class DataImports::Freshdesk::BaseJob < DataImports::BaseJob
     job.fail_import!(error)
   end
 
+  discard_on DataImports::Freshdesk::TicketLimitError
+
   def retry_job(options = {})
     error = options[:error]
     options = options.merge(wait: rate_limit_wait(error)) if error.is_a?(DataImports::Freshdesk::Client::RateLimitError)

--- a/app/services/data_imports/freshdesk/client.rb
+++ b/app/services/data_imports/freshdesk/client.rb
@@ -25,6 +25,7 @@ class DataImports::Freshdesk::Client
   Page = Struct.new(:data, :next_page, keyword_init: true)
 
   DEFAULT_PER_PAGE = 100
+  MAX_TICKET_PAGES = 300
   EARLIEST_TICKET_TIMESTAMP = '1970-01-01T00:00:00Z'.freeze
   FRESHDESK_DOMAIN_REGEX = /\A[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.freshdesk\.com\z/i
 

--- a/app/services/data_imports/freshdesk/importer.rb
+++ b/app/services/data_imports/freshdesk/importer.rb
@@ -36,7 +36,7 @@ class DataImports::Freshdesk::Importer < DataImports::Importer
   end
 
   def verify_ticket_history_complete!(response)
-    raise DataImports::Freshdesk::TicketLimitError if response.dig('pages', 'limit_reached')
+    raise CustomExceptions::DataImport::FreshdeskTicketLimitError if response.dig('pages', 'limit_reached')
   end
 
   def import_conversation_summaries(response)

--- a/app/services/data_imports/freshdesk/importer.rb
+++ b/app/services/data_imports/freshdesk/importer.rb
@@ -13,6 +13,7 @@ class DataImports::Freshdesk::Importer < DataImports::Importer
     return PageResult.new(next_cursor: nil) if import_stopped?
 
     reconcile_dirty_stats
+    verify_ticket_history_complete!(response)
     next_cursor = response.dig('pages', 'next', 'starting_after')
     next_cursor = update_cursor('conversations', next_cursor)
     PageResult.new(next_cursor: next_cursor)
@@ -32,6 +33,10 @@ class DataImports::Freshdesk::Importer < DataImports::Importer
       starting_after: cursor_for('conversations').presence || starting_after,
       per_page: @source.conversations_per_page
     )
+  end
+
+  def verify_ticket_history_complete!(response)
+    raise DataImports::Freshdesk::TicketLimitError if response.dig('pages', 'limit_reached')
   end
 
   def import_conversation_summaries(response)

--- a/app/services/data_imports/freshdesk/source.rb
+++ b/app/services/data_imports/freshdesk/source.rb
@@ -81,7 +81,8 @@ class DataImports::Freshdesk::Source
       'pages' => {
         'current' => { 'starting_after' => page.current_cursor },
         'next' => page.next_cursor.present? ? { 'starting_after' => page.next_cursor } : nil,
-        'checkpoints' => page.checkpoints
+        'checkpoints' => page.checkpoints,
+        'limit_reached' => page.limit_reached?
       }
     }
   end

--- a/app/services/data_imports/freshdesk/ticket_limit_error.rb
+++ b/app/services/data_imports/freshdesk/ticket_limit_error.rb
@@ -1,0 +1,9 @@
+class DataImports::Freshdesk::TicketLimitError < StandardError
+  def initialize
+    super(
+      'Freshdesk limits ticket listing to 300 pages. This import stopped after 30,000 tickets because the API cannot ' \
+      'confirm that the ticket history is complete. A Freshdesk admin Account Export is required for any remaining history, ' \
+      'but this importer does not support account exports yet.'
+    )
+  end
+end

--- a/app/services/data_imports/freshdesk/ticket_limit_error.rb
+++ b/app/services/data_imports/freshdesk/ticket_limit_error.rb
@@ -1,9 +1,0 @@
-class DataImports::Freshdesk::TicketLimitError < StandardError
-  def initialize
-    super(
-      'Freshdesk limits ticket listing to 300 pages. This import stopped after 30,000 tickets because the API cannot ' \
-      'confirm that the ticket history is complete. A Freshdesk admin Account Export is required for any remaining history, ' \
-      'but this importer does not support account exports yet.'
-    )
-  end
-end

--- a/app/services/data_imports/freshdesk/ticket_page.rb
+++ b/app/services/data_imports/freshdesk/ticket_page.rb
@@ -5,8 +5,11 @@ class DataImports::Freshdesk::TicketPage
 
   def initialize(client:, starting_after:, per_page:)
     @client = client
+    @per_page = per_page
     @cursor = normalize_cursor(starting_after)
     @tickets, next_page = ticket_page(per_page)
+    @page_limit_reached = page_limit_reached?
+    next_page = nil if @page_limit_reached
     @current_cursor = @cursor.merge('tickets' => @tickets, 'next_page' => next_page)
   end
 
@@ -22,6 +25,10 @@ class DataImports::Freshdesk::TicketPage
     return checkpoints.last if chunk.present?
 
     cursor_after(0)
+  end
+
+  def limit_reached?
+    @page_limit_reached && next_cursor.nil?
   end
 
   private
@@ -47,5 +54,9 @@ class DataImports::Freshdesk::TicketPage
     return { 'page' => current_cursor['next_page'], 'offset' => 0 } if current_cursor['next_page'].present?
 
     nil
+  end
+
+  def page_limit_reached?
+    @cursor['page'].to_i >= DataImports::Freshdesk::Client::MAX_TICKET_PAGES && @tickets.size >= @per_page
   end
 end

--- a/lib/custom_exceptions/data_import/freshdesk_ticket_limit_error.rb
+++ b/lib/custom_exceptions/data_import/freshdesk_ticket_limit_error.rb
@@ -1,0 +1,13 @@
+class CustomExceptions::DataImport::FreshdeskTicketLimitError < CustomExceptions::Base
+  MESSAGE = 'Freshdesk limits ticket listing to 300 pages. This import stopped after 30,000 tickets because the API cannot ' \
+            'confirm that the ticket history is complete. A Freshdesk admin Account Export is required for any remaining history, ' \
+            'but this importer does not support account exports yet.'.freeze
+
+  def initialize
+    super({})
+  end
+
+  def message
+    MESSAGE
+  end
+end

--- a/spec/jobs/data_imports/freshdesk/import_jobs_spec.rb
+++ b/spec/jobs/data_imports/freshdesk/import_jobs_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe DataImports::Freshdesk::ImportJob do
     end
 
     it 'discards a terminal ticket-limit error after recording the failed import' do
-      error = DataImports::Freshdesk::TicketLimitError.new
+      error = CustomExceptions::DataImport::FreshdeskTicketLimitError.new
       allow(importer).to receive_messages(conversations_completed?: false, fail!: true)
       allow(importer).to receive(:import_conversations_page).with(starting_after: nil).and_raise(error)
 

--- a/spec/jobs/data_imports/freshdesk/import_jobs_spec.rb
+++ b/spec/jobs/data_imports/freshdesk/import_jobs_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe DataImports::Freshdesk::ImportJob do
 
   describe DataImports::Freshdesk::BaseJob do
     it 'checks rate limit retry before the generic client retry' do
-      expect(described_class.rescue_handlers.last.first).to eq('DataImports::Freshdesk::Client::RateLimitError')
+      handlers = described_class.rescue_handlers.map(&:first)
+
+      expect(handlers.index('DataImports::Freshdesk::Client::RateLimitError')).to be > handlers.index('DataImports::Freshdesk::Client::Error')
     end
 
     it 'schedules a rate-limit retry using the Freshdesk Retry-After header' do
@@ -26,6 +28,18 @@ RSpec.describe DataImports::Freshdesk::ImportJob do
           DataImports::Freshdesk::ImportJob.perform_now(data_import, run_id)
         end.to have_enqueued_job(DataImports::Freshdesk::ImportJob).at(42.seconds.from_now)
       end
+    end
+
+    it 'discards a terminal ticket-limit error after recording the failed import' do
+      error = DataImports::Freshdesk::TicketLimitError.new
+      allow(importer).to receive_messages(conversations_completed?: false, fail!: true)
+      allow(importer).to receive(:import_conversations_page).with(starting_after: nil).and_raise(error)
+
+      expect do
+        DataImports::Freshdesk::ConversationsPageJob.perform_now(data_import, nil, run_id)
+      end.not_to have_enqueued_job
+
+      expect(importer).to have_received(:fail!).with(error)
     end
   end
 

--- a/spec/services/data_imports/freshdesk/importer_spec.rb
+++ b/spec/services/data_imports/freshdesk/importer_spec.rb
@@ -269,4 +269,33 @@ RSpec.describe DataImports::Freshdesk::Importer do
     expect(result.next_cursor).to eq(newer_cursor)
     expect(data_import.reload.cursor.dig('conversations', 'starting_after')).to eq(newer_cursor)
   end
+
+  it 'fails with an actionable error instead of completing at the REST ticket limit', :aggregate_failures do
+    tickets = Array.new(100) { |index| { 'id' => index + 1, 'source' => 1 } }
+    allow(client).to receive(:list_tickets).with(page: 300, per_page: 100).and_return(
+      DataImports::Freshdesk::Client::Page.new(data: tickets, next_page: nil)
+    )
+    importer = described_class.new(data_import: data_import)
+    processed_ticket_ids = []
+    allow(importer).to receive(:import_conversation_from_summary) { |summary| processed_ticket_ids << summary['id'] }
+    limit_error = nil
+
+    expect do
+      importer.import_conversations_page(starting_after: { 'page' => 300, 'offset' => 90 })
+    end.to raise_error(DataImports::Freshdesk::TicketLimitError) { |error| limit_error = error }
+    importer.fail!(limit_error)
+
+    expect(processed_ticket_ids).to eq((91..100).map(&:to_s))
+    expect(data_import.reload).to be_failed
+    expect(data_import.cursor.dig('conversations', 'starting_after')).to include('page' => 300, 'offset' => 99)
+    expect(data_import.import_errors.last).to have_attributes(
+      error_code: 'DataImports::Freshdesk::TicketLimitError',
+      message: limit_error.message
+    )
+    expect(data_import.import_errors.last.details).to include(
+      'kind' => 'run_error',
+      'source_provider' => 'freshdesk',
+      'error_class' => 'DataImports::Freshdesk::TicketLimitError'
+    )
+  end
 end

--- a/spec/services/data_imports/freshdesk/importer_spec.rb
+++ b/spec/services/data_imports/freshdesk/importer_spec.rb
@@ -280,9 +280,10 @@ RSpec.describe DataImports::Freshdesk::Importer do
     allow(importer).to receive(:import_conversation_from_summary) { |summary| processed_ticket_ids << summary['id'] }
     limit_error = nil
 
-    expect do
-      importer.import_conversations_page(starting_after: { 'page' => 300, 'offset' => 90 })
-    end.to raise_error(CustomExceptions::DataImport::FreshdeskTicketLimitError) { |error| limit_error = error }
+    expect { importer.import_conversations_page(starting_after: { 'page' => 300, 'offset' => 90 }) }.to raise_error do |error|
+      expect(error.class.name).to eq('CustomExceptions::DataImport::FreshdeskTicketLimitError')
+      limit_error = error
+    end
     importer.fail!(limit_error)
 
     expect(processed_ticket_ids).to eq((91..100).map(&:to_s))

--- a/spec/services/data_imports/freshdesk/importer_spec.rb
+++ b/spec/services/data_imports/freshdesk/importer_spec.rb
@@ -282,20 +282,20 @@ RSpec.describe DataImports::Freshdesk::Importer do
 
     expect do
       importer.import_conversations_page(starting_after: { 'page' => 300, 'offset' => 90 })
-    end.to raise_error(DataImports::Freshdesk::TicketLimitError) { |error| limit_error = error }
+    end.to raise_error(CustomExceptions::DataImport::FreshdeskTicketLimitError) { |error| limit_error = error }
     importer.fail!(limit_error)
 
     expect(processed_ticket_ids).to eq((91..100).map(&:to_s))
     expect(data_import.reload).to be_failed
     expect(data_import.cursor.dig('conversations', 'starting_after')).to include('page' => 300, 'offset' => 99)
     expect(data_import.import_errors.last).to have_attributes(
-      error_code: 'DataImports::Freshdesk::TicketLimitError',
+      error_code: 'CustomExceptions::DataImport::FreshdeskTicketLimitError',
       message: limit_error.message
     )
     expect(data_import.import_errors.last.details).to include(
       'kind' => 'run_error',
       'source_provider' => 'freshdesk',
-      'error_class' => 'DataImports::Freshdesk::TicketLimitError'
+      'error_class' => 'CustomExceptions::DataImport::FreshdeskTicketLimitError'
     )
   end
 end

--- a/spec/services/data_imports/freshdesk/source_spec.rb
+++ b/spec/services/data_imports/freshdesk/source_spec.rb
@@ -77,6 +77,34 @@ RSpec.describe DataImports::Freshdesk::Source do
       expect(response.dig('pages', 'checkpoints').last).to eq('page' => 3, 'offset' => 0)
       expect(response.dig('pages', 'next', 'starting_after')).to eq('page' => 3, 'offset' => 0)
     end
+
+    it 'reports the REST ticket limit only after the final chunk of a full page 300', :aggregate_failures do
+      tickets = Array.new(100) { |index| { 'id' => index + 1, 'source' => 1 } }
+      expect(client).to receive(:list_tickets).with(page: 300, per_page: 100).once.and_return(
+        DataImports::Freshdesk::Client::Page.new(data: tickets, next_page: nil)
+      )
+
+      first_chunk = source.list_conversations(starting_after: { 'page' => 300, 'offset' => 0 }, per_page: 100)
+      final_cursor = first_chunk.dig('pages', 'current', 'starting_after').merge('offset' => 90)
+      final_chunk = source.list_conversations(starting_after: final_cursor, per_page: 100)
+
+      expect(first_chunk.dig('pages', 'limit_reached')).to be(false)
+      expect(final_chunk['data'].pluck('id')).to eq((91..100).map(&:to_s))
+      expect(final_chunk.dig('pages', 'next')).to be_nil
+      expect(final_chunk.dig('pages', 'limit_reached')).to be(true)
+    end
+
+    it 'completes a partial page 300 without reporting the ticket limit' do
+      tickets = Array.new(99) { |index| { 'id' => index + 1, 'source' => 1 } }
+      allow(client).to receive(:list_tickets).with(page: 300, per_page: 100).and_return(
+        DataImports::Freshdesk::Client::Page.new(data: tickets, next_page: nil)
+      )
+
+      response = source.list_conversations(starting_after: { 'page' => 300, 'offset' => 90 }, per_page: 100)
+
+      expect(response.dig('pages', 'next')).to be_nil
+      expect(response.dig('pages', 'limit_reached')).to be(false)
+    end
   end
 
   describe '#retrieve_conversation' do


### PR DESCRIPTION
Freshdesk migrations now stop with an actionable import error when the REST API can no longer prove the ticket history is complete. This prevents an import with more than Freshdesk's documented 30,000-ticket listing ceiling from being reported as successfully completed.

This is a stacked follow-up to #15265.

## Closes

- https://linear.app/chatwoot/issue/CW-7639/freshdesk-freshworks-migration

## What changed

- Detect a full 300th ticket page, while still importing every ticket from that page.
- Mark the import as failed with an explanation that the remaining history requires a Freshdesk admin Account Export, which is not supported yet.
- Preserve the final cursor checkpoint so a future Account Export recovery path can remain idempotent.
- Treat this known terminal condition as discarded after the failure is recorded, avoiding repeated background-job retries.
- Allow page 300 to complete normally when it contains fewer than 100 tickets.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How to test

1. Run a Freshdesk import where ticket page 300 contains 100 tickets.
2. Verify all tickets on the page are imported and the import then moves to `failed`.
3. Verify the Import Errors section explains that complete history cannot be confirmed and that a Freshdesk admin Account Export is required for the remaining history.
4. Repeat with fewer than 100 tickets on page 300 and verify the import completes normally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
