### PR TITLE
perf: scale sidekiq worker MemoryMax with host memory

### DIFF
--- a/deployment/chatwoot-worker.1.service
+++ b/deployment/chatwoot-worker.1.service
@@ -17,7 +17,7 @@ StandardInput=null
 SyslogIdentifier=%p
 LimitNOFILE=65536
 
-MemoryMax=1.2G
+MemoryMax=60%
 MemoryHigh=infinity
 MemorySwapMax=0
 OOMPolicy=stop


### PR DESCRIPTION
## Description

This systemd unit is installed on every self-hosted Linux install (copied by `deployment/setup_18.04.sh` / `setup_20.04.sh`) as well as our own worker hosts, so the memory cap has to be correct across a wide range of box sizes.

It is currently a fixed `MemoryMax=1.2G`, chosen when workers ran on 2GB hosts (#12915). On larger hosts that fixed cap sits at a high fraction of the limit under normal load, so transient spikes hit the hard limit and the worker is OOM-restarted more often than necessary (each restart drops the jobs in-flight at that instant).

Switching to `MemoryMax=60%` makes the cap scale with the host's physical memory instead of being fixed:

- 2GB host: 60% = 1.2G, identical to today (no regression for small installs)
- 4GB host: 60% = ~2.4G, room to absorb spikes without a premature restart
- larger hosts scale proportionally

`MemoryHigh=infinity` is unchanged, so the worker is still never throttled by cgroup reclaim (kept intentionally since #12871 to avoid reclaim-induced worker stalls). Only the hard cap changes, and only its scaling.

Fixes https://linear.app/chatwoot/issue/INF-100

## Type of change

- [x] Performance (non-breaking change which improves performance)

## How Has This Been Tested?

Verified on a running 4GB worker host: the worker cgroup sits at ~1.0G under normal load against the current 1.2G cap (~80%), with the rest of box memory unused. `60%` yields ~2.4G on that host while resolving to exactly 1.2G on a 2GB host, matching the value the fixed cap was originally chosen for. No change to throttling behaviour.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
