### PR TITLE
feat: support internal feature model overrides

### DIFF
--- a/app/models/concerns/account_settings_schema.rb
+++ b/app/models/concerns/account_settings_schema.rb
@@ -1,7 +1,7 @@
 module AccountSettingsSchema
   extend ActiveSupport::Concern
 
-  CAPTAIN_MODEL_PROPERTIES = Llm::Models.feature_keys.index_with { { 'type': %w[string null] } }.freeze
+  CAPTAIN_MODEL_PROPERTIES = Llm::Models.model_feature_keys.index_with { { 'type': %w[string null] } }.freeze
   CAPTAIN_FEATURE_PROPERTIES = Llm::Models.feature_keys.index_with { { 'type': %w[boolean null] } }.freeze
 
   SETTINGS_PARAMS_SCHEMA = {

--- a/config/llm.yml
+++ b/config/llm.yml
@@ -70,7 +70,18 @@ models:
 
 features:
   conversation_completion:
-    models: [gpt-4.1]
+    models:
+      [
+        gpt-4.1-mini,
+        gpt-5-mini,
+        gpt-4.1,
+        gpt-5.1,
+        gpt-5.2,
+        claude-haiku-4.5,
+        claude-sonnet-4.5,
+        gemini-3-flash,
+        gemini-3-pro,
+      ]
     default: gpt-4.1
     internal: true
   editor:

--- a/config/llm.yml
+++ b/config/llm.yml
@@ -77,10 +77,6 @@ features:
         gpt-4.1,
         gpt-5.1,
         gpt-5.2,
-        claude-haiku-4.5,
-        claude-sonnet-4.5,
-        gemini-3-flash,
-        gemini-3-pro,
       ]
     default: gpt-4.1
     internal: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -631,17 +631,18 @@ en:
         empty: 'No suspension history recorded.'
     captain_model_overrides:
       form:
-        helper_text: 'Leave a model blank to use the YAML default for that AI feature.'
+        helper_text: 'Leave a model blank to use the default routing for that AI feature.'
         customer_features: 'Customer features'
         internal_features: 'Internal features'
         use_default: 'Use default: %{model} (%{model_id})'
-        use_default_routing: 'Use default routing'
+        use_installation_model: 'Use installation model: %{model} (%{model_id})'
       show:
         summary: 'View model routing'
         provider: 'Provider'
         model: 'Model'
       sources:
         account_override: 'Account override'
+        installation_override: 'Installation setting'
         default: 'Default'
       features:
         conversation_completion: 'Inactive conversation completion evaluator'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -632,7 +632,10 @@ en:
     captain_model_overrides:
       form:
         helper_text: 'Leave a model blank to use the YAML default for that AI feature.'
+        customer_features: 'Customer features'
+        internal_features: 'Internal features'
         use_default: 'Use default: %{model} (%{model_id})'
+        use_default_routing: 'Use default routing'
       show:
         summary: 'View model routing'
         provider: 'Provider'
@@ -641,6 +644,7 @@ en:
         account_override: 'Account override'
         default: 'Default'
       features:
+        conversation_completion: 'Conversation completion'
         editor: 'Editor'
         assistant: 'Assistant'
         copilot: 'Copilot'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -644,7 +644,7 @@ en:
         account_override: 'Account override'
         default: 'Default'
       features:
-        conversation_completion: 'Conversation completion'
+        conversation_completion: 'Inactive conversation completion evaluator'
         editor: 'Editor'
         assistant: 'Assistant'
         copilot: 'Copilot'

--- a/enterprise/app/fields/captain_model_overrides_field.rb
+++ b/enterprise/app/fields/captain_model_overrides_field.rb
@@ -50,10 +50,21 @@ class CaptainModelOverridesField < Administrate::Field::Base
   end
 
   def default_option_label(feature_key)
-    return I18n.t('super_admin.captain_model_overrides.form.use_default_routing') if Llm::Models.internal_feature?(feature_key)
+    return internal_default_option_label(feature_key) if Llm::Models.internal_feature?(feature_key)
 
     model_id = default_model_id(feature_key)
     I18n.t('super_admin.captain_model_overrides.form.use_default', model: model_label(model_id), model_id: model_id)
