### PR TITLE
feat(captain): warn about delayed follow-up conflicts

### DIFF
--- a/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.spec.js
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.spec.js
@@ -12,7 +12,10 @@ vi.mock('vue-i18n', () => ({
 }));
 
 vi.mock('dashboard/composables/useAccount', () => ({
-  useAccount: () => ({ isCloudFeatureEnabled: () => true }),
+  useAccount: () => ({
+    accountScopedRoute: (name, params, query) => ({ name, params, query }),
+    isCloudFeatureEnabled: () => true,
+  }),
 }));
 
 const assistant = {
@@ -26,10 +29,20 @@ const assistant = {
   },
 };
 
-const mountComponent = () =>
+const mountComponent = (assistantProp = assistant) =>
   shallowMount(AssistantSystemSettingsForm, {
-    props: { assistant },
-    global: { stubs: { Banner: false, SettingsToggleSection: false } },
+    props: { assistant: assistantProp },
+    global: {
+      stubs: {
+        Banner: false,
+        RouterLink: {
+          name: 'RouterLink',
+          props: ['to'],
+          template: '<a><slot /></a>',
+        },
+        SettingsToggleSection: false,
+      },
+    },
   });
 
 const submitForm = async wrapper => {
@@ -105,5 +118,50 @@ describe('AssistantSystemSettingsForm', () => {
     expect(wrapper.text()).toContain(
       'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.ALWAYS_WARNING'
     );
+  });
+
+  it('warns while the Captain timer can run before a pending follow up', async () => {
+    const wrapper = mountComponent({
+      ...assistant,
+      pending_follow_up_automations: [
+        { id: 1, execution_delay: 60 },
+        { id: 2, execution_delay: 120 },
+      ],
+    });
+
+    expect(wrapper.text()).toContain(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.TIMER_CONFLICT_WARNING'
+    );
+
+    wrapper.findComponent(DurationSelect).vm.$emit('update:modelValue', 120);
+    await nextTick();
+
+    expect(wrapper.text()).toContain(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.TIMER_CONFLICT_WARNING'
+    );
+
+    wrapper.findComponent(DurationSelect).vm.$emit('update:modelValue', 125);
+    await nextTick();
+
+    expect(wrapper.text()).not.toContain(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.TIMER_CONFLICT_WARNING'
+    );
+  });
+
+  it('links a single conflict to that automation', () => {
+    const wrapper = mountComponent({
+      ...assistant,
+      pending_follow_up_automations: [{ id: 7, execution_delay: 240 }],
+    });
+
+    const link = wrapper.findComponent({ name: 'RouterLink' });
+    expect(link.text()).toBe(
+      'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.TIMER_CONFLICT_LINK'
+    );
+    expect(link.props('to')).toEqual({
+      name: 'automation_list',
+      params: {},
+      query: { automationId: 7 },
+    });
   });
 });

