### PR TITLE
feat: back off IMAP fetch for repeatedly failing inboxes

### DIFF
--- a/app/jobs/inboxes/fetch_imap_email_inboxes_job.rb
+++ b/app/jobs/inboxes/fetch_imap_email_inboxes_job.rb
@@ -18,6 +18,7 @@ class Inboxes::FetchImapEmailInboxesJob < ApplicationJob
     return false if inbox.account.suspended?
     return false unless inbox.channel.imap_enabled
     return false if inbox.channel.reauthorization_required?
+    return false if inbox.channel.imap_fetch_paused?
 
     return true unless ChatwootApp.chatwoot_cloud?
     return false if default_plan?(inbox.account)

--- a/app/jobs/inboxes/fetch_imap_emails_job.rb
+++ b/app/jobs/inboxes/fetch_imap_emails_job.rb
@@ -10,7 +10,7 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
 
     fetch_mails_with_lock(channel, interval)
   rescue *ExceptionList::IMAP_EXCEPTIONS => e
-    Rails.logger.error "Authorization error for email channel - #{channel.inbox.id} : #{e.message}"
+    Rails.logger.error "Fetch error (network/protocol) for email channel - #{channel.inbox.id} : #{e.message}"
     channel.imap_fetch_error!
   rescue IOError, OpenSSL::SSL::SSLError, Net::IMAP::NoResponseError, Net::IMAP::BadResponseError, Net::IMAP::InvalidResponseError,
          Net::IMAP::ResponseParseError, Net::IMAP::ResponseReadError, Net::IMAP::ResponseTooLargeError => e
@@ -31,7 +31,7 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
   def handle_unexpected_error(error, channel)
     Rails.logger.error "[IMAP::FETCH_EMAIL_SERVICE] Unexpected error for inbox #{channel.inbox.id} : #{error.class} - #{error.message}"
     ChatwootExceptionTracker.new(error, account: channel.account).capture_exception
-    channel.imap_fetch_error! if error.is_a?(SystemCallError) || error.is_a?(SocketError)
+    channel.imap_fetch_error! if error.is_a?(SystemCallError) || error.is_a?(Timeout::Error)
   end
 
   def fetch_mails_with_lock(channel, interval)
@@ -79,9 +79,14 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
     Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Finished processing fetched emails for inbox #{channel.inbox.id}"
     true
   rescue OAuth2::Error => e
-    Rails.logger.error "[IMAP::FETCH_EMAIL_SERVICE] OAuth error for inbox #{channel.inbox.id} : #{e.message}"
-    channel.authorization_error!
+    handle_oauth_error(e, channel)
     false
+  end
+
+  def handle_oauth_error(error, channel)
+    Rails.logger.error "[IMAP::FETCH_EMAIL_SERVICE] OAuth error for inbox #{channel.inbox.id} : #{error.message}"
+    channel.authorization_error!
+    channel.imap_fetch_error!
   end
 
   def should_skip_email?(message_id)

--- a/app/jobs/inboxes/fetch_imap_emails_job.rb
+++ b/app/jobs/inboxes/fetch_imap_emails_job.rb
@@ -25,7 +25,7 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
   private
 
   def should_fetch_email?(channel)
-    channel.imap_enabled? && !channel.reauthorization_required?
+    channel.imap_enabled? && !channel.reauthorization_required? && !channel.imap_fetch_paused?
   end
 
   def handle_unexpected_error(error, channel)
@@ -57,7 +57,8 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
 
   def log_skipped_fetch(channel)
     Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Skipping fetch for #{channel.inbox.id} : " \
-                      "imap_enabled: #{channel.imap_enabled?}, reauthorization_required: #{channel.reauthorization_required?}"
+                      "imap_enabled: #{channel.imap_enabled?}, reauthorization_required: #{channel.reauthorization_required?}, " \
+                      "imap_fetch_paused: #{channel.imap_fetch_paused?}"
   end
 
   def process_email_for_channel(channel, interval)

