### PR TITLE
feat: expose Captain outcome statistics

### DIFF
--- a/app/javascript/dashboard/api/captain/assistantStats.js
+++ b/app/javascript/dashboard/api/captain/assistantStats.js
@@ -1,0 +1,40 @@
+/* global axios */
+import ApiClient from '../ApiClient';
+
+const getTimezoneOffset = () => -new Date().getTimezoneOffset() / 60;
+
+class CaptainAssistantStats extends ApiClient {
+  constructor() {
+    super('captain/assistants', { accountScoped: true });
+  }
+
+  getOverview(params) {
+    return this.getStats('overview', params);
+  }
+
+  getOverviewSummary(params) {
+    return this.getStats('overview_summary', params);
+  }
+
+  getResolutionFlow(params) {
+    return this.getStats('resolution_flow', params);
+  }
+
+  getResolutionTrend(params) {
+    return this.getStats('resolution_trend', params);
+  }
+
+  getStats(endpoint, { assistantId, range, signal }) {
+    const requestConfig = {
+      params: { range, timezone_offset: getTimezoneOffset() },
+    };
+    if (signal) requestConfig.signal = signal;
+
+    return axios.get(
+      `${this.url}/${assistantId}/stats/${endpoint}`,
+      requestConfig
+    );
+  }
+}
+
+export default new CaptainAssistantStats();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,12 @@ Rails.application.routes.draw do
                 get :summary
                 get :drilldown
               end
+              resource :stats, only: [], controller: :assistant_stats do
+                get :overview
+                get :overview_summary
+                get :resolution_flow
+                get :resolution_trend
+              end
               collection do
                 get :tools
               end

--- a/enterprise/app/builders/captain/assistant_stats_window.rb
+++ b/enterprise/app/builders/captain/assistant_stats_window.rb
@@ -14,11 +14,18 @@ class Captain::AssistantStatsWindow
   DEFAULT_RANGE = '7'.freeze
   ALLOWED_RANGES = %w[7 30 90 this_month last_month].freeze
 
-  attr_reader :range
+  attr_reader :range, :timezone
 
   def initialize(range = DEFAULT_RANGE, timezone_offset = nil)
     @range = ALLOWED_RANGES.include?(range.to_s) ? range.to_s : DEFAULT_RANGE
-    @timezone = timezone_name_from_offset(timezone_offset) || Time.zone
+    offset = Float(timezone_offset, exception: false) if timezone_offset.present?
+    @timezone = timezone_name_from_offset(offset) if offset
+    @timezone_offset_valid = timezone_offset.blank? || @timezone.present?
+    @timezone ||= Time.zone.name
+  end
+
+  def timezone_offset_valid?
+    @timezone_offset_valid
   end
 
   def current
@@ -48,7 +55,7 @@ class Captain::AssistantStatsWindow
   # Current time anchored to the viewer's timezone, so calendar boundaries land on
   # the viewer's day instead of UTC's.
   def now
-    @now ||= Time.current.in_time_zone(@timezone)
+    @now ||= Time.current.in_time_zone(timezone)
   end
 
   def this_month_ranges

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistant_stats_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistant_stats_controller.rb
@@ -11,7 +11,8 @@ class Api::V1::Accounts::Captain::AssistantStatsController < Api::V1::Accounts::
   end
 
   def overview_summary
-    result = Rails.cache.read(overview_summary_cache_key) || generate_overview_summary
+    cached_result = Redis::Alfred.get(overview_summary_cache_key)
+    result = cached_result ? JSON.parse(cached_result, symbolize_names: true) : generate_overview_summary
 
     if result[:error]
       render json: { error: result[:error] }, status: :unprocessable_content
@@ -38,7 +39,7 @@ class Api::V1::Accounts::Captain::AssistantStatsController < Api::V1::Accounts::
       timezone_offset: params[:timezone_offset]
     ).perform
 
-    Rails.cache.write(overview_summary_cache_key, result, expires_in: OVERVIEW_SUMMARY_CACHE_TTL) unless result[:error]
+    Redis::Alfred.set(overview_summary_cache_key, result.to_json, ex: OVERVIEW_SUMMARY_CACHE_TTL.to_i) unless result[:error]
     result
   end
 
@@ -51,7 +52,7 @@ class Api::V1::Accounts::Captain::AssistantStatsController < Api::V1::Accounts::
       stats_window.range,
       stats_window.timezone,
       Current.account.locale
-    ]
+    ].join(':')
   end
 
   def stats_window

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistant_stats_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistant_stats_controller.rb
@@ -1,4 +1,7 @@
 class Api::V1::Accounts::Captain::AssistantStatsController < Api::V1::Accounts::BaseController
