### PR TITLE
feat(automation): allow send email transcript action to target the contact's email

### DIFF
--- a/app/javascript/dashboard/components/widgets/AutomationActionInput.vue
+++ b/app/javascript/dashboard/components/widgets/AutomationActionInput.vue
@@ -7,6 +7,8 @@ import SingleSelect from 'dashboard/components-next/filter/inputs/SingleSelect.v
 import MultiSelect from 'dashboard/components-next/filter/inputs/MultiSelect.vue';
 import NextInput from 'dashboard/components-next/input/Input.vue';
 
+const CONTACT_EMAIL_TOKEN = '{{contact.email}}';
+
 export default {
   components: {
     AutomationActionTeamMessageInput,
@@ -118,6 +120,16 @@ export default {
       this.actionNameAsSelectModel = value;
       this.resetAction();
     },
+    insertContactEmailToken() {
+      const existingEmails = (this.castMessageVmodel || '')
+        .split(',')
+        .map(email => email.trim())
+        .filter(Boolean);
+
+      if (existingEmails.includes(CONTACT_EMAIL_TOKEN)) return;
+
+      this.action_params = [[...existingEmails, CONTACT_EMAIL_TOKEN].join(',')];
+    },
   },
 };
 </script>
@@ -150,13 +162,26 @@ export default {
             :options="dropdownValues"
             :dropdown-max-height="dropdownMaxHeight"
           />
-          <NextInput
+          <div
             v-else-if="inputType === 'email'"
-            v-model="action_params"
-            type="email"
-            size="sm"
-            :placeholder="$t('AUTOMATION.ACTION.EMAIL_INPUT_PLACEHOLDER')"
-          />
+            class="flex items-center w-full gap-2"
+          >
+            <NextInput
+              v-model="action_params"
+              type="text"
+              size="sm"
+              class="w-full"
+              :placeholder="$t('AUTOMATION.ACTION.EMAIL_INPUT_PLACEHOLDER')"
+            />
+            <NextButton
+              sm
+              link
+              slate
+              class="flex-shrink-0 whitespace-nowrap"
+              :label="$t('AUTOMATION.ACTION.INSERT_CONTACT_EMAIL')"
+              @click="insertContactEmailToken"
+            />
+          </div>
           <NextInput
             v-else-if="inputType === 'url'"
             v-model="action_params"

--- a/app/javascript/dashboard/components/widgets/AutomationActionInput.vue
+++ b/app/javascript/dashboard/components/widgets/AutomationActionInput.vue
@@ -95,7 +95,7 @@ export default {
       return this.actionTypes.map(a => ({ id: a.key, name: a.label }));
     },
     isVerticalLayout() {
-      return ['team_message', 'textarea'].includes(this.inputType);
+      return ['team_message', 'textarea', 'email'].includes(this.inputType);
     },
     castMessageVmodel: {
       get() {
@@ -126,7 +126,10 @@ export default {
         .map(email => email.trim())
         .filter(Boolean);
 
-      if (existingEmails.includes(CONTACT_EMAIL_TOKEN)) return;
+      const hasContactEmail = existingEmails.some(
+        email => email.replace(/\s+/g, '') === CONTACT_EMAIL_TOKEN
+      );
+      if (hasContactEmail) return;
 
       this.action_params = [[...existingEmails, CONTACT_EMAIL_TOKEN].join(',')];
     },
@@ -162,26 +165,6 @@ export default {
             :options="dropdownValues"
             :dropdown-max-height="dropdownMaxHeight"
           />
-          <div
-            v-else-if="inputType === 'email'"
-            class="flex items-center w-full gap-2"
-          >
-            <NextInput
-              v-model="action_params"
-              type="text"
-              size="sm"
-              class="w-full"
-              :placeholder="$t('AUTOMATION.ACTION.EMAIL_INPUT_PLACEHOLDER')"
-            />
-            <NextButton
-              sm
-              link
-              slate
-              class="flex-shrink-0 whitespace-nowrap"
-              :label="$t('AUTOMATION.ACTION.INSERT_CONTACT_EMAIL')"
-              @click="insertContactEmailToken"
-            />
-          </div>
           <NextInput
             v-else-if="inputType === 'url'"
             v-model="action_params"
@@ -205,14 +188,31 @@ export default {
           @click="removeAction"
         />
       </div>
+      <div v-if="inputType === 'email'" class="flex items-center w-full gap-2">
+        <NextInput
+          v-model="action_params"
+          type="text"
+          size="sm"
+          class="flex-1"
+          :placeholder="$t('AUTOMATION.ACTION.EMAIL_INPUT_PLACEHOLDER')"
+        />
+        <NextButton
+          sm
+          faded
+          slate
+          class="flex-shrink-0 whitespace-nowrap"
+          :label="$t('AUTOMATION.ACTION.INSERT_CONTACT_EMAIL')"
+          @click="insertContactEmailToken"
+        />
+      </div>
       <AutomationActionTeamMessageInput
-        v-if="inputType === 'team_message'"
+        v-else-if="inputType === 'team_message'"
         v-model="action_params"
         :teams="dropdownValues"
         :dropdown-max-height="dropdownMaxHeight"
       />
       <WootMessageEditor
-        v-if="inputType === 'textarea'"
+        v-else-if="inputType === 'textarea'"
         v-model="castMessageVmodel"
         rows="4"
         enable-variables

--- a/app/javascript/dashboard/i18n/locale/en/automation.json
+++ b/app/javascript/dashboard/i18n/locale/en/automation.json
@@ -143,7 +143,8 @@
       "TEAM_MESSAGE_INPUT_PLACEHOLDER": "Enter your message here",
       "TEAM_DROPDOWN_PLACEHOLDER": "Select teams",
       "EMAIL_INPUT_PLACEHOLDER": "Enter email",
-      "URL_INPUT_PLACEHOLDER": "Enter URL"
+      "URL_INPUT_PLACEHOLDER": "Enter URL",
+      "INSERT_CONTACT_EMAIL": "Use contact's email"
     },
     "TOGGLE": {
       "ACTIVATION_TITLE": "Activate Automation Rule",


### PR DESCRIPTION
Automations that send an email transcript now let you insert the conversation contact's email directly into the recipient field, instead of only accepting a hardcoded address typed in by hand.

## Closes
https://linear.app/chatwoot/issue/CW-7535/allow-automation-to-send-conversation-transcripts-to-user-emails

## How to test
1. Go to **Settings → Automation → Create Automation** (or edit an existing rule).
2. Add the **Send an Email Transcript** action.
3. Click **Use contact's email** next to the recipient field — it inserts `{{contact.email}}` into the field, appending to any address already typed rather than replacing it.
4. Save the rule and trigger it on a conversation with a contact that has an email address; confirm the transcript is delivered to that contact.

## What changed
- `AutomationActionInput.vue`: added a "Use contact's email" quick-insert action next to the recipient field for the `send_email_transcript` action, and switched the input from `type="email"` to `type="text"` so the dynamic token isn't fought by native email-format validation.
- No backend changes were needed — `send_email_transcript` already resolves `{{contact.email}}` via the existing Liquid templating support in `ActionService#send_email_transcript`; this change only exposes that capability in the UI.
- This also benefits the Macros editor, which shares the same input component.