--- a/app/jobs/inboxes/fetch_imap_emails_job.rb
+++ b/app/jobs/inboxes/fetch_imap_emails_job.rb
@@ -11,9 +11,11 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
     fetch_mails_with_lock(channel, interval)
   rescue *ExceptionList::IMAP_EXCEPTIONS => e
     Rails.logger.error "Authorization error for email channel - #{channel.inbox.id} : #{e.message}"
+    channel.imap_fetch_error!
   rescue IOError, OpenSSL::SSL::SSLError, Net::IMAP::NoResponseError, Net::IMAP::BadResponseError, Net::IMAP::InvalidResponseError,
          Net::IMAP::ResponseParseError, Net::IMAP::ResponseReadError, Net::IMAP::ResponseTooLargeError => e
     Rails.logger.error "Error for email channel - #{channel.inbox.id} : #{e.message}"
+    channel.imap_fetch_error!
   rescue LockAcquisitionError
     Rails.logger.error "Lock failed for #{channel.inbox.id}"
   rescue StandardError => e
@@ -29,6 +31,7 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
   def handle_unexpected_error(error, channel)
     Rails.logger.error "[IMAP::FETCH_EMAIL_SERVICE] Unexpected error for inbox #{channel.inbox.id} : #{error.class} - #{error.message}"
     ChatwootExceptionTracker.new(error, account: channel.account).capture_exception
+    channel.imap_fetch_error! if error.is_a?(SystemCallError) || error.is_a?(SocketError)
   end
 
   def fetch_mails_with_lock(channel, interval)
@@ -45,6 +48,7 @@ class Inboxes::FetchImapEmailsJob < MutexApplicationJob
 
     duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at).round(1)
     if success
+      channel.clear_imap_fetch_backoff!
       Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Job completed for inbox #{inbox_id} in #{duration}s"
     else
       Rails.logger.error "[IMAP::FETCH_EMAIL_SERVICE] Job completed with authorization error for inbox #{inbox_id} in #{duration}s"

--- a/app/models/channel/email.rb
+++ b/app/models/channel/email.rb
@@ -54,7 +54,8 @@ class Channel::Email < ApplicationRecord
                     :smtp_enabled, :smtp_login, :smtp_password, :smtp_address, :smtp_port, :smtp_domain, :smtp_enable_starttls_auto,
                     :smtp_enable_ssl_tls, :smtp_openssl_verify_mode, :smtp_authentication, :provider, :verified_for_sending].freeze
 
-  IMAP_SETTINGS_ATTRS = %w[imap_enabled imap_address imap_port imap_login imap_password imap_enable_ssl imap_authentication].freeze
+  IMAP_SETTINGS_ATTRS = %w[imap_enabled imap_address imap_port imap_login imap_password imap_enable_ssl imap_authentication
+                           provider provider_config].freeze
 
   validates :email, uniqueness: true
   validates :forward_to_email, uniqueness: true
@@ -72,7 +73,8 @@ class Channel::Email < ApplicationRecord
 
   # update_columns keeps internal retry bookkeeping out of audit logs
   def imap_fetch_error!
-    count = imap_fetch_error_count + 1
+    # read the persisted count, the in-memory value can be stale on long-running jobs
+    count = self.class.where(id: id).pick(:imap_fetch_error_count).to_i + 1
     update_columns(imap_fetch_error_count: count, imap_fetch_paused_till: imap_fetch_backoff_period(count)&.from_now) # rubocop:disable Rails/SkipsModelValidations
   end
 

--- a/app/models/channel/email.rb
+++ b/app/models/channel/email.rb
@@ -9,6 +9,8 @@
 #  imap_authentication       :string           default("plain")
 #  imap_enable_ssl           :boolean          default(TRUE)
 #  imap_enabled              :boolean          default(FALSE)
+#  imap_fetch_error_count    :integer          default(0), not null
+#  imap_fetch_paused_till    :datetime
 #  imap_login                :string           default("")
 #  imap_password             :string           default("")
 #  imap_port                 :integer          default(0)