+  OVERVIEW_SUMMARY_CACHE_VERSION = 'v1'.freeze
+  OVERVIEW_SUMMARY_CACHE_TTL = 1.hour
+
   before_action -> { authorize(Captain::Assistant, :metrics?) }
   before_action :set_assistant
 
@@ -7,12 +10,7 @@ class Api::V1::Accounts::Captain::AssistantStatsController < Api::V1::Accounts::
   end
 
   def overview_summary
-    result = Captain::AssistantOverviewSummaryService.new(
-      account: Current.account,
-      assistant: @assistant,
-      range: params[:range],
-      timezone_offset: params[:timezone_offset]
-    ).perform
+    result = Rails.cache.read(overview_summary_cache_key) || generate_overview_summary
 
     if result[:error]
       render json: { error: result[:error] }, status: :unprocessable_content
@@ -30,6 +28,33 @@ class Api::V1::Accounts::Captain::AssistantStatsController < Api::V1::Accounts::
   end
 
   private
+
+  def generate_overview_summary
+    result = Captain::AssistantOverviewSummaryService.new(
+      account: Current.account,
+      assistant: @assistant,
+      range: params[:range],
+      timezone_offset: params[:timezone_offset]
+    ).perform
+
+    Rails.cache.write(overview_summary_cache_key, result, expires_in: OVERVIEW_SUMMARY_CACHE_TTL) unless result[:error]
+    result
+  end
+
+  def overview_summary_cache_key
+    window = Captain::AssistantStatsWindow.new(params[:range], params[:timezone_offset])
+    timezone = params[:timezone_offset].presence || 'default'
+
+    [
+      'captain_assistant_overview_summary',
+      OVERVIEW_SUMMARY_CACHE_VERSION,
+      Current.account.id,
+      @assistant.cache_key_with_version,
+      window.range,
+      timezone,
+      Current.account.locale
+    ]
+  end
 
   def set_assistant
     @assistant = Current.account.captain_assistants.find(params[:assistant_id])

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistant_stats_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistant_stats_controller.rb
@@ -4,6 +4,7 @@ class Api::V1::Accounts::Captain::AssistantStatsController < Api::V1::Accounts::
 
   before_action -> { authorize(Captain::Assistant, :metrics?) }
   before_action :set_assistant
+  before_action :validate_timezone_offset, only: :overview_summary
 
   def overview
     render json: Captain::AssistantOverviewStatsBuilder.new(@assistant, params[:range], params[:timezone_offset]).metrics
@@ -42,18 +43,23 @@ class Api::V1::Accounts::Captain::AssistantStatsController < Api::V1::Accounts::
   end
 
   def overview_summary_cache_key
-    window = Captain::AssistantStatsWindow.new(params[:range], params[:timezone_offset])
-    timezone = params[:timezone_offset].presence || 'default'
-
     [
       'captain_assistant_overview_summary',
       OVERVIEW_SUMMARY_CACHE_VERSION,
       Current.account.id,
       @assistant.cache_key_with_version,
-      window.range,
-      timezone,
+      stats_window.range,
+      stats_window.timezone,
       Current.account.locale
     ]
+  end
+
+  def stats_window
+    @stats_window ||= Captain::AssistantStatsWindow.new(params[:range], params[:timezone_offset])
+  end
+
+  def validate_timezone_offset
+    head :unprocessable_entity unless stats_window.timezone_offset_valid?
   end
 
   def set_assistant

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistant_stats_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistant_stats_controller.rb
@@ -1,0 +1,37 @@
+class Api::V1::Accounts::Captain::AssistantStatsController < Api::V1::Accounts::BaseController
+  before_action -> { authorize(Captain::Assistant, :metrics?) }
+  before_action :set_assistant
+
+  def overview
+    render json: Captain::AssistantOverviewStatsBuilder.new(@assistant, params[:range], params[:timezone_offset]).metrics
+  end
+
+  def overview_summary
+    result = Captain::AssistantOverviewSummaryService.new(
+      account: Current.account,
+      assistant: @assistant,
+      range: params[:range],
+      timezone_offset: params[:timezone_offset]
+    ).perform
+
+    if result[:error]
+      render json: { error: result[:error] }, status: :unprocessable_content
+    else
+      render json: result
+    end
+  end
+
+  def resolution_flow
+    render json: Captain::AssistantResolutionFlowBuilder.new(@assistant, params[:range], params[:timezone_offset]).build
+  end
+
+  def resolution_trend
+    render json: Captain::AssistantResolutionTrendStatsBuilder.new(@assistant, params[:range], params[:timezone_offset]).metrics
+  end
+
+  private
+
+  def set_assistant
+    @assistant = Current.account.captain_assistants.find(params[:assistant_id])
+  end
+end

