### PR TITLE
feat: add native Telnyx SMS channel

### DIFF
--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -19,7 +19,7 @@ class ContactInboxBuilder
       wa_source_id
     when 'Channel::Email'
       email_source_id
-    when 'Channel::Sms'
+    when 'Channel::Sms', 'Channel::TelnyxSms'
       phone_source_id
     when 'Channel::Api', 'Channel::WebWidget'
       SecureRandom.uuid

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -104,9 +104,7 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
     account_channels_method.create!(permitted_params(channel_type_from_params::EDITABLE_ATTRS)[:channel].except(:type))
   end
 
-  def allowed_channel_types
-    %w[web_widget api email line telegram whatsapp sms]
-  end
+  def allowed_channel_types = %w[web_widget api email line telegram whatsapp sms telnyx_sms]
 
   def update_inbox_working_hours
     @inbox.update_working_hours(params.permit(working_hours: Inbox::OFFISABLE_ATTRS)[:working_hours]) if params[:working_hours]
@@ -215,7 +213,8 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
       'line' => Channel::Line,
       'telegram' => Channel::Telegram,
       'whatsapp' => Channel::Whatsapp,
-      'sms' => Channel::Sms
+      'sms' => Channel::Sms,
+      'telnyx_sms' => Channel::TelnyxSms
     }[permitted_params[:channel][:type]]
   end
 

--- a/app/controllers/webhooks/telnyx_sms_controller.rb
+++ b/app/controllers/webhooks/telnyx_sms_controller.rb
@@ -1,0 +1,11 @@
+class Webhooks::TelnyxSmsController < ActionController::API
+  def process_payload
+    if Rails.env.development?
+      Webhooks::TelnyxSmsEventsJob.perform_now(params.to_unsafe_hash)
+    else
+      Webhooks::TelnyxSmsEventsJob.perform_later(params.to_unsafe_hash)
+    end
+
+    head :ok
+  end
+end

--- a/app/helpers/api/v1/inboxes_helper.rb
+++ b/app/helpers/api/v1/inboxes_helper.rb
@@ -111,7 +111,8 @@ module Api::V1::InboxesHelper
       'line' => Current.account.line_channels,
       'telegram' => Current.account.telegram_channels,
       'whatsapp' => Current.account.whatsapp_channels,
-      'sms' => Current.account.sms_channels
+      'sms' => Current.account.sms_channels,
+      'telnyx_sms' => Current.account.telnyx_sms_channels
     }[permitted_params[:channel][:type]]
   end
 end