@@ -52,13 +54,31 @@ class Channel::Email < ApplicationRecord
                     :smtp_enabled, :smtp_login, :smtp_password, :smtp_address, :smtp_port, :smtp_domain, :smtp_enable_starttls_auto,
                     :smtp_enable_ssl_tls, :smtp_openssl_verify_mode, :smtp_authentication, :provider, :verified_for_sending].freeze
 
+  IMAP_SETTINGS_ATTRS = %w[imap_enabled imap_address imap_port imap_login imap_password imap_enable_ssl imap_authentication].freeze
+
   validates :email, uniqueness: true
   validates :forward_to_email, uniqueness: true
 
   before_validation :ensure_forward_to_email, on: :create
+  before_save :clear_imap_fetch_backoff, if: :imap_settings_changed?
 
   def name
     'Email'
+  end
+
+  def imap_fetch_paused?
+    imap_fetch_paused_till.present? && imap_fetch_paused_till.future?
+  end
+
+  def imap_fetch_error!
+    count = imap_fetch_error_count + 1
+    update!(imap_fetch_error_count: count, imap_fetch_paused_till: imap_fetch_backoff_period(count)&.from_now)
+  end
+
+  def clear_imap_fetch_backoff!
+    return if imap_fetch_error_count.zero? && imap_fetch_paused_till.nil?
+
+    update!(imap_fetch_error_count: 0, imap_fetch_paused_till: nil)
   end
 
   def microsoft?
@@ -77,5 +97,24 @@ class Channel::Email < ApplicationRecord
 
   def ensure_forward_to_email
     self.forward_to_email ||= "#{SecureRandom.hex}@#{account.inbound_email_domain}"
+  end
+
+  # first two failures are tolerated as transient blips, 60 minutes doubles as the probe cadence
+  def imap_fetch_backoff_period(count)
+    case count
+    when 0..2 then nil
+    when 3 then 5.minutes
+    when 4 then 15.minutes
+    else 60.minutes
+    end
+  end
+
+  def imap_settings_changed?
+    changed_attribute_names_to_save.intersect?(IMAP_SETTINGS_ATTRS)
+  end
+
+  def clear_imap_fetch_backoff
+    self.imap_fetch_error_count = 0
+    self.imap_fetch_paused_till = nil
   end
 end

--- a/app/models/channel/email.rb
+++ b/app/models/channel/email.rb
@@ -70,15 +70,16 @@ class Channel::Email < ApplicationRecord
     imap_fetch_paused_till.present? && imap_fetch_paused_till.future?
   end
 
+  # update_columns keeps internal retry bookkeeping out of audit logs
   def imap_fetch_error!
     count = imap_fetch_error_count + 1
-    update!(imap_fetch_error_count: count, imap_fetch_paused_till: imap_fetch_backoff_period(count)&.from_now)
+    update_columns(imap_fetch_error_count: count, imap_fetch_paused_till: imap_fetch_backoff_period(count)&.from_now) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def clear_imap_fetch_backoff!
     return if imap_fetch_error_count.zero? && imap_fetch_paused_till.nil?
 
-    update!(imap_fetch_error_count: 0, imap_fetch_paused_till: nil)
+    update_columns(imap_fetch_error_count: 0, imap_fetch_paused_till: nil) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def microsoft?

--- a/app/models/channel/email.rb
+++ b/app/models/channel/email.rb
@@ -54,8 +54,8 @@ class Channel::Email < ApplicationRecord
                     :smtp_enabled, :smtp_login, :smtp_password, :smtp_address, :smtp_port, :smtp_domain, :smtp_enable_starttls_auto,
                     :smtp_enable_ssl_tls, :smtp_openssl_verify_mode, :smtp_authentication, :provider, :verified_for_sending].freeze
 
-  IMAP_SETTINGS_ATTRS = %w[imap_enabled imap_address imap_port imap_login imap_password imap_enable_ssl imap_authentication
-                           provider provider_config].freeze
+  # provider_config is deliberately excluded, routine OAuth token refreshes update it
+  IMAP_SETTINGS_ATTRS = %w[imap_enabled imap_address imap_port imap_login imap_password imap_enable_ssl imap_authentication provider].freeze
 
   validates :email, uniqueness: true
   validates :forward_to_email, uniqueness: true
