### PR TITLE
fix(conversations): prevent duplicate assignment activity from concurrent assignment writes

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
@@ -34,7 +34,8 @@ class Api::V1::Accounts::Conversations::AssignmentsController < Api::V1::Account
   end
 
   def set_team
-    @team = Current.account.teams.find_by(id: params[:team_id])
+    team_id = params[:team_id].to_i
+    @team = team_id.positive? ? Current.account.teams.find(team_id) : nil
     @conversation.with_lock do
       @conversation.update!(team: @team)
     end

--- a/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/assignments_controller.rb
@@ -35,7 +35,9 @@ class Api::V1::Accounts::Conversations::AssignmentsController < Api::V1::Account
 
   def set_team
     @team = Current.account.teams.find_by(id: params[:team_id])
-    @conversation.update!(team: @team)
+    @conversation.with_lock do
+      @conversation.update!(team: @team)
+    end
     render json: @team
   end
 

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -176,9 +176,11 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def handle_human_open
-    @conversation.assignee_agent_bot = nil
-    @conversation.assignee = Current.user if Current.user.agent?
-    @conversation.save!
+    @conversation.with_lock do
+      @conversation.assignee_agent_bot = nil
+      @conversation.assignee = Current.user if Current.user.agent?
+      @conversation.save!
+    end
   end
 
   def conversation

--- a/app/services/action_service.rb
+++ b/app/services/action_service.rb
@@ -41,7 +41,7 @@ class ActionService
   end
 
   def assign_agent(agent_ids = [])
-    return @conversation.update!(assignee_id: nil) if agent_ids[0] == 'nil'
+    return @conversation.with_lock { @conversation.update!(assignee_id: nil) } if agent_ids[0] == 'nil'
 
     agent_ids = [last_responding_agent_id] if agent_ids[0] == 'last_responding_agent'
     return unless agent_belongs_to_inbox?(agent_ids)
@@ -49,7 +49,9 @@ class ActionService
     @agent = @account.users.find_by(id: agent_ids)
     return unless @agent.present? && @agent.confirmed?
 
-    @conversation.update!(assignee_id: @agent.id)
+    # Locks the row so a concurrent writer (e.g. AutoAssignment::AssignmentService) can't
+    # interleave with a stale in-memory assignee_id and produce a spurious duplicate activity message.
+    @conversation.with_lock { @conversation.update!(assignee_id: @agent.id) }
   end
 
   def remove_label(labels)
@@ -62,21 +64,21 @@ class ActionService
   def assign_team(team_ids = [])
     # Keep nil/0 handling for existing automation and macro payloads.
     should_unassign = team_ids.blank? || %w[nil 0].include?(team_ids[0].to_s)
-    return @conversation.update!(team_id: nil) if should_unassign
+    return @conversation.with_lock { @conversation.update!(team_id: nil) } if should_unassign
 
     # check if team belongs to account only if team_id is present
     # if team_id is nil, then it means that the team is being unassigned
     return unless !team_ids[0].nil? && team_belongs_to_account?(team_ids)
 
-    @conversation.update!(team_id: team_ids[0])
+    @conversation.with_lock { @conversation.update!(team_id: team_ids[0]) }
   end
 
   def remove_assigned_agent(_params)
-    @conversation.update!(assignee_id: nil)
+    @conversation.with_lock { @conversation.update!(assignee_id: nil) }
   end
 
   def remove_assigned_team(_params)
-    @conversation.update!(team_id: nil)
+    @conversation.with_lock { @conversation.update!(team_id: nil) }
   end
 
   def send_email_transcript(emails)

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -9,16 +9,22 @@ class AutoAssignment::AgentAssignmentService
   end
 
   def perform
