### PR TITLE
fix(widget): correct Hebrew availability card

### DIFF
--- a/app/javascript/widget/components/TeamAvailability.vue
+++ b/app/javascript/widget/components/TeamAvailability.vue
@@ -43,7 +43,7 @@ const startConversation = () => {
             : $t('START_CONVERSATION')
         }}
       </span>
-      <i class="i-lucide-chevron-right size-5 mt-px" />
+      <i class="i-lucide-chevron-right size-5 mt-px rtl:rotate-180" />
     </button>
   </div>
 </template>

--- a/app/javascript/widget/i18n/locale/he.json
+++ b/app/javascript/widget/i18n/locale/he.json
@@ -30,7 +30,7 @@
     "BACK_IN_MINUTES": "נחזור לאונליין בעוד {time} דקות",
     "BACK_AT_TIME": "נחזור לאונליין בשעה {time}",
     "BACK_ON_DAY": "נחזור לאונליין ביום {day}",
-    "BACK_TOMORROW": "נחזור לאונליין מחר",
+    "BACK_TOMORROW": "נחזור לפעילות מחר",
     "BACK_IN_SOME_TIME": "נחזור לאונליין בעוד זמן מה"
   },
   "DAY_NAMES": {
@@ -42,7 +42,7 @@
     "FRIDAY": "שישי",
     "SATURDAY": "יום שבת"
   },
-  "START_CONVERSATION": "התחל שיחה",
+  "START_CONVERSATION": "התחלת שיחה",
   "END_CONVERSATION": "סיים שיחה",
   "CONTINUE_CONVERSATION": "המשך שיחה",
   "YOU": "אתה",


### PR DESCRIPTION
Updates two Hebrew widget strings with the corrected phrasing approved in Crowdin and fixes the start-conversation chevron direction for RTL layouts.

## Why

The existing “back tomorrow” wording was unnatural in Hebrew, the “start conversation” label used gendered phrasing, and its chevron pointed in the LTR direction.

## What changed

- Updated the Hebrew “back tomorrow” message to `נחזור לפעילות מחר`.
- Updated the Hebrew “start conversation” label to `התחלת שיחה`.
- Mirrored the start-conversation chevron in RTL layouts.

## Validation

Set the widget language to Hebrew and verify the offline “back tomorrow” message, the start-conversation label, and the left-pointing chevron use the corrected RTL presentation.