+  end
+
+  def internal_default_option_label(feature_key)
+    route = Llm::FeatureRouter.resolve(feature: feature_key)
+    translation_key = route[:source] == :installation_override ? 'use_installation_model' : 'use_default'
+
+    I18n.t(
+      "super_admin.captain_model_overrides.form.#{translation_key}",
+      model: model_label(route[:model]),
+      model_id: route[:model]
+    )
   end
 
   def model_label(model_id)

--- a/enterprise/app/fields/captain_model_overrides_field.rb
+++ b/enterprise/app/fields/captain_model_overrides_field.rb
@@ -2,7 +2,17 @@ require 'administrate/field/base'
 
 class CaptainModelOverridesField < Administrate::Field::Base
   def feature_rows
-    Llm::Models.feature_keys.map do |feature_key|
+    build_feature_rows(Llm::Models.feature_keys)
+  end
+
+  def internal_feature_rows
+    build_feature_rows(Llm::Models.internal_feature_keys)
+  end
+
+  private
+
+  def build_feature_rows(feature_keys)
+    feature_keys.map do |feature_key|
       route = Llm::FeatureRouter.resolve(feature: feature_key, account: resource)
 
       {
@@ -14,6 +24,7 @@ class CaptainModelOverridesField < Administrate::Field::Base
         model_id: route[:model],
         default_model: model_label(default_model_id(feature_key)),
         default_model_id: default_model_id(feature_key),
+        default_option_label: default_option_label(feature_key),
         source: route[:source],
         source_label: source_label(route[:source]),
         selected_override: selected_override(feature_key),
@@ -21,8 +32,6 @@ class CaptainModelOverridesField < Administrate::Field::Base
       }
     end
   end
-
-  private
 
   def selected_override(feature_key)
     resource.captain_models&.[](feature_key).presence
@@ -38,6 +47,13 @@ class CaptainModelOverridesField < Administrate::Field::Base
     Llm::Models.feature_config(feature_key)[:models].map do |model|
       [model[:display_name] || model[:id], model[:id]]
     end
+  end
+
+  def default_option_label(feature_key)
+    return I18n.t('super_admin.captain_model_overrides.form.use_default_routing') if Llm::Models.internal_feature?(feature_key)
+
+    model_id = default_model_id(feature_key)
+    I18n.t('super_admin.captain_model_overrides.form.use_default', model: model_label(model_id), model_id: model_id)
   end
 
   def model_label(model_id)

--- a/enterprise/app/views/fields/captain_model_overrides_field/_form.html.erb
+++ b/enterprise/app/views/fields/captain_model_overrides_field/_form.html.erb
@@ -5,23 +5,32 @@
 <div class="field-unit__field max-w-5xl">
   <p class="mb-3 text-xs italic text-n-slate-10"><%= t('super_admin.captain_model_overrides.form.helper_text') %></p>
 
-  <div class="grid grid-cols-1 gap-2 lg:grid-cols-3">
-    <% field.feature_rows.each do |feature| %>
-      <div class="rounded-md border border-n-weak bg-white p-2.5">
-        <div class="mb-1.5">
-          <div class="text-xs font-medium text-n-slate-12"><%= feature[:name] %></div>
-          <div class="text-[11px] text-n-slate-10"><%= feature[:key] %></div>
-        </div>
+  <% [
+       [t('super_admin.captain_model_overrides.form.customer_features'), field.feature_rows],
+       [t('super_admin.captain_model_overrides.form.internal_features'), field.internal_feature_rows]
+     ].each do |section_name, features| %>
+    <section class="mb-4 last:mb-0">
+      <h3 class="mb-2 text-xs font-medium text-n-slate-11"><%= section_name %></h3>
 
-        <%= select_tag(
-              "account[captain_models][#{feature[:key]}]",
-              options_for_select(
-                [[t('super_admin.captain_model_overrides.form.use_default', model: feature[:default_model], model_id: feature[:default_model_id]), '']] + feature[:options],
-                feature[:selected_override]
-              ),
-              class: 'block w-full rounded-md border-n-strong py-1.5 pl-2 pr-8 text-xs'
-            ) %>
+      <div class="grid grid-cols-1 gap-2 lg:grid-cols-3">
+        <% features.each do |feature| %>
+          <div class="rounded-md border border-n-weak bg-white p-2.5">
+            <div class="mb-1.5">
+              <div class="text-xs font-medium text-n-slate-12"><%= feature[:name] %></div>
+              <div class="text-[11px] text-n-slate-10"><%= feature[:key] %></div>
+            </div>
+
+            <%= select_tag(
+                  "account[captain_models][#{feature[:key]}]",
+                  options_for_select(
+                    [[feature[:default_option_label], '']] + feature[:options],
+                    feature[:selected_override]
+                  ),
+                  class: 'block w-full rounded-md border-n-strong py-1.5 pl-2 pr-8 text-xs'
+                ) %>
+          </div>
+        <% end %>
       </div>
