### PR TITLE
perf: reduce per-request work in conversation filter endpoint

### DIFF
--- a/app/services/conversations/filter_service.rb
+++ b/app/services/conversations/filter_service.rb
@@ -24,8 +24,10 @@ class Conversations::FilterService < FilterService
   end
 
   def base_relation
+    # :messages is deliberately not preloaded: the list payload fetches messages through
+    # scoped queries (last message, last_non_activity_message), which bypass the preload.
     conversations = @account.conversations.includes(
-      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :messages, :contact_inbox
+      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox
     )
 
     Conversations::PermissionFilterService.new(

--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -107,12 +107,16 @@ class FilterService
     lt_gt_filter_query(updated_query_hash, current_index)
   end
 
+  # Computes mine/unassigned/all counts in one scan of the filtered set instead of
+  # three separate COUNT queries.
   def set_count_for_all_conversations
-    [
-      @conversations.assigned_to(@user).count,
-      @conversations.unassigned.count,
-      @conversations.count
-    ]
+    counts = @conversations.except(:includes, :order).pick(
+      Arel.sql(ActiveRecord::Base.sanitize_sql_array(['COUNT(*) FILTER (WHERE assignee_id = ?)', @user.id])),
+      Arel.sql('COUNT(*) FILTER (WHERE assignee_id IS NULL)'),
+      Arel.sql('COUNT(*)')
+    )
+    # pick short-circuits to nil on a none relation (e.g. permission scope with no access)
+    counts ? counts.map(&:to_i) : [0, 0, 0]
   end
 
   def tag_filter_query(query_hash, current_index)

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -670,6 +670,66 @@ describe Conversations::FilterService do
     end
   end
 
+  describe 'result counts' do
+    let!(:params) { { payload: [], page: 1 } }
+    let(:payload) do
+      [
+        {
+          attribute_key: 'status',
+          filter_operator: 'not_equal_to',
+          values: %w[resolved],
+          query_operator: nil,
+          custom_attribute_type: ''
+        }.with_indifferent_access
+      ]
+    end
+
+    before do
+      create(:conversation, account: account, inbox: inbox)
+    end
+
+    it 'returns mine, assigned, unassigned and all counts for the filtered set' do
+      params[:payload] = payload
+      result = filter_service.new(params, user_1, account).perform
+
+      expect(result[:count]).to eq(
+        mine_count: 3,
+        assigned_count: 4,
+        unassigned_count: 1,
+        all_count: 5
+      )
+    end
+
+    it 'returns zero counts when the permission scope resolves to no conversations' do
+      params[:payload] = payload
+      permission_filter = instance_double(Conversations::PermissionFilterService, perform: Conversation.none)
+      allow(Conversations::PermissionFilterService).to receive(:new).and_return(permission_filter)
+
+      result = filter_service.new(params, user_1, account).perform
+
+      expect(result[:count]).to eq(
+        mine_count: 0,
+        assigned_count: 0,
+        unassigned_count: 0,
+        all_count: 0
+      )
+    end
+
+    it 'computes all counts in a single query' do
+      params[:payload] = payload
+
+      count_queries = []
+      subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |_name, _started, _finished, _unique_id, event|
+        count_queries << event[:sql] if event[:sql].match?(/COUNT\(/i) && !event[:cached]
+      end
+
+      filter_service.new(params, user_1, account).perform
+      expect(count_queries.size).to eq(1)
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+  end
+
   describe '#base_relation' do
     let!(:account) { create(:account) }
     let!(:user_1) { create(:user, account: account, role: :agent) }


### PR DESCRIPTION
## Description

Every conversation filter request runs three separate unbounded COUNT queries over the filtered set (mine, unassigned, all) and eager-loads every message of every conversation on the page. On large accounts this adds a fixed 1-2s of latency per request regardless of the filter.

This PR trims both:

- The three counts are now computed in a single pass using `COUNT(*) FILTER (...)` aggregates. Response shape and count semantics are unchanged.
- The `:messages` eager-load is removed from the filter base relation. The list payload fetches messages through scoped queries (last message, last non-activity message, unread messages), which never read the preloaded collection, so it was loaded and discarded on every request.

Fixes https://linear.app/chatwoot/issue/CW-7830

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New service specs assert the mine/assigned/unassigned/all counts are unchanged, that the counts run as a single query, and that an empty permission scope returns zero counts.
- `bundle exec rspec spec/services/conversations/filter_service_spec.rb spec/services/conversations/unread_counts/filter_query_counter_spec.rb` (34 examples, 0 failures) and the conversations controller filter specs (4 examples, 0 failures).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
