### PR TITLE
fix(whatsapp): correctly sync Twilio template approval status

### DIFF
--- a/app/services/twilio/template_sync_service.rb
+++ b/app/services/twilio/template_sync_service.rb
@@ -48,7 +48,7 @@ class Twilio::TemplateSyncService
   end
 
   def derive_status(template)
-    template.approval_requests&.dig('whatsapp', 'status')&.downcase || 'unsubmitted'
+    template.approval_requests&.dig('status')&.downcase || 'unsubmitted'
   end
 
   def derive_template_type(template)

--- a/spec/services/twilio/template_sync_service_spec.rb
+++ b/spec/services/twilio/template_sync_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Twilio::TemplateSyncService do
   let(:twilio_client) { instance_double(Twilio::REST::Client) }
   let(:content_api) { double }
   let(:content_and_approvals_list) { double }
-  let(:approval_requests) { { 'whatsapp' => { 'status' => 'approved' } } }
+  let(:approval_requests) { { 'status' => 'approved' } }
 
   # Mock Twilio template objects
   let(:text_template) do
@@ -159,7 +159,7 @@ RSpec.describe Twilio::TemplateSyncService do
       end
 
       context 'when a template has a non-approved WhatsApp status' do
-        let(:approval_requests) { { 'whatsapp' => { 'status' => 'rejected' } } }
+        let(:approval_requests) { { 'status' => 'rejected' } }
 
         it 'stores the provider approval status' do
           sync_service.call


### PR DESCRIPTION
Twilio WhatsApp templates can be approved in Twilio but cached as `unsubmitted` in Chatwoot. This hides valid templates from the composer and prevents API template sends from finding them.

Twilio's `ContentAndApprovals` response exposes the WhatsApp approval fields directly in `approval_requests`, while the sync service expected an additional nested `whatsapp` object. This change reads the provider's top-level status and aligns the existing fixtures with the live response shape. Native WhatsApp template synchronization and Twilio send payloads remain unchanged.

Fixes https://github.com/chatwoot/chatwoot/issues/15350

### Things to know

- Existing cached statuses are corrected on the next successful Twilio template sync.
- Templates without an approval status continue to be stored as `unsubmitted`.

### How to reproduce

1. Configure a Twilio WhatsApp inbox with an approved Content Template.
2. Run the inbox template sync.
3. Observe that the approved template is cached as `unsubmitted` and is unavailable for sending.

### How to test

1. Sync a Twilio WhatsApp inbox containing approved, rejected, and unsubmitted templates.
2. Confirm each template retains the status returned by Twilio.
3. Confirm approved templates appear in the template picker and can be selected for sending.