-    <% end %>
-  </div>
+    </section>
+  <% end %>
 </div>

--- a/enterprise/app/views/fields/captain_model_overrides_field/_show.html.erb
+++ b/enterprise/app/views/fields/captain_model_overrides_field/_show.html.erb
@@ -7,37 +7,46 @@
   </summary>
 
   <div class="mt-3 w-full">
-    <div class="grid grid-cols-1 gap-2 lg:grid-cols-3">
-      <% field.feature_rows.each do |feature| %>
-        <div class="rounded-md border border-n-weak bg-white p-2.5">
-          <div class="flex items-start justify-between gap-2">
-            <div>
-              <div class="text-xs font-medium text-n-slate-12"><%= feature[:name] %></div>
-              <div class="text-[11px] text-n-slate-10"><%= feature[:key] %></div>
-            </div>
-            <span class="<%= feature[:source] == :account_override ? 'bg-green-400 text-white' : 'bg-slate-50 text-slate-800' %> shrink-0 rounded-full px-2 py-1 text-[11px]">
-              <%= feature[:source_label] %>
-            </span>
-          </div>
+    <% [
+         [t('super_admin.captain_model_overrides.form.customer_features'), field.feature_rows],
+         [t('super_admin.captain_model_overrides.form.internal_features'), field.internal_feature_rows]
+       ].each do |section_name, features| %>
+      <section class="mb-4 last:mb-0">
+        <h3 class="mb-2 text-xs font-medium text-n-slate-11"><%= section_name %></h3>
 
-          <div class="mt-2 grid grid-cols-1 gap-2 text-xs">
-            <div>
-              <div class="text-[11px] uppercase text-n-slate-10"><%= t('super_admin.captain_model_overrides.show.provider') %></div>
-              <div class="text-n-slate-12">
-                <%= feature[:provider] %>
-                <span class="text-n-slate-10">(<%= feature[:provider_id] %>)</span>
+        <div class="grid grid-cols-1 gap-2 lg:grid-cols-3">
+          <% features.each do |feature| %>
+            <div class="rounded-md border border-n-weak bg-white p-2.5">
+              <div class="flex items-start justify-between gap-2">
+                <div>
+                  <div class="text-xs font-medium text-n-slate-12"><%= feature[:name] %></div>
+                  <div class="text-[11px] text-n-slate-10"><%= feature[:key] %></div>
+                </div>
+                <span class="<%= feature[:source] == :account_override ? 'bg-green-400 text-white' : 'bg-slate-50 text-slate-800' %> shrink-0 rounded-full px-2 py-1 text-[11px]">
+                  <%= feature[:source_label] %>
+                </span>
+              </div>
+
+              <div class="mt-2 grid grid-cols-1 gap-2 text-xs">
+                <div>
+                  <div class="text-[11px] uppercase text-n-slate-10"><%= t('super_admin.captain_model_overrides.show.provider') %></div>
+                  <div class="text-n-slate-12">
+                    <%= feature[:provider] %>
+                    <span class="text-n-slate-10">(<%= feature[:provider_id] %>)</span>
+                  </div>
+                </div>
+                <div>
+                  <div class="text-[11px] uppercase text-n-slate-10"><%= t('super_admin.captain_model_overrides.show.model') %></div>
+                  <div class="text-n-slate-12">
+                    <%= feature[:model] %>
+                    <span class="text-n-slate-10">(<%= feature[:model_id] %>)</span>
+                  </div>
+                </div>
               </div>
             </div>
-            <div>
-              <div class="text-[11px] uppercase text-n-slate-10"><%= t('super_admin.captain_model_overrides.show.model') %></div>
-              <div class="text-n-slate-12">
-                <%= feature[:model] %>
-                <span class="text-n-slate-10">(<%= feature[:model_id] %>)</span>
-              </div>
-            </div>
-          </div>
+          <% end %>
         </div>
