### PR TITLE
Notify existing users when added to a new account

### DIFF
--- a/app/builders/agent_builder.rb
+++ b/app/builders/agent_builder.rb
@@ -32,6 +32,7 @@ class AgentBuilder
       end
     end
     @user.send_confirmation_instructions if user_needs_confirmation?
+    notify_existing_user_added_to_account unless new_user?
     @user
   end
 
@@ -40,6 +41,10 @@ class AgentBuilder
   end
 
   private
+
+  def notify_existing_user_added_to_account
+    AdministratorNotifications::AccountNotificationMailer.with(account: account).added_as_agent(@user, account).deliver_later
+  end
 
   def can_add_agent?
     account.usage_limits[:agents] > account.account_users.count

--- a/app/mailers/administrator_notifications/account_notification_mailer.rb
+++ b/app/mailers/administrator_notifications/account_notification_mailer.rb
@@ -58,6 +58,14 @@ class AdministratorNotifications::AccountNotificationMailer < AdministratorNotif
     send_notification(subject, action_url: action_url, meta: meta)
   end
 
+  def added_as_agent(user, account)
+    subject = "You've been added to #{account.name} on Chatwoot"
+    action_url = "#{ENV.fetch('FRONTEND_URL', nil)}/app/accounts/#{account.id}/dashboard"
+    meta = { 'account_name' => account.name }
+
+    send_notification(subject, to: user.email, action_url: action_url, meta: meta)
+  end
+
   private
 
   def format_deletion_date(deletion_date_str)

--- a/app/views/mailers/administrator_notifications/account_notification_mailer/added_as_agent.liquid
+++ b/app/views/mailers/administrator_notifications/account_notification_mailer/added_as_agent.liquid
@@ -1,0 +1,9 @@
+<p>Hello,</p>
+
+<p>Your existing Chatwoot account was just added as an agent to <strong>{{meta['account_name']}}</strong>.</p>
+
+<p>If you don't recognize this account or weren't expecting this, please contact your Chatwoot administrator.</p>
+
+<p>
+  Click <a href="{{action_url}}">here</a> to view the account.
+</p>

--- a/spec/builders/agent_builder_spec.rb
+++ b/spec/builders/agent_builder_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe AgentBuilder, type: :model do
         expect(account.emails_sent_today).to eq(1)
       end
 
+      it 'does not notify about being added to an existing account' do
+        expect { agent_builder.perform }.not_to have_enqueued_mail(AdministratorNotifications::AccountNotificationMailer, :added_as_agent)
+      end
+
       context 'when the account email limit is exhausted' do
         before do
           allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
@@ -85,6 +89,10 @@ RSpec.describe AgentBuilder, type: :model do
 
         expect { agent_builder.perform }.not_to have_enqueued_mail(Devise::Mailer, :confirmation_instructions)
         expect(account.emails_sent_today).to eq(0)
+      end
+
+      it 'notifies the user that they were added to a new account' do
+        expect { agent_builder.perform }.to have_enqueued_mail(AdministratorNotifications::AccountNotificationMailer, :added_as_agent)
       end
     end
 


### PR DESCRIPTION
## Summary
When an existing Chatwoot user is added as an agent to an account (rather than signing up fresh), they now receive an email letting them know.

## What changed
- New `AdministratorNotifications::AccountNotificationMailer#added_as_agent` mailer.
- `AgentBuilder` sends this notification whenever the added user already existed prior to the invite.

Stacked on #15388 — diff here is only the notification piece.