--- a/enterprise/app/services/captain/assistant_overview_summary_schema.rb
+++ b/enterprise/app/services/captain/assistant_overview_summary_schema.rb
@@ -1,0 +1,9 @@
+class Captain::AssistantOverviewSummarySchema < RubyLLM::Schema
+  MAX_POINTS = 3
+
+  array :points,
+        description: 'The most decision-useful observations from the report. Return fewer than three when fewer genuinely stand out.',
+        max_items: MAX_POINTS do
+    string min_length: 1, max_length: 300
+  end
+end

--- a/enterprise/app/services/captain/assistant_overview_summary_service.rb
+++ b/enterprise/app/services/captain/assistant_overview_summary_service.rb
@@ -4,6 +4,8 @@ class Captain::AssistantOverviewSummaryService < Captain::BaseTaskService
   pattr_initialize [:account!, :assistant!, { range: Captain::AssistantStatsWindow::DEFAULT_RANGE, timezone_offset: nil }]
 
   def perform
+    return { points: [] } unless report_has_activity?
+
     response = make_api_call(feature: 'editor', messages: messages, schema: RESPONSE_SCHEMA)
     return response if response[:error]
 
@@ -39,6 +41,10 @@ class Captain::AssistantOverviewSummaryService < Captain::BaseTaskService
 
   def stats_window
     @stats_window ||= Captain::AssistantStatsWindow.new(range, timezone_offset)
+  end
+
+  def report_has_activity?
+    report_data[:overview][:conversations_handled].values_at(:current, :previous).any?(&:positive?)
   end
 
   def extract_points(message)

--- a/enterprise/app/services/captain/assistant_overview_summary_service.rb
+++ b/enterprise/app/services/captain/assistant_overview_summary_service.rb
@@ -1,0 +1,64 @@
+class Captain::AssistantOverviewSummaryService < Captain::BaseTaskService
+  RESPONSE_SCHEMA = Captain::AssistantOverviewSummarySchema
+
+  pattr_initialize [:account!, :assistant!, { range: Captain::AssistantStatsWindow::DEFAULT_RANGE, timezone_offset: nil }]
+
+  def perform
+    response = make_api_call(feature: 'editor', messages: messages, schema: RESPONSE_SCHEMA)
+    return response if response[:error]
+
+    { points: extract_points(response[:message]) }
+  end
+
+  private
+
+  def messages
+    [
+      { role: 'system', content: system_prompt },
+      { role: 'user', content: 'Identify the standout points in this report.' }
+    ]
+  end
+
+  def system_prompt
+    Captain::PromptRenderer.render(
+      'assistant_overview_summary',
+      assistant_name: assistant.name,
+      language: account.locale_english_name,
+      report_data: JSON.pretty_generate(report_data)
+    )
+  end
+
+  def report_data
+    @report_data ||= {
+      period: stats_window.period,
+      overview: Captain::AssistantOverviewStatsBuilder.new(assistant, range, timezone_offset).metrics,
+      resolution_flow: Captain::AssistantResolutionFlowBuilder.new(assistant, range, timezone_offset).build,
+      resolution_trend: Captain::AssistantResolutionTrendStatsBuilder.new(assistant, range, timezone_offset).metrics
+    }
+  end
+
+  def stats_window
+    @stats_window ||= Captain::AssistantStatsWindow.new(range, timezone_offset)
+  end
+
+  def extract_points(message)
+    data = message.is_a?(Hash) ? message.deep_symbolize_keys : {}
+    Array(data[:points]).filter_map { |point| point.to_s.strip.presence }.first(RESPONSE_SCHEMA::MAX_POINTS)
+  end
+
+  def event_name
+    'captain_assistant_overview_summary'
+  end
+
+  def use_account_openai_hook?
+    true
+  end
+
+  def counts_toward_usage?
+    false
+  end
+
+  def build_follow_up_context?
+    false
+  end
+end

--- a/enterprise/lib/captain/prompts/assistant_overview_summary.liquid
+++ b/enterprise/lib/captain/prompts/assistant_overview_summary.liquid
@@ -4,7 +4,7 @@ Return up to three short, decision-useful points in {{ language }}. Return fewer
 
 Requirements for every point:
 - State the observation directly in one or two sentences, without a heading, greeting, bullet marker, or generic praise.
-- Cite the exact value and comparison that make it notable. Use the reporting period or bucket dates when time is relevant.
+- Cite the rounded value and comparison that make it notable. Use exact reporting-period or bucket dates when time is relevant.
 - Explain why the signal matters operationally, but never invent a cause, customer intent, or recommendation that the data does not support.
 - Cover one distinct theme. Do not repeat the same metric or rephrase another point.
 - Stay under 300 characters.
@@ -20,6 +20,8 @@ Interpretation rules:
 - For rates, trend is the percentage-point change from the previous period.
 - For scores, hours, depth, and median resolution seconds, trend is the absolute change.
 - Handoff distribution percentage is the share of all involved handoffs in the period.
