### PR TITLE
fix: inbox contact sidebar overflow

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
@@ -222,7 +222,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <section class="flex w-full h-full bg-n-surface-1">
+  <section class="flex w-full h-full min-w-0 bg-n-surface-1">
     <div
       class="flex flex-col h-full w-full lg:min-w-[340px] lg:max-w-[340px] ltr:border-r rtl:border-l border-n-weak"
       :class="!currentConversationId ? 'flex' : 'hidden xl:flex'"

--- a/app/javascript/dashboard/routes/dashboard/inbox/InboxView.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/InboxView.vue
@@ -185,7 +185,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="h-full w-full flex-1">
+  <div class="h-full w-full min-w-0 flex-1">
     <div v-if="showEmptyState" class="flex w-full h-full">
       <InboxEmptyState
         :empty-state-message="$t('INBOX.LIST.NO_MESSAGES_AVAILABLE')"


### PR DESCRIPTION
Keeps the inbox conversation and contact sidebar within the available viewport at desktop breakpoints.

## Preview


https://github.com/user-attachments/assets/aba1e25e-8741-4544-8659-a6024ad1e887



## How to reproduce

1. Open an inbox notification with the contact sidebar visible.
2. Resize the viewport around the 1536px breakpoint or expand the main navigation.
3. Confirm the inbox list, conversation, and contact sidebar remain visible.