### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ Chatwoot now supports 1-Click deployment to DigitalOcean as a kubernetes app.
   <img width="200" alt="Deploy to DO" src="https://www.deploytodo.com/do-btn-blue.svg"/>
 </a>
 
+### Zenith managed hosting
+
+One-click managed Chatwoot: storage, backups, email and a free subdomain included. A share of every subscription goes back to Chatwoot.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/chatwoot)
+
 ### Other deployment options
 
 For other supported options, checkout our [deployment page](https://chatwoot.com/deploy).


### PR DESCRIPTION
## Description

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Chatwoot to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Deployment (links to https://zenith.hosting/host/chatwoot).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

README-only change, sits alongside the existing Heroku and DigitalOcean one-click entries. no code touched.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

n/a, docs only. checked the badge image and the link both resolve, and previewed the rendered markdown in the Deployment section.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
