### PR TITLE
fix(whatsapp): return empty template arrays for malformed inbox data

### DIFF
--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -132,7 +132,8 @@ json.bot_name resource.channel.try(:bot_name) if resource.telegram?
 
 ### WhatsApp Channel
 if resource.whatsapp?
-  json.message_templates resource.channel.try(:message_templates)
+  message_templates = resource.channel.try(:message_templates)
+  json.message_templates message_templates.is_a?(Array) ? message_templates : []
   json.provider_config resource.channel.try(:provider_config) if Current.account_user&.administrator?
   if Current.account_user&.administrator? &&
      ChatwootApp.chatwoot_cloud? &&


### PR DESCRIPTION
WhatsApp inbox responses now return an empty template list when the stored `message_templates` value is not an array. This prevents mobile clients from receiving the legacy/default object shape that can crash the WhatsApp reply box.

Valid template arrays remain unchanged.

Related: https://github.com/chatwoot/chatwoot-mobile-app/pull/1127

### Things to know

- No database migration or backfill is included.
- This does not change the web template-button behavior; that can be handled separately.

### How to reproduce

1. In a local environment, set a WhatsApp inbox's `message_templates` value to `{}`.
2. Load the inbox API response and open one of its conversations in the mobile app.
3. Confirm the response contains `message_templates: []` and the reply box does not crash.
4. Repeat with a valid template array and confirm the templates are preserved.