### PR TITLE
fix(webhook): stop sending private note content as the last public message

### DIFF
--- a/app/controllers/api/v1/accounts/webhooks_controller.rb
+++ b/app/controllers/api/v1/accounts/webhooks_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::Accounts::WebhooksController < Api::V1::Accounts::BaseController
   private
 
   def webhook_params
-    params.require(:webhook).permit(:inbox_id, :name, :url, subscriptions: [])
+    params.require(:webhook).permit(:inbox_id, :name, :url, :include_private_notes, subscriptions: [])
   end
 
   def fetch_webhook

--- a/app/javascript/dashboard/i18n/locale/en/agentBots.json
+++ b/app/javascript/dashboard/i18n/locale/en/agentBots.json
@@ -98,6 +98,9 @@
         "PLACEHOLDER": "https://example.com/webhook",
         "REQUIRED": "Webhook URL is required"
       },
+      "INCLUDE_PRIVATE_NOTES": {
+        "LABEL": "Include private notes in message events"
+      },
       "ERRORS": {
         "NAME": "Bot name is required",
         "URL": "Webhook URL is required",

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -100,6 +100,10 @@
           "RESET_SUCCESS": "Webhook secret regenerated successfully",
           "RESET_ERROR": "Unable to regenerate webhook secret. Please try again"
         },
+        "CHANNEL_INCLUDE_PRIVATE_NOTES": {
+          "LABEL": "Private Notes",
+          "CHECKBOX_LABEL": "Include private notes in message events"
+        },
         "CHANNEL_DOMAIN": {
           "LABEL": "Website Domain",
           "PLACEHOLDER": "Enter your website domain (eg: acme.com)"

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -77,6 +77,9 @@
           "PLACEHOLDER": "Example: {webhookExampleURL}",
           "ERROR": "Please enter a valid URL"
         },
+        "PRIVATE_NOTES": {
+          "LABEL": "Include private notes in message events"
+        },
         "EDIT_SUBMIT": "Update webhook",
         "ADD_SUBMIT": "Create webhook"
       },

--- a/app/javascript/dashboard/routes/dashboard/settings/agentBots/components/AgentBotModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agentBots/components/AgentBotModal.vue
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n';
 import { required, helpers, url } from '@vuelidate/validators';
 import { useVuelidate } from '@vuelidate/core';
 import { copyTextToClipboard } from 'shared/helpers/clipboard';
+import { isTruthyFlag } from 'shared/helpers/booleanFlag';
 import { useToggle } from '@vueuse/core';
 
 import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
