### PR TITLE
feat: add Plivo as an SMS channel provider

### DIFF
--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -19,7 +19,7 @@ class ContactInboxBuilder
       wa_source_id
     when 'Channel::Email'
       email_source_id
-    when 'Channel::Sms'
+    when 'Channel::Sms', 'Channel::Plivo'
       phone_source_id
     when 'Channel::Api', 'Channel::WebWidget'
       SecureRandom.uuid

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -105,7 +105,7 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   end
 
   def allowed_channel_types
-    %w[web_widget api email line telegram whatsapp sms]
+    %w[web_widget api email line telegram whatsapp sms plivo]
   end
 
   def update_inbox_working_hours
@@ -215,7 +215,8 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
       'line' => Channel::Line,
       'telegram' => Channel::Telegram,
       'whatsapp' => Channel::Whatsapp,
-      'sms' => Channel::Sms
+      'sms' => Channel::Sms,
+      'plivo' => Channel::Plivo
     }[permitted_params[:channel][:type]]
   end
 

--- a/app/controllers/webhooks/plivo_controller.rb
+++ b/app/controllers/webhooks/plivo_controller.rb
@@ -1,0 +1,35 @@
+class Webhooks::PlivoController < ActionController::API
+  def process_payload
+    channel = find_channel
+    return head :not_found if channel.blank?
+    return head :unauthorized unless valid_signature?(channel)
+
+    Webhooks::PlivoEventsJob.perform_later(request.request_parameters.merge('phone_number' => params[:phone_number]))
+    head :ok
+  end
+
+  private
+
+  def find_channel
+    return if to_number.blank?
+
+    Channel::Plivo.find_by(phone_number: to_number)
+  end
+
+  def to_number
+    number = params[:To].presence || params[:phone_number]
+    return if number.blank?
+
+    number.start_with?('+') ? number : "+#{number}"
+  end
+
+  def valid_signature?(channel)
+    Plivo::SignatureValidator.new(
+      auth_token: channel.provider_config['auth_token'],
+      url: request.original_url.split('?').first,
+      params: request.request_parameters,
+      nonce: request.headers['X-Plivo-Signature-V3-Nonce'],
+      signature: request.headers['X-Plivo-Signature-Ma-V3'].presence || request.headers['X-Plivo-Signature-V3']
+    ).valid?
+  end
+end

--- a/app/controllers/webhooks/plivo_controller.rb
+++ b/app/controllers/webhooks/plivo_controller.rb
@@ -26,10 +26,21 @@ class Webhooks::PlivoController < ActionController::API
   def valid_signature?(channel)
     Plivo::SignatureValidator.new(
       auth_token: channel.provider_config['auth_token'],
-      url: request.original_url.split('?').first,
+      url: signed_url,
       params: request.request_parameters,
       nonce: request.headers['X-Plivo-Signature-V3-Nonce'],
       signature: request.headers['X-Plivo-Signature-Ma-V3'].presence || request.headers['X-Plivo-Signature-V3']
     ).valid?
