### PR TITLE
fix: validate days_before filter values before date arithmetic

### DIFF
--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -98,7 +98,12 @@ class FilterService
   end
 
   def days_before_filter_query(query_hash, current_index)
-    date = Time.zone.today - query_hash['values'][0].to_i.days
+    days = Integer(query_hash['values'][0].to_s, 10, exception: false)
+    # UI supports 1..998 days; anything else would silently coerce into an
+    # unintended cutoff (negative => future date matching everything)
+    raise CustomExceptions::CustomFilter::InvalidValue.new(attribute_name: query_hash['attribute_key']) unless days&.between?(1, 998)
+
+    date = Time.zone.today - days.days
     updated_query_hash = query_hash.to_h.with_indifferent_access.merge(
       values: [date.strftime],
       filter_operator: 'is_less_than'

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -628,7 +628,7 @@ describe Conversations::FilterService do
             {
               attribute_key: 'last_activity_at',
               filter_operator: 'days_before',
-              values: [3],
+              values: [2],
               query_operator: nil,
               custom_attribute_type: ''
             }.with_indifferent_access
@@ -638,6 +638,40 @@ describe Conversations::FilterService do
 
           result = filter_service.new(params, user_1, account).perform
           expect(result[:conversations].length).to eq expected_count
+        end
+
+        it 'parses string days_before values as base 10' do
+          params[:payload] = [
+            {
+              attribute_key: 'last_activity_at',
+              filter_operator: 'days_before',
+              values: ['02'],
+              query_operator: nil,
+              custom_attribute_type: ''
+            }.with_indifferent_access
+          ]
+
+          expected_count = account.conversations.where('last_activity_at < ?', (Time.zone.today - 2.days)).count
+
+          result = filter_service.new(params, user_1, account).perform
+          expect(result[:conversations].length).to eq expected_count
+        end
+
+        it 'raises InvalidValue for negative and non-numeric days_before values' do
+          [-1, 'abc', 0, 999].each do |invalid_value|
+            params[:payload] = [
+              {
+                attribute_key: 'last_activity_at',
+                filter_operator: 'days_before',
+                values: [invalid_value],
+                query_operator: nil,
+                custom_attribute_type: ''
+              }.with_indifferent_access
+            ]
+
+            expect { filter_service.new(params, user_1, account).perform }
+              .to raise_error(CustomExceptions::CustomFilter::InvalidValue)
+          end
         end
 
         it 'filter by last_activity_at days_before when payload is ActionController::Parameters' do


### PR DESCRIPTION
## Description

Follow-up to #15319, addressing the non-blocking review notes and the Ito QA finding there.

The `days_before` filter value went straight through `to_i`, which never fails: `-1` moves the cutoff into the future and matches every conversation, and a non-numeric string becomes `0`. The value is now parsed as a base-10 integer and must fall within the UI-supported `1..998` range; anything else raises the existing `CustomExceptions::CustomFilter::InvalidValue`, which the controller already turns into a client error.

Also corrects an existing weak spec that sent `3` days but computed its expectation with `2` days, passing only because the seeded data made both counts equal. It now sends `2` and exercises the exclusive boundary.

Refs https://linear.app/chatwoot/issue/CW-7832

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New specs: invalid values (`-1`, `abc`, `0`, `999`) raise `InvalidValue`; string values parse as base 10 (`'02'` means 2 days, not octal).
- `bundle exec rspec spec/services/conversations/filter_service_spec.rb` (36 examples, 0 failures).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
