### PR TITLE
fix: Handle NUL bytes in canned response search

### DIFF
--- a/app/controllers/api/v1/accounts/canned_responses_controller.rb
+++ b/app/controllers/api/v1/accounts/canned_responses_controller.rb
@@ -33,9 +33,10 @@ class Api::V1::Accounts::CannedResponsesController < Api::V1::Accounts::BaseCont
 
   def canned_responses
     if params[:search]
+      search = params[:search].delete("\0")
       Current.account.canned_responses
-             .where('short_code ILIKE :search OR content ILIKE :search', search: "%#{params[:search]}%")
-             .order_by_search(params[:search])
+             .where('short_code ILIKE :search OR content ILIKE :search', search: "%#{search}%")
+             .order_by_search(search)
 
     else
       Current.account.canned_responses

--- a/spec/controllers/api/v1/accounts/canned_responses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/canned_responses_controller_spec.rb
@@ -46,6 +46,18 @@ RSpec.describe 'Canned Responses API', type: :request do
           [cr3, cr2, cr1].as_json
         )
       end
+
+      it 'ignores null bytes in the search string' do
+        matching_response = create(:canned_response, account: account, content: 'Unique response', short_code: 'unique')
+
+        get "/api/v1/accounts/#{account.id}/canned_responses",
+            params: { search: "uni\0que" },
+            headers: agent.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body).to eq([matching_response].as_json)
+      end
     end
   end
 


### PR DESCRIPTION
Canned response search now removes NUL bytes from user-provided search text before passing it to PostgreSQL, so malformed input returns normal search results instead of a database encoding error.

## Closes

- [CW-7922](https://linear.app/chatwoot/issue/CW-7922/harden-backend-paths-causing-production-sentry-errors)
- [Sentry 7663466064](https://chatwoot-p3.sentry.io/issues/7663466064/)

## How to reproduce

Call the canned responses endpoint with a search parameter containing a NUL byte. PostgreSQL previously raised `PG::UntranslatableCharacter` while evaluating the search query.

## What changed

- Strip NUL bytes once at the controller boundary.
- Reuse the sanitized value for matching and result ranking.
- Add request coverage for a search term containing a NUL byte.
