### PR TITLE
fix: localize friendly email sender names

### DIFF
--- a/app/builders/email/base_builder.rb
+++ b/app/builders/email/base_builder.rb
@@ -29,7 +29,8 @@ class Email::BaseBuilder
         'conversations.reply.email.header.friendly_name',
         sender_name: custom_sender_name,
         business_name: business_name,
-        from_email: sender_email
+        from_email: sender_email,
+        locale: sender_locale
       )
     else
       I18n.t(
@@ -38,6 +39,12 @@ class Email::BaseBuilder
         from_email: sender_email
       )
     end
+  end
+
+  def sender_locale
+    return account.locale unless message&.sender.is_a?(User)
+
+    message.sender.ui_settings&.dig('locale').presence || account.locale
   end
 
   def business_name

--- a/app/builders/email/base_builder.rb
+++ b/app/builders/email/base_builder.rb
@@ -25,13 +25,13 @@ class Email::BaseBuilder
     # Friendly: <agent_name> from <business_name>
     # Professional: <business_name>
     if inbox.friendly?
-      I18n.t(
-        'conversations.reply.email.header.friendly_name',
+      Email::SenderNameBuilder.new(
+        account: account,
+        sender: message&.sender,
+        sender_email: sender_email,
         sender_name: custom_sender_name,
-        business_name: business_name,
-        from_email: sender_email,
-        locale: sender_locale
-      )
+        business_name: business_name
+      ).build
     else
       I18n.t(
         'conversations.reply.email.header.professional_name',
@@ -39,12 +39,6 @@ class Email::BaseBuilder
         from_email: sender_email
       )
     end
-  end
-
-  def sender_locale
-    return account.locale unless message&.sender.is_a?(User)
-
-    message.sender.ui_settings&.dig('locale').presence || account.locale
   end
 
   def business_name

--- a/app/builders/email/sender_name_builder.rb
+++ b/app/builders/email/sender_name_builder.rb
@@ -32,7 +32,7 @@ class Email::SenderNameBuilder
   end
 
   def sender_locale
-    locale_candidates.find { |locale| valid_locale?(locale) && I18n.exists?(TRANSLATION_KEY, locale) } || I18n.default_locale
+    locale_candidates.find { |locale| valid_locale?(locale) && I18n.exists?(TRANSLATION_KEY, locale, fallback: false) } || I18n.default_locale
   end
 
   def locale_candidates

--- a/app/builders/email/sender_name_builder.rb
+++ b/app/builders/email/sender_name_builder.rb
@@ -1,0 +1,46 @@
+class Email::SenderNameBuilder
+  TRANSLATION_KEY = 'conversations.reply.email.header.friendly_name'.freeze
+
+  pattr_initialize [:account!, :sender!, :sender_email!, :sender_name!, :business_name!]
+
+  def build
+    address = Mail::Address.new(sender_email)
+    address.display_name = localized_display_name(address.address)
+    address.format
+  rescue Mail::Field::ParseError, Mail::Field::IncompleteParseError
+    localized_header(sender_email)
+  end
+
+  private
+
+  def localized_display_name(email_address)
+    localized_header(email_address).sub(mailbox_pattern(email_address), '').strip
+  end
+
+  def localized_header(email_address)
+    I18n.t(
+      TRANSLATION_KEY,
+      sender_name: sender_name,
+      business_name: business_name,
+      from_email: email_address,
+      locale: sender_locale
+    )
+  end
+
+  def mailbox_pattern(email_address)
+    /\s*[<«]\s*(?:reply\+)?#{Regexp.escape(email_address)}\s*[>»]\s*/
+  end
+
+  def sender_locale
+    locale_candidates.find { |locale| valid_locale?(locale) && I18n.exists?(TRANSLATION_KEY, locale) } || I18n.default_locale
+  end
+
+  def locale_candidates
+    sender_locale = sender.ui_settings&.dig('locale') if sender.is_a?(User)
+    [sender_locale, account.locale, I18n.default_locale].compact.map(&:to_s).uniq
+  end
+
+  def valid_locale?(locale)
+    I18n.available_locales.map(&:to_s).include?(locale)
+  end
+end

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -91,17 +91,16 @@ class ConversationReplyMailer < ApplicationMailer
 
   def sender_name(sender_email)
     if @inbox.friendly?
