### PR TITLE
ci: use pull_request_target so auto-assign works on fork PRs

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,7 +1,7 @@
 name: Auto-assign PR to Author
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
## What

Auto-assign fails on every pull request opened from a fork, so outside contributors get a red X on their first PR from a maintainer-owned workflow, and the assignment never happens for them.

Splitting recent runs by head repo shows the pattern cleanly: PRs from branches on this repo succeed, PRs from forks fail. Every failure is the same:

```
RequestError [HttpError]: Resource not accessible by integration
status: 403
```

## Why

On a `pull_request` event raised from a fork, `GITHUB_TOKEN` is read-only regardless of what the `permissions:` block requests. That is deliberate on GitHub's side, since the workflow file itself comes from the untrusted head. So `issues.addAssignees` 403s.

## Change

`pull_request` → `pull_request_target`, which runs the workflow definition from the base repo and restores a writable token.

On the safety question, this is the case where that swap is safe rather than the dangerous one: the job has **no checkout step**. It runs `actions/github-script` and reads only `context.repo`, `context.payload.pull_request.number` and `context.payload.pull_request.user.login` from the event payload. No code from the pull request is fetched or executed, so the elevated token is never exposed to untrusted input.
