### PR TITLE
fix: preserve CSAT agent attribution when the conversation is unassigned before rating

### DIFF
--- a/app/builders/csat_surveys/response_builder.rb
+++ b/app/builders/csat_surveys/response_builder.rb
@@ -18,11 +18,23 @@ class CsatSurveys::ResponseBuilder
   def process_csat_response(conversation, rating, feedback_message)
     csat_survey_response = message.csat_survey_response || CsatSurveyResponse.new(
       message_id: message.id, account_id: message.account_id, conversation_id: message.conversation_id,
-      contact_id: conversation.contact_id, assigned_agent: conversation.assignee
+      contact_id: conversation.contact_id, assigned_agent: assigned_agent(conversation)
     )
     csat_survey_response.rating = rating
     csat_survey_response.feedback_message = feedback_message
     csat_survey_response.save!
     csat_survey_response
+  end
+
+  # The agent snapshotted into the survey message when it was sent, falling
+  # back to the conversation's current assignee for surveys sent before the
+  # snapshot existed. Reading the assignee only at submission time loses the
+  # attribution whenever an automation unassigns the conversation between
+  # resolution and the contact clicking the rating (#14872).
+  def assigned_agent(conversation)
+    snapshot_id = message.content_attributes['assigned_agent_id']
+    snapshot_agent = User.find_by(id: snapshot_id) if snapshot_id.present?
+
+    snapshot_agent || conversation.assignee
   end
 end

--- a/app/listeners/csat_survey_listener.rb
+++ b/app/listeners/csat_survey_listener.rb
@@ -4,7 +4,10 @@ class CsatSurveyListener < BaseListener
 
     return unless conversation.resolved?
 
-    CsatSurveyService.new(conversation: conversation).perform
+    # The event carries the assignee as it was when the status change was
+    # dispatched - the conversation itself is reloaded here and may already
+    # have been unassigned by an automation running off the resolved event.
+    CsatSurveyService.new(conversation: conversation, assignee_id: event.data[:assignee_id]).perform
   end
 
   def message_updated(event)

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -163,6 +163,16 @@ class Conversation < ApplicationRecord
     messages.where(account_id: account_id)&.incoming&.last
   end
 
+  # The agent a CSAT response for this conversation should credit: the live
+  # assignee when there is one, otherwise the last human agent who replied to
+  # the contact. The fallback matters because CONVERSATION_RESOLVED is
+  # dispatched before CONVERSATION_STATUS_CHANGED and each listener runs in
+  # its own job, so an unassign-on-resolve automation has typically already
+  # cleared the assignee by the time the survey job builds the message (#14872).
+  def csat_survey_agent_id
+    assignee_id || messages.outgoing.where(sender_type: 'User', private: false).reorder(created_at: :desc).pick(:sender_id)
+  end
+
   def toggle_status
     # FIXME: implement state machine with aasm
     self.status = open? ? :resolved : :open
@@ -382,9 +392,18 @@ class Conversation < ApplicationRecord
   end
 
   def dispatcher_dispatch(event_name, changed_attributes = nil)
-    Rails.configuration.dispatcher.dispatch(event_name, Time.zone.now, conversation: self, notifiable_assignee_change: notifiable_assignee_change?,
-                                                                       changed_attributes: changed_attributes,
-                                                                       performed_by: Current.executed_by)
+    payload = { conversation: self, notifiable_assignee_change: notifiable_assignee_change?,
+                changed_attributes: changed_attributes,
+                performed_by: Current.executed_by }
+    # Captured here, synchronously, because listeners run in their own jobs
+    # against a reloaded record: an automation triggered by an earlier event
+    # in this same batch (CONVERSATION_RESOLVED precedes
+    # CONVERSATION_STATUS_CHANGED) can unassign the conversation before the
+    # CSAT listener reads it, which is how survey responses lost their agent
+    # attribution (#14872).
+    payload[:assignee_id] = assignee_id if event_name == CONVERSATION_STATUS_CHANGED
+
+    Rails.configuration.dispatcher.dispatch(event_name, Time.zone.now, **payload)
   end
 
   def set_unread_count_deletion_data

--- a/app/services/csat_survey_service.rb
+++ b/app/services/csat_survey_service.rb
@@ -1,5 +1,7 @@
 class CsatSurveyService
-  pattr_initialize [:conversation!]
+  # assignee_id is the assignee as captured when the triggering event was
+  # dispatched; see CsatSurveyListener#conversation_status_changed.
+  pattr_initialize [:conversation!, :assignee_id]
 
   def perform
     return unless should_send_csat_survey?