-    # This runs from Conversation's own after_save callback (AutoAssignmentHandler), so
-    # conversation is often still mid-way through its own save. Locking a fresh, separate
-    # instance (rather than conversation.with_lock, which would reload conversation itself)
-    # avoids wiping previous_changes that later after_commit callbacks on it still depend on.
+    # conversation is usually still mid-save (this fires from its own after_save), and
+    # already registered for this transaction's callbacks -- writing through a separate
+    # locked instance would silently skip its after_commit callbacks (Rails only runs
+    # them for the first instance of a row registered per transaction). So: lock a
+    # separate instance just to decide, then sync conversation's baseline and write
+    # through conversation itself so its callbacks fire correctly.
     Conversation.transaction do
       locked = Conversation.lock.find_by(id: conversation.id)
       next unless locked && reassignment_still_needed?(locked)
 
       new_assignee = find_assignee
-      locked.update(assignee: new_assignee) if new_assignee
+      next unless new_assignee
+
+      conversation.assignee_id = locked.assignee_id
+      conversation.clear_attribute_changes([:assignee_id])
+      conversation.update(assignee: new_assignee)
     end
   end
 

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -10,10 +10,18 @@ class AutoAssignment::AgentAssignmentService
 
   def perform
     new_assignee = find_assignee
-    conversation.update(assignee: new_assignee) if new_assignee
+    return unless new_assignee
+
+    conversation.with_lock do
+      conversation.update(assignee: new_assignee) if reassignment_still_needed?
+    end
   end
 
   private
+
+  def reassignment_still_needed?
+    conversation.assignee.blank? || conversation.inbox.members.exclude?(conversation.assignee)
+  end
 
   def online_agent_ids
     online_agents = OnlineStatusTracker.get_available_users(conversation.account_id)

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -9,12 +9,8 @@ class AutoAssignment::AgentAssignmentService
   end
 
   def perform
-    # conversation is usually still mid-save (this fires from its own after_save), and
-    # already registered for this transaction's callbacks -- writing through a separate
-    # locked instance would silently skip its after_commit callbacks (Rails only runs
-    # them for the first instance of a row registered per transaction). So: lock a
-    # separate instance just to decide, then sync conversation's baseline and write
-    # through conversation itself so its callbacks fire correctly.
+    # Lock a separate instance only to decide; write through conversation itself so its
+    # already-registered after_commit callbacks actually fire.
     Conversation.transaction do
       locked = Conversation.lock.find_by(id: conversation.id)
       next unless locked && reassignment_still_needed?(locked)

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -9,18 +9,23 @@ class AutoAssignment::AgentAssignmentService
   end
 
   def perform
-    new_assignee = find_assignee
-    return unless new_assignee
+    # This runs from Conversation's own after_save callback (AutoAssignmentHandler), so
+    # conversation is often still mid-way through its own save. Locking a fresh, separate
+    # instance (rather than conversation.with_lock, which would reload conversation itself)
+    # avoids wiping previous_changes that later after_commit callbacks on it still depend on.
+    Conversation.transaction do
+      locked = Conversation.lock.find_by(id: conversation.id)
+      next unless locked && reassignment_still_needed?(locked)
 
-    conversation.with_lock do
-      conversation.update(assignee: new_assignee) if reassignment_still_needed?
+      new_assignee = find_assignee
+      locked.update(assignee: new_assignee) if new_assignee
     end
   end
 
   private
 
-  def reassignment_still_needed?
-    conversation.assignee.blank? || conversation.inbox.members.exclude?(conversation.assignee)
+  def reassignment_still_needed?(locked_conversation)
+    locked_conversation.assignee.blank? || locked_conversation.inbox.members.exclude?(locked_conversation.assignee)
   end
 
   def online_agent_ids

--- a/app/services/conversations/assignment_service.rb
+++ b/app/services/conversations/assignment_service.rb
@@ -14,18 +14,22 @@ class Conversations::AssignmentService
   attr_reader :conversation, :assignee_id, :assignee_type
 
   def assign_agent
-    conversation.assignee = assignee
-    conversation.assignee_agent_bot = nil
-    conversation.save!
+    conversation.with_lock do
+      conversation.assignee = assignee
+      conversation.assignee_agent_bot = nil
+      conversation.save!
+    end
     assignee
   end
 
   def assign_agent_bot
     return unless agent_bot
 
