### PR TITLE
chore: land super admin on dashboard after login

### DIFF
--- a/app/controllers/super_admin/devise/sessions_controller.rb
+++ b/app/controllers/super_admin/devise/sessions_controller.rb
@@ -10,7 +10,7 @@ class SuperAdmin::Devise::SessionsController < Devise::SessionsController
 
     sign_in(:super_admin, @super_admin)
     flash.discard
-    redirect_to super_admin_users_path
+    redirect_to super_admin_root_path
   end
 
   def destroy

--- a/spec/controllers/super_admin/devise/sessions_controller_spec.rb
+++ b/spec/controllers/super_admin/devise/sessions_controller_spec.rb
@@ -9,4 +9,18 @@ RSpec.describe 'Super Admin', type: :request do
       end
     end
   end
+
+  describe 'POST /super_admin/sign_in' do
+    let(:super_admin) { create(:super_admin, password: 'Password1!') }
+
+    it 'redirects to the dashboard on successful login' do
+      post '/super_admin/sign_in', params: { super_admin: { email: super_admin.email, password: 'Password1!' } }
+      expect(response).to redirect_to(super_admin_root_path)
+    end
+
+    it 'redirects back to the login page on invalid credentials' do
+      post '/super_admin/sign_in', params: { super_admin: { email: super_admin.email, password: 'wrong' } }
+      expect(response).to redirect_to(super_admin_session_path)
+    end
+  end
 end


### PR DESCRIPTION
## Description

After a successful super admin login, redirect to the super admin dashboard (`super_admin_root_path`) instead of the users list. The dashboard is a lighter, overview-first landing page, while the users index does an exact count over the full users table on every load and can be slow on large instances.

This only changes the post-login landing page. The users list is still reachable from the navigation.

Fixes https://linear.app/chatwoot/issue/CW-7928

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added request specs for `SuperAdmin::Devise::SessionsController#create`:
- successful login redirects to `super_admin_root_path`
- invalid credentials redirect back to the login page

`bundle exec rspec spec/controllers/super_admin/devise/sessions_controller_spec.rb` -> 3 examples, 0 failures.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
