### PR TITLE
Bind SAML logins on uid, not just provider

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,7 +132,18 @@ class User < ApplicationRecord
   end
 
   def set_password_and_uid
-    self.uid = email
+    self.uid = email if uid.blank?
+  end
+
+  # Marks a user as saml-provisioned before their real NameID is known (e.g. invited
+  # ahead of their first real login). Per-user, so it can't collide with the
+  # (uid, provider) uniqueness constraint the way a shared blank value would.
+  def pending_saml_uid
+    "pending-saml-uid:#{id}"
+  end
+
+  def pending_saml_uid?
+    uid == pending_saml_uid
   end
 
   def assigned_inboxes

--- a/enterprise/app/builders/enterprise/agent_builder.rb
+++ b/enterprise/app/builders/enterprise/agent_builder.rb
@@ -8,7 +8,8 @@ module Enterprise::AgentBuilder
 
   private
 
+  # uid stays pending until their first real SAML login binds it.
   def convert_to_saml_provider(user)
-    user.update!(provider: 'saml') unless user.provider == 'saml'
+    user.update!(provider: 'saml', uid: user.pending_saml_uid) unless user.provider == 'saml'
   end
 end

--- a/enterprise/app/builders/saml_user_builder.rb
+++ b/enterprise/app/builders/saml_user_builder.rb
@@ -25,12 +25,14 @@ class SamlUserBuilder
   end
 
   # Never bind a bare assertion to a user established via another provider.
+  # A pending uid means no real login has bound this user yet, so this one is trusted.
   def eligible_existing_user?(user)
-    user.provider == 'saml' && user_belongs_to_account?(user)
+    user.provider == 'saml' && (user.pending_saml_uid? || user.uid == uid) && user_belongs_to_account?(user)
   end
 
   def existing_user_for_account(user)
     confirm_user_if_required(user)
+    user.update!(uid: uid) if user.pending_saml_uid?
     user
   end
 

--- a/enterprise/app/jobs/saml/update_account_users_provider_job.rb
+++ b/enterprise/app/jobs/saml/update_account_users_provider_job.rb
@@ -9,7 +9,11 @@ class Saml::UpdateAccountUsersProviderJob < ApplicationJob
       next unless should_update_user_provider?(user, provider)
 
       # rubocop:disable Rails/SkipsModelValidations
-      user.update_column(:provider, provider)
+      if provider == 'saml' && user.provider != 'saml'
+        user.update_columns(provider: provider, uid: user.pending_saml_uid)
+      else
+        user.update_column(:provider, provider)
+      end
       # rubocop:enable Rails/SkipsModelValidations
     end
   end

--- a/spec/enterprise/builders/agent_builder_spec.rb
+++ b/spec/enterprise/builders/agent_builder_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe AgentBuilder do
         expect(user.encrypted_password).to be_present
       end
 
+      it 'leaves uid as a pending placeholder until a real SAML login binds it' do
+        user = builder.perform
+        expect(user.pending_saml_uid?).to be true
+      end
+
       it 'adds user to the account with correct role' do
         user = builder.perform
         account_user = AccountUser.find_by(user: user, account: account)

--- a/spec/enterprise/builders/saml_user_builder_spec.rb
+++ b/spec/enterprise/builders/saml_user_builder_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SamlUserBuilder do
         expect(user.name).to eq('SAML User')
         expect(user.display_name).to eq('SAML')
         expect(user.provider).to eq('saml')
-        expect(user.uid).to eq(email) # User model sets uid to email in before_validation callback
+        expect(user.uid).to eq('saml-uid-123') # the real SAML NameID, not clobbered to email
         expect(user.confirmed_at).to be_present
       end
 
@@ -73,8 +73,8 @@ RSpec.describe SamlUserBuilder do
       end
     end
 
-    context 'when user already exists with SAML provider' do
-      let!(:existing_user) { create(:user, email: email, account: account, provider: 'saml') }
+    context 'when user already exists with a matching SAML uid' do
+      let!(:existing_user) { create(:user, email: email, account: account, provider: 'saml', uid: 'saml-uid-123') }
 
       it 'does not create a new user' do
         expect { builder.perform }.not_to change(User, :count)
@@ -119,9 +119,36 @@ RSpec.describe SamlUserBuilder do
       end
     end
 
+    context 'when user already exists with SAML provider but a mismatched uid' do
+      let!(:existing_user) { create(:user, email: email, account: account, provider: 'saml', uid: 'a-different-uid') }
+
+      it 'raises an authentication failure instead of logging the user in' do
+        expect { builder.perform }.to raise_error do |error|
+          expect(error.class.name).to eq('SamlUserBuilder::AuthenticationFailed')
+          expect(error.message).to eq(I18n.t('auth.saml.authentication_failed'))
+        end
+        expect(existing_user.reload.uid).to eq('a-different-uid')
+      end
+    end
+
+    context 'when user already exists with SAML provider but no uid bound yet' do
+      let!(:existing_user) do
+        user = create(:user, email: email, account: account, provider: 'saml')
+        user.update!(uid: user.pending_saml_uid) # simulate a preemptive invite-time conversion
+        user
+      end
+
+      it 'logs the user in and binds the uid from this login' do
+        user = builder.perform
+
+        expect(user).to eq(existing_user)
+        expect(existing_user.reload.uid).to eq('saml-uid-123')
+      end
+    end
+
     context 'when the user does not belong to the target account' do
       let!(:other_account) { create(:account) }
