### PR TITLE
feat(captain): add inactivity handling policies (3/3)

### DIFF
--- a/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.vue
@@ -8,6 +8,7 @@ import { useAccount } from 'dashboard/composables/useAccount';
 
 import Button from 'dashboard/components-next/button/Button.vue';
 import Editor from 'dashboard/components-next/Editor/Editor.vue';
+import RadioCard from 'dashboard/components-next/radioCard/RadioCard.vue';
 import Select from 'dashboard/components-next/select/Select.vue';
 import SettingsToggleSection from 'dashboard/components-next/Settings/SettingsToggleSection.vue';
 
@@ -31,16 +32,49 @@ const initialState = {
   handoffMessage: '',
   resolutionMessage: '',
   instructions: '',
+  autoResolveMode: 'evaluated',
   inactivityThresholdMinutes: 60,
+  followUpBeforeResolving: false,
+  followUpResolveAfterMinutes: 60,
   sendInactivityResolutionMessage: true,
 };
 
 const state = reactive({ ...initialState });
 const isInactivityResolutionSettingsExpanded = ref(false);
 
-const inactivityThresholdLabel = computed(() => {
-  const hours = Math.floor(state.inactivityThresholdMinutes / 60);
-  const minutes = state.inactivityThresholdMinutes % 60;
+const autoResolveOptions = computed(() => [
+  {
+    value: 'evaluated',
+    label: t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.MODES.EVALUATED.LABEL'
+    ),
+    description: t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.MODES.EVALUATED.DESCRIPTION'
+    ),
+  },
+  {
+    value: 'legacy',
+    label: t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.MODES.LEGACY.LABEL'
+    ),
+    description: t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.MODES.LEGACY.DESCRIPTION'
+    ),
+  },
+  {
+    value: 'disabled',
+    label: t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.MODES.DISABLED.LABEL'
+    ),
+    description: t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.MODES.DISABLED.DESCRIPTION'
+    ),
+  },
+]);
+
+const formatDuration = durationMinutes => {
+  const hours = Math.floor(durationMinutes / 60);
+  const minutes = durationMinutes % 60;
 
   return [
     hours
@@ -56,15 +90,41 @@ const inactivityThresholdLabel = computed(() => {
   ]
     .filter(Boolean)
     .join(' ');
-});
+};
+
+const inactivityThresholdLabel = computed(() =>
+  formatDuration(state.inactivityThresholdMinutes)
+);
+const followUpResolutionThresholdLabel = computed(() =>
+  formatDuration(state.followUpResolveAfterMinutes)
+);
+const initialActionTimingLabel = computed(() =>
+  state.autoResolveMode === 'evaluated'
+    ? t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.REVIEW_AFTER')
+    : t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.RESOLVE_AFTER')
+);
 
 const selectedInactivityResolutionSummary = computed(() => {
-  const resolutionSummary = t(
-    'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.CURRENT_SETTING',
-    {
-      duration: inactivityThresholdLabel.value,
-    }
-  );
+  if (state.autoResolveMode === 'disabled') {
+    return t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.SUMMARY.PENDING');
+  }
+
+  let resolutionSummary =
+    state.autoResolveMode === 'evaluated'
+      ? t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.SUMMARY.REVIEW', {
+          duration: inactivityThresholdLabel.value,
+        })
+      : t(
+          'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.SUMMARY.ALWAYS_RESOLVE',
+          { duration: inactivityThresholdLabel.value }
+        );
+
+  if (state.autoResolveMode === 'evaluated' && state.followUpBeforeResolving) {
+    resolutionSummary = `${resolutionSummary} ${t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.SUMMARY.FOLLOW_UP',
+      { duration: followUpResolutionThresholdLabel.value }
+    )}`;
+  }
 
   if (state.sendInactivityResolutionMessage) return resolutionSummary;
 
