### PR TITLE
fix: close editor pickers when the composer state is rebuilt

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -469,6 +469,13 @@ function handleClickOutside(event) {
 }
 
 function reloadState(content = props.modelValue) {
+  range.value = null;
+  showUserMentions.value = false;
+  showCannedMenu.value = false;
+  showVariables.value = false;
+  showEmojiMenu.value = false;
+  showToolsMenu.value = false;
+
   const unrefContent = unref(content);
   state = createState(
     unrefContent,
@@ -827,9 +834,6 @@ watch(
 watch(
   computed(() => props.editorId),
   () => {
-    showCannedMenu.value = false;
-    showEmojiMenu.value = false;
-    showVariables.value = false;
     reloadState(props.modelValue);
   }
 );


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the mention picker staying open when switching between Reply and Private Note, or when switching conversations while a picker is open. The picker could keep a stale range from the previous editor state, and selecting an agent from it would crash the editor with `RangeError: Position N out of range`.

The pickers now close whenever the editor content is rebuilt, and the stored suggestion range is cleared before creating the new editor state.

This is a pre-existing issue and not a regression from the picker PR.

For the mention picker to open, `@` needs to be at the start of a line or preceded by whitespace, so the repro uses `hello @` instead of `abc@`.

#### What changed

Rebuilding the editor state creates new plugin instances, so the old suggestion plugin is removed without calling `onExit`. This leaves the picker's stored range pointing to a document that no longer exists.
`reloadState` now clears the stored suggestion range and closes all open pickers before rebuilding the editor state.
This is a pre-existing issue and not a regression from the picker PR.

Fixes https://linear.app/chatwoot/issue/CW-7919/mention-picker-opens-on-an-empty-private-note-and-crashes-when-an

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?


### Steps to reproduce

1. Open a conversation and stay in Reply mode.
2. Type `hello @` to open the mention picker.
3. Switch to Private Note.
4. Click any agent from the still-open picker.
5. The editor crashes with `RangeError: Position N out of range`.
6. The same issue can be reproduced by switching to another conversation while a picker is open.





## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
