### PR TITLE
feat: publish Sidekiq queue metrics to CloudWatch for autoscaling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -319,6 +319,7 @@ AZURE_APP_SECRET=
 # By default uses the instance role, which must allow cloudwatch:PutMetricData.
 # ENABLE_SIDEKIQ_CLOUDWATCH=true
 # SIDEKIQ_CLOUDWATCH_NAMESPACE=Chatwoot/Sidekiq
+# Publish interval in seconds (default 60; keep >= 60, sub-60 uses high-resolution CloudWatch pricing)
 # SIDEKIQ_CLOUDWATCH_INTERVAL=60
 # Optional: dedicated credentials for CloudWatch only, separate from the S3 (storage) keys.
 # Set these to override the instance role when a role is not available.

--- a/.env.example
+++ b/.env.example
@@ -316,7 +316,12 @@ AZURE_APP_SECRET=
 # REDIS_VELMA_SIZE=10
 
 # Publish Sidekiq queue metrics to AWS CloudWatch for autoscaling. Off by default.
-# Requires the Sidekiq process to have cloudwatch:PutMetricData (e.g. via instance role).
+# By default uses the instance role, which must allow cloudwatch:PutMetricData.
 # ENABLE_SIDEKIQ_CLOUDWATCH=true
 # SIDEKIQ_CLOUDWATCH_NAMESPACE=Chatwoot/Sidekiq
 # SIDEKIQ_CLOUDWATCH_INTERVAL=60
+# Optional: dedicated credentials for CloudWatch only, separate from the S3 (storage) keys.
+# Set these to override the instance role when a role is not available.
+# SIDEKIQ_CLOUDWATCH_AWS_ACCESS_KEY_ID=
+# SIDEKIQ_CLOUDWATCH_AWS_SECRET_ACCESS_KEY=
+# SIDEKIQ_CLOUDWATCH_AWS_REGION=us-east-1

--- a/.env.example
+++ b/.env.example
@@ -319,7 +319,7 @@ AZURE_APP_SECRET=
 # By default uses the instance role, which must allow cloudwatch:PutMetricData.
 # ENABLE_SIDEKIQ_CLOUDWATCH=true
 # SIDEKIQ_CLOUDWATCH_NAMESPACE=Chatwoot/Sidekiq
-# Publish interval in seconds (default 60; keep >= 60, sub-60 uses high-resolution CloudWatch pricing)
+# Publish interval in seconds (default 60; values below 60 work but bill as high-resolution CloudWatch metrics)
 # SIDEKIQ_CLOUDWATCH_INTERVAL=60
 # Optional: dedicated credentials for CloudWatch only, separate from the S3 (storage) keys.
 # Set these to override the instance role when a role is not available.

--- a/.env.example
+++ b/.env.example
@@ -314,3 +314,9 @@ AZURE_APP_SECRET=
 
 # REDIS_ALFRED_SIZE=10
 # REDIS_VELMA_SIZE=10
+
+# Publish Sidekiq queue metrics to AWS CloudWatch for autoscaling. Off by default.
+# Requires the Sidekiq process to have cloudwatch:PutMetricData (e.g. via instance role).
+# ENABLE_SIDEKIQ_CLOUDWATCH=true
+# SIDEKIQ_CLOUDWATCH_NAMESPACE=Chatwoot/Sidekiq
+# SIDEKIQ_CLOUDWATCH_INTERVAL=60

--- a/Gemfile
+++ b/Gemfile
@@ -139,6 +139,8 @@ gem 'sidekiq', '~> 7.3.10'
 gem 'sidekiq-cron', '>= 2.4.0'
 # for sidekiq healthcheck
 gem 'sidekiq_alive'
+# publishes Sidekiq queue metrics to CloudWatch for autoscaling (opt-in via ENABLE_SIDEKIQ_CLOUDWATCH)
+gem 'speedshop-cloudwatch', '~> 0.2.1', require: false
 
 ##-- Push notification service --##
 gem 'fcm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,9 @@ GEM
       aws-sdk-sns (~> 1, >= 1.61.0)
     aws-eventstream (1.4.0)
     aws-partitions (1.1198.0)
