### PR TITLE
feat(sla): allow choosing which admins are alerted on breach

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/sla.json
+++ b/app/javascript/dashboard/i18n/locale/en/sla.json
@@ -79,6 +79,21 @@
       "THRESHOLD_TIME": {
         "INVALID_FORMAT_ERROR": "Threshold should be a number and greater than zero"
       },
+      "ALERT_RECIPIENTS": {
+        "LABEL": "Alert on breach",
+        "EVERYONE": {
+          "LABEL": "All administrators",
+          "DESC": "Every administrator in this account is alerted when this SLA is breached."
+        },
+        "SPECIFIC": {
+          "LABEL": "Specific administrators",
+          "DESC": "Only the administrators you pick are alerted when this SLA is breached.",
+          "PLACEHOLDER": "Select administrators",
+          "SEARCH": "Search administrators",
+          "EMPTY": "No administrators found"
+        },
+        "EMPTY_ERROR": "Select at least one administrator to alert"
+      },
       "EDIT": "Edit",
       "CREATE": "Create",
       "DELETE": "Delete",
@@ -89,6 +104,14 @@
       "DESC": "Friendly promises for great service!",
       "API": {
         "SUCCESS_MESSAGE": "SLA added successfully",
+        "ERROR_MESSAGE": "There was an error, please try again"
+      }
+    },
+    "EDIT": {
+      "TITLE": "Edit SLA",
+      "DESC": "Response times and business hours cannot be changed after an SLA is created.",
+      "API": {
+        "SUCCESS_MESSAGE": "SLA updated successfully",
         "ERROR_MESSAGE": "There was an error, please try again"
       }
     },

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/AddSLA.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/AddSLA.vue
@@ -6,16 +6,18 @@ export default {
   components: {
     SlaForm,
   },
-  emits: ['close'],
   methods: {
-    onClose() {
-      this.$emit('close');
+    open() {
+      this.$refs.formRef.open();
+    },
+    close() {
+      this.$refs.formRef.close();
     },
     async addSLA(payload) {
       try {
         await this.$store.dispatch('sla/create', payload);
         useAlert(this.$t('SLA.ADD.API.SUCCESS_MESSAGE'));
-        this.onClose();
+        this.close();
       } catch (error) {
         const errorMessage =
           error.message || this.$t('SLA.ADD.API.ERROR_MESSAGE');
@@ -27,15 +29,5 @@ export default {
 </script>
 
 <template>
-  <div class="flex flex-col h-auto overflow-auto">
-    <woot-modal-header
-      :header-title="$t('SLA.ADD.TITLE')"
-      :header-content="$t('SLA.ADD.DESC')"
-    />
-    <SlaForm
-      :submit-label="$t('SLA.FORM.CREATE')"
-      @submit-sla="addSLA"
-      @close="onClose"
-    />
-  </div>
+  <SlaForm ref="formRef" mode="create" @submit-sla="addSLA" />
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/EditSLA.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/EditSLA.vue
@@ -1,0 +1,42 @@
+<script>
+import { useAlert } from 'dashboard/composables';
+import SlaForm from './SlaForm.vue';
+
+export default {
+  components: {
+    SlaForm,
+  },
+  props: {
+    selectedResponse: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  methods: {
+    open(sla) {
+      this.$refs.formRef.open(sla);
+    },
+    close() {
+      this.$refs.formRef.close();
+    },
+    async editSLA(payload) {
+      try {
+        await this.$store.dispatch('sla/update', {
+          id: this.selectedResponse.id,
+          ...payload,
+        });
+        useAlert(this.$t('SLA.EDIT.API.SUCCESS_MESSAGE'));
+        this.close();
+      } catch (error) {
+        const errorMessage =
+          error.message || this.$t('SLA.EDIT.API.ERROR_MESSAGE');
+        useAlert(errorMessage);
+      }
+    },
+  },
+};
+</script>
+
+<template>
+  <SlaForm ref="formRef" mode="edit" @submit-sla="editSLA" />
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/Index.vue
@@ -1,5 +1,6 @@
 <script>
 import AddSLA from './AddSLA.vue';
+import EditSLA from './EditSLA.vue';
 import SettingsLayout from '../SettingsLayout.vue';
 import BaseSettingsHeader from 'dashboard/routes/dashboard/settings/components/BaseSettingsHeader.vue';
 import SLAPaywallEnterprise from './SLAPaywallEnterprise.vue';
@@ -20,6 +21,7 @@ import { picoSearch } from '@scmmishra/pico-search';
 export default {
   components: {
     AddSLA,
+    EditSLA,
     SettingsLayout,
     BaseSettingsHeader,
     SLAPaywallEnterprise,
@@ -33,7 +35,6 @@ export default {
   data() {
     return {
       loading: {},
-      showAddPopup: false,
       showDeleteConfirmationPopup: false,
       selectedResponse: {},
       searchQuery: '',
@@ -87,10 +88,11 @@ export default {
       if (this.isBehindAPaywall) {
         return;
       }
-      this.showAddPopup = true;
+      this.$refs.addPanelRef.open();
     },
-    hideAddPopup() {
-      this.showAddPopup = false;
+    openEditPopup(response) {
+      this.selectedResponse = response;
+      this.$refs.editPanelRef.open(response);
     },
     openDeletePopup(response) {
       this.showDeleteConfirmationPopup = true;
@@ -281,8 +283,15 @@ export default {
                 </span>
               </BaseTableCell>
 
-              <BaseTableCell align="end" class="w-12">
-                <div class="flex justify-end">
+              <BaseTableCell align="end" class="w-20">
+                <div class="flex justify-end gap-1">
+                  <NextButton
+                    v-tooltip.top="$t('SLA.FORM.EDIT')"
+                    icon="i-lucide-pencil"
+                    slate
+                    sm
+                    @click="openEditPopup(sla)"
+                  />
                   <NextButton
                     v-tooltip.top="$t('SLA.FORM.DELETE')"
                     icon="i-woot-bin"
@@ -299,9 +308,9 @@ export default {
         </template>
       </BaseTable>
 
-      <woot-modal v-model:show="showAddPopup" :on-close="hideAddPopup">
-        <AddSLA @close="hideAddPopup" />
-      </woot-modal>
+      <AddSLA ref="addPanelRef" />
+
+      <EditSLA ref="editPanelRef" :selected-response="selectedResponse" />
 
       <woot-delete-modal
         v-model:show="showDeleteConfirmationPopup"

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/SlaAlertRecipients.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/SlaAlertRecipients.vue
@@ -1,0 +1,97 @@
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useStore, useMapGetter } from 'dashboard/composables/store';
+import RadioCard from 'dashboard/components-next/radioCard/RadioCard.vue';
+import TagMultiSelectComboBox from 'dashboard/components-next/combobox/TagMultiSelectComboBox.vue';
+
+const props = defineProps({
+  modelValue: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const emit = defineEmits(['update:modelValue', 'isInvalid']);
+
+const MODE = {
+  EVERYONE: 'everyone',
+  SPECIFIC: 'specific',
+};
+
+const { t } = useI18n();
+const store = useStore();
+
+const agents = useMapGetter('agents/getVerifiedAgents');
+
+const mode = ref(props.modelValue.length ? MODE.SPECIFIC : MODE.EVERYONE);
+
+const administratorOptions = computed(() =>
+  agents.value
+    .filter(agent => agent.role === 'administrator')
+    .map(agent => ({ value: agent.id, label: agent.name }))
+);
+
+const selectedIds = computed({
+  get: () => props.modelValue,
+  set: value => emit('update:modelValue', value),
+});
+
+const selectMode = value => {
+  mode.value = value;
+  if (value === MODE.EVERYONE) emit('update:modelValue', []);
+};
+
+watch(
+  () => props.modelValue,
+  value => {
+    mode.value = value.length ? MODE.SPECIFIC : MODE.EVERYONE;
+  }
+);
+
+watch(
+  () => mode.value === MODE.SPECIFIC && !props.modelValue.length,
+  isInvalid => emit('isInvalid', isInvalid),
+  { immediate: true }
+);
+
+onMounted(() => {
+  if (!agents.value.length) store.dispatch('agents/get');
+});
+</script>
+
+<template>
+  <div class="flex flex-col w-full gap-2 mt-4">
+    <label class="text-sm font-medium text-n-slate-12">
+      {{ t('SLA.FORM.ALERT_RECIPIENTS.LABEL') }}
+    </label>
+    <RadioCard
+      :id="MODE.EVERYONE"
+      :label="t('SLA.FORM.ALERT_RECIPIENTS.EVERYONE.LABEL')"
+      :description="t('SLA.FORM.ALERT_RECIPIENTS.EVERYONE.DESC')"
+      :is-active="mode === MODE.EVERYONE"
+      @select="selectMode(MODE.EVERYONE)"
+    />
+    <RadioCard
+      :id="MODE.SPECIFIC"
+      :label="t('SLA.FORM.ALERT_RECIPIENTS.SPECIFIC.LABEL')"
+      :description="t('SLA.FORM.ALERT_RECIPIENTS.SPECIFIC.DESC')"
+      :is-active="mode === MODE.SPECIFIC"
+      @select="selectMode(MODE.SPECIFIC)"
+    >
+      <TagMultiSelectComboBox
+        v-if="mode === MODE.SPECIFIC"
+        v-model="selectedIds"
+        class="w-full mt-2"
+        :options="administratorOptions"
+        :placeholder="t('SLA.FORM.ALERT_RECIPIENTS.SPECIFIC.PLACEHOLDER')"
+        :search-placeholder="t('SLA.FORM.ALERT_RECIPIENTS.SPECIFIC.SEARCH')"
+        :empty-state="t('SLA.FORM.ALERT_RECIPIENTS.SPECIFIC.EMPTY')"
+        :has-error="!selectedIds.length"
+        :message="
+          selectedIds.length ? '' : t('SLA.FORM.ALERT_RECIPIENTS.EMPTY_ERROR')
+        "
+      />
+    </RadioCard>
+  </div>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/sla/SlaForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/sla/SlaForm.vue
@@ -1,29 +1,49 @@
 <script>
 import { mapGetters } from 'vuex';
-import { convertSecondsToTimeUnit } from '@chatwoot/utils';
 import validations from './validations';
 import SlaTimeInput from './SlaTimeInput.vue';
+import SlaAlertRecipients from './SlaAlertRecipients.vue';
 import NextButton from 'dashboard/components-next/button/Button.vue';
+import SidePanel from 'dashboard/components-next/side-panel/SidePanel.vue';
 import { useVuelidate } from '@vuelidate/core';
 import ToggleSwitch from 'dashboard/components-next/switch/Switch.vue';
+
+const DEFAULT_TIME_INPUTS = [
+  {
+    threshold: null,
+    unit: 'Minutes',
+    label: 'SLA.FORM.FIRST_RESPONSE_TIME.LABEL',
+    placeholder: 'SLA.FORM.FIRST_RESPONSE_TIME.PLACEHOLDER',
+  },
+  {
+    threshold: null,
+    unit: 'Minutes',
+    label: 'SLA.FORM.NEXT_RESPONSE_TIME.LABEL',
+    placeholder: 'SLA.FORM.NEXT_RESPONSE_TIME.PLACEHOLDER',
+  },
+  {
+    threshold: null,
+    unit: 'Minutes',
+    label: 'SLA.FORM.RESOLUTION_TIME.LABEL',
+    placeholder: 'SLA.FORM.RESOLUTION_TIME.PLACEHOLDER',
+  },
+];
 
 export default {
   components: {
     SlaTimeInput,
+    SlaAlertRecipients,
     NextButton,
+    SidePanel,
     ToggleSwitch,
   },
   props: {
-    selectedResponse: {
-      type: Object,
-      default: () => {},
-    },
-    submitLabel: {
+    mode: {
       type: String,
-      required: true,
+      default: 'create',
     },
   },
-  emits: ['close', 'submitSla'],
+  emits: ['submitSla'],
   setup() {
     return { v$: useVuelidate() };
   },
@@ -33,27 +53,10 @@ export default {
       description: '',
       isSlaTimeInputsInvalid: false,
       slaTimeInputsValidation: {},
-      slaTimeInputs: [
-        {
-          threshold: null,
-          unit: 'Minutes',
-          label: 'SLA.FORM.FIRST_RESPONSE_TIME.LABEL',
-          placeholder: 'SLA.FORM.FIRST_RESPONSE_TIME.PLACEHOLDER',
-        },
-        {
-          threshold: null,
-          unit: 'Minutes',
-          label: 'SLA.FORM.NEXT_RESPONSE_TIME.LABEL',
-          placeholder: 'SLA.FORM.NEXT_RESPONSE_TIME.PLACEHOLDER',
-        },
-        {
-          threshold: null,
-          unit: 'Minutes',
-          label: 'SLA.FORM.RESOLUTION_TIME.LABEL',
-          placeholder: 'SLA.FORM.RESOLUTION_TIME.PLACEHOLDER',
-        },
-      ],
+      slaTimeInputs: structuredClone(DEFAULT_TIME_INPUTS),
       onlyDuringBusinessHours: false,
+      notifyUserIds: [],
+      isAlertRecipientsInvalid: false,
     };
   },
   validations,
@@ -61,10 +64,29 @@ export default {
     ...mapGetters({
       uiFlags: 'sla/getUIFlags',
     }),
+    isEditing() {
+      return this.mode === 'edit';
+    },
+    panelTitle() {
+      return this.isEditing
+        ? this.$t('SLA.EDIT.TITLE')
+        : this.$t('SLA.ADD.TITLE');
+    },
+    panelDescription() {
+      return this.isEditing
+        ? this.$t('SLA.EDIT.DESC')
+        : this.$t('SLA.ADD.DESC');
+    },
+    submitLabel() {
+      return this.isEditing
+        ? this.$t('SLA.FORM.EDIT')
+        : this.$t('SLA.FORM.CREATE');
+    },
     isSubmitDisabled() {
       return (
         this.v$.name.$invalid ||
         this.isSlaTimeInputsInvalid ||
+        this.isAlertRecipientsInvalid ||
         this.uiFlags.isUpdating
       );
     },
@@ -80,41 +102,30 @@ export default {
       return errorMessage;
     },
   },
-  mounted() {
-    if (this.selectedResponse) this.setFormValues();
-  },
   methods: {
-    onClose() {
-      this.$emit('close');
+    // The record is passed in on open, the prop on the parent updates only a tick later
+    open(sla) {
+      this.resetForm();
+      if (sla) this.setFormValues(sla);
+      this.$refs.panelRef.open();
     },
-    setFormValues() {
-      const {
-        name,
-        description,
-        first_response_time_threshold: firstResponseTimeThreshold,
-        next_response_time_threshold: nextResponseTimeThreshold,
-        resolution_time_threshold: resolutionTimeThreshold,
-        only_during_business_hours: onlyDuringBusinessHours,
-      } = this.selectedResponse;
-
+    close() {
+      this.$refs.panelRef.close();
+    },
+    resetForm() {
+      this.name = '';
+      this.description = '';
+      this.notifyUserIds = [];
+      this.onlyDuringBusinessHours = false;
+      this.slaTimeInputs = structuredClone(DEFAULT_TIME_INPUTS);
+      this.slaTimeInputsValidation = {};
+      this.isSlaTimeInputsInvalid = false;
+      this.v$.$reset();
+    },
+    setFormValues({ name, description, notify_user_ids: notifyUserIds }) {
       this.name = name;
       this.description = description;
-      this.onlyDuringBusinessHours = onlyDuringBusinessHours;
-
-      const thresholds = [
-        firstResponseTimeThreshold,
-        nextResponseTimeThreshold,
-        resolutionTimeThreshold,
-      ];
-      this.slaTimeInputs.forEach((input, index) => {
-        const converted = convertSecondsToTimeUnit(thresholds[index], {
-          minute: 'Minutes',
-          hour: 'Hours',
-          day: 'Days',
-        });
-        input.threshold = converted.time;
-        input.unit = converted.unit;
-      });
+      this.notifyUserIds = notifyUserIds || [];
     },
     updateThreshold(index, value) {
       this.slaTimeInputs[index].threshold = value;
@@ -126,11 +137,17 @@ export default {
       const payload = {
         name: this.name,
         description: this.description,
-        first_response_time_threshold: this.convertToSeconds(0),
-        next_response_time_threshold: this.convertToSeconds(1),
-        resolution_time_threshold: this.convertToSeconds(2),
-        only_during_business_hours: this.onlyDuringBusinessHours,
+        notify_user_ids: this.notifyUserIds,
       };
+
+      // Thresholds and business hours are locked once the SLA is created
+      if (!this.isEditing) {
+        payload.first_response_time_threshold = this.convertToSeconds(0);
+        payload.next_response_time_threshold = this.convertToSeconds(1);
+        payload.resolution_time_threshold = this.convertToSeconds(2);
+        payload.only_during_business_hours = this.onlyDuringBusinessHours;
+      }
+
       this.$emit('submitSla', payload);
     },
     convertToSeconds(index) {
@@ -158,8 +175,13 @@ export default {
 </script>
 
 <template>
-  <div class="flex flex-col h-auto overflow-auto">
-    <form class="flex flex-wrap mx-0" @submit.prevent="onSubmit">
+  <SidePanel
+    ref="panelRef"
+    width="xl"
+    :title="panelTitle"
+    :description="panelDescription"
+  >
+    <div class="flex flex-wrap w-full mx-0">
       <woot-input
         v-model="name"
         :class="{ error: v$.name.$error }"
@@ -187,42 +209,51 @@ export default {
         :placeholder="$t('SLA.FORM.DESCRIPTION.PLACEHOLDER')"
       />
 
-      <SlaTimeInput
-        v-for="(input, index) in slaTimeInputs"
-        :key="index"
-        :threshold="input.threshold"
-        :threshold-unit="input.unit"
-        :label="$t(input.label)"
-        :placeholder="$t(input.placeholder)"
-        @update-threshold="updateThreshold(index, $event)"
-        @unit="updateUnit(index, $event)"
-        @is-in-valid="handleIsInvalid(index, $event)"
+      <template v-if="!isEditing">
+        <SlaTimeInput
+          v-for="(input, index) in slaTimeInputs"
+          :key="index"
+          :threshold="input.threshold"
+          :threshold-unit="input.unit"
+          :label="$t(input.label)"
+          :placeholder="$t(input.placeholder)"
+          @update-threshold="updateThreshold(index, $event)"
+          @unit="updateUnit(index, $event)"
+          @is-in-valid="handleIsInvalid(index, $event)"
+        />
+
+        <div
+          class="mt-3 flex h-10 items-center text-sm w-full gap-2 border border-solid border-n-strong px-3 py-1.5 rounded-xl justify-between"
+        >
+          <span for="sla_bh" class="text-n-slate-11">
+            {{ $t('SLA.FORM.BUSINESS_HOURS.PLACEHOLDER') }}
+          </span>
+          <ToggleSwitch id="sla_bh" v-model="onlyDuringBusinessHours" />
+        </div>
+      </template>
+
+      <SlaAlertRecipients
+        v-model="notifyUserIds"
+        @is-invalid="isAlertRecipientsInvalid = $event"
       />
-
-      <div
-        class="mt-3 flex h-10 items-center text-sm w-full gap-2 border border-solid border-n-strong px-3 py-1.5 rounded-xl justify-between"
-      >
-        <span for="sla_bh" class="text-n-slate-11">
-          {{ $t('SLA.FORM.BUSINESS_HOURS.PLACEHOLDER') }}
-        </span>
-        <ToggleSwitch id="sla_bh" v-model="onlyDuringBusinessHours" />
-      </div>
-
-      <div class="flex items-center justify-end w-full gap-2 mt-8">
+    </div>
+    <template #footer>
+      <div class="flex flex-row justify-end w-full gap-2">
         <NextButton
           faded
           slate
-          type="reset"
+          type="button"
           :label="$t('SLA.FORM.CANCEL')"
-          @click.prevent="onClose"
+          @click="close"
         />
         <NextButton
-          type="submit"
+          type="button"
           :label="submitLabel"
           :disabled="isSubmitDisabled"
           :is-loading="uiFlags.isUpdating"
+          @click="onSubmit"
         />
       </div>
-    </form>
-  </div>
+    </template>
+  </SidePanel>
 </template>

--- a/app/javascript/dashboard/store/modules/sla.js
+++ b/app/javascript/dashboard/store/modules/sla.js
@@ -11,6 +11,7 @@ export const state = {
     isFetching: false,
     isFetchingItem: false,
     isCreating: false,
+    isUpdating: false,
     isDeleting: false,
   },
 };
@@ -50,6 +51,19 @@ export const actions = {
     }
   },
 
+  update: async function update({ commit }, { id, ...slaObj }) {
+    commit(types.SET_SLA_UI_FLAG, { isUpdating: true });
+    try {
+      const response = await SlaAPI.update(id, slaObj);
+      AnalyticsHelper.track(SLA_EVENTS.UPDATE);
+      commit(types.EDIT_SLA, response.data.payload);
+    } catch (error) {
+      throwErrorMessage(error);
+    } finally {
+      commit(types.SET_SLA_UI_FLAG, { isUpdating: false });
+    }
+  },
+
   delete: async function deleteSla({ commit }, id) {
     commit(types.SET_SLA_UI_FLAG, { isDeleting: true });
     try {
@@ -74,6 +88,7 @@ export const mutations = {
 
   [types.SET_SLA]: MutationHelpers.set,
   [types.ADD_SLA]: MutationHelpers.create,
+  [types.EDIT_SLA]: MutationHelpers.update,
   [types.DELETE_SLA]: MutationHelpers.destroy,
 };
 

--- a/db/migrate/20260810000001_add_notify_user_ids_to_sla_policies.rb
+++ b/db/migrate/20260810000001_add_notify_user_ids_to_sla_policies.rb
@@ -1,0 +1,5 @@
+class AddNotifyUserIdsToSlaPolicies < ActiveRecord::Migration[7.1]
+  def change
+    add_column :sla_policies, :notify_user_ids, :bigint, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_04_000003) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_10_000001) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -1416,6 +1416,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_04_000003) do
     t.datetime "updated_at", null: false
     t.string "description"
     t.float "resolution_time_threshold"
+    t.bigint "notify_user_ids", default: [], array: true
     t.index ["account_id"], name: "index_sla_policies_on_account_id"
   end
 

--- a/enterprise/app/controllers/api/v1/accounts/sla_policies_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/sla_policies_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::Accounts::SlaPoliciesController < Api::V1::Accounts::EnterpriseAc
   end
 
   def update
-    @sla_policy.update!(permitted_params)
+    @sla_policy.update!(update_permitted_params)
   end
 
   def destroy
@@ -24,7 +24,13 @@ class Api::V1::Accounts::SlaPoliciesController < Api::V1::Accounts::EnterpriseAc
 
   def permitted_params
     params.require(:sla_policy).permit(:name, :description, :first_response_time_threshold, :next_response_time_threshold,
-                                       :resolution_time_threshold, :only_during_business_hours)
+                                       :resolution_time_threshold, :only_during_business_hours, notify_user_ids: [])
+  end
+
+  # Thresholds and business hours are locked after creation, conversations already
+  # tracked against this SLA were measured using those values.
+  def update_permitted_params
+    params.require(:sla_policy).permit(:name, :description, notify_user_ids: [])
   end
 
   def fetch_sla

--- a/enterprise/app/models/sla_event.rb
+++ b/enterprise/app/models/sla_event.rb
@@ -63,8 +63,8 @@ class SlaEvent < ApplicationRecord
 
   def create_notifications
     notify_users = conversation.conversation_participants.map(&:user)
-    # Add all admins from the account to notify list
-    notify_users += account.administrators
+    # Add the admins configured on the SLA policy, defaults to all admins in the account
+    notify_users += sla_policy.notify_users
     # Ensure conversation assignee is notified
     notify_users += [conversation.assignee] if conversation.assignee.present?
 

--- a/enterprise/app/models/sla_policy.rb
+++ b/enterprise/app/models/sla_policy.rb
@@ -7,6 +7,7 @@
 #  first_response_time_threshold :float
 #  name                          :string           not null
 #  next_response_time_threshold  :float
+#  notify_user_ids               :bigint           default([]), is an Array
 #  only_during_business_hours    :boolean          default(FALSE)
 #  resolution_time_threshold     :float
 #  created_at                    :datetime         not null
@@ -20,9 +21,20 @@
 class SlaPolicy < ApplicationRecord
   belongs_to :account
   validates :name, presence: true
+  validate :notify_users_are_administrators
 
   has_many :conversations, dependent: :nullify
   has_many :applied_slas, dependent: :destroy_async
+
+  before_validation :sanitize_notify_user_ids
+
+  # Users alerted when this SLA is breached. Defaults to every administrator in the account
+  # when no specific administrators are configured.
+  def notify_users
+    return account.administrators if notify_user_ids.blank?
+
+    account.administrators.where(id: notify_user_ids)
+  end
 
   def push_event_data
     {
@@ -32,5 +44,18 @@ class SlaPolicy < ApplicationRecord
       nrt: next_response_time_threshold,
       rt: resolution_time_threshold
     }
+  end
+
+  private
+
+  def sanitize_notify_user_ids
+    self.notify_user_ids = Array(notify_user_ids).compact_blank.map(&:to_i).uniq
+  end
+
+  def notify_users_are_administrators
+    return if notify_user_ids.blank?
+    return if account.administrators.where(id: notify_user_ids).count == notify_user_ids.size
+
+    errors.add(:notify_user_ids, 'must be administrators of the account')
   end
 end

--- a/enterprise/app/views/api/v1/models/_sla_policy.json.jbuilder
+++ b/enterprise/app/views/api/v1/models/_sla_policy.json.jbuilder
@@ -5,3 +5,4 @@ json.first_response_time_threshold sla_policy.first_response_time_threshold
 json.next_response_time_threshold sla_policy.next_response_time_threshold
 json.resolution_time_threshold sla_policy.resolution_time_threshold
 json.only_during_business_hours sla_policy.only_during_business_hours
+json.notify_user_ids sla_policy.notify_user_ids


### PR DESCRIPTION
SLA breach alerts went to every administrator in the account, which gets noisy in larger teams. You can now pick exactly who hears about it: while creating an SLA, choose between alerting all administrators (the existing behaviour, and still the default) or selecting specific administrators. Existing SLAs keep alerting everyone until someone narrows the list.

SLAs are also editable now — previously they could only be created and deleted. Editing is limited to the name, description, and alert recipients: response times and business hours stay locked after creation, since conversations already tracked against the SLA were measured using those values. Add and edit both open in a side panel, matching automation rules, instead of a modal that covers the page.

<img width="558" height="320" alt="Screenshot 2026-08-10 at 7 52 31 PM" src="https://github.com/user-attachments/assets/0b650d06-1638-495f-ba1a-e870fad40227" />



## Closes

<!-- Add issue links here -->

## How to test

1. Enable the `sla` feature on the account and go to Settings → SLA.
2. Click **Add SLA**. The form now opens in a side panel. Under **Alert on breach**, keep **All administrators** and create the SLA — breach notifications behave exactly as before.
3. Create a second SLA, pick **Specific administrators**, and select one or two admins. Saving is blocked until at least one is picked.
4. Apply the second SLA to a conversation (via automation or the conversation SLA picker) and let a threshold lapse. Only the selected administrators get the SLA-missed notification, alongside the conversation participants and assignee, who are notified as before.
5. Click the pencil icon on any SLA row. The panel lets you change the name, description, and alert recipients only — response times and business hours are not shown, and the API rejects them on update.