+  end
+
+  # Plivo signs the exact URL it was configured to post to, which is the
+  # public callback URL Chatwoot advertises (built from FRONTEND_URL), not the
+  # request URL seen behind a reverse proxy or tunnel. Fall back to the request
+  # URL only when FRONTEND_URL is not configured.
+  def signed_url
+    frontend_url = ENV.fetch('FRONTEND_URL', nil)
+    return request.original_url.split('?').first if frontend_url.blank?
+
+    "#{frontend_url}/webhooks/plivo/#{params[:phone_number]}"
   end
 end

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -197,7 +197,8 @@
         "PROVIDERS": {
           "LABEL": "API Provider",
           "TWILIO": "Twilio",
-          "BANDWIDTH": "Bandwidth"
+          "BANDWIDTH": "Bandwidth",
+          "PLIVO": "Plivo"
         },
         "API": {
           "ERROR_MESSAGE": "We were not able to save the SMS channel"
@@ -240,6 +241,36 @@
           "API_CALLBACK": {
             "TITLE": "Callback URL",
             "SUBTITLE": "You have to configure the message callback URL in Bandwidth with the URL mentioned here."
+          }
+        },
+        "PLIVO": {
+          "INBOX_NAME": {
+            "LABEL": "Inbox Name",
+            "PLACEHOLDER": "Please enter a inbox name",
+            "ERROR": "This field is required"
+          },
+          "PHONE_NUMBER": {
+            "LABEL": "Phone number",
+            "PLACEHOLDER": "Please enter the phone number from which message will be sent.",
+            "ERROR": "Please provide a valid phone number that starts with a `+` sign and does not contain any spaces."
+          },
+          "AUTH_ID": {
+            "LABEL": "Auth ID",
+            "PLACEHOLDER": "Please enter your Plivo Auth ID",
+            "ERROR": "This field is required"
+          },
+          "AUTH_TOKEN": {
+            "LABEL": "Auth Token",
+            "PLACEHOLDER": "Please enter your Plivo Auth Token",
+            "ERROR": "This field is required"
+          },
+          "SUBMIT_BUTTON": "Create Plivo Channel",
+          "API": {
+            "ERROR_MESSAGE": "We were not able to authenticate Plivo credentials, please try again"
+          },
+          "API_CALLBACK": {
+            "TITLE": "Callback URL",
+            "SUBTITLE": "You have to configure the message callback URL in Plivo with the URL mentioned here."
           }
         }
       },

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Plivo.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Plivo.vue
@@ -1,0 +1,145 @@
+<script>
+import { mapGetters } from 'vuex';
+import { useVuelidate } from '@vuelidate/core';
+import { useAlert } from 'dashboard/composables';
+import { required } from '@vuelidate/validators';
+import router from '../../../../index';
+
+import NextButton from 'dashboard/components-next/button/Button.vue';
+
+const shouldStartWithPlusSign = (value = '') => value.startsWith('+');
+
+export default {
+  components: {
+    NextButton,
+  },
+  setup() {
+    return { v$: useVuelidate() };
+  },
+  data() {
+    return {
+      authId: '',
+      authToken: '',
+      inboxName: '',
+      phoneNumber: '',
+    };
+  },
+  computed: {
+    ...mapGetters({
+      uiFlags: 'inboxes/getUIFlags',
+    }),
+  },
+  validations: {
+    inboxName: { required },
+    phoneNumber: { required, shouldStartWithPlusSign },
+    authId: { required },
+    authToken: { required },
+  },
+  methods: {
+    async createChannel() {
+      this.v$.$touch();
+      if (this.v$.$invalid) {
+        return;
+      }
+
+      try {
+        const plivoChannel = await this.$store.dispatch('inboxes/createChannel', {
+          name: this.inboxName?.trim(),
+          channel: {
+            type: 'plivo',
+            phone_number: this.phoneNumber,
+            provider_config: {
+              auth_id: this.authId,
+              auth_token: this.authToken,
+            },
+          },
+        });
+
+        router.replace({
+          name: 'settings_inboxes_add_agents',
+          params: {
+            page: 'new',
+            inbox_id: plivoChannel.id,
+          },
+        });
+      } catch (error) {
+        useAlert(this.$t('INBOX_MGMT.ADD.SMS.API.ERROR_MESSAGE'));
+      }
+    },
+  },
+};
+</script>
+
+<template>
+  <form class="flex flex-wrap flex-col mx-0" @submit.prevent="createChannel()">
+    <div class="flex-shrink-0 flex-grow-0">
+      <label :class="{ error: v$.inboxName.$error }">
+        {{ $t('INBOX_MGMT.ADD.SMS.PLIVO.INBOX_NAME.LABEL') }}
+        <input
+          v-model="inboxName"
+          type="text"
+          :placeholder="$t('INBOX_MGMT.ADD.SMS.PLIVO.INBOX_NAME.PLACEHOLDER')"
+          @blur="v$.inboxName.$touch"
+        />
+        <span v-if="v$.inboxName.$error" class="message">{{
+          $t('INBOX_MGMT.ADD.SMS.PLIVO.INBOX_NAME.ERROR')
+        }}</span>
+      </label>
+    </div>
+
+    <div class="flex-shrink-0 flex-grow-0">
+      <label :class="{ error: v$.phoneNumber.$error }">
+        {{ $t('INBOX_MGMT.ADD.SMS.PLIVO.PHONE_NUMBER.LABEL') }}
+        <input
+          v-model="phoneNumber"
+          type="text"
+          :placeholder="$t('INBOX_MGMT.ADD.SMS.PLIVO.PHONE_NUMBER.PLACEHOLDER')"
+          @blur="v$.phoneNumber.$touch"
+        />
+        <span v-if="v$.phoneNumber.$error" class="message">{{
+          $t('INBOX_MGMT.ADD.SMS.PLIVO.PHONE_NUMBER.ERROR')
+        }}</span>
+      </label>
+    </div>
+
+    <div class="flex-shrink-0 flex-grow-0">
+      <label :class="{ error: v$.authId.$error }">
+        {{ $t('INBOX_MGMT.ADD.SMS.PLIVO.AUTH_ID.LABEL') }}
+        <input
+          v-model="authId"
+          type="text"
+          :placeholder="$t('INBOX_MGMT.ADD.SMS.PLIVO.AUTH_ID.PLACEHOLDER')"
+          @blur="v$.authId.$touch"
+        />
+        <span v-if="v$.authId.$error" class="message">{{
+          $t('INBOX_MGMT.ADD.SMS.PLIVO.AUTH_ID.ERROR')
+        }}</span>
+      </label>
+    </div>
+
+    <div class="flex-shrink-0 flex-grow-0">
+      <label :class="{ error: v$.authToken.$error }">
+        {{ $t('INBOX_MGMT.ADD.SMS.PLIVO.AUTH_TOKEN.LABEL') }}
+        <input
+          v-model="authToken"
+          type="text"
+          :placeholder="$t('INBOX_MGMT.ADD.SMS.PLIVO.AUTH_TOKEN.PLACEHOLDER')"
+          @blur="v$.authToken.$touch"
+        />
+        <span v-if="v$.authToken.$error" class="message">{{
+          $t('INBOX_MGMT.ADD.SMS.PLIVO.AUTH_TOKEN.ERROR')
+        }}</span>
+      </label>
+    </div>
+
+    <div class="w-full mt-4">
+      <NextButton
+        :is-loading="uiFlags.isCreating"
+        type="submit"
+        solid
+        blue
+        :label="$t('INBOX_MGMT.ADD.SMS.PLIVO.SUBMIT_BUTTON')"
+      />
+    </div>
+  </form>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Sms.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Sms.vue
@@ -2,12 +2,14 @@
 import PageHeader from '../../SettingsSubPageHeader.vue';
 import BandwidthSms from './BandwidthSms.vue';
 import Twilio from './Twilio.vue';
+import Plivo from './Plivo.vue';
 
 export default {
   components: {
     PageHeader,
     Twilio,
     BandwidthSms,
+    Plivo,
   },
   data() {
     return {
@@ -33,10 +35,14 @@ export default {
           <option value="360dialog">
             {{ $t('INBOX_MGMT.ADD.SMS.PROVIDERS.BANDWIDTH') }}
           </option>
+          <option value="plivo">
+            {{ $t('INBOX_MGMT.ADD.SMS.PROVIDERS.PLIVO') }}
+          </option>
         </select>
       </label>
     </div>
     <Twilio v-if="provider === 'twilio'" type="sms" />
+    <Plivo v-else-if="provider === 'plivo'" />
     <BandwidthSms v-else />
   </div>
 </template>

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -8,6 +8,7 @@ class SendReplyJob < ApplicationJob
     'Channel::Telegram' => ::Telegram::SendOnTelegramService,
     'Channel::Whatsapp' => ::Whatsapp::SendOnWhatsappService,
     'Channel::Sms' => ::Sms::SendOnSmsService,
+    'Channel::Plivo' => ::Plivo::SendOnPlivoService,
     'Channel::Instagram' => ::Instagram::SendOnInstagramService,
     'Channel::Tiktok' => ::Tiktok::SendOnTiktokService,
     'Channel::Email' => ::Email::SendOnEmailService,

--- a/app/jobs/webhooks/plivo_events_job.rb
+++ b/app/jobs/webhooks/plivo_events_job.rb
@@ -1,0 +1,58 @@
+class Webhooks::PlivoEventsJob < ApplicationJob
+  queue_as :default
+
+  def perform(params = {})
+    params = params.with_indifferent_access
+    channel = find_channel(params)
+    return unless channel
+
+    if delivery_event?(params)
+      Plivo::DeliveryStatusService.new(inbox: channel.inbox, params: delivery_params(params)).perform
+    elsif incoming_event?(params)
+      Plivo::IncomingMessageService.new(inbox: channel.inbox, params: incoming_params(params)).perform
+    end
+  end
+
+  private
+
+  def find_channel(params)
+    number = params[:To].presence || params[:phone_number]
+    return if number.blank?
+
+    number = "+#{number}" unless number.start_with?('+')
+    Channel::Plivo.find_by(phone_number: number)
+  end
+
+  def delivery_event?(params)
+    params[:Status].present?
+  end
+
+  def incoming_event?(params)
+    params[:Type].blank? || %w[sms mms].include?(params[:Type])
+  end
+
+  def incoming_params(params)
+    {
+      from: params[:From],
+      to: params[:To],
+      text: params[:Text],
+      id: params[:MessageUUID],
+      media: media_urls(params)
+    }
+  end
+
+  def delivery_params(params)
+    {
+      id: params[:MessageUUID],
+      status: params[:Status],
+      error_code: params[:ErrorCode]
+    }
+  end
+
+  def media_urls(params)
+    count = params[:MediaCount].to_i
+    return [] if count.zero?
+
+    (0...count).map { |index| params["Media#{index}"] }.compact
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -95,6 +95,7 @@ class Account < ApplicationRecord
   has_many :notifications, dependent: :destroy_async
   has_many :portals, dependent: :destroy_async, class_name: '::Portal'
   has_many :sms_channels, dependent: :destroy_async, class_name: '::Channel::Sms'
+  has_many :plivo_channels, dependent: :destroy_async, class_name: '::Channel::Plivo'
   has_many :teams, dependent: :destroy_async
   has_many :telegram_channels, dependent: :destroy_async, class_name: '::Channel::Telegram'
   has_many :twilio_sms, dependent: :destroy_async, class_name: '::Channel::TwilioSms'

--- a/app/models/channel/plivo.rb
+++ b/app/models/channel/plivo.rb
@@ -1,0 +1,90 @@
+# == Schema Information
+#
+# Table name: channel_plivo
+#
+#  id              :bigint           not null, primary key
+#  phone_number    :string           not null
+#  provider_config :jsonb
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  account_id      :integer          not null
+#
+# Indexes
+#
+#  index_channel_plivo_on_phone_number  (phone_number) UNIQUE
+#
+
+class Channel::Plivo < ApplicationRecord
+  include Channelable
+
+  self.table_name = 'channel_plivo'
+  EDITABLE_ATTRS = [:phone_number, { provider_config: {} }].freeze
+
+  validates :phone_number, presence: true, uniqueness: true
+
+  def name
+    'Plivo'
+  end
+
+  def messaging_url
+    "https://api.plivo.com/v1/Account/#{provider_config['auth_id']}/Message/"
+  end
+
+  def send_message(contact_number, message)
+    body = message_body(contact_number, message.outgoing_content)
+    if message.attachments.present?
+      body[:type] = 'mms'
+      body[:media_urls] = message.attachments.map(&:download_url)
+    end
+
+    send_to_plivo(body, message)
+  end
+
+  def send_text_message(contact_number, message_content)
+    send_to_plivo(message_body(contact_number, message_content))
+  end
+
+  private
+
+  def message_body(contact_number, message_content)
+    {
+      src: phone_number,
+      dst: contact_number,
+      text: message_content
+    }
+  end
+
+  def send_to_plivo(body, message = nil)
+    response = HTTParty.post(
+      messaging_url,
+      basic_auth: plivo_auth,
+      headers: { 'Content-Type' => 'application/json' },
+      body: body.to_json
+    )
+
+    if response.success?
+      response.parsed_response['message_uuid']&.first
+    else
+      handle_error(response, message)
+      nil
+    end
+  end
+
+  def handle_error(response, message)
+    error = response.parsed_response.is_a?(Hash) ? response.parsed_response['error'] : response.body
+    Rails.logger.error("[#{account_id}] Error sending Plivo message: #{error}")
+    return if message.blank?
+
+    message.external_error = error
+    message.status = :failed
+    message.save!
+  end
+
+  def plivo_auth
+    { username: provider_config['auth_id'], password: plivo_token }
+  end
+
+  def plivo_token
+    provider_config['auth_token']
+  end
+end

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -123,6 +123,10 @@ class Inbox < ApplicationRecord
     channel_type == 'Channel::Sms'
   end
 
+  def plivo?
+    channel_type == 'Channel::Plivo'
+  end
+
   def facebook?
     channel_type == 'Channel::FacebookPage'
   end
@@ -192,6 +196,8 @@ class Inbox < ApplicationRecord
       "#{ENV.fetch('FRONTEND_URL', nil)}/twilio/callback"
     when 'Channel::Sms'
       "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/sms/#{channel.phone_number.delete_prefix('+')}"
+    when 'Channel::Plivo'
+      "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/plivo/#{channel.phone_number.delete_prefix('+')}"
     when 'Channel::Line'
       "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/line/#{channel.line_channel_id}"
     when 'Channel::Whatsapp'

--- a/app/services/contacts/contactable_inboxes_service.rb
+++ b/app/services/contacts/contactable_inboxes_service.rb
@@ -16,6 +16,8 @@ class Contacts::ContactableInboxesService
       whatsapp_contactable_inbox(inbox)
     when 'Channel::Sms'
       sms_contactable_inbox(inbox)
+    when 'Channel::Plivo'
+      plivo_contactable_inbox(inbox)
     when 'Channel::Email'
       email_contactable_inbox(inbox)
     when 'Channel::Api'
@@ -55,6 +57,12 @@ class Contacts::ContactableInboxesService
   end
 
   def sms_contactable_inbox(inbox)
+    return if @contact.phone_number.blank?
+
+    { source_id: @contact.phone_number, inbox: inbox }
+  end
+
+  def plivo_contactable_inbox(inbox)
     return if @contact.phone_number.blank?
 
     { source_id: @contact.phone_number, inbox: inbox }

--- a/app/services/messages/markdown_renderer_service.rb
+++ b/app/services/messages/markdown_renderer_service.rb
@@ -9,6 +9,7 @@ class Messages::MarkdownRendererService
     'Channel::Line' => :render_line,
     'Channel::TwitterProfile' => :render_plain_text,
     'Channel::Sms' => :render_plain_text,
+    'Channel::Plivo' => :render_plain_text,
     'Channel::TwilioSms' => :render_plain_text
   }.freeze
 

--- a/app/services/plivo/delivery_status_service.rb
+++ b/app/services/plivo/delivery_status_service.rb
@@ -1,0 +1,51 @@
+class Plivo::DeliveryStatusService
+  pattr_initialize [:inbox!, :params!]
+
+  # Plivo message states:
+  # https://www.plivo.com/docs/sms/api/message#the-message-object
+  STATUS_MAPPING = {
+    'sent' => 'sent',
+    'delivered' => 'delivered',
+    'undelivered' => 'failed',
+    'failed' => 'failed',
+    'rejected' => 'failed'
+  }.freeze
+
+  def perform
+    return unless supported_status?
+
+    process_status if message.present?
+  end
+
+  private
+
+  def process_status
+    @message.status = status
+    @message.external_error = external_error if error_occurred?
+    @message.save!
+  end
+
+  def supported_status?
+    STATUS_MAPPING.key?(params[:status])
+  end
+
+  def status
+    STATUS_MAPPING[params[:status]]
+  end
+
+  def error_occurred?
+    params[:error_code].present? && status == 'failed'
+  end
+
+  def external_error
+    return nil unless error_occurred?
+
+    params[:error_code]
+  end
+
+  def message
+    return if params[:id].blank?
+
+    @message ||= inbox.messages.find_by(source_id: params[:id])
+  end
+end

--- a/app/services/plivo/incoming_message_service.rb
+++ b/app/services/plivo/incoming_message_service.rb
@@ -29,7 +29,8 @@ class Plivo::IncomingMessageService
   end
 
   def phone_number
-    params[:from]
+    number = params[:from].to_s
+    number.start_with?('+') ? number : "+#{number}"
   end
 
   def formatted_phone_number
@@ -38,7 +39,7 @@ class Plivo::IncomingMessageService
 
   def set_contact
     contact_inbox = ::ContactInboxWithContactBuilder.new(
-      source_id: params[:from],
+      source_id: phone_number,
       inbox: @inbox,
       contact_attributes: contact_attributes
     ).perform

--- a/app/services/plivo/incoming_message_service.rb
+++ b/app/services/plivo/incoming_message_service.rb
@@ -1,0 +1,98 @@
+class Plivo::IncomingMessageService
+  include ::FileTypeHelper
+
+  pattr_initialize [:inbox!, :params!]
+
+  def perform
+    set_contact
+    set_conversation
+    @message = @conversation.messages.create!(
+      content: params[:text],
+      account_id: @inbox.account_id,
+      inbox_id: @inbox.id,
+      message_type: :incoming,
+      sender: @contact,
+      source_id: params[:id]
+    )
+    attach_files
+    @message.save!
+  end
+
+  private
+
+  def account
+    @account ||= @inbox.account
+  end
+
+  def channel
+    @channel ||= @inbox.channel
+  end
+
+  def phone_number
+    params[:from]
+  end
+
+  def formatted_phone_number
+    TelephoneNumber.parse(phone_number).international_number
+  end
+
+  def set_contact
+    contact_inbox = ::ContactInboxWithContactBuilder.new(
+      source_id: params[:from],
+      inbox: @inbox,
+      contact_attributes: contact_attributes
+    ).perform
+
+    @contact_inbox = contact_inbox
+    @contact = contact_inbox.contact
+  end
+
+  def conversation_params
+    {
+      account_id: @inbox.account_id,
+      inbox_id: @inbox.id,
+      contact_id: @contact.id,
+      contact_inbox_id: @contact_inbox.id
+    }
+  end
+
+  def set_conversation
+    @conversation = if @inbox.lock_to_single_conversation
+                      @contact_inbox.conversations.last
+                    else
+                      @contact_inbox.conversations.where
+                                    .not(status: :resolved).last
+                    end
+    return if @conversation
+
+    @conversation = ::Conversation.create!(conversation_params)
+  end
+
+  def contact_attributes
+    {
+      name: formatted_phone_number,
+      phone_number: phone_number
+    }
+  end
+
+  def attach_files
+    return if params[:media].blank?
+
+    params[:media].each do |media_url|
+      attachment_file = Down.download(
+        media_url,
+        http_basic_authentication: [channel.provider_config['auth_id'], channel.provider_config['auth_token']]
+      )
+
+      @message.attachments.new(
+        account_id: @message.account_id,
+        file_type: file_type(attachment_file.content_type),
+        file: {
+          io: attachment_file,
+          filename: attachment_file.original_filename,
+          content_type: attachment_file.content_type
+        }
+      )
+    end
+  end
+end

--- a/app/services/plivo/send_on_plivo_service.rb
+++ b/app/services/plivo/send_on_plivo_service.rb
@@ -1,0 +1,12 @@
+class Plivo::SendOnPlivoService < Base::SendOnChannelService
+  private
+
+  def channel_class
+    Channel::Plivo
+  end
+
+  def perform_reply
+    message_id = channel.send_message(message.conversation.contact_inbox.source_id, message)
+    message.update!(source_id: message_id) if message_id.present?
+  end
+end

--- a/app/services/plivo/signature_validator.rb
+++ b/app/services/plivo/signature_validator.rb
@@ -1,0 +1,27 @@
+class Plivo::SignatureValidator
+  # Recomputes Plivo's V3 request signature and compares it against the header.
+  # Base string is the exact posted URL, a sorted concatenation of the body
+  # parameters, and the nonce, keyed by the Auth Token with HMAC-SHA256.
+  # Ported from the verified Plivo Kestra plugin implementation.
+  # https://www.plivo.com/docs/messaging/concepts/validate-signature/
+  pattr_initialize [:auth_token!, :url!, :params!, :nonce!, :signature!]
+
+  def valid?
+    return false if auth_token.blank? || url.blank? || nonce.blank? || signature.blank?
+
+    ActiveSupport::SecurityUtils.secure_compare(computed_signature, signature)
+  end
+
+  private
+
+  def computed_signature
+    base = +url
+    if params.present?
+      base << '?'
+      params.sort_by { |key, _| key.to_s }.each { |key, value| base << "#{key}#{value}" }
+    end
+    base << ".#{nonce}"
+
+    Base64.strict_encode64(OpenSSL::HMAC.digest('sha256', auth_token, base))
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -653,6 +653,7 @@ Rails.application.routes.draw do
   post 'webhooks/line/:line_channel_id', to: 'webhooks/line#process_payload'
   post 'webhooks/telegram/:bot_token', to: 'webhooks/telegram#process_payload'
   post 'webhooks/sms/:phone_number', to: 'webhooks/sms#process_payload'
+  post 'webhooks/plivo/:phone_number', to: 'webhooks/plivo#process_payload'
   get 'webhooks/whatsapp/:phone_number', to: 'webhooks/whatsapp#verify'
   post 'webhooks/whatsapp/:phone_number', to: 'webhooks/whatsapp#process_payload'
   get 'webhooks/instagram', to: 'webhooks/instagram#verify'

--- a/db/migrate/20260814120000_create_channel_plivo.rb
+++ b/db/migrate/20260814120000_create_channel_plivo.rb
@@ -1,0 +1,12 @@
+class CreateChannelPlivo < ActiveRecord::Migration[7.1]
+  def change
+    create_table :channel_plivo do |t|
+      t.string :phone_number, null: false
+      t.jsonb :provider_config, default: {}
+      t.integer :account_id, null: false
+      t.timestamps
+    end
+
+    add_index :channel_plivo, :phone_number, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_07_101420) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_14_120000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -614,6 +614,15 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_07_101420) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["line_channel_id"], name: "index_channel_line_on_line_channel_id", unique: true
+  end
+
+  create_table "channel_plivo", force: :cascade do |t|
+    t.string "phone_number", null: false
+    t.jsonb "provider_config", default: {}
+    t.integer "account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["phone_number"], name: "index_channel_plivo_on_phone_number", unique: true
   end
 
   create_table "channel_sms", force: :cascade do |t|


### PR DESCRIPTION
## Summary

Adds Plivo as a native two-way SMS channel, following the existing built-in SMS channel structure. Creating a Plivo SMS inbox lets an account send and receive SMS as conversations using a Plivo number, Auth ID, and Auth Token. Outbound replies send through the Plivo Messaging API, and inbound Plivo messages arrive over a signature-validated webhook and create or continue a conversation keyed on the contact phone number.

Closes #15476.

## What is included

- `Channel::Plivo` model and migration (`channel_plivo`)
- Outbound send via `Plivo::SendOnPlivoService`
- Inbound via `Webhooks::PlivoController` to `Webhooks::PlivoEventsJob` to `Plivo::IncomingMessageService`, with `Plivo::DeliveryStatusService` for delivery reports
- Webhook signature validation (`Plivo::SignatureValidator`)
- Inbox creation form (`Plivo.vue`) and a Plivo option in the SMS provider screen, with i18n
- Wiring across routes, send reply job, account, inbox, contact inbox builder, contactable inboxes service, inboxes controller, and the markdown renderer

## Design note

Implemented as a standalone `Channel::Plivo`, consistent with how each SMS provider currently has its own channel model, rather than a provider flag on the shared SMS channel. The inbound webhook payload differs from the existing provider, so a standalone class keeps the change self-contained. Happy to reshape into a provider option if that is preferred, as raised in #15476.

## Test plan

Validated end to end against a live Plivo account.

- [x] Outbound reply delivered (Plivo reported the message as delivered)
- [x] Inbound message with a valid signature accepted and a conversation created
- [x] Invalid signature rejected
- [x] Full two-way exchange within one conversation

The signature is validated against the canonical callback URL built from `FRONTEND_URL`, so it holds behind a proxy. Inbound numbers are normalized to E.164 since Plivo omits the leading `+`.

Inbound MMS media parameters are not yet covered.

This is a draft to prototype the approach described in #15476.
