### PR TITLE
fix: scope Twilio media download credentials to the provider host

### DIFF
--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -187,12 +187,20 @@ class Twilio::IncomingMessageService # rubocop:disable Metrics/ClassLength
 
   def twilio_https_url?(media_url)
     uri = URI.parse(media_url)
-    return false unless uri.scheme == 'https'
-
-    host = uri.host&.downcase
-    host == TWILIO_DOMAIN || host&.end_with?(".#{TWILIO_DOMAIN}") || false
+    canonical_https?(uri) && twilio_host?(uri.host)
   rescue URI::InvalidURIError
     false
+  end
+
+  # Credentials go only to the provider's exact endpoint form: https, default port,
+  # no embedded userinfo.
+  def canonical_https?(uri)
+    uri.scheme == 'https' && uri.userinfo.nil? && uri.port == URI::HTTPS.default_port
+  end
+
+  def twilio_host?(host)
+    host = host&.downcase
+    host == TWILIO_DOMAIN || host&.end_with?(".#{TWILIO_DOMAIN}") || false
   end
 
   def handle_download_attachment_error(error, media_url)

--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -3,6 +3,8 @@ class Twilio::IncomingMessageService
   include ::Twilio::WhatsappIdentifierHelper
   include ::Twilio::ReferralParamsHelper
 
+  TWILIO_DOMAIN = 'twilio.com'.freeze
+
   pattr_initialize [:params!]
 
   def perform
@@ -171,15 +173,18 @@ class Twilio::IncomingMessageService
   end
 
   def download_with_auth(media_url)
-    auth_credentials = if twilio_channel.api_key_sid.present?
-                         # When using api_key_sid, the auth token should be the api_secret_key
-                         [twilio_channel.api_key_sid, twilio_channel.auth_token]
-                       else
-                         # When using account_sid, the auth token is the account's auth token
-                         [twilio_channel.account_sid, twilio_channel.auth_token]
-                       end
+    Down.download(media_url, **credential_options(media_url))
+  end
 
-    Down.download(media_url, http_basic_authentication: auth_credentials)
+  # Attach Twilio credentials only for media hosted on a Twilio domain.
+  def credential_options(media_url)
+    host = URI.parse(media_url).host&.downcase
+    return {} unless host == TWILIO_DOMAIN || host&.end_with?(".#{TWILIO_DOMAIN}")
+
+    # auth_token is the password for both api-key and account-sid auth
+    { http_basic_authentication: [twilio_channel.api_key_sid.presence || twilio_channel.account_sid, twilio_channel.auth_token] }
+  rescue URI::InvalidURIError
+    {}
   end
 
   def handle_download_attachment_error(error, media_url)

--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -1,4 +1,4 @@
-class Twilio::IncomingMessageService
+class Twilio::IncomingMessageService # rubocop:disable Metrics/ClassLength
   include ::FileTypeHelper
   include ::Twilio::WhatsappIdentifierHelper
   include ::Twilio::ReferralParamsHelper
@@ -176,15 +176,23 @@ class Twilio::IncomingMessageService
     Down.download(media_url, **credential_options(media_url))
   end
 
-  # Attach Twilio credentials only for media hosted on a Twilio domain.
+  # Attach Twilio credentials only for media on an https Twilio domain, so they are
+  # never sent to a plaintext (http) URL from the payload.
   def credential_options(media_url)
-    host = URI.parse(media_url).host&.downcase
-    return {} unless host == TWILIO_DOMAIN || host&.end_with?(".#{TWILIO_DOMAIN}")
+    return {} unless twilio_https_url?(media_url)
 
     # auth_token is the password for both api-key and account-sid auth
     { http_basic_authentication: [twilio_channel.api_key_sid.presence || twilio_channel.account_sid, twilio_channel.auth_token] }
+  end
+
+  def twilio_https_url?(media_url)
+    uri = URI.parse(media_url)
+    return false unless uri.scheme == 'https'
+
+    host = uri.host&.downcase
+    host == TWILIO_DOMAIN || host&.end_with?(".#{TWILIO_DOMAIN}") || false
   rescue URI::InvalidURIError
-    {}
+    false
   end
 
   def handle_download_attachment_error(error, media_url)

