### PR TITLE
docs: document message read status APIs for API channels

### DIFF
--- a/swagger/paths/application/conversation/messages/update.yml
+++ b/swagger/paths/application/conversation/messages/update.yml
@@ -1,0 +1,60 @@
+tags:
+  - Messages
+operationId: update-message-status
+summary: Update message status
+security:
+  - userApiKey: []
+description: |
+  Updates the delivery status of a single message. Available only for messages in
+  API channel inboxes, where your own system is responsible for delivering messages
+  and reporting what happened. Use this to push `sent`, `delivered`, and `read`
+  receipts into Chatwoot, for example, to mark an agent's message as read when the
+  end user views it in your client, so the agent sees the read indicator on the
+  message.
+
+  A message already marked `read` cannot be moved back to `delivered`. When
+  reporting a failure, include `external_error` with the reason, which is shown to
+  the agent along with the failed indicator.
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+          - status
+        properties:
+          status:
+            type: string
+            enum: [sent, delivered, read, failed]
+            description: The new status of the message
+          external_error:
+            type: string
+            description: Error description, stored only when status is failed
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: '#/components/schemas/generic_id'
+            - $ref: '#/components/schemas/message'
+  '401':
+    description: Unauthorized
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'
+  '403':
+    description: The message does not belong to an API channel inbox
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'
+  '404':
+    description: The message or conversation does not exist in the account
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/index.yml
+++ b/swagger/paths/index.yml
@@ -487,6 +487,8 @@
     - $ref: '#/components/parameters/account_id'
     - $ref: '#/components/parameters/conversation_id'
     - $ref: '#/components/parameters/message_id'
+  patch:
+    $ref: ./application/conversation/messages/update.yml
   delete:
     $ref: ./application/conversation/messages/delete.yml
 

--- a/swagger/paths/public/inboxes/conversations/update_last_seen.yml
+++ b/swagger/paths/public/inboxes/conversations/update_last_seen.yml
@@ -1,8 +1,11 @@
 tags:
   - Conversations API
 operationId: update-last-seen
-summary: Update last seen
-description: Updates the last seen time of the contact in a conversation
+summary: Update last seen and mark messages read
+description: |
+  Updates the contact's last seen time for the conversation and marks agent messages
+  sent before that time as read. Use this to send read receipts from a custom client
+  built on the API channel, so agents can see when the contact has read their messages.
 security: []
 responses:
   '200':

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1279,8 +1279,8 @@
           "Conversations API"
         ],
         "operationId": "update-last-seen",
-        "summary": "Update last seen",
-        "description": "Updates the last seen time of the contact in a conversation",
+        "summary": "Update last seen and mark messages read",
+        "description": "Updates the contact's last seen time for the conversation and marks agent messages\nsent before that time as read. Use this to send read receipts from a custom client\nbuilt on the API channel, so agents can see when the contact has read their messages.\n",
         "security": [],
         "responses": {
           "200": {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -7186,6 +7186,97 @@
           "$ref": "#/components/parameters/message_id"
         }
       ],
+      "patch": {
+        "tags": [
+          "Messages"
+        ],
+        "operationId": "update-message-status",
+        "summary": "Update message status",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Updates the delivery status of a single message. Available only for messages in\nAPI channel inboxes, where your own system is responsible for delivering messages\nand reporting what happened. Use this to push `sent`, `delivered`, and `read`\nreceipts into Chatwoot, for example, to mark an agent's message as read when the\nend user views it in your client, so the agent sees the read indicator on the\nmessage.\n\nA message already marked `read` cannot be moved back to `delivered`. When\nreporting a failure, include `external_error` with the reason, which is shown to\nthe agent along with the failed indicator.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "status"
+                ],
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "sent",
+                      "delivered",
+                      "read",
+                      "failed"
+                    ],
+                    "description": "The new status of the message"
+                  },
+                  "external_error": {
+                    "type": "string",
+                    "description": "Error description, stored only when status is failed"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/generic_id"
+                    },
+                    {
+                      "$ref": "#/components/schemas/message"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The message does not belong to an API channel inbox",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The message or conversation does not exist in the account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "tags": [
           "Messages"

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -5729,6 +5729,97 @@
           "$ref": "#/components/parameters/message_id"
         }
       ],
+      "patch": {
+        "tags": [
+          "Messages"
+        ],
+        "operationId": "update-message-status",
+        "summary": "Update message status",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Updates the delivery status of a single message. Available only for messages in\nAPI channel inboxes, where your own system is responsible for delivering messages\nand reporting what happened. Use this to push `sent`, `delivered`, and `read`\nreceipts into Chatwoot, for example, to mark an agent's message as read when the\nend user views it in your client, so the agent sees the read indicator on the\nmessage.\n\nA message already marked `read` cannot be moved back to `delivered`. When\nreporting a failure, include `external_error` with the reason, which is shown to\nthe agent along with the failed indicator.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "status"
+                ],
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "sent",
+                      "delivered",
+                      "read",
+                      "failed"
+                    ],
+                    "description": "The new status of the message"
+                  },
+                  "external_error": {
+                    "type": "string",
+                    "description": "Error description, stored only when status is failed"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/generic_id"
+                    },
+                    {
+                      "$ref": "#/components/schemas/message"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The message does not belong to an API channel inbox",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The message or conversation does not exist in the account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "tags": [
           "Messages"

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -449,8 +449,8 @@
           "Conversations API"
         ],
         "operationId": "update-last-seen",
-        "summary": "Update last seen",
-        "description": "Updates the last seen time of the contact in a conversation",
+        "summary": "Update last seen and mark messages read",
+        "description": "Updates the contact's last seen time for the conversation and marks agent messages\nsent before that time as read. Use this to send read receipts from a custom client\nbuilt on the API channel, so agents can see when the contact has read their messages.\n",
         "security": [],
         "responses": {
           "200": {


### PR DESCRIPTION
## Description

Customers building on the API channel could not find how to push message read status into Chatwoot. Two endpoints are involved, one was entirely missing from the API reference and one was undocumented in what it actually does:

- `PATCH /api/v1/accounts/{account_id}/conversations/{conversation_id}/messages/{message_id}` accepts `status` (`sent`/`delivered`/`read`/`failed`, plus `external_error` for failures) and is restricted to API channel inboxes. The path previously documented only DELETE; this adds the PATCH operation.
- The public `update_last_seen` endpoint marks agent messages sent before the contact's last seen time as read, but its description only mentioned updating the timestamp, so searching the docs for read receipts found nothing. The summary and description now state the read-receipt behavior.

Derived swagger files regenerated via `rake swagger:build`.

Fixes https://linear.app/chatwoot/issue/CW-7937

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

Ran `bundle exec rake swagger:build` and verified the generated `swagger.json`, `application_swagger.json`, and `client_swagger.json` contain only the new PATCH operation and the updated summary/description strings. Documented behavior cross-checked against the controller, status update service, and dashboard read-indicator logic.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings