### PR TITLE
feat: add Captain inactivity policy controls

### DIFF
--- a/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.vue
@@ -1,13 +1,15 @@
 <script setup>
-import { reactive, computed, watch } from 'vue';
+import { reactive, computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useVuelidate } from '@vuelidate/core';
-import { minLength } from '@vuelidate/validators';
+import { maxValue, minLength, minValue, required } from '@vuelidate/validators';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import { useAccount } from 'dashboard/composables/useAccount';
 
 import Button from 'dashboard/components-next/button/Button.vue';
 import Editor from 'dashboard/components-next/Editor/Editor.vue';
+import Select from 'dashboard/components-next/select/Select.vue';
+import SettingsToggleSection from 'dashboard/components-next/Settings/SettingsToggleSection.vue';
 
 const props = defineProps({
   assistant: {
@@ -29,14 +31,100 @@ const initialState = {
   handoffMessage: '',
   resolutionMessage: '',
   instructions: '',
+  inactivityThresholdMinutes: 60,
+  sendInactivityResolutionMessage: true,
 };
 
 const state = reactive({ ...initialState });
+const isInactivityResolutionSettingsExpanded = ref(false);
+
+const inactivityThresholdLabel = computed(() => {
+  const hours = Math.floor(state.inactivityThresholdMinutes / 60);
+  const minutes = state.inactivityThresholdMinutes % 60;
+
+  return [
+    hours
+      ? t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.DURATION_HOURS', {
+          count: hours,
+        })
+      : '',
+    minutes
+      ? t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.DURATION_MINUTES', {
+          count: minutes,
+        })
+      : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+});
+
+const selectedInactivityResolutionSummary = computed(() => {
+  const resolutionSummary = t(
+    'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.CURRENT_SETTING',
+    {
+      duration: inactivityThresholdLabel.value,
+    }
+  );
+
+  if (state.sendInactivityResolutionMessage) return resolutionSummary;
+
+  return `${resolutionSummary} ${t(
+    'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.RESOLUTION_MESSAGE.DISABLED_SUMMARY'
+  )}`;
+});
+
+const inactivityHourOptions = Array.from({ length: 25 }, (_, hours) => ({
+  value: hours,
+  label: String(hours),
+}));
+
+const inactivityThresholdHours = computed({
+  get: () => Math.floor(state.inactivityThresholdMinutes / 60),
+  set: hours => {
+    const remainingMinutes = state.inactivityThresholdMinutes % 60;
+    const requestedMinutes = Number(hours) * 60 + remainingMinutes;
+    state.inactivityThresholdMinutes = Math.min(
+      Math.max(requestedMinutes, 5),
+      24 * 60
+    );
+  },
+});
+
+const inactivityThresholdRemainingMinutes = computed({
+  get: () => state.inactivityThresholdMinutes % 60,
+  set: minutes => {
+    const completeHours = Math.floor(state.inactivityThresholdMinutes / 60);
+    const requestedMinutes = completeHours * 60 + Number(minutes);
+    state.inactivityThresholdMinutes = Math.min(
+      Math.max(requestedMinutes, 5),
+      24 * 60
+    );
+  },
+});
+
+const inactivityMinuteOptions = computed(() => {
+  return Array.from({ length: 12 }, (_, index) => {
+    const minutes = index * 5;
+    const hours = inactivityThresholdHours.value;
+
+    return {
+      value: minutes,
+      label: String(minutes).padStart(2, '0'),
+      disabled:
+        (hours === 0 && minutes === 0) || (hours === 24 && minutes !== 0),
+    };
+  });
+});
 
 const validationRules = {
   handoffMessage: { minLength: minLength(1) },
   resolutionMessage: { minLength: minLength(1) },
   instructions: { minLength: minLength(1) },
+  inactivityThresholdMinutes: {
+    required,
+    minValue: minValue(5),
+    maxValue: maxValue(24 * 60),
+  },
 };
 
 const v$ = useVuelidate(validationRules, state);
@@ -49,23 +137,47 @@ const formErrors = computed(() => ({
   handoffMessage: getErrorMessage('handoffMessage'),
   resolutionMessage: getErrorMessage('resolutionMessage'),
   instructions: getErrorMessage('instructions'),
+  inactivityThresholdMinutes: getErrorMessage('inactivityThresholdMinutes'),
 }));