-      <% end %>
-    </div>
+      </section>
+    <% end %>
   </div>
 </details>

--- a/enterprise/lib/captain/conversation_completion_service.rb
+++ b/enterprise/lib/captain/conversation_completion_service.rb
@@ -17,7 +17,6 @@ class Captain::ConversationCompletionService < Captain::BaseTaskService
 
     response = make_api_call(
       feature: 'conversation_completion',
-      model: self_hosted_model_override,
       messages: [
         { role: 'system', content: prompt_from_file('conversation_completion') },
         { role: 'user', content: content }
@@ -31,12 +30,6 @@ class Captain::ConversationCompletionService < Captain::BaseTaskService
   end
 
   private
-
-  def self_hosted_model_override
-    return unless ChatwootApp.self_hosted_enterprise?
-
-    InstallationConfig.find_by(name: 'CAPTAIN_OPEN_AI_MODEL')&.value.presence
-  end
 
   def prompt_from_file(file_name)
     Rails.root.join('enterprise/lib/captain/prompts', "#{file_name}.liquid").read

--- a/lib/llm/feature_router.rb
+++ b/lib/llm/feature_router.rb
@@ -8,14 +8,11 @@ module Llm::FeatureRouter
       feature_key = feature.to_s
       raise UnknownFeatureError, "Unknown LLM feature: #{feature_key}" unless Llm::Models.feature?(feature_key)
 
-      model = account_model_override(account, feature_key)
-      source = model.present? ? :account_override : :default
-      model ||= captain_v2_assistant_model(account, feature_key)
-      model ||= Llm::Models.default_model_for(feature_key)
+      model, source = model_and_source(account, feature_key)
 
       {
         feature: feature_key,
-        provider: Llm::Models.provider_for(model),
+        provider: provider_for(model, source),
         model: model,
         source: source
       }
@@ -23,10 +20,31 @@ module Llm::FeatureRouter
 
     private
 
+    def model_and_source(account, feature_key)
+      account_model = account_model_override(account, feature_key)
+      return [account_model, :account_override] if account_model.present?
+
+      installation_model = installation_model_override(feature_key)
+      return [installation_model, :installation_override] if installation_model.present?
+
+      [captain_v2_assistant_model(account, feature_key) || Llm::Models.default_model_for(feature_key), :default]
+    end
+
     def account_model_override(account, feature_key)
       model = account&.captain_models&.[](feature_key).presence
       return unless model
       return model if Llm::Models.valid_model_for?(feature_key, model)
+    end
+
+    def installation_model_override(feature_key)
+      return unless feature_key == 'conversation_completion'
+      return unless ChatwootApp.self_hosted_enterprise?
+
+      InstallationConfig.find_by(name: 'CAPTAIN_OPEN_AI_MODEL')&.value.presence
+    end
+
+    def provider_for(model, source)
+      Llm::Models.provider_for(model) || ('openai' if source == :installation_override)
     end
 
     def captain_v2_assistant_model(account, feature_key)

--- a/lib/llm/feature_router.rb
+++ b/lib/llm/feature_router.rb
@@ -24,8 +24,6 @@ module Llm::FeatureRouter
     private
 
     def account_model_override(account, feature_key)
-      return if Llm::Models.internal_feature?(feature_key)
-
       model = account&.captain_models&.[](feature_key).presence
       return unless model
       return model if Llm::Models.valid_model_for?(feature_key, model)

--- a/lib/llm/models.rb
+++ b/lib/llm/models.rb
@@ -6,6 +6,8 @@ module Llm::Models
     def models = CONFIG.fetch('models')
     def features = CONFIG.fetch('features')
     def feature_keys = features.reject { |_key, config| config['internal'] }.keys
+    def internal_feature_keys = features.select { |_key, config| config['internal'] }.keys
+    def model_feature_keys = features.keys
 
     def internal_feature?(feature)
       features.dig(feature.to_s, 'internal') == true

--- a/spec/controllers/super_admin/accounts_controller_spec.rb
+++ b/spec/controllers/super_admin/accounts_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Super Admin accounts API', type: :request do
         expect(summaries).to include('View model routing')
         expect(summaries).not_to include('All features', 'Captain models')
         expect(routing_panel.text.squish).to include('Customer features', 'Internal features')
-        expect(completion_card.text.squish).to include('Conversation completion', 'GPT-5.2', 'Account override')
+        expect(completion_card.text.squish).to include('Inactive conversation completion evaluator', 'GPT-5.2', 'Account override')
         expect(response.body).to include('Editor', 'OpenAI', 'openai', 'gpt-4.1', 'Label suggestion', 'Default')
       end
     end

--- a/spec/controllers/super_admin/accounts_controller_spec.rb
+++ b/spec/controllers/super_admin/accounts_controller_spec.rb
@@ -28,26 +28,29 @@ RSpec.describe 'Super Admin accounts API', type: :request do
   describe 'GET /super_admin/accounts/{account_id}' do
     context 'when it is an authenticated user' do
       it 'shows effective Captain model routing', if: ChatwootApp.enterprise? do
-        account.update!(captain_models: { 'editor' => 'gpt-4.1' })
+        account.update!(captain_models: { 'editor' => 'gpt-4.1', 'conversation_completion' => 'gpt-5.2' })
         sign_in(super_admin, scope: :super_admin)
 
         get "/super_admin/accounts/#{account.id}"
         document = Nokogiri::HTML(response.body)
         summaries = document.css('details summary').map { |summary| summary.text.squish }
+        routing_panel = document.at_css('#captain_models').parent.at_css('details')
+        completion_card = routing_panel.css('.rounded-md').find { |card| card.text.include?('conversation_completion') }
 
         expect(response).to have_http_status(:success)
         expect(document.at_css('#captain_models').text.squish).to eq('Captain models')
         expect(summaries).to include('View model routing')
-        expect(summaries).not_to include('All features')
-        expect(summaries).not_to include('Captain models')
-        expect(response.body).to include('Editor', 'OpenAI', 'openai', 'gpt-4.1', 'Account override', 'Label suggestion', 'Default')
+        expect(summaries).not_to include('All features', 'Captain models')
+        expect(routing_panel.text.squish).to include('Customer features', 'Internal features')
+        expect(completion_card.text.squish).to include('Conversation completion', 'GPT-5.2', 'Account override')
+        expect(response.body).to include('Editor', 'OpenAI', 'openai', 'gpt-4.1', 'Label suggestion', 'Default')
       end
     end
   end
 
   describe 'GET /super_admin/accounts/{account_id}/edit' do
     context 'when it is an authenticated user' do
-      it 'renders a Captain model selector for every AI feature', if: ChatwootApp.enterprise? do
+      it 'renders separate Captain model selectors for customer and internal AI features', if: ChatwootApp.enterprise? do
         account.update!(captain_models: { 'editor' => 'gpt-4.1' })
         sign_in(super_admin, scope: :super_admin)
 
@@ -57,14 +60,20 @@ RSpec.describe 'Super Admin accounts API', type: :request do
         Llm::Models.feature_keys.each do |feature_key|
           expect(response.body).to include("account[captain_models][#{feature_key}]")
         end
-        expect(response.body).not_to include('account[captain_models][conversation_completion]')
+        Llm::Models.internal_feature_keys.each do |feature_key|
+          expect(response.body).to include("account[captain_models][#{feature_key}]")
+        end
 
         document = Nokogiri::HTML(response.body)
         editor_select = document.at_css('select[name="account[captain_models][editor]"]')
+        completion_select = document.at_css('select[name="account[captain_models][conversation_completion]"]')
         default_model_id = Llm::Models.default_model_for('editor')
         default_model = Llm::Models.model_config(default_model_id)['display_name']
 
+        expect(response.body).to include('Customer features', 'Internal features')
         expect(editor_select.at_css('option[value=""]').text.squish).to eq("Use default: #{default_model} (#{default_model_id})")
+        expect(completion_select.at_css('option[value=""]').text.squish).to eq('Use default routing')
+        expect(completion_select.css('option').pluck('value')).to eq([''] + Llm::Models.models_for('conversation_completion'))
       end
 
       it 'shows the Captain V2 assistant default in the model selector', if: ChatwootApp.enterprise? do
@@ -101,13 +110,17 @@ RSpec.describe 'Super Admin accounts API', type: :request do
                   status: account.status,
                   captain_models: {
                     editor: '',
-                    assistant: 'gpt-5.2'
+                    assistant: 'gpt-5.2',
+                    conversation_completion: 'gpt-5.2'
                   }
                 }
               }
 
         expect(response).to have_http_status(:redirect)
