### PR TITLE
perf: avoid cross-table OR in conversation search

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -31,10 +31,19 @@ class SearchService
   end
 
   def filter_conversations
-    conversations_query = current_account.conversations.where(inbox_id: accessable_inbox_ids)
-                                         .joins('INNER JOIN contacts ON conversations.contact_id = contacts.id')
-                                         .where("cast(conversations.display_id as text) ILIKE :search OR contacts.name ILIKE :search OR contacts.email
-                            ILIKE :search OR contacts.phone_number ILIKE :search OR contacts.identifier ILIKE :search", search: "%#{search_query}%")
+    # Filtering on contacts via a subquery instead of an OR across the joined tables
+    # lets postgres use the trigram index on contacts and skip the join entirely,
+    # since an OR spanning two tables forces a full scan of both.
+    base_query = current_account.conversations.where(inbox_id: accessable_inbox_ids)
+    conversations_query = base_query.where(contact_id: matching_contact_ids)
+
+    # display_id is numeric, so a search term with non-digit characters can never match it
+    if search_query.match?(/\A\d+\z/)
+      conversations_query = conversations_query.or(
+        base_query.where.not(contact_id: nil)
+                  .where('CAST(conversations.display_id AS TEXT) ILIKE :search', search: "%#{search_query}%")
+      )
+    end
 
     if current_account.feature_enabled?('advanced_search')
       conversations_query = apply_time_filter(conversations_query,
@@ -44,6 +53,13 @@ class SearchService
     @conversations = conversations_query.order('conversations.created_at DESC')
                                         .page(params[:page])
                                         .per(15)
+  end
+
+  def matching_contact_ids
+    current_account.contacts.where(
+      'name ILIKE :search OR email ILIKE :search OR phone_number ILIKE :search OR identifier ILIKE :search',
+      search: "%#{search_query}%"
+    ).select(:id)
   end
 
   def filter_messages


### PR DESCRIPTION
Conversation search (omnisearch / Conversation tab) becomes extremely slow on large installations. On a self-hosted database with 4.4M conversations and 750k contacts, a single search took 24–80 seconds and spilled ~3.5GB to temp files, showing up as the top query by total load in query insights. This PR makes the same search return in ~110ms for text terms.

## How to reproduce

On an account with a large number of conversations and contacts, type any text into the dashboard search (Conversation results). `SearchService#filter_conversations` runs:

```sql
... INNER JOIN contacts ON conversations.contact_id = contacts.id
WHERE cast(conversations.display_id as text) ILIKE :search
   OR contacts.name ILIKE :search OR contacts.email ILIKE :search
   OR contacts.phone_number ILIKE :search OR contacts.identifier ILIKE :search
```

Because the OR spans columns from two different tables, postgres cannot use any index for it — not even the existing trigram GIN index on contacts. The plan degrades to `all conversations of accessible inboxes ⋈ all contacts of the account`, evaluating the ILIKEs per joined row.

## What changed

- Contacts are matched in a subquery (`conversations.contact_id IN (SELECT id FROM contacts WHERE ...)`), which lets postgres use the existing `index_contacts_on_name_email_phone_number_identifier` trigram index and drop the join.
- The `display_id` condition is only added when the search term consists solely of digits — `display_id` is numeric, so a term containing any non-digit character can never match it. `contact_id IS NOT NULL` is kept on that branch to preserve the previous INNER JOIN semantics.
- Search results and their ordering are unchanged; existing specs in `spec/services/search_service_spec.rb` (contact-info search, display_id search, time caps) cover both branches.

Measured on the dataset above (`EXPLAIN ANALYZE`, warm cache):

| search term | before | after |
|---|---|---|
| text (e.g. a name) | ~24s | ~110ms |
| digits only | ~24s | ~4.4s |

The digit-only case still can't use an index for the `display_id` substring match; fixing that would need a trigram expression index on `cast(display_id as text)`, which felt out of scope for this change but I'm happy to add it if you'd take it.