+- Never expose an exact metric value from the report. Round counts and durations down to one or two significant digits, rates and trends to clean whole numbers, and CSAT scores to one decimal place. Soften each approximation with words such as "around", "roughly", "about", "nearly", or "upwards of".
+- For example, express 1,248 conversations as "upwards of 1,200 conversations", 63.2% as "around 60%", and a 5.4-point change as "about 5 percentage points".
 - When fewer than 30 conversations were handled, explicitly describe rate-based conclusions as tentative.
 - Do not treat a zero caused by no activity as excellent performance.
 - Do not merely recap the report. If nothing is exceptional, concerning, or meaningfully changed, return no points.

--- a/enterprise/lib/captain/prompts/assistant_overview_summary.liquid
+++ b/enterprise/lib/captain/prompts/assistant_overview_summary.liquid
@@ -1,0 +1,29 @@
+You analyze the performance of an AI customer-support assistant named "{{ assistant_name }}".
+
+Return up to three short, decision-useful points in {{ language }}. Return fewer points when fewer signals genuinely stand out, and return an empty array when there is no meaningful activity to assess.
+
+Requirements for every point:
+- State the observation directly in one or two sentences, without a heading, greeting, bullet marker, or generic praise.
+- Cite the exact value and comparison that make it notable. Use the reporting period or bucket dates when time is relevant.
+- Explain why the signal matters operationally, but never invent a cause, customer intent, or recommendation that the data does not support.
+- Cover one distinct theme. Do not repeat the same metric or rephrase another point.
+- Stay under 300 characters.
+
+Prioritize these signals:
+1. Material changes from the previous period, especially auto-resolution, handoff, reopen, durable resolution, CSAT, or resolution time.
+2. Clear quality strengths or risks: auto-resolution above 50% or below 30%, handoff below 30% or above 60%, reopen above 15%, or a meaningful CSAT gap.
+3. A dominant handoff reason or a clear spike, drop, or sustained shift in the resolution trend.
+4. Volume, hours saved, or conversation depth only when unusually large or when they add necessary context to a stronger quality signal.
+
+Interpretation rules:
+- For conversations_handled, autonomous_resolutions, and handoff_count, trend is the relative percentage change from the previous period.
+- For rates, trend is the percentage-point change from the previous period.
+- For scores, hours, depth, and median resolution seconds, trend is the absolute change.
+- Handoff distribution percentage is the share of all involved handoffs in the period.
+- When fewer than 30 conversations were handled, explicitly describe rate-based conclusions as tentative.
+- Do not treat a zero caused by no activity as excellent performance.
+- Do not merely recap the report. If nothing is exceptional, concerning, or meaningfully changed, return no points.
+
+<report_data>
+{{ report_data }}
+</report_data>


### PR DESCRIPTION
Captain outcome reporting is now available through dedicated assistant stats endpoints. The new overview summary analyzes outcome, resolution-flow, and trend data to surface up to three specific, evidence-backed insights using rounded approximations suited to an hourly cached summary.

## Closes

Follow-up to https://github.com/chatwoot/chatwoot/pull/15425

## How to test

1. Select an assistant with recorded conversation outcomes.
2. Request the overview, resolution flow, and resolution trend endpoints for different reporting ranges.
3. Confirm the overview summary returns no more than three distinct points backed by rounded, softened report values rather than exact figures.
4. Confirm low-volume reports qualify rate-based conclusions and reports without meaningful activity return no points.
5. Request the overview summary again with the same assistant, range, timezone, and locale, and confirm the successful summary is reused from the one-hour cache.
6. Confirm raw statistics remain uncached and continue reflecting the selected reporting range and timezone.

## Chatwoot CLI

View the 30-day statistics for assistant ID `1` using a UTC+5:30 viewer timezone:

```bash
chatwoot api "/captain/assistants/1/stats/overview?range=30&timezone_offset=5.5" -o json
chatwoot api "/captain/assistants/1/stats/resolution_flow?range=30&timezone_offset=5.5" -o json
chatwoot api "/captain/assistants/1/stats/resolution_trend?range=30&timezone_offset=5.5" -o json
chatwoot api "/captain/assistants/1/stats/overview_summary?range=30&timezone_offset=5.5" -o json
```

## What changed

- Added a dedicated assistant stats controller for overview, resolution-flow, and resolution-trend data.
- Added a server-generated overview summary based on all three reporting datasets.
- Added a structured LLM response schema and a focused prompt for up to three standout insights.
- Rounded and softened metric values in generated insights so cached summaries do not present stale figures as exact.
- Cached successful LLM summaries for one hour while leaving raw statistics uncached and avoiding caching generation failures.
- Added a frontend API client for the new endpoints.
- Preserved the existing assistant metrics and summary endpoints for compatibility.