### PR TITLE
fix: allow resizing the reply editor while a Copilot suggestion is active

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/CopilotEditor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/CopilotEditor.vue
@@ -203,16 +203,16 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="space-y-2 mb-4">
-    <div class="overflow-y-auto max-h-56">
+  <div class="resizable-editor-body flex flex-col gap-2 mb-3">
+    <div class="flex-1 min-h-0 overflow-y-auto">
       <p
         v-dompurify-html="formatMessage(generatedContent, false)"
-        class="text-n-iris-12 text-sm prose-sm font-normal !mb-4"
+        class="text-n-iris-12 text-sm prose-sm font-normal"
       />
     </div>
-    <div class="editor-root relative editor--copilot space-x-2">
+    <div class="editor-root relative editor--copilot shrink-0">
       <div ref="editor" />
-      <div class="flex items-center justify-end absolute right-2 bottom-2">
+      <div class="flex items-center justify-end absolute end-2 bottom-2">
         <NextButton
           class="bg-n-iris-9 text-white !rounded-full"
           icon="i-lucide-arrow-up"
@@ -233,9 +233,9 @@ onMounted(() => {
 
   .ProseMirror-woot-style {
     min-height: 5rem;
-    max-height: 7.5rem !important;
+    max-height: 7.5rem;
     overflow: auto;
-    @apply px-2 !important;
+    @apply ps-2 pe-10 !important;
 
     .empty-node {
       &::before {

--- a/app/javascript/dashboard/components/widgets/WootWriter/CopilotEditor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/CopilotEditor.vue
@@ -248,4 +248,9 @@ onMounted(() => {
     }
   }
 }
+
+.resizable-editor-wrapper .editor--copilot .ProseMirror-woot-style {
+  min-height: min(5rem, calc(var(--editor-height) - 2.5rem));
+  max-height: min(7.5rem, calc(var(--editor-height) - 2.5rem));
+}
 </style>

--- a/app/javascript/dashboard/components/widgets/WootWriter/CopilotEditor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/CopilotEditor.vue
@@ -204,7 +204,7 @@ onMounted(() => {
 
 <template>
   <div class="resizable-editor-body flex flex-col gap-2 mb-3">
-    <div class="flex-1 min-h-0 overflow-y-auto">
+    <div class="copilot-suggestion flex-1 min-h-0 overflow-y-auto">
       <p
         v-dompurify-html="formatMessage(generatedContent, false)"
         class="text-n-iris-12 text-sm prose-sm font-normal"
@@ -227,6 +227,10 @@ onMounted(() => {
 
 <style lang="scss">
 @import '@chatwoot/prosemirror-schema/src/styles/base.scss';
+
+.copilot-suggestion:not(:where(.resizable-editor-wrapper *)) {
+  @apply max-h-56;
+}
 
 .editor--copilot {
   @apply bg-n-iris-5 rounded;

--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -739,6 +739,7 @@ function createEditorView() {
   editorView = new EditorView(editor.value, {
     state: state,
     editable: () => !props.disabled,
+    attributes: { class: 'resizable-editor-body' },
     nodeViews: {
       image: imageResizeView,
     },
@@ -992,28 +993,9 @@ useEmitter(BUS_EVENTS.INSERT_INTO_RICH_EDITOR, insertContentIntoEditor);
 }
 
 .ProseMirror-woot-style:not(
-    :where(.resizable-editor-wrapper .ProseMirror-woot-style)
+    :where(.resizable-editor-wrapper .resizable-editor-body)
   ) {
   @apply min-h-[5rem] max-h-[7.5rem];
-}
-
-// Resizable editor wrapper styles
-.resizable-editor-wrapper {
-  .ProseMirror-woot-style {
-    min-height: clamp(
-      var(--editor-min-allowed, var(--editor-min-height, 5rem)),
-      var(--editor-height, var(--editor-min-height, 5rem)),
-      var(--editor-max-allowed, var(--editor-max-height, 7.5rem))
-    );
-    max-height: clamp(
-      var(--editor-min-allowed, var(--editor-min-height, 5rem)),
-      var(--editor-height, var(--editor-min-height, 5rem)),
-      var(--editor-max-allowed, var(--editor-max-height, 7.5rem))
-    );
-    transition:
-      min-height var(--editor-height-transition, 180ms ease),
-      max-height var(--editor-height-transition, 180ms ease);
-  }
 }
 
 .ProseMirror-prompt-backdrop::backdrop {

--- a/app/javascript/dashboard/components/widgets/conversation/CopilotEditorSection.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/CopilotEditorSection.vue
@@ -73,13 +73,17 @@ const onSend = () => {
     <div
       v-else-if="isGeneratingContent"
       key="loading-state"
-      class="bg-n-iris-5 rounded min-h-[4.75rem] w-full mb-4 p-4 flex items-start"
+      class="resizable-editor-body flex flex-col justify-end mb-3"
     >
-      <div class="flex items-center gap-2">
-        <CaptainLoader class="text-n-iris-10 size-4" />
-        <span class="text-sm text-n-iris-10">
-          {{ $t('CONVERSATION.REPLYBOX.COPILOT_THINKING') }}
-        </span>
+      <div
+        class="bg-n-iris-5 rounded min-h-[4.75rem] w-full p-4 flex items-start"
+      >
+        <div class="flex items-center gap-2">
+          <CaptainLoader class="text-n-iris-10 size-4" />
+          <span class="text-sm text-n-iris-10">
+            {{ $t('CONVERSATION.REPLYBOX.COPILOT_THINKING') }}
+          </span>
+        </div>
       </div>
     </div>
   </Transition>

--- a/app/javascript/dashboard/components/widgets/conversation/ResizableEditorWrapper.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ResizableEditorWrapper.vue
@@ -152,3 +152,25 @@ defineExpose({ toggleEditorExpand, resetEditorHeight });
     <slot />
   </div>
 </template>
+
+<style lang="scss">
+.resizable-editor-wrapper {
+  .resizable-editor-body {
+    @apply overflow-auto;
+
+    min-height: clamp(
+      var(--editor-min-allowed, 5rem),
+      var(--editor-height, 5rem),
+      var(--editor-max-allowed, 7.5rem)
+    );
+    max-height: clamp(
+      var(--editor-min-allowed, 5rem),
+      var(--editor-height, 5rem),
+      var(--editor-max-allowed, 7.5rem)
+    );
+    transition:
+      min-height var(--editor-height-transition, 180ms ease),
+      max-height var(--editor-height-transition, 180ms ease);
+  }
+}
+</style>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where the reply editor's drag handle did nothing while a Copilot suggestion or the "Copilot is thinking" loader was visible.

The handle now resizes the Copilot section the same way it resizes the normal editor. The reply box also keeps the same height when switching between the editor, loader, and suggestion states.


Fixes https://linear.app/chatwoot/issue/CW-7902/i-cant-change-the-size-of-the-editor-when-the-ai-suggestion-is-active

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screencast

https://github.com/user-attachments/assets/9ef45f12-0b97-4e2b-9bcb-453e4d4773fd



### Steps to reproduce

1. Open a conversation and trigger a Copilot reply suggestion.
2. Drag the handle above the reply box. Nothing moves.
3. Discard or accept the suggestion. The reply box jumps to a different height.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
