### PR TITLE
fix: fetch non-provider SMS media through the safe fetcher

### DIFF
--- a/app/services/sms/incoming_message_service.rb
+++ b/app/services/sms/incoming_message_service.rb
@@ -83,29 +83,45 @@ class Sms::IncomingMessageService
       # we don't need to process this files since chatwoot doesn't support it
       next if media_url.end_with?('.smil', '.xml')
 
-      attachment_file = Down.download(media_url, **download_options(media_url))
-
-      @message.attachments.new(
-        account_id: @message.account_id,
-        file_type: file_type(attachment_file.content_type),
-        file: {
-          io: attachment_file,
-          filename: attachment_file.original_filename,
-          content_type: attachment_file.content_type
-        }
-      )
+      download_media(media_url) do |io, filename, content_type|
+        @message.attachments.new(
+          account_id: @message.account_id,
+          file_type: file_type(content_type),
+          file: { io: io, filename: filename, content_type: content_type }
+        )
+      end
     end
   end
 
-  # Attach the provider credentials only for media on the provider's own host, and
-  # do not follow redirects on that request.
-  def download_options(media_url)
-    return {} unless provider_hosted?(media_url)
+  # Provider media comes from a known host and is fetched directly with credentials.
+  # Any other URL from the payload is fetched through SafeFetch so it cannot reach
+  # internal addresses.
+  def download_media(media_url)
+    if provider_hosted?(media_url)
+      file = Down.download(media_url, http_basic_authentication: provider_credentials, max_redirects: 0)
+      yield file, file.original_filename, file.content_type
+    else
+      # SafeFetch closes its tempfile when the block returns, but the attachment is
+      # uploaded later on save!, so stream the contents into a tempfile that survives.
+      SafeFetch.fetch(media_url, validate_content_type: false) do |result|
+        yield persisted_copy(result.tempfile), result.original_filename, result.content_type
+      end
+    end
+  rescue SafeFetch::Error => e
+    Rails.logger.warn("[SMS] skipping media download: #{e.class}")
+  end
 
-    {
-      http_basic_authentication: [channel.provider_config['api_key'], channel.provider_config['api_secret']],
-      max_redirects: 0
-    }
+  def provider_credentials
+    [channel.provider_config['api_key'], channel.provider_config['api_secret']]
+  end
+
+  # Copy the streamed download into a tempfile that outlives the SafeFetch block
+  # (cleaned up on GC), without buffering the whole file in memory.
+  def persisted_copy(source)
+    tempfile = Tempfile.new('sms-media', binmode: true)
+    IO.copy_stream(source, tempfile)
+    tempfile.rewind
+    tempfile
   end
 
   # Attach credentials only to the provider's exact configured endpoint: same

--- a/app/services/sms/incoming_message_service.rb
+++ b/app/services/sms/incoming_message_service.rb
@@ -107,7 +107,9 @@ class Sms::IncomingMessageService
         yield persisted_copy(result.tempfile), result.original_filename, result.content_type
       end
     end
-  rescue SafeFetch::Error => e
+    # Skip only unsafe/permanent failures; let transient errors (timeout, 5xx) raise
+    # so the job retries, as before this change.
+  rescue SafeFetch::UnsafeUrlError, SafeFetch::InvalidUrlError, SafeFetch::FileTooLargeError, SafeFetch::UnsupportedContentTypeError => e
     Rails.logger.warn("[SMS] skipping media download: #{e.class}")
   end
 

--- a/spec/services/sms/incoming_message_service_spec.rb
+++ b/spec/services/sms/incoming_message_service_spec.rb
@@ -175,6 +175,15 @@ describe Sms::IncomingMessageService do
 
         expect(sms_channel.inbox.messages.first.attachments.present?).to be false
       end
+
+      it 'lets a transient download failure raise so the job retries' do
+        stub_request(:get, 'http://other.example/file.png').to_return(status: 500)
+        media_params = { 'media': ['http://other.example/file.png'] }.with_indifferent_access
+
+        expect do
+          described_class.new(inbox: sms_channel.inbox, params: params.merge(media_params)).perform
+        end.to raise_error(SafeFetch::HttpError)
+      end
     end
   end
 end

