### PR TITLE
fix: keep bulk action bar on a single line for longer translations

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/conversationBulkActions/Index.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/conversationBulkActions/Index.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, useAttrs } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useMapGetter } from 'dashboard/composables/store.js';
 import { getUnixTime } from 'date-fns';
 import { findSnoozeTime } from 'dashboard/helper/snoozeHelpers';
@@ -54,6 +55,7 @@ defineOptions({
 });
 
 const attrs = useAttrs();
+const { t } = useI18n();
 
 const {
   selectedConversations,
@@ -74,6 +76,12 @@ const appliedLabelsForSelection = computed(() => {
   });
   return Array.from(applied);
 });
+
+const selectedLabel = computed(() =>
+  t('BULK_ACTION.CONVERSATIONS_SELECTED', {
+    conversationCount: props.conversations.length,
+  })
+);
 
 const showCustomTimeSnoozeModal = ref(false);
 
@@ -148,32 +156,29 @@ onUnmounted(() => {
         {{ $t('BULK_ACTION.ALL_CONVERSATIONS_SELECTED_ALERT') }}
       </div>
       <div
-        class="flex items-center justify-between p-2 bg-n-button-color outline outline-1 -outline-offset-1 rounded-[10px] outline-n-weak shadow-[0_0_12px_0_rgba(27,40,59,0.08)]"
+        class="flex items-center justify-between gap-2 p-2 bg-n-button-color outline outline-1 -outline-offset-1 rounded-[10px] outline-n-weak shadow-[0_0_12px_0_rgba(27,40,59,0.08)]"
       >
-        <div class="ltr:ml-0.5 rtl:mr-0.5 flex items-center gap-1">
-          <label class="cursor-pointer flex items-center gap-1.5">
+        <div class="ms-0.5 flex items-center gap-1 min-w-0">
+          <label class="cursor-pointer flex items-center gap-1.5 min-w-0">
             <Checkbox
               v-model="allSelected"
               :indeterminate="!allConversationsSelected"
+              class="flex-shrink-0"
             />
-            <span class="cursor-pointer">
-              {{
-                $t('BULK_ACTION.CONVERSATIONS_SELECTED', {
-                  conversationCount: conversations.length,
-                })
-              }}
+            <span :title="selectedLabel" class="cursor-pointer truncate">
+              {{ selectedLabel }}
             </span>
           </label>
-          <div class="w-px h-3 bg-n-weak rounded-lg ltr:ml-1 rtl:mr-1" />
+          <div class="w-px h-3 bg-n-weak rounded-lg ms-1 flex-shrink-0" />
           <NextButton
             :label="$t('BULK_ACTION.CLEAR_SELECTION')"
             ghost
-            class="!text-n-blue-11 !px-1 !h-6"
+            class="!text-n-blue-11 !px-1 !h-6 flex-shrink-0"
             sm
             @click="allSelected = false"
           />
         </div>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 flex-shrink-0">
           <BulkLabelActions @assign="onAssignLabels" />
           <BulkLabelActions
             action="remove"


### PR DESCRIPTION
# Pull Request Template

## Description

The conversation bulk action bar now stays on a single line even in languages with longer translations. The selection count truncates with an ellipsis when needed and shows the full text on hover, while the "Clear selection" button always keeps its full label instead of being clipped.

Fixes https://linear.app/chatwoot/issue/CW-7844/bulk-action-bar-breaks-with-longer-translated-text

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

#### Screenshots

**Before**
<img width="419" height="124" alt="image" src="https://github.com/user-attachments/assets/17c10a84-032f-4f13-bcf7-6db8f8a341d7" />


**After**
<img width="419" height="124" alt="image" src="https://github.com/user-attachments/assets/c0735feb-dee5-4b00-81c7-ed97d644b495" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