@@ -82,6 +82,11 @@ class Channel::Email < ApplicationRecord
     return if imap_fetch_error_count.zero? && imap_fetch_paused_till.nil?
 
     update_columns(imap_fetch_error_count: 0, imap_fetch_paused_till: nil) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def reauthorized!
+    clear_imap_fetch_backoff!
+    super
   end
 
   def microsoft?

--- a/db/migrate/20260806000000_add_imap_fetch_backoff_to_channel_email.rb
+++ b/db/migrate/20260806000000_add_imap_fetch_backoff_to_channel_email.rb
@@ -1,0 +1,6 @@
+class AddImapFetchBackoffToChannelEmail < ActiveRecord::Migration[7.1]
+  def change
+    add_column :channel_email, :imap_fetch_error_count, :integer, default: 0, null: false
+    add_column :channel_email, :imap_fetch_paused_till, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_04_000003) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_06_000000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -579,6 +579,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_04_000003) do
     t.string "provider"
     t.string "imap_authentication", default: "plain"
     t.boolean "verified_for_sending", default: false, null: false
+    t.integer "imap_fetch_error_count", default: 0, null: false
+    t.datetime "imap_fetch_paused_till"
     t.index ["email"], name: "index_channel_email_on_email", unique: true
     t.index ["forward_to_email"], name: "index_channel_email_on_forward_to_email", unique: true
   end

--- a/spec/jobs/inboxes/fetch_imap_email_inboxes_job_spec.rb
+++ b/spec/jobs/inboxes/fetch_imap_email_inboxes_job_spec.rb
@@ -64,5 +64,21 @@ RSpec.describe Inboxes::FetchImapEmailInboxesJob do
 
       described_class.perform_now
     end
+
+    it 'skips channels paused for imap fetch backoff' do
+      imap_email_channel.update!(imap_fetch_paused_till: 5.minutes.from_now)
+
+      expect(Inboxes::FetchImapEmailsJob).not_to receive(:perform_later).with(imap_email_channel)
+
+      described_class.perform_now
+    end
+
+    it 'fetches channels whose imap fetch pause has expired' do
+      imap_email_channel.update!(imap_fetch_paused_till: 5.minutes.ago)
+
+      expect(Inboxes::FetchImapEmailsJob).to receive(:perform_later).with(imap_email_channel).once
+
+      described_class.perform_now
+    end
   end
 end

--- a/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
+++ b/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
@@ -87,6 +87,75 @@ RSpec.describe Inboxes::FetchImapEmailsJob do
       end
     end
 
