### PR TITLE
fix: stop Captain handling blocked contacts [CW-7525]

### DIFF
--- a/enterprise/app/jobs/captain/conversation/response_builder_job.rb
+++ b/enterprise/app/jobs/captain/conversation/response_builder_job.rb
@@ -15,6 +15,7 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
     @assistant = assistant
     @responding_to_message_id = responding_to_message_id if captain_v2_enabled?
 
+    return if @conversation.contact.blocked?
     return log_non_pending unless conversation_pending?
 
     Current.executed_by = @assistant

--- a/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
+++ b/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
@@ -27,6 +27,8 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
     Current.executed_by = inbox.captain_assistant
 
     resolvable_pending_conversations(inbox).each do |conversation|
+      next unless still_resolvable?(conversation)
+
       create_resolution_message(conversation, inbox)
       conversation.resolved!
       Captain::ConversationEvents.resolved(
@@ -42,8 +44,10 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
     Current.executed_by = inbox.captain_assistant
 
     resolvable_pending_conversations(inbox).each do |conversation|
+      next unless still_resolvable?(conversation)
+
       evaluation = evaluate_conversation(conversation, inbox)
-      next unless still_resolvable_after_evaluation?(conversation)
+      next unless still_resolvable?(conversation)
 
       if evaluation[:complete]
         resolve_conversation(conversation, inbox, evaluation[:reason])
@@ -61,14 +65,14 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
   end
 
   def resolvable_pending_conversations(inbox)
-    inbox.conversations.pending
-         .where('last_activity_at < ?', auto_resolve_cutoff_time)
+    inbox.conversations.pending.joins(:contact).where(contacts: { blocked: false })
+         .where('conversations.last_activity_at < ?', auto_resolve_cutoff_time)
          .limit(Limits::BULK_ACTIONS_LIMIT)
   end
 
-  def still_resolvable_after_evaluation?(conversation)
+  def still_resolvable?(conversation)
     conversation.reload
-    conversation.pending? && conversation.last_activity_at < auto_resolve_cutoff_time
+    !conversation.contact.blocked? && conversation.pending? && conversation.last_activity_at < auto_resolve_cutoff_time
   rescue ActiveRecord::RecordNotFound
     false
   end

--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -65,6 +65,8 @@ class Captain::Assistant < ApplicationRecord
   end
 
   def engages?(contact, conversation)
+    return false if contact.blocked?
+
     responds_to_audience?(contact, conversation) && available_now?(conversation)
   end
 

--- a/enterprise/app/models/enterprise/concerns/contact.rb
+++ b/enterprise/app/models/enterprise/concerns/contact.rb
@@ -8,6 +8,7 @@ module Enterprise::Concerns::Contact
                  if: :should_associate_company?
     before_save :sync_company_name_from_company, if: :will_save_change_to_company_id?
     after_update_commit :record_company_activity, if: :saved_change_to_last_activity_at?
+    after_update_commit :resolve_captain_conversations, if: -> { saved_change_to_blocked? && blocked? }
   end
 
   private
@@ -37,6 +38,13 @@ module Enterprise::Concerns::Contact
 
   def record_company_activity
     company&.record_activity_at!(last_activity_at) if last_activity_at.present?
+  end
+
+  def resolve_captain_conversations
+    conversations.pending
+                 .joins(inbox: :captain_inbox)
+                 .where(assignee_agent_bot_id: nil)
+                 .find_each(&:resolved!)
   end
 
   def sync_company_name_from_company

--- a/enterprise/app/services/enterprise/message_templates/hook_execution_service.rb
+++ b/enterprise/app/services/enterprise/message_templates/hook_execution_service.rb
@@ -34,7 +34,8 @@ module Enterprise::MessageTemplates::HookExecutionService
   def should_process_captain_response?
     # Audience and schedule are decided when Captain first takes or reopens a conversation.
     # Do not re-evaluate an existing pending conversation for each new message.
-    conversation.pending? && message.captain_response_triggering? && captain_assistant_configured? && !inbox.external_bot_active?
+    conversation.pending? && !conversation.contact.blocked? && message.captain_response_triggering? &&
+      captain_assistant_configured? && !inbox.external_bot_active?
   end
 
   def perform_handoff

--- a/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
+++ b/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
@@ -34,6 +34,23 @@ RSpec.describe Captain::Conversation::ResponseBuilderJob, type: :job do
       allow(mock_false_promise_service).to receive(:detect).and_return({ 'decision' => 'safe', 'reason' => 'safe_response' })
     end
 
+    context 'when the contact is blocked after the job is queued' do
+      before do
+        conversation.contact.update_columns(blocked: true) # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      it 'does not generate a response or consume usage' do
+        expect(Captain::Llm::AssistantChatService).not_to receive(:new)
+        expect(Captain::Assistant::AgentRunnerService).not_to receive(:new)
+
+        expect do
+          described_class.perform_now(conversation, assistant)
+        end.not_to(change { account.reload.usage_limits[:captain][:responses][:consumed] })
+
+        expect(conversation.messages.outgoing).to be_empty
+      end
+    end
+
     context 'when captain_v2 is disabled' do
       before do
         allow(account).to receive(:feature_enabled?).and_return(false)

--- a/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
+++ b/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
@@ -31,6 +31,36 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
     end
   end
 
+  context 'when an inactive pending conversation belongs to a blocked contact' do
+    let!(:blocked_pending_conversation) do
+      create(:conversation, inbox: inbox, last_activity_at: 2.hours.ago, status: :pending).tap do |conversation|
+        conversation.contact.update_columns(blocked: true) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+
+    it 'does not resolve the conversation in time-based mode' do
+      allow(inbox.account).to receive(:feature_enabled?).and_call_original
+      allow(inbox.account).to receive(:feature_enabled?).with('captain_tasks').and_return(false)
+
+      described_class.perform_now(inbox)
+
+      expect(blocked_pending_conversation.reload.status).to eq('pending')
+      expect(blocked_pending_conversation.messages.outgoing).to be_empty
+    end
+
+    it 'does not evaluate or hand off the conversation in evaluated mode' do
+      allow(inbox.account).to receive(:feature_enabled?).and_call_original
+      allow(inbox.account).to receive(:feature_enabled?).with('captain_tasks').and_return(true)
+      mock_service = instance_double(Captain::ConversationCompletionService, perform: { complete: false, reason: 'Needs clarification' })
+      expect(Captain::ConversationCompletionService).to receive(:new).once.and_return(mock_service)
+
+      described_class.perform_now(inbox)
+
+      expect(blocked_pending_conversation.reload.status).to eq('pending')
+      expect(blocked_pending_conversation.messages.outgoing).to be_empty
+    end
+  end
+
   context 'when captain_tasks is disabled' do
     before do
       allow(inbox.account).to receive(:feature_enabled?).and_call_original

--- a/spec/enterprise/models/captain/assistant_spec.rb
+++ b/spec/enterprise/models/captain/assistant_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe Captain::Assistant, type: :model do
   let(:contact) { create(:contact, account: account, additional_attributes: { 'country_code' => 'US' }) }
   let(:conversation) { create(:conversation, account: account, contact: contact) }
 
+  describe '#engages?' do
+    it 'returns false when the contact is blocked' do
+      contact.update!(blocked: true)
+
+      expect(assistant.engages?(contact, conversation)).to be(false)
+    end
+  end
+
   describe '#responds_to_audience?' do
     it 'returns true when no audience is configured' do
       expect(assistant.responds_to_audience?(contact, conversation)).to be(true)

--- a/spec/enterprise/models/contact_spec.rb
+++ b/spec/enterprise/models/contact_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Contact, type: :model do
+  describe 'blocking a contact with an active Captain conversation' do
+    let(:account) { create(:account) }
+    let(:contact) { create(:contact, account: account) }
+    let(:captain_assistant) { create(:captain_assistant, account: account) }
+    let(:captain_enabled_inbox) { create(:inbox, account: account) }
+    let(:regular_inbox) { create(:inbox, account: account) }
+    let(:captain_inbox) do
+      create(:captain_inbox, captain_assistant: captain_assistant, inbox: captain_enabled_inbox)
+    end
+    let!(:captain_conversation) do
+      captain_inbox
+      create(:conversation, account: account, contact: contact, inbox: captain_enabled_inbox, status: :pending)
+    end
+    let!(:regular_pending_conversation) do
+      create(:conversation, account: account, contact: contact, inbox: regular_inbox, status: :pending)
+    end
+
+    it 'resolves the Captain conversation without changing other pending conversations' do
+      contact.update!(blocked: true)
+
+      expect(captain_conversation.reload).to be_resolved
+      expect(regular_pending_conversation.reload).to be_pending
+    end
+  end
+end

--- a/spec/enterprise/services/enterprise/message_templates/hook_execution_service_spec.rb
+++ b/spec/enterprise/services/enterprise/message_templates/hook_execution_service_spec.rb
@@ -12,6 +12,19 @@ RSpec.describe MessageTemplates::HookExecutionService do
   end
 
   context 'when captain assistant is configured' do
+    context 'when the contact is blocked while the conversation is pending' do
+      before do
+        contact.update_columns(blocked: true) # rubocop:disable Rails/SkipsModelValidations
+        conversation.reload
+      end
+
+      it 'does not schedule a Captain response' do
+        expect(Captain::Conversation::ResponseBuilderJob).not_to receive(:perform_later)
+
+        create(:message, conversation: conversation, message_type: :incoming, account: account)
+      end
+    end
+
     context 'when within business hours' do
       before do
         inbox.update!(working_hours_enabled: true)


### PR DESCRIPTION
Blocked contacts no longer trigger Captain replies or inactive-conversation actions. Blocking a contact also resolves active Captain conversations, including when a response was already queued.

## Closes

- CW-7525: https://linear.app/chatwoot/issue/CW-7525/captain-should-stop-handling-conversations-from-blocked-contacts

## How to reproduce

1. Configure Captain for an inbox and start a pending conversation.
2. Block the contact before the queued Captain response runs.
3. Confirm Captain does not reply, hand off, auto-resolve, or consume response usage.