### PR TITLE
fix(captain): prevent AgentBot inbox overlap

### DIFF
--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
 
   def index
     @inboxes = policy_scope(Current.account.inboxes)
-               .includes(:channel, :portal, :working_hours, { avatar_attachment: :blob })
+               .includes(:channel, :portal, :working_hours, :agent_bot_inbox, { avatar_attachment: :blob })
                .order_by_name
   end
 

--- a/app/javascript/dashboard/components-next/captain/pageComponents/inbox/ConnectInboxForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/inbox/ConnectInboxForm.vue
@@ -39,12 +39,18 @@ const inboxList = computed(() => {
   const captainInboxIds = formState.captainInboxes.value.map(inbox => inbox.id);
 
   return formState.inboxes.value
-    .filter(inbox => !captainInboxIds.includes(inbox.id))
+    .filter(
+      inbox => !captainInboxIds.includes(inbox.id) && !inbox.agent_bot_connected
+    )
     .map(inbox => ({
       value: inbox.id,
       label: inbox.name,
     }));
 });
+
+const hasAgentBotInboxes = computed(() =>
+  formState.inboxes.value.some(inbox => inbox.agent_bot_connected)
+);
 
 const v$ = useVuelidate(validationRules, state);
 
@@ -92,6 +98,9 @@ const handleSubmit = async () => {
         class="[&>div>button]:bg-n-alpha-black2 [&>div>button:not(.focused)]:dark:outline-n-weak [&>div>button:not(.focused)]:hover:!outline-n-slate-6"
         :message="formErrors.inboxId"
       />
+      <p v-if="hasAgentBotInboxes" class="mb-0 text-xs text-n-slate-11">
+        {{ t('CAPTAIN.INBOXES.FORM.AGENT_BOT_UNAVAILABLE') }}
+      </p>
     </div>
 
     <div class="flex items-center justify-between w-full gap-3">

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -1211,6 +1211,7 @@
         "ERROR_MESSAGE": "An error occurred while connecting the inbox. Please try again."
       },
       "FORM": {
+        "AGENT_BOT_UNAVAILABLE": "Inboxes with an active AgentBot are not available.",
         "INBOX": {
           "LABEL": "Inbox",
           "PLACEHOLDER": "Choose the inbox to deploy the assistant.",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/BotConfiguration.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/BotConfiguration.vue
@@ -61,7 +61,10 @@ export default {
         });
         useAlert(this.$t('AGENT_BOTS.BOT_CONFIGURATION.SUCCESS_MESSAGE'));
       } catch (error) {
-        useAlert(this.$t('AGENT_BOTS.BOT_CONFIGURATION.ERROR_MESSAGE'));
+        useAlert(
+          error?.message ||
+            this.$t('AGENT_BOTS.BOT_CONFIGURATION.ERROR_MESSAGE')
+        );
       }
     },
     async disconnectBot() {

--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -19,6 +19,7 @@ json.allow_messages_after_resolved resource.allow_messages_after_resolved
 json.lock_to_single_conversation resource.lock_to_single_conversation
 json.sender_name_type resource.sender_name_type
 json.business_name resource.business_name
+json.agent_bot_connected resource.agent_bot_inbox&.active? || false
 
 if resource.portal.present?
   json.help_center do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,8 @@ en:
       cannot_revoke_current: You cannot revoke the current session.
 
   errors:
+    inbox:
+      captain_agent_bot_conflict: Captain and AgentBot cannot be connected to the same inbox.
     account:
       not_authorized: You are not authorized to access this account
       email_limit_exceeded: The daily email limit for this account has been reached

--- a/enterprise/app/controllers/api/v1/accounts/captain/inboxes_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/inboxes_controller.rb
@@ -8,6 +8,8 @@ class Api::V1::Accounts::Captain::InboxesController < Api::V1::Accounts::BaseCon
 
   def create
     inbox = Current.account.inboxes.find(assistant_params[:inbox_id])
+    return render_could_not_create_error(I18n.t('errors.inbox.captain_agent_bot_conflict')) if inbox.agent_bot_inbox&.active?
+
     @captain_inbox = @assistant.captain_inboxes.build(inbox: inbox)
     @captain_inbox.save!
   end

--- a/enterprise/app/controllers/enterprise/api/v1/accounts/inboxes_controller.rb
+++ b/enterprise/app/controllers/enterprise/api/v1/accounts/inboxes_controller.rb
@@ -41,6 +41,12 @@ module Enterprise::Api::V1::Accounts::InboxesController
     render_could_not_create_error(e.message)
   end
 
+  def set_agent_bot
+    return render_could_not_create_error(I18n.t('errors.inbox.captain_agent_bot_conflict')) if @agent_bot.present? && @inbox.captain_inbox.present?
+
+    super
+  end
+
   def ee_inbox_attributes
     [auto_assignment_config: [:max_assignment_limit]]
   end


### PR DESCRIPTION
Prevents Captain and AgentBot from being connected to the same inbox, so only one bot can own new conversations.

This PR is intended to merge before #14902. Existing inboxes that already have both bots connected are left unchanged.

## How to reproduce

1. Connect an AgentBot to an inbox.
2. Try to connect Captain to the same inbox.
3. Captain currently connects and both bots can reply to the same customer message.

The same conflict can be created in reverse by connecting an AgentBot to an inbox that already has Captain.

## What changed

- Rejects both conflicting connection paths in the backend.
- Hides inboxes with an active AgentBot from the Captain inbox picker.
- Shows the backend conflict message when an AgentBot connection is rejected.
- Allows existing connections to disconnect either bot.