@@ -9,7 +11,7 @@ class CsatSurveyService
     elsif inbox.twilio_whatsapp? && twilio_template_available_and_approved?
       send_twilio_whatsapp_template_survey
     elsif within_messaging_window?
-      ::MessageTemplates::Template::CsatSurvey.new(conversation: conversation).perform
+      ::MessageTemplates::Template::CsatSurvey.new(conversation: conversation, assigned_agent_id: survey_agent_id).perform
     else
       create_csat_not_sent_activity_message
     end
@@ -18,6 +20,15 @@ class CsatSurveyService
   private
 
   delegate :inbox, :contact, to: :conversation
+
+  # Precedence: the assignee captured at event dispatch (before any
+  # unassign-on-resolve automation could run), then the conversation's own
+  # resolution - live assignee, else the last human agent who replied, for
+  # conversations that were already unassigned when they were resolved and
+  # for surveys enqueued before the event carried the assignee.
+  def survey_agent_id
+    @survey_agent_id ||= assignee_id || conversation.csat_survey_agent_id
+  end
 
   def should_send_csat_survey?
     conversation_allows_csat? && csat_enabled? && !csat_already_sent? && csat_allowed_by_survey_rules?
@@ -140,7 +151,11 @@ class CsatSurveyService
       inbox: inbox,
       message_type: :outgoing,
       content: inbox.csat_config&.dig('message') || 'Please rate this conversation',
-      content_type: :input_csat
+      content_type: :input_csat,
+      # Same snapshot MessageTemplates::Template::CsatSurvey takes: the agent
+      # must be captured when the survey goes out, or an unassign-on-resolve
+      # automation erases the attribution before the rating arrives (#14872).
+      content_attributes: { assigned_agent_id: survey_agent_id }
     )
   end
 

--- a/app/services/message_templates/template/csat_survey.rb
+++ b/app/services/message_templates/template/csat_survey.rb
@@ -1,5 +1,8 @@
 class MessageTemplates::Template::CsatSurvey
-  pattr_initialize [:conversation!]
+  # assigned_agent_id: who the eventual response should credit, captured by
+  # the caller while it was still known. Falls back to what the conversation
+  # itself can still tell us.
+  pattr_initialize [:conversation!, :assigned_agent_id]
 
   def perform
     ActiveRecord::Base.transaction do
@@ -34,7 +37,13 @@ class MessageTemplates::Template::CsatSurvey
 
   def content_attributes
     {
-      display_type: csat_config['display_type'] || 'emoji'
+      display_type: csat_config['display_type'] || 'emoji',
+      # Captured when the survey is sent, not when the contact answers it:
+      # by submission time an automation may long since have unassigned the
+      # conversation and the response would be recorded without an agent
+      # (#14872). See Conversation#csat_survey_agent_id for why the assignee
+      # alone is not enough even at this point.
+      assigned_agent_id: assigned_agent_id || @conversation.csat_survey_agent_id
     }
   end
 end

--- a/spec/builders/csat_surveys/response_builder_spec.rb
+++ b/spec/builders/csat_surveys/response_builder_spec.rb
@@ -26,5 +26,44 @@ describe CsatSurveys::ResponseBuilder do
       expect(csat_survey_response.id).to eq(existing_survey_response.id)
       expect(csat_survey_response.rating).to eq(5)
     end
+
+    context 'when the conversation is unassigned before the contact submits the rating' do
+      let(:account) { create(:account) }
+      let(:agent) { create(:user, account: account, role: :agent) }
+      let(:conversation) { create(:conversation, account: account, assignee: nil) }
+      let(:message) do
+        create(
+          :message, account: account, conversation: conversation, content_type: :input_csat,
+                    content_attributes: {
+                      'assigned_agent_id': agent.id,
+                      'submitted_values': { 'csat_survey_response': { 'rating': 4 } }
+                    }
+        )
+      end
+
+      it 'attributes the response to the agent snapshotted when the survey was sent' do
+        csat_survey_response = described_class.new(message: message).perform
+
+        expect(csat_survey_response.assigned_agent).to eq(agent)
+      end
+    end
+
+    context 'when the survey message predates the assignee snapshot' do
+      let(:account) { create(:account) }
+      let(:agent) { create(:user, account: account, role: :agent) }
+      let(:conversation) { create(:conversation, account: account, assignee: agent) }
+      let(:message) do
+        create(
+          :message, account: account, conversation: conversation, content_type: :input_csat,
+                    content_attributes: { 'submitted_values': { 'csat_survey_response': { 'rating': 4 } } }
+        )
+      end
+
+      it 'falls back to the conversation assignee' do
+        csat_survey_response = described_class.new(message: message).perform
+
+        expect(csat_survey_response.assigned_agent).to eq(agent)
+      end
+    end
   end
 end