-      let!(:existing_user) { create(:user, email: email, account: other_account, provider: 'saml') }
+      let!(:existing_user) { create(:user, email: email, account: other_account, provider: 'saml', uid: 'saml-uid-123') }
 
       it 'raises an authentication failure' do
         expect { builder.perform }.to raise_error do |error|
@@ -169,7 +196,7 @@ RSpec.describe SamlUserBuilder do
       end
       let(:unconfirmed_builder) { described_class.new(unconfirmed_auth_hash, account.id) }
       let!(:existing_user) do
-        user = build(:user, email: unconfirmed_email, account: account, provider: 'saml')
+        user = build(:user, email: unconfirmed_email, account: account, provider: 'saml', uid: 'saml-uid-123')
         user.confirmed_at = nil
         user.save!(validate: false)
         user
@@ -185,7 +212,7 @@ RSpec.describe SamlUserBuilder do
     end
 
     context 'when user is already confirmed' do
-      let!(:existing_user) { create(:user, email: email, account: account, provider: 'saml', confirmed_at: Time.current) }
+      let!(:existing_user) { create(:user, email: email, account: account, provider: 'saml', uid: 'saml-uid-123', confirmed_at: Time.current) }
 
       it 'keeps already confirmed user confirmed' do
         expect(existing_user.confirmed?).to be true

--- a/spec/enterprise/controllers/enterprise/devise_overrides/omniauth_callbacks_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/devise_overrides/omniauth_callbacks_controller_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe 'Enterprise SAML OmniAuth Callbacks', type: :request do
       end
     end
 
-    it 'logs in existing user already provisioned via SAML' do
+    it 'logs in existing user already provisioned via SAML with a matching uid' do
       with_modified_env FRONTEND_URL: 'http://www.example.com' do
-        create(:user, email: 'existing@example.com', account: account, provider: 'saml')
+        create(:user, email: 'existing@example.com', account: account, provider: 'saml', uid: '123545')
         set_saml_config('existing@example.com')
 
         get "/omniauth/saml/callback?account_id=#{account.id}"
@@ -63,7 +63,7 @@ RSpec.describe 'Enterprise SAML OmniAuth Callbacks', type: :request do
 
     it 'redirects mobile SAML login to the mobile deep link' do
       with_modified_env FRONTEND_URL: 'http://www.example.com' do
-        create(:user, email: 'mobile@example.com', account: account, provider: 'saml')
+        create(:user, email: 'mobile@example.com', account: account, provider: 'saml', uid: '123545')
         set_saml_config('mobile@example.com')
 
         get "/omniauth/saml/callback?account_id=#{account.id}&RelayState=mobile"

--- a/spec/enterprise/jobs/saml/update_account_users_provider_job_spec.rb
+++ b/spec/enterprise/jobs/saml/update_account_users_provider_job_spec.rb
@@ -8,12 +8,25 @@ RSpec.describe Saml::UpdateAccountUsersProviderJob, type: :job do
 
   describe '#perform' do
     context 'when setting provider to saml' do
-      it 'updates all account users to saml provider' do
+      it 'updates all account users to saml provider with a pending uid' do
         described_class.new.perform(account.id, 'saml')
 
         expect(user1.reload.provider).to eq('saml')
+        expect(user1.pending_saml_uid?).to be true
         expect(user2.reload.provider).to eq('saml')
+        expect(user2.pending_saml_uid?).to be true
         expect(user3.reload.provider).to eq('saml')
+        expect(user3.pending_saml_uid?).to be true
+      end
+
+      context 'when a user is already using saml with a bound uid' do
+        before { user1.update!(provider: 'saml', uid: 'real-idp-uid-123') }
+
+        it 'does not overwrite their uid' do
+          described_class.new.perform(account.id, 'saml')
+
+          expect(user1.reload.uid).to eq('real-idp-uid-123')
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
An existing SAML user's login now also has to match on `uid` (their real IdP NameID), not just have `provider` set to `saml`. Users marked `saml` before their real NameID is known (invited ahead of their first login, or migrated in bulk when an account turns SAML on) get a per-user pending placeholder instead, and their first real login binds the real `uid`, same as a brand-new user would.

## What changed
- `SamlUserBuilder` requires a matching `uid` (or an unconfirmed/pending one) before binding a login to an existing user.
- `User#pending_saml_uid` / `#pending_saml_uid?` — a per-user placeholder marking "saml, but not yet confirmed by a real login," avoiding a collision on the `(uid, provider)` uniqueness constraint that a shared blank value would cause.
- `Enterprise::AgentBuilder` and `Saml::UpdateAccountUsersProviderJob` set this placeholder instead of leaving `uid` stale when marking a user as saml ahead of their first login.

No migration required.

Stacked on #15388 — diff here is only this uid-binding piece.