### PR TITLE
fix(spec): i18n assertion failing for full editor spec

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.spec.js
+++ b/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.spec.js
@@ -2,9 +2,14 @@ import { flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createStore } from 'vuex';
 import { Selection } from '@chatwoot/prosemirror-schema';
+import { withFullI18n } from 'test-i18n';
 import { emitter } from 'shared/helpers/mitt';
 import { ARTICLE_EDITOR_MENU_OPTIONS } from 'dashboard/constants/editor';
 import FullEditor from './FullEditor.vue';
+
+// The slash menu specs assert on translated labels, so this spec needs the
+// real message catalogue instead of the empty global i18n instance.
+withFullI18n();
 
 let view = null;
 


### PR DESCRIPTION
Fixes the three `FullEditor.spec.js` slash-menu failures that appeared after #15291 and #15296 crossed on develop: #15296 added slash-menu specs that assert real translated labels ("Divider", "Heading 1"), while #15291 emptied the global i18n catalogue in the vitest setup, so `t()` started returning raw keys like `SLASH_COMMANDS.DIVIDER`.

The spec now calls `withFullI18n()` from the `test-i18n` helper introduced in #15291, opting into the full message catalogue the same way `MacroProperties.spec.js` does. Test-only change, no production code touched.


Related: https://github.com/chatwoot/chatwoot/pull/15291