@@ -73,6 +133,12 @@ const selectedInactivityResolutionSummary = computed(() => {
   )}`;
 });
 
+const shouldShowInactivityDuration = computed(
+  () => state.autoResolveMode !== 'disabled'
+);
+const shouldShowFollowUpSettings = computed(
+  () => state.autoResolveMode === 'evaluated'
+);
 const inactivityHourOptions = Array.from({ length: 25 }, (_, hours) => ({
   value: hours,
   label: String(hours),
@@ -116,11 +182,54 @@ const inactivityMinuteOptions = computed(() => {
   });
 });
 
+const followUpResolutionThresholdHours = computed({
+  get: () => Math.floor(state.followUpResolveAfterMinutes / 60),
+  set: hours => {
+    const remainingMinutes = state.followUpResolveAfterMinutes % 60;
+    const requestedMinutes = Number(hours) * 60 + remainingMinutes;
+    state.followUpResolveAfterMinutes = Math.min(
+      Math.max(requestedMinutes, 5),
+      24 * 60
+    );
+  },
+});
+
+const followUpResolutionThresholdRemainingMinutes = computed({
+  get: () => state.followUpResolveAfterMinutes % 60,
+  set: minutes => {
+    const completeHours = Math.floor(state.followUpResolveAfterMinutes / 60);
+    const requestedMinutes = completeHours * 60 + Number(minutes);
+    state.followUpResolveAfterMinutes = Math.min(
+      Math.max(requestedMinutes, 5),
+      24 * 60
+    );
+  },
+});
+
+const followUpResolutionMinuteOptions = computed(() => {
+  return Array.from({ length: 12 }, (_, index) => {
+    const minutes = index * 5;
+    const hours = followUpResolutionThresholdHours.value;
+
+    return {
+      value: minutes,
+      label: String(minutes).padStart(2, '0'),
+      disabled:
+        (hours === 0 && minutes === 0) || (hours === 24 && minutes !== 0),
+    };
+  });
+});
+
 const validationRules = {
   handoffMessage: { minLength: minLength(1) },
   resolutionMessage: { minLength: minLength(1) },
   instructions: { minLength: minLength(1) },
   inactivityThresholdMinutes: {
+    required,
+    minValue: minValue(5),
+    maxValue: maxValue(24 * 60),
+  },
+  followUpResolveAfterMinutes: {
     required,
     minValue: minValue(5),
     maxValue: maxValue(24 * 60),
@@ -138,11 +247,18 @@ const formErrors = computed(() => ({
   resolutionMessage: getErrorMessage('resolutionMessage'),
   instructions: getErrorMessage('instructions'),
   inactivityThresholdMinutes: getErrorMessage('inactivityThresholdMinutes'),
+  followUpResolveAfterMinutes: getErrorMessage('followUpResolveAfterMinutes'),
 }));
 
 const handleInactivityResolutionUpdate = async () => {
   const validations = [v$.value.inactivityThresholdMinutes.$validate()];
-  if (state.sendInactivityResolutionMessage) {
+  if (state.autoResolveMode === 'evaluated' && state.followUpBeforeResolving) {
+    validations.push(v$.value.followUpResolveAfterMinutes.$validate());
+  }
+  if (
+    shouldShowInactivityDuration.value &&
+    state.sendInactivityResolutionMessage
+  ) {
     validations.push(v$.value.resolutionMessage.$validate());
   }
   const result = await Promise.all(validations).then(results =>
@@ -153,7 +269,10 @@ const handleInactivityResolutionUpdate = async () => {
   emit('submit', {
     config: {
       ...props.assistant.config,
+      auto_resolve_mode: state.autoResolveMode,
       auto_resolve_after: state.inactivityThresholdMinutes,
+      follow_up_before_resolving: state.followUpBeforeResolving,
+      follow_up_resolve_after: state.followUpResolveAfterMinutes,
       send_inactivity_resolution_message: state.sendInactivityResolutionMessage,
       resolution_message: state.resolutionMessage,
     },
@@ -165,7 +284,10 @@ const updateStateFromAssistant = assistant => {
   state.handoffMessage = config.handoff_message;
   state.resolutionMessage = config.resolution_message;
   state.instructions = config.instructions;
+  state.autoResolveMode = config.auto_resolve_mode ?? 'evaluated';
   state.inactivityThresholdMinutes = config.auto_resolve_after ?? 60;
+  state.followUpBeforeResolving = config.follow_up_before_resolving ?? false;
+  state.followUpResolveAfterMinutes = config.follow_up_resolve_after ?? 60;
   state.sendInactivityResolutionMessage =
     config.send_inactivity_resolution_message ?? true;
 };
@@ -213,11 +335,11 @@ watch(
   <div class="flex flex-col gap-6">
     <div
       v-if="isCaptainV2Enabled"
-      class="overflow-hidden rounded-xl border border-n-weak bg-n-solid-1"
+      class="flex flex-col border-b border-n-weak pb-6"
     >
       <button
         type="button"
-        class="flex w-full items-center justify-between gap-4 p-4 text-left"
+        class="flex w-full items-center justify-between gap-4 text-left"
         :aria-expanded="isInactivityResolutionSettingsExpanded"
         @click="
           isInactivityResolutionSettingsExpanded =
@@ -248,13 +370,23 @@ watch(
 
       <div
         v-if="isInactivityResolutionSettingsExpanded"
-        class="flex flex-col gap-4 border-t border-n-weak p-4"
+        class="flex flex-col gap-4 pt-4"
       >
-        <div class="flex flex-col gap-2">
+        <div class="flex flex-col gap-3">
+          <RadioCard
+            v-for="option in autoResolveOptions"
+            :id="`auto-resolve-${option.value}`"
+            :key="option.value"
+            :label="option.label"
+            :description="option.description"
+            :is-active="state.autoResolveMode === option.value"
+            @select="state.autoResolveMode = option.value"
+          />
+        </div>
+
+        <div v-if="shouldShowInactivityDuration" class="flex flex-col gap-2">
           <p class="text-sm font-medium text-n-slate-12">
-            {{
-              t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.DURATION_LABEL')
-            }}
+            {{ initialActionTimingLabel }}
           </p>
           <div class="grid grid-cols-2 gap-3">
             <label class="flex flex-col gap-1.5 text-xs text-n-slate-11">
@@ -292,7 +424,90 @@ watch(
           </p>
         </div>
 
+        <div
+          v-if="state.autoResolveMode === 'legacy'"
+          class="flex items-start gap-2 rounded-lg bg-n-amber-3 p-3 text-sm text-n-amber-12"
+        >
+          <span class="i-lucide-triangle-alert mt-0.5 size-4 shrink-0" />
+          <p>
+            {{
+              t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.ALWAYS_WARNING')
+            }}
+          </p>
+        </div>
+
+        <div
+          v-if="state.autoResolveMode === 'disabled'"
+          class="flex items-start gap-2 rounded-lg bg-n-blue-3 p-3 text-sm text-n-blue-12"
+        >
+          <span class="i-lucide-info mt-0.5 size-4 shrink-0" />
+          <p>
+            {{
+              t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.PENDING_INFO')
+            }}
+          </p>
+        </div>
+
         <SettingsToggleSection
+          v-if="shouldShowFollowUpSettings"
+          v-model="state.followUpBeforeResolving"
+          :header="
+            t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.FOLLOW_UP.TITLE')
+          "
+          :description="
+            t(
+              'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.FOLLOW_UP.DESCRIPTION'
+            )
+          "
+        />
+
+        <div
+          v-if="shouldShowFollowUpSettings && state.followUpBeforeResolving"
+          class="flex flex-col gap-2"
+        >
+          <p class="text-sm font-medium text-n-slate-12">
+            {{
+              t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.RESOLVE_AFTER')
+            }}
+          </p>
+          <div class="grid grid-cols-2 gap-3">
+            <label class="flex flex-col gap-1.5 text-xs text-n-slate-11">
+              {{
+                t(
+                  'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.DURATION_HOURS_LABEL'
+                )
+              }}
+              <Select
+                v-model="followUpResolutionThresholdHours"
+                :options="inactivityHourOptions"
+                :error="formErrors.followUpResolveAfterMinutes"
+                class="!w-full [&>select]:w-full"
+              />
+            </label>
+            <label class="flex flex-col gap-1.5 text-xs text-n-slate-11">
+              {{
+                t(
+                  'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.DURATION_MINUTES_LABEL'
+                )
+              }}
+              <Select
+                v-model="followUpResolutionThresholdRemainingMinutes"
+                :options="followUpResolutionMinuteOptions"
+                :error="formErrors.followUpResolveAfterMinutes"
+                class="!w-full [&>select]:w-full"
+              />
+            </label>
+          </div>
+          <p
+            v-if="formErrors.followUpResolveAfterMinutes"
+            class="text-xs text-n-ruby-9"
+          >
+            {{ formErrors.followUpResolveAfterMinutes }}
+          </p>
+        </div>
+
+        <SettingsToggleSection
+          v-if="shouldShowInactivityDuration"
           v-model="state.sendInactivityResolutionMessage"
           :header="
             t(
@@ -305,8 +520,9 @@ watch(
             )
           "
         >
-          <template v-if="state.sendInactivityResolutionMessage" #editor>
+          <template #editor>
             <Editor
+              v-if="state.sendInactivityResolutionMessage"
               v-model="state.resolutionMessage"
               :placeholder="
                 t('CAPTAIN.ASSISTANTS.FORM.RESOLUTION_MESSAGE.PLACEHOLDER')
@@ -315,6 +531,13 @@ watch(
               :message-type="formErrors.resolutionMessage ? 'error' : 'info'"
               class="z-0"
             />
+            <p v-else class="text-xs text-n-slate-11">
+              {{
+                t(
+                  'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.RESOLUTION_MESSAGE.RETAINED'
+                )
+              }}
+            </p>
           </template>
         </SettingsToggleSection>
 

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -602,16 +602,44 @@
         },
         "INACTIVITY_RESOLUTION": {
           "TITLE": "Inactive conversations",
-          "DESCRIPTION": "Choose when Captain should act on conversations that are waiting for the customer.",
-          "CURRENT_SETTING": "Captain acts after {duration} of inactivity.",
+          "DESCRIPTION": "Choose what Captain should do when the customer stops replying.",
           "DURATION_HOURS": "{count} hour | {count} hours",
           "DURATION_MINUTES": "{count} minute | {count} minutes",
-          "RESOLUTION_MESSAGE": {
-            "TITLE": "Send a resolution message",
-            "DESCRIPTION": "Captain sends this message before resolving an inactive conversation.",
-            "DISABLED_SUMMARY": "Captain will not send a resolution message."
+          "REVIEW_AFTER": "Review after",
+          "RESOLVE_AFTER": "Resolve after",
+          "ALWAYS_WARNING": "Captain will resolve every inactive conversation without reviewing it. Some conversations that still need help may be closed.",
+          "PENDING_INFO": "Captain won't close the conversation because it has been inactive.",
+          "SUMMARY": {
+            "REVIEW": "Captain reviews the conversation after {duration}.",
+            "ALWAYS_RESOLVE": "Captain resolves the conversation after {duration} without reviewing it.",
+            "PENDING": "Captain waits for the customer and continues when they reply.",
+            "FOLLOW_UP": "If Captain follows up, it waits another {duration} before resolving."
           },
-          "DURATION_LABEL": "Inactivity timer",
+          "FOLLOW_UP": {
+            "TITLE": "Follow up before resolving",
+            "DESCRIPTION": "Captain sends a follow-up based on the conversation."
+          },
+          "RESOLUTION_MESSAGE": {
+            "TITLE": "Send a message when resolving",
+            "DESCRIPTION": "Send this closing message after Captain decides to resolve.",
+            "DISABLED_SUMMARY": "Captain will not send a resolution message.",
+            "RETAINED": "The saved resolution message is kept and will return if messages are turned on again."
+          },
+          "MODES": {
+            "DISABLED": {
+              "LABEL": "Captain will handle it",
+              "DESCRIPTION": "Captain waits for the customer and continues the conversation when they reply."
+            },
+            "LEGACY": {
+              "LABEL": "Always resolve",
+              "DESCRIPTION": "Skip Captain's review and resolve every inactive conversation after the selected time."
+            },
+            "EVALUATED": {
+              "LABEL": "Let Captain review it (recommended)",
+              "DESCRIPTION": "Captain decides whether to resolve, follow up, or hand off."
+            }
+          },
+          "DURATION_LABEL": "Take action after",
           "DURATION_HOURS_LABEL": "Hours",
           "DURATION_MINUTES_LABEL": "Minutes"
         },

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
@@ -130,7 +130,10 @@ class Api::V1::Accounts::Captain::AssistantsController < Api::V1::Accounts::Base
       :resolution_message, :instructions, :temperature, :auto_resolve_mode
     ]
     if Current.account.feature_enabled?('captain_integration_v2')
-      assistant_config_attributes += [:auto_resolve_after, :send_inactivity_resolution_message]
+      assistant_config_attributes += [
+        :auto_resolve_after, :send_inactivity_resolution_message,
+        :follow_up_before_resolving, :follow_up_resolve_after
+      ]
     end
 
     permitted = params.require(:assistant).permit(:name, :description,

--- a/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
+++ b/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
@@ -1,16 +1,18 @@
+# rubocop:disable Metrics/ClassLength
 class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
   CAPTAIN_INFERENCE_RESOLVE_ACTIVITY_REASON = 'no outstanding questions'.freeze
   CAPTAIN_INFERENCE_HANDOFF_ACTIVITY_REASON = 'pending clarification from customer'.freeze
-
   queue_as :low
 
   def perform(inbox)
-    captain_assistant = inbox.captain_assistant
+    @captain_assistant = inbox.captain_assistant
     return if captain_assistant.inactive_conversation_resolution_disabled?
 
-    @inactivity_cutoff_time = Time.now.utc - captain_assistant.inactivity_threshold_minutes.minutes
+    now = Time.current
+    @inactivity_cutoff_time = now - captain_assistant.inactivity_threshold_minutes.minutes
+    @follow_up_resolution_cutoff_time = now - captain_assistant.follow_up_resolution_threshold_minutes.minutes
 
-    if evaluate_conversation_completion?(captain_assistant, inbox.account)
+    if evaluate_conversation_completion?(inbox.account)
       perform_with_evaluation(inbox)
     else
       perform_time_based(inbox)
@@ -21,40 +23,51 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
 
   private
 
-  attr_reader :inactivity_cutoff_time
+  attr_reader :captain_assistant, :inactivity_cutoff_time, :follow_up_resolution_cutoff_time
 
-  def evaluate_conversation_completion?(assistant, account)
-    account.feature_enabled?('captain_tasks') && assistant.evaluate_inactive_conversations_before_resolving?
+  def evaluate_conversation_completion?(account)
+    account.feature_enabled?('captain_tasks') && captain_assistant.evaluate_inactive_conversations_before_resolving?
   end
 
   def perform_time_based(inbox)
-    Current.executed_by = inbox.captain_assistant
+    Current.executed_by = captain_assistant
 
     resolvable_pending_conversations(inbox).each do |conversation|
-      create_resolution_message(conversation, inbox)
-      conversation.resolved!
-      Captain::ConversationEvents.resolved(
-        conversation: conversation,
-        assistant: inbox.captain_assistant,
-        source: Captain::ConversationEvents::Sources::TIME_BASED,
-        at: Time.current
-      )
+      resolve_time_based_conversation(conversation, inbox)
     end
   end
 
   def perform_with_evaluation(inbox)
-    Current.executed_by = inbox.captain_assistant
+    Current.executed_by = captain_assistant
 
-    resolvable_pending_conversations(inbox).each do |conversation|
+    candidate_pending_conversations(inbox).each do |conversation|
+      next if process_pending_follow_up(conversation, inbox)
+      next unless inactive_for_initial_action?(conversation)
+
       evaluation = evaluate_conversation(conversation, inbox)
       next unless still_resolvable_after_evaluation?(conversation)
 
-      if evaluation[:complete]
-        resolve_conversation(conversation, inbox, evaluation[:reason])
-      else
-        handoff_conversation(conversation, inbox, evaluation[:reason])
-      end
+      perform_evaluated_action(conversation, inbox, evaluation)
     end
+  end
+
+  def perform_evaluated_action(conversation, inbox, evaluation)
+    case evaluation_action(evaluation)
+    when 'resolve'
+      resolve_conversation(conversation, inbox, evaluation[:reason])
+    when 'follow_up'
+      if captain_assistant.follow_up_before_resolving? && evaluation[:follow_up_message].present?
+        follow_up_conversation(conversation, evaluation[:reason], evaluation[:follow_up_message])
+      else
+        handoff_conversation(conversation, evaluation[:reason])
+      end
+    else
+      handoff_conversation(conversation, evaluation[:reason])
+    end
+  end
+
+  def evaluation_action(evaluation)
+    evaluation[:action].presence_in(Captain::ConversationCompletionSchema::ACTIONS) || (evaluation[:complete] ? 'resolve' : 'handoff')
   end
 
   def evaluate_conversation(conversation, inbox)
@@ -70,58 +83,138 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
          .limit(Limits::BULK_ACTIONS_LIMIT)
   end
 
+  def candidate_pending_conversations(inbox)
+    cutoff_time = if captain_assistant.follow_up_before_resolving?
+                    [inactivity_cutoff_time, follow_up_resolution_cutoff_time].max
+                  else
+                    inactivity_cutoff_time
+                  end
+
+    inbox.conversations.pending
+         .where('last_activity_at < ?', cutoff_time)
+         .limit(Limits::BULK_ACTIONS_LIMIT)
+  end
+
+  def inactive_for_initial_action?(conversation) = conversation.last_activity_at < inactivity_cutoff_time
+
   def still_resolvable_after_evaluation?(conversation)
     conversation.reload
-    conversation.pending? && conversation.last_activity_at < inactivity_cutoff_time
+    conversation.pending? && inactive_for_initial_action?(conversation)
   rescue ActiveRecord::RecordNotFound
     false
   end
 
-  def resolve_conversation(conversation, inbox, reason)
-    create_private_note(conversation, inbox, "Auto-resolved: #{reason}")
+  def process_pending_follow_up(conversation, inbox)
+    follow_up_message = follow_up_service(conversation).active_message
+    return false unless follow_up_message
+    return true unless follow_up_message.created_at < follow_up_resolution_cutoff_time
+
+    conversation.reload
+    follow_up_message = follow_up_service(conversation).active_message
+    return true unless conversation.pending? && follow_up_message
+    return true unless follow_up_message.created_at < follow_up_resolution_cutoff_time
+
+    create_private_note(conversation, 'Auto-resolved after follow-up: Customer did not reply')
     create_resolution_message(conversation, inbox)
     conversation.with_captain_activity_context(
       reason: CAPTAIN_INFERENCE_RESOLVE_ACTIVITY_REASON,
       reason_type: :inference
     ) { conversation.resolved! }
+    record_inference_resolution(conversation)
+    true
+  rescue ActiveRecord::RecordNotFound
+    true
+  end
+
+  def resolve_time_based_conversation(conversation, inbox)
+    resolved = false
+    conversation.with_lock do
+      conversation.reload
+      next unless conversation.pending? && inactive_for_initial_action?(conversation)
+
+      create_resolution_message(conversation, inbox)
+      conversation.resolved!
+      resolved = true
+    end
+    return unless resolved
+
     Captain::ConversationEvents.resolved(
       conversation: conversation,
-      assistant: inbox.captain_assistant,
+      assistant: captain_assistant,
+      source: Captain::ConversationEvents::Sources::TIME_BASED,
+      at: Time.current
+    )
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+
+  def resolve_conversation(conversation, inbox, reason)
+    conversation.reload
+    return unless conversation.pending? && inactive_for_initial_action?(conversation)
+
+    create_private_note(conversation, "Auto-resolved: #{reason}")
+    create_resolution_message(conversation, inbox)
+    conversation.with_captain_activity_context(
+      reason: CAPTAIN_INFERENCE_RESOLVE_ACTIVITY_REASON,
+      reason_type: :inference
+    ) { conversation.resolved! }
+    record_inference_resolution(conversation)
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+
+  def follow_up_conversation(conversation, reason, message)
+    follow_up_service(conversation).send!(reason: reason, content: message)
+  end
+
+  def record_inference_resolution(conversation)
+    Captain::ConversationEvents.resolved(
+      conversation: conversation,
+      assistant: captain_assistant,
       source: Captain::ConversationEvents::Sources::INFERENCE,
       at: Time.current
     )
   end
 
-  def handoff_conversation(conversation, inbox, reason)
-    create_private_note(conversation, inbox, "Auto-handoff: #{reason}")
-    create_handoff_message(conversation, inbox)
+  def follow_up_service(conversation)
+    Captain::Conversation::InactivityFollowUpService.new(
+      conversation: conversation,
+      assistant: captain_assistant,
+      inactivity_cutoff_time: inactivity_cutoff_time
+    )
+  end
+
+  def handoff_conversation(conversation, reason)
+    conversation.reload
+    return unless conversation.pending? && inactive_for_initial_action?(conversation)
+
+    create_private_note(conversation, "Auto-handoff: #{reason}")
+    create_handoff_message(conversation)
     conversation.with_captain_activity_context(
       reason: CAPTAIN_INFERENCE_HANDOFF_ACTIVITY_REASON,
       reason_type: :inference
     ) { conversation.bot_handoff! }
     Captain::ConversationEvents.handed_off(
       conversation: conversation,
-      assistant: inbox.captain_assistant,
+      assistant: captain_assistant,
       source: Captain::ConversationEvents::Sources::INFERENCE,
       reason_category: :pending_clarification,
       at: Time.current
     )
     send_out_of_office_message_if_applicable(conversation.reload)
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 
   def send_out_of_office_message_if_applicable(conversation)
-    # Campaign conversations should never receive OOO templates — the campaign itself
-    # serves as the initial outreach, and OOO would be confusing in that context.
-    return if conversation.campaign.present?
-
-    ::MessageTemplates::Template::OutOfOffice.perform_if_applicable(conversation)
+    ::MessageTemplates::Template::OutOfOffice.perform_if_applicable(conversation) if conversation.campaign.blank?
   end
 
-  def create_private_note(conversation, inbox, content)
+  def create_private_note(conversation, content)
     conversation.messages.create!(
       message_type: :outgoing,
       private: true,
-      sender: inbox.captain_assistant,
+      sender: captain_assistant,
       account_id: conversation.account_id,
       inbox_id: conversation.inbox_id,
       content: content
@@ -129,27 +222,27 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
   end
 
   def create_resolution_message(conversation, inbox)
-    return unless inbox.captain_assistant.send_inactivity_resolution_message?
+    return unless captain_assistant.send_inactivity_resolution_message?
 
     I18n.with_locale(inbox.account.locale) do
-      resolution_message = inbox.captain_assistant.config['resolution_message']
+      resolution_message = captain_assistant.config['resolution_message']
       conversation.messages.create!(
         message_type: :outgoing,
         account_id: conversation.account_id,
         inbox_id: conversation.inbox_id,
         content: resolution_message.presence || I18n.t('conversations.activity.auto_resolution_message'),
-        sender: inbox.captain_assistant
+        sender: captain_assistant
       )
     end
   end
 
-  def create_handoff_message(conversation, inbox)
-    handoff_message = inbox.captain_assistant.config['handoff_message']
+  def create_handoff_message(conversation)
+    handoff_message = captain_assistant.config['handoff_message']
     return if handoff_message.blank?
 
     conversation.messages.create!(
       message_type: :outgoing,
-      sender: inbox.captain_assistant,
+      sender: captain_assistant,
       account_id: conversation.account_id,
       inbox_id: conversation.inbox_id,
       content: handoff_message,
@@ -157,3 +250,4 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
     )
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -20,6 +20,7 @@ class Captain::Assistant < ApplicationRecord
   DESCRIPTION_LENGTH_LIMIT = 500
   AUTO_RESOLVE_MODES = %w[disabled legacy evaluated].freeze
   DEFAULT_INACTIVITY_THRESHOLD_MINUTES = 60
+  DEFAULT_FOLLOW_UP_RESOLUTION_THRESHOLD_MINUTES = 60
   MINIMUM_INACTIVITY_THRESHOLD_MINUTES = 5
   MAXIMUM_INACTIVITY_THRESHOLD_MINUTES = 1.day.in_minutes.to_i
 
@@ -45,14 +46,23 @@ class Captain::Assistant < ApplicationRecord
   has_many :agent_sessions, class_name: 'Captain::AgentSession', dependent: :destroy_async
 
   store_accessor :config, :temperature, :feature_faq, :feature_memory, :feature_contact_attributes, :product_name,
-                 :auto_resolve_mode, :auto_resolve_after, :send_inactivity_resolution_message
+                 :auto_resolve_mode, :auto_resolve_after, :send_inactivity_resolution_message,
+                 :follow_up_before_resolving, :follow_up_resolve_after
 
   validates :name, presence: true
   validates :description, presence: true, length: { maximum: DESCRIPTION_LENGTH_LIMIT }
   validates :account_id, presence: true
   validates :auto_resolve_mode, inclusion: { in: AUTO_RESOLVE_MODES }
   validates :send_inactivity_resolution_message, inclusion: { in: [true, false] }
+  validates :follow_up_before_resolving, inclusion: { in: [true, false] }
   validates :auto_resolve_after,
+            numericality: {
+              only_integer: true,
+              greater_than_or_equal_to: MINIMUM_INACTIVITY_THRESHOLD_MINUTES,
+              less_than_or_equal_to: MAXIMUM_INACTIVITY_THRESHOLD_MINUTES
+            },
+            allow_nil: true
+  validates :follow_up_resolve_after,
             numericality: {
               only_integer: true,
               greater_than_or_equal_to: MINIMUM_INACTIVITY_THRESHOLD_MINUTES,
@@ -90,6 +100,18 @@ class Captain::Assistant < ApplicationRecord
 
   def send_inactivity_resolution_message?
     send_inactivity_resolution_message
+  end
+
+  def follow_up_before_resolving
+    config.fetch('follow_up_before_resolving', false)
+  end
+
+  def follow_up_before_resolving?
+    follow_up_before_resolving
+  end
+
+  def follow_up_resolution_threshold_minutes
+    config.fetch('follow_up_resolve_after', DEFAULT_FOLLOW_UP_RESOLUTION_THRESHOLD_MINUTES).to_i
   end
 
   def available_agent_tools

--- a/enterprise/app/services/captain/conversation/inactivity_follow_up_service.rb
+++ b/enterprise/app/services/captain/conversation/inactivity_follow_up_service.rb
@@ -1,0 +1,48 @@
+class Captain::Conversation::InactivityFollowUpService
+  MESSAGE_ATTRIBUTE = 'captain_inactivity_follow_up'.freeze
+
+  pattr_initialize [:conversation!, :assistant!, :inactivity_cutoff_time!]
+
+  def active_message
+    follow_up_message = conversation.messages.outgoing
+                                    .where('additional_attributes @> ?', { MESSAGE_ATTRIBUTE => true }.to_json)
+                                    .last
+    return unless follow_up_message
+    return if conversation.messages.incoming.exists?(['id > ?', follow_up_message.id])
+
+    follow_up_message
+  end
+
+  def send!(reason:, content:)
+    conversation.with_lock do
+      conversation.reload
+      next unless conversation.pending? && conversation.last_activity_at < inactivity_cutoff_time
+      next if active_message
+
+      create_private_note("Auto-followed up: #{reason}")
+      conversation.messages.create!(
+        message_type: :outgoing,
+        sender: assistant,
+        account_id: conversation.account_id,
+        inbox_id: conversation.inbox_id,
+        content: content,
+        additional_attributes: { MESSAGE_ATTRIBUTE => true }
+      )
+    end
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+
+  private
+
+  def create_private_note(content)
+    conversation.messages.create!(
+      message_type: :outgoing,
+      private: true,
+      sender: assistant,
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      content: content
+    )
+  end
+end

--- a/enterprise/app/views/api/v1/models/captain/_assistant.json.jbuilder
+++ b/enterprise/app/views/api/v1/models/captain/_assistant.json.jbuilder
@@ -2,7 +2,9 @@ json.account_id resource.account_id
 json.config resource.config.merge(
   'auto_resolve_mode' => resource.auto_resolve_mode,
   'auto_resolve_after' => resource.inactivity_threshold_minutes,
-  'send_inactivity_resolution_message' => resource.send_inactivity_resolution_message?
+  'send_inactivity_resolution_message' => resource.send_inactivity_resolution_message?,
+  'follow_up_before_resolving' => resource.follow_up_before_resolving?,
+  'follow_up_resolve_after' => resource.follow_up_resolution_threshold_minutes
 )
 json.created_at resource.created_at.to_i
 json.description resource.description

--- a/enterprise/lib/captain/conversation_completion_schema.rb
+++ b/enterprise/lib/captain/conversation_completion_schema.rb
@@ -1,4 +1,7 @@
 class Captain::ConversationCompletionSchema < RubyLLM::Schema
-  boolean :complete, description: 'Whether the conversation is complete and can be closed'
-  string :reason, description: 'Brief explanation of why the conversation is complete or incomplete'
+  ACTIONS = %w[resolve follow_up handoff].freeze
+
+  string :action, enum: ACTIONS, description: 'The safest next action for the inactive conversation'
+  string :reason, description: 'Brief explanation for the selected action'
+  string :follow_up_message, description: 'Context-specific customer follow-up, or an empty string unless the action is follow_up'
 end

--- a/enterprise/lib/captain/conversation_completion_service.rb
+++ b/enterprise/lib/captain/conversation_completion_service.rb
@@ -1,6 +1,4 @@
-# Evaluates whether a conversation is complete and can be auto-resolved.
-# Used by InboxPendingConversationsResolutionJob to determine if inactive
-# conversations should be resolved or handed off to human agents.
+# Selects the safest next action for an inactive Captain conversation.
 #
 # NOTE: This service intentionally does NOT count toward Captain usage limits.
 # The response excludes the :message key that Enterprise::Captain::BaseTaskService
@@ -13,7 +11,7 @@ class Captain::ConversationCompletionService < Captain::BaseTaskService
 
   def perform
     content = format_evaluation_input
-    return default_incomplete_response('No messages found') if content.blank?
+    return default_handoff_response('No messages found') if content.blank?
 
     response = make_api_call(
       model: InstallationConfig.find_by(name: 'CAPTAIN_OPEN_AI_MODEL')&.value.presence || GPT_MODEL,
@@ -24,7 +22,7 @@ class Captain::ConversationCompletionService < Captain::BaseTaskService
       schema: RESPONSE_SCHEMA
     )
 
-    return default_incomplete_response(response[:error]) if response[:error].present?
+    return default_handoff_response(response[:error]) if response[:error].present?
 
     parse_response(response[:message])
   end
@@ -90,16 +88,21 @@ class Captain::ConversationCompletionService < Captain::BaseTaskService
   end
 
   def parse_response(message)
-    return default_incomplete_response('Invalid response format') unless message.is_a?(Hash)
+    return default_handoff_response('Invalid response format') unless message.is_a?(Hash)
+
+    action = message['action']
+    return default_handoff_response('Invalid action') unless action.in?(Captain::ConversationCompletionSchema::ACTIONS)
+    return default_handoff_response('Missing follow-up message') if action == 'follow_up' && message['follow_up_message'].blank?
 
     {
-      complete: message['complete'] == true,
-      reason: message['reason'] || 'No reason provided'
+      action: action,
+      reason: message['reason'] || 'No reason provided',
+      follow_up_message: action == 'follow_up' ? message['follow_up_message'] : nil
     }
   end
 
-  def default_incomplete_response(reason)
-    { complete: false, reason: reason }
+  def default_handoff_response(reason)
+    { action: 'handoff', reason: reason, follow_up_message: nil }
   end
 
   # This is an internal operational evaluation, not a customer-triggered feature,

--- a/enterprise/lib/captain/prompts/conversation_completion.liquid
+++ b/enterprise/lib/captain/prompts/conversation_completion.liquid
@@ -1,4 +1,4 @@
-You are evaluating whether a customer support conversation is complete and can be safely closed. When in doubt, keep the conversation OPEN. It is far better to hand off to a human agent unnecessarily than to close a conversation where the customer still needs help.
+You are choosing the safest next action for an inactive customer support conversation. When in doubt, HAND OFF. It is far better to hand off unnecessarily than to close a conversation where the customer still needs help.
 
 The conversation may be in any language. Apply these criteria based on the intent and meaning of messages, regardless of language.
 
@@ -9,7 +9,9 @@ You will receive:
 This evaluator runs for inactive pending conversations. Focus on the latest pending exchange or latest unresolved customer request. Older messages may be present only for context.
 If the conversation status is "pending", the conversation is still with Captain. Do not assume a handoff happened because Captain mentioned one.
 
-A conversation is INCOMPLETE (keep open) if ANY of these apply:
+A conversation needs FOLLOW_UP if Captain is waiting only for the customer to answer a clear question or provide requested information. Write one short, natural follow-up based on the conversation. Do not use a fixed template. Do not promise future work.
+
+A conversation needs HANDOFF if ANY of these apply:
 - The assistant asked a question or requested information that the customer hasn't provided
 - The customer asked a question that wasn't fully answered
 - The customer asked for something the assistant couldn't do — even if the assistant explained why, the customer's need is unmet
@@ -30,13 +32,15 @@ Important handoff rule:
 - A handoff, escalation, transfer, acknowledgement, or promise of future follow-up is not a resolution by itself
 - If conversation status is "pending" and Captain/Bot/Assistant says it handed off, will hand off, or that another party will continue the work in the latest pending exchange, keep the conversation INCOMPLETE.
 
-A conversation is COMPLETE only if ALL of these are true:
+A conversation can be RESOLVED only if ALL of these are true:
 - The assistant's answer fully addressed the customer's question or issue and is self-contained — it requires no further action from the customer
 - There are no unanswered questions, unmet requests, or outstanding follow-ups from either side
 - Note: customers often do not explicitly say thanks or confirm resolution. If the assistant gave a complete, self-contained answer and the customer had no follow-up, that is sufficient. Do not require explicit gratitude or confirmation.
 - If the customer sent only one or two short text messages (greetings, single words, names, phone numbers, or gibberish) with no recognizable question or request across the entire conversation, and Captain/Bot/Assistant has responded asking what they need or offering help, the conversation is COMPLETE.
 
 Analyze the conversation and respond with ONLY a JSON object (no other text):
-{"complete": true, "reason": "brief explanation"}
+{"action": "resolve", "reason": "brief explanation", "follow_up_message": ""}
 or
-{"complete": false, "reason": "brief explanation"}
+{"action": "follow_up", "reason": "brief explanation", "follow_up_message": "a short message grounded in this conversation"}
+or
+{"action": "handoff", "reason": "brief explanation", "follow_up_message": ""}

--- a/spec/enterprise/controllers/api/v1/accounts/captain/assistants_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/assistants_controller_spec.rb
@@ -217,14 +217,53 @@ RSpec.describe 'Api::V1::Accounts::Captain::Assistants', type: :request do
         expect(json_response[:config][:feature_citation]).to be(false)
       end
 
-      it 'updates inactive conversation settings for Captain v2' do
+      it 'keeps timer and follow-up settings behind Captain V2' do
+        assistant.update!(
+          config: {
+            'auto_resolve_mode' => 'evaluated',
+            'auto_resolve_after' => 60,
+            'follow_up_before_resolving' => false,
+            'follow_up_resolve_after' => 60,
+            'send_inactivity_resolution_message' => true
+          }
+        )
+
+        patch "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}",
+              params: {
+                assistant: {
+                  config: {
+                    auto_resolve_mode: 'disabled',
+                    auto_resolve_after: 120,
+                    follow_up_before_resolving: true,
+                    follow_up_resolve_after: 45,
+                    send_inactivity_resolution_message: false
+                  }
+                }
+              },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(assistant.reload.config).to include(
+          'auto_resolve_mode' => 'disabled',
+          'auto_resolve_after' => 60,
+          'follow_up_before_resolving' => false,
+          'follow_up_resolve_after' => 60,
+          'send_inactivity_resolution_message' => true
+        )
+      end
+
+      it 'stores and returns the inactivity follow-up policy for Captain V2' do
         account.enable_features('captain_integration_v2')
 
         patch "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}",
               params: {
                 assistant: {
                   config: {
-                    auto_resolve_after: 90,
+                    auto_resolve_mode: 'evaluated',
+                    auto_resolve_after: 120,
+                    follow_up_before_resolving: true,
+                    follow_up_resolve_after: 45,
                     send_inactivity_resolution_message: false,
                     resolution_message: 'Saved closing message'
                   }
@@ -235,7 +274,10 @@ RSpec.describe 'Api::V1::Accounts::Captain::Assistants', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(json_response[:config]).to include(
-          auto_resolve_after: 90,
+          auto_resolve_mode: 'evaluated',
+          auto_resolve_after: 120,
+          follow_up_before_resolving: true,
+          follow_up_resolve_after: 45,
           send_inactivity_resolution_message: false,
           resolution_message: 'Saved closing message'
         )

--- a/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
+++ b/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
@@ -132,6 +132,116 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
       expect(Captain::ConversationCompletionService).not_to have_received(:new)
       expect(resolvable_pending_conversation.reload.status).to eq('resolved')
     end
+
+    it 'uses the assistant always-resolve policy instead of the account policy' do
+      captain_assistant.update!(config: captain_assistant.config.merge('auto_resolve_mode' => 'legacy'))
+      allow(Captain::ConversationCompletionService).to receive(:new)
+
+      described_class.perform_now(inbox)
+
+      expect(Captain::ConversationCompletionService).not_to have_received(:new)
+      expect(resolvable_pending_conversation.reload.status).to eq('resolved')
+    end
+  end
+
+  context 'when Captain chooses to follow up' do
+    let(:follow_up_message) { 'Could you share the order number so I can help?' }
+
+    before do
+      captain_assistant.update!(
+        config: captain_assistant.config.merge(
+          'follow_up_before_resolving' => true,
+          'follow_up_resolve_after' => 30,
+          'resolution_message' => 'I will close this for now.'
+        )
+      )
+      mock_service = instance_double(Captain::ConversationCompletionService)
+      allow(mock_service).to receive(:perform).and_return(
+        {
+          action: 'follow_up',
+          reason: 'Captain is waiting for the customer order number',
+          follow_up_message: follow_up_message
+        }
+      )
+      allow(Captain::ConversationCompletionService).to receive(:new).and_return(mock_service)
+    end
+
+    it 'sends the generated follow-up and keeps the conversation pending' do
+      described_class.perform_now(inbox)
+
+      generated_message = resolvable_pending_conversation.messages.outgoing.where(private: false).last
+      expect(generated_message.content).to eq(follow_up_message)
+      expect(generated_message.additional_attributes['captain_inactivity_follow_up']).to be true
+      expect(resolvable_pending_conversation.reload.status).to eq('pending')
+    end
+
+    it 'does not send the same follow-up twice when the job runs again' do
+      described_class.perform_now(inbox)
+
+      expect do
+        described_class.perform_now(inbox)
+      end.not_to(change do
+        resolvable_pending_conversation.messages.outgoing
+                                       .where('additional_attributes @> ?', { captain_inactivity_follow_up: true }.to_json)
+                                       .count
+      end)
+    end
+
+    it 'resolves after the second duration without another customer reply' do
+      described_class.perform_now(inbox)
+
+      travel 31.minutes do
+        described_class.perform_now(inbox)
+      end
+
+      public_messages = resolvable_pending_conversation.messages.outgoing.where(private: false).pluck(:content)
+      expect(public_messages).to include(follow_up_message, 'I will close this for now.')
+      expect(resolvable_pending_conversation.reload.status).to eq('resolved')
+    end
+
+    it 'cancels the second-stage resolution when the customer replies' do
+      described_class.perform_now(inbox)
+
+      travel 1.minute do
+        create(
+          :message,
+          conversation: resolvable_pending_conversation,
+          inbox: inbox,
+          account: inbox.account,
+          message_type: :incoming,
+          content: 'My order number is 1234'
+        )
+      end
+
+      travel 32.minutes do
+        described_class.perform_now(inbox)
+      end
+
+      expect(resolvable_pending_conversation.reload.status).to eq('pending')
+      expect(resolvable_pending_conversation.messages.outgoing.where(private: false).pluck(:content))
+        .to contain_exactly(follow_up_message)
+    end
+  end
+
+  context 'when Captain recommends a follow-up but the setting is disabled' do
+    before do
+      mock_service = instance_double(Captain::ConversationCompletionService)
+      allow(mock_service).to receive(:perform).and_return(
+        {
+          action: 'follow_up',
+          reason: 'Captain is waiting for the customer',
+          follow_up_message: 'Are you still there?'
+        }
+      )
+      allow(Captain::ConversationCompletionService).to receive(:new).and_return(mock_service)
+    end
+
+    it 'hands off instead of sending a follow-up' do
+      described_class.perform_now(inbox)
+
+      expect(resolvable_pending_conversation.reload.status).to eq('open')
+      expect(resolvable_pending_conversation.messages.outgoing.where(private: false)).to be_empty
+    end
   end
 
   context 'when LLM evaluation returns complete' do
@@ -388,6 +498,17 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
 
   it 'does not resolve conversations when auto-resolve is disabled at execution time' do
     captain_assistant.update!(auto_resolve_mode: 'disabled')
+
+    expect do
+      described_class.perform_now(inbox)
+    end.not_to(change { resolvable_pending_conversation.reload.status })
+
+    expect(resolvable_pending_conversation.reload.status).to eq('pending')
+    expect(resolvable_pending_conversation.messages.outgoing).to be_empty
+  end
+
+  it 'does not resolve conversations when the assistant policy is disabled at execution time' do
+    captain_assistant.update!(config: captain_assistant.config.merge('auto_resolve_mode' => 'disabled'))
 
     expect do
       described_class.perform_now(inbox)

--- a/spec/enterprise/jobs/enterprise/account/conversations_resolution_scheduler_job_spec.rb
+++ b/spec/enterprise/jobs/enterprise/account/conversations_resolution_scheduler_job_spec.rb
@@ -46,6 +46,22 @@ RSpec.describe Account::ConversationsResolutionSchedulerJob, type: :job do
       end
     end
 
+    context 'when the assistant inactivity policy is disabled' do
+      let!(:regular_inbox) { create(:inbox, account: account) }
+
+      before do
+        create(:captain_inbox, captain_assistant: assistant, inbox: regular_inbox)
+        assistant.update!(config: assistant.config.merge('auto_resolve_mode' => 'disabled'))
+      end
+
+      it 'does not enqueue resolution jobs' do
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Captain::InboxPendingConversationsResolutionJob)
+          .with(regular_inbox)
+      end
+    end
+
     context 'when account uses legacy disabled settings key' do
       let!(:regular_inbox) { create(:inbox, account: account) }
 

--- a/spec/enterprise/lib/captain/conversation_completion_service_spec.rb
+++ b/spec/enterprise/lib/captain/conversation_completion_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Captain::ConversationCompletionService do
   let(:mock_context) { instance_double(RubyLLM::Context, chat: mock_chat) }
 
   before do
-    create(:installation_config, name: 'CAPTAIN_OPEN_AI_API_KEY', value: 'test-key')
+    InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_API_KEY').update!(value: 'test-key')
     allow(Llm::Config).to receive(:with_api_key).and_yield(mock_context)
     allow(mock_chat).to receive(:with_instructions)
     allow(mock_chat).to receive(:with_schema).and_return(mock_chat)
@@ -23,7 +23,7 @@ RSpec.describe Captain::ConversationCompletionService do
       let(:mock_response) do
         instance_double(
           RubyLLM::Message,
-          content: { 'complete' => true, 'reason' => 'Customer question was fully answered' },
+          content: { 'action' => 'resolve', 'reason' => 'Customer question was fully answered', 'follow_up_message' => '' },
           input_tokens: 100,
           output_tokens: 20
         )
@@ -36,10 +36,10 @@ RSpec.describe Captain::ConversationCompletionService do
         allow(mock_chat).to receive(:ask).and_return(mock_response)
       end
 
-      it 'returns complete: true with reason' do
+      it 'returns the resolve action with reason' do
         result = service.perform
 
-        expect(result[:complete]).to be true
+        expect(result[:action]).to eq('resolve')
         expect(result[:reason]).to eq('Customer question was fully answered')
       end
     end
@@ -48,7 +48,11 @@ RSpec.describe Captain::ConversationCompletionService do
       let(:mock_response) do
         instance_double(
           RubyLLM::Message,
-          content: { 'complete' => false, 'reason' => 'Assistant asked for order number but customer did not respond' },
+          content: {
+            'action' => 'follow_up',
+            'reason' => 'Assistant asked for order number but customer did not respond',
+            'follow_up_message' => 'Could you share your order number?'
+          },
           input_tokens: 100,
           output_tokens: 20
         )
@@ -60,11 +64,12 @@ RSpec.describe Captain::ConversationCompletionService do
         allow(mock_chat).to receive(:ask).and_return(mock_response)
       end
 
-      it 'returns complete: false with reason' do
+      it 'returns a generated follow-up grounded in the conversation' do
         result = service.perform
 
-        expect(result[:complete]).to be false
+        expect(result[:action]).to eq('follow_up')
         expect(result[:reason]).to eq('Assistant asked for order number but customer did not respond')
+        expect(result[:follow_up_message]).to eq('Could you share your order number?')
       end
     end
 
@@ -73,7 +78,7 @@ RSpec.describe Captain::ConversationCompletionService do
       let(:mock_response) do
         instance_double(
           RubyLLM::Message,
-          content: { 'complete' => false, 'reason' => 'Human follow-up is still pending' },
+          content: { 'action' => 'handoff', 'reason' => 'Human follow-up is still pending', 'follow_up_message' => '' },
           input_tokens: 100,
           output_tokens: 20
         )
@@ -105,7 +110,7 @@ RSpec.describe Captain::ConversationCompletionService do
 
         result = service.perform
 
-        expect(result[:complete]).to be false
+        expect(result[:action]).to eq('handoff')
       end
 
       it 'includes pending captain handoff evidence in the transcript' do
@@ -132,7 +137,7 @@ RSpec.describe Captain::ConversationCompletionService do
 
         result = service.perform
 
-        expect(result[:complete]).to be false
+        expect(result[:action]).to eq('handoff')
       end
 
       it 'reuses computed message content while formatting the transcript' do
@@ -176,7 +181,7 @@ RSpec.describe Captain::ConversationCompletionService do
       it 'returns incomplete with appropriate reason' do
         result = service.perform
 
-        expect(result[:complete]).to be false
+        expect(result[:action]).to eq('handoff')
         expect(result[:reason]).to eq('No messages found')
       end
     end
@@ -199,7 +204,7 @@ RSpec.describe Captain::ConversationCompletionService do
       it 'returns incomplete as safe default' do
         result = service.perform
 
-        expect(result[:complete]).to be false
+        expect(result[:action]).to eq('handoff')
         expect(result[:reason]).to eq('Invalid response format')
       end
     end
@@ -210,10 +215,10 @@ RSpec.describe Captain::ConversationCompletionService do
         allow(mock_chat).to receive(:ask).and_raise(StandardError.new('API Error'))
       end
 
-      it 'returns incomplete with error message' do
+      it 'hands off with the error message' do
         result = service.perform
 
-        expect(result[:complete]).to be false
+        expect(result[:action]).to eq('handoff')
         expect(result[:reason]).to eq('API Error')
       end
     end
@@ -227,7 +232,7 @@ RSpec.describe Captain::ConversationCompletionService do
       it 'does not evaluate the conversation as complete' do
         result = service.perform
 
-        expect(result[:complete]).not_to be true
+        expect(result[:action]).not_to eq('resolve')
       end
     end
 
@@ -240,7 +245,12 @@ RSpec.describe Captain::ConversationCompletionService do
       it 'uses the system API key instead of the account hook key' do
         expect(Llm::Config).to receive(:with_api_key).with('test-key', api_base: anything).and_yield(mock_context)
         allow(mock_chat).to receive(:ask).and_return(
-          instance_double(RubyLLM::Message, content: { 'complete' => true, 'reason' => 'Done' }, input_tokens: 10, output_tokens: 5)
+          instance_double(
+            RubyLLM::Message,
+            content: { 'action' => 'resolve', 'reason' => 'Done', 'follow_up_message' => '' },
+            input_tokens: 10,
+            output_tokens: 5
+          )
         )
 
         service.perform
@@ -253,7 +263,7 @@ RSpec.describe Captain::ConversationCompletionService do
 
         result = service.perform
 
-        expect(result[:complete]).to be false
+        expect(result[:action]).to eq('handoff')
         expect(result[:reason]).to eq(I18n.t('captain.api_key_missing'))
       end
     end
@@ -262,7 +272,7 @@ RSpec.describe Captain::ConversationCompletionService do
       let(:mock_response) do
         instance_double(
           RubyLLM::Message,
-          content: { 'complete' => true, 'reason' => 'Customer question was fully answered' },
+          content: { 'action' => 'resolve', 'reason' => 'Customer question was fully answered', 'follow_up_message' => '' },
           input_tokens: 100,
           output_tokens: 20
         )
@@ -286,7 +296,7 @@ RSpec.describe Captain::ConversationCompletionService do
         result = service.perform
 
         expect(result[:error]).to be_nil
-        expect(result[:complete]).to be true
+        expect(result[:action]).to eq('resolve')
         expect(result[:reason]).to eq('Customer question was fully answered')
       end
 

--- a/spec/enterprise/models/captain/assistant_spec.rb
+++ b/spec/enterprise/models/captain/assistant_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Captain::Assistant do
-  describe 'inactive conversation settings' do
-    let(:assistant) { build(:captain_assistant, config: {}) }
+  describe 'inactivity policy settings' do
+    let(:assistant) { create(:captain_assistant, config: {}) }
 
     it 'uses safe defaults when settings have not been saved' do
       expect(assistant.inactivity_threshold_minutes).to eq(60)
-      expect(assistant.send_inactivity_resolution_message?).to be(true)
+      expect(assistant.send_inactivity_resolution_message?).to be true
+      expect(assistant.follow_up_before_resolving?).to be false
+      expect(assistant.follow_up_resolution_threshold_minutes).to eq(60)
     end
 
     it 'validates the inactivity timer range' do
@@ -14,6 +16,18 @@ RSpec.describe Captain::Assistant do
 
       expect(assistant).not_to be_valid
       expect(assistant.errors[:auto_resolve_after]).to be_present
+    end
+
+    it 'reads the saved follow-up policy' do
+      assistant.update!(
+        config: assistant.config.merge(
+          'follow_up_before_resolving' => true,
+          'follow_up_resolve_after' => 90
+        )
+      )
+
+      expect(assistant.follow_up_before_resolving?).to be true
+      expect(assistant.follow_up_resolution_threshold_minutes).to eq(90)
     end
   end
 


### PR DESCRIPTION
Captain assistants can now choose how inactive conversations are handled: let Captain review the context, always resolve after a timer, or wait for the customer to return. Review mode can also send a context-aware follow-up before resolving, while keeping the existing resolution message setting separate.

## Closes

- [AI-163](https://linear.app/chatwoot/issue/AI-163)

## Depends on

This is a stacked draft PR based on and dependent on draft PR [#15215](https://github.com/chatwoot/chatwoot/pull/15215). Merge #15215 first.

## What changed

- Stores assistant-level inactivity policy, review timing, follow-up behavior, and second-stage resolution timing with backward-compatible defaults.
- Lets Captain resolve, generate a contextual follow-up, or hand off after reviewing conversation context.
- Cancels inactivity handling when the customer replies and uses locked, idempotent follow-up handling for retries.
- Adds always-resolve and wait-for-customer behavior, plus scheduler support for assistant-level policies.
- Adds the matching Captain settings UI with one inactivity save action and separate resolution and handoff message controls.

## How to test

1. Open a Captain V2 assistant's Settings page and expand **Inactive conversations**.
2. Select **Let Captain review it**, enable **Follow up before resolving**, set both durations, save, and reload. Confirm the saved summary and controls are restored.
3. Select **Always resolve** and confirm the warning and **Resolve after** timing are shown.
4. Select **Captain will handle it** and confirm inactivity timing, follow-up, and resolution message controls are hidden.
5. Exercise an inactive conversation in review mode and confirm Captain can resolve, follow up from context, or hand off; reply as the customer before the next stage and confirm the pending inactivity action is cancelled.