--- a/spec/listeners/csat_survey_listener_spec.rb
+++ b/spec/listeners/csat_survey_listener_spec.rb
@@ -48,7 +48,18 @@ describe CsatSurveyListener do
       it 'triggers CSAT survey service' do
         event = Events::Base.new(event_name, Time.zone.now, conversation: resolved_conversation)
         expect(csat_service).to receive(:perform)
-        expect(CsatSurveyService).to receive(:new).with(conversation: resolved_conversation).and_return(csat_service)
+        expect(CsatSurveyService).to receive(:new).with(conversation: resolved_conversation, assignee_id: nil).and_return(csat_service)
+
+        listener.conversation_status_changed(event)
+      end
+
+      it 'passes the assignee captured at event dispatch to the service' do
+        # The event snapshot is authoritative: by the time this listener runs,
+        # an automation triggered by the resolved event may already have
+        # unassigned the reloaded conversation.
+        event = Events::Base.new(event_name, Time.zone.now, conversation: resolved_conversation, assignee_id: user.id)
+        expect(csat_service).to receive(:perform)
+        expect(CsatSurveyService).to receive(:new).with(conversation: resolved_conversation, assignee_id: user.id).and_return(csat_service)
 
         listener.conversation_status_changed(event)
       end

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -1070,6 +1070,38 @@ RSpec.describe Conversation do
     end
   end
 
+  describe '#csat_survey_agent_id' do
+    let(:account) { create(:account) }
+    let(:agent) { create(:user, account: account, role: :agent) }
+    let(:other_agent) { create(:user, account: account, role: :agent) }
+    let(:conversation) { create(:conversation, account: account, assignee: nil) }
+
+    it 'returns the assignee when the conversation is assigned' do
+      conversation.update!(assignee: agent)
+
+      expect(conversation.csat_survey_agent_id).to eq(agent.id)
+    end
+
+    it 'falls back to the last replying agent when the conversation is unassigned' do
+      create(:message, conversation: conversation, account: account, message_type: :outgoing, sender: other_agent)
+      create(:message, conversation: conversation, account: account, message_type: :outgoing, sender: agent)
+
+      expect(conversation.csat_survey_agent_id).to eq(agent.id)
+    end
+
+    it 'ignores private notes and incoming messages' do
+      create(:message, conversation: conversation, account: account, message_type: :incoming)
+      create(:message, conversation: conversation, account: account, message_type: :outgoing, sender: agent)
+      create(:message, conversation: conversation, account: account, message_type: :outgoing, private: true, sender: other_agent)
+
+      expect(conversation.csat_survey_agent_id).to eq(agent.id)
+    end
+
+    it 'returns nil when nobody was assigned and no agent replied' do
+      expect(conversation.csat_survey_agent_id).to be_nil
+    end
+  end
+
   describe '#can_reply?' do
     let(:conversation) { create(:conversation) }
     let(:message_window_service) { instance_double(Conversations::MessageWindowService) }

--- a/spec/services/csat_survey_service_spec.rb
+++ b/spec/services/csat_survey_service_spec.rb
@@ -25,7 +25,7 @@ describe CsatSurveyService do
       it 'sends CSAT survey when within messaging window' do
         service.perform
 
-        expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: conversation)
+        expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: conversation, assigned_agent_id: nil)
         expect(csat_template).to have_received(:perform)
       end
     end
@@ -225,7 +225,7 @@ describe CsatSurveyService do
 
           whatsapp_service.perform
 
-          expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: whatsapp_conversation)
+          expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: whatsapp_conversation, assigned_agent_id: nil)
           expect(csat_template).to have_received(:perform)
         end
 
@@ -234,7 +234,7 @@ describe CsatSurveyService do
 
           whatsapp_service.perform
 
-          expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: whatsapp_conversation)
+          expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: whatsapp_conversation, assigned_agent_id: nil)
           expect(csat_template).to have_received(:perform)
         end
 
@@ -245,7 +245,7 @@ describe CsatSurveyService do
 
           whatsapp_service.perform
 
-          expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: whatsapp_conversation)
+          expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: whatsapp_conversation, assigned_agent_id: nil)
           expect(csat_template).to have_received(:perform)
         end
 
@@ -255,7 +255,7 @@ describe CsatSurveyService do
 
           whatsapp_service.perform
 