--- a/spec/services/twilio/incoming_message_service_spec.rb
+++ b/spec/services/twilio/incoming_message_service_spec.rb
@@ -271,6 +271,15 @@ describe Twilio::IncomingMessageService do
 
         expect(a_request(:get, http_url).with(basic_auth: ['ACxxx', twilio_channel.auth_token])).not_to have_been_made
       end
+
+      it 'does not attach credentials to a Twilio url on a non-default port' do
+        url = 'https://api.twilio.com:8443/2010-04-01/Accounts/ACxxx/Messages/MMxx/Media/MExx'
+        stub_request(:get, url).to_return(status: 200, body: 'image data', headers: { 'Content-Type' => 'image/png' })
+
+        described_class.new(params: media_params.merge(MediaUrl0: url)).perform
+
+        expect(a_request(:get, url).with(basic_auth: ['ACxxx', twilio_channel.auth_token])).not_to have_been_made
+      end
     end
 
     context 'when a message with multiple attachments is received' do

--- a/spec/services/twilio/incoming_message_service_spec.rb
+++ b/spec/services/twilio/incoming_message_service_spec.rb
@@ -230,6 +230,40 @@ describe Twilio::IncomingMessageService do
       end
     end
 
+    context 'when downloading media attachments' do
+      let(:twilio_media_url) { 'https://api.twilio.com/2010-04-01/Accounts/ACxxx/Messages/MMxx/Media/MExx' }
+
+      let(:media_params) do
+        {
+          SmsSid: 'SMxx',
+          From: '+12345',
+          AccountSid: 'ACxxx',
+          MessagingServiceSid: twilio_channel.messaging_service_sid,
+          Body: 'media',
+          NumMedia: '1',
+          MediaContentType0: 'image/png'
+        }
+      end
+
+      it 'attaches Twilio credentials for media on a Twilio host' do
+        stub_request(:get, twilio_media_url).to_return(status: 200, body: 'image data', headers: { 'Content-Type' => 'image/png' })
+
+        described_class.new(params: media_params.merge(MediaUrl0: twilio_media_url)).perform
+
+        expect(a_request(:get, twilio_media_url).with(basic_auth: ['ACxxx', twilio_channel.auth_token])).to have_been_made
+      end
+
+      it 'downloads media from non-Twilio hosts without credentials' do
+        other_url = 'http://other.example/file.png'
+        stub_request(:get, other_url).to_return(status: 200, body: 'image data', headers: { 'Content-Type' => 'image/png' })
+
+        described_class.new(params: media_params.merge(MediaUrl0: other_url)).perform
+
+        expect(a_request(:get, other_url).with(basic_auth: ['ACxxx', twilio_channel.auth_token])).not_to have_been_made
+        expect(conversation.reload.messages.last.attachments.count).to eq(1)
+      end
+    end
+
     context 'when a message with multiple attachments is received' do
       before do
         stub_request(:get, 'https://chatwoot-assets.local/sample.png')

--- a/spec/services/twilio/incoming_message_service_spec.rb
+++ b/spec/services/twilio/incoming_message_service_spec.rb
@@ -262,6 +262,15 @@ describe Twilio::IncomingMessageService do
         expect(a_request(:get, other_url).with(basic_auth: ['ACxxx', twilio_channel.auth_token])).not_to have_been_made
         expect(conversation.reload.messages.last.attachments.count).to eq(1)
       end
+
+      it 'does not attach credentials to a plaintext Twilio url' do
+        http_url = 'http://api.twilio.com/2010-04-01/Accounts/ACxxx/Messages/MMxx/Media/MExx'
+        stub_request(:get, http_url).to_return(status: 200, body: 'image data', headers: { 'Content-Type' => 'image/png' })
+
+        described_class.new(params: media_params.merge(MediaUrl0: http_url)).perform
+
+        expect(a_request(:get, http_url).with(basic_auth: ['ACxxx', twilio_channel.auth_token])).not_to have_been_made
+      end
     end
 
     context 'when a message with multiple attachments is received' do


### PR DESCRIPTION
## Description

Inbound Twilio media is downloaded from URLs contained in the callback payload. This change attaches the channel's Twilio credentials only for media hosted on a Twilio domain. Media on other hosts is downloaded without credentials.

Ref https://linear.app/chatwoot/issue/CW-7469

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added specs in `spec/services/twilio/incoming_message_service_spec.rb` covering credential handling by media host. Full spec file green (39 examples, 0 failures), rubocop clean.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
