### PR TITLE
fix: bind public API HMAC verification to the target contact

### DIFF
--- a/app/controllers/public/api/v1/inboxes/contacts_controller.rb
+++ b/app/controllers/public/api/v1/inboxes/contacts_controller.rb
@@ -36,15 +36,25 @@ class Public::Api::V1::Inboxes::ContactsController < Public::Api::V1::InboxesCon
   end
 
   def valid_hmac?
+    expected_identifier = hmac_identifier
+    return false if expected_identifier.blank?
+    return false unless params[:identifier].to_s == expected_identifier
+
     expected_hash = OpenSSL::HMAC.hexdigest(
       'sha256',
       @inbox_channel.hmac_token,
-      params[:identifier].to_s
+      expected_identifier
     )
     identifier_hash = params[:identifier_hash].to_s
     return false unless identifier_hash.bytesize == expected_hash.bytesize
 
     ActiveSupport::SecurityUtils.secure_compare(identifier_hash, expected_hash)
+  end
+
+  def hmac_identifier
+    return params[:identifier].to_s if @contact_inbox.blank?
+
+    @contact_inbox.contact.identifier.to_s
   end
 
   def permitted_params

--- a/spec/controllers/public/api/v1/inbox/contacts_controller_spec.rb
+++ b/spec/controllers/public/api/v1/inbox/contacts_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Public Inbox Contacts API', type: :request do
   let!(:api_channel) { create(:channel_api) }
-  let!(:contact) { create(:contact) }
+  let!(:contact) { create(:contact, account: api_channel.account, identifier: 'victim-identifier') }
   let!(:contact_inbox) { create(:contact_inbox, contact: contact, inbox: api_channel.inbox) }
 
   describe 'POST /public/api/v1/inboxes/{identifier}/contact' do
@@ -35,6 +35,26 @@ RSpec.describe 'Public Inbox Contacts API', type: :request do
       expect(data.keys).to include('email', 'id', 'name', 'phone_number', 'pubsub_token', 'source_id')
       expect(data['source_id']).to eq contact_inbox.source_id
       expect(data['pubsub_token']).to eq contact_inbox.pubsub_token
+    end
+
+    it 'marks the contact inbox verified when the identifier hash matches the selected contact' do
+      identifier_hash = OpenSSL::HMAC.hexdigest('sha256', api_channel.hmac_token, contact.identifier)
+
+      get "/public/api/v1/inboxes/#{api_channel.identifier}/contacts/#{contact_inbox.source_id}",
+          params: { identifier: contact.identifier, identifier_hash: identifier_hash }
+
+      expect(response).to have_http_status(:success)
+      expect(contact_inbox.reload.hmac_verified).to be(true)
+    end
+
+    it 'does not verify a contact inbox with a hash for a different identifier' do
+      attacker_hash = OpenSSL::HMAC.hexdigest('sha256', api_channel.hmac_token, 'attacker-identifier')
+
+      get "/public/api/v1/inboxes/#{api_channel.identifier}/contacts/#{contact_inbox.source_id}",
+          params: { identifier: 'attacker-identifier', identifier_hash: attacker_hash }
+
+      expect(response).to have_http_status(:internal_server_error)
+      expect(contact_inbox.reload.hmac_verified).to be(false)
     end
   end
 


### PR DESCRIPTION
## Description

The public inbox contact endpoint computed its HMAC over the client-supplied `identifier` and compared it to `identifier_hash`, without checking that the identifier belonged to the contact selected by the URL `source_id`. This binds the verification to the selected contact: it derives the expected identifier from the target contact inbox, rejects a request whose `identifier` does not match it, and compares hashes with a constant-time `secure_compare` (plus a length guard).

Ref https://linear.app/chatwoot/issue/CW-7444

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`bundle exec rspec spec/controllers/public/api/v1/inbox/contacts_controller_spec.rb` (7 examples, 0 failures) - added cases for a matching identifier hash (verifies) and a hash for a different identifier (does not verify).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
