### PR TITLE
Require existing users to already be saml before binding a SAML login

### DIFF
--- a/app/builders/agent_builder.rb
+++ b/app/builders/agent_builder.rb
@@ -35,6 +35,10 @@ class AgentBuilder
     @user
   end
 
+  def new_user?
+    @new_user
+  end
+
   private
 
   def can_add_agent?

--- a/enterprise/app/builders/enterprise/agent_builder.rb
+++ b/enterprise/app/builders/enterprise/agent_builder.rb
@@ -1,7 +1,8 @@
 module Enterprise::AgentBuilder
   def perform
     super.tap do |user|
-      convert_to_saml_provider(user) if user.persisted? && account.saml_enabled?
+      # Never flip an existing user's provider just by inviting them.
+      convert_to_saml_provider(user) if user.persisted? && new_user? && account.saml_enabled?
     end
   end
 

--- a/enterprise/app/builders/saml_user_builder.rb
+++ b/enterprise/app/builders/saml_user_builder.rb
@@ -19,14 +19,18 @@ class SamlUserBuilder
     user = User.from_email(auth_attribute('email'))
 
     return create_user unless user
-    return existing_user_for_account(user) if user_belongs_to_account?(user)
+    return existing_user_for_account(user) if eligible_existing_user?(user)
 
     raise AuthenticationFailed, I18n.t('auth.saml.authentication_failed')
   end
 
+  # Never bind a bare assertion to a user established via another provider.
+  def eligible_existing_user?(user)
+    user.provider == 'saml' && user_belongs_to_account?(user)
+  end
+
   def existing_user_for_account(user)
     confirm_user_if_required(user)
-    convert_existing_user_to_saml(user)
     user
   end
 
@@ -39,12 +43,6 @@ class SamlUserBuilder
 
     user.skip_confirmation!
     user.save!
-  end
-
-  def convert_existing_user_to_saml(user)
-    return if user.provider == 'saml'
-
-    user.update!(provider: 'saml')
   end
 
   def create_user

--- a/spec/enterprise/builders/agent_builder_spec.rb
+++ b/spec/enterprise/builders/agent_builder_spec.rb
@@ -55,12 +55,12 @@ RSpec.describe AgentBuilder do
         expect { builder.perform }.not_to change(User, :count)
       end
 
-      it 'converts existing user to SAML provider' do
+      it 'does not convert the existing user to SAML provider' do
         expect(existing_user.provider).to eq('email')
 
         builder.perform
 
-        expect(existing_user.reload.provider).to eq('saml')
+        expect(existing_user.reload.provider).to eq('email')
       end
 
       it 'adds existing user to the account' do

--- a/spec/enterprise/builders/saml_user_builder_spec.rb
+++ b/spec/enterprise/builders/saml_user_builder_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe SamlUserBuilder do
       end
     end
 
-    context 'when user already exists' do
-      let!(:existing_user) { create(:user, email: email, account: account) }
+    context 'when user already exists with SAML provider' do
+      let!(:existing_user) { create(:user, email: email, account: account, provider: 'saml') }
 
       it 'does not create a new user' do
         expect { builder.perform }.not_to change(User, :count)
@@ -90,101 +90,111 @@ RSpec.describe SamlUserBuilder do
         expect(user.accounts).to include(account)
       end
 
-      it 'converts existing user to SAML' do
-        expect(existing_user.provider).not_to eq('saml')
-
-        builder.perform
-
-        expect(existing_user.reload.provider).to eq('saml')
-      end
-
-      it 'does not change provider if user is already SAML' do
-        existing_user.update!(provider: 'saml')
-
+      it 'does not change provider' do
         expect { builder.perform }.not_to(change { existing_user.reload.provider })
       end
 
       it 'does not duplicate account association' do
         expect { builder.perform }.not_to change(AccountUser, :count)
       end
+    end
 
-      context 'when the user does not belong to the target account' do
-        let!(:other_account) { create(:account) }
-        let!(:existing_user) { create(:user, email: email, account: other_account) }
+    context 'when user already exists with a non-SAML provider' do
+      let!(:existing_user) { create(:user, email: email, account: account, provider: 'email') }
 
-        it 'raises an authentication failure' do
-          expect { builder.perform }.to raise_error do |error|
-            expect(error.class.name).to eq('SamlUserBuilder::AuthenticationFailed')
-            expect(error.message).to eq(I18n.t('auth.saml.authentication_failed'))
-          end
+      it 'raises an authentication failure instead of converting the user' do
+        expect { builder.perform }.to raise_error do |error|
+          expect(error.class.name).to eq('SamlUserBuilder::AuthenticationFailed')
+          expect(error.message).to eq(I18n.t('auth.saml.authentication_failed'))
         end
+        expect(existing_user.reload.provider).to eq('email')
+      end
 
-        it 'does not add the user to the target account' do
-          expect do
-            builder.perform
-          rescue StandardError => e
-            raise unless e.class.name == 'SamlUserBuilder::AuthenticationFailed' # rubocop:disable Style/ClassEqualityComparison
-          end.not_to change(AccountUser, :count)
-          expect(existing_user.reload.accounts).not_to include(account)
-        end
+      it 'does not create a new user' do
+        expect do
+          builder.perform
+        rescue SamlUserBuilder::AuthenticationFailed
+          nil
+        end.not_to change(User, :count)
+      end
+    end
 
-        it 'does not convert the user provider to saml' do
-          expect do
-            builder.perform
-          rescue StandardError => e
-            raise unless e.class.name == 'SamlUserBuilder::AuthenticationFailed' # rubocop:disable Style/ClassEqualityComparison
-          end.not_to(change { existing_user.reload.provider })
+    context 'when the user does not belong to the target account' do
+      let!(:other_account) { create(:account) }
+      let!(:existing_user) { create(:user, email: email, account: other_account, provider: 'saml') }
+
+      it 'raises an authentication failure' do
+        expect { builder.perform }.to raise_error do |error|
+          expect(error.class.name).to eq('SamlUserBuilder::AuthenticationFailed')
+          expect(error.message).to eq(I18n.t('auth.saml.authentication_failed'))
         end
       end
 
