### PR TITLE
fix: accept inbound Twilio SMS from short codes

### DIFF
--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -1,4 +1,6 @@
 class Twilio::IncomingMessageService
+  E164_REGEX = /\A\+[1-9]\d{1,14}\z/
+
   include ::FileTypeHelper
   include ::Twilio::WhatsappIdentifierHelper
   include ::Twilio::ReferralParamsHelper
@@ -58,7 +60,7 @@ class Twilio::IncomingMessageService
   # payloads use `whatsapp:<BSUID>` in `From`, so this intentionally returns
   # nil when `From` is not phone-shaped.
   def phone_number
-    return params[:From] if twilio_channel.sms?
+    return params[:From] if twilio_channel.sms? && params[:From].to_s.match?(E164_REGEX)
     return unless twilio_whatsapp_phone_source?
 
     params[:From].gsub('whatsapp:', '')

--- a/lib/regex_helper.rb
+++ b/lib/regex_helper.rb
@@ -13,7 +13,7 @@ module RegexHelper
   # while notifications use CommonMarker for better markdown processing
   MENTION_REGEX = Regexp.new('\[(@[^\\]]+)\]\(mention://(?:user|team)/\d+/([^)]+)\)')
 
-  TWILIO_CHANNEL_SMS_REGEX = Regexp.new('\A\+\d{1,15}\z')
+  TWILIO_CHANNEL_SMS_REGEX = Regexp.new('\A(?:\+\d{1,15}|\d{5,6})\z')
   WHATSAPP_BSUID_PATTERN = '[A-Z]{2}\.(?:ENT\.)?[A-Za-z0-9]{1,128}'.freeze
   WHATSAPP_WAMID_TOKEN_PATTERN = '(?<![0-9a-f])(?:[0-9a-f]{32}|[0-9a-f]{20})(?![0-9a-f])'.freeze
   WHATSAPP_BSUID_REGEX = Regexp.new("\\A#{WHATSAPP_BSUID_PATTERN}\\z")

--- a/spec/models/contact_inbox_spec.rb
+++ b/spec/models/contact_inbox_spec.rb
@@ -77,9 +77,11 @@ RSpec.describe ContactInbox do
         twilio_sms_inbox = create(:channel_twilio_sms).inbox
         contact = create(:contact)
         valid_source_id = build(:contact_inbox, contact: contact, inbox: twilio_sms_inbox, source_id: '+1234567890')
+        valid_short_code_source_id = build(:contact_inbox, contact: contact, inbox: twilio_sms_inbox, source_id: '12345')
         ci_character_in_source_id = build(:contact_inbox, contact: contact, inbox: twilio_sms_inbox, source_id: '+1234567890aaa')
         ci_without_plus_in_source_id = build(:contact_inbox, contact: contact, inbox: twilio_sms_inbox, source_id: '1234567890')
         expect(valid_source_id.valid?).to be(true)
+        expect(valid_short_code_source_id.valid?).to be(true)
         expect(ci_character_in_source_id.valid?).to be(false)
         expect(ci_character_in_source_id.errors.full_messages).to eq(
           ["Source invalid source id for twilio sms inbox. valid Regex #{RegexHelper::TWILIO_CHANNEL_SMS_REGEX}"]

--- a/spec/services/twilio/incoming_message_service_spec.rb
+++ b/spec/services/twilio/incoming_message_service_spec.rb
@@ -62,6 +62,24 @@ describe Twilio::IncomingMessageService do
       expect(twilio_channel.inbox.conversations.count).to eq(2)
     end
 
+    it 'creates a message from a short code without storing it as a phone number' do
+      params = {
+        SmsSid: 'SM-shortcode',
+        From: '12345',
+        AccountSid: 'ACxxx',
+        MessagingServiceSid: twilio_channel.messaging_service_sid,
+        Body: 'Your verification code is 123456'
+      }
+
+      described_class.new(params: params).perform
+
+      shortcode_conversation = twilio_channel.inbox.conversations.order(:created_at).last
+      expect(shortcode_conversation.contact_inbox.source_id).to eq('12345')
+      expect(shortcode_conversation.contact.name).to eq('12345')
+      expect(shortcode_conversation.contact.phone_number).to be_nil
+      expect(shortcode_conversation.messages.last.content).to eq('Your verification code is 123456')
+    end
+
     # Since we support the case with phone number as well. the previous case is with accoud_sid and messaging_service_sid
     context 'with a phone number' do
       let!(:twilio_channel) do


### PR DESCRIPTION
Twilio can deliver inbound SMS from 5-6 digit short codes, but Chatwoot currently requires every Twilio SMS source to be E.164. The callback job then fails when creating both the contact and contact inbox, after the callback has already returned 204.

This change accepts 5-6 digit short codes as Twilio SMS source IDs while only storing E.164 senders in the contact phone number field. It adds model and service regressions covering complete message creation with synthetic values.

Closes #15283