### PR TITLE
ci: bump lock-threads to v6 so the hourly job can run again

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'chatwoot/chatwoot' }}
     steps:
-      - uses: dessant/lock-threads@v3
+      - uses: dessant/lock-threads@v6
         with: 
           issue-inactive-days: '30'
           issue-lock-reason: 'resolved'


### PR DESCRIPTION
## What

Lock Threads has been failing on every scheduled run for roughly three months. The last 100 runs have zero successes, and each one ends at input validation before doing any work:

```
##[error]"github-token" length must be less than or equal to 100 characters long
```

## Why

`dessant/lock-threads` validates `github-token` against a max length in its schema. v3, v4 and v5 all cap it at 100 characters; v6 raises the cap to 1000. `GITHUB_TOKEN` has since grown past 100 characters, so the pinned `@v3` now rejects the token it is handed. Failures start around late May and have been continuous since.

The practical effect is the thing the workflow comment describes — keeping stale closed threads from collecting noise for the original reporter — has silently not happened since then, plus a failed run every hour.

## Change

`@v3` → `@v6`. All four inputs this workflow passes (`issue-inactive-days`, `issue-lock-reason`, `pr-inactive-days`, `pr-lock-reason`) exist unchanged in v6, so it is a drop-in bump with no config changes needed.
