### PR TITLE
fix: broken previews and empty rows in contact history

### DIFF
--- a/app/javascript/dashboard/components-next/Conversation/ConversationCard/CardMessagePreview.vue
+++ b/app/javascript/dashboard/components-next/Conversation/ConversationCard/CardMessagePreview.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import snakecaseKeys from 'snakecase-keys';
+import { useSnakeCase } from 'dashboard/composables/useTransformKeys';
 
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
 import MessagePreview from './MessagePreview.vue';
@@ -12,10 +12,8 @@ const props = defineProps({
   },
 });
 
-// Conversations are camelcased in the store, MessagePreview reads the message
-// in the API's snake_case shape.
 const lastNonActivityMessage = computed(() =>
-  snakecaseKeys(props.conversation.lastNonActivityMessage ?? {}, { deep: true })
+  useSnakeCase(props.conversation.lastNonActivityMessage ?? {}, { deep: true })
 );
 
 const assignee = computed(() => {
@@ -38,7 +36,8 @@ const unreadMessagesCount = computed(() => {
     <MessagePreview
       :message="lastNonActivityMessage"
       multi-line
-      class="w-full text-n-slate-12"
+      class="w-full"
+      :class="unreadMessagesCount > 0 ? 'text-n-slate-12' : 'text-n-slate-11'"
     />
     <div class="flex items-center flex-shrink-0 gap-2 pb-2">
       <Avatar

--- a/app/javascript/dashboard/components-next/Conversation/ConversationCard/CardMessagePreview.vue
+++ b/app/javascript/dashboard/components-next/Conversation/ConversationCard/CardMessagePreview.vue
@@ -1,9 +1,9 @@
 <script setup>
 import { computed } from 'vue';
-import { useI18n } from 'vue-i18n';
-import { useMessageFormatter } from 'shared/composables/useMessageFormatter';
+import snakecaseKeys from 'snakecase-keys';
 
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
+import MessagePreview from './MessagePreview.vue';
 
 const props = defineProps({
   conversation: {
@@ -12,18 +12,11 @@ const props = defineProps({
   },
 });
 
-const { t } = useI18n();
-
-const { getPlainText } = useMessageFormatter();
-
-const lastNonActivityMessageContent = computed(() => {
-  const { lastNonActivityMessage = {}, customAttributes = {} } =
-    props.conversation;
-  const { email: { subject } = {} } = customAttributes;
-  return getPlainText(
-    subject || lastNonActivityMessage?.content || t('CHAT_LIST.NO_CONTENT')
-  );
-});
+// Conversations are camelcased in the store, MessagePreview reads the message
+// in the API's snake_case shape.
+const lastNonActivityMessage = computed(() =>
+  snakecaseKeys(props.conversation.lastNonActivityMessage ?? {}, { deep: true })
+);
 
 const assignee = computed(() => {
   const { meta: { assignee: agent = {} } = {} } = props.conversation;
@@ -42,9 +35,11 @@ const unreadMessagesCount = computed(() => {
 
 <template>
   <div class="flex items-end w-full gap-2 pb-1">
-    <p class="w-full mb-0 text-sm leading-7 text-n-slate-12 line-clamp-2">
-      {{ lastNonActivityMessageContent }}
-    </p>
+    <MessagePreview
+      :message="lastNonActivityMessage"
+      multi-line
+      class="w-full text-n-slate-12"
+    />
     <div class="flex items-center flex-shrink-0 gap-2 pb-2">
       <Avatar
         v-if="assignee.name"

--- a/app/javascript/dashboard/components-next/Conversation/ConversationCard/CardMessagePreviewWithMeta.vue
+++ b/app/javascript/dashboard/components-next/Conversation/ConversationCard/CardMessagePreviewWithMeta.vue
@@ -1,9 +1,9 @@
 <script setup>
 import { computed, ref } from 'vue';
-import { useI18n } from 'vue-i18n';
-import { useMessageFormatter } from 'shared/composables/useMessageFormatter';
+import snakecaseKeys from 'snakecase-keys';
 
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
+import MessagePreview from 'dashboard/components-next/Conversation/ConversationCard/MessagePreview.vue';
 import CardLabels from 'dashboard/components-next/Conversation/ConversationCard/CardLabels.vue';
 import SLACardLabel from 'dashboard/components-next/Conversation/ConversationCard/SLACardLabel.vue';
 
@@ -20,22 +20,17 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  hasLabels: {
+    type: Boolean,
+    default: false,
+  },
 });
-
-const { t } = useI18n();
 
 const slaCardLabelRef = ref(null);
 
-const { getPlainText } = useMessageFormatter();
-
-const lastNonActivityMessageContent = computed(() => {
-  const { lastNonActivityMessage = {}, customAttributes = {} } =
-    props.conversation;
-  const { email: { subject } = {} } = customAttributes;
-  return getPlainText(
-    subject || lastNonActivityMessage?.content || t('CHAT_LIST.NO_CONTENT')
-  );
-});
+const lastNonActivityMessage = computed(() =>
+  snakecaseKeys(props.conversation.lastNonActivityMessage ?? {}, { deep: true })
+);
 
 const assignee = computed(() => {
   const { meta: { assignee: agent = {} } = {} } = props.conversation;
@@ -67,9 +62,10 @@ defineExpose({
 <template>
   <div class="flex flex-col w-full gap-1">
     <div class="flex items-center justify-between w-full gap-2 py-1 h-7">
-      <p class="mb-0 text-sm leading-7 text-n-slate-12 line-clamp-1">
-        {{ lastNonActivityMessageContent }}
-      </p>
+      <MessagePreview
+        :message="lastNonActivityMessage"
+        class="flex-1 min-w-0 text-n-slate-12"
+      />
 
       <div
         v-if="unreadMessagesCount > 0"
@@ -84,7 +80,7 @@ defineExpose({
     <div
       class="grid items-center gap-2.5 h-7"
       :class="
-        hasSlaThreshold
+        hasSlaThreshold && hasLabels
           ? 'grid-cols-[auto_auto_1fr_20px]'
           : 'grid-cols-[1fr_20px]'
       "
@@ -94,8 +90,8 @@ defineExpose({
         ref="slaCardLabelRef"
         :conversation="conversation"
       />
-      <div v-if="hasSlaThreshold" class="w-px h-3 bg-n-slate-4" />
-      <div class="overflow-hidden">
+      <div v-if="hasSlaThreshold && hasLabels" class="w-px h-3 bg-n-slate-4" />
+      <div v-if="hasLabels" class="overflow-hidden">
         <CardLabels
           :conversation-labels="conversation.labels"
           :account-labels="accountLabels"

--- a/app/javascript/dashboard/components-next/Conversation/ConversationCard/CardMessagePreviewWithMeta.vue
+++ b/app/javascript/dashboard/components-next/Conversation/ConversationCard/CardMessagePreviewWithMeta.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, ref } from 'vue';
-import snakecaseKeys from 'snakecase-keys';
+import { useSnakeCase } from 'dashboard/composables/useTransformKeys';
 
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
 import MessagePreview from 'dashboard/components-next/Conversation/ConversationCard/MessagePreview.vue';
@@ -29,7 +29,7 @@ const props = defineProps({
 const slaCardLabelRef = ref(null);
 
 const lastNonActivityMessage = computed(() =>
-  snakecaseKeys(props.conversation.lastNonActivityMessage ?? {}, { deep: true })
+  useSnakeCase(props.conversation.lastNonActivityMessage ?? {}, { deep: true })
 );
 
 const assignee = computed(() => {
@@ -64,7 +64,8 @@ defineExpose({
     <div class="flex items-center justify-between w-full gap-2 py-1 h-7">
       <MessagePreview
         :message="lastNonActivityMessage"
-        class="flex-1 min-w-0 text-n-slate-12"
+        class="flex-1 min-w-0"
+        :class="unreadMessagesCount > 0 ? 'text-n-slate-12' : 'text-n-slate-11'"
       />
 
       <div

--- a/app/javascript/dashboard/components-next/Conversation/ConversationCard/ConversationCard.vue
+++ b/app/javascript/dashboard/components-next/Conversation/ConversationCard/ConversationCard.vue
@@ -57,10 +57,15 @@ const lastActivityAt = computed(() => {
   return timestamp ? shortTimestamp(dynamicTime(timestamp)) : '';
 });
 
-const showMessagePreviewWithoutMeta = computed(() => {
+const hasVisibleLabels = computed(() => {
   const { labels = [] } = props.conversation;
+  return props.accountLabels.some(({ title }) => labels.includes(title));
+});
+
+const showMessagePreviewWithoutMeta = computed(() => {
   return (
-    !cardMessagePreviewWithMetaRef.value?.hasSlaThreshold && labels.length === 0
+    !cardMessagePreviewWithMetaRef.value?.hasSlaThreshold &&
+    !hasVisibleLabels.value
   );
 });
 
@@ -128,6 +133,7 @@ const onCardClick = e => {
         :conversation="conversation"
         :contact="contact"
         :account-labels="accountLabels"
+        :has-labels="hasVisibleLabels"
       />
     </div>
   </div>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where email conversations in the contact and company history sidebars displayed the raw HTML body instead of the email subject. It also removes empty meta rows when there are no labels to render, which was leaving a blank strip and pushing the assignee avatar onto a separate line.

The cards now reuse the same `MessagePreview` component as the conversation list, so email conversations show their subject, attachments show their type, and private or outgoing messages display the appropriate icon. The meta row is only rendered when it contains content, and the SLA divider is shown only when a label follows it.

Fixes https://linear.app/chatwoot/issue/CW-7204/fix-the-description-for-contact-conversation-history-for-email

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="449" height="1052" alt="image" src="https://github.com/user-attachments/assets/946854c9-0b2e-4e7d-8129-cd6daa847e5f" />
<img width="449" height="674" alt="image" src="https://github.com/user-attachments/assets/2e334790-b61d-4e48-bb25-37813e2baba7" />



**After**
<img width="449" height="981" alt="image" src="https://github.com/user-attachments/assets/569df47b-aeb1-458d-a478-f83225088a7e" />

<img width="449" height="622" alt="image" src="https://github.com/user-attachments/assets/e3890ab1-de3e-4abf-be15-8539f8a4b989" />




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
