### PR TITLE
fix: make the changelog card visible in dark mode

### DIFF
--- a/app/javascript/dashboard/components-next/changelog-card/StackedChangelogCard.vue
+++ b/app/javascript/dashboard/components-next/changelog-card/StackedChangelogCard.vue
@@ -34,7 +34,7 @@ const handleImgClick = () => {
 <template>
   <div
     data-testid="changelog-card"
-    class="flex flex-col justify-between p-3 w-full rounded-lg border shadow-sm transition-all duration-200 border-n-weak bg-n-card text-n-slate-12"
+    class="flex flex-col justify-between p-3 w-full rounded-lg border shadow-sm transition-all duration-200 border-n-weak bg-n-card dark:bg-n-solid-1 text-n-slate-12"
     :class="{
       'animate-fade-out pointer-events-none': isDismissing,
       'hover:shadow': isActive,


### PR DESCRIPTION
# Pull Request Template

## Description


The sidebar changelog card is now properly visible in dark mode. Its background has been updated to provide enough contrast with the sidebar, making both the card and the stacked cards behind it clearly distinguishable.


Fixes https://linear.app/chatwoot/issue/CW-7845/changelog-card-is-invisible-in-dark-mode

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

#### Screenshots

**Before**
<img width="215" height="359" alt="image" src="https://github.com/user-attachments/assets/f25ac954-22c2-4b32-83b6-d64b25527267" />


**After**
<img width="215" height="359" alt="image" src="https://github.com/user-attachments/assets/77073aef-52a5-4cbe-b074-898b07a7f3dc" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
