### PR TITLE
fix: route inbound reply addresses from Cc

### DIFF
--- a/app/mailboxes/application_mailbox.rb
+++ b/app/mailboxes/application_mailbox.rb
@@ -19,8 +19,10 @@ class ApplicationMailbox < ActionMailbox::Base
 
   class << self
     # checks if follows this pattern: reply+<conversation-uuid>@<mailer-domain.com>
+    # the reply address can appear in either To or Cc (e.g. replying to your own sent message)
     def reply_uuid_mail?(inbound_mail)
-      inbound_mail.mail.to&.any? do |email|
+      recipients = Array(inbound_mail.mail.to) + Array(inbound_mail.mail.cc)
+      recipients.any? do |email|
         conversation_uuid = email.split('@')[0]
         conversation_uuid.match?(REPLY_EMAIL_UUID_PATTERN)
       end

--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -156,13 +156,12 @@ class MailPresenter < SimpleDelegator
   end
 
   def mail_receiver
-    if @mail.to.blank?
-      return [email_forwarded_for] if email_forwarded_for.present?
+    receivers = Array(@mail.to) + Array(@mail.cc)
+    return receivers if receivers.present?
 
-      []
-    else
-      @mail.to
-    end
+    return [email_forwarded_for] if email_forwarded_for.present?
+
+    []
   end
 
   def auto_reply?

--- a/spec/fixtures/files/reply_uuid_in_cc.eml
+++ b/spec/fixtures/files/reply_uuid_in_cc.eml
@@ -1,0 +1,20 @@
+From: Sony Mathew <sony@chatwoot.com>
+Mime-Version: 1.0 (Apple Message framework v1244.3)
+Content-Type: multipart/alternative; boundary="Apple-Mail=_33A037C7-4BB3-4772-AE52-FCF2D7535F74"
+Subject: Discussion: Let's debate these attachments
+Date: Tue, 20 Apr 2020 04:20:20 -0400
+In-Reply-To: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
+References: <4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>
+Message-Id: <0CB459E0-0336-41DA-BC88-E6E28C697DDB@chatwoot.com>
+X-Mailer: Apple Mail (2.1244.3)
+To: Sony Mathew <sony@chatwoot.com>
+Cc: "Replies" <reply+6bdc3f4d-0bec-4515-a284-5d916fdde489@example.com>
+
+--Apple-Mail=_33A037C7-4BB3-4772-AE52-FCF2D7535F74
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain;
+  charset=utf-8
+
+Let's talk about these images:
+
+--Apple-Mail=_33A037C7-4BB3-4772-AE52-FCF2D7535F74--

--- a/spec/mailboxes/application_mailbox_spec.rb
+++ b/spec/mailboxes/application_mailbox_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ApplicationMailbox do
     let(:welcome_mail) { create_inbound_email_from_fixture('welcome.eml') }
     let(:reply_mail) { create_inbound_email_from_fixture('reply.eml') }
     let(:reply_cc_mail) { create_inbound_email_from_fixture('reply_cc.eml') }
+    let(:reply_uuid_in_cc_mail) { create_inbound_email_from_fixture('reply_uuid_in_cc.eml') }
     let(:reply_mail_without_uuid) { create_inbound_email_from_fixture('reply.eml') }
     let(:reply_mail_with_in_reply_to) { create_inbound_email_from_fixture('in_reply_to.eml') }
     let(:support_mail) { create_inbound_email_from_fixture('support.eml') }
@@ -35,6 +36,13 @@ RSpec.describe ApplicationMailbox do
         expect(ReplyMailbox).to receive(:new).and_return(dbl)
         expect(dbl).to receive(:perform_processing).and_return(true)
         described_class.route reply_mail_without_uuid
+      end
+
+      it 'routes reply emails to Reply Mailbox when reply+uuid is in Cc' do
+        dbl = double
+        expect(ReplyMailbox).to receive(:new).and_return(dbl)
+        expect(dbl).to receive(:perform_processing).and_return(true)
+        described_class.route reply_uuid_in_cc_mail
       end
     end
 

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -179,6 +179,66 @@ RSpec.describe MailPresenter do
       end
     end
 
