### PR TITLE
fix: guard Channel::Telegram#process_error against a non-Hash response body

### DIFF
--- a/app/models/channel/telegram.rb
+++ b/app/models/channel/telegram.rb
@@ -60,10 +60,13 @@ class Channel::Telegram < ApplicationRecord
   end
 
   def process_error(message, response)
-    return unless response.parsed_response['ok'] == false
+    parsed_response = response.parsed_response
+    # Telegram's error body is expected to be a JSON object, but a non-2xx response can also arrive
+    # with a body that parses to something else (e.g. a bare `null`), which isn't safe to index with `[]`.
+    return unless parsed_response.is_a?(Hash) && parsed_response['ok'] == false
 
     # https://github.com/TelegramBotAPI/errors/tree/master/json
-    message.external_error = "#{response.parsed_response['error_code']}, #{response.parsed_response['description']}"
+    message.external_error = "#{parsed_response['error_code']}, #{parsed_response['description']}"
     message.status = :failed
     message.save!
   end

--- a/spec/models/channel/telegram_spec.rb
+++ b/spec/models/channel/telegram_spec.rb
@@ -153,6 +153,57 @@ RSpec.describe Channel::Telegram do
       expect(message.reload.status).to eq('failed')
       expect(message.reload.external_error).to eq('403, Forbidden: bot was blocked by the user')
     end
+
+    it 'send text message failed with a non-JSON-object response body' do
+      # Telegram (or an intermediary proxy) can return a non-2xx response whose body parses to
+      # something other than a JSON object (e.g. a bare `null`). `process_error` used to call
+      # `[]` directly on that parsed value and raise NoMethodError instead of failing gracefully.
+      message = create(:message, message_type: :outgoing, content: 'test',
+                                 conversation: create(:conversation, inbox: telegram_channel.inbox, additional_attributes: { 'chat_id' => '123' }))
+
+      stub_request(:post, "https://api.telegram.org/bot#{telegram_channel.bot_token}/sendMessage")
+        .with(
+          body: 'chat_id=123&text=test&reply_markup=&parse_mode=HTML&reply_to_message_id='
+        )
+        .to_return(
+          status: 502,
+          headers: { 'Content-Type' => 'application/json' },
+          body: 'null'
+        )
+
+      expect { telegram_channel.send_message_on_telegram(message) }.not_to raise_error
+      expect(message.reload.status).not_to eq('failed')
+    end
+  end
+
+  describe '#process_error' do
+    let(:message) do
+      create(:message, message_type: :outgoing, content: 'test',
+                       conversation: create(:conversation, inbox: telegram_channel.inbox, additional_attributes: { 'chat_id' => '123' }))
+    end
+
+    it 'marks the message as failed when the response body is a JSON object with ok: false' do
+      response = OpenStruct.new(parsed_response: { 'ok' => false, 'error_code' => 403, 'description' => 'Forbidden' })
+
+      telegram_channel.process_error(message, response)
+
+      expect(message.reload.status).to eq('failed')
+      expect(message.external_error).to eq('403, Forbidden')
+    end
+
+    it 'does not raise and leaves the message untouched when parsed_response is nil' do
+      response = OpenStruct.new(parsed_response: nil)
+
+      expect { telegram_channel.process_error(message, response) }.not_to raise_error
+      expect(message.reload.status).not_to eq('failed')
+    end
+
+    it 'does not raise and leaves the message untouched when parsed_response is an Array' do
+      response = OpenStruct.new(parsed_response: [{ 'ok' => false }])
+
+      expect { telegram_channel.process_error(message, response) }.not_to raise_error
+      expect(message.reload.status).not_to eq('failed')
+    end
   end
 
   context 'when message contains attachments' do


### PR DESCRIPTION
## Description

Fixes #13415.

`Channel::Telegram#process_error` did `response.parsed_response['ok']` unconditionally. `parsed_response` is not guaranteed to be a Hash:

- `Telegram::SendAttachmentsService#send_file` posts through a raw Faraday connection and normalizes the response via `parse_faraday_response`, which does `JSON.parse(response.body)` and stores whatever that returns. `JSON.parse("null")` is valid JSON and returns Ruby `nil` — `JSON::ParserError` is only raised for genuinely malformed (non-JSON) bodies, which already fall back to a Hash in the `rescue` branch.
- When a non-2xx response's body parses to `nil` (or any other non-Hash value), `process_error` raises `NoMethodError: undefined method '[]' for nil` instead of marking the message failed.

This matches the report in #13415: a `SendReplyJob` dead job in Sidekiq with `NoMethodError: undefined method '[]' for nil`, stack trace through `Channel::Telegram#process_error` called from `Telegram::SendAttachmentsService#handle_response`.

**What I verified, and how:** I read the full call path from `SendReplyJob` through `SendAttachmentsService#send_individual_attachments` → `document_request` → `send_file` → `parse_faraday_response` → `handle_response` → `Channel::Telegram#process_error`, and confirmed `JSON.parse("null") #=> nil` is standard Ruby behavior (not a hypothetical). I could not reproduce the reporter's *exact* upstream trigger (their report only includes the app-level stack trace, not what Telegram/their proxy actually returned), so I can't confirm their body was literally `"null"` versus some other non-Hash JSON value — but the crash class itself (a non-2xx response whose body parses to something other than a JSON object) is real and independently reproducible by construction, not just theorized.

I ran the full existing `spec/models/channel/telegram_spec.rb` and `spec/services/telegram/send_attachments_service_spec.rb` suites plus the new specs added here, against a real local Rails env (Ruby 3.4.4, PostgreSQL 16 with pgvector, Redis) — all pass. I also confirmed the new specs fail with the exact reported `NoMethodError` when run against the pre-fix code, and pass after the fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `bundle exec rspec spec/models/channel/telegram_spec.rb spec/services/telegram/send_attachments_service_spec.rb`
- Added:
  - `Channel::Telegram#process_error` unit specs covering a well-formed `{"ok": false, ...}` body (existing behavior, unchanged), a `nil` `parsed_response`, and an `Array` `parsed_response` — the latter two previously raised `NoMethodError`.
  - An integration-level spec on `#send_message_on_telegram` stubbing a real HTTP 502 response with body `"null"`, reproducing the exact `JSON.parse` → `nil` path described above.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

🤖 This fix was authored by an AI coding agent (Claude) working on behalf of Mithtech, an ERPNext/Frappe/Medusa.js implementation studio, as part of a deliberate effort to build a track record of verified upstream open-source contributions. Flagging this transparently per common courtesy — happy to answer any questions about the change.
