### PR TITLE
fix: oversized message cursors

### DIFF
--- a/app/finders/message_finder.rb
+++ b/app/finders/message_finder.rb
@@ -1,4 +1,6 @@
 class MessageFinder
+  MESSAGE_ID_MAX = 2_147_483_647
+
   def initialize(conversation, params)
     @conversation = conversation
     @params = params
@@ -22,11 +24,11 @@ class MessageFinder
 
   def current_messages
     if @params[:after].present? && @params[:before].present?
-      messages_between(@params[:after].to_i, @params[:before].to_i)
+      messages_between(normalized_message_id(@params[:after]), normalized_message_id(@params[:before]))
     elsif @params[:before].present?
-      messages_before(@params[:before].to_i)
+      messages_before(normalized_message_id(@params[:before]))
     elsif @params[:after].present?
-      messages_after(@params[:after].to_i)
+      messages_after(normalized_message_id(@params[:after]))
     else
       messages_latest
     end
@@ -46,6 +48,10 @@ class MessageFinder
 
   def messages_latest
     messages.reorder('created_at desc').limit(20).reverse
+  end
+
+  def normalized_message_id(value)
+    value.to_i.clamp(0, MESSAGE_ID_MAX)
   end
 end
 

--- a/app/finders/message_finder.rb
+++ b/app/finders/message_finder.rb
@@ -24,9 +24,9 @@ class MessageFinder
 
   def current_messages
     if @params[:after].present? && @params[:before].present?
-      messages_between(normalized_message_id(@params[:after]), normalized_message_id(@params[:before]))
+      messages_between(normalized_message_id(@params[:after]), @params[:before].to_i)
     elsif @params[:before].present?
-      messages_before(normalized_message_id(@params[:before]))
+      messages_before(@params[:before].to_i)
     elsif @params[:after].present?
       messages_after(normalized_message_id(@params[:after]))
     else
@@ -39,11 +39,16 @@ class MessageFinder
   end
 
   def messages_before(before_id)
+    return messages_latest if before_id > MESSAGE_ID_MAX
+
+    before_id = normalized_message_id(before_id)
     messages.reorder('created_at desc').where('id < ?', before_id).limit(20).reverse
   end
 
   def messages_between(after_id, before_id)
-    messages.reorder('created_at asc').where('id >= ? AND id < ?', after_id, before_id).limit(1000)
+    message_scope = messages.reorder('created_at asc').where('id >= ?', after_id)
+    message_scope = message_scope.where('id < ?', normalized_message_id(before_id)) if before_id <= MESSAGE_ID_MAX
+    message_scope.limit(1000)
   end
 
   def messages_latest

--- a/app/finders/message_finder.rb
+++ b/app/finders/message_finder.rb
@@ -23,6 +23,8 @@ class MessageFinder
   end
 
   def current_messages
+    return messages.none if oversized_message_id?(@params[:after])
+
     if @params[:after].present? && @params[:before].present?
       messages_between(normalized_message_id(@params[:after]), @params[:before].to_i)
     elsif @params[:before].present?
@@ -39,7 +41,7 @@ class MessageFinder
   end
 
   def messages_before(before_id)
-    return messages_latest if before_id > MESSAGE_ID_MAX
+    return messages_latest if oversized_message_id?(before_id)
 
     before_id = normalized_message_id(before_id)
     messages.reorder('created_at desc').where('id < ?', before_id).limit(20).reverse
@@ -47,7 +49,7 @@ class MessageFinder
 
   def messages_between(after_id, before_id)
     message_scope = messages.reorder('created_at asc').where('id >= ?', after_id)
-    message_scope = message_scope.where('id < ?', normalized_message_id(before_id)) if before_id <= MESSAGE_ID_MAX
+    message_scope = message_scope.where('id < ?', normalized_message_id(before_id)) unless oversized_message_id?(before_id)
     message_scope.limit(1000)
   end
 
@@ -57,6 +59,10 @@ class MessageFinder
 
   def normalized_message_id(value)
     value.to_i.clamp(0, MESSAGE_ID_MAX)
+  end
+
+  def oversized_message_id?(value)
+    value.to_i > MESSAGE_ID_MAX
   end
 end
 

--- a/spec/finders/message_finder_spec.rb
+++ b/spec/finders/message_finder_spec.rb
@@ -49,10 +49,13 @@ describe MessageFinder do
     end
 
     context 'with a before attribute above the message id range' do
+      let!(:max_id_message) do
+        create(:message, id: described_class::MESSAGE_ID_MAX, account: account, inbox: inbox, conversation: conversation)
+      end
       let(:params) { { before: 4_611_686_018_427_387_903 } }
 
-      it 'returns the latest messages without overflowing the database column' do
-        expect(message_finder.perform.count).to be 6
+      it 'includes the maximum valid message id without overflowing the database column' do
+        expect(message_finder.perform).to include(max_id_message)
       end
     end
 

--- a/spec/finders/message_finder_spec.rb
+++ b/spec/finders/message_finder_spec.rb
@@ -92,5 +92,24 @@ describe MessageFinder do
         expect(result.last.id).to be conversation.messages[-2].id
       end
     end
+
+    context 'with after and before attributes above the message id range' do
+      let!(:max_id_message) do
+        create(:message, id: described_class::MESSAGE_ID_MAX, account: account, inbox: inbox, conversation: conversation)
+      end
+      let(:params) do
+        {
+          after: 881_965_304_328,
+          before: 4_611_686_018_427_387_903
+        }
+      end
+
+      it 'returns no messages' do
+        result = message_finder.perform
+
+        expect(result).to be_empty
+        expect(result).not_to include(max_id_message)
+      end
+    end
   end
 end

--- a/spec/finders/message_finder_spec.rb
+++ b/spec/finders/message_finder_spec.rb
@@ -48,6 +48,14 @@ describe MessageFinder do
       end
     end
 
+    context 'with a before attribute above the message id range' do
+      let(:params) { { before: 4_611_686_018_427_387_903 } }
+
+      it 'returns the latest messages without overflowing the database column' do
+        expect(message_finder.perform.count).to be 6
+      end
+    end
+
     context 'with after attribute' do
       let(:params) { { after: conversation.messages.first.id } }
 
@@ -56,6 +64,14 @@ describe MessageFinder do
         expect(result.count).to be 5
         expect(result.first.id).to be conversation.messages.second.id
         expect(result.last.message_type).to eq 'outgoing'
+      end
+    end
+
+    context 'with an after attribute above the message id range' do
+      let(:params) { { after: 881_965_304_328 } }
+
+      it 'returns no messages without overflowing the database column' do
+        expect(message_finder.perform).to be_empty
       end
     end
 


### PR DESCRIPTION
Message pagination now constrains client-provided cursors to the PostgreSQL integer range used by `messages.id`, preventing oversized values from raising database errors while preserving before/after pagination semantics.

## Closes

- [CW-7922](https://linear.app/chatwoot/issue/CW-7922/harden-backend-paths-causing-production-sentry-errors)
- [Sentry 7663397140](https://chatwoot-p3.sentry.io/issues/7663397140/)
- [Sentry 7663397546](https://chatwoot-p3.sentry.io/issues/7663397546/)
- [Sentry 7663464772](https://chatwoot-p3.sentry.io/issues/7663464772/)

## How to reproduce

Request conversation messages with an extremely large `before` or `after` cursor, such as `4611686018427387903`. PostgreSQL previously rejected the value as outside the range for the integer `messages.id` column.

## What changed

- Normalize message cursors before they reach the query.
- Clamp them to the valid signed 32-bit integer ID range.
- Cover oversized `before` and `after` cursors with finder specs.