+    describe '#mail_receiver' do
+      context 'when mail has both To and Cc recipients' do
+        let(:mail_with_to_and_cc) do
+          Mail.new do
+            from 'Sender <sender@example.com>'
+            to 'to@example.com'
+            cc 'cc@example.com'
+            subject :header
+            body 'Hi'
+          end
+        end
+
+        it 'returns To and Cc recipients' do
+          expect(described_class.new(mail_with_to_and_cc).mail_receiver).to eq(%w[to@example.com cc@example.com])
+        end
+      end
+
+      context 'when mail has Cc but no To recipients' do
+        let(:mail_with_cc_only) do
+          Mail.new do
+            from 'Sender <sender@example.com>'
+            cc 'cc@example.com'
+            subject :header
+            body 'Hi'
+          end
+        end
+
+        it 'returns Cc recipients' do
+          expect(described_class.new(mail_with_cc_only).mail_receiver).to eq(['cc@example.com'])
+        end
+      end
+
+      context 'when mail has no To or Cc recipients' do
+        let(:mail_with_forwarded_header) do
+          Mail.new do
+            from 'Sender <sender@example.com>'
+            subject :header
+            body 'Hi'
+            header['X-Forwarded-For'] = 'forwarder@example.com'
+          end
+        end
+
+        let(:mail_without_recipients) do
+          Mail.new do
+            from 'Sender <sender@example.com>'
+            subject :header
+            body 'Hi'
+          end
+        end
+
+        it 'falls back to the X-Forwarded-For header' do
+          expect(described_class.new(mail_with_forwarded_header).mail_receiver).to eq(['forwarder@example.com'])
+        end
+
+        it 'returns an empty array' do
+          expect(described_class.new(mail_without_recipients).mail_receiver).to eq([])
+        end
+      end
+    end
+
     describe 'malformed sender headers' do
       let(:mail_with_malformed_from) do
         Mail.new do

--- a/spec/services/mailbox/conversation_finder_strategies/receiver_uuid_strategy_spec.rb
+++ b/spec/services/mailbox/conversation_finder_strategies/receiver_uuid_strategy_spec.rb
@@ -43,6 +43,19 @@ RSpec.describe Mailbox::ConversationFinderStrategies::ReceiverUuidStrategy do
       end
     end
 
+    context 'when mail has reply+uuid in Cc' do
+      before do
+        conversation.update!(uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+        mail.to = 'customer@example.com'
+        mail.cc = 'reply+aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee@example.com'
+      end
+
+      it 'extracts UUID from Cc recipients' do
+        strategy = described_class.new(mail)
+        expect(strategy.find).to eq(conversation)
+      end
+    end
+
     context 'when UUID does not exist in database' do
       before do
         mail.to = 'reply+99999999-9999-9999-9999-999999999999@example.com'


### PR DESCRIPTION
Fixes #15365.

## Summary

Inbound replies can put the `reply+<conversation-uuid>@...` address in `Cc` instead of `To`. The mailbox routing gate only inspected `To`, and the presenter later exposed only `To` to the conversation finder, so those replies were dropped.

This change:

- checks both `To` and `Cc` when identifying reply UUID mail
- passes both recipient lists to the receiver UUID strategy
- adds fixture, mailbox-routing, presenter, and receiver-strategy regression coverage
- preserves the `X-Forwarded-For` fallback when neither recipient header exists

## Verification

- `bundle exec rubocop` on all 5 changed Ruby files - passed
- isolated Mail fixture/routing check - passed; reply UUID in `Cc` is detected
- `git diff --check` - passed

The Rails specs were attempted but couldn't boot because the local PostgreSQL 16 server is missing the `vector` extension. Homebrew's available pgvector bottle targets PostgreSQL 17/18, so I didn't replace the active database installation. No application test failure was observed beyond that environment prerequisite.