--- a/app/javascript/dashboard/components-next/NewConversation/helpers/composeConversationHelper.js
+++ b/app/javascript/dashboard/components-next/NewConversation/helpers/composeConversationHelper.js
@@ -7,9 +7,10 @@ const CHANNEL_PRIORITY = {
   'Channel::Email': 1,
   'Channel::Whatsapp': 2,
   'Channel::Sms': 3,
-  'Channel::TwilioSms': 4,
-  'Channel::WebWidget': 5,
-  'Channel::Api': 6,
+  'Channel::TelnyxSms': 4,
+  'Channel::TwilioSms': 5,
+  'Channel::WebWidget': 6,
+  'Channel::Api': 7,
 };
 
 export const generateLabelForContactableInboxesList = ({
@@ -23,6 +24,7 @@ export const generateLabelForContactableInboxesList = ({
   }
   if (
     channelType === INBOX_TYPES.TWILIO ||
+    channelType === INBOX_TYPES.TELNYX_SMS ||
     channelType === INBOX_TYPES.WHATSAPP
   ) {
     return phoneNumber ? `${name} (${phoneNumber})` : name;

--- a/app/javascript/dashboard/components-next/icon/provider.js
+++ b/app/javascript/dashboard/components-next/icon/provider.js
@@ -12,6 +12,7 @@ const channelTypeIconMap = {
   'Channel::FacebookPage': 'i-woot-messenger',
   'Channel::Line': 'i-woot-line',
   'Channel::Sms': 'i-woot-sms',
+  'Channel::TelnyxSms': 'i-woot-sms',
   'Channel::Telegram': 'i-woot-telegram',
   'Channel::TwilioSms': 'i-woot-sms',
   'Channel::TwitterProfile': 'i-woot-x',

--- a/app/javascript/dashboard/composables/useInbox.js
+++ b/app/javascript/dashboard/composables/useInbox.js
@@ -101,7 +101,11 @@ export const useInbox = (inboxId = null) => {
   });
 
   const isASmsInbox = computed(() => {
-    return channelType.value === INBOX_TYPES.SMS || isATwilioSMSChannel.value;
+    return (
+      channelType.value === INBOX_TYPES.SMS ||
+      channelType.value === INBOX_TYPES.TELNYX_SMS ||
+      isATwilioSMSChannel.value
+    );
   });
 
   const isATwilioWhatsAppChannel = computed(() => {

--- a/app/javascript/dashboard/constants/editor.js
+++ b/app/javascript/dashboard/constants/editor.js
@@ -71,6 +71,11 @@ export const FORMATTING = {
     nodes: [],
     menu: [],
   },
+  'Channel::TelnyxSms': {
+    marks: [],
+    nodes: [],
+    menu: [],
+  },
   'Channel::Whatsapp': {
     marks: ['strong', 'em', 'code', 'strike'],
     nodes: ['bulletList', 'orderedList', 'codeBlock'],

--- a/app/javascript/dashboard/helper/inbox.js
+++ b/app/javascript/dashboard/helper/inbox.js
@@ -9,6 +9,7 @@ export const INBOX_TYPES = {
   TELEGRAM: 'Channel::Telegram',
   LINE: 'Channel::Line',
   SMS: 'Channel::Sms',
+  TELNYX_SMS: 'Channel::TelnyxSms',
   INSTAGRAM: 'Channel::Instagram',
   TIKTOK: 'Channel::Tiktok',
 };

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -197,7 +197,8 @@
         "PROVIDERS": {
           "LABEL": "API Provider",
           "TWILIO": "Twilio",
-          "BANDWIDTH": "Bandwidth"
+          "BANDWIDTH": "Bandwidth",
+          "TELNYX": "Telnyx"
         },
         "API": {
           "ERROR_MESSAGE": "We were not able to save the SMS channel"
@@ -240,6 +241,33 @@
           "API_CALLBACK": {
             "TITLE": "Callback URL",
             "SUBTITLE": "You have to configure the message callback URL in Bandwidth with the URL mentioned here."
+          }
+        },
+        "TELNYX": {
+          "INBOX_NAME": {
+            "LABEL": "Inbox Name",
+            "PLACEHOLDER": "Enter your Inbox Name",
+            "ERROR": "Inbox Name is required"
+          },
+          "PHONE_NUMBER": {
+            "LABEL": "Phone Number",
+            "PLACEHOLDER": "Enter your Phone Number to determine the sender of message",
+            "ERROR": "Phone Number is required and must starts with a `+` sign and does not contain any spaces."
+          },
+          "API_KEY": {
+            "LABEL": "API Key",
+            "PLACEHOLDER": "Enter your Telnyx API Key",
+            "ERROR": "API Key is required"
+          },
+          "MESSAGING_PROFILE_ID": {
+            "LABEL": "Messaging Profile ID",
+            "PLACEHOLDER": "Enter your Telnyx Messaging Profile ID",
+            "ERROR": "Messaging Profile ID is required"
+          },
+          "SUBMIT_BUTTON": "Create Telnyx Channel",
+          "API_CALLBACK": {
+            "TITLE": "Callback URL",
+            "SUBTITLE": "You have to configure the message webhook URL in Telnyx with the URL mentioned here."
           }
         }
       },
@@ -1368,6 +1396,7 @@
       "TWILIO_SMS": "Twilio SMS",
       "WHATSAPP": "WhatsApp",
       "SMS": "SMS",
+      "TELNYX_SMS": "Telnyx SMS",
       "EMAIL": "Email",
       "TELEGRAM": "Telegram",
       "LINE": "Line",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Sms.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Sms.vue
@@ -1,6 +1,7 @@
 <script>
 import PageHeader from '../../SettingsSubPageHeader.vue';
 import BandwidthSms from './BandwidthSms.vue';
+import TelnyxSms from './TelnyxSms.vue';
 import Twilio from './Twilio.vue';
 
 export default {
@@ -8,6 +9,7 @@ export default {
     PageHeader,
     Twilio,
     BandwidthSms,
+    TelnyxSms,
   },
   data() {
     return {
@@ -33,10 +35,14 @@ export default {
           <option value="360dialog">
             {{ $t('INBOX_MGMT.ADD.SMS.PROVIDERS.BANDWIDTH') }}
           </option>
+          <option value="telnyx">
+            {{ $t('INBOX_MGMT.ADD.SMS.PROVIDERS.TELNYX') }}
+          </option>
         </select>
       </label>
     </div>
     <Twilio v-if="provider === 'twilio'" type="sms" />
+    <TelnyxSms v-else-if="provider === 'telnyx'" />
     <BandwidthSms v-else />
   </div>
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/TelnyxSms.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/TelnyxSms.vue
@@ -1,73 +1,65 @@
-<script>
-import { mapGetters } from 'vuex';
+<script setup>
+import { reactive } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 import { useVuelidate } from '@vuelidate/core';
 import { useAlert } from 'dashboard/composables';
+import { useMapGetter, useStore } from 'dashboard/composables/store';
 import { required } from '@vuelidate/validators';
-import router from '../../../../index';
 
 import NextButton from 'dashboard/components-next/button/Button.vue';
 
 const shouldStartWithPlusSign = (value = '') => value.startsWith('+');
 
-export default {
-  components: {
-    NextButton,
-  },
-  setup() {
-    return { v$: useVuelidate() };
-  },
-  data() {
-    return {
-      apiKey: '',
-      messagingProfileId: '',
-      inboxName: '',
-      phoneNumber: '',
-    };
-  },
-  computed: {
-    ...mapGetters({
-      uiFlags: 'inboxes/getUIFlags',
-    }),
-  },
-  validations: {
-    inboxName: { required },
-    phoneNumber: { required, shouldStartWithPlusSign },
-    apiKey: { required },
-    messagingProfileId: { required },
-  },
-  methods: {
-    async createChannel() {
-      this.v$.$touch();
-      if (this.v$.$invalid) {
-        return;
-      }
+const { t } = useI18n();
+const router = useRouter();
+const store = useStore();
+const uiFlags = useMapGetter('inboxes/getUIFlags');
 
-      try {
-        const smsChannel = await this.$store.dispatch('inboxes/createChannel', {
-          name: this.inboxName?.trim(),
-          channel: {
-            type: 'telnyx_sms',
-            phone_number: this.phoneNumber,
-            provider_config: {
-              api_key: this.apiKey,
-              messaging_profile_id: this.messagingProfileId,
-            },
-          },
-        });
+const state = reactive({
+  apiKey: '',
+  messagingProfileId: '',
+  inboxName: '',
+  phoneNumber: '',
+});
 
-        router.replace({
-          name: 'settings_inboxes_add_agents',
-          params: {
-            page: 'new',
-            inbox_id: smsChannel.id,
-          },
-        });
-      } catch (error) {
-        useAlert(this.$t('INBOX_MGMT.ADD.SMS.API.ERROR_MESSAGE'));
-      }
-    },
-  },
+const validationRules = {
+  inboxName: { required },
+  phoneNumber: { required, shouldStartWithPlusSign },
+  apiKey: { required },
+  messagingProfileId: { required },
 };
+
+const v$ = useVuelidate(validationRules, state);
+
+async function createChannel() {
+  const isFormValid = await v$.value.$validate();
+  if (!isFormValid) return;
+
+  try {
+    const smsChannel = await store.dispatch('inboxes/createChannel', {
+      name: state.inboxName.trim(),
+      channel: {
+        type: 'telnyx_sms',
+        phone_number: state.phoneNumber,
+        provider_config: {
+          api_key: state.apiKey,
+          messaging_profile_id: state.messagingProfileId,
+        },
+      },
+    });
+
+    router.replace({
+      name: 'settings_inboxes_add_agents',
+      params: {
+        page: 'new',
+        inbox_id: smsChannel.id,
+      },
+    });
+  } catch {
+    useAlert(t('INBOX_MGMT.ADD.SMS.API.ERROR_MESSAGE'));
+  }
+}
 </script>
 
 <template>
@@ -76,7 +68,7 @@ export default {
       <label :class="{ error: v$.inboxName.$error }">
         {{ $t('INBOX_MGMT.ADD.SMS.TELNYX.INBOX_NAME.LABEL') }}
         <input
-          v-model="inboxName"
+          v-model="state.inboxName"
           type="text"
           :placeholder="$t('INBOX_MGMT.ADD.SMS.TELNYX.INBOX_NAME.PLACEHOLDER')"
           @blur="v$.inboxName.$touch"
@@ -91,7 +83,7 @@ export default {
       <label :class="{ error: v$.phoneNumber.$error }">
         {{ $t('INBOX_MGMT.ADD.SMS.TELNYX.PHONE_NUMBER.LABEL') }}
         <input
-          v-model="phoneNumber"
+          v-model="state.phoneNumber"
           type="text"
           :placeholder="
             $t('INBOX_MGMT.ADD.SMS.TELNYX.PHONE_NUMBER.PLACEHOLDER')
@@ -108,7 +100,7 @@ export default {
       <label :class="{ error: v$.apiKey.$error }">
         {{ $t('INBOX_MGMT.ADD.SMS.TELNYX.API_KEY.LABEL') }}
         <input
-          v-model="apiKey"
+          v-model="state.apiKey"
           type="text"
           :placeholder="$t('INBOX_MGMT.ADD.SMS.TELNYX.API_KEY.PLACEHOLDER')"
           @blur="v$.apiKey.$touch"
@@ -123,7 +115,7 @@ export default {
       <label :class="{ error: v$.messagingProfileId.$error }">
         {{ $t('INBOX_MGMT.ADD.SMS.TELNYX.MESSAGING_PROFILE_ID.LABEL') }}
         <input
-          v-model="messagingProfileId"
+          v-model="state.messagingProfileId"
           type="text"
           :placeholder="
             $t('INBOX_MGMT.ADD.SMS.TELNYX.MESSAGING_PROFILE_ID.PLACEHOLDER')

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/TelnyxSms.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/TelnyxSms.vue
@@ -1,0 +1,149 @@
+<script>
+import { mapGetters } from 'vuex';
+import { useVuelidate } from '@vuelidate/core';
+import { useAlert } from 'dashboard/composables';
+import { required } from '@vuelidate/validators';
+import router from '../../../../index';
+
+import NextButton from 'dashboard/components-next/button/Button.vue';
+
+const shouldStartWithPlusSign = (value = '') => value.startsWith('+');
+
+export default {
+  components: {
+    NextButton,
+  },
+  setup() {
+    return { v$: useVuelidate() };
+  },
+  data() {
+    return {
+      apiKey: '',
+      messagingProfileId: '',
+      inboxName: '',
+      phoneNumber: '',
+    };
+  },
+  computed: {
+    ...mapGetters({
+      uiFlags: 'inboxes/getUIFlags',
+    }),
+  },
+  validations: {
+    inboxName: { required },
+    phoneNumber: { required, shouldStartWithPlusSign },
+    apiKey: { required },
+    messagingProfileId: { required },
+  },
+  methods: {
+    async createChannel() {
+      this.v$.$touch();
+      if (this.v$.$invalid) {
+        return;
+      }
+
+      try {
+        const smsChannel = await this.$store.dispatch('inboxes/createChannel', {
+          name: this.inboxName?.trim(),
+          channel: {
+            type: 'telnyx_sms',
+            phone_number: this.phoneNumber,
+            provider_config: {
+              api_key: this.apiKey,
+              messaging_profile_id: this.messagingProfileId,
+            },
+          },
+        });
+
+        router.replace({
+          name: 'settings_inboxes_add_agents',
+          params: {
+            page: 'new',
+            inbox_id: smsChannel.id,
+          },
+        });
+      } catch (error) {
+        useAlert(this.$t('INBOX_MGMT.ADD.SMS.API.ERROR_MESSAGE'));
+      }
+    },
+  },
+};
+</script>
+
+<template>
+  <form class="flex flex-wrap flex-col mx-0" @submit.prevent="createChannel()">
+    <div class="flex-shrink-0 flex-grow-0">
+      <label :class="{ error: v$.inboxName.$error }">
+        {{ $t('INBOX_MGMT.ADD.SMS.TELNYX.INBOX_NAME.LABEL') }}
+        <input
+          v-model="inboxName"
+          type="text"
+          :placeholder="$t('INBOX_MGMT.ADD.SMS.TELNYX.INBOX_NAME.PLACEHOLDER')"
+          @blur="v$.inboxName.$touch"
+        />
+        <span v-if="v$.inboxName.$error" class="message">{{
+          $t('INBOX_MGMT.ADD.SMS.TELNYX.INBOX_NAME.ERROR')
+        }}</span>
+      </label>
+    </div>
+
+    <div class="flex-shrink-0 flex-grow-0">
+      <label :class="{ error: v$.phoneNumber.$error }">
+        {{ $t('INBOX_MGMT.ADD.SMS.TELNYX.PHONE_NUMBER.LABEL') }}
+        <input
+          v-model="phoneNumber"
+          type="text"
+          :placeholder="
+            $t('INBOX_MGMT.ADD.SMS.TELNYX.PHONE_NUMBER.PLACEHOLDER')
+          "
+          @blur="v$.phoneNumber.$touch"
+        />
+        <span v-if="v$.phoneNumber.$error" class="message">{{
+          $t('INBOX_MGMT.ADD.SMS.TELNYX.PHONE_NUMBER.ERROR')
+        }}</span>
+      </label>
+    </div>
+
+    <div class="flex-shrink-0 flex-grow-0">
+      <label :class="{ error: v$.apiKey.$error }">
+        {{ $t('INBOX_MGMT.ADD.SMS.TELNYX.API_KEY.LABEL') }}
+        <input
+          v-model="apiKey"
+          type="text"
+          :placeholder="$t('INBOX_MGMT.ADD.SMS.TELNYX.API_KEY.PLACEHOLDER')"
+          @blur="v$.apiKey.$touch"
+        />
+        <span v-if="v$.apiKey.$error" class="message">{{
+          $t('INBOX_MGMT.ADD.SMS.TELNYX.API_KEY.ERROR')
+        }}</span>
+      </label>
+    </div>
+
+    <div class="flex-shrink-0 flex-grow-0">
+      <label :class="{ error: v$.messagingProfileId.$error }">
+        {{ $t('INBOX_MGMT.ADD.SMS.TELNYX.MESSAGING_PROFILE_ID.LABEL') }}
+        <input
+          v-model="messagingProfileId"
+          type="text"
+          :placeholder="
+            $t('INBOX_MGMT.ADD.SMS.TELNYX.MESSAGING_PROFILE_ID.PLACEHOLDER')
+          "
+          @blur="v$.messagingProfileId.$touch"
+        />
+        <span v-if="v$.messagingProfileId.$error" class="message">{{
+          $t('INBOX_MGMT.ADD.SMS.TELNYX.MESSAGING_PROFILE_ID.ERROR')
+        }}</span>
+      </label>
+    </div>
+
+    <div class="w-full mt-4">
+      <NextButton
+        :is-loading="uiFlags.isCreating"
+        type="submit"
+        solid
+        blue
+        :label="$t('INBOX_MGMT.ADD.SMS.TELNYX.SUBMIT_BUTTON')"
+      />
+    </div>
+  </form>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/TelnyxSms.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/TelnyxSms.vue
@@ -6,10 +6,9 @@ import { useVuelidate } from '@vuelidate/core';
 import { useAlert } from 'dashboard/composables';
 import { useMapGetter, useStore } from 'dashboard/composables/store';
 import { required } from '@vuelidate/validators';
+import { isPhoneE164 } from 'shared/helpers/Validators';
 
 import NextButton from 'dashboard/components-next/button/Button.vue';
-
-const shouldStartWithPlusSign = (value = '') => value.startsWith('+');
 
 const { t } = useI18n();
 const router = useRouter();
@@ -25,7 +24,7 @@ const state = reactive({
 
 const validationRules = {
   inboxName: { required },
-  phoneNumber: { required, shouldStartWithPlusSign },
+  phoneNumber: { required, isPhoneE164 },
   apiKey: { required },
   messagingProfileId: { required },
 };

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/ChannelName.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/ChannelName.vue
@@ -28,6 +28,7 @@ const i18nMap = {
   'Channel::TwilioSms': 'TWILIO_SMS',
   'Channel::Whatsapp': 'WHATSAPP',
   'Channel::Sms': 'SMS',
+  'Channel::TelnyxSms': 'TELNYX_SMS',
   'Channel::Email': 'EMAIL',
   'Channel::Telegram': 'TELEGRAM',
   'Channel::Line': 'LINE',

--- a/app/javascript/dashboard/store/modules/inboxes.js
+++ b/app/javascript/dashboard/store/modules/inboxes.js
@@ -110,6 +110,7 @@ export const getters = {
     return $state.records.filter(
       item =>
         item.channel_type === INBOX_TYPES.SMS ||
+        item.channel_type === INBOX_TYPES.TELNYX_SMS ||
         (item.channel_type === INBOX_TYPES.TWILIO && item.medium === 'sms')
     );
   },

--- a/app/javascript/shared/mixins/inboxMixin.js
+++ b/app/javascript/shared/mixins/inboxMixin.js
@@ -73,7 +73,11 @@ export default {
       return this.isATwilioChannel && medium === 'sms';
     },
     isASmsInbox() {
-      return this.channelType === INBOX_TYPES.SMS || this.isATwilioSMSChannel;
+      return (
+        this.channelType === INBOX_TYPES.SMS ||
+        this.channelType === INBOX_TYPES.TELNYX_SMS ||
+        this.isATwilioSMSChannel
+      );
     },
     isATwilioWhatsAppChannel() {
       const { medium: medium = '' } = this.inbox;

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -8,6 +8,7 @@ class SendReplyJob < ApplicationJob
     'Channel::Telegram' => ::Telegram::SendOnTelegramService,
     'Channel::Whatsapp' => ::Whatsapp::SendOnWhatsappService,
     'Channel::Sms' => ::Sms::SendOnSmsService,
+    'Channel::TelnyxSms' => ::Sms::SendOnTelnyxService,
     'Channel::Instagram' => ::Instagram::SendOnInstagramService,
     'Channel::Tiktok' => ::Tiktok::SendOnTiktokService,
     'Channel::Email' => ::Email::SendOnEmailService,

--- a/app/jobs/webhooks/telnyx_sms_events_job.rb
+++ b/app/jobs/webhooks/telnyx_sms_events_job.rb
@@ -27,8 +27,8 @@ class Webhooks::TelnyxSmsEventsJob < ApplicationJob
   end
 
   def handle_delivery_status(payload)
-    to_number = payload.dig('to', 0, 'phone_number') || payload['to']
-    channel = Channel::TelnyxSms.find_by(phone_number: to_number)
+    from_number = payload.dig('from', 'phone_number')
+    channel = Channel::TelnyxSms.find_by(phone_number: from_number)
     return unless channel
 
     Sms::TelnyxDeliveryStatusService.new(

--- a/app/jobs/webhooks/telnyx_sms_events_job.rb
+++ b/app/jobs/webhooks/telnyx_sms_events_job.rb
@@ -1,0 +1,49 @@
+class Webhooks::TelnyxSmsEventsJob < ApplicationJob
+  queue_as :default
+
+  def perform(params = {})
+    event_type = params.dig('data', 'event_type')
+    payload = params.dig('data', 'payload') || {}
+
+    case event_type
+    when 'message.received'
+      handle_incoming(payload)
+    when 'message.finalized'
+      handle_delivery_status(payload)
+    end
+  end
+
+  private
+
+  def handle_incoming(payload)
+    to_number = payload.dig('to', 0, 'phone_number') || payload['to']
+    channel = Channel::TelnyxSms.find_by(phone_number: to_number)
+    return unless channel
+
+    Sms::IncomingMessageService.new(
+      inbox: channel.inbox,
+      params: get_incoming_params(payload)
+    ).perform
+  end
+
+  def handle_delivery_status(payload)
+    to_number = payload.dig('to', 0, 'phone_number') || payload['to']
+    channel = Channel::TelnyxSms.find_by(phone_number: to_number)
+    return unless channel
+
+    Sms::TelnyxDeliveryStatusService.new(
+      inbox: channel.inbox,
+      params: payload.with_indifferent_access
+    ).perform
+  end
+
+  def get_incoming_params(payload)
+    {
+      id: payload['id'],
+      from: payload.dig('from', 'phone_number'),
+      to: payload.dig('to', 0, 'phone_number'),
+      text: payload['text'],
+      media: Array(payload['media']).pluck('url')
+    }.with_indifferent_access
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -95,6 +95,7 @@ class Account < ApplicationRecord
   has_many :notifications, dependent: :destroy_async
   has_many :portals, dependent: :destroy_async, class_name: '::Portal'
   has_many :sms_channels, dependent: :destroy_async, class_name: '::Channel::Sms'
+  has_many :telnyx_sms_channels, dependent: :destroy_async, class_name: '::Channel::TelnyxSms'
   has_many :teams, dependent: :destroy_async
   has_many :telegram_channels, dependent: :destroy_async, class_name: '::Channel::Telegram'
   has_many :twilio_sms, dependent: :destroy_async, class_name: '::Channel::TwilioSms'

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -93,7 +93,7 @@ class Campaign < ApplicationRecord
     case inbox.inbox_type
     when 'Twilio SMS'
       Twilio::OneoffSmsCampaignService.new(campaign: self).perform
-    when 'Sms'
+    when 'Sms', 'Telnyx SMS'
       Sms::OneoffSmsCampaignService.new(campaign: self).perform
     when 'Whatsapp'
       Whatsapp::OneoffCampaignService.new(campaign: self).perform
@@ -116,14 +116,14 @@ class Campaign < ApplicationRecord
   def validate_campaign_inbox
     return unless inbox
 
-    errors.add :inbox, 'Unsupported Inbox type' unless ['Website', 'Twilio SMS', 'Sms', 'Whatsapp'].include? inbox.inbox_type
+    errors.add :inbox, 'Unsupported Inbox type' unless ['Website', 'Twilio SMS', 'Sms', 'Telnyx SMS', 'Whatsapp'].include? inbox.inbox_type
   end
 
   # TO-DO we clean up with better validations when campaigns evolve into more inboxes
   def ensure_correct_campaign_attributes
     return if inbox.blank?
 
-    if ['Twilio SMS', 'Sms', 'Whatsapp'].include?(inbox.inbox_type)
+    if ['Twilio SMS', 'Sms', 'Telnyx SMS', 'Whatsapp'].include?(inbox.inbox_type)
       self.campaign_type = 'one_off'
       self.scheduled_at ||= Time.now.utc
     else

--- a/app/models/channel/telnyx_sms.rb
+++ b/app/models/channel/telnyx_sms.rb
@@ -1,0 +1,101 @@
+# == Schema Information
+#
+# Table name: channel_telnyx_sms
+#
+#  id           :bigint           not null, primary key
+#  phone_number :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  account_id   :integer          not null
+#
+# Indexes
+#
+#  index_channel_telnyx_sms_on_phone_number  (phone_number) UNIQUE
+#
+
+class Channel::TelnyxSms < ApplicationRecord
+  include Channelable
+
+  self.table_name = 'channel_telnyx_sms'
+
+  PROVIDER_CONFIG_ATTRS = %i[api_key messaging_profile_id].freeze
+  EDITABLE_ATTRS = [:phone_number, { provider_config: PROVIDER_CONFIG_ATTRS }].freeze
+
+  has_one :telnyx_sms_config, dependent: :destroy, inverse_of: :channel_telnyx_sms, autosave: true
+
+  validates :phone_number, presence: true, uniqueness: true
+  validates :telnyx_sms_config, presence: true
+
+  def name
+    'Telnyx SMS'
+  end
+
+  def send_message(contact_number, message)
+    body = message_body(contact_number, message.outgoing_content)
+    body[:media_urls] = message.attachments.map(&:download_url) if message.attachments.present?
+    send_to_telnyx(body, message)
+  end
+
+  def send_text_message(contact_number, message_content)
+    send_to_telnyx(message_body(contact_number, message_content))
+  end
+
+  def provider_config
+    return {} unless telnyx_sms_config
+
+    {
+      'api_key' => telnyx_sms_config.api_key,
+      'messaging_profile_id' => telnyx_sms_config.messaging_profile_id
+    }
+  end
+
+  def provider_config=(config)
+    attributes = config.to_h.with_indifferent_access.slice(*PROVIDER_CONFIG_ATTRS)
+    telnyx_sms_config ? telnyx_sms_config.assign_attributes(attributes) : build_telnyx_sms_config(attributes)
+  end
+
+  private
+
+  def message_body(contact_number, text)
+    {
+      from: phone_number,
+      to: contact_number,
+      text: text,
+      messaging_profile_id: telnyx_sms_config.messaging_profile_id
+    }
+  end
+
+  def send_to_telnyx(body, message = nil)
+    if Rails.env.development? && ENV.fetch('TELNYX_MOCK_ENABLED', 'false') == 'true'
+      mock_message_id = "mock-telnyx-#{SecureRandom.uuid}"
+      Rails.logger.info("[#{account_id}] Mocked Telnyx message #{mock_message_id}")
+      return mock_message_id
+    end
+
+    response = HTTParty.post(
+      'https://api.telnyx.com/v2/messages',
+      headers: {
+        'Authorization' => "Bearer #{telnyx_sms_config.api_key}",
+        'Content-Type' => 'application/json'
+      },
+      body: body.to_json
+    )
+
+    return response.parsed_response.dig('data', 'id') if response.success?
+
+    handle_error(response, message)
+    nil
+  end
+
+  def handle_error(response, message)
+    error_detail = response.parsed_response.dig('errors', 0, 'detail') || response.body
+    Rails.logger.error("[#{account_id}] Telnyx error: #{error_detail}")
+    return if message.blank?
+
+    message.external_error = error_detail
+    message.status = :failed
+    message.save!
+  end
+end
+
+Channel::TelnyxSms.prepend_mod_with('Channel::TelnyxSms')

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -119,9 +119,7 @@ class Inbox < ApplicationRecord
     sanitize_raw_name(business_name) || sanitized_name
   end
 
-  def sms?
-    channel_type == 'Channel::Sms'
-  end
+  def sms? = channel_type.in?(%w[Channel::Sms Channel::TelnyxSms])
 
   def facebook?
     channel_type == 'Channel::FacebookPage'
@@ -192,6 +190,8 @@ class Inbox < ApplicationRecord
       "#{ENV.fetch('FRONTEND_URL', nil)}/twilio/callback"
     when 'Channel::Sms'
       "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/sms/#{channel.phone_number.delete_prefix('+')}"
+    when 'Channel::TelnyxSms'
+      "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/telnyx_sms/#{channel.phone_number}"
     when 'Channel::Line'
       "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/line/#{channel.line_channel_id}"
     when 'Channel::Whatsapp'

--- a/app/models/telnyx_sms_config.rb
+++ b/app/models/telnyx_sms_config.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: telnyx_sms_configs
+#
+#  id                    :bigint           not null, primary key
+#  api_key               :string           not null
+#  messaging_profile_id  :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  channel_telnyx_sms_id :bigint           not null
+#
+# Indexes
+#
+#  index_telnyx_sms_configs_on_channel_telnyx_sms_id  (channel_telnyx_sms_id) UNIQUE
+#
+class TelnyxSmsConfig < ApplicationRecord
+  belongs_to :channel_telnyx_sms, class_name: 'Channel::TelnyxSms'
+
+  encrypts :api_key if Chatwoot.encryption_configured?
+
+  validates :api_key, :messaging_profile_id, presence: true
+end

--- a/app/services/contacts/contactable_inboxes_service.rb
+++ b/app/services/contacts/contactable_inboxes_service.rb
@@ -14,7 +14,7 @@ class Contacts::ContactableInboxesService
       twilio_contactable_inbox(inbox)
     when 'Channel::Whatsapp'
       whatsapp_contactable_inbox(inbox)
-    when 'Channel::Sms'
+    when 'Channel::Sms', 'Channel::TelnyxSms'
       sms_contactable_inbox(inbox)
     when 'Channel::Email'
       email_contactable_inbox(inbox)

--- a/app/services/messages/markdown_renderer_service.rb
+++ b/app/services/messages/markdown_renderer_service.rb
@@ -9,6 +9,7 @@ class Messages::MarkdownRendererService
     'Channel::Line' => :render_line,
     'Channel::TwitterProfile' => :render_plain_text,
     'Channel::Sms' => :render_plain_text,
+    'Channel::TelnyxSms' => :render_plain_text,
     'Channel::TwilioSms' => :render_plain_text
   }.freeze
 

--- a/app/services/sms/incoming_message_service.rb
+++ b/app/services/sms/incoming_message_service.rb
@@ -83,10 +83,7 @@ class Sms::IncomingMessageService
       # we don't need to process this files since chatwoot doesn't support it
       next if media_url.end_with?('.smil', '.xml')
 
-      attachment_file = Down.download(
-        media_url,
-        http_basic_authentication: [channel.provider_config['api_key'], channel.provider_config['api_secret']]
-      )
+      attachment_file = Down.download(media_url, **attachment_download_options)
 
       @message.attachments.new(
         account_id: @message.account_id,
@@ -98,5 +95,16 @@ class Sms::IncomingMessageService
         }
       )
     end
+  end
+
+  def attachment_download_options
+    return {} if channel.is_a?(Channel::TelnyxSms)
+
+    {
+      http_basic_authentication: [
+        channel.provider_config['api_key'],
+        channel.provider_config['api_secret']
+      ]
+    }
   end
 end

--- a/app/services/sms/oneoff_sms_campaign_service.rb
+++ b/app/services/sms/oneoff_sms_campaign_service.rb
@@ -2,7 +2,7 @@ class Sms::OneoffSmsCampaignService
   pattr_initialize [:campaign!]
 
   def perform
-    raise "Invalid campaign #{campaign.id}" if campaign.inbox.inbox_type != 'Sms' || !campaign.one_off?
+    raise "Invalid campaign #{campaign.id}" unless campaign.inbox.sms? && campaign.one_off?
     raise 'Completed Campaign' if campaign.completed?
 
     audience_label_ids = campaign.audience.select { |audience| audience['type'] == 'Label' }.pluck('id')

--- a/app/services/sms/send_on_telnyx_service.rb
+++ b/app/services/sms/send_on_telnyx_service.rb
@@ -1,0 +1,12 @@
+class Sms::SendOnTelnyxService < Base::SendOnChannelService
+  private
+
+  def channel_class
+    Channel::TelnyxSms
+  end
+
+  def perform_reply
+    message_id = channel.send_message(message.conversation.contact_inbox.source_id, message)
+    message.update!(source_id: message_id) if message_id.present?
+  end
+end

--- a/app/services/sms/telnyx_delivery_status_service.rb
+++ b/app/services/sms/telnyx_delivery_status_service.rb
@@ -1,4 +1,6 @@
 class Sms::TelnyxDeliveryStatusService
+  FAILED_STATUSES = %w[failed gw_timeout sending_failed delivery_failed delivery_unconfirmed].freeze
+
   pattr_initialize [:inbox!, :params!]
 
   def perform
@@ -13,8 +15,7 @@ class Sms::TelnyxDeliveryStatusService
 
   def delivery_status
     to_status = params.dig('to', 0, 'status')
-    failed_statuses = %w[failed gw_timeout]
-    failed_statuses.include?(to_status) ? 'failed' : 'delivered'
+    FAILED_STATUSES.include?(to_status) ? 'failed' : 'delivered'
   end
 
   def failed?

--- a/app/services/sms/telnyx_delivery_status_service.rb
+++ b/app/services/sms/telnyx_delivery_status_service.rb
@@ -1,0 +1,34 @@
+class Sms::TelnyxDeliveryStatusService
+  pattr_initialize [:inbox!, :params!]
+
+  def perform
+    return unless message
+
+    message.status = delivery_status
+    message.external_error = error_detail if failed?
+    message.save!
+  end
+
+  private
+
+  def delivery_status
+    to_status = params.dig('to', 0, 'status')
+    failed_statuses = %w[failed gw_timeout]
+    failed_statuses.include?(to_status) ? 'failed' : 'delivered'
+  end
+
+  def failed?
+    delivery_status == 'failed'
+  end
+
+  def error_detail
+    errors = Array(params['errors'])
+    return nil if errors.empty?
+
+    "#{errors.first['code']} - #{errors.first['title']}"
+  end
+
+  def message
+    @message ||= inbox.messages.find_by(source_id: params['id'])
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,9 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :sidekiq
 
+  # Barnes is used for Heroku metrics and relies on process clocks unavailable on Windows.
+  config.barnes[:statsd] = nil
+
   Rails.application.routes.default_url_options = { host: ENV['FRONTEND_URL'] }
 
   # Print deprecation notices to the Rails logger.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -664,6 +664,7 @@ Rails.application.routes.draw do
   post 'webhooks/line/:line_channel_id', to: 'webhooks/line#process_payload'
   post 'webhooks/telegram/:bot_token', to: 'webhooks/telegram#process_payload'
   post 'webhooks/sms/:phone_number', to: 'webhooks/sms#process_payload'
+  post 'webhooks/telnyx_sms/:phone_number', to: 'webhooks/telnyx_sms#process_payload'
   get 'webhooks/whatsapp/:phone_number', to: 'webhooks/whatsapp#verify'
   post 'webhooks/whatsapp/:phone_number', to: 'webhooks/whatsapp#process_payload'
   get 'webhooks/instagram', to: 'webhooks/instagram#verify'

--- a/db/migrate/20260731000000_create_channel_telnyx_sms.rb
+++ b/db/migrate/20260731000000_create_channel_telnyx_sms.rb
@@ -1,0 +1,122 @@
+class CreateChannelTelnyxSms < ActiveRecord::Migration[7.1]
+  def up
+    create_table :channel_telnyx_sms do |t|
+      t.string :phone_number, null: false
+      t.integer :account_id, null: false
+      t.timestamps
+    end
+
+    add_index :channel_telnyx_sms, :phone_number, unique: true
+
+    create_table :telnyx_sms_configs do |t|
+      t.references :channel_telnyx_sms, null: false, foreign_key: true, index: { unique: true }
+      t.string :api_key, null: false
+      t.string :messaging_profile_id, null: false
+      t.timestamps
+    end
+
+    migrate_telnyx_channels
+    reset_pk_sequence!(:channel_telnyx_sms)
+  end
+
+  def down
+    migrate_telnyx_channels_back
+    reset_pk_sequence!(:channel_sms)
+    drop_table :telnyx_sms_configs if table_exists?(:telnyx_sms_configs)
+    drop_table :channel_telnyx_sms
+  end
+
+  private
+
+  def migrate_telnyx_channels
+    copy_telnyx_channels
+    copy_telnyx_configs
+    update_telnyx_inboxes('Channel::TelnyxSms')
+    execute "DELETE FROM channel_sms WHERE provider = 'telnyx'"
+  end
+
+  def copy_telnyx_channels
+    execute <<~SQL.squish
+      INSERT INTO channel_telnyx_sms (id, phone_number, account_id, created_at, updated_at)
+      SELECT id, phone_number, account_id, created_at, updated_at
+      FROM channel_sms
+      WHERE provider = 'telnyx'
+    SQL
+  end
+
+  def copy_telnyx_configs
+    execute <<~SQL.squish
+      INSERT INTO telnyx_sms_configs (
+        channel_telnyx_sms_id, api_key, messaging_profile_id, created_at, updated_at
+      )
+      SELECT
+        id,
+        provider_config->>'api_key',
+        provider_config->>'messaging_profile_id',
+        created_at,
+        updated_at
+      FROM channel_sms
+      WHERE provider = 'telnyx'
+    SQL
+  end
+
+  def update_telnyx_inboxes(channel_type)
+    execute <<~SQL.squish
+      UPDATE inboxes
+      SET channel_type = '#{channel_type}'
+      WHERE channel_type IN ('Channel::Sms', 'Channel::TelnyxSms')
+        AND channel_id IN (
+          SELECT id FROM channel_sms WHERE provider = 'telnyx'
+          UNION
+          SELECT id FROM channel_telnyx_sms
+        )
+    SQL
+  end
+
+  def migrate_telnyx_channels_back
+    return migrate_legacy_telnyx_channels_back unless table_exists?(:telnyx_sms_configs)
+
+    copy_telnyx_channels_back
+    update_telnyx_inboxes('Channel::Sms')
+  end
+
+  def copy_telnyx_channels_back
+    execute <<~SQL.squish
+      INSERT INTO channel_sms (id, phone_number, provider, provider_config, account_id, created_at, updated_at)
+      SELECT
+        channel_telnyx_sms.id,
+        channel_telnyx_sms.phone_number,
+        'telnyx',
+        jsonb_build_object(
+          'api_key', telnyx_sms_configs.api_key,
+          'messaging_profile_id', telnyx_sms_configs.messaging_profile_id
+        ),
+        channel_telnyx_sms.account_id,
+        channel_telnyx_sms.created_at,
+        channel_telnyx_sms.updated_at
+      FROM channel_telnyx_sms
+      INNER JOIN telnyx_sms_configs
+        ON telnyx_sms_configs.channel_telnyx_sms_id = channel_telnyx_sms.id
+    SQL
+  end
+
+  def migrate_legacy_telnyx_channels_back
+    execute <<~SQL.squish
+      INSERT INTO channel_sms (id, phone_number, provider, provider_config, account_id, created_at, updated_at)
+      SELECT id, phone_number, 'telnyx', provider_config, account_id, created_at, updated_at
+      FROM channel_telnyx_sms
+    SQL
+
+    update_telnyx_inboxes('Channel::Sms')
+  end
+
+  def reset_pk_sequence!(table)
+    execute <<~SQL.squish
+      SELECT setval(
+        pg_get_serial_sequence('#{table}', 'id'),
+        COALESCE((SELECT MAX(id) FROM #{table}), 1),
+        EXISTS (SELECT 1 FROM #{table})
+      )
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -665,6 +665,14 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
     t.index ["bot_token"], name: "index_channel_telegram_on_bot_token", unique: true
   end
 
+  create_table "channel_telnyx_sms", force: :cascade do |t|
+    t.string "phone_number", null: false
+    t.integer "account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["phone_number"], name: "index_channel_telnyx_sms_on_phone_number", unique: true
+  end
+
   create_table "channel_tiktok", force: :cascade do |t|
     t.integer "account_id", null: false
     t.string "business_id", null: false
@@ -1501,6 +1509,15 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
     t.index ["name", "account_id"], name: "index_teams_on_name_and_account_id", unique: true
   end
 
+  create_table "telnyx_sms_configs", force: :cascade do |t|
+    t.bigint "channel_telnyx_sms_id", null: false
+    t.string "api_key", null: false
+    t.string "messaging_profile_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["channel_telnyx_sms_id"], name: "index_telnyx_sms_configs_on_channel_telnyx_sms_id", unique: true
+  end
+
   create_table "user_sessions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "client_id", null: false
@@ -1597,6 +1614,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
   add_foreign_key "campaign_recipients", "contacts", on_delete: :cascade
   add_foreign_key "campaign_recipients", "inboxes", on_delete: :cascade
   add_foreign_key "inboxes", "portals"
+  add_foreign_key "telnyx_sms_configs", "channel_telnyx_sms", column: "channel_telnyx_sms_id"
   add_foreign_key "user_sessions", "users"
   create_trigger("accounts_after_insert_row_tr", :generated => true, :compatibility => 1).
       on("accounts").

--- a/enterprise/lib/captain/message_length_limit.rb
+++ b/enterprise/lib/captain/message_length_limit.rb
@@ -6,6 +6,7 @@ class Captain::MessageLengthLimit
     'Channel::Instagram' => 1_000,
     'Channel::Line' => 5_000,
     'Channel::Sms' => 320,
+    'Channel::TelnyxSms' => 320,
     'Channel::Telegram' => 4_096,
     'Channel::Tiktok' => 6_000,
     'Channel::Whatsapp' => 4_096

--- a/spec/factories/channel/channel_telnyx_sms.rb
+++ b/spec/factories/channel/channel_telnyx_sms.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :channel_telnyx_sms, class: 'Channel::TelnyxSms' do
+    sequence(:phone_number) { |n| "+123456780#{n}1" }
+    account
+    provider_config do
+      {
+        'api_key' => 'test-api-key',
+        'messaging_profile_id' => 'test-messaging-profile-id'
+      }
+    end
+
+    after(:create) do |channel|
+      create(:inbox, channel: channel, account: channel.account)
+    end
+  end
+end

--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe SendReplyJob do
       expect_mapped_service_to_perform(message, 'Sms::SendOnSmsService')
     end
 
+    it 'calls ::Sms::SendOnTelnyxService when its Telnyx SMS message' do
+      telnyx_channel = create(:channel_telnyx_sms)
+      message = create(:message, conversation: create(:conversation, inbox: telnyx_channel.inbox))
+      expect_mapped_service_to_perform(message, 'Sms::SendOnTelnyxService')
+    end
+
     it 'calls ::Instagram::Direct::SendOnInstagramService when its instagram message' do
       instagram_channel = create(:channel_instagram)
       message = create(:message, conversation: create(:conversation, inbox: instagram_channel.inbox))

--- a/spec/jobs/webhooks/telnyx_sms_events_job_spec.rb
+++ b/spec/jobs/webhooks/telnyx_sms_events_job_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Webhooks::TelnyxSmsEventsJob do
+  let(:channel) { create(:channel_telnyx_sms) }
+
+  it 'passes received messages to the incoming message service' do
+    payload = {
+      'id' => 'telnyx-message-id',
+      'from' => { 'phone_number' => '+15555550123' },
+      'to' => [{ 'phone_number' => channel.phone_number }],
+      'text' => 'Hello',
+      'media' => [{ 'url' => 'https://example.com/image.png' }]
+    }
+    params = { 'data' => { 'event_type' => 'message.received', 'payload' => payload } }
+    service = instance_double(Sms::IncomingMessageService, perform: nil)
+
+    expect(Sms::IncomingMessageService).to receive(:new).with(
+      inbox: channel.inbox,
+      params: {
+        id: 'telnyx-message-id',
+        from: '+15555550123',
+        to: channel.phone_number,
+        text: 'Hello',
+        media: ['https://example.com/image.png']
+      }.with_indifferent_access
+    ).and_return(service)
+
+    described_class.perform_now(params)
+  end
+
+  it 'passes finalized messages to the delivery status service' do
+    payload = {
+      'id' => 'telnyx-message-id',
+      'to' => [{ 'phone_number' => channel.phone_number, 'status' => 'delivered' }]
+    }
+    params = { 'data' => { 'event_type' => 'message.finalized', 'payload' => payload } }
+    service = instance_double(Sms::TelnyxDeliveryStatusService, perform: nil)
+
+    expect(Sms::TelnyxDeliveryStatusService).to receive(:new).with(
+      inbox: channel.inbox,
+      params: payload.with_indifferent_access
+    ).and_return(service)
+
+    described_class.perform_now(params)
+  end
+end

--- a/spec/jobs/webhooks/telnyx_sms_events_job_spec.rb
+++ b/spec/jobs/webhooks/telnyx_sms_events_job_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Webhooks::TelnyxSmsEventsJob do
   it 'passes finalized messages to the delivery status service' do
     payload = {
       'id' => 'telnyx-message-id',
-      'to' => [{ 'phone_number' => channel.phone_number, 'status' => 'delivered' }]
+      'from' => { 'phone_number' => channel.phone_number },
+      'to' => [{ 'phone_number' => '+15555550123', 'status' => 'delivered' }]
     }
     params = { 'data' => { 'event_type' => 'message.finalized', 'payload' => payload } }
     service = instance_double(Sms::TelnyxDeliveryStatusService, perform: nil)

--- a/spec/models/channel/telnyx_sms_spec.rb
+++ b/spec/models/channel/telnyx_sms_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe Channel::TelnyxSms do
+  describe '#provider_config' do
+    it 'stores provider credentials in the Telnyx SMS config record' do
+      channel = create(:channel_telnyx_sms)
+
+      expect(channel.telnyx_sms_config).to have_attributes(
+        api_key: 'test-api-key',
+        messaging_profile_id: 'test-messaging-profile-id'
+      )
+      expect(channel.attributes).not_to include('provider_config')
+    end
+
+    it 'accepts only the supported provider configuration attributes' do
+      channel = build(:channel_telnyx_sms)
+
+      channel.provider_config = {
+        api_key: 'updated-api-key',
+        messaging_profile_id: 'updated-profile-id',
+        unsupported: 'ignored'
+      }
+
+      expect(channel.telnyx_sms_config.attributes).to include(
+        'api_key' => 'updated-api-key',
+        'messaging_profile_id' => 'updated-profile-id'
+      )
+      expect(channel.telnyx_sms_config).not_to respond_to(:unsupported)
+    end
+  end
+
+  describe '#send_text_message' do
+    let(:channel) { create(:channel_telnyx_sms) }
+    let(:response) { instance_double(HTTParty::Response, success?: true, parsed_response: { 'data' => { 'id' => 'message-id' } }) }
+
+    it 'sends the message through the Telnyx API' do
+      expect(HTTParty).to receive(:post).with(
+        'https://api.telnyx.com/v2/messages',
+        headers: {
+          'Authorization' => 'Bearer test-api-key',
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          from: channel.phone_number,
+          to: '+15555550123',
+          text: 'Hello from Chatwoot',
+          messaging_profile_id: 'test-messaging-profile-id'
+        }.to_json
+      ).and_return(response)
+
+      expect(channel.send_text_message('+15555550123', 'Hello from Chatwoot')).to eq('message-id')
+    end
+  end
+end

--- a/spec/models/telnyx_sms_config_spec.rb
+++ b/spec/models/telnyx_sms_config_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe TelnyxSmsConfig do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:api_key) }
+    it { is_expected.to validate_presence_of(:messaging_profile_id) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:channel_telnyx_sms).class_name('Channel::TelnyxSms') }
+  end
+end

--- a/spec/services/sms/send_on_telnyx_service_spec.rb
+++ b/spec/services/sms/send_on_telnyx_service_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Sms::SendOnTelnyxService do
+  describe '#perform' do
+    let(:channel) { create(:channel_telnyx_sms) }
+    let(:contact_inbox) { create(:contact_inbox, inbox: channel.inbox, source_id: '+15555550123') }
+    let(:conversation) { create(:conversation, contact_inbox: contact_inbox, inbox: channel.inbox) }
+    let(:message) { create(:message, message_type: :outgoing, content: 'Hello', conversation: conversation) }
+
+    it 'stores the Telnyx message ID on the message' do
+      allow(channel).to receive(:send_message).with('+15555550123', message).and_return('telnyx-message-id')
+      allow(Channel::TelnyxSms).to receive(:find).with(channel.id).and_return(channel)
+
+      described_class.new(message: message).perform
+
+      expect(message.reload.source_id).to eq('telnyx-message-id')
+    end
+  end
+end

--- a/spec/services/sms/telnyx_delivery_status_service_spec.rb
+++ b/spec/services/sms/telnyx_delivery_status_service_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Sms::TelnyxDeliveryStatusService do
+  let(:channel) { create(:channel_telnyx_sms) }
+  let(:conversation) { create(:conversation, inbox: channel.inbox) }
+  let!(:message) do
+    create(:message, conversation: conversation, inbox: channel.inbox, source_id: 'telnyx-message-id', status: :sent)
+  end
+
+  it 'marks a finalized message as delivered' do
+    params = {
+      'id' => message.source_id,
+      'to' => [{ 'status' => 'delivered' }]
+    }
+
+    described_class.new(inbox: channel.inbox, params: params).perform
+
+    expect(message.reload.status).to eq('delivered')
+  end
+
+  it 'marks a failed message as failed and records the error' do
+    params = {
+      'id' => message.source_id,
+      'to' => [{ 'status' => 'failed' }],
+      'errors' => [{ 'code' => '40300', 'title' => 'Blocked destination' }]
+    }
+
+    described_class.new(inbox: channel.inbox, params: params).perform
+
+    expect(message.reload).to have_attributes(status: 'failed', external_error: '40300 - Blocked destination')
+  end
+end


### PR DESCRIPTION
Adds native Telnyx SMS/MMS inbox support so teams can configure a Telnyx number, receive webhook events, and send replies directly from Chatwoot

## How Has This Been Tested


https://github.com/user-attachments/assets/262be9b7-38b8-49f8-82c8-7dcdf1d8a8df


## Closes

Closes https://github.com/chatwoot/chatwoot/issues/15203

## How to test

1. Create a new Telnyx SMS inbox from Settings → Inboxes.
2. Enter a Telnyx phone number, API key, and messaging profile ID.
3. Configure the generated callback URL in Telnyx.
4. Send an inbound SMS and confirm a conversation is created in the Telnyx inbox.
5. Reply from Chatwoot and confirm the outbound message is sent through Telnyx.
6. Send delivered and failed webhook events and confirm the message status is updated.

## What changed

- Adds a dedicated `Channel::TelnyxSms` channel and encrypted one-to-one Telnyx configuration.
- Adds inbound webhook and delivery-status processing.
- Adds outbound Telnyx message delivery and campaign support.
- Adds inbox creation UI and focused backend coverage.