### PR TITLE
fix(whatsapp): hide manual transfer for coexistence inboxes

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -937,7 +937,7 @@
       "WHATSAPP_MANUAL_MIGRATION": {
         "BANNER": {
           "TITLE": "Manual setup recommended",
-          "DESCRIPTION": "This inbox uses WhatsApp Embedded Signup without WhatsApp Business app Coexistence. You can reconnect it with your own Meta app to manage the WhatsApp API connection directly.",
+          "DESCRIPTION": "This inbox connects through the shared Meta app used for embedded signup, which recent Meta restrictions have affected. To avoid similar issues in the future, we recommend reconnecting it with your own Meta app.",
           "START": "Start manual migration",
           "GUIDE": "View guide"
         },

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -937,7 +937,7 @@
       "WHATSAPP_MANUAL_MIGRATION": {
         "BANNER": {
           "TITLE": "Manual setup recommended",
-          "DESCRIPTION": "This inbox connects through the shared Meta app used for embedded signup, which recent Meta restrictions have affected. To avoid similar issues in the future, we recommend reconnecting it with your own Meta app.",
+          "DESCRIPTION": "This inbox uses WhatsApp Embedded Signup without WhatsApp Business app Coexistence. You can reconnect it with your own Meta app to manage the WhatsApp API connection directly.",
           "START": "Start manual migration",
           "GUIDE": "View guide"
         },

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -421,6 +421,7 @@ export default {
       return (
         this.isAWhatsAppCloudChannel &&
         this.isEmbeddedSignupWhatsApp &&
+        this.healthData?.is_on_biz_app === false &&
         this.healthError?.type !== 'authorization' &&
         this.isFeatureEnabledonAccount(
           this.accountId,


### PR DESCRIPTION
WhatsApp Business app Coexistence inboxes currently see the manual migration prompt even though they cannot move to the generic manual setup flow without losing the supported Coexistence path.

This change waits for WhatsApp health data and shows manual transfer only when Meta confirms the number is not connected to the WhatsApp Business app. Other eligible Embedded Signup inboxes continue to see the migration prompt.

### Things to know

- This is frontend-only gating; the migration API behavior is unchanged.
- The prompt remains hidden while the WhatsApp Business app state is unknown or unavailable.

### How to test

1. Enable `whatsapp_manual_transfer` for an account with an Embedded Signup WhatsApp inbox.
2. Open an inbox whose health response reports `is_on_biz_app: true`; confirm the migration banner and dialog are unavailable.
3. Open an inbox whose health response reports `is_on_biz_app: false`; confirm the migration banner appears and opens the existing manual migration dialog.