@@ -232,7 +233,9 @@ const initializeForm = () => {
     formState.botDescription = description || '';
     formState.botUrl = botUrl || botConfig?.webhook_url || '';
     formState.botAvatarUrl = thumbnail || '';
-    formState.includePrivateNotes = botConfig?.include_private_notes || false;
+    formState.includePrivateNotes = isTruthyFlag(
+      botConfig?.include_private_notes
+    );
 
     if (props.type === MODAL_TYPES.EDIT) {
       if (botAccessToken) accessToken.value = botAccessToken;

--- a/app/javascript/dashboard/routes/dashboard/settings/agentBots/components/AgentBotModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agentBots/components/AgentBotModal.vue
@@ -165,10 +165,7 @@ const handleSubmit = async () => {
     outgoing_url: formState.botUrl,
     bot_type: 'webhook',
     avatar: formState.botAvatar,
-    bot_config: {
-      ...(props.selectedBot?.bot_config || {}),
-      include_private_notes: formState.includePrivateNotes,
-    },
+    bot_config: { include_private_notes: formState.includePrivateNotes },
   };
 
   const isCreate = props.type === MODAL_TYPES.CREATE;

--- a/app/javascript/dashboard/routes/dashboard/settings/agentBots/components/AgentBotModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/agentBots/components/AgentBotModal.vue
@@ -13,6 +13,7 @@ import NextButton from 'dashboard/components-next/button/Button.vue';
 import Input from 'dashboard/components-next/input/Input.vue';
 import TextArea from 'dashboard/components-next/textarea/TextArea.vue';
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
+import Checkbox from 'dashboard/components-next/checkbox/Checkbox.vue';
 import AccessToken from 'dashboard/routes/dashboard/settings/profile/AccessToken.vue';
 
 const props = defineProps({
@@ -43,6 +44,7 @@ const formState = reactive({
   botUrl: '',
   botAvatar: null,
   botAvatarUrl: '',
+  includePrivateNotes: false,
 });
 
 const [showAccessToken, toggleAccessToken] = useToggle();
@@ -122,6 +124,7 @@ const resetForm = () => {
     botUrl: '',
     botAvatar: null,
     botAvatarUrl: '',
+    includePrivateNotes: false,
   });
   v$.value.$reset();
 };
@@ -161,6 +164,10 @@ const handleSubmit = async () => {
     outgoing_url: formState.botUrl,
     bot_type: 'webhook',
     avatar: formState.botAvatar,
+    bot_config: {
+      ...(props.selectedBot?.bot_config || {}),
+      include_private_notes: formState.includePrivateNotes,
+    },
   };
 
   const isCreate = props.type === MODAL_TYPES.CREATE;
@@ -225,6 +232,7 @@ const initializeForm = () => {
     formState.botDescription = description || '';
     formState.botUrl = botUrl || botConfig?.webhook_url || '';
     formState.botAvatarUrl = thumbnail || '';
+    formState.includePrivateNotes = botConfig?.include_private_notes || false;
 
     if (props.type === MODAL_TYPES.EDIT) {
       if (botAccessToken) accessToken.value = botAccessToken;
@@ -344,6 +352,13 @@ defineExpose({ dialogRef });
           :message-type="botUrlError ? 'error' : 'info'"
           @blur="v$.botUrl.$touch()"
         />
+
+        <label class="flex items-center gap-2 cursor-pointer">
+          <Checkbox v-model="formState.includePrivateNotes" />
+          <span class="text-sm text-n-slate-11">
+            {{ $t('AGENT_BOTS.FORM.INCLUDE_PRIVATE_NOTES.LABEL') }}
+          </span>
+        </label>
       </div>
 
       <div

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -45,6 +45,7 @@ import ColorPicker from 'dashboard/components-next/colorpicker/ColorPicker.vue';
 import SelectInput from 'dashboard/components-next/select/Select.vue';
 import Widget from 'dashboard/modules/widget-preview/components/Widget.vue';
 import AccessToken from 'dashboard/routes/dashboard/settings/profile/AccessToken.vue';
+import Checkbox from 'dashboard/components-next/checkbox/Checkbox.vue';
 import { copyTextToClipboard } from 'shared/helpers/clipboard';
 import { META_RESTRICTION_STATUS_URL } from 'dashboard/constants/globals';
 
@@ -85,6 +86,7 @@ export default {
     Widget,
     AccessToken,
     Icon,
+    Checkbox,
   },
   mixins: [inboxMixin],
   setup() {
@@ -105,6 +107,7 @@ export default {
       selectedInboxName: '',
       channelWebsiteUrl: '',
       webhookUrl: '',
+      includePrivateNotes: false,
       channelWelcomeTitle: '',
       channelWelcomeTagline: '',
       selectedFeatureFlags: [],
@@ -547,6 +550,8 @@ export default {
       this.avatarUrl = this.inbox.avatar_url;
       this.selectedInboxName = this.inbox.name;
       this.webhookUrl = this.inbox.webhook_url;
+      this.includePrivateNotes =
+        this.inbox.additional_attributes?.include_private_notes || false;
       this.greetingEnabled = this.inbox.greeting_enabled || false;
       this.greetingMessage = this.inbox.greeting_message || '';
       this.emailCollectEnabled = this.inbox.enable_email_collect;
@@ -697,6 +702,10 @@ export default {
             widget_color: this.inbox.widget_color,
             website_url: this.channelWebsiteUrl,
             webhook_url: this.webhookUrl,
+            additional_attributes: {
+              ...(this.inbox.additional_attributes || {}),
+              include_private_notes: this.includePrivateNotes,
+            },
             welcome_title: this.channelWelcomeTitle || '',
             welcome_tagline: this.channelWelcomeTagline || '',
             selectedFeatureFlags: this.selectedFeatureFlags,
@@ -946,6 +955,26 @@ export default {
                 @on-copy="copyWebhookSecret"
                 @on-reset="resetWebhookSecret"
               />
+            </SettingsFieldSection>
+
+            <SettingsFieldSection
+              v-if="isAPIInbox"
+              :label="
+                $t(
+                  'INBOX_MGMT.ADD.WEBSITE_CHANNEL.CHANNEL_INCLUDE_PRIVATE_NOTES.LABEL'
+                )
+              "
+            >
+              <label class="flex items-center gap-2 cursor-pointer">
+                <Checkbox v-model="includePrivateNotes" />
+                <span class="text-sm text-n-slate-11">
+                  {{
+                    $t(
+                      'INBOX_MGMT.ADD.WEBSITE_CHANNEL.CHANNEL_INCLUDE_PRIVATE_NOTES.CHECKBOX_LABEL'
+                    )
+                  }}
+                </span>
+              </label>
             </SettingsFieldSection>
 
             <SettingsFieldSection

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -47,6 +47,7 @@ import Widget from 'dashboard/modules/widget-preview/components/Widget.vue';
 import AccessToken from 'dashboard/routes/dashboard/settings/profile/AccessToken.vue';
 import Checkbox from 'dashboard/components-next/checkbox/Checkbox.vue';
 import { copyTextToClipboard } from 'shared/helpers/clipboard';
+import { isTruthyFlag } from 'shared/helpers/booleanFlag';
 import { META_RESTRICTION_STATUS_URL } from 'dashboard/constants/globals';
 
 export default {
@@ -550,8 +551,9 @@ export default {
       this.avatarUrl = this.inbox.avatar_url;
       this.selectedInboxName = this.inbox.name;
       this.webhookUrl = this.inbox.webhook_url;
-      this.includePrivateNotes =
-        this.inbox.additional_attributes?.include_private_notes || false;
+      this.includePrivateNotes = isTruthyFlag(
+        this.inbox.additional_attributes?.include_private_notes
+      );
       this.greetingEnabled = this.inbox.greeting_enabled || false;
       this.greetingMessage = this.inbox.greeting_message || '';
       this.emailCollectEnabled = this.inbox.enable_email_collect;

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -705,7 +705,6 @@ export default {
             website_url: this.channelWebsiteUrl,
             webhook_url: this.webhookUrl,
             additional_attributes: {
-              ...(this.inbox.additional_attributes || {}),
               include_private_notes: this.includePrivateNotes,
             },
             welcome_title: this.channelWelcomeTitle || '',

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
@@ -61,6 +61,7 @@ export default {
       url: this.value.url || '',
       name: this.value.name || '',
       subscriptions: this.value.subscriptions || [],
+      includePrivateNotes: this.value.include_private_notes || false,
       secretVisible: false,
       supportedWebhookEvents: inboxEventsEnabled
         ? [...SUPPORTED_WEBHOOK_EVENTS, 'inbox_updated']
@@ -89,6 +90,7 @@ export default {
         url: this.url,
         name: this.name,
         subscriptions: this.subscriptions,
+        include_private_notes: this.includePrivateNotes,
       });
     },
     async copySecret() {
@@ -182,6 +184,18 @@ export default {
             }}
           </label>
         </div>
+      </div>
+      <div class="flex items-center mb-4">
+        <input
+          id="includePrivateNotes"
+          v-model="includePrivateNotes"
+          type="checkbox"
+          name="includePrivateNotes"
+          class="mr-2"
+        />
+        <label for="includePrivateNotes" class="text-sm">
+          {{ $t('INTEGRATION_SETTINGS.WEBHOOK.FORM.PRIVATE_NOTES.LABEL') }}
+        </label>
       </div>
     </div>
 

--- a/app/javascript/dashboard/store/modules/agentBots.js
+++ b/app/javascript/dashboard/store/modules/agentBots.js
@@ -37,6 +37,13 @@ export const getters = {
   },
 };
 
+const appendBotConfig = (formData, botConfig) => {
+  if (!botConfig) return;
+  Object.keys(botConfig).forEach(key => {
+    formData.append(`bot_config[${key}]`, botConfig[key]);
+  });
+};
+
 export const actions = {
   get: async ({ commit }) => {
     commit(types.SET_AGENT_BOT_UI_FLAG, { isFetching: true });
@@ -59,6 +66,7 @@ export const actions = {
       formData.append('description', botData.description);
       formData.append('bot_type', botData.bot_type || 'webhook');
       formData.append('outgoing_url', botData.outgoing_url);
+      appendBotConfig(formData, botData.bot_config);
 
       // Add avatar file if available
       if (botData.avatar) {
@@ -85,6 +93,7 @@ export const actions = {
       formData.append('description', data.description);
       formData.append('bot_type', data.bot_type || 'webhook');
       formData.append('outgoing_url', data.outgoing_url);
+      appendBotConfig(formData, data.bot_config);
 
       if (data.avatar) {
         formData.append('avatar', data.avatar);

--- a/app/javascript/dashboard/store/modules/inboxes/channelActions.js
+++ b/app/javascript/dashboard/store/modules/inboxes/channelActions.js
@@ -9,7 +9,11 @@ export const buildInboxData = inboxParams => {
   Object.keys(inboxProperties).forEach(key => {
     formData.append(key, inboxProperties[key]);
   });
-  const { selectedFeatureFlags, ...channelParams } = channel;
+  const {
+    selectedFeatureFlags,
+    additional_attributes: additionalAttributes,
+    ...channelParams
+  } = channel;
   // selectedFeatureFlags needs to be empty when creating a website channel
   if (selectedFeatureFlags) {
     if (selectedFeatureFlags.length) {
@@ -19,6 +23,14 @@ export const buildInboxData = inboxParams => {
     } else {
       formData.append('channel[selected_feature_flags][]', '');
     }
+  }
+  if (additionalAttributes) {
+    Object.keys(additionalAttributes).forEach(key => {
+      formData.append(
+        `channel[additional_attributes][${key}]`,
+        additionalAttributes[key]
+      );
+    });
   }
   Object.keys(channelParams).forEach(key => {
     formData.append(`channel[${key}]`, channel[key]);

--- a/app/javascript/dashboard/store/modules/inboxes/specs/channelActions.spec.js
+++ b/app/javascript/dashboard/store/modules/inboxes/specs/channelActions.spec.js
@@ -1,0 +1,30 @@
+import { buildInboxData } from '../channelActions';
+
+describe('#buildInboxData', () => {
+  it('serializes nested additional_attributes as bracketed form fields', () => {
+    const formData = buildInboxData({
+      name: 'Test inbox',
+      channel: {
+        webhook_url: 'https://example.com',
+        additional_attributes: { include_private_notes: true },
+      },
+    });
+
+    expect(
+      formData.get('channel[additional_attributes][include_private_notes]')
+    ).toBe('true');
+    expect(formData.get('channel[webhook_url]')).toBe('https://example.com');
+    expect(formData.get('channel[additional_attributes]')).toBeNull();
+  });
+
+  it('does not append additional_attributes fields when absent', () => {
+    const formData = buildInboxData({
+      name: 'Test inbox',
+      channel: { webhook_url: 'https://example.com' },
+    });
+
+    expect(
+      formData.get('channel[additional_attributes][include_private_notes]')
+    ).toBeNull();
+  });
+});

--- a/app/javascript/dashboard/store/modules/specs/agentBots/agentBots.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/agentBots/agentBots.spec.js
@@ -51,6 +51,17 @@ describe('#actions', () => {
         [types.SET_AGENT_BOT_UI_FLAG, { isCreating: false }],
       ]);
     });
+
+    it('includes bot_config fields in the request', async () => {
+      axios.post.mockResolvedValue({ data: agentBotRecords[0] });
+      await actions.create(
+        { commit },
+        { ...agentBotData, bot_config: { include_private_notes: true } }
+      );
+
+      const formDataArg = axios.post.mock.calls[0][1];
+      expect(formDataArg.get('bot_config[include_private_notes]')).toBe('true');
+    });
   });
 
   describe('#update', () => {

--- a/app/javascript/shared/helpers/booleanFlag.js
+++ b/app/javascript/shared/helpers/booleanFlag.js
@@ -1,0 +1,4 @@
+// jsonb-backed flags (bot_config, additional_attributes) round-trip through multipart
+// form submissions as the literal strings "true"/"false" rather than real booleans,
+// so a plain `value || false` treats a saved-off "false" as truthy. Normalize explicitly.
+export const isTruthyFlag = value => value === true || value === 'true';

--- a/app/javascript/shared/helpers/booleanFlag.js
+++ b/app/javascript/shared/helpers/booleanFlag.js
@@ -1,4 +1,20 @@
-// jsonb-backed flags (bot_config, additional_attributes) round-trip through multipart
-// form submissions as the literal strings "true"/"false" rather than real booleans,
-// so a plain `value || false` treats a saved-off "false" as truthy. Normalize explicitly.
-export const isTruthyFlag = value => value === true || value === 'true';
+// jsonb-backed flags (bot_config, additional_attributes) can be saved as non-boolean
+// values: multipart form submissions send the literal strings "true"/"false", and the
+// public API accepts anything ActiveModel::Type::Boolean casts (e.g. 1, "t", "off").
+// Mirror that casting here so the UI never disagrees with what the backend will do.
+const FALSE_VALUES = new Set([
+  false,
+  0,
+  '0',
+  'f',
+  'F',
+  'false',
+  'FALSE',
+  'off',
+  'OFF',
+]);
+
+export const isTruthyFlag = value => {
+  if (value === null || value === undefined || value === '') return false;
+  return !FALSE_VALUES.has(value);
+};

--- a/app/javascript/shared/helpers/specs/booleanFlag.spec.js
+++ b/app/javascript/shared/helpers/specs/booleanFlag.spec.js
@@ -1,23 +1,21 @@
 import { isTruthyFlag } from '../booleanFlag';
 
 describe('#isTruthyFlag', () => {
-  it('returns true for the boolean true', () => {
-    expect(isTruthyFlag(true)).toBe(true);
-  });
+  it.each([true, 'true', 1, '1', 't', 'T', 'on', 'ON', 'yes'])(
+    'returns true for %p, matching ActiveModel::Type::Boolean',
+    value => {
+      expect(isTruthyFlag(value)).toBe(true);
+    }
+  );
 
-  it('returns true for the string "true"', () => {
-    expect(isTruthyFlag('true')).toBe(true);
-  });
+  it.each([false, 'false', 'FALSE', 0, '0', 'f', 'F', 'off', 'OFF'])(
+    'returns false for %p, matching ActiveModel::Type::Boolean::FALSE_VALUES',
+    value => {
+      expect(isTruthyFlag(value)).toBe(false);
+    }
+  );
 
-  it('returns false for the boolean false', () => {
-    expect(isTruthyFlag(false)).toBe(false);
-  });
-
-  it('returns false for the string "false"', () => {
-    expect(isTruthyFlag('false')).toBe(false);
-  });
-
-  it('returns false for undefined', () => {
-    expect(isTruthyFlag(undefined)).toBe(false);
+  it.each([null, undefined, ''])('returns false for %p', value => {
+    expect(isTruthyFlag(value)).toBe(false);
   });
 });

--- a/app/javascript/shared/helpers/specs/booleanFlag.spec.js
+++ b/app/javascript/shared/helpers/specs/booleanFlag.spec.js
@@ -1,0 +1,23 @@
+import { isTruthyFlag } from '../booleanFlag';
+
+describe('#isTruthyFlag', () => {
+  it('returns true for the boolean true', () => {
+    expect(isTruthyFlag(true)).toBe(true);
+  });
+
+  it('returns true for the string "true"', () => {
+    expect(isTruthyFlag('true')).toBe(true);
+  });
+
+  it('returns false for the boolean false', () => {
+    expect(isTruthyFlag(false)).toBe(false);
+  });
+
+  it('returns false for the string "false"', () => {
+    expect(isTruthyFlag('false')).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isTruthyFlag(undefined)).toBe(false);
+  });
+});

--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -77,7 +77,7 @@ class AgentBotListener < BaseListener
   end
 
   def process_message_event(method_name, agent_bot, message, _event)
-    return if message.private? && !agent_bot.bot_config['include_private_notes']
+    return if message.private? && !include_private_notes?(agent_bot.bot_config)
 
     # Only webhook bots are supported
     payload = message.webhook_data.merge(event: method_name)

--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -77,6 +77,8 @@ class AgentBotListener < BaseListener
   end
 
   def process_message_event(method_name, agent_bot, message, _event)
+    return if message.private? && !agent_bot.bot_config['include_private_notes']
+
     # Only webhook bots are supported
     payload = message.webhook_data.merge(event: method_name)
     process_webhook_bot_event(agent_bot, payload)

--- a/app/listeners/base_listener.rb
+++ b/app/listeners/base_listener.rb
@@ -36,4 +36,10 @@ class BaseListener
 
     changed_attributes.map { |k, v| { k => { previous_value: v[0], current_value: v[1] } } }
   end
+
+  # jsonb-backed config (bot_config, additional_attributes) stores whatever was submitted,
+  # including the string "true"/"false" that multipart form submissions send.
+  def include_private_notes?(config)
+    ActiveModel::Type::Boolean.new.cast(config['include_private_notes'])
+  end
 end

--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -112,6 +112,7 @@ class WebhookListener < BaseListener
 
     account.webhooks.account_type.each do |webhook|
       next unless webhook.subscriptions.include?(payload[:event])
+      next if payload[:private] && !webhook.include_private_notes?
 
       WebhookJob.perform_later(webhook.url, payload, :account_webhook,
                                secret: webhook.secret,

--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -123,6 +123,7 @@ class WebhookListener < BaseListener
   def deliver_api_inbox_webhooks(payload, inbox)
     return unless inbox.channel_type == 'Channel::Api'
     return if inbox.channel.webhook_url.blank?
+    return if payload[:private] && !inbox.channel.additional_attributes['include_private_notes']
 
     WebhookJob.perform_later(inbox.channel.webhook_url, payload, :api_inbox_webhook,
                              secret: inbox.channel.secret, delivery_id: SecureRandom.uuid)

--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -123,7 +123,7 @@ class WebhookListener < BaseListener
   def deliver_api_inbox_webhooks(payload, inbox)
     return unless inbox.channel_type == 'Channel::Api'
     return if inbox.channel.webhook_url.blank?
-    return if payload[:private] && !inbox.channel.additional_attributes['include_private_notes']
+    return if payload[:private] && !include_private_notes?(inbox.channel.additional_attributes)
 
     WebhookJob.perform_later(inbox.channel.webhook_url, payload, :api_inbox_webhook,
                              secret: inbox.channel.secret, delivery_id: SecureRandom.uuid)

--- a/app/models/agent_bot.rb
+++ b/app/models/agent_bot.rb
@@ -66,6 +66,12 @@ class AgentBot < ApplicationRecord
   def system_bot?
     account.nil?
   end
+
+  # Merge, don't replace: callers (e.g. the agent bot settings form) only ever intend to update
+  # specific keys, and a blind replace would drop unrelated ones already stored here.
+  def bot_config=(value)
+    super(bot_config.merge(value.to_h))
+  end
 end
 
 AgentBot.include_mod_with('Audit::AgentBot')

--- a/app/models/channel/api.rb
+++ b/app/models/channel/api.rb
@@ -35,6 +35,12 @@ class Channel::Api < ApplicationRecord
     'API'
   end
 
+  # Merge, don't replace: callers (e.g. the inbox settings form) only ever intend to update
+  # specific keys, and a blind replace would drop unrelated ones already stored here.
+  def additional_attributes=(value)
+    super(additional_attributes.merge(value.to_h))
+  end
+
   private
 
   def ensure_valid_agent_reply_time_window

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -185,7 +185,7 @@ class Message < ApplicationRecord
       content_attributes: content_attributes,
       content_type: content_type,
       content: webhook_content,
-      conversation: conversation.webhook_data,
+      conversation: conversation.webhook_data.merge(messages: [webhook_push_event_data]),
       created_at: created_at,
       id: id,
       inbox: inbox.webhook_data,

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -2,16 +2,17 @@
 #
 # Table name: webhooks
 #
-#  id            :bigint           not null, primary key
-#  name          :string
-#  secret        :string
-#  subscriptions :jsonb
-#  url           :text
-#  webhook_type  :integer          default("account_type")
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  account_id    :integer
-#  inbox_id      :integer
+#  id                    :bigint           not null, primary key
+#  include_private_notes :boolean          default(FALSE), not null
+#  name                  :string
+#  secret                :string
+#  subscriptions         :jsonb
+#  url                   :text
+#  webhook_type          :integer          default("account_type")
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  account_id            :integer
+#  inbox_id              :integer
 #
 # Indexes
 #

--- a/app/views/api/v1/accounts/webhooks/_webhook.json.jbuilder
+++ b/app/views/api/v1/accounts/webhooks/_webhook.json.jbuilder
@@ -4,6 +4,7 @@ json.url webhook.url
 json.account_id webhook.account_id
 json.subscriptions webhook.subscriptions
 json.secret webhook.secret
+json.include_private_notes webhook.include_private_notes
 if webhook.inbox
   json.inbox do
     json.id webhook.inbox.id

--- a/db/migrate/20260810120000_add_include_private_notes_to_webhooks.rb
+++ b/db/migrate/20260810120000_add_include_private_notes_to_webhooks.rb
@@ -1,0 +1,5 @@
+class AddIncludePrivateNotesToWebhooks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :webhooks, :include_private_notes, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_04_000003) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_10_120000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -1538,6 +1538,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_04_000003) do
     t.jsonb "subscriptions", default: ["conversation_status_changed", "conversation_updated", "conversation_created", "contact_created", "contact_updated", "message_created", "message_updated", "webwidget_triggered"]
     t.string "name"
     t.string "secret"
+    t.boolean "include_private_notes", default: false, null: false
     t.index ["account_id", "url"], name: "index_webhooks_on_account_id_and_url", unique: true
   end
 

--- a/spec/controllers/api/v1/accounts/agent_bots_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/agent_bots_controller_spec.rb
@@ -225,6 +225,21 @@ RSpec.describe 'Agent Bot API', type: :request do
         expect(response).to have_http_status(:success)
         expect(Avatar::AvatarFromUrlJob).to have_been_enqueued.with(agent_bot, 'http://example.com/avatar.png')
       end
+
+      it 'merges bot_config instead of replacing it, preserving existing keys' do
+        agent_bot.update!(bot_config: { 'webhook_url' => 'https://example.com/hook' })
+
+        patch "/api/v1/accounts/#{account.id}/agent_bots/#{agent_bot.id}",
+              headers: admin.create_new_auth_token,
+              params: valid_params.merge(bot_config: { include_private_notes: 'true' }),
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(agent_bot.reload.bot_config).to eq(
+          'webhook_url' => 'https://example.com/hook',
+          'include_private_notes' => 'true'
+        )
+      end
     end
   end
 

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -595,6 +595,24 @@ RSpec.describe 'Inboxes API', type: :request do
         expect(api_channel.reload.webhook_url).to eq('webhook.test')
       end
 
+      it 'merges additional_attributes instead of replacing them, preserving existing key types' do
+        api_channel = create(:channel_api, account: account,
+                                           additional_attributes: { 'import_placeholder' => true, 'source_provider' => 'zendesk' })
+        api_inbox = create(:inbox, channel: api_channel, account: account)
+
+        patch "/api/v1/accounts/#{account.id}/inboxes/#{api_inbox.id}",
+              headers: admin.create_new_auth_token,
+              params: { channel: { additional_attributes: { 'include_private_notes' => 'true' } } },
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(api_channel.reload.additional_attributes).to eq(
+          'import_placeholder' => true,
+          'source_provider' => 'zendesk',
+          'include_private_notes' => 'true'
+        )
+      end
+
       it 'updates whatsapp inbox when administrator' do
         stub_request(:post, 'https://waba.360dialog.io/v1/configs/webhook').to_return(status: 200, body: '', headers: {})
         stub_request(:get, 'https://waba.360dialog.io/v1/configs/templates').to_return(status: 200, body: '', headers: {})

--- a/spec/listeners/agent_bot_listener_spec.rb
+++ b/spec/listeners/agent_bot_listener_spec.rb
@@ -61,6 +61,20 @@ describe AgentBotListener do
           ).once
           listener.message_created(private_event)
         end
+
+        it 'sends the message when bot_config stores the opt-in as a string, as multipart form submissions do' do
+          bot = create(:agent_bot, bot_config: { 'include_private_notes' => 'true' })
+          create(:agent_bot_inbox, inbox: inbox, agent_bot: bot)
+          expect(AgentBots::WebhookJob).to receive(:perform_later).once
+          listener.message_created(private_event)
+        end
+
+        it 'does not send the message when bot_config stores the opt-in as the string "false"' do
+          bot = create(:agent_bot, bot_config: { 'include_private_notes' => 'false' })
+          create(:agent_bot_inbox, inbox: inbox, agent_bot: bot)
+          expect(AgentBots::WebhookJob).not_to receive(:perform_later)
+          listener.message_created(private_event)
+        end
       end
 
       context 'when conversation has a different assignee agent bot' do

--- a/spec/listeners/agent_bot_listener_spec.rb
+++ b/spec/listeners/agent_bot_listener_spec.rb
@@ -39,6 +39,30 @@ describe AgentBotListener do
         listener.message_created(event)
       end
 
+      context 'when the message is private' do
+        let!(:private_message) do
+          create(:message, message_type: 'outgoing', private: true,
+                           account: account, inbox: inbox, conversation: conversation)
+        end
+        let(:private_event) { Events::Base.new(event_name, Time.zone.now, message: private_message) }
+
+        it 'does not send the message to the agent bot by default' do
+          create(:agent_bot_inbox, inbox: inbox, agent_bot: agent_bot)
+          expect(AgentBots::WebhookJob).not_to receive(:perform_later)
+          listener.message_created(private_event)
+        end
+
+        it 'sends the message when the agent bot opts in to private notes' do
+          bot = create(:agent_bot, bot_config: { 'include_private_notes' => true })
+          create(:agent_bot_inbox, inbox: inbox, agent_bot: bot)
+          expect(AgentBots::WebhookJob).to receive(:perform_later).with(
+            bot.outgoing_url, private_message.webhook_data.merge(event: 'message_created'),
+            :agent_bot_webhook, secret: bot.secret, delivery_id: instance_of(String)
+          ).once
+          listener.message_created(private_event)
+        end
+      end
+
       context 'when conversation has a different assignee agent bot' do
         let!(:conversation_bot) { create(:agent_bot) }
 

--- a/spec/listeners/webhook_listener_spec.rb
+++ b/spec/listeners/webhook_listener_spec.rb
@@ -44,6 +44,29 @@ describe WebhookListener do
       end
     end
 
+    context 'when the message is private' do
+      let!(:private_message) do
+        create(:message, message_type: 'outgoing', private: true,
+                         account: account, inbox: inbox, conversation: conversation)
+      end
+      let(:private_message_created_event) { Events::Base.new(event_name, Time.zone.now, message: private_message) }
+
+      it 'does not trigger the webhook by default' do
+        create(:webhook, inbox: inbox, account: account)
+        expect(WebhookJob).not_to receive(:perform_later)
+        listener.message_created(private_message_created_event)
+      end
+
+      it 'triggers the webhook when it opts in to private notes' do
+        webhook = create(:webhook, inbox: inbox, account: account, include_private_notes: true)
+        expect(WebhookJob).to receive(:perform_later).with(
+          webhook.url, private_message.webhook_data.merge(event: 'message_created'), :account_webhook,
+          secret: webhook.secret, delivery_id: instance_of(String)
+        ).once
+        listener.message_created(private_message_created_event)
+      end
+    end
+
     context 'when API and webhook access is disabled for the account' do
       before do
         allow(account).to receive(:api_and_webhooks_enabled?).and_return(false)

--- a/spec/listeners/webhook_listener_spec.rb
+++ b/spec/listeners/webhook_listener_spec.rb
@@ -146,6 +146,33 @@ describe WebhookListener do
         expect(WebhookJob).not_to receive(:perform_later)
         listener.message_created(api_event)
       end
+
+      context 'when the message is private' do
+        it 'does not trigger the webhook by default' do
+          channel_api = create(:channel_api, account: account)
+          api_inbox = channel_api.inbox
+          api_conversation = create(:conversation, account: account, inbox: api_inbox, assignee: user)
+          api_message = create(:message, message_type: 'outgoing', private: true,
+                                         account: account, inbox: api_inbox, conversation: api_conversation)
+          api_event = Events::Base.new(event_name, Time.zone.now, message: api_message)
+          expect(WebhookJob).not_to receive(:perform_later)
+          listener.message_created(api_event)
+        end
+
+        it 'triggers the webhook when it opts in to private notes' do
+          channel_api = create(:channel_api, account: account, additional_attributes: { 'include_private_notes' => true })
+          api_inbox = channel_api.inbox
+          api_conversation = create(:conversation, account: account, inbox: api_inbox, assignee: user)
+          api_message = create(:message, message_type: 'outgoing', private: true,
+                                         account: account, inbox: api_inbox, conversation: api_conversation)
+          api_event = Events::Base.new(event_name, Time.zone.now, message: api_message)
+          expect(WebhookJob).to receive(:perform_later).with(
+            channel_api.webhook_url, api_message.webhook_data.merge(event: 'message_created'),
+            :api_inbox_webhook, secret: channel_api.secret, delivery_id: instance_of(String)
+          ).once
+          listener.message_created(api_event)
+        end
+      end
     end
   end
 

--- a/spec/listeners/webhook_listener_spec.rb
+++ b/spec/listeners/webhook_listener_spec.rb
@@ -172,6 +172,28 @@ describe WebhookListener do
           ).once
           listener.message_created(api_event)
         end
+
+        it 'triggers the webhook when additional_attributes stores the opt-in as a string, as multipart form submissions do' do
+          channel_api = create(:channel_api, account: account, additional_attributes: { 'include_private_notes' => 'true' })
+          api_inbox = channel_api.inbox
+          api_conversation = create(:conversation, account: account, inbox: api_inbox, assignee: user)
+          api_message = create(:message, message_type: 'outgoing', private: true,
+                                         account: account, inbox: api_inbox, conversation: api_conversation)
+          api_event = Events::Base.new(event_name, Time.zone.now, message: api_message)
+          expect(WebhookJob).to receive(:perform_later).once
+          listener.message_created(api_event)
+        end
+
+        it 'does not trigger the webhook when additional_attributes stores the opt-in as the string "false"' do
+          channel_api = create(:channel_api, account: account, additional_attributes: { 'include_private_notes' => 'false' })
+          api_inbox = channel_api.inbox
+          api_conversation = create(:conversation, account: account, inbox: api_inbox, assignee: user)
+          api_message = create(:message, message_type: 'outgoing', private: true,
+                                         account: account, inbox: api_inbox, conversation: api_conversation)
+          api_event = Events::Base.new(event_name, Time.zone.now, message: api_message)
+          expect(WebhookJob).not_to receive(:perform_later)
+          listener.message_created(api_event)
+        end
       end
     end
   end

--- a/spec/models/agent_bot_spec.rb
+++ b/spec/models/agent_bot_spec.rb
@@ -66,4 +66,17 @@ RSpec.describe AgentBot do
       end
     end
   end
+
+  describe '#bot_config=' do
+    it 'merges into existing config instead of replacing it' do
+      agent_bot = create(:agent_bot, bot_config: { 'webhook_url' => 'https://example.com/hook' })
+
+      agent_bot.update!(bot_config: { 'include_private_notes' => 'true' })
+
+      expect(agent_bot.reload.bot_config).to eq(
+        'webhook_url' => 'https://example.com/hook',
+        'include_private_notes' => 'true'
+      )
+    end
+  end
 end

--- a/spec/models/channel/api_spec.rb
+++ b/spec/models/channel/api_spec.rb
@@ -20,4 +20,18 @@ RSpec.describe Channel::Api do
       end
     end
   end
+
+  describe '#additional_attributes=' do
+    it 'merges into existing attributes instead of replacing them' do
+      channel_api = create(:channel_api, additional_attributes: { 'import_placeholder' => true, 'source_provider' => 'zendesk' })
+
+      channel_api.update!(additional_attributes: { 'include_private_notes' => 'true' })
+
+      expect(channel_api.reload.additional_attributes).to eq(
+        'import_placeholder' => true,
+        'source_provider' => 'zendesk',
+        'include_private_notes' => 'true'
+      )
+    end
+  end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -415,6 +415,17 @@ RSpec.describe Message do
 
       expect(message.webhook_data[:content]).to include('survey/responses/')
     end
+
+    it 'embeds the private message itself in conversation.messages, not the last public message' do
+      conversation = create(:conversation)
+      create(:message, conversation: conversation, message_type: :outgoing, private: false, content: 'Public message')
+      private_message = create(:message, conversation: conversation, message_type: :outgoing, private: true, content: 'Private note')
+
+      webhook_data = private_message.webhook_data
+
+      expect(webhook_data[:content]).to eq('Private note')
+      expect(webhook_data[:conversation][:messages].first[:content]).to eq('Private note')
+    end
   end
 
   context 'when message is created' do


### PR DESCRIPTION
When a private note (internal note) was added to a conversation, `message_created`/`message_updated` webhooks still fired, but the payload's nested `conversation.messages` field showed the content of the last *public* message instead of the private note itself — making the payload look wrong/misleading to anyone relying on that field.

Since sending private note content to third-party consumers by default could unexpectedly expose internal-only data to existing integrations, private notes no longer trigger these events by default across all three delivery paths Chatwoot has for `message_created`/`message_updated`: account/inbox webhooks, agent bot webhooks, and a `Channel::Api` inbox's dedicated webhook URL. Each can individually opt in to receiving private notes, in which case the payload correctly reflects the note's own content.

## Closes
- https://linear.app/chatwoot/issue/CW-6829/private-message-webhook-sends-incorrect-content
- https://github.com/chatwoot/chatwoot/issues/14023

## How to reproduce
1. Configure a webhook subscribed to `message_created`.
2. Send a public message in a conversation, then add a private note in the same conversation.
3. Before this fix: the webhook fires for the private note, but the payload's `conversation.messages` shows the earlier public message's content, not the note.
4. After this fix: the webhook does not fire for the private note unless "Include private notes in message events" is enabled on that webhook/agent bot/API inbox — in which case the payload correctly shows the note's own content.

## What changed
- Added `include_private_notes` (boolean, default `false`) to `webhooks`, exposed via the webhooks API and a new checkbox in the webhook form.
- Agent bots and `Channel::Api` inboxes gained the same opt-in, stored in their existing `bot_config`/`additional_attributes` jsonb columns (no migration needed for those two), with matching checkboxes in the agent bot modal and inbox settings page.
- `WebhookListener` and `AgentBotListener` now skip delivering `message_created`/`message_updated` when the message is private and the target (webhook/agent bot/API inbox) hasn't opted in.
- `Message#webhook_data` now embeds the actual message in the nested `conversation.messages` field instead of always re-querying the conversation's last public chat message, so the payload is internally consistent when private notes are delivered.