### PR TITLE
fix: prevent NoMethodError when content_attributes.items is missing or malformed

### DIFF
--- a/app/models/concerns/content_attribute_validator.rb
+++ b/app/models/concerns/content_attribute_validator.rb
@@ -8,26 +8,44 @@ class ContentAttributeValidator < ActiveModel::Validator
   def validate(record)
     case record.content_type
     when 'input_select'
-      validate_items!(record)
-      validate_item_attributes!(record, ALLOWED_SELECT_ITEM_KEYS)
+      validate_dependent_items!(record, ALLOWED_SELECT_ITEM_KEYS)
     when 'cards'
-      validate_items!(record)
-      validate_item_attributes!(record, ALLOWED_CARD_ITEM_KEYS)
-      validate_item_actions!(record)
+      validate_dependent_items!(record, ALLOWED_CARD_ITEM_KEYS, validate_actions: true)
     when 'form'
-      validate_items!(record)
-      validate_item_attributes!(record, ALLOWED_FORM_ITEM_KEYS)
+      validate_dependent_items!(record, ALLOWED_FORM_ITEM_KEYS)
     when 'article'
-      validate_items!(record)
-      validate_item_attributes!(record, ALLOWED_ARTICLE_KEYS)
+      validate_dependent_items!(record, ALLOWED_ARTICLE_KEYS)
     end
   end
 
   private
 
+  # `validate_item_attributes!` / `validate_item_actions!` assume `record.items` is an enumerable of
+  # hashes and blow up with a NoMethodError on nil/malformed input instead of surfacing a normal
+  # validation error, so only run them once `validate_items!` has confirmed that's safe.
+  def validate_dependent_items!(record, valid_keys, validate_actions: false)
+    return unless validate_items!(record)
+
+    validate_item_attributes!(record, valid_keys)
+    validate_item_actions!(record) if validate_actions
+  end
+
+  # Returns true when `record.items` is a present, well-formed array of hashes and it's safe for
+  # the caller to run the per-item validations above.
   def validate_items!(record)
-    record.errors.add(:content_attributes, 'At least one item is required.') if record.items.blank?
-    record.errors.add(:content_attributes, 'Items should be a hash.') if record.items.reject { |item| item.is_a?(Hash) }.present?
+    if record.items.blank?
+      record.errors.add(:content_attributes, 'At least one item is required.')
+      return false
+    end
+
+    # `items` itself must be an Array before it's safe to call Array methods on it below -- a client
+    # can send any JSON value here (e.g. a String or a Hash), and only an Array responds to `reject`.
+    unless record.items.is_a?(Array) && record.items.reject { |item| item.is_a?(Hash) }.blank?
+      record.errors.add(:content_attributes, 'Items should be a hash.')
+      return false
+    end
+
+    true
   end
 
   def validate_item_attributes!(record, valid_keys)

--- a/spec/models/concerns/content_attribute_validator_spec.rb
+++ b/spec/models/concerns/content_attribute_validator_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+# Regression coverage for a crash where `content_attributes.items` being blank or malformed
+# (nil, a String, ...) raised NoMethodError from inside the validator instead of producing a
+# normal ActiveModel validation error. See app/models/concerns/content_attribute_validator.rb.
+RSpec.describe ContentAttributeValidator, type: :validator do
+  # Each content_type only allows a different set of item keys (see the ALLOWED_*_KEYS constants),
+  # so the "well-formed" fixture has to match the content_type under test.
+  valid_item_by_content_type = {
+    'input_select' => { title: 'a', value: 'a' },
+    'cards' => { title: 'a', description: 'd', media_url: 'https://example.com/a.png',
+                 actions: [{ text: 'Go', type: 'link', uri: 'https://example.com' }] },
+    'form' => { type: 'text', label: 'Name', name: 'name' },
+    'article' => { title: 'a', description: 'd', link: 'https://example.com' }
+  }.freeze
+
+  %w[input_select cards form article].each do |content_type|
+    context "when content_type is #{content_type}" do
+      it 'is valid with well-formed items' do
+        message = build(:message, content_type: content_type, content_attributes: { items: [valid_item_by_content_type.fetch(content_type)] })
+
+        message.valid?
+
+        expect(message.errors[:content_attributes]).to be_empty
+      end
+
+      it 'does not raise and adds an error when items is missing entirely' do
+        message = build(:message, content_type: content_type, content_attributes: {})
+
+        expect { message.valid? }.not_to raise_error
+        expect(message.errors[:content_attributes]).to include('At least one item is required.')
+      end
+
+      it 'does not raise and adds an error when items is explicitly nil' do
+        message = build(:message, content_type: content_type, content_attributes: { items: nil })
+
+        expect { message.valid? }.not_to raise_error
+        expect(message.errors[:content_attributes]).to include('At least one item is required.')
+      end
+
+      it 'does not raise and adds an error when items is a String' do
+        message = build(:message, content_type: content_type, content_attributes: { items: 'not-an-array' })
+
+        expect { message.valid? }.not_to raise_error
+        expect(message.errors[:content_attributes]).to include('Items should be a hash.')
+      end
+
+      it 'does not raise and adds an error when items contains non-hash entries' do
+        message = build(:message, content_type: content_type, content_attributes: { items: ['not-a-hash'] })
+
+        expect { message.valid? }.not_to raise_error
+        expect(message.errors[:content_attributes]).to include('Items should be a hash.')
+      end
+
+      it 'does not run per-item validation (which itself assumes an array of hashes) when items is invalid' do
+        message = build(:message, content_type: content_type, content_attributes: { items: nil })
+
+        message.valid?
+
+        # A single, clear "items required" error -- not also a NoMethodError-triggered crash and
+        # not a confusing second "invalid keys" error computed against a blank items list.
+        expect(message.errors[:content_attributes]).to eq(['At least one item is required.'])
+      end
+    end
+  end
+
+  context 'when content_type is cards and items are present but missing actions' do
+    it 'still runs the cards-specific action validation' do
+      message = build(:message, content_type: 'cards', content_attributes: { items: [{ title: 'a' }] })
+
+      message.valid?
+
+      expect(message.errors[:content_attributes]).to include('contains items missing actions')
+    end
+  end
+
+  context 'when content_type does not require items (e.g. text)' do
+    it 'is valid regardless of content_attributes' do
+      message = build(:message, content_type: 'text', content_attributes: {})
+
+      expect { message.valid? }.not_to raise_error
+      expect(message.errors[:content_attributes]).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Description

