### PR TITLE
feat: enable data imports for paid plans

### DIFF
--- a/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
+++ b/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
@@ -19,6 +19,7 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
     linear_integration
     channel_voice
     api_and_webhooks
+    data_import
   ].freeze
 
   BUSINESS_PLAN_FEATURES = %w[


### PR DESCRIPTION
Data Imports is now part of the shared paid-plan entitlement set. Startups, Business, and Enterprise accounts receive the feature through billing reconciliation, while Hacker/default accounts remain gated and the existing API/UI feature checks stay unchanged.

### Closes

- [CW-7878](https://linear.app/chatwoot/issue/CW-7878/enable-data-imports-for-all-paid-cloud-plans)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

1. Reconcile a Hacker account and confirm Data Imports remains disabled.
2. Reconcile Startups, Business, and Enterprise accounts and confirm Data Imports is enabled for each paid tier.
3. Exercise the Stripe subscription update path and confirm the same plan hierarchy is applied.

## Rollout

Existing paid accounts need a one-time reconciliation after deployment. Run the following in the Rails console:

```rb
paid_plan_names = InstallationConfig.find_by!(name: 'CHATWOOT_CLOUD_PLANS').value.drop(1).pluck('name')
paid_accounts = Account.where("custom_attributes ->> 'plan_name' IN (?)", paid_plan_names)

puts "Reconciling #{paid_accounts.count} paid accounts"

paid_accounts.find_each do |account|
  Enterprise::Billing::ReconcilePlanFeaturesService.new(account: account).perform
end
```

Future plan changes and subscription renewals are handled by the normal Stripe reconciliation path.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
