### PR TITLE
fix: add default names to data imports

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -64,6 +64,7 @@ class DataImport < ApplicationRecord
   has_one_attached :import_file
   has_one_attached :failed_records
 
+  before_validation :set_default_name, on: :create
   after_create_commit :process_data_import
 
   def legacy_contacts_csv_import?
@@ -123,6 +124,12 @@ class DataImport < ApplicationRecord
   end
 
   private
+
+  def set_default_name
+    return if name.present? || data_type.blank?
+
+    self.name = "#{data_type.titleize} - #{Date.current.iso8601}"
+  end
 
   def process_data_import
     return unless legacy_contacts_csv_import?


### PR DESCRIPTION
Data imports created without a name now receive a readable default such as `Contacts - 2026-08-06`. This prevents legacy CSV contact imports from appearing as `Untitled import` under Settings → Data while preserving names supplied by users or other import providers.

### Closes

- [CW-7877](https://linear.app/chatwoot/issue/CW-7877/add-default-names-for-unnamed-data-imports)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

1. Create a contact CSV import without supplying a name.
2. Open Settings → Data and confirm its name follows `Contacts - YYYY-MM-DD`.
3. Create an import with an explicit name and confirm that name remains unchanged.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