-        expect(account.reload.captain_models).to eq('assistant' => 'gpt-5.2')
+        expect(account.reload.captain_models).to eq(
+          'assistant' => 'gpt-5.2',
+          'conversation_completion' => 'gpt-5.2'
+        )
         expect(account.keep_pending_on_bot_failure).to be true
       end
 

--- a/spec/controllers/super_admin/accounts_controller_spec.rb
+++ b/spec/controllers/super_admin/accounts_controller_spec.rb
@@ -45,12 +45,32 @@ RSpec.describe 'Super Admin accounts API', type: :request do
         expect(completion_card.text.squish).to include('Inactive conversation completion evaluator', 'GPT-5.2', 'Account override')
         expect(response.body).to include('Editor', 'OpenAI', 'openai', 'gpt-4.1', 'Label suggestion', 'Default')
       end
+
+      it 'shows the installation model for internal routing on self-hosted Enterprise', if: ChatwootApp.enterprise? do
+        allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+        InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'gpt-5.1')
+        sign_in(super_admin, scope: :super_admin)
+
+        get "/super_admin/accounts/#{account.id}"
+        document = Nokogiri::HTML(response.body)
+        routing_panel = document.at_css('#captain_models').parent.at_css('details')
+        completion_card = routing_panel.css('.rounded-md').find { |card| card.text.include?('conversation_completion') }
+
+        expect(response).to have_http_status(:success)
+        expect(completion_card.text.squish).to include(
+          'Inactive conversation completion evaluator',
+          'GPT-5.1',
+          'Installation setting'
+        )
+      end
     end
   end
 
   describe 'GET /super_admin/accounts/{account_id}/edit' do
     context 'when it is an authenticated user' do
       it 'renders separate Captain model selectors for customer and internal AI features', if: ChatwootApp.enterprise? do