+    context 'when the IMAP fetch fails' do
+      it 'records a fetch error on connection errors' do
+        allow(Imap::FetchEmailService).to receive(:new).and_raise(Errno::ECONNREFUSED)
+
+        expect do
+          described_class.perform_now(imap_email_channel)
+        end.to change { imap_email_channel.reload.imap_fetch_error_count }.by(1)
+      end
+
+      it 'records a fetch error on SSL errors' do
+        allow(Imap::FetchEmailService).to receive(:new).and_raise(OpenSSL::SSL::SSLError)
+
+        expect do
+          described_class.perform_now(imap_email_channel)
+        end.to change { imap_email_channel.reload.imap_fetch_error_count }.by(1)
+      end
+
+      it 'records a fetch error when a connection error reaches the generic handler' do
+        allow(Imap::FetchEmailService).to receive(:new).and_raise(Errno::ETIMEDOUT)
+        allow(ChatwootExceptionTracker).to receive(:new).and_return(instance_double(ChatwootExceptionTracker, capture_exception: true))
+
+        expect do
+          described_class.perform_now(imap_email_channel)
+        end.to change { imap_email_channel.reload.imap_fetch_error_count }.by(1)
+      end
+
+      it 'does not record a fetch error for non-connection unexpected errors' do
+        allow(Imap::FetchEmailService).to receive(:new).and_raise(StandardError)
+        allow(ChatwootExceptionTracker).to receive(:new).and_return(instance_double(ChatwootExceptionTracker, capture_exception: true))
+
+        expect do
+          described_class.perform_now(imap_email_channel)
+        end.not_to(change { imap_email_channel.reload.imap_fetch_error_count })
+      end
+
+      it 'does not record a fetch error when the lock cannot be acquired' do
+        lock_manager = instance_double(Redis::LockManager, lock: false)
+        allow(Redis::LockManager).to receive(:new).and_return(lock_manager)
+
+        expect do
+          described_class.perform_now(imap_email_channel)
+        end.not_to(change { imap_email_channel.reload.imap_fetch_error_count })
+      end
+
+      it 'pauses the channel after the third consecutive failure' do
+        imap_email_channel.update!(imap_fetch_error_count: 2)
+        allow(Imap::FetchEmailService).to receive(:new).and_raise(Errno::ECONNREFUSED)
+
+        described_class.perform_now(imap_email_channel)
+
+        expect(imap_email_channel.reload.imap_fetch_paused_till).to be_within(10.seconds).of(5.minutes.from_now)
+      end
+    end
+
+    context 'when the IMAP fetch succeeds after failures' do
+      it 'resets the backoff state' do
+        imap_email_channel.update!(imap_fetch_error_count: 4, imap_fetch_paused_till: 1.minute.ago)
+
+        fetch_service = double
+        allow(Imap::FetchEmailService).to receive(:new).with(channel: imap_email_channel, interval: 1).and_return(fetch_service)
+        allow(fetch_service).to receive(:perform).and_return([])
+
+        described_class.perform_now(imap_email_channel)
+
+        expect(imap_email_channel.reload.imap_fetch_error_count).to eq(0)
+        expect(imap_email_channel.imap_fetch_paused_till).to be_nil
+      end
+    end
+
     context 'when the fetch service returns the email objects' do
       let(:inbound_mail) { instance_double(Mail::Message, message_id: 'message-id') }
       let(:failure_cache_key) { "email_failures:#{inbound_mail.message_id}" }

--- a/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
+++ b/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
@@ -87,6 +87,16 @@ RSpec.describe Inboxes::FetchImapEmailsJob do
       end
     end
 
+    context 'when the channel is paused for fetch backoff' do
+      it 'does not fetch emails' do
+        imap_email_channel.update!(imap_fetch_paused_till: 5.minutes.from_now)
+
+        expect(Imap::FetchEmailService).not_to receive(:new)
+
+        described_class.perform_now(imap_email_channel)
+      end
+    end
+
     context 'when the IMAP fetch fails' do
       it 'records a fetch error on connection errors' do
         allow(Imap::FetchEmailService).to receive(:new).and_raise(Errno::ECONNREFUSED)

--- a/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
+++ b/spec/jobs/inboxes/fetch_imap_emails_job_spec.rb
@@ -85,6 +85,19 @@ RSpec.describe Inboxes::FetchImapEmailsJob do
 
         described_class.perform_now(microsoft_imap_email_channel)
       end
+
+      it 'records a fetch error' do
+        error_response = double
+        oauth_error = OAuth2::Error.new(error_response)
+
+        allow(Imap::MicrosoftFetchEmailService).to receive(:new)
+          .with(channel: microsoft_imap_email_channel, interval: 1)
+          .and_raise(oauth_error)
+
+        expect do
+          described_class.perform_now(microsoft_imap_email_channel)
+        end.to change { microsoft_imap_email_channel.reload.imap_fetch_error_count }.by(1)
+      end
     end
 
     context 'when the channel is paused for fetch backoff' do
@@ -108,6 +121,15 @@ RSpec.describe Inboxes::FetchImapEmailsJob do
 
       it 'records a fetch error on SSL errors' do
         allow(Imap::FetchEmailService).to receive(:new).and_raise(OpenSSL::SSL::SSLError)
+
+        expect do
+          described_class.perform_now(imap_email_channel)
+        end.to change { imap_email_channel.reload.imap_fetch_error_count }.by(1)
+      end
+
+      it 'records a fetch error on read timeouts' do
+        allow(Imap::FetchEmailService).to receive(:new).and_raise(Net::ReadTimeout)
+        allow(ChatwootExceptionTracker).to receive(:new).and_return(instance_double(ChatwootExceptionTracker, capture_exception: true))
 
         expect do
           described_class.perform_now(imap_email_channel)

