### PR TITLE
feat(whatsapp): expose message templates through the API

### DIFF
--- a/app/controllers/api/v1/accounts/concerns/whatsapp_health_management.rb
+++ b/app/controllers/api/v1/accounts/concerns/whatsapp_health_management.rb
@@ -2,7 +2,7 @@ module Api::V1::Accounts::Concerns::WhatsappHealthManagement
   extend ActiveSupport::Concern
 
   included do
-    skip_before_action :check_authorization, only: [:health, :register_webhook, :message_templates]
+    skip_before_action :check_authorization, only: [:health, :register_webhook]
     before_action :check_admin_authorization?, only: [:register_webhook]
     before_action :validate_whatsapp_cloud_channel, only: [:health, :register_webhook]
   end

--- a/app/controllers/api/v1/accounts/concerns/whatsapp_health_management.rb
+++ b/app/controllers/api/v1/accounts/concerns/whatsapp_health_management.rb
@@ -2,7 +2,7 @@ module Api::V1::Accounts::Concerns::WhatsappHealthManagement
   extend ActiveSupport::Concern
 
   included do
-    skip_before_action :check_authorization, only: [:health, :register_webhook]
+    skip_before_action :check_authorization, only: [:health, :register_webhook, :message_templates]
     before_action :check_admin_authorization?, only: [:register_webhook]
     before_action :validate_whatsapp_cloud_channel, only: [:health, :register_webhook]
   end
@@ -14,6 +14,15 @@ module Api::V1::Accounts::Concerns::WhatsappHealthManagement
     render status: :ok, json: { message: 'Template sync initiated successfully' }
   rescue StandardError => e
     render status: :internal_server_error, json: { error: e.message }
+  end
+
+  def message_templates
+    return render status: :unprocessable_entity, json: { error: 'Message templates are only available for WhatsApp channels' } unless @inbox.whatsapp?
+
+    templates = @inbox.channel.message_templates.presence || []
+    templates = templates.select { |template| template['name'] == params[:name] } if params[:name].present?
+
+    render json: { payload: templates }
   end
 
   def health

--- a/app/policies/inbox_policy.rb
+++ b/app/policies/inbox_policy.rb
@@ -34,6 +34,10 @@ class InboxPolicy < ApplicationPolicy
     true
   end
 
+  def message_templates?
+    true
+  end
+
   def campaigns?
     @account_user.administrator?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -280,6 +280,7 @@ Rails.application.routes.draw do
             get :assignable_agents, on: :member
             get :campaigns, on: :member
             get :agent_bot, on: :member
+            get :message_templates, on: :member
             post :set_agent_bot, on: :member
             delete :avatar, on: :member
             post :sync_templates, on: :member

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -1274,6 +1274,88 @@ RSpec.describe 'Inboxes API', type: :request do
     end
   end
 
+  describe 'GET /api/v1/accounts/{account.id}/inboxes/:id/message_templates' do
+    let(:message_templates) do
+      [
+        { 'name' => 'shipping_update', 'language' => 'en_US' },
+        { 'name' => 'shipping_update', 'language' => 'es' },
+        { 'name' => 'account_update', 'language' => 'en_US' }
+      ]
+    end
+    let(:whatsapp_channel) do
+      create(
+        :channel_whatsapp,
+        account: account,
+        message_templates: message_templates,
+        sync_templates: false,
+        validate_provider_config: false
+      )
+    end
+    let(:whatsapp_inbox) { whatsapp_channel.inbox }
+
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized' do
+        get "/api/v1/accounts/#{account.id}/inboxes/#{whatsapp_inbox.id}/message_templates"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an authenticated agent' do
+      it 'returns unauthorized when the agent is not assigned to the inbox' do
+        get "/api/v1/accounts/#{account.id}/inboxes/#{whatsapp_inbox.id}/message_templates",
+            headers: agent.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns the templates when the agent is assigned to the inbox' do
+        create(:inbox_member, user: agent, inbox: whatsapp_inbox)
+
+        get "/api/v1/accounts/#{account.id}/inboxes/#{whatsapp_inbox.id}/message_templates",
+            headers: agent.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['payload']).to eq(message_templates)
+      end
+    end
+
+    context 'when it is an authenticated administrator' do
+      it 'filters templates by exact name' do
+        get "/api/v1/accounts/#{account.id}/inboxes/#{whatsapp_inbox.id}/message_templates",
+            headers: admin.create_new_auth_token,
+            params: { name: 'shipping_update' },
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['payload']).to eq(message_templates.first(2))
+      end
+
+      it 'returns an empty payload when the template name does not match' do
+        get "/api/v1/accounts/#{account.id}/inboxes/#{whatsapp_inbox.id}/message_templates",
+            headers: admin.create_new_auth_token,
+            params: { name: 'missing_template' },
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['payload']).to eq([])
+      end
+
+      it 'returns unprocessable entity for a non-WhatsApp inbox' do
+        inbox = create(:inbox, account: account)
+
+        get "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}/message_templates",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to eq('Message templates are only available for WhatsApp channels')
+      end
+    end
+  end
+
   describe 'POST /api/v1/accounts/{account.id}/inboxes/:id/sync_templates' do
     let(:whatsapp_channel) do
       create(:channel_whatsapp, account: account, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false)