+        allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+        InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'gpt-5.1')
         account.update!(captain_models: { 'editor' => 'gpt-4.1' })
         sign_in(super_admin, scope: :super_admin)
 
@@ -72,7 +92,7 @@ RSpec.describe 'Super Admin accounts API', type: :request do
 
         expect(response.body).to include('Customer features', 'Internal features')
         expect(editor_select.at_css('option[value=""]').text.squish).to eq("Use default: #{default_model} (#{default_model_id})")
-        expect(completion_select.at_css('option[value=""]').text.squish).to eq('Use default routing')
+        expect(completion_select.at_css('option[value=""]').text.squish).to eq('Use installation model: GPT-5.1 (gpt-5.1)')
         expect(completion_select.css('option').pluck('value')).to eq([''] + Llm::Models.models_for('conversation_completion'))
       end
 

--- a/spec/enterprise/lib/captain/conversation_completion_service_spec.rb
+++ b/spec/enterprise/lib/captain/conversation_completion_service_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe Captain::ConversationCompletionService do
         expect(service.perform).to include(complete: true)
       end
 
+      it 'uses the account override ahead of the installation model on self-hosted Enterprise' do
+        allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+        InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'gpt-5.1')
+        account.update!(captain_models: { 'conversation_completion' => 'gpt-5.2' })
+        allow(mock_context).to receive(:chat).with(model: 'gpt-5.2').and_return(mock_chat)
+
+        expect(service.perform).to include(complete: true)
+      end
+
       it 'falls back to the internal GPT-4.1 route when the self-hosted installation model is blank' do
         allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
         InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: '')

--- a/spec/lib/llm/feature_router_spec.rb
+++ b/spec/lib/llm/feature_router_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Llm::FeatureRouter do
   let(:account) { create(:account) }
 
   describe '.resolve' do
+    before do
+      allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(false)
+    end
+
     it 'returns the feature default without an account' do
       resolved = described_class.resolve(feature: 'editor')
 
