### PR TITLE
fix: resolve mobile app mention format in MentionService

### DIFF
--- a/app/services/messages/mention_service.rb
+++ b/app/services/messages/mention_service.rb
@@ -25,7 +25,8 @@ class Messages::MentionService
     # where the URL is just the numeric user ID (e.g. " @[Name](1) ") instead
     # of the mention:// scheme used by the web app. Extract IDs from both
     # patterns so mention notifications fire regardless of the source client.
-    mobile_user_mentions = message.content.scan(/@\[[^\]]+\]\((\d+)\)/).map(&:first)
+    # The non-greedy label match allows display names to contain "]".
+    mobile_user_mentions = message.content.scan(/@\[.+?\]\((\d+)\)/).map(&:first)
 
     expanded_user_ids = expand_team_mentions_to_users(team_mentions)
 

--- a/app/services/messages/mention_service.rb
+++ b/app/services/messages/mention_service.rb
@@ -21,10 +21,15 @@ class Messages::MentionService
   def mentioned_ids
     user_mentions = message.content.scan(%r{\(mention://user/(\d+)/(.+?)\)}).map(&:first)
     team_mentions = message.content.scan(%r{\(mention://team/(\d+)/(.+?)\)}).map(&:first)
+    # The mobile app sends private-note mentions as standard Markdown links
+    # where the URL is just the numeric user ID (e.g. " @[Name](1) ") instead
+    # of the mention:// scheme used by the web app. Extract IDs from both
+    # patterns so mention notifications fire regardless of the source client.
+    mobile_user_mentions = message.content.scan(/@\[[^\]]+\]\((\d+)\)/).map(&:first)
 
     expanded_user_ids = expand_team_mentions_to_users(team_mentions)
 
-    (user_mentions + expanded_user_ids).uniq
+    (user_mentions + mobile_user_mentions + expanded_user_ids).uniq
   end
 
   def expand_team_mentions_to_users(team_ids)

--- a/spec/services/messages/mention_service_spec.rb
+++ b/spec/services/messages/mention_service_spec.rb
@@ -278,6 +278,112 @@ describe Messages::MentionService do
     end
   end
 
+  describe 'mobile app mentions' do
+    context 'when message contains a mobile-style user mention' do
+      it 'creates a notification for the mentioned inbox member' do
+        message = build(
+          :message,
+          conversation: conversation,
+          account: account,
+          content: "hi @[#{first_agent.name}](#{first_agent.id})",
+          private: true
+        )
+
+        described_class.new(message: message).perform
+
+        expect(NotificationBuilder).to have_received(:new).with(
+          notification_type: 'conversation_mention',
+          user: first_agent,
+          account: account,
+          primary_actor: message.conversation,
+          secondary_actor: message
+        )
+      end
+
+      it 'adds the mentioned user as a conversation participant' do
+        message = build(
+          :message,
+          conversation: conversation,
+          account: account,
+          content: "hi @[#{first_agent.name}](#{first_agent.id})",
+          private: true
+        )
+
+        described_class.new(message: message).perform
+
+        expect(conversation.conversation_participants.map(&:user_id)).to include(first_agent.id)
+      end
+
+      it 'does not notify non-inbox members' do
+        non_member = create(:user, account: account)
+
+        message = build(
+          :message,
+          conversation: conversation,
+          account: account,
+          content: "hi @[#{non_member.name}](#{non_member.id})",
+          private: true
+        )
+
+        described_class.new(message: message).perform
+
+        expect(NotificationBuilder).not_to have_received(:new)
+        expect(Conversations::UserMentionJob).not_to have_received(:perform_later)
+      end
+
+      it 'skips self-mention notifications' do
+        message = build(
+          :message,
+          conversation: conversation,
+          account: account,
+          content: "hi @[#{first_agent.name}](#{first_agent.id})",
+          private: true,
+          sender: first_agent
+        )
+
+        described_class.new(message: message).perform
+
+        expect(NotificationBuilder).not_to have_received(:new).with(
+          notification_type: 'conversation_mention',
+          user: first_agent,
+          account: account,
+          primary_actor: message.conversation,
+          secondary_actor: message
+        )
+      end
+    end
+
+    context 'when message contains both web and mobile user mentions' do
+      it 'creates notifications for users mentioned in both formats' do
+        message = build(
+          :message,
+          conversation: conversation,
+          account: account,
+          content: "hey (mention://user/#{first_agent.id}/#{first_agent.name}) " \
+                   "and @[#{second_agent.name}](#{second_agent.id})",
+          private: true
+        )
+
+        described_class.new(message: message).perform
+
+        expect(NotificationBuilder).to have_received(:new).with(
+          notification_type: 'conversation_mention',
+          user: first_agent,
+          account: account,
+          primary_actor: message.conversation,
+          secondary_actor: message
+        )
+        expect(NotificationBuilder).to have_received(:new).with(
+          notification_type: 'conversation_mention',
+          user: second_agent,
+          account: account,
+          primary_actor: message.conversation,
+          secondary_actor: message
+        )
+      end
+    end
+  end
+
   describe 'team mentions' do
     context 'when message contains single team mention' do
       it 'creates notifications for all team members who are inbox members' do

--- a/spec/services/messages/mention_service_spec.rb
+++ b/spec/services/messages/mention_service_spec.rb
@@ -382,6 +382,28 @@ describe Messages::MentionService do
         )
       end
     end
+
+    context 'when the mobile mention label contains a bracket character' do
+      it 'still resolves the mentioned user ID' do
+        message = build(
+          :message,
+          conversation: conversation,
+          account: account,
+          content: "hi @[QA] Lead](#{first_agent.id})",
+          private: true
+        )
+
+        described_class.new(message: message).perform
+
+        expect(NotificationBuilder).to have_received(:new).with(
+          notification_type: 'conversation_mention',
+          user: first_agent,
+          account: account,
+          primary_actor: message.conversation,
+          secondary_actor: message
+        )
+      end
+    end
   end
 
   describe 'team mentions' do


### PR DESCRIPTION
## Summary

Mention notifications were not triggered when an agent mentioned another agent in a private note from the Chatwoot mobile app. The mentioned user was also not added as a conversation participant.

The web app serializes mentions using the `mention://` scheme (e.g. `[@Jane](mention://user/5/Jane)`), but the mobile app sends them as standard Markdown links where the URL is just the numeric user ID (e.g. `@[Jane](5)`). `Messages::MentionService#mentioned_ids` only scanned for the `mention://user/` and `mention://team/` patterns, so mentions arriving in the mobile format were never resolved.

This change extracts user IDs from both formats so mention notifications fire regardless of the source client. The existing `filter_mentioned_ids_by_inbox` check already filters extracted IDs against valid inbox members and admins, so there is no risk of false-positive notifications from arbitrary Markdown links.

Closes #15292

## How to test

1. Open a conversation in the Chatwoot mobile app
2. Switch to private note mode
3. Mention another agent who is a member of the inbox (especially one whose name contains characters outside `[\w\s]`, such as a hyphen, apostrophe, or accented character)
4. Send the note
5. Verify the mentioned agent receives a `conversation_mention` push notification
6. Verify the mentioned agent is added as a conversation participant

## What changed

- `app/services/messages/mention_service.rb` — `mentioned_ids` now also scans for the mobile mention format `@[Name](ID)` in addition to the existing `mention://user/` and `mention://team/` patterns
- `spec/services/messages/mention_service_spec.rb` — added coverage for mobile-style mentions, mixed web/mobile mentions, non-inbox-member filtering, and self-mention skipping