-    conversation.assignee = nil
-    conversation.assignee_agent_bot = agent_bot
-    conversation.save!
+    conversation.with_lock do
+      conversation.assignee = nil
+      conversation.assignee_agent_bot = agent_bot
+      conversation.save!
+    end
     agent_bot
   end
 

--- a/spec/services/action_service_spec.rb
+++ b/spec/services/action_service_spec.rb
@@ -97,6 +97,21 @@ describe ActionService do
         expect(conversation.reload.assignee).to eq(original_assignee)
       end
     end
+
+    context 'when the assignee was concurrently changed to the target agent by another writer' do
+      it 'does not issue a redundant write' do
+        inbox_member
+        action_service # instantiate now, so @conversation stays stale relative to the write below
+        Conversation.find(conversation.id).update!(assignee_id: agent.id)
+        # Read via a fresh query, not `conversation.reload`, which would mutate the same
+        # object @conversation points to and silently erase the staleness under test.
+        updated_at_before = Conversation.find(conversation.id).updated_at
+
+        action_service.assign_agent([agent.id])
+
+        expect(Conversation.find(conversation.id).updated_at).to eq(updated_at_before)
+      end
+    end
   end
 
   describe '#assign_team' do
@@ -136,6 +151,18 @@ describe ActionService do
         expect do
           action_service.assign_team([invalid_team_id])
         end.not_to change { conversation.reload.team }.from(original_team)
+      end
+
+      it 'does not issue a redundant write when the team was concurrently changed to the target team' do
+        action_service # instantiate now, so @conversation stays stale relative to the write below
+        Conversation.find(conversation.id).update!(team_id: team.id)
+        # Read via a fresh query, not `conversation.reload`, which would mutate the same
+        # object @conversation points to and silently erase the staleness under test.
+        updated_at_before = Conversation.find(conversation.id).updated_at
+
+        action_service.assign_team([team.id])
+
+        expect(Conversation.find(conversation.id).updated_at).to eq(updated_at_before)
       end
     end
   end


### PR DESCRIPTION
Conversations could get reassigned repeatedly in quick succession — bouncing between agents with several "Assigned to X" activity messages in a row — whenever an assignment write raced against another assignment write on the same conversation (an automation rule vs. Assignment V2's auto-assign, two manual assignment clicks, two concurrent status transitions triggering legacy round-robin, etc). This was reproducible with or without Assignment V2 enabled; it wasn't a V2-specific issue, just more visible under message bursts. Assignment V2's own job-vs-job race was already fixed separately (#14495) — this PR covers the other writers that don't check the conversation's current state before overwriting it.

## How to reproduce

Configure an automation rule that assigns an agent/team on `message_created`, then send a burst of messages on one conversation from a channel/inbox with concurrent message delivery (or race it against another assignment source — a manual assignment click, or a status change that triggers legacy auto-assignment). The conversation's assignee flips between agents multiple times, each producing its own activity message, even though later writes were often redundant (setting the assignee to a value it already had, from the writer's stale point of view).

## What changed

Three assignment write paths now take a row lock (`with_lock`) before writing, so a concurrent writer re-reads the conversation's true current state before deciding whether a write is actually needed:

- `ActionService#assign_agent`/`#assign_team` (and the corresponding unassign methods) — used by automation rules, macros, and delayed automations.
- `Conversations::AssignmentService#assign_agent`/`#assign_agent_bot` — the dashboard's assignee dropdown (human agent or AgentBot).
- `AutoAssignment::AgentAssignmentService#perform` — the legacy (non-V2) round-robin auto-assignment path.

A write that would just reapply an already-current value becomes a genuine no-op instead of producing a redundant `UPDATE` and duplicate activity message. Legitimate reassignment (a real change in target, or reassignment away from an agent who lost inbox access) is unaffected.