+
+const handleInactivityResolutionUpdate = async () => {
+  const validations = [v$.value.inactivityThresholdMinutes.$validate()];
+  if (state.sendInactivityResolutionMessage) {
+    validations.push(v$.value.resolutionMessage.$validate());
+  }
+  const result = await Promise.all(validations).then(results =>
+    results.every(Boolean)
+  );
+  if (!result) return;
+
+  emit('submit', {
+    config: {
+      ...props.assistant.config,
+      auto_resolve_after: state.inactivityThresholdMinutes,
+      send_inactivity_resolution_message: state.sendInactivityResolutionMessage,
+      resolution_message: state.resolutionMessage,
+    },
+  });
+};
 
 const updateStateFromAssistant = assistant => {
   const { config = {} } = assistant;
   state.handoffMessage = config.handoff_message;
   state.resolutionMessage = config.resolution_message;
   state.instructions = config.instructions;
+  state.inactivityThresholdMinutes = config.auto_resolve_after ?? 60;
+  state.sendInactivityResolutionMessage =
+    config.send_inactivity_resolution_message ?? true;
 };
 
 const handleSystemMessagesUpdate = async () => {
-  const validations = [
-    v$.value.handoffMessage.$validate(),
-    v$.value.resolutionMessage.$validate(),
-  ];
+  const validations = [v$.value.handoffMessage.$validate()];
 
   if (!isCaptainV2Enabled.value) {
-    validations.push(v$.value.instructions.$validate());
+    validations.push(
+      v$.value.resolutionMessage.$validate(),
+      v$.value.instructions.$validate()
+    );
   }
 
   const result = await Promise.all(validations).then(results =>
@@ -77,11 +189,11 @@ const handleSystemMessagesUpdate = async () => {
     config: {
       ...props.assistant.config,
       handoff_message: state.handoffMessage,
-      resolution_message: state.resolutionMessage,
     },
   };
 
   if (!isCaptainV2Enabled.value) {
+    payload.config.resolution_message = state.resolutionMessage;
     payload.config.instructions = state.instructions;
   }
 
@@ -99,6 +211,122 @@ watch(
 
 <template>
   <div class="flex flex-col gap-6">
+    <div
+      v-if="isCaptainV2Enabled"
+      class="overflow-hidden rounded-xl border border-n-weak bg-n-solid-1"
+    >
+      <button
+        type="button"
+        class="flex w-full items-center justify-between gap-4 p-4 text-left"
+        :aria-expanded="isInactivityResolutionSettingsExpanded"
+        @click="
+          isInactivityResolutionSettingsExpanded =
+            !isInactivityResolutionSettingsExpanded
+        "
+      >
+        <div class="flex flex-col gap-1">
+          <h4 class="text-sm font-medium text-n-slate-12">
+            {{ t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.TITLE') }}
+          </h4>
+          <p class="text-sm text-n-slate-11">
+            {{ t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.DESCRIPTION') }}
+          </p>
+          <p
+            v-if="!isInactivityResolutionSettingsExpanded"
+            class="text-xs font-medium text-n-slate-12"
+          >
+            {{ selectedInactivityResolutionSummary }}
+          </p>
+        </div>
+        <div class="flex shrink-0 items-center">
+          <span
+            class="i-lucide-chevron-down size-4 text-n-slate-11 transition-transform"
+            :class="{ 'rotate-180': isInactivityResolutionSettingsExpanded }"
+          />
+        </div>
+      </button>
+
+      <div
+        v-if="isInactivityResolutionSettingsExpanded"
+        class="flex flex-col gap-4 border-t border-n-weak p-4"
+      >
+        <div class="flex flex-col gap-2">
+          <p class="text-sm font-medium text-n-slate-12">
+            {{
+              t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.DURATION_LABEL')
+            }}
+          </p>
+          <div class="grid grid-cols-2 gap-3">
+            <label class="flex flex-col gap-1.5 text-xs text-n-slate-11">
+              {{
+                t(
+                  'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.DURATION_HOURS_LABEL'
+                )
+              }}
+              <Select
+                v-model="inactivityThresholdHours"
+                :options="inactivityHourOptions"
+                :error="formErrors.inactivityThresholdMinutes"
+                class="!w-full [&>select]:w-full"
+              />
+            </label>
+            <label class="flex flex-col gap-1.5 text-xs text-n-slate-11">
+              {{
+                t(
+                  'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.DURATION_MINUTES_LABEL'
+                )
+              }}
+              <Select
+                v-model="inactivityThresholdRemainingMinutes"
+                :options="inactivityMinuteOptions"
+                :error="formErrors.inactivityThresholdMinutes"
+                class="!w-full [&>select]:w-full"
+              />
+            </label>
+          </div>
+          <p
+            v-if="formErrors.inactivityThresholdMinutes"
+            class="text-xs text-n-ruby-9"
+          >
+            {{ formErrors.inactivityThresholdMinutes }}
+          </p>
+        </div>
+
+        <SettingsToggleSection
+          v-model="state.sendInactivityResolutionMessage"
+          :header="
+            t(
+              'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.RESOLUTION_MESSAGE.TITLE'
+            )
+          "
+          :description="
+            t(
+              'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.RESOLUTION_MESSAGE.DESCRIPTION'
+            )
+          "
+        >
+          <template v-if="state.sendInactivityResolutionMessage" #editor>
+            <Editor
+              v-model="state.resolutionMessage"
+              :placeholder="
+                t('CAPTAIN.ASSISTANTS.FORM.RESOLUTION_MESSAGE.PLACEHOLDER')
+              "
+              :message="formErrors.resolutionMessage"
+              :message-type="formErrors.resolutionMessage ? 'error' : 'info'"
+              class="z-0"
+            />
+          </template>
+        </SettingsToggleSection>
+
+        <div>
+          <Button
+            :label="t('CAPTAIN.ASSISTANTS.FORM.SAVE_INACTIVITY_SETTINGS')"
+            @click="handleInactivityResolutionUpdate"
+          />
+        </div>
+      </div>
+    </div>
+
     <Editor
       v-model="state.handoffMessage"
       :label="t('CAPTAIN.ASSISTANTS.FORM.HANDOFF_MESSAGE.LABEL')"
@@ -109,6 +337,7 @@ watch(
     />
 
     <Editor
+      v-if="!isCaptainV2Enabled"
       v-model="state.resolutionMessage"
       :label="t('CAPTAIN.ASSISTANTS.FORM.RESOLUTION_MESSAGE.LABEL')"
       :placeholder="t('CAPTAIN.ASSISTANTS.FORM.RESOLUTION_MESSAGE.PLACEHOLDER')"
@@ -130,7 +359,11 @@ watch(
 
     <div>
       <Button
-        :label="t('CAPTAIN.ASSISTANTS.FORM.UPDATE')"
+        :label="
+          isCaptainV2Enabled
+            ? t('CAPTAIN.ASSISTANTS.FORM.SAVE_HANDOFF_MESSAGE')
+            : t('CAPTAIN.ASSISTANTS.FORM.UPDATE')
+        "
         @click="handleSystemMessagesUpdate"
       />
     </div>

--- a/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.vue
@@ -8,6 +8,7 @@ import { useAccount } from 'dashboard/composables/useAccount';
 
 import Button from 'dashboard/components-next/button/Button.vue';
 import Editor from 'dashboard/components-next/Editor/Editor.vue';
+import RadioCard from 'dashboard/components-next/radioCard/RadioCard.vue';
 import Select from 'dashboard/components-next/select/Select.vue';
 import SettingsToggleSection from 'dashboard/components-next/Settings/SettingsToggleSection.vue';
 
@@ -31,12 +32,49 @@ const initialState = {
   handoffMessage: '',
   resolutionMessage: '',
   instructions: '',
+  autoResolveMode: 'evaluated',
   inactivityThresholdMinutes: 60,
   sendInactivityResolutionMessage: true,
 };
 
 const state = reactive({ ...initialState });
 const isInactivityResolutionSettingsExpanded = ref(false);
+
+const autoResolveOptions = computed(() => [
+  {
+    value: 'disabled',
+    label: t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.MODES.DISABLED.LABEL'
+    ),
+    description: t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.MODES.DISABLED.DESCRIPTION'
+    ),
+  },
+  {
+    value: 'legacy',
+    label: t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.MODES.LEGACY.LABEL'
+    ),
+    description: t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.MODES.LEGACY.DESCRIPTION'
+    ),
+  },
+  {
+    value: 'evaluated',
+    label: t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.MODES.EVALUATED.LABEL'
+    ),
+    description: t(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.MODES.EVALUATED.DESCRIPTION'
+    ),
+  },
+]);
+
+const selectedAutoResolveModeLabel = computed(() => {
+  return autoResolveOptions.value.find(
+    option => option.value === state.autoResolveMode
+  )?.label;
+});
 
 const inactivityThresholdLabel = computed(() => {
   const hours = Math.floor(state.inactivityThresholdMinutes / 60);
@@ -59,9 +97,16 @@ const inactivityThresholdLabel = computed(() => {
 });
 
 const selectedInactivityResolutionSummary = computed(() => {
+  if (state.autoResolveMode === 'disabled') {
+    return t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.CURRENT_MODE', {
+      mode: selectedAutoResolveModeLabel.value,
+    });
+  }
+
   const resolutionSummary = t(
-    'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.CURRENT_SETTING',
+    'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.CURRENT_MODE_AFTER',
     {
+      mode: selectedAutoResolveModeLabel.value,
       duration: inactivityThresholdLabel.value,
     }
   );
@@ -72,6 +117,10 @@ const selectedInactivityResolutionSummary = computed(() => {
     'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.RESOLUTION_MESSAGE.DISABLED_SUMMARY'
   )}`;
 });
+
+const shouldShowInactivityDuration = computed(
+  () => state.autoResolveMode !== 'disabled'
+);
 
 const inactivityHourOptions = Array.from({ length: 25 }, (_, hours) => ({
   value: hours,
@@ -141,8 +190,14 @@ const formErrors = computed(() => ({
 }));
 
 const handleInactivityResolutionUpdate = async () => {
-  const validations = [v$.value.inactivityThresholdMinutes.$validate()];
-  if (state.sendInactivityResolutionMessage) {
+  const validations = [];
+  if (shouldShowInactivityDuration.value) {
+    validations.push(v$.value.inactivityThresholdMinutes.$validate());
+  }
+  if (
+    shouldShowInactivityDuration.value &&
+    state.sendInactivityResolutionMessage
+  ) {
     validations.push(v$.value.resolutionMessage.$validate());
   }
   const result = await Promise.all(validations).then(results =>
@@ -153,6 +208,7 @@ const handleInactivityResolutionUpdate = async () => {
   emit('submit', {
     config: {
       ...props.assistant.config,
+      auto_resolve_mode: state.autoResolveMode,
       auto_resolve_after: state.inactivityThresholdMinutes,
       send_inactivity_resolution_message: state.sendInactivityResolutionMessage,
       resolution_message: state.resolutionMessage,
@@ -165,6 +221,7 @@ const updateStateFromAssistant = assistant => {
   state.handoffMessage = config.handoff_message;
   state.resolutionMessage = config.resolution_message;
   state.instructions = config.instructions;
+  state.autoResolveMode = config.auto_resolve_mode ?? 'evaluated';
   state.inactivityThresholdMinutes = config.auto_resolve_after ?? 60;
   state.sendInactivityResolutionMessage =
     config.send_inactivity_resolution_message ?? true;
@@ -250,7 +307,19 @@ watch(
         v-if="isInactivityResolutionSettingsExpanded"
         class="flex flex-col gap-4 border-t border-n-weak p-4"
       >
-        <div class="flex flex-col gap-2">
+        <div class="flex flex-col gap-3">
+          <RadioCard
+            v-for="option in autoResolveOptions"
+            :id="`auto-resolve-${option.value}`"
+            :key="option.value"
+            :label="option.label"
+            :description="option.description"
+            :is-active="state.autoResolveMode === option.value"
+            @select="state.autoResolveMode = option.value"
+          />
+        </div>
+
+        <div v-if="shouldShowInactivityDuration" class="flex flex-col gap-2">
           <p class="text-sm font-medium text-n-slate-12">
             {{
               t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.DURATION_LABEL')
@@ -293,6 +362,7 @@ watch(
         </div>
 
         <SettingsToggleSection
+          v-if="shouldShowInactivityDuration"
           v-model="state.sendInactivityResolutionMessage"
           :header="
             t(

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -564,6 +564,8 @@
       },
       "FORM": {
         "UPDATE": "Update",
+        "SAVE_INACTIVITY_SETTINGS": "Save inactive conversation settings",
+        "SAVE_HANDOFF_MESSAGE": "Save handoff message",
         "SECTIONS": {
           "BASIC_INFO": "Basic Information",
           "SYSTEM_MESSAGES": "System Messages",
@@ -598,6 +600,21 @@
           "LABEL": "Resolution Message",
           "PLACEHOLDER": "Enter resolution message"
         },
+        "INACTIVITY_RESOLUTION": {
+          "TITLE": "Inactive conversations",
+          "DESCRIPTION": "Choose when Captain should act on conversations that are waiting for the customer.",
+          "CURRENT_SETTING": "Captain acts after {duration} of inactivity.",
+          "DURATION_HOURS": "{count} hour | {count} hours",
+          "DURATION_MINUTES": "{count} minute | {count} minutes",
+          "RESOLUTION_MESSAGE": {
+            "TITLE": "Send a resolution message",
+            "DESCRIPTION": "Captain sends this message before resolving an inactive conversation.",
+            "DISABLED_SUMMARY": "Captain will not send a resolution message."
+          },
+          "DURATION_LABEL": "Inactivity timer",
+          "DURATION_HOURS_LABEL": "Hours",
+          "DURATION_MINUTES_LABEL": "Minutes"
+        },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
           "PLACEHOLDER": "Enter instructions for the assistant"
@@ -624,7 +641,8 @@
         },
         "SYSTEM_SETTINGS": {
           "TITLE": "System settings",
-          "DESCRIPTION": "Customize what the assistant says when ending a conversation or transferring to a human."
+          "DESCRIPTION": "Customize what the assistant says when ending a conversation or transferring to a human.",
+          "DESCRIPTION_V2": "Manage inactive conversations and Captain's handoff message."
         },
         "CONTROL_ITEMS": {
           "TITLE": "The Fun Stuff",

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -602,8 +602,9 @@
         },
         "INACTIVITY_RESOLUTION": {
           "TITLE": "Inactive conversations",
-          "DESCRIPTION": "Choose when Captain should act on conversations that are waiting for the customer.",
-          "CURRENT_SETTING": "Captain acts after {duration} of inactivity.",
+          "DESCRIPTION": "Choose how Captain handles conversations that are waiting for the customer.",
+          "CURRENT_MODE": "Current setting: {mode}",
+          "CURRENT_MODE_AFTER": "Current setting: {mode} after {duration}",
           "DURATION_HOURS": "{count} hour | {count} hours",
           "DURATION_MINUTES": "{count} minute | {count} minutes",
           "RESOLUTION_MESSAGE": {
@@ -611,7 +612,21 @@
             "DESCRIPTION": "Captain sends this message before resolving an inactive conversation.",
             "DISABLED_SUMMARY": "Captain will not send a resolution message."
           },
-          "DURATION_LABEL": "Inactivity timer",
+          "MODES": {
+            "DISABLED": {
+              "LABEL": "Keep conversations pending",
+              "DESCRIPTION": "Inactive conversations remain pending. Captain does not resolve them or send them to a human."
+            },
+            "LEGACY": {
+              "LABEL": "Resolve without checking",
+              "DESCRIPTION": "Captain resolves every inactive conversation after the selected time without checking whether it is complete."
+            },
+            "EVALUATED": {
+              "LABEL": "Check before resolving",
+              "DESCRIPTION": "Captain checks whether each inactive conversation is complete. It resolves completed conversations and sends the rest to a human."
+            }
+          },
+          "DURATION_LABEL": "Take action after",
           "DURATION_HOURS_LABEL": "Hours",
           "DURATION_MINUTES_LABEL": "Minutes"
         },

--- a/app/javascript/dashboard/routes/dashboard/captain/assistants/settings/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/assistants/settings/Settings.vue
@@ -21,6 +21,11 @@ const { isCloudFeatureEnabled } = useAccount();
 const isCaptainV2Enabled = computed(() =>
   isCloudFeatureEnabled(FEATURE_FLAGS.CAPTAIN_V2)
 );
+const systemSettingsDescription = computed(() =>
+  isCaptainV2Enabled.value
+    ? t('CAPTAIN.ASSISTANTS.SETTINGS.SYSTEM_SETTINGS.DESCRIPTION_V2')
+    : t('CAPTAIN.ASSISTANTS.SETTINGS.SYSTEM_SETTINGS.DESCRIPTION')
+);
 const route = useRoute();
 const router = useRouter();
 const store = useStore();
@@ -134,9 +139,7 @@ const handleDeleteSuccess = () => {
           <div class="flex flex-col gap-6">
             <SettingsHeader
               :heading="t('CAPTAIN.ASSISTANTS.SETTINGS.SYSTEM_SETTINGS.TITLE')"
-              :description="
-                t('CAPTAIN.ASSISTANTS.SETTINGS.SYSTEM_SETTINGS.DESCRIPTION')
-              "
+              :description="systemSettingsDescription"
             />
             <AssistantSystemSettingsForm
               :assistant="assistant"

--- a/db/migrate/20260803000000_enqueue_copy_captain_auto_resolve_mode_to_assistants_job.rb
+++ b/db/migrate/20260803000000_enqueue_copy_captain_auto_resolve_mode_to_assistants_job.rb
@@ -1,0 +1,7 @@
+class EnqueueCopyCaptainAutoResolveModeToAssistantsJob < ActiveRecord::Migration[7.1]
+  def up
+    Migration::CopyCaptainAutoResolveModeToAssistantsJob.perform_later if ChatwootApp.enterprise?
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_29_051500) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_03_000000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
@@ -119,13 +119,15 @@ class Api::V1::Accounts::Captain::AssistantsController < Api::V1::Accounts::Base
   end
 
   def assistant_params
+    assistant_config_attributes = [
+      :product_name, :feature_faq, :feature_memory, :feature_citation,
+      :feature_contact_attributes, :welcome_message, :handoff_message,
+      :resolution_message, :instructions, :temperature
+    ]
+    assistant_config_attributes << :auto_resolve_mode if Current.account.feature_enabled?('captain_integration_v2')
+
     permitted = params.require(:assistant).permit(:name, :description,
-                                                  config: [
-                                                    :product_name, :feature_faq, :feature_memory, :feature_citation,
-                                                    :feature_contact_attributes,
-                                                    :welcome_message, :handoff_message, :resolution_message,
-                                                    :instructions, :temperature
-                                                  ])
+                                                  config: assistant_config_attributes)
 
     # Handle array parameters separately to allow partial updates
     permitted[:response_guidelines] = params[:assistant][:response_guidelines] if params[:assistant].key?(:response_guidelines)

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
@@ -124,7 +124,9 @@ class Api::V1::Accounts::Captain::AssistantsController < Api::V1::Accounts::Base
       :feature_contact_attributes, :welcome_message, :handoff_message,
       :resolution_message, :instructions, :temperature
     ]
-    assistant_config_attributes << :auto_resolve_mode if Current.account.feature_enabled?('captain_integration_v2')
+    if Current.account.feature_enabled?('captain_integration_v2')
+      assistant_config_attributes += [:auto_resolve_mode, :auto_resolve_after, :send_inactivity_resolution_message]
+    end
 
     permitted = params.require(:assistant).permit(:name, :description,
                                                   config: assistant_config_attributes)

--- a/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
+++ b/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
@@ -8,6 +8,8 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
     captain_assistant = inbox.captain_assistant
     return if captain_assistant.inactive_conversation_resolution_disabled?
 
+    @inactivity_cutoff_time = Time.now.utc - captain_assistant.inactivity_threshold_minutes.minutes
+
     if evaluate_conversation_completion?(captain_assistant, inbox.account)
       perform_with_evaluation(inbox)
     else
@@ -18,6 +20,8 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
   end
 
   private
+
+  attr_reader :inactivity_cutoff_time
 
   def evaluate_conversation_completion?(assistant, account)
     account.feature_enabled?('captain_tasks') && assistant.evaluate_inactive_conversations_before_resolving?
@@ -62,19 +66,15 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
 
   def resolvable_pending_conversations(inbox)
     inbox.conversations.pending
-         .where('last_activity_at < ?', auto_resolve_cutoff_time)
+         .where('last_activity_at < ?', inactivity_cutoff_time)
          .limit(Limits::BULK_ACTIONS_LIMIT)
   end
 
   def still_resolvable_after_evaluation?(conversation)
     conversation.reload
-    conversation.pending? && conversation.last_activity_at < auto_resolve_cutoff_time
+    conversation.pending? && conversation.last_activity_at < inactivity_cutoff_time
   rescue ActiveRecord::RecordNotFound
     false
-  end
-
-  def auto_resolve_cutoff_time
-    Time.now.utc - 1.hour
   end
 
   def resolve_conversation(conversation, inbox, reason)
@@ -129,6 +129,8 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
   end
 
   def create_resolution_message(conversation, inbox)
+    return unless inbox.captain_assistant.send_inactivity_resolution_message?
+
     I18n.with_locale(inbox.account.locale) do
       resolution_message = inbox.captain_assistant.config['resolution_message']
       conversation.messages.create!(

--- a/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
+++ b/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
@@ -5,9 +5,10 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
   queue_as :low
 
   def perform(inbox)
-    return if inbox.account.captain_auto_resolve_disabled?
+    captain_assistant = inbox.captain_assistant
+    return if captain_assistant.inactive_conversation_resolution_disabled?
 
-    if evaluate_conversation_completion?(inbox.account)
+    if evaluate_conversation_completion?(captain_assistant, inbox.account)
       perform_with_evaluation(inbox)
     else
       perform_time_based(inbox)
@@ -18,8 +19,8 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
 
   private
 
-  def evaluate_conversation_completion?(account)
-    account.feature_enabled?('captain_tasks') && account.captain_auto_resolve_evaluated?
+  def evaluate_conversation_completion?(assistant, account)
+    account.feature_enabled?('captain_tasks') && assistant.evaluate_inactive_conversations_before_resolving?
   end
 
   def perform_time_based(inbox)

--- a/enterprise/app/jobs/enterprise/account/conversations_resolution_scheduler_job.rb
+++ b/enterprise/app/jobs/enterprise/account/conversations_resolution_scheduler_job.rb
@@ -12,7 +12,7 @@ module Enterprise::Account::ConversationsResolutionSchedulerJob
       inbox = captain_inbox.inbox
 
       next if inbox.email?
-      next if inbox.account.captain_auto_resolve_disabled?
+      next if captain_inbox.captain_assistant.inactive_conversation_resolution_disabled?
 
       Captain::InboxPendingConversationsResolutionJob.perform_later(
         inbox

--- a/enterprise/app/jobs/migration/copy_captain_auto_resolve_mode_to_assistants_job.rb
+++ b/enterprise/app/jobs/migration/copy_captain_auto_resolve_mode_to_assistants_job.rb
@@ -1,0 +1,17 @@
+class Migration::CopyCaptainAutoResolveModeToAssistantsJob < ApplicationJob
+  queue_as :async_database_migration
+
+  def perform
+    Captain::Assistant.includes(:account).find_each do |assistant|
+      assistant.with_lock do
+        next if assistant.config.key?('auto_resolve_mode')
+
+        config = assistant.config.merge('auto_resolve_mode' => assistant.account.captain_auto_resolve_mode)
+
+        # rubocop:disable Rails/SkipsModelValidations
+        assistant.update_columns(config: config)
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+    end
+  end
+end

--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -19,6 +19,9 @@
 class Captain::Assistant < ApplicationRecord
   DESCRIPTION_LENGTH_LIMIT = 500
   AUTO_RESOLVE_MODES = %w[disabled legacy evaluated].freeze
+  DEFAULT_INACTIVITY_THRESHOLD_MINUTES = 60
+  MINIMUM_INACTIVITY_THRESHOLD_MINUTES = 5
+  MAXIMUM_INACTIVITY_THRESHOLD_MINUTES = 1.day.in_minutes.to_i
 
   include Avatarable
   include Concerns::CaptainToolsHelpers
@@ -42,12 +45,20 @@ class Captain::Assistant < ApplicationRecord
   has_many :agent_sessions, class_name: 'Captain::AgentSession', dependent: :destroy_async
 
   store_accessor :config, :temperature, :feature_faq, :feature_memory, :feature_contact_attributes, :product_name,
-                 :auto_resolve_mode
+                 :auto_resolve_mode, :auto_resolve_after, :send_inactivity_resolution_message
 
   validates :name, presence: true
   validates :description, presence: true, length: { maximum: DESCRIPTION_LENGTH_LIMIT }
   validates :account_id, presence: true
   validates :auto_resolve_mode, inclusion: { in: AUTO_RESOLVE_MODES }
+  validates :send_inactivity_resolution_message, inclusion: { in: [true, false] }
+  validates :auto_resolve_after,
+            numericality: {
+              only_integer: true,
+              greater_than_or_equal_to: MINIMUM_INACTIVITY_THRESHOLD_MINUTES,
+              less_than_or_equal_to: MAXIMUM_INACTIVITY_THRESHOLD_MINUTES
+            },
+            allow_nil: true
 
   scope :ordered, -> { order(created_at: :desc) }
 
@@ -67,6 +78,18 @@ class Captain::Assistant < ApplicationRecord
 
   def evaluate_inactive_conversations_before_resolving?
     auto_resolve_mode == 'evaluated'
+  end
+
+  def inactivity_threshold_minutes
+    config.fetch('auto_resolve_after', DEFAULT_INACTIVITY_THRESHOLD_MINUTES).to_i
+  end
+
+  def send_inactivity_resolution_message
+    config.fetch('send_inactivity_resolution_message', true)
+  end
+
+  def send_inactivity_resolution_message?
+    send_inactivity_resolution_message
   end
 
   def available_agent_tools

--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -18,6 +18,7 @@
 #
 class Captain::Assistant < ApplicationRecord
   DESCRIPTION_LENGTH_LIMIT = 500
+  AUTO_RESOLVE_MODES = %w[disabled legacy evaluated].freeze
 
   include Avatarable
   include Concerns::CaptainToolsHelpers
@@ -40,11 +41,13 @@ class Captain::Assistant < ApplicationRecord
   has_many :scenarios, class_name: 'Captain::Scenario', dependent: :destroy_async
   has_many :agent_sessions, class_name: 'Captain::AgentSession', dependent: :destroy_async
 
-  store_accessor :config, :temperature, :feature_faq, :feature_memory, :feature_contact_attributes, :product_name
+  store_accessor :config, :temperature, :feature_faq, :feature_memory, :feature_contact_attributes, :product_name,
+                 :auto_resolve_mode
 
   validates :name, presence: true
   validates :description, presence: true, length: { maximum: DESCRIPTION_LENGTH_LIMIT }
   validates :account_id, presence: true
+  validates :auto_resolve_mode, inclusion: { in: AUTO_RESOLVE_MODES }
 
   scope :ordered, -> { order(created_at: :desc) }
 
@@ -52,6 +55,18 @@ class Captain::Assistant < ApplicationRecord
 
   def available_name
     name
+  end
+
+  def auto_resolve_mode
+    config.fetch('auto_resolve_mode') { account&.captain_auto_resolve_mode || 'evaluated' }
+  end
+
+  def inactive_conversation_resolution_disabled?
+    auto_resolve_mode == 'disabled'
+  end
+
+  def evaluate_inactive_conversations_before_resolving?
+    auto_resolve_mode == 'evaluated'
   end
 
   def available_agent_tools

--- a/enterprise/app/views/api/v1/models/captain/_assistant.json.jbuilder
+++ b/enterprise/app/views/api/v1/models/captain/_assistant.json.jbuilder
@@ -1,5 +1,9 @@
 json.account_id resource.account_id
-json.config resource.config.merge('auto_resolve_mode' => resource.auto_resolve_mode)
+json.config resource.config.merge(
+  'auto_resolve_mode' => resource.auto_resolve_mode,
+  'auto_resolve_after' => resource.inactivity_threshold_minutes,
+  'send_inactivity_resolution_message' => resource.send_inactivity_resolution_message?
+)
 json.created_at resource.created_at.to_i
 json.description resource.description
 json.guardrails resource.guardrails

--- a/enterprise/app/views/api/v1/models/captain/_assistant.json.jbuilder
+++ b/enterprise/app/views/api/v1/models/captain/_assistant.json.jbuilder
@@ -1,5 +1,5 @@
 json.account_id resource.account_id
-json.config resource.config
+json.config resource.config.merge('auto_resolve_mode' => resource.auto_resolve_mode)
 json.created_at resource.created_at.to_i
 json.description resource.description
 json.guardrails resource.guardrails

--- a/spec/enterprise/controllers/api/v1/accounts/captain/assistants_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/assistants_controller_spec.rb
@@ -216,6 +216,30 @@ RSpec.describe 'Api::V1::Accounts::Captain::Assistants', type: :request do
         expect(response).to have_http_status(:success)
         expect(json_response[:config][:feature_citation]).to be(false)
       end
+
+      it 'updates inactive conversation settings for Captain v2' do
+        account.enable_features('captain_integration_v2')
+
+        patch "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}",
+              params: {
+                assistant: {
+                  config: {
+                    auto_resolve_after: 90,
+                    send_inactivity_resolution_message: false,
+                    resolution_message: 'Saved closing message'
+                  }
+                }
+              },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:config]).to include(
+          auto_resolve_after: 90,
+          send_inactivity_resolution_message: false,
+          resolution_message: 'Saved closing message'
+        )
+      end
     end
   end
 

--- a/spec/enterprise/controllers/api/v1/accounts/captain/assistants_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/assistants_controller_spec.rb
@@ -224,6 +224,7 @@ RSpec.describe 'Api::V1::Accounts::Captain::Assistants', type: :request do
               params: {
                 assistant: {
                   config: {
+                    auto_resolve_mode: 'legacy',
                     auto_resolve_after: 90,
                     send_inactivity_resolution_message: false,
                     resolution_message: 'Saved closing message'
@@ -235,6 +236,7 @@ RSpec.describe 'Api::V1::Accounts::Captain::Assistants', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(json_response[:config]).to include(
+          auto_resolve_mode: 'legacy',
           auto_resolve_after: 90,
           send_inactivity_resolution_message: false,
           resolution_message: 'Saved closing message'

--- a/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
+++ b/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
 
       expect(Captain::ConversationCompletionService).not_to have_received(:new)
     end
+
+    it 'uses the assistant inactivity timer' do
+      captain_assistant.update!(config: captain_assistant.config.merge('auto_resolve_after' => 180))
+
+      described_class.perform_now(inbox)
+
+      expect(resolvable_pending_conversation.reload.status).to eq('pending')
+    end
+
+    it 'resolves silently when the resolution message is disabled' do
+      captain_assistant.update!(config: captain_assistant.config.merge('send_inactivity_resolution_message' => false))
+
+      described_class.perform_now(inbox)
+
+      expect(resolvable_pending_conversation.reload.status).to eq('resolved')
+      expect(resolvable_pending_conversation.messages.outgoing).to be_empty
+    end
   end
 
   context 'when captain_tasks is enabled' do

--- a/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
+++ b/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
   let!(:resolvable_pending_conversation) { create(:conversation, inbox: inbox, last_activity_at: 2.hours.ago, status: :pending) }
   let!(:recent_pending_conversation) { create(:conversation, inbox: inbox, last_activity_at: 1.minute.ago, status: :pending) }
   let!(:open_conversation) { create(:conversation, inbox: inbox, last_activity_at: 1.hour.ago, status: :open) }
-  let!(:captain_assistant) { create(:captain_assistant, account: inbox.account) }
+  let!(:captain_assistant) { create(:captain_assistant, account: inbox.account, config: { 'auto_resolve_mode' => 'evaluated' }) }
 
   before do
     create(:captain_inbox, inbox: inbox, captain_assistant: captain_assistant)
@@ -19,6 +19,11 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
   end
 
   context 'when captain_tasks is disabled' do
+    before do
+      allow(inbox.account).to receive(:feature_enabled?).and_call_original
+      allow(inbox.account).to receive(:feature_enabled?).with('captain_tasks').and_return(false)
+    end
+
     it 'resolves pending conversations inactive for over 1 hour' do
       described_class.perform_now(inbox)
 
@@ -101,8 +106,8 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
       expect(resolvable_pending_conversation.messages.outgoing).to be_empty
     end
 
-    it 'falls back to legacy time-based resolve when legacy auto-resolve is forced' do
-      inbox.account.update!(captain_auto_resolve_mode: 'legacy')
+    it 'uses legacy time-based resolve when configured on the assistant' do
+      captain_assistant.update!(auto_resolve_mode: 'legacy')
       allow(Captain::ConversationCompletionService).to receive(:new)
 
       described_class.perform_now(inbox)
@@ -365,7 +370,7 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
   end
 
   it 'does not resolve conversations when auto-resolve is disabled at execution time' do
-    inbox.account.update!(captain_auto_resolve_mode: 'disabled')
+    captain_assistant.update!(auto_resolve_mode: 'disabled')
 
     expect do
       described_class.perform_now(inbox)
@@ -376,6 +381,7 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
   end
 
   it 'falls back to disabled mode from legacy settings key' do
+    captain_assistant.update!(config: captain_assistant.config.except('auto_resolve_mode'))
     inbox.account.update!(settings: inbox.account.settings.merge('captain_disable_auto_resolve' => true))
 
     expect do

--- a/spec/enterprise/jobs/enterprise/account/conversations_resolution_scheduler_job_spec.rb
+++ b/spec/enterprise/jobs/enterprise/account/conversations_resolution_scheduler_job_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe Account::ConversationsResolutionSchedulerJob, type: :job do
       end
     end
 
-    context 'when account has captain auto resolve disabled' do
+    context 'when assistant has captain auto resolve disabled' do
       let!(:regular_inbox) { create(:inbox, account: account) }
 
       before do
         create(:captain_inbox, captain_assistant: assistant, inbox: regular_inbox)
-        account.update!(captain_auto_resolve_mode: 'disabled')
+        assistant.update!(auto_resolve_mode: 'disabled')
       end
 
       it 'does not enqueue resolution jobs' do

--- a/spec/enterprise/jobs/migration/copy_captain_auto_resolve_mode_to_assistants_job_spec.rb
+++ b/spec/enterprise/jobs/migration/copy_captain_auto_resolve_mode_to_assistants_job_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Migration::CopyCaptainAutoResolveModeToAssistantsJob, type: :job do
+  it 'copies the account mode to assistants without an assistant setting' do
+    account = create(:account, captain_auto_resolve_mode: 'legacy')
+    assistant = create(:captain_assistant, account: account)
+
+    described_class.perform_now
+
+    expect(assistant.reload.config['auto_resolve_mode']).to eq('legacy')
+  end
+
+  it 'preserves an existing assistant setting' do
+    account = create(:account, captain_auto_resolve_mode: 'legacy')
+    assistant = create(:captain_assistant, account: account, config: { 'auto_resolve_mode' => 'disabled' })
+
+    described_class.perform_now
+
+    expect(assistant.reload.config['auto_resolve_mode']).to eq('disabled')
+  end
+end

--- a/spec/enterprise/models/captain/assistant_spec.rb
+++ b/spec/enterprise/models/captain/assistant_spec.rb
@@ -1,6 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Captain::Assistant do
+  describe 'inactive conversation settings' do
+    let(:assistant) { build(:captain_assistant, config: {}) }
+
+    it 'uses safe defaults when settings have not been saved' do
+      expect(assistant.inactivity_threshold_minutes).to eq(60)
+      expect(assistant.send_inactivity_resolution_message?).to be(true)
+    end
+
+    it 'validates the inactivity timer range' do
+      assistant.auto_resolve_after = 4
+
+      expect(assistant).not_to be_valid
+      expect(assistant.errors[:auto_resolve_after]).to be_present
+    end
+  end
+
   describe '#auto_resolve_mode' do
     let(:account) { create(:account, captain_auto_resolve_mode: 'legacy') }
 

--- a/spec/enterprise/models/captain/assistant_spec.rb
+++ b/spec/enterprise/models/captain/assistant_spec.rb
@@ -1,6 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe Captain::Assistant do
+  describe '#auto_resolve_mode' do
+    let(:account) { create(:account, captain_auto_resolve_mode: 'legacy') }
+
+    it 'uses the assistant setting when configured' do
+      assistant = create(:captain_assistant, account: account, config: { 'auto_resolve_mode' => 'disabled' })
+
+      expect(assistant.auto_resolve_mode).to eq('disabled')
+    end
+
+    it 'falls back to the account setting for assistants that have not been migrated' do
+      assistant = create(:captain_assistant, account: account)
+
+      expect(assistant.auto_resolve_mode).to eq('legacy')
+    end
+
+    it 'rejects unsupported modes' do
+      assistant = build(:captain_assistant, account: account, config: { 'auto_resolve_mode' => 'unsupported' })
+
+      expect(assistant).not_to be_valid
+      expect(assistant.errors[:auto_resolve_mode]).to be_present
+    end
+  end
+
   describe '#agent_tools' do
     let(:account) { create(:account) }
     let(:assistant) { create(:captain_assistant, account: account) }


### PR DESCRIPTION
Captain assistants can now choose how to handle inactive conversations: keep them pending, resolve after the timer without checking, or evaluate completion before resolving. The policy selection is stored on the assistant and uses the assistant-owned runtime introduced at the base of this stack.

## Closes

[AI-163](https://linear.app/chatwoot/issue/AI-163)

## How to test

1. Open a Captain V2 assistant and expand Inactive conversations.
2. Select Keep conversations pending and confirm the timer and message controls are hidden.
3. Save and reload, then confirm the selected policy is preserved.
4. Select Resolve without checking and confirm the timer and message controls are available.
5. Select Check before resolving and confirm completed conversations resolve while incomplete conversations are handed off when `captain_tasks` is available.
6. Confirm changing one assistant does not change another assistant in the same account.

## What changed

- Added the assistant-level `disabled`, `legacy`, and `evaluated` policy selector.
- Added policy-aware summaries and conditional timer/message controls.
- Included the selected assistant mode in the existing inactivity Save action.
- Kept contextual follow-up, a second timer, and thank-you detection out of this PR.

Stack: 3 of 3. Based on #15303, which is based on #15299.