+    aws-sdk-cloudwatch (1.126.0)
+      aws-sdk-core (~> 3, >= 3.239.1)
+      aws-sigv4 (~> 1.5)
     aws-sdk-core (3.240.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -942,6 +945,8 @@ GEM
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
     sorbet-runtime (0.5.11934)
+    speedshop-cloudwatch (0.2.1)
+      aws-sdk-cloudwatch (>= 1.81.0)
     spring (4.1.1)
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
@@ -1177,6 +1182,7 @@ DEPENDENCIES
   simplecov_json_formatter
   skooma
   slack-ruby-client (~> 2.7.0)
+  speedshop-cloudwatch (~> 0.2.1)
   spring
   spring-watcher-listen
   squasher

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -34,9 +34,10 @@ Sidekiq.configure_server do |config|
 end
 
 # Publish Sidekiq queue metrics (latency, depth) to CloudWatch for autoscaling.
-# Opt-in via ENABLE_SIDEKIQ_CLOUDWATCH; the gem's lifecycle hooks report from the
-# Sidekiq process only, so web/other processes are unaffected.
-if ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_SIDEKIQ_CLOUDWATCH', false))
+# Opt-in via ENABLE_SIDEKIQ_CLOUDWATCH, and gated on Sidekiq.server? so the AWS
+# client and credential lookup run only in the Sidekiq process, never in web,
+# console, or rake.
+if Sidekiq.server? && ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_SIDEKIQ_CLOUDWATCH', false))
   require 'speedshop/cloudwatch'
   require 'speedshop/cloudwatch/sidekiq'
 
@@ -50,13 +51,20 @@ if ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_SIDEKIQ_CLOUDWATCH', fa
       Aws::InstanceProfileCredentials.new
     end
 
+  # Region: dedicated override, else the shared storage region, else a default. Uses presence
+  # so a present-but-blank env var (as .env.example ships AWS_REGION=) does not become "".
+  cloudwatch_region = ENV['SIDEKIQ_CLOUDWATCH_AWS_REGION'].presence || ENV['AWS_REGION'].presence || 'us-east-1'
+
+  # Interval: fall back to the 60s default unless a positive integer is given. This only rejects
+  # blank/zero/negative/non-numeric values (which would make the reporter busy-loop); a valid
+  # sub-60 value is honoured, though it bills as high-resolution CloudWatch metrics.
+  configured_interval = Integer(ENV.fetch('SIDEKIQ_CLOUDWATCH_INTERVAL', 60), exception: false)
+  cloudwatch_interval = configured_interval&.positive? ? configured_interval : 60
+
   Speedshop::Cloudwatch.configure do |cw|
-    cw.client = Aws::CloudWatch::Client.new(
-      region: ENV.fetch('SIDEKIQ_CLOUDWATCH_AWS_REGION', ENV.fetch('AWS_REGION', 'us-east-1')),
-      credentials: cloudwatch_credentials
-    )
+    cw.client = Aws::CloudWatch::Client.new(region: cloudwatch_region, credentials: cloudwatch_credentials)
     cw.namespaces[:sidekiq] = ENV.fetch('SIDEKIQ_CLOUDWATCH_NAMESPACE', 'Chatwoot/Sidekiq')
-    cw.interval = ENV.fetch('SIDEKIQ_CLOUDWATCH_INTERVAL', 60).to_i
+    cw.interval = cloudwatch_interval
     cw.metrics[:sidekiq] = %i[QueueLatency QueueSize EnqueuedJobs Utilization]
     cw.enabled_environments = [cw.environment]
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -33,6 +33,22 @@ Sidekiq.configure_server do |config|
   end
 end
 
+# Publish Sidekiq queue metrics (latency, depth) to CloudWatch for autoscaling.
+# Opt-in via ENABLE_SIDEKIQ_CLOUDWATCH; the gem's lifecycle hooks report from the
+# Sidekiq process only, so web/other processes are unaffected.
+if ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_SIDEKIQ_CLOUDWATCH', false))
+  require 'speedshop/cloudwatch'
+  require 'speedshop/cloudwatch/sidekiq'
+
+  Speedshop::Cloudwatch.configure do |cw|
+    cw.client = Aws::CloudWatch::Client.new(region: ENV.fetch('AWS_REGION', 'us-east-1'))
+    cw.namespaces[:sidekiq] = ENV.fetch('SIDEKIQ_CLOUDWATCH_NAMESPACE', 'Chatwoot/Sidekiq')
+    cw.interval = ENV.fetch('SIDEKIQ_CLOUDWATCH_INTERVAL', 60).to_i
+    cw.metrics[:sidekiq] = %i[QueueLatency QueueSize EnqueuedJobs Utilization]
+    cw.enabled_environments = [cw.environment]
+  end
+end
+
 # https://github.com/ondrejbartas/sidekiq-cron
 Rails.application.reloader.to_prepare do
   # load_from_hash! upserts jobs from the YAML and removes any Redis-persisted

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -40,8 +40,21 @@ if ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_SIDEKIQ_CLOUDWATCH', fa
   require 'speedshop/cloudwatch'
   require 'speedshop/cloudwatch/sidekiq'
 
+  # Use the instance role by default. Do not fall through to the default AWS chain: the shared
+  # AWS_ACCESS_KEY_ID is scoped to storage (S3) and would lack cloudwatch:PutMetricData.
+  # Dedicated keys can be supplied to override when an instance role is not available.
+  cloudwatch_credentials =
+    if ENV['SIDEKIQ_CLOUDWATCH_AWS_ACCESS_KEY_ID'].present?
+      Aws::Credentials.new(ENV.fetch('SIDEKIQ_CLOUDWATCH_AWS_ACCESS_KEY_ID'), ENV.fetch('SIDEKIQ_CLOUDWATCH_AWS_SECRET_ACCESS_KEY'))
+    else
+      Aws::InstanceProfileCredentials.new
+    end
+
   Speedshop::Cloudwatch.configure do |cw|
-    cw.client = Aws::CloudWatch::Client.new(region: ENV.fetch('AWS_REGION', 'us-east-1'))
+    cw.client = Aws::CloudWatch::Client.new(
+      region: ENV.fetch('SIDEKIQ_CLOUDWATCH_AWS_REGION', ENV.fetch('AWS_REGION', 'us-east-1')),
+      credentials: cloudwatch_credentials
+    )
     cw.namespaces[:sidekiq] = ENV.fetch('SIDEKIQ_CLOUDWATCH_NAMESPACE', 'Chatwoot/Sidekiq')
     cw.interval = ENV.fetch('SIDEKIQ_CLOUDWATCH_INTERVAL', 60).to_i
     cw.metrics[:sidekiq] = %i[QueueLatency QueueSize EnqueuedJobs Utilization]


### PR DESCRIPTION
## Description

Adds optional publishing of Sidekiq queue metrics (queue latency, queue size, enqueued jobs, worker utilization) to AWS CloudWatch, so background-worker capacity can be autoscaled on queue backlog rather than CPU/memory, which are weak signals for I/O-bound job workloads.

Uses the `speedshop-cloudwatch` gem. It is off by default and opt-in via `ENABLE_SIDEKIQ_CLOUDWATCH`. The gem is loaded with `require: false` and wired only inside the Sidekiq server lifecycle, so web and other processes are unaffected (no Rack middleware is inserted). Namespace and interval are configurable.

Credentials: by default it uses the EC2 instance role, which must allow `cloudwatch:PutMetricData`. This avoids picking up the shared `AWS_ACCESS_KEY_ID` used for object storage, which is not scoped for CloudWatch. Dedicated credentials can be supplied via `SIDEKIQ_CLOUDWATCH_AWS_ACCESS_KEY_ID` / `SIDEKIQ_CLOUDWATCH_AWS_SECRET_ACCESS_KEY` / `SIDEKIQ_CLOUDWATCH_AWS_REGION` to override the instance role where one is not available.

This supersedes the earlier #12087, which had the same goal with a different gem. This one is purpose-built for autoscaling and reports on a background thread.

Fixes https://linear.app/chatwoot/issue/INF-98

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Verified end to end on a staging environment:

- Wiring: with the flag enabled, config resolves to the `Chatwoot/Sidekiq` namespace, only the allow-listed metrics publish, per-queue `QueueLatency`/`QueueSize` are emitted with a `QueueName` dimension, and no Rack middleware or Puma collector is loaded (Sidekiq only). Rubocop clean.
- Live at idle: deployed with `ENABLE_SIDEKIQ_CLOUDWATCH=true`; metrics published every 60s to CloudWatch via the instance role (no dedicated keys needed).
- Under load: enqueued ~110k jobs to an unconsumed test queue; `EnqueuedJobs` and per-queue depth/latency rose accordingly, then returned to baseline once the queue was cleared.
- Autoscaling usability: the published metric drove an ASG target-tracking policy that scaled the worker fleet out under backlog and back in once drained.
