### PR TITLE
fix: handle empty round robin queues

### DIFF
--- a/app/services/auto_assignment/inbox_round_robin_service.rb
+++ b/app/services/auto_assignment/inbox_round_robin_service.rb
@@ -17,8 +17,9 @@ class AutoAssignment::InboxRoundRobinService
   end
 
   def reset_queue
+    user_ids = inbox.inbox_members.map(&:user_id)
     clear_queue
-    add_agent_to_queue(inbox.inbox_members.map(&:user_id))
+    add_agent_to_queue(user_ids) if user_ids.any?
   end
 
   # end of queue management functions

--- a/spec/services/auto_assignment/inbox_round_robin_service_spec.rb
+++ b/spec/services/auto_assignment/inbox_round_robin_service_spec.rb
@@ -30,6 +30,7 @@ describe AutoAssignment::InboxRoundRobinService do
     it 'keeps the queue empty when the inbox has no members' do
       empty_inbox = create(:inbox, account: account)
       service = described_class.new(inbox: empty_inbox)
+      service.add_agent_to_queue(-1)
 
       expect(service.available_agent).to be_nil
       expect(service.send(:queue)).to be_empty

--- a/spec/services/auto_assignment/inbox_round_robin_service_spec.rb
+++ b/spec/services/auto_assignment/inbox_round_robin_service_spec.rb
@@ -27,6 +27,14 @@ describe AutoAssignment::InboxRoundRobinService do
       expect(inbox_round_robin_service.send(:queue).map(&:to_i)).to match_array(inbox_members.map(&:user_id))
     end
 
+    it 'keeps the queue empty when the inbox has no members' do
+      empty_inbox = create(:inbox, account: account)
+      service = described_class.new(inbox: empty_inbox)
+
+      expect(service.available_agent).to be_nil
+      expect(service.send(:queue)).to be_empty
+    end
+
     it 'validates the queue and correct it before performing round robin' do
       # adding some invalid ids to queue
       inbox_round_robin_service.add_agent_to_queue([2, 3, 5, 9])


### PR DESCRIPTION
Round-robin queue resets now leave the Redis queue empty when an inbox has no members, avoiding an invalid sorted-set write while keeping normal queue population unchanged.

## Closes

- [CW-7922](https://linear.app/chatwoot/issue/CW-7922/harden-backend-paths-causing-production-sentry-errors)
- [Sentry 7663380084](https://chatwoot-p3.sentry.io/issues/7663380084/)

## How to reproduce

Run round-robin assignment for an inbox with no inbox members. Resetting the queue previously attempted a Redis sorted-set write without any member/score pairs.

## What changed

- Clear the existing queue as before.
- Skip queue population when there are no eligible user IDs.
- Add service coverage for an inbox with no members.