@@ -38,6 +42,46 @@ RSpec.describe Llm::FeatureRouter do
       expect(resolved).to include(
         feature: 'conversation_completion',
         provider: 'openai',
+        model: 'gpt-5.2',
+        source: :account_override
+      )
+    end
+
+    it 'uses the installation model for conversation completion on self-hosted Enterprise' do
+      allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+      InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'gpt-5.1')
+
+      resolved = described_class.resolve(feature: 'conversation_completion', account: account)
+
+      expect(resolved).to eq(
+        feature: 'conversation_completion',
+        provider: 'openai',
+        model: 'gpt-5.1',
+        source: :installation_override
+      )
+    end
+
+    it 'keeps the OpenAI provider for a custom installation model' do
+      allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+      InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'custom-openai-model')
+
+      resolved = described_class.resolve(feature: 'conversation_completion', account: account)
+
+      expect(resolved).to include(
+        provider: 'openai',
+        model: 'custom-openai-model',
+        source: :installation_override
+      )
+    end
+
+    it 'keeps account overrides ahead of the installation model' do
+      allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+      InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'gpt-5.1')
+      account.update!(captain_models: { 'conversation_completion' => 'gpt-5.2' })
+
+      resolved = described_class.resolve(feature: 'conversation_completion', account: account)
+
+      expect(resolved).to include(
         model: 'gpt-5.2',
         source: :account_override
       )

--- a/spec/lib/llm/feature_router_spec.rb
+++ b/spec/lib/llm/feature_router_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe Llm::FeatureRouter do
       )
     end
 
+    it 'uses a valid account model override for an internal feature' do
+      account.update!(captain_models: { 'conversation_completion' => 'gpt-5.2' })
+
+      resolved = described_class.resolve(feature: 'conversation_completion', account: account)
+
+      expect(resolved).to include(
+        feature: 'conversation_completion',
+        provider: 'openai',
+        model: 'gpt-5.2',
+        source: :account_override
+      )
+    end
+
     it 'resolves GPT-5.2 as the assistant default when Captain V2 is enabled without storing an account override' do
       account.enable_features!('captain_integration_v2')
 

--- a/spec/lib/llm/models_spec.rb
+++ b/spec/lib/llm/models_spec.rb
@@ -32,8 +32,10 @@ RSpec.describe Llm::Models do
       expect(described_class.default_model_for('conversation_faq_matching')).to eq('gpt-4.1-mini')
     end
 
-    it 'offers the assistant model list for conversation completion' do
-      expect(described_class.models_for('conversation_completion')).to eq(described_class.models_for('assistant'))
+    it 'offers only supported OpenAI models for conversation completion' do
+      expect(described_class.models_for('conversation_completion')).to eq(
+        %w[gpt-4.1-mini gpt-5-mini gpt-4.1 gpt-5.1 gpt-5.2]
+      )
     end
   end
 

--- a/spec/lib/llm/models_spec.rb
+++ b/spec/lib/llm/models_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe Llm::Models do
       expect(described_class.default_model_for('conversation_faq_generation')).to eq('gpt-5.2')
       expect(described_class.default_model_for('conversation_faq_matching')).to eq('gpt-4.1-mini')
     end
+
+    it 'offers the assistant model list for conversation completion' do
+      expect(described_class.models_for('conversation_completion')).to eq(described_class.models_for('assistant'))
+    end
   end
 
   describe '.models' do


### PR DESCRIPTION
## Description

PR #15317 moved conversation completion to FeatureRouter as an internal feature. Internal features were then missing from Super Admin model routing, and FeatureRouter ignored any internal account override.

The change adds separate Customer features and Internal features sections to the Super Admin account show and edit pages. It allows known internal model keys in account settings and makes valid account overrides work for internal features. Customer Captain preferences still hide internal features.

Conversation completion now uses the same model list as the Assistant feature. A per-account override takes priority over CAPTAIN_OPEN_AI_MODEL on self-hosted Enterprise. The installation model still takes priority over the YAML default when no account override exists.

Follow-up to #15317.

<img width="738" height="414" alt="CleanShot 2026-08-13 at 16 42 01@2x" src="https://github.com/user-attachments/assets/08444805-1a0e-4085-a5fc-b3e60e2e2597" />


## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## How has this been tested?

- Ran the FeatureRouter, Super Admin account, conversation completion service, model catalog, account validation, and customer Captain preferences specs.
- Ran RuboCop on the changed Ruby files.
- Checked the changed ERB, Ruby, YAML, and Git diff syntax.
- Used Playwright against the Cook UI to expand the account routing panel and confirm the Conversation completion card appears under Internal features.
- Inspected the Playwright screenshot for layout, clipping, and readable selected values.

## Checklist

- [x] My code follows the project style guidelines.
- [x] I reviewed the complete diff.
- [x] I added tests that prove the change works.
- [x] New and existing focused tests pass locally.
- [x] Internal features remain hidden from customer Captain preferences.
