### PR TITLE
fix: encode contact search params so emails with a plus sign match

### DIFF
--- a/app/javascript/dashboard/api/contacts.js
+++ b/app/javascript/dashboard/api/contacts.js
@@ -1,16 +1,13 @@
 /* global axios */
 import ApiClient from './ApiClient';
 
-export const buildContactParams = (page, sortAttr, label, search) => {
-  let params = `include_contact_inboxes=false&page=${page}&sort=${sortAttr}`;
-  if (search) {
-    params = `${params}&q=${search}`;
-  }
-  if (label) {
-    params = `${params}&labels[]=${label}`;
-  }
-  return params;
-};
+export const buildContactParams = (page, sortAttr, label, search) => ({
+  include_contact_inboxes: false,
+  page,
+  sort: sortAttr,
+  ...(search ? { q: search } : {}),
+  ...(label ? { labels: [label] } : {}),
+});
 
 class ContactAPI extends ApiClient {
   constructor() {
@@ -18,13 +15,9 @@ class ContactAPI extends ApiClient {
   }
 
   get(page, sortAttr = 'name', label = '') {
-    let requestURL = `${this.url}?${buildContactParams(
-      page,
-      sortAttr,
-      label,
-      ''
-    )}`;
-    return axios.get(requestURL);
+    return axios.get(this.url, {
+      params: buildContactParams(page, sortAttr, label, ''),
+    });
   }
 
   show(id) {
@@ -66,24 +59,23 @@ class ContactAPI extends ApiClient {
   }
 
   search(search = '', page = 1, sortAttr = 'name', label = '', options = {}) {
-    let requestURL = `${this.url}/search?${buildContactParams(
-      page,
-      sortAttr,
-      label,
-      search
-    )}`;
-    return axios.get(requestURL, { signal: options.signal });
+    return axios.get(`${this.url}/search`, {
+      params: buildContactParams(page, sortAttr, label, search),
+      signal: options.signal,
+    });
   }
 
   active(page = 1, sortAttr = 'name') {
-    let requestURL = `${this.url}/active?${buildContactParams(page, sortAttr)}`;
-    return axios.get(requestURL);
+    return axios.get(`${this.url}/active`, {
+      params: buildContactParams(page, sortAttr),
+    });
   }
 
   // eslint-disable-next-line default-param-last
   filter(page = 1, sortAttr = 'name', queryPayload) {
-    let requestURL = `${this.url}/filter?${buildContactParams(page, sortAttr)}`;
-    return axios.post(requestURL, queryPayload);
+    return axios.post(`${this.url}/filter`, queryPayload, {
+      params: buildContactParams(page, sortAttr),
+    });
   }
 
   importContacts(file) {

--- a/app/javascript/dashboard/api/specs/contacts.spec.js
+++ b/app/javascript/dashboard/api/specs/contacts.spec.js
@@ -33,9 +33,14 @@ describe('#ContactsAPI', () => {
 
     it('#get', () => {
       contactAPI.get(1, 'name', 'customer-support');
-      expect(axiosMock.get).toHaveBeenCalledWith(
-        '/api/v1/contacts?include_contact_inboxes=false&page=1&sort=name&labels[]=customer-support'
-      );
+      expect(axiosMock.get).toHaveBeenCalledWith('/api/v1/contacts', {
+        params: {
+          include_contact_inboxes: false,
+          page: 1,
+          sort: 'name',
+          labels: ['customer-support'],
+        },
+      });
     });
 
     it('#getConversations', () => {
@@ -68,10 +73,16 @@ describe('#ContactsAPI', () => {
 
     it('#search', () => {
       contactAPI.search('leads', 1, 'date', 'customer-support');
-      expect(axiosMock.get).toHaveBeenCalledWith(
-        '/api/v1/contacts/search?include_contact_inboxes=false&page=1&sort=date&q=leads&labels[]=customer-support',
-        { signal: undefined }
-      );
+      expect(axiosMock.get).toHaveBeenCalledWith('/api/v1/contacts/search', {
+        params: {
+          include_contact_inboxes: false,
+          page: 1,
+          sort: 'date',
+          q: 'leads',
+          labels: ['customer-support'],
+        },
+        signal: undefined,
+      });
     });
 
     it('#search with signal', () => {
@@ -79,10 +90,29 @@ describe('#ContactsAPI', () => {
       contactAPI.search('leads', 1, 'date', 'customer-support', {
         signal: controller.signal,
       });
-      expect(axiosMock.get).toHaveBeenCalledWith(
-        '/api/v1/contacts/search?include_contact_inboxes=false&page=1&sort=date&q=leads&labels[]=customer-support',
-        { signal: controller.signal }
-      );
+      expect(axiosMock.get).toHaveBeenCalledWith('/api/v1/contacts/search', {
+        params: {
+          include_contact_inboxes: false,
+          page: 1,
+          sort: 'date',
+          q: 'leads',
+          labels: ['customer-support'],
+        },
+        signal: controller.signal,
+      });
+    });
+
+    it('#search passes the term as a param so it is encoded', () => {
+      contactAPI.search('jane+shop@gmail.com');
+      expect(axiosMock.get).toHaveBeenCalledWith('/api/v1/contacts/search', {
+        params: {
+          include_contact_inboxes: false,
+          page: 1,
+          sort: 'name',
+          q: 'jane+shop@gmail.com',
+        },
+        signal: undefined,
+      });
     });
 
     it('#destroyCustomAttributes', () => {
@@ -120,8 +150,11 @@ describe('#ContactsAPI', () => {
       };
       contactAPI.filter(1, 'name', queryPayload);
       expect(axiosMock.post).toHaveBeenCalledWith(
-        '/api/v1/contacts/filter?include_contact_inboxes=false&page=1&sort=name',
-        queryPayload
+        '/api/v1/contacts/filter',
+        queryPayload,
+        {
+          params: { include_contact_inboxes: false, page: 1, sort: 'name' },
+        }
       );
     });
 
@@ -135,17 +168,26 @@ describe('#ContactsAPI', () => {
 });
 
 describe('#buildContactParams', () => {
-  it('returns correct string', () => {
-    expect(buildContactParams(1, 'name', '', '')).toBe(
-      'include_contact_inboxes=false&page=1&sort=name'
-    );
-    expect(buildContactParams(1, 'name', 'customer-support', '')).toBe(
-      'include_contact_inboxes=false&page=1&sort=name&labels[]=customer-support'
-    );
+  it('returns correct params', () => {
+    expect(buildContactParams(1, 'name', '', '')).toEqual({
+      include_contact_inboxes: false,
+      page: 1,
+      sort: 'name',
+    });
+    expect(buildContactParams(1, 'name', 'customer-support', '')).toEqual({
+      include_contact_inboxes: false,
+      page: 1,
+      sort: 'name',
+      labels: ['customer-support'],
+    });
     expect(
       buildContactParams(1, 'name', 'customer-support', 'message-content')
-    ).toBe(
-      'include_contact_inboxes=false&page=1&sort=name&q=message-content&labels[]=customer-support'
-    );
+    ).toEqual({
+      include_contact_inboxes: false,
+      page: 1,
+      sort: 'name',
+      q: 'message-content',
+      labels: ['customer-support'],
+    });
   });
 });

--- a/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
@@ -114,9 +114,11 @@ const handleSelectedContact = async ({ value, action, ...rest }) => {
       isCreatingContact.value = false;
     } catch (error) {
       isCreatingContact.value = false;
+      const message = parseAPIErrorResponse(error);
       useAlert(
-        parseAPIErrorResponse(error) ||
-          t('COMPOSE_NEW_CONVERSATION.CONTACT_CREATE.ERROR_MESSAGE')
+        typeof message === 'string'
+          ? message
+          : t('COMPOSE_NEW_CONVERSATION.CONTACT_CREATE.ERROR_MESSAGE')
       );
       return;
     }

--- a/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
@@ -4,6 +4,7 @@ import { useStore, useMapGetter } from 'dashboard/composables/store';
 import { useI18n } from 'vue-i18n';
 import { useUISettings } from 'dashboard/composables/useUISettings';
 import { useAlert } from 'dashboard/composables';
+import { parseAPIErrorResponse } from 'dashboard/store/utils/api';
 import { ExceptionWithMessage } from 'shared/helpers/CustomErrors';
 import { debounce } from '@chatwoot/utils';
 import { emitter } from 'shared/helpers/mitt';
@@ -113,6 +114,10 @@ const handleSelectedContact = async ({ value, action, ...rest }) => {
       isCreatingContact.value = false;
     } catch (error) {
       isCreatingContact.value = false;
+      useAlert(
+        parseAPIErrorResponse(error) ||
+          t('COMPOSE_NEW_CONVERSATION.CONTACT_CREATE.ERROR_MESSAGE')
+      );
       return;
     }
   } else {

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -614,6 +614,9 @@
     "CONTACT_SEARCH": {
       "ERROR_MESSAGE": "We couldn’t complete the search. Please try again."
     },
+    "CONTACT_CREATE": {
+      "ERROR_MESSAGE": "We couldn’t create the contact. Please try again."
+    },
     "FORM": {
       "GO_TO_CONVERSATION": "View",
       "SUCCESS_MESSAGE": "The message was sent successfully!",

--- a/app/javascript/dashboard/routes/dashboard/contacts/pages/ContactsIndex.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/pages/ContactsIndex.vue
@@ -262,7 +262,7 @@ const searchContacts = debounce(
     updatePageParam(page, value);
     await store.dispatch('contacts/search', {
       ...getCommonFetchParams(page),
-      search: encodeURIComponent(value),
+      search: value,
       append,
     });
     searchPageNumber.value = page;
@@ -278,7 +278,7 @@ const loadMoreSearchResults = async () => {
 
   await store.dispatch('contacts/search', {
     ...getCommonFetchParams(nextPage),
-    search: encodeURIComponent(searchValue.value),
+    search: searchValue.value,
     append: true,
   });
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where contact search failed for emails containing a `+`, such as `jane+shop@gmail.com`. We were building the search URL manually, so `+` was treated as a space in the query string and the server searched for `jane shop@gmail.com` instead.

This also fixed an issue in the compose window. When the search returned no results, the dropdown offered to create a new contact. Since the contact already existed, the API returned an error, but it was swallowed and the **To:** field was cleared without any feedback.

The search request now passes parameters through Axios `params`, allowing Axios to handle URL encoding correctly. This also fixes searches containing other reserved characters like `&`, `#`, and `%`, where `%` could previously cause a `400` response. The redundant `encodeURIComponent` on the Contacts page has been removed to avoid double encoding, and the compose window now surfaces the actual API error when contact creation fails.


### How to reproduce

1. Create a contact with an email containing a `+`, for example `jane+shop@gmail.com`.
2. Open the compose window and search for the full email.
3. Before, the contact was not found, the dropdown offered to create a new contact, and selecting it silently failed while clearing the **To:** field. After this change, the existing contact is found correctly, and any contact creation error is shown to the user.


Fixes https://linear.app/chatwoot/issue/CW-7812/contact-search-sends-q-unencoded-so-emails-containing-never-match-and

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="1751" height="591" alt="image" src="https://github.com/user-attachments/assets/90051c6a-6ee6-4b24-9616-258bfef42fad" />
<img width="1751" height="591" alt="image" src="https://github.com/user-attachments/assets/bb8728c3-7192-49dd-aaaf-4bb19a4d8039" />
<img width="1751" height="591" alt="image" src="https://github.com/user-attachments/assets/e7469034-d3ae-4b33-b5cb-a7bafb0c5d1b" />



**After**
<img width="1751" height="591" alt="image" src="https://github.com/user-attachments/assets/bd0fa442-03fa-4912-91cc-47a10a862040" />
<img width="1751" height="591" alt="image" src="https://github.com/user-attachments/assets/b28fac9f-bc31-4bd5-b153-6ea20005a837" />
<img width="1751" height="591" alt="image" src="https://github.com/user-attachments/assets/824ae489-fa77-42f6-81d4-1eca2ec160fd" />





## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