Fixes #11827.

`ContentAttributeValidator#validate_items!` added a "items required" error when `record.items` was blank, but then fell through unconditionally to `record.items.reject { |item| item.is_a?(Hash) }` on the very next line — calling `.reject` on `record.items` regardless of whether it was actually present. When `items` is `nil` (e.g. omitted entirely from `content_attributes`, or explicitly `null`), that raises `NoMethodError: undefined method 'reject' for nil`.

Worse, `validate_items!` never stopped the caller from proceeding: `ContentAttributeValidator#validate` always called `validate_item_attributes!` (and, for `cards`, `validate_item_actions!`) right after `validate_items!`, regardless of whether items were valid. Those methods do `record.items.collect(&:keys)` / `record.items.select { ... }`, which also raise on `nil` `items` — so even shielding just the first crash would only move the exception one call further down.

This reproduces the class of error in #11827 (`{"error":"undefined method 'reject' for nil"}` from the messages API) for any of the four content types that require `items` (`input_select`, `cards`, `form`, `article`) whenever `content_attributes.items` is missing or `null`. I could not confirm the *exact* payload from the issue's own curl example still 500s on current `develop` the same way (the codebase has moved on since v4.1.0), but the underlying crash is real and directly reproducible by omitting `items`, which is a very plausible client mistake (e.g. forgetting the key, or a client library serializing an empty/absent field as `null`).

While in there, I also hardened `validate_items!` against `items` being present but not an `Array` (e.g. a String) — `"foo".reject { }` raises the same class of `NoMethodError` for the same underlying reason (an un-checked assumption that `items` responds to `Array` methods), so the fix uses `is_a?(Array)` explicitly rather than special-casing just `nil`.

## What changed

- `validate_items!` now returns `true`/`false` and adds the appropriate validation error instead of raising.
- `ContentAttributeValidator#validate`'s branches now only call the per-item validators (`validate_item_attributes!`, `validate_item_actions!`) when `validate_items!` returned `true`.
- No change in behavior for valid payloads (the existing "items required" / "items should be a hash" error messages and conditions are preserved).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran against a real local Rails env (Ruby 3.4.4, PostgreSQL 16 with pgvector, Redis):

`bundle exec rspec spec/models/concerns/content_attribute_validator_spec.rb spec/models/message_spec.rb`

Added `spec/models/concerns/content_attribute_validator_spec.rb`, covering all four `items`-requiring content types with: well-formed items (valid, unchanged), missing `items` key, explicit `items: nil`, `items` as a String, and `items` containing non-Hash entries — confirming each produces a normal validation error instead of raising, and that valid payloads are unaffected. Confirmed the new specs raise the exact `NoMethodError` described above when run against the pre-fix validator, and pass after the fix.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

🤖 This fix was authored by an AI coding agent (Claude) working on behalf of Mithtech, an ERPNext/Frappe/Medusa.js implementation studio, as part of a deliberate effort to build a track record of verified upstream open-source contributions. Flagging this transparently per common courtesy — happy to answer any questions about the change.