--- a/spec/models/channel/email_spec.rb
+++ b/spec/models/channel/email_spec.rb
@@ -74,6 +74,14 @@ RSpec.describe Channel::Email do
         expect(channel.reload.imap_fetch_paused_till).to be_within(10.seconds).of(15.minutes.from_now)
       end
 
+      it 'increments from the persisted count when the in-memory value is stale' do
+        stale_channel = described_class.find(channel.id)
+        channel.imap_fetch_error!
+        stale_channel.imap_fetch_error!
+
+        expect(channel.reload.imap_fetch_error_count).to eq(2)
+      end
+
       it 'does not run update callbacks for backoff bookkeeping' do
         expect(channel).not_to receive(:create_audit_log_entry)
 
@@ -104,6 +112,13 @@ RSpec.describe Channel::Email do
 
       it 'resets backoff when imap settings are updated' do
         channel.update!(imap_address: 'imap.example.com')
+
+        expect(channel.reload.imap_fetch_error_count).to eq(0)
+        expect(channel.imap_fetch_paused_till).to be_nil
+      end
+
+      it 'resets backoff when provider_config is updated' do
+        channel.update!(provider_config: { access_token: 'new-token' })
 
         expect(channel.reload.imap_fetch_error_count).to eq(0)
         expect(channel.imap_fetch_paused_till).to be_nil

--- a/spec/models/channel/email_spec.rb
+++ b/spec/models/channel/email_spec.rb
@@ -74,6 +74,12 @@ RSpec.describe Channel::Email do
         expect(channel.reload.imap_fetch_paused_till).to be_within(10.seconds).of(15.minutes.from_now)
       end
 
+      it 'does not run update callbacks for backoff bookkeeping' do
+        expect(channel).not_to receive(:create_audit_log_entry)
+
+        expect { channel.imap_fetch_error! }.not_to(change { channel.reload.updated_at })
+      end
+
       it 'caps the pause at 60 minutes from the fifth failure onwards' do
         7.times { channel.imap_fetch_error! }
 

--- a/spec/models/channel/email_spec.rb
+++ b/spec/models/channel/email_spec.rb
@@ -117,11 +117,17 @@ RSpec.describe Channel::Email do
         expect(channel.imap_fetch_paused_till).to be_nil
       end
 
-      it 'resets backoff when provider_config is updated' do
-        channel.update!(provider_config: { access_token: 'new-token' })
+      it 'resets backoff on reauthorization' do
+        channel.reauthorized!
 
         expect(channel.reload.imap_fetch_error_count).to eq(0)
         expect(channel.imap_fetch_paused_till).to be_nil
+      end
+
+      it 'does not reset backoff on routine provider_config token refreshes' do
+        channel.update!(provider_config: { access_token: 'new-token' })
+
+        expect(channel.reload.imap_fetch_error_count).to eq(5)
       end
 
       it 'does not reset backoff when unrelated attributes are updated' do

--- a/spec/models/channel/email_spec.rb
+++ b/spec/models/channel/email_spec.rb
@@ -36,6 +36,82 @@ RSpec.describe Channel::Email do
     end
   end
 
+  describe 'imap fetch backoff' do
+    describe '#imap_fetch_paused?' do
+      it 'returns false when paused_till is not set' do
+        expect(channel.imap_fetch_paused?).to be(false)
+      end
+
+      it 'returns false when paused_till is in the past' do
+        channel.update!(imap_fetch_paused_till: 5.minutes.ago)
+        expect(channel.imap_fetch_paused?).to be(false)
+      end
+
+      it 'returns true when paused_till is in the future' do
+        channel.update!(imap_fetch_paused_till: 5.minutes.from_now)
+        expect(channel.imap_fetch_paused?).to be(true)
+      end
+    end
+
+    describe '#imap_fetch_error!' do
+      it 'does not pause on the first two failures' do
+        2.times { channel.imap_fetch_error! }
+
+        expect(channel.reload.imap_fetch_error_count).to eq(2)
+        expect(channel.imap_fetch_paused_till).to be_nil
+      end
+
+      it 'pauses for 5 minutes on the third failure' do
+        3.times { channel.imap_fetch_error! }
+
+        expect(channel.reload.imap_fetch_error_count).to eq(3)
+        expect(channel.imap_fetch_paused_till).to be_within(10.seconds).of(5.minutes.from_now)
+      end
+
+      it 'pauses for 15 minutes on the fourth failure' do
+        4.times { channel.imap_fetch_error! }
+
+        expect(channel.reload.imap_fetch_paused_till).to be_within(10.seconds).of(15.minutes.from_now)
+      end
+
+      it 'caps the pause at 60 minutes from the fifth failure onwards' do
+        7.times { channel.imap_fetch_error! }
+
+        expect(channel.reload.imap_fetch_error_count).to eq(7)
+        expect(channel.imap_fetch_paused_till).to be_within(10.seconds).of(60.minutes.from_now)
+      end
+    end
+
+    describe '#clear_imap_fetch_backoff!' do
+      it 'resets the error count and pause' do
+        5.times { channel.imap_fetch_error! }
+
+        channel.clear_imap_fetch_backoff!
+
+        expect(channel.reload.imap_fetch_error_count).to eq(0)
+        expect(channel.imap_fetch_paused_till).to be_nil
+      end
+    end
+
+    describe 'reset on imap settings change' do
+      before { 5.times { channel.imap_fetch_error! } }
+
+      it 'resets backoff when imap settings are updated' do
+        channel.update!(imap_address: 'imap.example.com')
+
+        expect(channel.reload.imap_fetch_error_count).to eq(0)
+        expect(channel.imap_fetch_paused_till).to be_nil
+      end
+
+      it 'does not reset backoff when unrelated attributes are updated' do
+        channel.update!(smtp_address: 'smtp.example.com')
+
+        expect(channel.reload.imap_fetch_error_count).to eq(5)
+        expect(channel.imap_fetch_paused_till).to be_present
+      end
+    end
+  end
+
   context 'when google?' do
     it 'returns false' do
       expect(channel.google?).to be(false)


### PR DESCRIPTION
# Pull Request Template

## Description

The IMAP fetch scheduler enqueues a fetch job for every IMAP-enabled inbox each minute. When a remote IMAP server is unreachable or misconfigured (connection refused, timeouts, SSL or protocol errors), the job logs the error and retries on the next tick indefinitely, roughly 1,440 failed connection attempts per day per broken inbox. Mail providers can read this pattern of repeated failed logins as brute force and block or report the sender IP.

This PR adds a per-channel backoff for failing IMAP fetches:

- New columns on `channel_email`: `imap_fetch_error_count` and `imap_fetch_paused_till`.
- Connection-level fetch failures increment the counter and pause scheduling with an escalating backoff: first two failures are tolerated (no pause), 3rd pauses 5 minutes, 4th pauses 15 minutes, 5th onwards 60 minutes (cap, which also acts as the probe cadence for permanently broken remotes).
- `Inboxes::FetchImapEmailInboxesJob` skips paused channels at enqueue time, and `Inboxes::FetchImapEmailsJob` re-checks the pause so already-queued jobs also skip.
- Backoff state is persisted with `update_columns` so internal retry bookkeeping does not generate audit log entries.
- OAuth fetch failures also count toward the backoff (the existing reauthorization flow is unchanged).
- A successful fetch resets the backoff state. Lock contention (`LockAcquisitionError`) is not counted as a failure.
- Updating IMAP settings or reauthorizing the channel clears the backoff, so a fixed configuration resumes syncing immediately. Routine OAuth token refreshes do not clear it.

Fixes https://linear.app/chatwoot/issue/CW-7881

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- `bundle exec rspec spec/jobs/inboxes/ spec/models/channel/email_spec.rb` covering: skip when paused, no pause on first two failures, 5/15/60 minute escalation and cap, reset on success, lock failures not counted, reset on IMAP settings change.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