-      I18n.t('conversations.reply.email.header.friendly_name', sender_name: custom_sender_name, business_name: business_name,
-                                                               from_email: sender_email, locale: sender_locale)
+      Email::SenderNameBuilder.new(
+        account: @account,
+        sender: current_message&.sender,
+        sender_email: sender_email,
+        sender_name: custom_sender_name,
+        business_name: business_name
+      ).build
     else
       I18n.t('conversations.reply.email.header.professional_name', business_name: business_name, from_email: sender_email)
     end
-  end
-
-  def sender_locale
-    return @account.locale unless current_message&.sender.is_a?(User)
-
-    current_message.sender.ui_settings&.dig('locale').presence || @account.locale
   end
 
   def current_message

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -92,10 +92,16 @@ class ConversationReplyMailer < ApplicationMailer
   def sender_name(sender_email)
     if @inbox.friendly?
       I18n.t('conversations.reply.email.header.friendly_name', sender_name: custom_sender_name, business_name: business_name,
-                                                               from_email: sender_email)
+                                                               from_email: sender_email, locale: sender_locale)
     else
       I18n.t('conversations.reply.email.header.professional_name', business_name: business_name, from_email: sender_email)
     end
+  end
+
+  def sender_locale
+    return @account.locale unless current_message&.sender.is_a?(User)
+
+    current_message.sender.ui_settings&.dig('locale').presence || @account.locale
   end
 
   def current_message

--- a/spec/builders/email/from_builder_spec.rb
+++ b/spec/builders/email/from_builder_spec.rb
@@ -28,6 +28,22 @@ RSpec.describe Email::FromBuilder do
           expect(result).to include(agent.available_name)
           expect(result).to include('support@example.com')
         end
+
+        it 'uses the sender locale for the friendly name' do
+          agent.update!(ui_settings: { 'locale' => 'de' })
+
+          result = described_class.new(inbox: inbox, message: current_message).build
+
+          expect(result).to eq("#{agent.available_name} von #{inbox.sanitized_business_name} <support@example.com>")
+        end
+
+        it 'falls back to the account locale when the sender locale is not set' do
+          account.update!(locale: :de)
+
+          result = described_class.new(inbox: inbox, message: current_message).build
+
+          expect(result).to eq("#{agent.available_name} von #{inbox.sanitized_business_name} <support@example.com>")
+        end
       end
 
       context 'with professional inbox' do

--- a/spec/builders/email/sender_name_builder_spec.rb
+++ b/spec/builders/email/sender_name_builder_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe Email::SenderNameBuilder do
+  let(:account) { create(:account, locale: :en) }
+  let(:sender) { create(:user, account: account, ui_settings: { 'locale' => 'de' }) }
+  let(:builder) do
+    described_class.new(
+      account: account,
+      sender: sender,
+      sender_email: 'care@example.com',
+      sender_name: 'Ivan',
+      business_name: 'Juvigo'
+    )
+  end
+
+  it 'uses the user locale for the display name' do
+    expect(builder.build).to eq('Ivan von Juvigo <care@example.com>')
+  end
+
+  it 'keeps the supplied email address authoritative for every supported locale' do
+    I18n.available_locales.each do |locale|
+      sender.update!(ui_settings: { 'locale' => locale.to_s })
+
+      expect(Mail::Address.new(builder.build).address).to eq('care@example.com')
+    end
+  end
+
+  it 'does not apply an address prefix from the localized template' do
+    sender.update!(ui_settings: { 'locale' => 'sk' })
+
+    expect(builder.build).to eq('Ivan z Juvigo <care@example.com>')
+  end
+
+  it 'falls back to the account locale when the user locale is invalid' do
+    account.update!(locale: :de)
+    sender.update!(ui_settings: { 'locale' => 'not-a-locale' })
+
+    expect(builder.build).to eq('Ivan von Juvigo <care@example.com>')
+  end
+
+  it 'falls back to the account locale when the sender name translation is missing' do
+    sender.update!(ui_settings: { 'locale' => 'sr' })
+
+    expect(builder.build).to eq('Ivan from Juvigo <care@example.com>')
+  end
+
+  it 'falls back to the account locale when the sender is not a user' do
+    account.update!(locale: :de)
+    builder = described_class.new(
+      account: account,
+      sender: create(:agent_bot, account: account),
+      sender_email: 'care@example.com',
+      sender_name: 'Ivan',
+      business_name: 'Juvigo'
+    )
+
+    expect(builder.build).to eq('Ivan von Juvigo <care@example.com>')
+  end
+end