--- a/swagger/paths/application/inboxes/message_templates.yml
+++ b/swagger/paths/application/inboxes/message_templates.yml
@@ -1,0 +1,54 @@
+get:
+  tags:
+    - Inboxes
+  operationId: listWhatsappMessageTemplates
+  summary: List WhatsApp message templates
+  security:
+    - userApiKey: []
+  description: List the cached message templates available for a WhatsApp inbox
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+    - name: id
+      in: path
+      schema:
+        type: number
+      description: ID of the WhatsApp inbox
+      required: true
+    - name: name
+      in: query
+      schema:
+        type: string
+      description: Exact template name to filter by
+      required: false
+  responses:
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              payload:
+                type: array
+                description: WhatsApp message templates available for the inbox
+                items:
+                  type: object
+                  additionalProperties: true
+    '404':
+      description: Inbox not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/bad_request_error'
+    '403':
+      description: Access denied
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/bad_request_error'
+    '422':
+      description: The inbox is not a WhatsApp inbox
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/index.yml
+++ b/swagger/paths/index.yml
@@ -424,6 +424,8 @@
   $ref: ./application/inboxes/index.yml
 /api/v1/accounts/{account_id}/inboxes/{id}:
   $ref: ./application/inboxes/update.yml
+/api/v1/accounts/{account_id}/inboxes/{id}/message_templates:
+  $ref: ./application/inboxes/message_templates.yml
 /api/v1/accounts/{account_id}/inboxes/{id}/agent_bot:
   $ref: ./application/inboxes/get_agent_bot.yml
 /api/v1/accounts/{account_id}/inboxes/{id}/set_agent_bot:

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -6094,6 +6094,96 @@
         }
       }
     },
+    "/api/v1/accounts/{account_id}/inboxes/{id}/message_templates": {
+      "get": {
+        "tags": [
+          "Inboxes"
+        ],
+        "operationId": "listWhatsappMessageTemplates",
+        "summary": "List WhatsApp message templates",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "List the cached message templates available for a WhatsApp inbox",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/account_id"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "number"
+            },
+            "description": "ID of the WhatsApp inbox",
+            "required": true
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Exact template name to filter by",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "payload": {
+                      "type": "array",
+                      "description": "WhatsApp message templates available for the inbox",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Inbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The inbox is not a WhatsApp inbox",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/accounts/{account_id}/inboxes/{id}/agent_bot": {
       "get": {
         "tags": [

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -4637,6 +4637,96 @@
         }
       }
     },
+    "/api/v1/accounts/{account_id}/inboxes/{id}/message_templates": {
+      "get": {
+        "tags": [
+          "Inboxes"
+        ],
+        "operationId": "listWhatsappMessageTemplates",
+        "summary": "List WhatsApp message templates",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "List the cached message templates available for a WhatsApp inbox",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/account_id"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "number"
+            },
+            "description": "ID of the WhatsApp inbox",
+            "required": true
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Exact template name to filter by",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "payload": {
+                      "type": "array",
+                      "description": "WhatsApp message templates available for the inbox",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Inbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The inbox is not a WhatsApp inbox",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/accounts/{account_id}/inboxes/{id}/agent_bot": {
       "get": {
         "tags": [


### PR DESCRIPTION
External integrations can send WhatsApp template messages, but they do not have a focused API to discover the templates available for an inbox. This adds an authenticated endpoint that lists the inbox's cached WhatsApp templates and optionally filters them by exact template name.

Existing inbox responses and template synchronization behavior remain unchanged.

Fixes https://github.com/chatwoot/chatwoot/issues/13959

### Things to know

- The endpoint returns templates already synchronized and cached for a direct WhatsApp inbox; it does not make a new provider request.
- Non-WhatsApp inboxes return an unprocessable entity response.

### How to test

1. Authenticate as a user assigned to a WhatsApp inbox.
2. Request `GET /api/v1/accounts/:account_id/inboxes/:id/message_templates` and verify the response contains the inbox's templates under `payload`.
3. Repeat the request with `?name=<template_name>` and verify only the exact matching template is returned.
4. Request the endpoint for a non-WhatsApp inbox and verify it returns an unprocessable entity response.