--- a/spec/services/sms/incoming_message_service_spec.rb
+++ b/spec/services/sms/incoming_message_service_spec.rb
@@ -21,6 +21,15 @@ describe Sms::IncomingMessageService do
       }.with_indifferent_access
     end
 
+    # Non-provider media is fetched through SafeFetch (SsrfFilter), which resolves the
+    # host and rejects private addresses. Stub resolution to public IPs for test hosts.
+    before do
+      allow(Resolv).to receive(:getaddresses).and_call_original
+      allow(Resolv).to receive(:getaddresses).with('test.com').and_return(['93.184.216.34'])
+      allow(Resolv).to receive(:getaddresses).with('other.example').and_return(['93.184.216.34'])
+      allow(Resolv).to receive(:getaddresses).with('internal.example').and_return(['169.254.169.254'])
+    end
+
     context 'when valid text message params' do
       it 'creates appropriate conversations, message and contacts' do
         described_class.new(inbox: sms_channel.inbox, params: params).perform
@@ -77,8 +86,10 @@ describe Sms::IncomingMessageService do
       end
 
       it 'creates attachment messages and ignores .smil files' do
-        stub_request(:get, 'http://test.com/test.png').to_return(status: 200, body: File.read('spec/assets/sample.png'), headers: {})
-        stub_request(:get, 'http://test.com/test2.png').to_return(status: 200, body: File.read('spec/assets/sample.png'), headers: {})
+        stub_request(:get, 'http://test.com/test.png').to_return(status: 200, body: File.read('spec/assets/sample.png'),
+                                                                 headers: { 'Content-Type' => 'image/png' })
+        stub_request(:get, 'http://test.com/test2.png').to_return(status: 200, body: File.read('spec/assets/sample.png'),
+                                                                  headers: { 'Content-Type' => 'image/png' })
 
         media_params = { 'media': [
           'http://test.com/test.smil',
@@ -107,7 +118,8 @@ describe Sms::IncomingMessageService do
       end
 
       it 'downloads media from other hosts without provider credentials' do
-        stub_request(:get, 'http://other.example/file.png').to_return(status: 200, body: File.read('spec/assets/sample.png'))
+        stub_request(:get, 'http://other.example/file.png').to_return(status: 200, body: File.read('spec/assets/sample.png'),
+                                                                      headers: { 'Content-Type' => 'image/png' })
         media_params = { 'media': ['http://other.example/file.png'] }.with_indifferent_access
 
         described_class.new(inbox: sms_channel.inbox, params: params.merge(media_params)).perform
@@ -154,6 +166,14 @@ describe Sms::IncomingMessageService do
           described_class.new(inbox: sms_channel.inbox, params: params.merge(media_params)).perform
         end.to raise_error(Down::TooManyRedirects)
         expect(redirected_request).not_to have_been_requested
+      end
+
+      it 'does not fetch media that resolves to an internal address' do
+        media_params = { 'media': ['http://internal.example/file.png'] }.with_indifferent_access
+
+        described_class.new(inbox: sms_channel.inbox, params: params.merge(media_params)).perform
+
+        expect(sms_channel.inbox.messages.first.attachments.present?).to be false
       end
     end
   end


### PR DESCRIPTION
## Description

Inbound SMS media is downloaded from URLs contained in the webhook payload. For hosts other than the provider, this change routes the download through `SafeFetch`, which resolves the host and rejects private/internal addresses (revalidating each redirect hop). Provider-hosted media continues to be fetched directly.

Stacked on #15463 (same method); please review/merge that first.

Ref https://linear.app/chatwoot/issue/CW-7469

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added/updated specs in `spec/services/sms/incoming_message_service_spec.rb`, including a case where a media host resolves to an internal address and is not fetched. Full spec file green (10 examples, 0 failures), rubocop clean.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
