### PR TITLE
fix: skip self-hosted Captain usage tracking

### DIFF
--- a/enterprise/app/models/enterprise/account/plan_usage_and_limits.rb
+++ b/enterprise/app/models/enterprise/account/plan_usage_and_limits.rb
@@ -16,6 +16,8 @@ module Enterprise::Account::PlanUsageAndLimits # rubocop:disable Metrics/ModuleL
   end
 
   def increment_response_usage
+    return unless ChatwootApp.chatwoot_cloud?
+
     increment_custom_attribute(CAPTAIN_RESPONSES_USAGE)
   end
 

--- a/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
+++ b/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Captain::Conversation::ResponseBuilderJob, type: :job do
     let(:v2_response_parts) { [{ 'text' => 'Hey, welcome to Captain V2', 'citation_indexes' => [] }] }
 
     before do
+      allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
       allow(inbox).to receive(:captain_active?).and_return(true)
       allow(Captain::Llm::AssistantChatService).to receive(:new).and_return(mock_llm_chat_service)
       allow(mock_llm_chat_service).to receive(:generate_response).and_return({ 'response' => 'Hey, welcome to Captain Specs' })

--- a/spec/enterprise/lib/captain/base_task_service_spec.rb
+++ b/spec/enterprise/lib/captain/base_task_service_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Captain::BaseTaskService, type: :model do
   describe '#perform with enterprise usage tracking' do
     # Ensure captain is enabled by default for tests unless explicitly testing disabled state
     before do
+      allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
       allow(account).to receive(:feature_enabled?).and_call_original
       allow(account).to receive(:feature_enabled?).with('captain_tasks').and_return(true)
       allow(Integrations::Openai::KeyValidator).to receive(:valid?).and_return(true)

--- a/spec/enterprise/models/account_spec.rb
+++ b/spec/enterprise/models/account_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Account, type: :model do
     let(:assistant) { create(:captain_assistant, account: account) }
 
     before do
+      allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
       create(:installation_config, name: 'ACCOUNT_AGENTS_LIMIT', value: 20)
     end
 

--- a/spec/enterprise/services/captain/copilot/chat_service_spec.rb
+++ b/spec/enterprise/services/captain/copilot/chat_service_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Captain::Copilot::ChatService do
   end
 
   before do
+    allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
     InstallationConfig.find_or_create_by(name: 'CAPTAIN_OPEN_AI_API_KEY') do |c|
       c.value = 'test-key'
     end
@@ -102,6 +103,18 @@ RSpec.describe Captain::Copilot::ChatService do
       expect do
         service.generate_response('Hello')
       end.to(change { account.reload.custom_attributes['captain_responses_usage'].to_i }.by(1))
+    end
+
+    context 'when self-hosted' do
+      before do
+        allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(false)
+      end
+
+      it 'does not increment response usage' do
+        expect do
+          service.generate_response('Hello')
+        end.not_to(change { account.reload.custom_attributes['captain_responses_usage'].to_i })
+      end
     end
   end
 

--- a/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
@@ -9,6 +9,7 @@ describe Enterprise::Billing::HandleStripeEventService do
   let!(:account) { create(:account, custom_attributes: { stripe_customer_id: 'cus_123' }) }
 
   before do
+    allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
     # Create cloud plans configuration
     create(:installation_config, {
              name: 'CHATWOOT_CLOUD_PLANS',


### PR DESCRIPTION
Captain response usage is a Chatwoot Cloud billing counter. Self hosted installations use their own model credentials, so their responses should not increase this counter.

## Root cause

`Account#increment_response_usage` increased `captain_responses_usage` on every installation.

Self hosted installations do not receive the Cloud billing reset. Their stored usage could therefore keep growing even though they do not buy model credits from Chatwoot.

## What changed

`increment_response_usage` now returns without changing the counter unless the installation is Chatwoot Cloud.

No credit limits, routing rules, pricing plan checks, Community behavior, document behavior, crawling behavior, or frontend behavior changed.

Existing self hosted accounts with a high stored counter need a one time counter reset after deployment. Future self hosted responses will not increase it again.

## Checks

The focused backend suite passed 176 examples.

RuboCop inspected 6 files and found no offenses. `git diff --check` passed.
