### PR TITLE
fix: prevent vertical tab labels from overlapping

### DIFF
--- a/app/javascript/dashboard/components-next/vertical-tabs/VerticalTabs.vue
+++ b/app/javascript/dashboard/components-next/vertical-tabs/VerticalTabs.vue
@@ -26,7 +26,7 @@ const activeTab = defineModel({ type: String, required: true });
         v-for="tab in tabs"
         :key="tab.id"
         type="button"
-        class="flex items-center h-9 gap-2 px-2.5 text-sm transition-colors rounded-lg shrink-0 md:w-full"
+        class="flex items-center gap-2 px-2.5 py-2 text-sm text-start transition-colors rounded-lg shrink-0 min-h-9 md:w-full"
         :class="
           activeTab === tab.id
             ? 'bg-n-alpha-2 text-n-slate-12 font-medium'
@@ -36,7 +36,9 @@ const activeTab = defineModel({ type: String, required: true });
         @click="activeTab = tab.id"
       >
         <Icon v-if="tab.icon" :icon="tab.icon" class="shrink-0 size-4" />
-        {{ tab.label }}
+        <span class="min-w-0 whitespace-nowrap md:whitespace-normal">
+          {{ tab.label }}
+        </span>
       </button>
     </nav>
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where long tab labels in the settings sidebar, common in translated locales, could wrap out of their fixed-height button and overlap the next tab. Tabs now grow to fit their label, keeping them readable in every language.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="569" height="563" alt="image" src="https://github.com/user-attachments/assets/bc6cf1fa-0ec7-4ca2-a853-fc18b6a311b6" />


**After**
<img width="569" height="563" alt="image" src="https://github.com/user-attachments/assets/09871acd-4174-46f8-9b4e-c17388290259" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
