### PR TITLE
docs: document UserDrop#last_name

### DIFF
--- a/app/drops/user_drop.rb
+++ b/app/drops/user_drop.rb
@@ -15,6 +15,13 @@ class UserDrop < BaseDrop
     @obj.try(:name).try(:split).try(:first).try(:capitalize)
   end
 
+  # Returns the capitalized last name extracted from the user's full name.
+  #
+  # The full name is split on whitespace and the final segment is
+  # capitalized. If the name has only one word (no separate last name)
+  # or is blank, this returns nil.
+  #
+  # @return [String, nil] the user's last name, or nil if unavailable
   def last_name
     @obj.try(:name).try(:split).try(:last).try(:capitalize) if @obj.try(:name).try(:split).try(:size).to_i > 1
   end


### PR DESCRIPTION
## Description
Adds a YARD-style doc comment to `UserDrop#last_name`, explaining what it
returns and under which conditions it returns `nil` (single-word names,
blank names, or missing user). No behavior was changed — comment-only.

This was picked up via CodeTriage's "no docs" method list.

## Type of change
- [x] This change requires a documentation update

## How Has This Been Tested?
This is a comment-only change with no logic modification, so the existing
test suite is unaffected. To validate the accuracy of the new comment,
I manually exercised the method's logic with edge cases (nil name, blank
name, single-word name, multi-word name, name with extra whitespace) and
confirmed the return values match what the comment describes.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules