### PR TITLE
feat: classify outbound email send errors and add deferred message state [1/2]

### DIFF
--- a/app/javascript/dashboard/components-next/message/MessageMeta.vue
+++ b/app/javascript/dashboard/components-next/message/MessageMeta.vue
@@ -123,6 +123,7 @@ const isRead = computed(() => {
 });
 
 const statusToShow = computed(() => {
+  if (status.value === MESSAGE_STATUS.DEFERRED) return MESSAGE_STATUS.DEFERRED;
   if (isRead.value) return MESSAGE_STATUS.READ;
   if (isDelivered.value) return MESSAGE_STATUS.DELIVERED;
   if (isSent.value) return MESSAGE_STATUS.SENT;

--- a/app/javascript/dashboard/components-next/message/MessageStatus.vue
+++ b/app/javascript/dashboard/components-next/message/MessageStatus.vue
@@ -49,6 +49,7 @@ const statusIcon = computed(() => {
     [MESSAGE_STATUS.SENT]: 'i-lucide-check',
     [MESSAGE_STATUS.DELIVERED]: 'i-lucide-check-check',
     [MESSAGE_STATUS.READ]: 'i-lucide-check-check',
+    [MESSAGE_STATUS.DEFERRED]: 'i-lucide-history',
   };
 
   return statusIconMap[status];
@@ -59,6 +60,7 @@ const statusColor = computed(() => {
     [MESSAGE_STATUS.SENT]: 'text-n-slate-10',
     [MESSAGE_STATUS.DELIVERED]: 'text-n-slate-10',
     [MESSAGE_STATUS.READ]: 'text-[#7EB6FF]',
+    [MESSAGE_STATUS.DEFERRED]: 'text-n-slate-10',
   };
 
   return statusIconMap[status];
@@ -69,6 +71,7 @@ const tooltipText = computed(() => {
     [MESSAGE_STATUS.SENT]: t('CHAT_LIST.SENT'),
     [MESSAGE_STATUS.DELIVERED]: t('CHAT_LIST.DELIVERED'),
     [MESSAGE_STATUS.READ]: t('CHAT_LIST.MESSAGE_READ'),
+    [MESSAGE_STATUS.DEFERRED]: t('CHAT_LIST.DEFERRED'),
     [MESSAGE_STATUS.PROGRESS]: t('CHAT_LIST.SENDING'),
   };
 

--- a/app/javascript/dashboard/components-next/message/constants.js
+++ b/app/javascript/dashboard/components-next/message/constants.js
@@ -35,6 +35,7 @@ export const MESSAGE_STATUS = {
   DELIVERED: 'delivered',
   READ: 'read',
   FAILED: 'failed',
+  DEFERRED: 'deferred',
   PROGRESS: 'progress',
 };
 

--- a/app/javascript/dashboard/i18n/locale/en/chatlist.json
+++ b/app/javascript/dashboard/i18n/locale/en/chatlist.json
@@ -145,6 +145,7 @@
     "SHOW_QUOTED_TEXT": "Show Quoted Text",
     "MESSAGE_READ": "Read",
     "SENDING": "Sending",
+    "DEFERRED": "Waiting to retry",
     "UNREAD_COUNT_OVERFLOW": "9+"
   }
 }

--- a/app/javascript/shared/constants/messages.js
+++ b/app/javascript/shared/constants/messages.js
@@ -3,6 +3,7 @@ export const MESSAGE_STATUS = {
   SENT: 'sent',
   DELIVERED: 'delivered',
   READ: 'read',
+  DEFERRED: 'deferred',
   PROGRESS: 'progress',
 };
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -101,7 +101,10 @@ class Message < ApplicationRecord
     sticker: 11,
     voice_call: 12
   }
-  enum status: { sent: 0, delivered: 1, read: 2, failed: 3 }
+  # `deferred` (10) is introduced as foundation for send-error handling; the
+  # transition into it is wired up by a follow-up (CW-7882). Appended with an
+  # explicit integer so existing values keep their numbers.
+  enum status: { sent: 0, delivered: 1, read: 2, failed: 3, deferred: 10 }
   # [:submitted_email, :items, :submitted_values] : Used for bot message types
   # [:email] : Used by conversation_continuity incoming email messages
   # [:in_reply_to] : Used to reply to a particular tweet in threads

--- a/app/services/messages/status_update_service.rb
+++ b/app/services/messages/status_update_service.rb
@@ -26,6 +26,9 @@ class Messages::StatusUpdateService
   def valid_status_transition?
     return false unless Message.statuses.key?(status)
 
+    # `deferred` exists as foundation only; the transition into it is enabled by CW-7882.
+    return false if status.to_s == 'deferred'
+
     # Don't allow changing from 'read' to 'delivered'
     return false if message.read? && status == 'delivered'
 

--- a/app/services/provider_error_classifier.rb
+++ b/app/services/provider_error_classifier.rb
@@ -1,0 +1,78 @@
+require 'net/smtp'
+
+# Classifies an outbound provider error (SMTP / OAuth / HTTP) into a coarse
+# category so callers can decide how to react. This ticket only ships the
+# classification; retry behaviour is wired up separately (CW-7882).
+#
+#   ProviderErrorClassifier.classify(error) => Symbol
+#     :throttle   retryable rate-limit / slow-down
+#     :transient  network blip worth a limited retry
+#     :auth       credentials / permission problem
+#     :permanent  do not retry
+#     :unknown    unmatched, caller decides (default fail-fast)
+class ProviderErrorClassifier
+  TRANSIENT_ERRORS = [
+    Net::OpenTimeout, Net::ReadTimeout, Timeout::Error,
+    Errno::ECONNRESET, Errno::ECONNREFUSED, SocketError, IOError,
+    OpenSSL::SSL::SSLError
+  ].freeze
+
+  PERMANENT_ERRORS = [Net::SMTPFatalError, Net::SMTPSyntaxError].freeze
+
+  THROTTLE_PATTERNS = /too many login attempts|too many messages|rate.?limit|throttl|try again later|slow down|too many requests|\b429\b/i
+  # `x` flag is only for line-wrapping, so every literal space is written as `\s`.
+  AUTH_PATTERNS = /invalid_grant|invalid_client|smtpclientauthentication\sis\sdisabled|revoked|
+                   authentication\s(failed|required|unsuccessful)|username\sand\spassword\snot\saccepted|\b535\b/xi
+  PERMANENT_PATTERNS = /recipient\s(address\s)?rejected|mailbox\s(unavailable|not\sfound)|user\sunknown|
+                        no\ssuch\suser|address\srejected|message\srejected|content\s.*reject|policy/xi
+
+  def self.classify(error)
+    return :unknown if error.nil?
+
+    message = error_message(error)
+    code = smtp_reply_code(error, message)
+
+    # Gmail sends "454 4.7.0 Too many login attempts" as an auth error class,
+    # but a 4xx code means slow down, not bad credentials.
+    return smtp_auth_code_class(code) if error.is_a?(Net::SMTPAuthenticationError)
+    return :throttle if throttle?(error, message, code)
+    return :auth if AUTH_PATTERNS.match?(message)
+    return :transient if match_class?(error, TRANSIENT_ERRORS)
+    return :permanent if permanent?(error, message, code)
+
+    :unknown
+  end
+
+  def self.smtp_auth_code_class(code)
+    code&.start_with?('4') ? :throttle : :auth
+  end
+
+  def self.throttle?(error, message, code)
+    error.is_a?(Net::SMTPServerBusy) || code&.start_with?('4') || THROTTLE_PATTERNS.match?(message)
+  end
+
+  def self.permanent?(error, message, code)
+    match_class?(error, PERMANENT_ERRORS) || code&.start_with?('5') || PERMANENT_PATTERNS.match?(message)
+  end
+
+  def self.match_class?(error, classes)
+    classes.any? { |klass| error.is_a?(klass) }
+  end
+
+  def self.error_message(error)
+    (error.respond_to?(:message) ? error.message : error).to_s
+  rescue StandardError
+    ''
+  end
+
+  # Only SMTP replies carry a 4xx/5xx reply code with retry semantics; a bare
+  # "400"/"500" in an HTTP/OAuth message must not be read as an SMTP code.
+  # Returns the 3-digit code (leading, else the first 4xx/5xx token) or nil.
+  def self.smtp_reply_code(error, message)
+    return nil unless error.is_a?(Net::SMTPError)
+
+    message[/\A\s*(\d{3})\b/, 1] || message[/\b([45]\d\d)\b/, 1]
+  end
+
+  private_class_method :smtp_auth_code_class, :throttle?, :permanent?, :match_class?, :error_message, :smtp_reply_code
+end

--- a/spec/services/messages/status_update_service_spec.rb
+++ b/spec/services/messages/status_update_service_spec.rb
@@ -41,6 +41,12 @@ describe Messages::StatusUpdateService do
         expect(service.perform).to be false
         expect(message.reload.status).to eq('read')
       end
+
+      it 'does not allow setting deferred (foundation only, enabled by a follow-up)' do
+        service = described_class.new(message, 'deferred')
+        expect(service.perform).to be false
+        expect(message.reload.status).not_to eq('deferred')
+      end
     end
   end
 end

--- a/spec/services/provider_error_classifier_spec.rb
+++ b/spec/services/provider_error_classifier_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe ProviderErrorClassifier do
+  describe '.classify' do
+    context 'when the error is a rate-limit / slow-down' do
+      it 'classifies Net::SMTPServerBusy as :throttle' do
+        expect(described_class.classify(Net::SMTPServerBusy.new('421 4.7.0 Try again later'))).to eq(:throttle)
+      end
+
+      it 'classifies an HTTP 429 as :throttle' do
+        expect(described_class.classify(StandardError.new('429 Too Many Requests'))).to eq(:throttle)
+      end
+
+      it 'classifies a 454 SMTPAuthenticationError (Gmail "too many login attempts") as :throttle' do
+        error = Net::SMTPAuthenticationError.new('454 4.7.0 Too many login attempts, please try again later')
+        expect(described_class.classify(error)).to eq(:throttle)
+      end
+    end
+
+    context 'when the error is a network blip' do
+      it 'classifies Net::ReadTimeout as :transient' do
+        expect(described_class.classify(Net::ReadTimeout.new)).to eq(:transient)
+      end
+
+      it 'classifies Errno::ECONNRESET as :transient' do
+        expect(described_class.classify(Errno::ECONNRESET.new)).to eq(:transient)
+      end
+
+      it 'classifies SocketError as :transient' do
+        expect(described_class.classify(SocketError.new('getaddrinfo failed'))).to eq(:transient)
+      end
+
+      it 'classifies an SSL error as :transient' do
+        expect(described_class.classify(OpenSSL::SSL::SSLError.new('SSL_connect failed'))).to eq(:transient)
+      end
+    end
+
+    context 'when the error is credentials / permission related' do
+      it 'classifies a 535 SMTPAuthenticationError as :auth' do
+        error = Net::SMTPAuthenticationError.new('535-5.7.8 Username and Password not accepted')
+        expect(described_class.classify(error)).to eq(:auth)
+      end
+
+      it 'classifies an OAuth invalid_grant as :auth' do
+        expect(described_class.classify(StandardError.new('invalid_grant: Token has been expired or revoked'))).to eq(:auth)
+      end
+
+      it 'does not read an HTTP status code in an OAuth error as an SMTP reply code' do
+        expect(described_class.classify(StandardError.new('400 invalid_grant: Token expired'))).to eq(:auth)
+      end
+
+      it 'classifies O365 SmtpClientAuthentication disabled as :auth' do
+        error = Net::SMTPAuthenticationError.new('535 5.7.139 SmtpClientAuthentication is disabled for the Tenant')
+        expect(described_class.classify(error)).to eq(:auth)
+      end
+
+      it 'matches multi-word auth messages that do not carry an SMTP class or code' do
+        expect(described_class.classify(StandardError.new('authentication failed'))).to eq(:auth)
+      end
+    end
+
+    context 'when the error is permanent' do
+      it 'classifies Net::SMTPFatalError (5xx) as :permanent' do
+        expect(described_class.classify(Net::SMTPFatalError.new('550 5.1.1 Recipient address rejected'))).to eq(:permanent)
+      end
+
+      it 'classifies Net::SMTPSyntaxError as :permanent' do
+        expect(described_class.classify(Net::SMTPSyntaxError.new('501 Syntax error'))).to eq(:permanent)
+      end
+
+      it 'matches multi-word recipient-rejection messages without an SMTP class or code' do
+        expect(described_class.classify(StandardError.new('Recipient address rejected: user unknown'))).to eq(:permanent)
+      end
+    end
+
+    context 'when the error is unknown or nil' do
+      it 'classifies nil as :unknown without raising' do
+        expect(described_class.classify(nil)).to eq(:unknown)
+      end
+
+      it 'classifies an unrecognised error as :unknown' do
+        expect(described_class.classify(StandardError.new('something odd happened'))).to eq(:unknown)
+      end
+
+      it 'does not treat a generic HTTP 500 as a permanent SMTP error' do
+        expect(described_class.classify(StandardError.new('500 Internal Server Error'))).to eq(:unknown)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Template

## Description

Outbound email send failures are currently all treated the same way: the sender rescues `StandardError`, reports it, and marks the message failed with no distinction between a temporary "slow down" and a permanent "wrong password / bad address". This PR lays the foundation for handling those cases differently.

It adds:

- `ProviderErrorClassifier`, a small pure class that buckets a provider error (SMTP / OAuth / HTTP) into one of `:throttle`, `:transient`, `:auth`, `:permanent`, or `:unknown`. It is robust to `nil`/unknown input and never raises. SMTP reply codes are parsed only from SMTP errors, so an HTTP/OAuth message that happens to contain a status code is not misread as an SMTP code. Note: Gmail returns "454 4.7.0 Too many login attempts" as an authentication error class but it is semantically a throttle, so a 454 classifies `:throttle` while a 535 classifies `:auth`.
- A new `deferred` message status, appended to the enum with an explicit integer so existing values keep their numbers, plus the frontend status mapping (constant, icon, colour, tooltip) so the UI is ready to render it.

The `deferred` status is introduced as foundation only. Nothing sets it in this change and it is intentionally rejected by the public status-update path; the transition into it is wired up by a follow-up (CW-7882), which also consumes the classifier. No retry behaviour is implemented here.

**Merge order:** this is PR 1 of 2. The follow-up that wires up retry (CW-7882) is stacked on top of this branch. Merge this one first; the follow-up will retarget to `develop` automatically once this is merged.

Fixes https://linear.app/chatwoot/issue/CW-7880

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- New RSpec unit specs for `ProviderErrorClassifier` covering one example per branch, the 454-vs-535 distinction, the HTTP/OAuth-code regression cases, and `nil` input.
- Added an `Messages::StatusUpdateService` spec asserting `deferred` cannot be set through the update path.
- `bundle exec rspec` on the changed specs and the message model spec, all green; `bundle exec rubocop` clean on changed Ruby files.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
