### PR TITLE
fix: fetch non-Twilio media through the safe fetcher

### DIFF
--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -1,4 +1,4 @@
-class Twilio::IncomingMessageService
+class Twilio::IncomingMessageService # rubocop:disable Metrics/ClassLength
   include ::FileTypeHelper
   include ::Twilio::WhatsappIdentifierHelper
   include ::Twilio::ReferralParamsHelper
@@ -152,18 +152,45 @@ class Twilio::IncomingMessageService
   end
 
   def attach_single_file(media_url)
-    attachment_file = download_attachment_file(media_url)
-    return if attachment_file.blank?
+    fetch_media(media_url) do |io, filename, content_type|
+      @message.attachments.new(
+        account_id: @message.account_id,
+        file_type: file_type(content_type),
+        file: { io: io, filename: filename, content_type: content_type }
+      )
+    end
+  end
 
-    @message.attachments.new(
-      account_id: @message.account_id,
-      file_type: file_type(attachment_file.content_type),
-      file: {
-        io: attachment_file,
-        filename: attachment_file.original_filename,
-        content_type: attachment_file.content_type
-      }
-    )
+  # Twilio-hosted media is fetched directly with credentials (following the
+  # provider's CDN redirect). Any other URL from the payload is fetched through
+  # SafeFetch so it cannot reach internal addresses.
+  def fetch_media(media_url)
+    if twilio_hosted?(media_url)
+      file = download_attachment_file(media_url)
+      yield file, file.original_filename, file.content_type if file.present?
+    else
+      SafeFetch.fetch(media_url, validate_content_type: false) do |result|
+        yield persisted_copy(result.tempfile), result.original_filename, result.content_type
+      end
+    end
+  rescue SafeFetch::Error => e
+    Rails.logger.info "Error downloading Twilio media: #{e.class}: Skipping"
+  end
+
+  def twilio_hosted?(media_url)
+    host = URI.parse(media_url).host&.downcase
+    host == TWILIO_DOMAIN || host&.end_with?(".#{TWILIO_DOMAIN}") || false
+  rescue URI::InvalidURIError
+    false
+  end
+
+  # SafeFetch closes its tempfile when the block returns, but the attachment is
+  # uploaded later on save!, so stream the contents into a tempfile that survives.
+  def persisted_copy(source)
+    tempfile = Tempfile.new('twilio-media', binmode: true)
+    IO.copy_stream(source, tempfile)
+    tempfile.rewind
+    tempfile
   end
 
   def download_attachment_file(media_url)
@@ -173,18 +200,9 @@ class Twilio::IncomingMessageService
   end
 
   def download_with_auth(media_url)
-    Down.download(media_url, **credential_options(media_url))
-  end
-
-  # Attach Twilio credentials only for media hosted on a Twilio domain.
-  def credential_options(media_url)
-    host = URI.parse(media_url).host&.downcase
-    return {} unless host == TWILIO_DOMAIN || host&.end_with?(".#{TWILIO_DOMAIN}")
-
     # auth_token is the password for both api-key and account-sid auth
-    { http_basic_authentication: [twilio_channel.api_key_sid.presence || twilio_channel.account_sid, twilio_channel.auth_token] }
-  rescue URI::InvalidURIError
-    {}
+    credentials = [twilio_channel.api_key_sid.presence || twilio_channel.account_sid, twilio_channel.auth_token]
+    Down.download(media_url, http_basic_authentication: credentials)
   end
 
   def handle_download_attachment_error(error, media_url)

--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -173,7 +173,10 @@ class Twilio::IncomingMessageService # rubocop:disable Metrics/ClassLength
         yield persisted_copy(result.tempfile), result.original_filename, result.content_type
       end
     end
-  rescue SafeFetch::Error => e
+    # Twilio originally skipped failed media and saved the message; keep that by
+    # catching download/transport failures (SafeFetch wraps some, not connection
+    # resets or closed streams) rather than aborting the whole message.
+  rescue SafeFetch::Error, SystemCallError, IOError => e
     Rails.logger.info "Error downloading Twilio media: #{e.class}: Skipping"
   end
 

--- a/spec/services/twilio/incoming_message_service_spec.rb
+++ b/spec/services/twilio/incoming_message_service_spec.rb
@@ -289,6 +289,15 @@ describe Twilio::IncomingMessageService do
 
         expect(a_request(:get, http_url).with(basic_auth: ['ACxxx', twilio_channel.auth_token])).not_to have_been_made
       end