-      context 'when user is not confirmed' do
-        let(:unconfirmed_email) { 'unconfirmed_saml_user@example.com' }
-        let(:unconfirmed_auth_hash) do
-          {
-            'provider' => 'saml',
-            'uid' => 'saml-uid-123',
-            'info' => {
-              'email' => unconfirmed_email,
-              'name' => 'SAML User',
-              'first_name' => 'SAML',
-              'last_name' => 'User'
-            },
-            'extra' => {
-              'raw_info' => {
-                'groups' => %w[Administrators Users]
-              }
+      it 'does not add the user to the target account' do
+        expect do
+          builder.perform
+        rescue StandardError => e
+          raise unless e.class.name == 'SamlUserBuilder::AuthenticationFailed' # rubocop:disable Style/ClassEqualityComparison
+        end.not_to change(AccountUser, :count)
+        expect(existing_user.reload.accounts).not_to include(account)
+      end
+
+      it 'does not convert the user provider to saml' do
+        expect do
+          builder.perform
+        rescue StandardError => e
+          raise unless e.class.name == 'SamlUserBuilder::AuthenticationFailed' # rubocop:disable Style/ClassEqualityComparison
+        end.not_to(change { existing_user.reload.provider })
+      end
+    end
+
+    context 'when user is not confirmed' do
+      let(:unconfirmed_email) { 'unconfirmed_saml_user@example.com' }
+      let(:unconfirmed_auth_hash) do
+        {
+          'provider' => 'saml',
+          'uid' => 'saml-uid-123',
+          'info' => {
+            'email' => unconfirmed_email,
+            'name' => 'SAML User',
+            'first_name' => 'SAML',
+            'last_name' => 'User'
+          },
+          'extra' => {
+            'raw_info' => {
+              'groups' => %w[Administrators Users]
             }
           }
-        end
-        let(:unconfirmed_builder) { described_class.new(unconfirmed_auth_hash, account.id) }
-        let!(:existing_user) do
-          user = build(:user, email: unconfirmed_email, account: account)
-          user.confirmed_at = nil
-          user.save!(validate: false)
-          user
-        end
-
-        it 'confirms unconfirmed user after SAML authentication' do
-          expect(existing_user.confirmed?).to be false
-
-          unconfirmed_builder.perform
-
-          expect(existing_user.reload.confirmed?).to be true
-        end
+        }
+      end
+      let(:unconfirmed_builder) { described_class.new(unconfirmed_auth_hash, account.id) }
+      let!(:existing_user) do
+        user = build(:user, email: unconfirmed_email, account: account, provider: 'saml')
+        user.confirmed_at = nil
+        user.save!(validate: false)
+        user
       end
 
-      context 'when user is already confirmed' do
-        let!(:existing_user) { create(:user, email: email, account: account, confirmed_at: Time.current) }
+      it 'confirms unconfirmed user after SAML authentication' do
+        expect(existing_user.confirmed?).to be false
 
-        it 'keeps already confirmed user confirmed' do
-          expect(existing_user.confirmed?).to be true
-          original_confirmed_at = existing_user.confirmed_at
+        unconfirmed_builder.perform
 
-          builder.perform
+        expect(existing_user.reload.confirmed?).to be true
+      end
+    end
 
-          expect(existing_user.reload.confirmed?).to be true
-          expect(existing_user.reload.confirmed_at).to be_within(2.seconds).of(original_confirmed_at)
-        end
+    context 'when user is already confirmed' do
+      let!(:existing_user) { create(:user, email: email, account: account, provider: 'saml', confirmed_at: Time.current) }
+
+      it 'keeps already confirmed user confirmed' do
+        expect(existing_user.confirmed?).to be true
+        original_confirmed_at = existing_user.confirmed_at
+
+        builder.perform
+
+        expect(existing_user.reload.confirmed?).to be true
+        expect(existing_user.reload.confirmed_at).to be_within(2.seconds).of(original_confirmed_at)
       end
     end
 

--- a/spec/enterprise/controllers/enterprise/devise_overrides/omniauth_callbacks_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/devise_overrides/omniauth_callbacks_controller_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe 'Enterprise SAML OmniAuth Callbacks', type: :request do
       end
     end
 
-    it 'logs in existing user' do
+    it 'logs in existing user already provisioned via SAML' do
       with_modified_env FRONTEND_URL: 'http://www.example.com' do
-        create(:user, email: 'existing@example.com', account: account)
+        create(:user, email: 'existing@example.com', account: account, provider: 'saml')
         set_saml_config('existing@example.com')
 
         get "/omniauth/saml/callback?account_id=#{account.id}"
@@ -49,9 +49,21 @@ RSpec.describe 'Enterprise SAML OmniAuth Callbacks', type: :request do
       end
     end
 
+    it 'rejects an existing user already a member of the account but with a non-SAML provider' do
+      with_modified_env FRONTEND_URL: 'http://www.example.com' do
+        existing_user = create(:user, email: 'existing@example.com', account: account, provider: 'email')
+        set_saml_config('existing@example.com')
+
+        get "/omniauth/saml/callback?account_id=#{account.id}"
+
+        expect(response).to redirect_to('http://www.example.com/app/login?error=saml-authentication-failed')
+        expect(existing_user.reload.provider).to eq('email')
+      end
+    end
+
     it 'redirects mobile SAML login to the mobile deep link' do
       with_modified_env FRONTEND_URL: 'http://www.example.com' do
-        create(:user, email: 'mobile@example.com', account: account)
+        create(:user, email: 'mobile@example.com', account: account, provider: 'saml')
         set_saml_config('mobile@example.com')
 
         get "/omniauth/saml/callback?account_id=#{account.id}&RelayState=mobile"


### PR DESCRIPTION
## Summary
A SAML login can now only be matched to an existing user when that user is already provider `saml` — matching by email alone is no longer sufficient. Inviting an existing user into a SAML-enabled account no longer silently changes their authentication provider either.

## What changed
- `SamlUserBuilder` requires `provider == 'saml'` before binding a login to an existing user; otherwise the login is rejected.
- `Enterprise::AgentBuilder` only sets `provider: 'saml'` for newly created users, not existing ones being added to an account.