### PR TITLE
fix: flaky AppliedSla scope spec after Rails reloads

### DIFF
--- a/spec/enterprise/models/applied_sla_spec.rb
+++ b/spec/enterprise/models/applied_sla_spec.rb
@@ -80,8 +80,10 @@ RSpec.describe AppliedSla, type: :model do
       blocked_applied_sla.conversation.contact.update!(blocked: true)
       missing_contact_applied_sla.conversation.update_columns(contact_id: nil, contact_inbox_id: nil) # rubocop:disable Rails/SkipsModelValidations
 
-      expect(described_class.with_sla_applicable_conversation).to include(applied_sla, missing_contact_applied_sla)
-      expect(described_class.with_sla_applicable_conversation).not_to include(blocked_applied_sla)
+      applicable_sla_ids = described_class.with_sla_applicable_conversation.ids
+
+      expect(applicable_sla_ids).to include(applied_sla.id, missing_contact_applied_sla.id)
+      expect(applicable_sla_ids).not_to include(blocked_applied_sla.id)
     end
   end
 


### PR DESCRIPTION
CI no longer fails when the AppliedSla scope spec runs after Rails reloads model classes. The spec now compares record IDs, so it checks which SLA records the scope returns without depending on Ruby class identity.

## How to reproduce

Run the report builder and assignment policy controller specs before `spec/enterprise/models/applied_sla_spec.rb` in the same RSpec process. Before the fix, the scope returns records with the expected IDs, but the assertion rejects them because FactoryBot and Rails use different `AppliedSla` class objects after the reload.

## What changed

The spec reads the IDs returned by `with_sla_applicable_conversation` and checks the normal conversation, missing contact, and blocked contact cases with those IDs.

The affected CircleCI shard passes locally after the change.