--- a/spec/builders/email/sender_name_builder_spec.rb
+++ b/spec/builders/email/sender_name_builder_spec.rb
@@ -38,10 +38,27 @@ RSpec.describe Email::SenderNameBuilder do
     expect(builder.build).to eq('Ivan von Juvigo <care@example.com>')
   end
 
-  it 'falls back to the account locale when the sender name translation is missing' do
-    sender.update!(ui_settings: { 'locale' => 'sr' })
+  context 'with production-style locale fallbacks' do
+    around do |example|
+      original_backend = I18n.backend
+      original_fallbacks = I18n.fallbacks
+      fallback_backend = I18n::Backend::Simple.new
+      fallback_backend.extend(I18n::Backend::Fallbacks)
+      I18n.backend = fallback_backend
+      I18n.fallbacks = I18n::Locale::Fallbacks.new(I18n.default_locale)
 
-    expect(builder.build).to eq('Ivan from Juvigo <care@example.com>')
+      example.run
+    ensure
+      I18n.backend = original_backend
+      I18n.fallbacks = original_fallbacks
+    end
+
+    it 'falls back to the account locale when the sender name translation is missing' do
+      account.update!(locale: :de)
+      sender.update!(ui_settings: { 'locale' => 'sr' })
+
+      expect(builder.build).to eq('Ivan von Juvigo <care@example.com>')
+    end
   end
 
   it 'falls back to the account locale when the sender is not a user' do

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -666,6 +666,31 @@ RSpec.describe ConversationReplyMailer do
           mail = described_class.email_reply(message)
           expect(mail['from'].value).to eq "#{agent_2.available_name} from #{conversation.inbox.business_name} <#{smtp_channel.email}>"
         end
+
+        it 'uses the sender locale for the friendly name' do
+          message.sender.update!(ui_settings: { 'locale' => 'de' })
+
+          mail = described_class.email_reply(message)
+
+          expect(mail['from'].value).to eq "#{message.sender.available_name} von #{conversation.inbox.business_name} <#{smtp_channel.email}>"
+        end
+
+        it 'falls back to the account locale when the sender locale is not set' do
+          account.update!(locale: :de)
+
+          mail = described_class.email_reply(message)
+
+          expect(mail['from'].value).to eq "#{message.sender.available_name} von #{conversation.inbox.business_name} <#{smtp_channel.email}>"
+        end
+
+        it 'uses the account locale when the sender is not a user' do
+          account.update!(locale: :de)
+          message.update!(sender_id: nil)
+
+          mail = described_class.email_reply(message)
+
+          expect(mail['from'].value).to eq "#{conversation.assignee.available_name} von #{conversation.inbox.business_name} <#{smtp_channel.email}>"
+        end
       end
 
       context 'when friendly name disabled' do


### PR DESCRIPTION
# Pull Request Template

## Description

Friendly sender names in outgoing emails now follow the sending user's selected profile language. When the sender is not a user or has no explicit locale preference, the sender name falls back to the account locale.

This keeps the delivered sender name consistent with the localized preview without changing the locale used for the email subject or body. Both the legacy reply mailer and the migrated email builder path use the same locale precedence.

### Closes

https://linear.app/chatwoot/issue/CW-7940/friendly-sender-name-shows-english-format-instead-of-selected-locale

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified friendly sender formatting when the user locale differs from the account locale, when the user has no locale preference, and when the sender is not a user. Existing reply-mailer and email-builder behavior remains covered.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