-          expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: whatsapp_conversation)
+          expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: whatsapp_conversation, assigned_agent_id: nil)
           expect(csat_template).to have_received(:perform)
         end
       end
@@ -264,7 +264,7 @@ describe CsatSurveyService do
         it 'falls back to regular survey' do
           whatsapp_service.perform
 
-          expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: whatsapp_conversation)
+          expect(MessageTemplates::Template::CsatSurvey).to have_received(:new).with(conversation: whatsapp_conversation, assigned_agent_id: nil)
           expect(csat_template).to have_received(:perform)
         end
       end

--- a/spec/services/message_templates/template/csat_survey_spec.rb
+++ b/spec/services/message_templates/template/csat_survey_spec.rb
@@ -37,5 +37,32 @@ describe MessageTemplates::Template::CsatSurvey do
         expect(message.content_attributes['display_type']).to eq('star')
       end
     end
+
+    context 'when snapshotting the agent for response attribution' do
+      let(:agent) { create(:user, account: account, role: :agent) }
+      let(:other_agent) { create(:user, account: account, role: :agent) }
+
+      it 'prefers the agent id handed in by the caller' do
+        # The caller captured it from the event payload - the conversation
+        # itself may already have been unassigned by an automation.
+        conversation.update!(assignee: other_agent)
+        inbox.update(csat_config: {})
+
+        described_class.new(conversation: conversation, assigned_agent_id: agent.id).perform
+
+        message = conversation.messages.template.last
+        expect(message.content_attributes['assigned_agent_id']).to eq(agent.id)
+      end
+
+      it 'snapshots the assignee when the caller has nothing better' do
+        conversation.update!(assignee: agent)
+        inbox.update(csat_config: {})
+
+        service.perform
+
+        message = conversation.messages.template.last
+        expect(message.content_attributes['assigned_agent_id']).to eq(agent.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
## The bug

`CsatSurveys::ResponseBuilder` reads `conversation.assignee` at the moment the contact **submits** the rating. Any automation that unassigns the conversation before then (the built-in `assign_agent: nil` / `remove_assigned_agent` actions, a common round-robin hygiene pattern) clears it first, and the response is silently recorded with no agent — the CSAT report shows *No assigned agent* for conversations that were fully handled.

On our self-hosted instance (4.16.2) this orphaned **99.6% of a month's responses** — details in #14872, which this fixes.

## The fix

Three layers, each with a concrete production path (no speculative guards):

1. **The event carries the assignee.** `CONVERSATION_STATUS_CHANGED` now includes `assignee_id`, captured synchronously at dispatch in `Conversation#dispatcher_dispatch` — before any listener job runs. This is the authoritative value: the unassign automation runs off `CONVERSATION_RESOLVED`, which is dispatched first as its own job, so by the time `CsatSurveyListener` runs, the reloaded conversation may already be unassigned. Scoped to that single event so the exact-payload expectations on other conversation events remain untouched.
2. **The survey message snapshots the agent at send time**, in both creation paths (`MessageTemplates::Template::CsatSurvey` and `CsatSurveyService#build_csat_message`, covering both WhatsApp template flows). `ResponseBuilder` prefers the snapshot; survey messages that predate it fall back to the live assignee, exactly as before.
3. **`Conversation#csat_survey_agent_id`** (live assignee, else the last human agent who publicly replied) covers conversations that were **already unassigned when they were resolved** — the routine steady state under these automations, and most of our 99.6% — plus surveys enqueued before the event carried the key.

(`performed_by` cannot serve here: `Current.executed_by` is only set for automation/bot actors, so an agent clicking Resolve leaves it nil.)

## Why this is safe

- The public widget update endpoint permits only `submitted_values` (`Public::Api::V1::Inboxes::MessagesController#message_update_params`), and Rails `store` accessors write single keys — the snapshot cannot be altered or forged from the contact side.
- `User.find_by` + fallback means a deleted agent degrades to the previous behaviour instead of raising.
- No schema change; responses recorded before the fix are unaffected (they can be recovered separately via `reporting_events`, SQL in #14872).

## Tests

- Listener: the event's `assignee_id` flows into `CsatSurveyService`.
- Service: template receives the resolved snapshot (existing expectations updated for the new argument).
- Template: a caller-provided agent id wins over the live assignee; assignee snapshotted when no caller value exists.
- Model: `csat_survey_agent_id` — assignee when assigned; last replying agent when unassigned; private notes and incoming messages ignored; nil when neither exists.
- Builder: response attributed to the snapshotted agent when the conversation is already unassigned at submission; falls back to the conversation assignee when no snapshot exists.

Fixes #14872