--- a/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.vue
@@ -1,10 +1,12 @@
 <script setup>
 import { computed, reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { RouterLink } from 'vue-router';
 import { useVuelidate } from '@vuelidate/core';
 import { maxValue, minLength, minValue, required } from '@vuelidate/validators';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import { useAccount } from 'dashboard/composables/useAccount';
+import { formatDelay } from 'dashboard/helper/automationHelper';
 
 import Banner from 'dashboard/components-next/banner/Banner.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
@@ -24,7 +26,7 @@ const props = defineProps({
 const emit = defineEmits(['submit']);
 
 const { t } = useI18n();
-const { isCloudFeatureEnabled } = useAccount();
+const { accountScopedRoute, isCloudFeatureEnabled } = useAccount();
 
 const isCaptainV2Enabled = computed(() =>
   isCloudFeatureEnabled(FEATURE_FLAGS.CAPTAIN_V2)
@@ -82,6 +84,38 @@ const initialActionTimingLabel = computed(() =>
     ? t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.REVIEW_AFTER')
     : t('CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.RESOLVE_AFTER')
 );
+const conflictingPendingFollowUps = computed(() => {
+  if (!shouldShowInactivityDuration.value) return [];
+
+  return (props.assistant.pending_follow_up_automations || []).filter(
+    automation => state.inactivityThresholdMinutes <= automation.execution_delay
+  );
+});
+const timerConflictWarning = computed(() => {
+  const count = conflictingPendingFollowUps.value.length;
+  if (!count) return '';
+
+  const longestDelay = Math.max(
+    ...conflictingPendingFollowUps.value.map(
+      automation => automation.execution_delay
+    )
+  );
+  return t(
+    'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.TIMER_CONFLICT_WARNING',
+    { count, delay: formatDelay(longestDelay) },
+    count
+  );
+});
+const matchingAutomationRoute = computed(() => {
+  const automations = conflictingPendingFollowUps.value;
+  if (!automations.length) return null;
+
+  const query =
+    automations.length === 1
+      ? { automationId: automations[0].id }
+      : { tab: 'delayed' };
+  return accountScopedRoute('automation_list', {}, query);
+});
 
 const validationRules = {
   handoffMessage: { minLength: minLength(1) },
@@ -230,6 +264,32 @@ watch(
             {{ formErrors.inactivityThresholdMinutes }}
           </p>
         </div>
+
+        <Banner
+          v-if="timerConflictWarning"
+          color="amber"
+          class="mx-4"
+          role="alert"
+        >
+          <div class="flex items-start gap-2">
+            <span class="i-lucide-triangle-alert mt-0.5 size-4 shrink-0" />
+            <span>
+              {{ timerConflictWarning }}
+              <RouterLink
+                :to="matchingAutomationRoute"
+                class="link ml-1 font-medium underline"
+              >
+                {{
+                  t(
+                    'CAPTAIN.ASSISTANTS.FORM.INACTIVITY_RESOLUTION.TIMER_CONFLICT_LINK',
+                    { count: conflictingPendingFollowUps.length },
+                    conflictingPendingFollowUps.length
+                  )
+                }}
+              </RouterLink>
+            </span>
+          </div>
+        </Banner>
 
         <Banner
           v-if="state.autoResolveMode === 'legacy'"

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -713,6 +713,8 @@
           "REVIEW_AFTER": "Review after",
           "RESOLVE_AFTER": "Resolve after",
           "ALWAYS_WARNING": "Captain will resolve every conversation after the selected time without reviewing it. Some conversations that still need help may be closed.",
+          "TIMER_CONFLICT_WARNING": "Captain may resolve or hand off the conversation before a delayed follow up runs. One matching automation waits for {delay}. Set this timer to more than {delay}, or shorten the automation wait. | Captain may resolve or hand off the conversation before a delayed follow up runs. {count} matching automations wait for up to {delay}. Set this timer to more than {delay}, or shorten the automation waits.",
+          "TIMER_CONFLICT_LINK": "View automation | View automations",
           "PENDING_INFO": "The conversation remains pending until the customer replies.",
           "RESOLUTION_MESSAGE": {
             "TITLE": "Send a message when resolving",
@@ -806,7 +808,8 @@
         "SYSTEM_SETTINGS": {
           "TITLE": "System settings",
           "DESCRIPTION": "Customize what the assistant says when ending a conversation or transferring to a human.",
-          "DESCRIPTION_V2": "Manage what Captain does when customers stop replying and set the handoff message."
+          "DESCRIPTION_V2": "Manage what Captain does when customers stop replying and set the handoff message.",
+          "LOAD_ERROR": "Could not load the latest assistant settings. Try again."
         },
         "AUDIENCE": {
           "TITLE": "Audience",

--- a/app/javascript/dashboard/routes/dashboard/captain/assistants/settings/System.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/captain/assistants/settings/System.spec.js
@@ -1,0 +1,152 @@
+import { nextTick, ref } from 'vue';
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { useI18n } from 'vue-i18n';
+import { useAlert } from 'dashboard/composables';
+import { useAccount } from 'dashboard/composables/useAccount';
+import AssistantSystemSettingsForm from 'dashboard/components-next/captain/pageComponents/assistant/settings/AssistantSystemSettingsForm.vue';
+import { useAssistantSettings } from './useAssistantSettings';
+import System from './System.vue';
+
+vi.mock('vue-i18n');
+vi.mock('dashboard/composables');
+vi.mock('dashboard/composables/useAccount');
+vi.mock('./useAssistantSettings');
+
+const deferredPromise = () => {
+  let resolve;
+  const promise = new Promise(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
+const assistants = {
+  1: { id: 1, pending_follow_up_automations: [] },
+  2: {
+    id: 2,
+    pending_follow_up_automations: [{ id: 9, execution_delay: 60 }],
+  },
+};
+
+const mountSystem = async () => {
+  const wrapper = shallowMount(System, {
+    global: {
+      stubs: {
+        SettingsPageLayout: { template: '<div><slot /></div>' },
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+};
+
+const displayedAssistant = wrapper =>
+  wrapper.findComponent(AssistantSystemSettingsForm).props('assistant');
+
+describe('System', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useI18n.mockReturnValue({ t: key => key });
+    useAccount.mockReturnValue({ isCloudFeatureEnabled: vi.fn(() => false) });
+  });
+
+  it('shows settings for the newly selected assistant', async () => {
+    const assistantId = ref(1);
+    const assistant = ref();
+    const fetchAssistant = vi.fn(() => {
+      assistant.value = assistants[assistantId.value];
+      return assistant.value;
+    });
+
+    useAssistantSettings.mockReturnValue({
+      assistantId,
+      assistant,
+      fetchAssistant,
+      updateAssistant: vi.fn(),
+    });
+
+    const wrapper = await mountSystem();
+    expect(displayedAssistant(wrapper)).toEqual(assistants[1]);
+
+    assistantId.value = 2;
+    await flushPromises();
+
+    expect(displayedAssistant(wrapper)).toEqual(assistants[2]);
+  });
+
+  it('keeps the selected assistant when an earlier request finishes last', async () => {
+    const assistantId = ref(1);
+    const requests = {
+      1: deferredPromise(),
+      2: deferredPromise(),
+    };
+
+    useAssistantSettings.mockReturnValue({
+      assistantId,
+      assistant: ref(),
+      fetchAssistant: vi.fn(() => requests[assistantId.value].promise),
+      updateAssistant: vi.fn(),
+    });
+
+    const wrapper = await mountSystem();
+
+    assistantId.value = 2;
+    await flushPromises();
+    requests[2].resolve(assistants[2]);
+    await flushPromises();
+    requests[1].resolve(assistants[1]);
+    await flushPromises();
+
+    expect(displayedAssistant(wrapper)).toEqual(assistants[2]);
+  });
+
+  it('keeps cached settings when the refresh fails', async () => {
+    const assistantId = ref(1);
+    const assistant = ref();
+    useAssistantSettings.mockReturnValue({
+      assistantId,
+      assistant,
+      fetchAssistant: vi.fn(() => Promise.reject(new Error('Network error'))),
+      updateAssistant: vi.fn(),
+    });
+
+    const wrapper = await mountSystem();
+    expect(wrapper.findComponent(AssistantSystemSettingsForm).exists()).toBe(
+      false
+    );
+
+    assistant.value = assistants[1];
+    await nextTick();
+
+    expect(displayedAssistant(wrapper)).toEqual(assistants[1]);
+    expect(useAlert).toHaveBeenCalledWith(
+      'CAPTAIN.ASSISTANTS.SETTINGS.SYSTEM_SETTINGS.LOAD_ERROR'
+    );
+  });
+
+  it('ignores a saved response after switching assistants', async () => {
+    const assistantId = ref(1);
+    const pendingUpdate = deferredPromise();
+
+    useAssistantSettings.mockReturnValue({
+      assistantId,
+      assistant: ref(),
+      fetchAssistant: vi.fn(() =>
+        Promise.resolve(assistants[assistantId.value])
+      ),
+      updateAssistant: vi.fn(() => pendingUpdate.promise),
+    });
+
+    const wrapper = await mountSystem();
+
+    wrapper
+      .findComponent(AssistantSystemSettingsForm)
+      .vm.$emit('submit', { config: {} });
+    assistantId.value = 2;
+    await flushPromises();
+    pendingUpdate.resolve(assistants[1]);
+    await flushPromises();
+
+    expect(displayedAssistant(wrapper)).toEqual(assistants[2]);
+  });
+});

--- a/app/javascript/dashboard/routes/dashboard/captain/assistants/settings/System.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/assistants/settings/System.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
+import { useAlert } from 'dashboard/composables';
 import { useAccount } from 'dashboard/composables/useAccount';
 import { useAssistantSettings } from './useAssistantSettings';
 import SettingsPageLayout from 'dashboard/components-next/captain/pageComponents/assistant/settings/SettingsPageLayout.vue';
@@ -9,13 +10,46 @@ import AssistantSystemSettingsForm from 'dashboard/components-next/captain/pageC
 
 const { t } = useI18n();
 const { isCloudFeatureEnabled } = useAccount();
-const { assistant, updateAssistant } = useAssistantSettings();
+const { assistantId, assistant, fetchAssistant, updateAssistant } =
+  useAssistantSettings();
+const systemAssistant = ref(assistant.value);
 
 const systemSettingsDescription = computed(() =>
   isCloudFeatureEnabled(FEATURE_FLAGS.CAPTAIN_V2)
     ? t('CAPTAIN.ASSISTANTS.SETTINGS.SYSTEM_SETTINGS.DESCRIPTION_V2')
     : t('CAPTAIN.ASSISTANTS.SETTINGS.SYSTEM_SETTINGS.DESCRIPTION')
 );
+
+const loadAssistant = async selectedAssistantId => {
+  systemAssistant.value =
+    assistant.value?.id === selectedAssistantId ? assistant.value : null;
+
+  try {
+    const loadedAssistant = await fetchAssistant();
+    if (loadedAssistant && assistantId.value === selectedAssistantId) {
+      systemAssistant.value = loadedAssistant;
+    }
+  } catch {
+    if (assistantId.value === selectedAssistantId) {
+      useAlert(t('CAPTAIN.ASSISTANTS.SETTINGS.SYSTEM_SETTINGS.LOAD_ERROR'));
+    }
+  }
+};
+
+const saveAssistant = async values => {
+  const selectedAssistantId = assistantId.value;
+  const savedAssistant = await updateAssistant(values);
+  if (savedAssistant && assistantId.value === selectedAssistantId) {
+    systemAssistant.value = savedAssistant;
+  }
+};
+
+watch(assistantId, loadAssistant, { immediate: true });
+watch(assistant, cachedAssistant => {
+  if (!systemAssistant.value && cachedAssistant?.id === assistantId.value) {
+    systemAssistant.value = cachedAssistant;
+  }
+});
 </script>
 
 <template>
@@ -24,8 +58,9 @@ const systemSettingsDescription = computed(() =>
     :description="systemSettingsDescription"
   >
     <AssistantSystemSettingsForm
-      :assistant="assistant"
-      @submit="updateAssistant"
+      v-if="systemAssistant?.id === assistantId"
+      :assistant="systemAssistant"
+      @submit="saveAssistant"
     />
   </SettingsPageLayout>
 </template>

--- a/app/javascript/dashboard/routes/dashboard/captain/assistants/settings/useAssistantSettings.js
+++ b/app/javascript/dashboard/routes/dashboard/captain/assistants/settings/useAssistantSettings.js
@@ -15,17 +15,22 @@ export function useAssistantSettings() {
     assistantId
   );
 
+  const fetchAssistant = () =>
+    store.dispatch('captainAssistants/show', assistantId.value);
+
   const updateAssistant = async updatedAssistant => {
     try {
-      await store.dispatch('captainAssistants/update', {
+      const savedAssistant = await store.dispatch('captainAssistants/update', {
         id: assistantId.value,
         ...updatedAssistant,
       });
       useAlert(t('CAPTAIN.ASSISTANTS.EDIT.SUCCESS_MESSAGE'));
+      return savedAssistant;
     } catch (error) {
       useAlert(error?.message || t('CAPTAIN.ASSISTANTS.EDIT.ERROR_MESSAGE'));
+      return undefined;
     }
   };
 
-  return { assistantId, assistant, updateAssistant };
+  return { assistantId, assistant, fetchAssistant, updateAssistant };
 }

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/Index.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/Index.spec.js
@@ -1,0 +1,67 @@
+import { ref } from 'vue';
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
+import { useStore, useStoreGetters } from 'dashboard/composables/store';
+import Index from './Index.vue';
+
+vi.mock('vue-i18n');
+vi.mock('vue-router');
+vi.mock('dashboard/composables/store');
+vi.mock('dashboard/composables', () => ({ useAlert: vi.fn() }));
+
+describe('Automation settings', () => {
+  it('opens the automation linked in the URL', async () => {
+    const automation = {
+      id: 7,
+      name: 'Pending follow up',
+      execution_delay: 240,
+    };
+    const openEditDialog = vi.fn();
+    let finishLoadingInboxes;
+    const inboxesLoaded = new Promise(resolve => {
+      finishLoadingInboxes = resolve;
+    });
+    const store = {
+      dispatch: vi.fn(action =>
+        action === 'inboxes/get' ? inboxesLoaded : Promise.resolve()
+      ),
+    };
+
+    useI18n.mockReturnValue({ t: key => key });
+    useRoute.mockReturnValue({ query: { automationId: '7' } });
+    useStore.mockReturnValue(store);
+    useStoreGetters.mockReturnValue({
+      'automations/getAutomations': ref([automation]),
+      'automations/getUIFlags': ref({ isFetching: false }),
+      'accounts/isFeatureEnabledonAccount': ref(() => true),
+      getCurrentAccountId: ref(1),
+    });
+
+    shallowMount(Index, {
+      global: {
+        stubs: {
+          SettingsLayout: { template: '<div><slot /></div>' },
+          EditAutomationRule: {
+            props: ['selectedResponse'],
+            setup(_, { expose }) {
+              expose({ open: openEditDialog, close: vi.fn() });
+            },
+            template: '<div />',
+          },
+          'woot-confirm-modal': true,
+          'woot-delete-modal': true,
+        },
+      },
+    });
+    await flushPromises();
+
+    expect(openEditDialog).not.toHaveBeenCalled();
+
+    finishLoadingInboxes();
+    await flushPromises();
+
+    expect(store.dispatch).toHaveBeenCalledWith('automations/get');
+    expect(openEditDialog).toHaveBeenCalledWith(automation);
+  });
+});

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/Index.vue
@@ -6,6 +6,7 @@ import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';
 import SettingsLayout from '../SettingsLayout.vue';
 import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
 import { useStoreGetters, useStore } from 'dashboard/composables/store';
 import { picoSearch } from '@chatwoot/pico-search';
 import AutomationRuleRow from './AutomationRuleRow.vue';
@@ -17,6 +18,7 @@ import { DEFAULT_DELAY_MINUTES } from './constants';
 const getters = useStoreGetters();
 const store = useStore();
 const { t } = useI18n();
+const route = useRoute();
 const confirmDialog = ref(null);
 
 const loading = ref({});
@@ -62,7 +64,7 @@ const showTabs = computed(
     records.value.some(automation => automation.execution_delay)
 );
 
-const activeTab = ref('instant');
+const activeTab = ref(route.query.tab === 'delayed' ? 'delayed' : 'instant');
 
 const tabs = computed(() => [
   {
@@ -119,19 +121,6 @@ const showDelayDisabledBanner = computed(
     records.value.some(automation => automation.execution_delay)
 );
 
-onMounted(() => {
-  store.dispatch('inboxes/get');
-  store.dispatch('agents/get');
-  store.dispatch('contacts/get');
-  store.dispatch('teams/get');
-  store.dispatch('labels/get');
-  store.dispatch('campaigns/get');
-  store.dispatch('automations/get');
-  if (isSLAEnabled.value) {
-    store.dispatch('sla/get');
-  }
-});
-
 const openAddPopup = () => {
   const startsWithWait =
     isDelayedAutomationsEnabled.value && activeTab.value === 'delayed';
@@ -148,6 +137,31 @@ const openEditPopup = response => {
 const hideEditPopup = () => {
   editDialogRef.value?.close();
 };
+
+onMounted(async () => {
+  const loadRequests = [
+    store.dispatch('inboxes/get'),
+    store.dispatch('agents/get'),
+    store.dispatch('contacts/get'),
+    store.dispatch('teams/get'),
+    store.dispatch('labels/get'),
+    store.dispatch('campaigns/get'),
+    store.dispatch('automations/get'),
+  ];
+  if (isSLAEnabled.value) {
+    loadRequests.push(store.dispatch('sla/get'));
+  }
+  await Promise.all(loadRequests);
+
+  const automationId = Number(route.query.automationId);
+  if (!automationId) return;
+
+  const automation = records.value.find(record => record.id === automationId);
+  if (!automation) return;
+
+  activeTab.value = automation.execution_delay ? 'delayed' : 'instant';
+  openEditPopup(automation);
+});
 
 const openDeletePopup = response => {
   showDeleteConfirmationPopup.value = true;

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
@@ -7,7 +7,9 @@ class Api::V1::Accounts::Captain::AssistantsController < Api::V1::Accounts::Base
     @assistants = account_assistants.ordered
   end
 
-  def show; end
+  def show
+    load_pending_follow_up_automations
+  end
 
   def create
     @assistant = account_assistants.create!(assistant_params)
@@ -20,6 +22,7 @@ class Api::V1::Accounts::Captain::AssistantsController < Api::V1::Accounts::Base
 
       @assistant.update!(permitted_params)
     end
+    load_pending_follow_up_automations
   end
 
   def destroy
@@ -78,6 +81,12 @@ class Api::V1::Accounts::Captain::AssistantsController < Api::V1::Accounts::Base
   end
 
   private
+
+  def load_pending_follow_up_automations
+    return unless Current.account_user.administrator?
+
+    @pending_follow_up_automations = Captain::PendingFollowUpAutomationFinder.new(@assistant).perform
+  end
 
   def drilldown_params
     params.permit(:metric, :range, :timezone_offset, :page, :per_page)

--- a/enterprise/app/finders/captain/pending_follow_up_automation_finder.rb
+++ b/enterprise/app/finders/captain/pending_follow_up_automation_finder.rb
@@ -1,0 +1,74 @@
+class Captain::PendingFollowUpAutomationFinder
+  def initialize(assistant)
+    @assistant = assistant
+  end
+
+  def perform
+    return [] unless assistant.account.feature_enabled?('delayed_automations')
+    return [] if connected_inbox_ids.empty?
+
+    delayed_follow_up_rules.select { |rule| pending_follow_up?(rule) }
+  end
+
+  private
+
+  attr_reader :assistant
+
+  def connected_inbox_ids
+    @connected_inbox_ids ||= assistant.inboxes.select(&:captain_inactivity_resolution_supported?).map(&:id)
+  end
+
+  def delayed_follow_up_rules
+    assistant.account.automation_rules.active
+             .where(event_name: %w[conversation_updated message_created])
+             .where.not(execution_delay: nil)
+  end
+
+  def pending_follow_up?(rule)
+    follow_up_trigger?(rule) &&
+      sends_follow_up?(rule) &&
+      overlaps_connected_inbox?(rule)
+  end
+
+  def follow_up_trigger?(rule)
+    return pending_status_condition?(rule) if rule.event_name == 'conversation_updated'
+
+    equal_to_condition?(rule, 'message_type', 'outgoing') && equal_to_condition?(rule, 'private_note', false)
+  end
+
+  def pending_status_condition?(rule)
+    condition = condition_for(rule, 'status')
+    condition&.dig('filter_operator') == 'equal_to' && Array(condition['values']).include?('pending')
+  end
+
+  def sends_follow_up?(rule)
+    rule.actions.any? { |action| action['action_name'].in?(%w[send_message send_attachment]) }
+  end
+
+  def equal_to_condition?(rule, attribute_key, value)
+    condition = condition_for(rule, attribute_key)
+    condition&.dig('filter_operator') == 'equal_to' && Array(condition['values']).include?(value)
+  end
+
+  def overlaps_connected_inbox?(rule)
+    condition = condition_for(rule, 'inbox_id')
+    return true if condition.blank?
+
+    inbox_ids = Array(condition['values']).map(&:to_i)
+
+    case condition['filter_operator']
+    when 'equal_to'
+      inbox_ids.intersect?(connected_inbox_ids)
+    when 'not_equal_to'
+      (connected_inbox_ids - inbox_ids).any?
+    when 'is_present'
+      true
+    when 'is_not_present'
+      false
+    end
+  end
+
+  def condition_for(rule, attribute_key)
+    rule.conditions.find { |condition| condition['attribute_key'] == attribute_key }
+  end
+end

--- a/enterprise/app/jobs/enterprise/account/conversations_resolution_scheduler_job.rb
+++ b/enterprise/app/jobs/enterprise/account/conversations_resolution_scheduler_job.rb
@@ -12,7 +12,7 @@ module Enterprise::Account::ConversationsResolutionSchedulerJob
       inbox = captain_inbox.inbox
       assistant = captain_inbox.captain_assistant
 
-      next if inbox.email? || inbox.external_bot_active?
+      next unless inbox.captain_inactivity_resolution_supported?
       next if assistant.blank? || assistant.inactive_conversation_resolution_disabled?
 
       Captain::InboxPendingConversationsResolutionJob.perform_later(

--- a/enterprise/app/models/enterprise/concerns/inbox.rb
+++ b/enterprise/app/models/enterprise/concerns/inbox.rb
@@ -16,4 +16,8 @@ module Enterprise::Concerns::Inbox
   def ensure_create_permitted
     raise CustomExceptions::Inbox::LimitExceeded.new({}) if account.inboxes.count >= account.usage_limits[:inboxes]
   end
+
+  def captain_inactivity_resolution_supported?
+    !email? && !external_bot_active?
+  end
 end

--- a/enterprise/app/views/api/v1/accounts/captain/assistants/_details.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/assistants/_details.json.jbuilder
@@ -1,0 +1,7 @@
+json.partial! 'api/v1/models/captain/assistant', formats: [:json], resource: assistant
+if pending_follow_up_automations
+  json.pending_follow_up_automations pending_follow_up_automations do |automation|
+    json.id automation.id
+    json.execution_delay automation.execution_delay
+  end
+end

--- a/enterprise/app/views/api/v1/accounts/captain/assistants/show.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/assistants/show.json.jbuilder
@@ -1,1 +1,3 @@
-json.partial! 'api/v1/models/captain/assistant', formats: [:json], resource: @assistant
+json.partial! 'api/v1/accounts/captain/assistants/details',
+              assistant: @assistant,
+              pending_follow_up_automations: @pending_follow_up_automations

--- a/enterprise/app/views/api/v1/accounts/captain/assistants/update.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/assistants/update.json.jbuilder
@@ -1,1 +1,3 @@
-json.partial! 'api/v1/models/captain/assistant', formats: [:json], resource: @assistant
+json.partial! 'api/v1/accounts/captain/assistants/details',
+              assistant: @assistant,
+              pending_follow_up_automations: @pending_follow_up_automations

--- a/spec/enterprise/controllers/api/v1/accounts/captain/assistants_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/assistants_controller_spec.rb
@@ -9,6 +9,26 @@ RSpec.describe 'Api::V1::Accounts::Captain::Assistants', type: :request do
     JSON.parse(response.body, symbolize_names: true)
   end
 
+  def create_pending_follow_up_automation(inbox:, delay: 240)
+    create(
+      :automation_rule,
+      account: account,
+      event_name: 'message_created',
+      execution_delay: delay,
+      conditions: [
+        { 'attribute_key' => 'message_type', 'filter_operator' => 'equal_to',
+          'values' => ['outgoing'], 'query_operator' => 'and' },
+        { 'attribute_key' => 'private_note', 'filter_operator' => 'equal_to',
+          'values' => [false], 'query_operator' => 'and' },
+        { 'attribute_key' => 'inbox_id', 'filter_operator' => 'equal_to',
+          'values' => [inbox.id], 'query_operator' => 'and' },
+        { 'attribute_key' => 'status', 'filter_operator' => 'equal_to',
+          'values' => ['pending'], 'query_operator' => nil }
+      ],
+      actions: [{ 'action_name' => 'send_message', 'action_params' => ['Are you still there?'] }]
+    )
+  end
+
   describe 'GET /api/v1/accounts/{account.id}/captain/assistants' do
     context 'when it is an un-authenticated user' do
       it 'does not fetch assistants' do
@@ -53,6 +73,45 @@ RSpec.describe 'Api::V1::Accounts::Captain::Assistants', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(json_response[:id]).to eq(assistant.id)
+      end
+
+      it 'does not expose delayed automation details' do
+        account.enable_features!('delayed_automations')
+        inbox = create(:inbox, account: account)
+        create(:captain_inbox, captain_assistant: assistant, inbox: inbox)
+        create_pending_follow_up_automation(inbox: inbox)
+
+        get "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}",
+            headers: agent.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response).not_to have_key(:pending_follow_up_automations)
+      end
+    end
+
+    context 'when it is an administrator' do
+      it 'includes only the delays that can conflict with Captain inactivity resolution' do
+        account.enable_features!('delayed_automations')
+        supported_inbox = create(:inbox, account: account)
+        email_inbox = create(:inbox, :with_email, account: account)
+        external_bot_inbox = create(:inbox, account: account)
+        create(:agent_bot_inbox, inbox: external_bot_inbox, agent_bot: create(:agent_bot, account: account))
+        [supported_inbox, email_inbox, external_bot_inbox].each do |inbox|
+          create(:captain_inbox, captain_assistant: assistant, inbox: inbox)
+        end
+        supported_automation = create_pending_follow_up_automation(inbox: supported_inbox, delay: 120)
+        create_pending_follow_up_automation(inbox: email_inbox, delay: 180)
+        create_pending_follow_up_automation(inbox: external_bot_inbox, delay: 240)
+
+        get "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:pending_follow_up_automations]).to eq(
+          [{ id: supported_automation.id, execution_delay: 120 }]
+        )
       end
     end
   end
@@ -199,6 +258,23 @@ RSpec.describe 'Api::V1::Accounts::Captain::Assistants', type: :request do
         expect(json_response[:name]).to eq('Updated Assistant')
         expect(json_response[:response_guidelines]).to eq(['Updated guideline'])
         expect(json_response[:guardrails]).to eq(['Updated guardrail'])
+      end
+
+      it 'keeps delayed pending follow ups in the updated assistant response' do
+        account.enable_features!('delayed_automations')
+        inbox = create(:inbox, account: account)
+        create(:captain_inbox, captain_assistant: assistant, inbox: inbox)
+        automation = create_pending_follow_up_automation(inbox: inbox)
+
+        patch "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}",
+              params: { assistant: { name: 'Updated Assistant' } },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(json_response[:pending_follow_up_automations]).to eq(
+          [{ id: automation.id, execution_delay: 240 }]
+        )
       end
 
       it 'updates only response_guidelines when only that is provided' do

--- a/spec/enterprise/finders/captain/pending_follow_up_automation_finder_spec.rb
+++ b/spec/enterprise/finders/captain/pending_follow_up_automation_finder_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe Captain::PendingFollowUpAutomationFinder do
+  let(:account) { create(:account) }
+  let(:assistant) { create(:captain_assistant, account: account) }
+  let(:connected_inbox) { create(:inbox, account: account) }
+  let(:other_inbox) { create(:inbox, account: account) }
+  let(:pending_condition) do
+    { 'attribute_key' => 'status', 'filter_operator' => 'equal_to', 'values' => ['pending'], 'query_operator' => nil }
+  end
+  let(:send_message_action) { { 'action_name' => 'send_message', 'action_params' => ['Are you still there?'] } }
+  let(:send_attachment_action) { { 'action_name' => 'send_attachment', 'action_params' => [123] } }
+  let(:customer_unresponsive_conditions) do
+    [
+      { 'attribute_key' => 'message_type', 'filter_operator' => 'equal_to',
+        'values' => ['outgoing'], 'query_operator' => 'and' },
+      { 'attribute_key' => 'private_note', 'filter_operator' => 'equal_to',
+        'values' => [false], 'query_operator' => 'and' },
+      { 'attribute_key' => 'inbox_id', 'filter_operator' => 'equal_to',
+        'values' => [connected_inbox.id], 'query_operator' => nil }
+    ]
+  end
+
+  before do
+    account.enable_features!('delayed_automations')
+    create(:captain_inbox, captain_assistant: assistant, inbox: connected_inbox)
+  end
+
+  def create_inbox_scoped_follow_up(operator:, inbox_ids: [], execution_delay: 60)
+    create(
+      :automation_rule,
+      account: account,
+      event_name: 'conversation_updated',
+      execution_delay: execution_delay,
+      conditions: [
+        pending_condition.merge('query_operator' => 'and'),
+        { 'attribute_key' => 'inbox_id', 'filter_operator' => operator,
+          'values' => inbox_ids, 'query_operator' => nil }
+      ],
+      actions: [send_message_action]
+    )
+  end
+
+  it 'returns active pending follow ups that apply to a connected inbox' do
+    account_rule = create(:automation_rule, account: account, event_name: 'conversation_updated', execution_delay: 60,
+                                            conditions: [pending_condition], actions: [send_message_action])
+    inbox_rule = create(:automation_rule, account: account, event_name: 'message_created', execution_delay: 120,
+                                          conditions: customer_unresponsive_conditions,
+                                          actions: [send_message_action])
+    create(:automation_rule, account: account, event_name: 'conversation_updated', execution_delay: 180,
+                             conditions: [pending_condition.merge('query_operator' => 'AND'),
+                                          { 'attribute_key' => 'inbox_id', 'filter_operator' => 'equal_to',
+                                            'values' => [other_inbox.id], 'query_operator' => nil }],
+                             actions: [send_message_action])
+
+    expect(described_class.new(assistant).perform).to contain_exactly(account_rule, inbox_rule)
+  end
+
+  it 'returns pending attachment follow ups' do
+    attachment_rule = create(:automation_rule, account: account, event_name: 'conversation_updated', execution_delay: 60,
+                                               conditions: [pending_condition], actions: [send_attachment_action])
+
+    expect(described_class.new(assistant).perform).to contain_exactly(attachment_rule)
+  end
+
+  it 'returns follow ups whose inbox exclusions and presence filters include a connected inbox' do
+    excluded_other_inbox_rule = create_inbox_scoped_follow_up(
+      operator: 'not_equal_to', inbox_ids: [other_inbox.id]
+    )
+    inbox_present_rule = create_inbox_scoped_follow_up(
+      operator: 'is_present', execution_delay: 120
+    )
+    create_inbox_scoped_follow_up(
+      operator: 'not_equal_to', inbox_ids: [connected_inbox.id], execution_delay: 180
+    )
+    create_inbox_scoped_follow_up(operator: 'is_not_present', execution_delay: 240)
+
+    expect(described_class.new(assistant).perform).to contain_exactly(excluded_other_inbox_rule, inbox_present_rule)
+  end
+
+  it 'ignores rules that cannot send a pending follow up' do
+    create(:automation_rule, account: account, event_name: 'conversation_updated', execution_delay: 60, active: false,
+                             conditions: [pending_condition], actions: [send_message_action])
+    create(:automation_rule, account: account, event_name: 'conversation_updated', execution_delay: 60,
+                             conditions: [pending_condition.merge('values' => ['open'])], actions: [send_message_action])
+    create(:automation_rule, account: account, event_name: 'conversation_updated', execution_delay: 60,
+                             conditions: [pending_condition], actions: [{ 'action_name' => 'add_label', 'action_params' => ['stale'] }])
+    create(:automation_rule, account: account, event_name: 'message_created', execution_delay: 60,
+                             conditions: customer_unresponsive_conditions.map do |condition|
+                               condition['attribute_key'] == 'message_type' ? condition.merge('values' => ['incoming']) : condition
+                             end,
+                             actions: [send_message_action])
+
+    expect(described_class.new(assistant).perform).to be_empty
+  end
+end


### PR DESCRIPTION
## Summary

This is stacked on #15472. Review this pull request against `codex/delayed-automation-pending`.

Captain System settings now warn administrators when Captain may resolve or hand off a conversation before a matching delayed follow-up automation runs. A singular warning links directly to that automation, while multiple matches link to the delayed automation list.

The warning uses only automations that can affect an inbox where Captain inactivity resolution can run. The Assistant API exposes the matching automation IDs and delays only to administrators.

## Review fixes

- Handle included, excluded, present, and missing inbox filters when finding overlap.
- Ignore Assistant fetch and save responses after the selected Assistant changes.
- Keep cached settings when a detail refresh fails and never expose an editable default form.
- Wait for automation filter options before opening a deep-linked automation.

## Validation

- 16 focused frontend tests passed.
- 47 focused backend examples passed.
- Three deterministic Playwright scenarios passed for the warning link, out-of-order Assistant responses, and failed refresh fallback.
- ESLint, Prettier, RuboCop, JSON parsing, and `git diff --check` passed.

