### PR TITLE
feat(captain): persist cited document IDs

### DIFF
--- a/app/javascript/dashboard/components-next/message/CaptainGenerationDetails.vue
+++ b/app/javascript/dashboard/components-next/message/CaptainGenerationDetails.vue
@@ -37,6 +37,11 @@ const isLoading = computed(
 );
 
 const citations = computed(() => session.value?.citations || []);
+const usedFaqs = computed(() => session.value?.usedFaqs || []);
+const knowledgeSources = computed(() => [
+  ...citations.value.map(source => ({ ...source, type: 'document' })),
+  ...usedFaqs.value.map(source => ({ ...source, type: 'faq' })),
+]);
 
 const scenarioTitles = computed(() =>
   (session.value?.scenarios || []).reduce((map, scenario) => {
@@ -289,7 +294,7 @@ const onPopoverHide = () => {
                 </div>
               </div>
             </div>
-            <div v-if="citations.length" class="flex flex-col gap-2">
+            <div v-if="knowledgeSources.length" class="flex flex-col gap-2">
               <div class="flex items-baseline gap-1.5">
                 <span class="text-xs font-medium text-n-slate-11">
                   {{ t('CONVERSATION.CAPTAIN_GENERATION.SOURCES') }}
@@ -298,15 +303,15 @@ const onPopoverHide = () => {
                   {{
                     t(
                       'CONVERSATION.CAPTAIN_GENERATION.SOURCES_SUMMARY',
-                      citations.length
+                      knowledgeSources.length
                     )
                   }}
                 </span>
               </div>
               <ul class="flex flex-col gap-1 m-0 list-disc ps-4">
                 <li
-                  v-for="citation in citations"
-                  :key="citation.id"
+                  v-for="citation in knowledgeSources"
+                  :key="`${citation.type}-${citation.id}`"
                   class="text-xs text-n-slate-12"
                 >
                   <a

--- a/db/migrate/20260803000000_add_cited_document_ids_to_agent_sessions.rb
+++ b/db/migrate/20260803000000_add_cited_document_ids_to_agent_sessions.rb
@@ -1,0 +1,5 @@
+class AddCitedDocumentIdsToAgentSessions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :agent_sessions, :cited_document_ids, :jsonb, default: [], null: false
+  end
+end

--- a/db/migrate/20260803000001_add_index_on_agent_sessions_cited_document_ids.rb
+++ b/db/migrate/20260803000001_add_index_on_agent_sessions_cited_document_ids.rb
@@ -1,0 +1,7 @@
+class AddIndexOnAgentSessionsCitedDocumentIds < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :agent_sessions, :cited_document_ids, using: :gin, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260803000002_add_used_faq_ids_to_agent_sessions.rb
+++ b/db/migrate/20260803000002_add_used_faq_ids_to_agent_sessions.rb
@@ -1,0 +1,5 @@
+class AddUsedFaqIdsToAgentSessions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :agent_sessions, :used_faq_ids, :jsonb, default: [], null: false
+  end
+end

--- a/db/migrate/20260803000003_add_index_on_agent_sessions_used_faq_ids.rb
+++ b/db/migrate/20260803000003_add_index_on_agent_sessions_used_faq_ids.rb
@@ -1,0 +1,7 @@
+class AddIndexOnAgentSessionsUsedFaqIds < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :agent_sessions, :used_faq_ids, using: :gin, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_31_140853) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_03_000001) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -163,11 +163,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_31_140853) do
     t.jsonb "run_context", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "cited_document_ids", default: [], null: false
     t.index ["account_id", "result_type", "result_id"], name: "idx_on_account_id_result_type_result_id_ca66c00cd7"
     t.index ["account_id", "session_type", "created_at"], name: "idx_on_account_id_session_type_created_at_c20a14bd4e"
     t.index ["account_id", "subject_type", "subject_id"], name: "idx_on_account_id_subject_type_subject_id_6d60963b3d"
     t.index ["account_id"], name: "index_agent_sessions_on_account_id"
     t.index ["assistant_id"], name: "index_agent_sessions_on_assistant_id"
+    t.index ["cited_document_ids"], name: "index_agent_sessions_on_cited_document_ids", using: :gin
     t.index ["user_id"], name: "index_agent_sessions_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_03_000001) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_03_000003) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -164,12 +164,14 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_03_000001) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "cited_document_ids", default: [], null: false
+    t.jsonb "used_faq_ids", default: [], null: false
     t.index ["account_id", "result_type", "result_id"], name: "idx_on_account_id_result_type_result_id_ca66c00cd7"
     t.index ["account_id", "session_type", "created_at"], name: "idx_on_account_id_session_type_created_at_c20a14bd4e"
     t.index ["account_id", "subject_type", "subject_id"], name: "idx_on_account_id_subject_type_subject_id_6d60963b3d"
     t.index ["account_id"], name: "index_agent_sessions_on_account_id"
     t.index ["assistant_id"], name: "index_agent_sessions_on_assistant_id"
     t.index ["cited_document_ids"], name: "index_agent_sessions_on_cited_document_ids", using: :gin
+    t.index ["used_faq_ids"], name: "index_agent_sessions_on_used_faq_ids", using: :gin
     t.index ["user_id"], name: "index_agent_sessions_on_user_id"
   end
 

--- a/enterprise/app/controllers/api/v1/accounts/captain/agent_sessions_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/agent_sessions_controller.rb
@@ -6,9 +6,7 @@ class Api::V1::Accounts::Captain::AgentSessionsController < Api::V1::Accounts::B
     @agent_session = Current.account.captain_agent_sessions.find_by(result_type: 'Message', result_id: @message.id)
     return head :not_found if @agent_session.blank?
 
-    @citations = Current.account.captain_assistant_responses
-                        .where(id: @agent_session.faq_ids)
-                        .includes(:documentable)
+    @citations = Current.account.captain_documents.where(id: @agent_session.cited_document_ids)
     @scenario_titles = Captain::Scenario.where(account_id: Current.account.id, id: @agent_session.scenario_ids)
                                         .pluck(:id, :title).to_h
   end

--- a/enterprise/app/controllers/api/v1/accounts/captain/agent_sessions_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/agent_sessions_controller.rb
@@ -7,6 +7,10 @@ class Api::V1::Accounts::Captain::AgentSessionsController < Api::V1::Accounts::B
     return head :not_found if @agent_session.blank?
 
     @citations = Current.account.captain_documents.where(id: @agent_session.cited_document_ids)
+    @used_faqs = Current.account.captain_assistant_responses.approved.where(
+      id: @agent_session.used_faq_ids,
+      documentable_type: 'User'
+    )
     @scenario_titles = Captain::Scenario.where(account_id: Current.account.id, id: @agent_session.scenario_ids)
                                         .pluck(:id, :title).to_h
   end

--- a/enterprise/app/models/captain/agent_session.rb
+++ b/enterprise/app/models/captain/agent_session.rb
@@ -2,23 +2,24 @@
 #
 # Table name: agent_sessions
 #
-#  id               :bigint           not null, primary key
-#  credits_consumed :float
-#  document_ids     :jsonb
-#  faq_ids          :jsonb
-#  llm_model        :string
-#  result_type      :string
-#  run_context      :jsonb
-#  scenario_ids     :jsonb
-#  session_type     :integer          not null
-#  subject_type     :string           not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  account_id       :bigint           not null
-#  assistant_id     :bigint           not null
-#  result_id        :bigint
-#  subject_id       :bigint           not null
-#  user_id          :bigint
+#  id                 :bigint           not null, primary key
+#  cited_document_ids :jsonb            not null
+#  credits_consumed   :float
+#  document_ids       :jsonb
+#  faq_ids            :jsonb
+#  llm_model          :string
+#  result_type        :string
+#  run_context        :jsonb
+#  scenario_ids       :jsonb
+#  session_type       :integer          not null
+#  subject_type       :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  account_id         :bigint           not null
+#  assistant_id       :bigint           not null
+#  result_id          :bigint
+#  subject_id         :bigint           not null
+#  user_id            :bigint
 #
 # Indexes
 #
@@ -27,6 +28,7 @@
 #  idx_on_account_id_subject_type_subject_id_6d60963b3d  (account_id,subject_type,subject_id)
 #  index_agent_sessions_on_account_id                    (account_id)
 #  index_agent_sessions_on_assistant_id                  (assistant_id)
+#  index_agent_sessions_on_cited_document_ids            (cited_document_ids) USING gin
 #  index_agent_sessions_on_user_id                       (user_id)
 #
 class Captain::AgentSession < ApplicationRecord

--- a/enterprise/app/models/captain/agent_session.rb
+++ b/enterprise/app/models/captain/agent_session.rb
@@ -13,6 +13,7 @@
 #  scenario_ids       :jsonb
 #  session_type       :integer          not null
 #  subject_type       :string           not null
+#  used_faq_ids       :jsonb            not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  account_id         :bigint           not null
@@ -29,6 +30,7 @@
 #  index_agent_sessions_on_account_id                    (account_id)
 #  index_agent_sessions_on_assistant_id                  (assistant_id)
 #  index_agent_sessions_on_cited_document_ids            (cited_document_ids) USING gin
+#  index_agent_sessions_on_used_faq_ids                  (used_faq_ids) USING gin
 #  index_agent_sessions_on_user_id                       (user_id)
 #
 class Captain::AgentSession < ApplicationRecord

--- a/enterprise/app/services/captain/assistant/session_capture_service.rb
+++ b/enterprise/app/services/captain/assistant/session_capture_service.rb
@@ -31,6 +31,7 @@ class Captain::Assistant::SessionCaptureService
       llm_model: "#{Llm::Models.provider_for(model)}-#{model}",
       credits_consumed: @credits_consumed,
       faq_ids: metadata[:faq_ids] || [],
+      used_faq_ids: metadata[:used_faq_ids] || [],
       cited_document_ids: cited_document_ids,
       document_ids: metadata[:document_ids] || [],
       scenario_ids: scenario_ids,

--- a/enterprise/app/services/captain/assistant/session_capture_service.rb
+++ b/enterprise/app/services/captain/assistant/session_capture_service.rb
@@ -52,7 +52,7 @@ class Captain::Assistant::SessionCaptureService
   def cited_document_ids
     return [] unless @assistant.config['feature_citation']
 
-    citation_document_ids = (context.dig(:state, :captain_v2_citation_sources) || {}).transform_keys(&:to_i)
+    citation_document_ids = (context.dig(:state, Captain::Assistant::CITATION_SOURCES_STATE_KEY) || {}).transform_keys(&:to_i)
     visible_citation_indexes = @assistant.customer_visible_citation_urls(citation_document_ids).keys
     stored_response_parts = result_message.additional_attributes.to_h[Captain::Assistant::ResponseParts::MESSAGE_ATTRIBUTE_KEY]
     response_parts = Captain::Assistant::ResponseParts.new(stored_response_parts)

--- a/enterprise/app/services/captain/assistant/session_capture_service.rb
+++ b/enterprise/app/services/captain/assistant/session_capture_service.rb
@@ -31,6 +31,7 @@ class Captain::Assistant::SessionCaptureService
       llm_model: "#{Llm::Models.provider_for(model)}-#{model}",
       credits_consumed: @credits_consumed,
       faq_ids: metadata[:faq_ids] || [],
+      cited_document_ids: cited_document_ids,
       document_ids: metadata[:document_ids] || [],
       scenario_ids: scenario_ids,
       run_context: current_turn_history
@@ -45,6 +46,17 @@ class Captain::Assistant::SessionCaptureService
 
   def metadata
     @metadata ||= context.dig(:state, :cw_metadata) || {}
+  end
+
+  def cited_document_ids
+    return [] unless @assistant.config['feature_citation']
+
+    citation_document_ids = (context.dig(:state, :captain_v2_citation_sources) || {}).transform_keys(&:to_i)
+    visible_citation_indexes = @assistant.customer_visible_citation_urls(citation_document_ids).keys
+    response_parts = Captain::Assistant::ResponseParts.from_response(@run_result.output)
+    selected_citation_indexes = response_parts.to_a.flat_map { |part| part['citation_indexes'] }.uniq
+
+    (selected_citation_indexes & visible_citation_indexes).filter_map { |index| citation_document_ids[index] }.uniq
   end
 
   # On handoff, HandoffTool records the private reason note it created; the session

--- a/enterprise/app/services/captain/assistant/session_capture_service.rb
+++ b/enterprise/app/services/captain/assistant/session_capture_service.rb
@@ -53,7 +53,8 @@ class Captain::Assistant::SessionCaptureService
 
     citation_document_ids = (context.dig(:state, :captain_v2_citation_sources) || {}).transform_keys(&:to_i)
     visible_citation_indexes = @assistant.customer_visible_citation_urls(citation_document_ids).keys
-    response_parts = Captain::Assistant::ResponseParts.from_response(@run_result.output)
+    stored_response_parts = result_message.additional_attributes.to_h[Captain::Assistant::ResponseParts::MESSAGE_ATTRIBUTE_KEY]
+    response_parts = Captain::Assistant::ResponseParts.new(stored_response_parts)
     selected_citation_indexes = response_parts.to_a.flat_map { |part| part['citation_indexes'] }.uniq
 
     (selected_citation_indexes & visible_citation_indexes).filter_map { |index| citation_document_ids[index] }.uniq

--- a/enterprise/app/views/api/v1/accounts/captain/agent_sessions/show.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/agent_sessions/show.json.jbuilder
@@ -12,6 +12,10 @@ json.citations @citations do |citation|
   link = citation.display_url
   json.link link&.match?(%r{\Ahttps?://}) ? link : nil
 end
+json.used_faqs @used_faqs do |faq|
+  json.id faq.id
+  json.title faq.question
+end
 json.scenarios @scenario_titles do |id, title|
   json.id id
   json.title title

--- a/enterprise/app/views/api/v1/accounts/captain/agent_sessions/show.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/agent_sessions/show.json.jbuilder
@@ -5,11 +5,11 @@ json.credits_consumed @agent_session.credits_consumed
 json.run_context @agent_session.run_context.is_a?(Array) ? @agent_session.run_context : []
 json.citations @citations do |citation|
   json.id citation.id
-  json.title citation.question
+  json.title citation.name
   # display_url resolves uploaded PDFs to their blob URL; external_link holds a
   # "PDF: ..." placeholder for those. Guard on scheme so placeholders render as
   # plain text instead of dead anchors.
-  link = citation.documentable.is_a?(Captain::Document) ? citation.documentable.display_url : nil
+  link = citation.display_url
   json.link link&.match?(%r{\Ahttps?://}) ? link : nil
 end
 json.scenarios @scenario_titles do |id, title|

--- a/enterprise/lib/captain/tools/faq_lookup_tool.rb
+++ b/enterprise/lib/captain/tools/faq_lookup_tool.rb
@@ -30,8 +30,12 @@ class Captain::Tools::FaqLookupTool < Captain::Tools::BasePublicTool
     metadata = tool_context.state[:cw_metadata] ||= {}
     metadata[:faq_ids] = Array(metadata[:faq_ids]) | responses.map(&:id)
 
-    document_ids = responses.filter_map { |response| response.documentable_id if response.documentable_type == 'Captain::Document' }
+    responses_by_type = responses.group_by(&:documentable_type)
+    document_ids = Array(responses_by_type['Captain::Document']).map(&:documentable_id)
     metadata[:document_ids] = Array(metadata[:document_ids]) | document_ids
+
+    used_faq_ids = Array(responses_by_type['User']).map(&:id)
+    metadata[:used_faq_ids] = Array(metadata[:used_faq_ids]) | used_faq_ids
   end
 
   def format_responses(tool_context, responses)

--- a/spec/enterprise/controllers/api/v1/accounts/captain/agent_sessions_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/agent_sessions_controller_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe 'Api::V1::Accounts::Captain::AgentSessions', type: :request do
         create(:captain_assistant_response, account: account, assistant: assistant,
                                             question: 'How do I reset my password?', documentable: document)
       end
+      let(:used_faq) do
+        create(:captain_assistant_response, account: account, assistant: assistant,
+                                            question: 'How long do refunds take?', documentable: agent, status: :approved)
+      end
       let(:scenario) { create(:captain_scenario, account: account, assistant: assistant, title: 'Refund flow') }
       let(:run_context) do
         [
@@ -46,6 +50,7 @@ RSpec.describe 'Api::V1::Accounts::Captain::AgentSessions', type: :request do
                                        subject: conversation, result: message,
                                        llm_model: 'openai-gpt-5.2', credits_consumed: 1.0,
                                        faq_ids: [documented_faq.id],
+                                       used_faq_ids: [used_faq.id],
                                        document_ids: [document.id],
                                        cited_document_ids: [document.id],
                                        scenario_ids: [scenario.id],
@@ -69,6 +74,8 @@ RSpec.describe 'Api::V1::Accounts::Captain::AgentSessions', type: :request do
           expect(citations.keys).to contain_exactly(document.id)
           expect(citations[document.id][:title]).to eq('Password reset guide')
           expect(citations[document.id][:link]).to eq(document.external_link)
+
+          expect(json_response[:used_faqs]).to eq([{ id: used_faq.id, title: 'How long do refunds take?' }])
 
           expect(json_response[:scenarios]).to eq([{ id: scenario.id, title: 'Refund flow' }])
         end

--- a/spec/enterprise/controllers/api/v1/accounts/captain/agent_sessions_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/agent_sessions_controller_spec.rb
@@ -26,21 +26,10 @@ RSpec.describe 'Api::V1::Accounts::Captain::AgentSessions', type: :request do
     end
 
     context 'when the message has an agent session' do
-      let(:document) { create(:captain_document, account: account, assistant: assistant) }
+      let(:document) { create(:captain_document, account: account, assistant: assistant, name: 'Password reset guide') }
       let(:documented_faq) do
         create(:captain_assistant_response, account: account, assistant: assistant,
                                             question: 'How do I reset my password?', documentable: document)
-      end
-      let(:plain_faq) do
-        create(:captain_assistant_response, account: account, assistant: assistant, question: 'How do I change my email?')
-      end
-      let(:pdf_document) do
-        create(:captain_document, account: account, assistant: assistant, external_link: nil,
-                                  pdf_file: Rack::Test::UploadedFile.new(Rails.root.join('spec/assets/sample.pdf'), 'application/pdf'))
-      end
-      let(:pdf_faq) do
-        create(:captain_assistant_response, account: account, assistant: assistant,
-                                            question: 'What are the pricing tiers?', documentable: pdf_document)
       end
       let(:scenario) { create(:captain_scenario, account: account, assistant: assistant, title: 'Refund flow') }
       let(:run_context) do
@@ -56,7 +45,9 @@ RSpec.describe 'Api::V1::Accounts::Captain::AgentSessions', type: :request do
         create(:captain_agent_session, account: account, assistant: assistant,
                                        subject: conversation, result: message,
                                        llm_model: 'openai-gpt-5.2', credits_consumed: 1.0,
-                                       faq_ids: [documented_faq.id, plain_faq.id, pdf_faq.id, documented_faq.id + 100_000],
+                                       faq_ids: [documented_faq.id],
+                                       document_ids: [document.id],
+                                       cited_document_ids: [document.id],
                                        scenario_ids: [scenario.id],
                                        run_context: run_context)
       end
@@ -75,13 +66,9 @@ RSpec.describe 'Api::V1::Accounts::Captain::AgentSessions', type: :request do
           expect(json_response[:run_context].second[:tool_calls].first[:arguments][:query]).to eq('refund')
 
           citations = json_response[:citations].index_by { |citation| citation[:id] }
-          expect(citations.keys).to contain_exactly(documented_faq.id, plain_faq.id, pdf_faq.id)
-          expect(citations[documented_faq.id][:title]).to eq('How do I reset my password?')
-          expect(citations[documented_faq.id][:link]).to eq(document.external_link)
-          expect(citations[plain_faq.id][:link]).to be_nil
-          expect(pdf_document.external_link).to start_with('PDF:')
-          expect(citations[pdf_faq.id][:link]).to eq(pdf_document.display_url)
-          expect(citations[pdf_faq.id][:link]).to match(%r{\Ahttps?://})
+          expect(citations.keys).to contain_exactly(document.id)
+          expect(citations[document.id][:title]).to eq('Password reset guide')
+          expect(citations[document.id][:link]).to eq(document.external_link)
 
           expect(json_response[:scenarios]).to eq([{ id: scenario.id, title: 'Refund flow' }])
         end

--- a/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
+++ b/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
@@ -572,6 +572,8 @@ RSpec.describe Captain::Conversation::ResponseBuilderJob, type: :job do
           expect(conversation.messages.outgoing.last.content).to eq(
             'Hey, welcome to Captain V2 [[1](https://help.example.com/password)]'
           )
+          cited_document_id = mock_agent_runner_service.last_run_result.context[:state][:captain_v2_citation_sources][1]
+          expect(Captain::AgentSession.last.cited_document_ids).to eq([cited_document_id])
         end
 
         it 'encodes Markdown delimiters in citation URLs' do
@@ -866,6 +868,7 @@ RSpec.describe Captain::Conversation::ResponseBuilderJob, type: :job do
           llm_model: 'openai-gpt-5.2',
           credits_consumed: 1.0,
           faq_ids: [7, 9],
+          cited_document_ids: [],
           document_ids: [3],
           scenario_ids: [],
           user_id: nil

--- a/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
+++ b/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
@@ -572,7 +572,7 @@ RSpec.describe Captain::Conversation::ResponseBuilderJob, type: :job do
           expect(conversation.messages.outgoing.last.content).to eq(
             'Hey, welcome to Captain V2 [[1](https://help.example.com/password)]'
           )
-          cited_document_id = mock_agent_runner_service.last_run_result.context[:state][:captain_v2_citation_sources][1]
+          cited_document_id = mock_agent_runner_service.last_run_result.context[:state][Captain::Assistant::CITATION_SOURCES_STATE_KEY][1]
           expect(Captain::AgentSession.last.cited_document_ids).to eq([cited_document_id])
         end
 

--- a/spec/enterprise/lib/captain/tools/faq_lookup_tool_spec.rb
+++ b/spec/enterprise/lib/captain/tools/faq_lookup_tool_spec.rb
@@ -132,7 +132,15 @@ RSpec.describe Captain::Tools::FaqLookupTool, type: :model do
       it 'records retrieved faq ids and document ids into Chatwoot metadata' do
         tool.perform(tool_context, query: 'password reset')
 
-        expect(tool_context.state.dig(:cw_metadata, :faq_ids)).to contain_exactly(response1.id, response2.id)
+        user = create(:user, account: account)
+        user_faq = create(:captain_assistant_response, assistant: assistant, documentable: user, status: :approved)
+        allow(Captain::AssistantResponse).to receive(:nearest_neighbors).and_return(
+          Captain::AssistantResponse.where(id: user_faq.id)
+        )
+        tool.perform(tool_context, query: 'user faq')
+
+        expect(tool_context.state.dig(:cw_metadata, :faq_ids)).to contain_exactly(response1.id, response2.id, user_faq.id)
+        expect(tool_context.state.dig(:cw_metadata, :used_faq_ids)).to contain_exactly(user_faq.id)
         expect(tool_context.state.dig(:cw_metadata, :document_ids)).to contain_exactly(document.id)
       end
 

--- a/spec/enterprise/models/captain/agent_session_spec.rb
+++ b/spec/enterprise/models/captain/agent_session_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe Captain::AgentSession, type: :model do
       session = create(:captain_agent_session, account: account, assistant: assistant)
 
       expect(session.faq_ids).to eq([])
+      expect(session.used_faq_ids).to eq([])
       expect(session.cited_document_ids).to eq([])
       expect(session.document_ids).to eq([])
       expect(session.scenario_ids).to eq([])

--- a/spec/enterprise/models/captain/agent_session_spec.rb
+++ b/spec/enterprise/models/captain/agent_session_spec.rb
@@ -129,10 +129,11 @@ RSpec.describe Captain::AgentSession, type: :model do
   end
 
   describe 'defaults' do
-    it 'defaults faq_ids, document_ids, scenario_ids and run_context' do
+    it 'defaults source ids, scenario ids and run_context' do
       session = create(:captain_agent_session, account: account, assistant: assistant)
 
       expect(session.faq_ids).to eq([])
+      expect(session.cited_document_ids).to eq([])
       expect(session.document_ids).to eq([])
       expect(session.scenario_ids).to eq([])
       expect(session.run_context).to eq({})

--- a/spec/enterprise/services/captain/assistant/session_capture_service_spec.rb
+++ b/spec/enterprise/services/captain/assistant/session_capture_service_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Captain::Assistant::SessionCaptureService do
         llm_model: 'openai-gpt-5.2',
         credits_consumed: 1.0,
         faq_ids: [11, 12],
+        cited_document_ids: [],
         document_ids: [5],
         scenario_ids: [],
         user_id: nil
@@ -149,8 +150,41 @@ RSpec.describe Captain::Assistant::SessionCaptureService do
 
       expect(session.result).to eq(result_message)
       expect(session.faq_ids).to eq([])
+      expect(session.cited_document_ids).to eq([])
       expect(session.document_ids).to eq([])
       expect(session.run_context).to eq([])
+    end
+
+    it 'stores only selected customer-visible document citations' do
+      cited_document = create(:captain_document, assistant: assistant, external_link: 'https://help.example.com/reset-password')
+      cited_faq = create(:captain_assistant_response, assistant: assistant, documentable: cited_document)
+      retrieved_document = create(:captain_document, assistant: assistant, external_link: 'https://help.example.com/change-email')
+      retrieved_faq = create(:captain_assistant_response, assistant: assistant, documentable: retrieved_document)
+      assistant.update!(config: assistant.config.merge('feature_citation' => true))
+      run_context[:state] = {
+        cw_metadata: { faq_ids: [cited_faq.id, retrieved_faq.id], document_ids: [cited_document.id, retrieved_document.id] },
+        captain_v2_citation_sources: { 1 => cited_document.id, 2 => retrieved_document.id }
+      }
+      run_result.output = {
+        'response_parts' => [{ 'text' => 'Reset your password from settings.', 'citation_indexes' => [1] }],
+        'reasoning' => 'Used the password FAQ'
+      }
+
+      session = service.capture!
+
+      expect(session.faq_ids).to contain_exactly(cited_faq.id, retrieved_faq.id)
+      expect(session.cited_document_ids).to eq([cited_document.id])
+    end
+
+    it 'does not store citations when citations are disabled' do
+      document = create(:captain_document, assistant: assistant, external_link: 'https://help.example.com/reset-password')
+      run_context[:state][:captain_v2_citation_sources] = { 1 => document.id }
+      run_result.output = {
+        'response_parts' => [{ 'text' => 'Reset your password from settings.', 'citation_indexes' => [1] }],
+        'reasoning' => 'Used the password FAQ'
+      }
+
+      expect(service.capture!.cited_document_ids).to eq([])
     end
 
     it 'extracts every scenario that authored a message in the current turn' do

--- a/spec/enterprise/services/captain/assistant/session_capture_service_spec.rb
+++ b/spec/enterprise/services/captain/assistant/session_capture_service_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Captain::Assistant::SessionCaptureService do
         llm_model: 'openai-gpt-5.2',
         credits_consumed: 1.0,
         faq_ids: [11, 12],
+        used_faq_ids: [],
         cited_document_ids: [],
         document_ids: [5],
         scenario_ids: [],
@@ -150,6 +151,7 @@ RSpec.describe Captain::Assistant::SessionCaptureService do
 
       expect(session.result).to eq(result_message)
       expect(session.faq_ids).to eq([])
+      expect(session.used_faq_ids).to eq([])
       expect(session.cited_document_ids).to eq([])
       expect(session.document_ids).to eq([])
       expect(session.run_context).to eq([])
@@ -160,9 +162,15 @@ RSpec.describe Captain::Assistant::SessionCaptureService do
       cited_faq = create(:captain_assistant_response, assistant: assistant, documentable: cited_document)
       retrieved_document = create(:captain_document, assistant: assistant, external_link: 'https://help.example.com/change-email')
       retrieved_faq = create(:captain_assistant_response, assistant: assistant, documentable: retrieved_document)
+      user = create(:user, account: account)
+      used_faq = create(:captain_assistant_response, assistant: assistant, documentable: user, status: :approved)
       assistant.update!(config: assistant.config.merge('feature_citation' => true))
       run_context[:state] = {
-        cw_metadata: { faq_ids: [cited_faq.id, retrieved_faq.id], document_ids: [cited_document.id, retrieved_document.id] },
+        cw_metadata: {
+          faq_ids: [cited_faq.id, retrieved_faq.id, used_faq.id],
+          used_faq_ids: [used_faq.id],
+          document_ids: [cited_document.id, retrieved_document.id]
+        },
         captain_v2_citation_sources: { 1 => cited_document.id, 2 => retrieved_document.id }
       }
       run_result.output = {
@@ -177,7 +185,8 @@ RSpec.describe Captain::Assistant::SessionCaptureService do
 
       session = service.capture!
 
-      expect(session.faq_ids).to contain_exactly(cited_faq.id, retrieved_faq.id)
+      expect(session.faq_ids).to contain_exactly(cited_faq.id, retrieved_faq.id, used_faq.id)
+      expect(session.used_faq_ids).to eq([used_faq.id])
       expect(session.cited_document_ids).to eq([cited_document.id])
     end
 

--- a/spec/enterprise/services/captain/assistant/session_capture_service_spec.rb
+++ b/spec/enterprise/services/captain/assistant/session_capture_service_spec.rb
@@ -166,12 +166,12 @@ RSpec.describe Captain::Assistant::SessionCaptureService do
       used_faq = create(:captain_assistant_response, assistant: assistant, documentable: user, status: :approved)
       assistant.update!(config: assistant.config.merge('feature_citation' => true))
       run_context[:state] = {
-        cw_metadata: {
+        :cw_metadata => {
           faq_ids: [cited_faq.id, retrieved_faq.id, used_faq.id],
           used_faq_ids: [used_faq.id],
           document_ids: [cited_document.id, retrieved_document.id]
         },
-        captain_v2_citation_sources: { 1 => cited_document.id, 2 => retrieved_document.id }
+        Captain::Assistant::CITATION_SOURCES_STATE_KEY => { 1 => cited_document.id, 2 => retrieved_document.id }
       }
       run_result.output = {
         'response_parts' => [{ 'text' => 'Reset your password from settings.', 'citation_indexes' => [1] }],
@@ -192,7 +192,7 @@ RSpec.describe Captain::Assistant::SessionCaptureService do
 
     it 'does not store citations when citations are disabled' do
       document = create(:captain_document, assistant: assistant, external_link: 'https://help.example.com/reset-password')
-      run_context[:state][:captain_v2_citation_sources] = { 1 => document.id }
+      run_context[:state][Captain::Assistant::CITATION_SOURCES_STATE_KEY] = { 1 => document.id }
       run_result.output = {
         'response_parts' => [{ 'text' => 'Reset your password from settings.', 'citation_indexes' => [1] }],
         'reasoning' => 'Used the password FAQ'

--- a/spec/enterprise/services/captain/assistant/session_capture_service_spec.rb
+++ b/spec/enterprise/services/captain/assistant/session_capture_service_spec.rb
@@ -169,6 +169,11 @@ RSpec.describe Captain::Assistant::SessionCaptureService do
         'response_parts' => [{ 'text' => 'Reset your password from settings.', 'citation_indexes' => [1] }],
         'reasoning' => 'Used the password FAQ'
       }
+      result_message.update!(
+        additional_attributes: {
+          Captain::Assistant::ResponseParts::MESSAGE_ATTRIBUTE_KEY => run_result.output['response_parts']
+        }
+      )
 
       session = service.capture!
 


### PR DESCRIPTION
Captain now records the exact documents cited in each V2 assistant response, separately from all documents retrieved during generation. Generation details therefore show only customer-visible documents selected in the final response, and the source identity remains stable when generated FAQs are refreshed.

Depends on #15159 and is intentionally stacked on `feature/ai-138`.

## What changed

- Added `cited_document_ids` to Captain agent sessions while preserving `document_ids` as retrieval telemetry.
- Resolved final response-part citation indexes through the trusted document mapping before session capture.
- Updated generation details to hydrate cited documents directly.
- Added a concurrent GIN index for future document usage queries.
- Existing sessions default to an empty cited document list because the historical citation mapping was not persisted.

## How to test

1. Enable citations for a Captain assistant with FAQ results from multiple documents.
2. Ask a question that retrieves multiple documents and produces a response citing one of them.
3. Confirm the customer message renders the expected citation.
4. Open the Captain generation details and confirm only the cited document appears under Sources.
5. Disable citations and confirm the response and session contain no cited documents.