### PR TITLE
fix: honour a single since/until bound instead of silently dropping the date filter

### DIFF
--- a/app/helpers/date_range_helper.rb
+++ b/app/helpers/date_range_helper.rb
@@ -5,9 +5,19 @@
 
 module DateRangeHelper
   def range
-    return if params[:since].blank? || params[:until].blank?
+    return if params[:since].blank? && params[:until].blank?
 
-    parse_date_time(params[:since])...parse_date_time(params[:until])
+    # A single bound must not disable filtering: this used to return nil when
+    # either param was missing, and every caller treats a nil range as "no
+    # filter" - so an API consumer sending only `since` silently received the
+    # account's full history. The missing bound defaults instead: the epoch
+    # for `since`, now for `until`. Concrete bounds rather than beginless or
+    # endless ranges, because report builders call range.first / range.last,
+    # which raise on those.
+    since = params[:since].present? ? parse_date_time(params[:since]) : DateTime.strptime('0', '%s')
+    till = params[:until].present? ? parse_date_time(params[:until]) : DateTime.current
+
+    since...till
   end
 
   def parse_date_time(datetime)

--- a/spec/helpers/date_range_helper_spec.rb
+++ b/spec/helpers/date_range_helper_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe DateRangeHelper do
+  let(:helper_class) do
+    Class.new do
+      include DateRangeHelper
+
+      attr_reader :params
+
+      def initialize(params)
+        @params = params
+      end
+    end
+  end
+
+  def range_for(params)
+    helper_class.new(ActionController::Parameters.new(params)).range
+  end
+
+  describe '#range' do
+    let(:since_epoch) { 3.days.ago.beginning_of_day.to_i.to_s }
+    let(:until_epoch) { 1.day.ago.end_of_day.to_i.to_s }
+
+    it 'returns nil when neither bound is given' do
+      expect(range_for({})).to be_nil
+    end
+
+    it 'builds the range from both bounds' do
+      range = range_for(since: since_epoch, until: until_epoch)
+
+      expect(range.first.to_i).to eq(since_epoch.to_i)
+      expect(range.last.to_i).to eq(until_epoch.to_i)
+      expect(range).to be_exclude_end
+    end
+
+    it 'defaults the upper bound to now when only since is given' do
+      # Regression: a single bound used to return nil, which every caller
+      # treats as "no filter" - a since-only request silently received the
+      # full unfiltered history.
+      range = range_for(since: since_epoch)
+
+      expect(range).not_to be_nil
+      expect(range.first.to_i).to eq(since_epoch.to_i)
+      expect(range.last.to_i).to be_within(5).of(Time.zone.now.to_i)
+    end
+
+    it 'defaults the lower bound to the epoch when only until is given' do
+      range = range_for(until: until_epoch)
+
+      expect(range).not_to be_nil
+      expect(range.first.to_i).to eq(0)
+      expect(range.last.to_i).to eq(until_epoch.to_i)
+    end
+
+    it 'keeps both bounds concrete so callers may use range.first and range.last' do
+      range = range_for(since: since_epoch)
+
+      expect { range.first }.not_to raise_error
+      expect { range.last }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## The bug

`DateRangeHelper#range` returns nil unless **both** `since` and `until` are present, and every caller treats a nil range as "no filter" — so an API request carrying only `since` is answered with the account's **entire unfiltered history**. No error, nothing to tell the caller their filter was ignored. On a large account that turns an incremental since-only poll into a full-history export on every run (which is how we found it: our exporter pulled all 23,740 historical CSAT rows).

Affected through the shared helper: `csat_survey_responses`, `conversations`, `notifications`, bulk actions, and the v2 report builders.

## The fix

The missing bound defaults instead of disabling the filter: the epoch for `since`, `DateTime.current` for `until`. The caller gets exactly the half-open window they asked for.

Deliberately **concrete bounds, not beginless/endless ranges** — the report builders call `range.first` / `range.last` (e.g. `drilldown_builder`, the Captain stats builders), and both raise on open-ended Ruby ranges. Defaulting keeps every existing consumer working unchanged.

Requests with both bounds, or with neither, behave exactly as before — the only behavioural change is that a half-bounded request now filters instead of silently returning everything.

## Tests

New `spec/helpers/date_range_helper_spec.rb`: both bounds; since-only (upper defaults to now); until-only (lower defaults to epoch); neither (nil, unchanged); and that both bounds stay usable via `range.first`/`range.last`.

Fixes #15490