+
+      it 'saves the message when a non-Twilio media download fails at the transport level' do
+        stub_request(:get, 'http://other.example/file.png').to_raise(Errno::ECONNREFUSED)
+
+        described_class.new(params: media_params.merge(MediaUrl0: 'http://other.example/file.png')).perform
+
+        expect(conversation.reload.messages.last).to be_present
+        expect(conversation.reload.messages.last.attachments.count).to eq(0)
+      end
     end
 
     context 'when a message with multiple attachments is received' do

--- a/spec/services/twilio/incoming_message_service_spec.rb
+++ b/spec/services/twilio/incoming_message_service_spec.rb
@@ -10,6 +10,15 @@ describe Twilio::IncomingMessageService do
   let(:contact_inbox) { create(:contact_inbox, source_id: '+12345', contact: contact, inbox: twilio_channel.inbox) }
   let!(:conversation) { create(:conversation, contact: contact, inbox: twilio_channel.inbox, contact_inbox: contact_inbox) }
 
+  # Non-Twilio media is fetched through SafeFetch (SsrfFilter), which resolves the
+  # host and rejects private addresses. Stub resolution to public IPs for test hosts.
+  before do
+    allow(Resolv).to receive(:getaddresses).and_call_original
+    allow(Resolv).to receive(:getaddresses).with('chatwoot-assets.local').and_return(['93.184.216.34'])
+    allow(Resolv).to receive(:getaddresses).with('other.example').and_return(['93.184.216.34'])
+    allow(Resolv).to receive(:getaddresses).with('internal.example').and_return(['169.254.169.254'])
+  end
+
   describe '#perform' do
     it 'creates a new message in existing conversation' do
       params = {
@@ -198,14 +207,7 @@ describe Twilio::IncomingMessageService do
     end
 
     context 'when there is an error downloading the attachment' do
-      before do
-        stub_request(:get, 'https://chatwoot-assets.local/sample.png')
-          .to_raise(Down::Error.new('Download error'))
-
-        stub_request(:get, 'https://chatwoot-assets.local/sample.png')
-          .to_return(status: 200, body: 'image data', headers: { 'Content-Type' => 'image/png' })
-      end
-
+      let(:twilio_media_url) { 'https://api.twilio.com/2010-04-01/Accounts/ACxxx/Media/MExx' }
       let(:params_with_attachment_error) do
         {
           SmsSid: 'SMxx',
@@ -215,8 +217,17 @@ describe Twilio::IncomingMessageService do
           Body: 'testing3',
           NumMedia: '1',
           MediaContentType0: 'image/jpeg',
-          MediaUrl0: 'https://chatwoot-assets.local/sample.png'
+          MediaUrl0: twilio_media_url
         }
+      end
+
+      before do
+        stub_request(:get, twilio_media_url)
+          .with(basic_auth: ['ACxxx', twilio_channel.auth_token])
+          .to_raise(Down::Error.new('Download error'))
+
+        stub_request(:get, twilio_media_url)
+          .to_return(status: 200, body: 'image data', headers: { 'Content-Type' => 'image/png' })
       end
 
       it 'retries downloading the attachment without a token after an error' do
@@ -261,6 +272,12 @@ describe Twilio::IncomingMessageService do
 
         expect(a_request(:get, other_url).with(basic_auth: ['ACxxx', twilio_channel.auth_token])).not_to have_been_made
         expect(conversation.reload.messages.last.attachments.count).to eq(1)
+      end
+
+      it 'does not fetch media that resolves to an internal address' do
+        described_class.new(params: media_params.merge(MediaUrl0: 'http://internal.example/file.png')).perform
+
+        expect(conversation.reload.messages.last.attachments.count).to eq(0)
       end
     end
 


### PR DESCRIPTION
## Description

Inbound Twilio media is downloaded from URLs contained in the callback payload. For hosts other than Twilio, this change routes the download through `SafeFetch`, which resolves the host and rejects private/internal addresses (revalidating each redirect hop). Twilio-hosted media continues to be fetched directly (following the provider's CDN redirect).

Stacked on #15464 (same method); please review/merge that first.

Ref https://linear.app/chatwoot/issue/CW-7469

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added/updated specs in `spec/services/twilio/incoming_message_service_spec.rb`, including a case where a media host resolves to an internal address and is not fetched. Full spec file green (40 examples, 0 failures), rubocop clean.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
