### PR TITLE
fix: skip business email validation on self-hosted installations (#14805)

### DIFF
--- a/app/javascript/v3/views/auth/signup/components/Signup/Form.spec.js
+++ b/app/javascript/v3/views/auth/signup/components/Signup/Form.spec.js
@@ -1,8 +1,9 @@
 import { mount } from '@vue/test-utils';
 import Form from './Form.vue';
 
-const { globalConfigState } = vi.hoisted(() => ({
+const { globalConfigState, isOnChatwootCloudState } = vi.hoisted(() => ({
   globalConfigState: { value: {} },
+  isOnChatwootCloudState: { value: false },
 }));
 
 vi.mock('vuex', () => ({
@@ -11,6 +12,13 @@ vi.mock('vuex', () => ({
       'globalConfig/get': globalConfigState.value,
     },
   }),
+}));
+
+vi.mock('dashboard/composables/store.js', () => ({
+  useMapGetter: getter =>
+    getter === 'globalConfig/isOnChatwootCloud'
+      ? isOnChatwootCloudState
+      : { value: undefined },
 }));
 
 vi.mock('vue-i18n', () => ({
@@ -60,8 +68,9 @@ describe('Signup Form', () => {
     window.chatwootConfig = { allowedLoginMethods: ['email'] };
   });
 
-  it('rejects a personal email address when installationName is Chatwoot', async () => {
+  it('rejects a personal email address on Chatwoot Cloud', async () => {
     globalConfigState.value = { installationName: 'Chatwoot' };
+    isOnChatwootCloudState.value = true;
     const wrapper = mountForm();
     const emailInput = wrapper.find('input[name="email_address"]');
 
@@ -71,8 +80,33 @@ describe('Signup Form', () => {
     expect(emailInput.classes()).toContain('error');
   });
 
-  it('skips the business email restriction on self-hosted installations', async () => {
+  it('skips the business email restriction on a rebranded self-hosted installation', async () => {
     globalConfigState.value = { installationName: 'My Self Hosted Chatwoot' };
+    isOnChatwootCloudState.value = false;
+    const wrapper = mountForm();
+    const emailInput = wrapper.find('input[name="email_address"]');
+
+    await emailInput.setValue('personal@gmail.com');
+    await emailInput.trigger('blur');
+
+    expect(emailInput.classes()).not.toContain('error');
+  });
+
+  it('skips the business email restriction on a stock self-hosted installation with the default installation name', async () => {
+    globalConfigState.value = { installationName: 'Chatwoot' };
+    isOnChatwootCloudState.value = false;
+    const wrapper = mountForm();
+    const emailInput = wrapper.find('input[name="email_address"]');
+
+    await emailInput.setValue('personal@gmail.com');
+    await emailInput.trigger('blur');
+
+    expect(emailInput.classes()).not.toContain('error');
+  });
+
+  it('skips the business email restriction when globalConfig is empty', async () => {
+    globalConfigState.value = {};
+    isOnChatwootCloudState.value = false;
     const wrapper = mountForm();
     const emailInput = wrapper.find('input[name="email_address"]');
 

--- a/app/javascript/v3/views/auth/signup/components/Signup/Form.spec.js
+++ b/app/javascript/v3/views/auth/signup/components/Signup/Form.spec.js
@@ -1,0 +1,84 @@
+import { mount } from '@vue/test-utils';
+import Form from './Form.vue';
+
+const { globalConfigState } = vi.hoisted(() => ({
+  globalConfigState: { value: {} },
+}));
+
+vi.mock('vuex', () => ({
+  useStore: () => ({
+    getters: {
+      'globalConfig/get': globalConfigState.value,
+    },
+  }),
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: key => key,
+  }),
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('dashboard/composables', () => ({
+  useAlert: vi.fn(),
+}));
+
+vi.mock('../../../../../api/auth', () => ({
+  register: vi.fn(),
+}));
+
+vi.mock('@hcaptcha/vue3-hcaptcha', () => ({
+  default: { name: 'VueHcaptcha', template: '<div />' },
+}));
+
+vi.mock('../../../../../components/GoogleOauth/Button.vue', () => ({
+  default: { name: 'GoogleOAuthButton', template: '<div><slot /></div>' },
+}));
+
+const mountForm = () =>
+  mount(Form, {
+    global: {
+      stubs: {
+        FormInput: {
+          props: ['modelValue', 'name', 'hasError'],
+          emits: ['update:modelValue'],
+          template:
+            '<input :name="name" :class="{ error: hasError }" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+        },
+        NextButton: true,
+        PasswordRequirements: true,
+      },
+    },
+  });
+
+describe('Signup Form', () => {
+  beforeEach(() => {
+    window.chatwootConfig = { allowedLoginMethods: ['email'] };
+  });
+
+  it('rejects a personal email address when installationName is Chatwoot', async () => {
+    globalConfigState.value = { installationName: 'Chatwoot' };
+    const wrapper = mountForm();
+    const emailInput = wrapper.find('input[name="email_address"]');
+
+    await emailInput.setValue('personal@gmail.com');
+    await emailInput.trigger('blur');
+
+    expect(emailInput.classes()).toContain('error');
+  });
+
+  it('skips the business email restriction on self-hosted installations', async () => {
+    globalConfigState.value = { installationName: 'My Self Hosted Chatwoot' };
+    const wrapper = mountForm();
+    const emailInput = wrapper.find('input[name="email_address"]');
+
+    await emailInput.setValue('personal@gmail.com');
+    await emailInput.trigger('blur');
+
+    expect(emailInput.classes()).not.toContain('error');
+  });
+});

--- a/app/javascript/v3/views/auth/signup/components/Signup/Form.vue
+++ b/app/javascript/v3/views/auth/signup/components/Signup/Form.vue
@@ -13,6 +13,7 @@ import PasswordRequirements from './PasswordRequirements.vue';
 import { isValidPassword } from 'shared/helpers/Validators';
 import GoogleOAuthButton from '../../../../../components/GoogleOauth/Button.vue';
 import { register } from '../../../../../api/auth';
+import { useMapGetter } from 'dashboard/composables/store.js';
 import * as CompanyEmailValidator from 'company-email-validator';
 
 const MIN_PASSWORD_LENGTH = 6;
@@ -32,9 +33,7 @@ const credentials = reactive({
 });
 
 const globalConfig = computed(() => store.getters['globalConfig/get']);
-const isAChatwootInstance = computed(
-  () => globalConfig.value.installationName === 'Chatwoot'
-);
+const isOnChatwootCloud = useMapGetter('globalConfig/isOnChatwootCloud');
 
 const rules = {
   credentials: {
@@ -42,7 +41,7 @@ const rules = {
       required,
       email,
       businessEmailValidator(value) {
-        if (!isAChatwootInstance.value) return true;
+        if (!isOnChatwootCloud.value) return true;
         return CompanyEmailValidator.isCompanyEmail(value);
       },
     },

--- a/app/javascript/v3/views/auth/signup/components/Signup/Form.vue
+++ b/app/javascript/v3/views/auth/signup/components/Signup/Form.vue
@@ -31,12 +31,18 @@ const credentials = reactive({
   hCaptchaClientResponse: '',
 });
 
+const globalConfig = computed(() => store.getters['globalConfig/get']);
+const isAChatwootInstance = computed(
+  () => globalConfig.value.installationName === 'Chatwoot'
+);
+
 const rules = {
   credentials: {
     email: {
       required,
       email,
       businessEmailValidator(value) {
+        if (!isAChatwootInstance.value) return true;
         return CompanyEmailValidator.isCompanyEmail(value);
       },
     },
@@ -49,8 +55,6 @@ const rules = {
 };
 
 const v$ = useVuelidate(rules, { credentials });
-
-const globalConfig = computed(() => store.getters['globalConfig/get']);
 
 const termsLink = computed(() =>
   t('REGISTER.TERMS_ACCEPT')


### PR DESCRIPTION
## What
The signup form's `businessEmailValidator` (backed by `company-email-validator`) ran unconditionally in `Form.vue`, blocking personal/free-provider email addresses (e.g. Gmail) at the client level before the form was even submitted — including on self-hosted installations.

This PR gates the validator so it only runs when `globalConfig.installationName === 'Chatwoot'`, reusing the existing `isAChatwootInstance` pattern already present in the parent `Index.vue`.

## Why
Closes #14805.

On discussion #12690, maintainer @pranavrajs confirmed the intended behavior:

> You can already do this on self-hosted installations. There's no restriction on using any valid email.
>
> On the cloud side, our experience has been different. When we allowed signups using Gmail or Yahoo addresses, we saw a lot of abuse. After we restricted those domains, both spam and low-quality signups dropped significantly. Because of that, we don't plan to re-enable those domains for new signups.

So the free-email restriction is meant to be a Chatwoot Cloud-only policy, not a self-hosted default. The reporter's self-hosted instance was hitting the restriction unexpectedly because `Form.vue` had no installation gate at all (unlike `Index.vue`, which already conditions cloud-only UI on `isAChatwootInstance`).

I did not touch server-side validation — `SignUpEmailValidationService`/`AccountBuilder` (see closed PR #14493) already scope free-email enforcement to specific paths and were not part of this bug report; this fix is limited to the client-side validator that was surfacing the wrong error immediately on self-hosted installs.

## Test plan
- Added `Form.spec.js` (new file, no prior spec existed for this component) with two cases:
  - a personal Gmail address is flagged invalid when `installationName === 'Chatwoot'`
  - the same address passes when `installationName` is anything else (self-hosted)
- Verified the new test fails against the pre-fix code (`git stash` the `Form.vue` change) and passes once the fix is applied, confirming it actually exercises the regression.
- Ran `npx vitest run app/javascript/v3/views/auth/signup/components/Signup/Form.spec.js` — 2/2 passing.
- Ran `npx eslint` on both changed files — clean.
- Did not run the full frontend/backend suite (out of scope for this change) or a live self-hosted signup flow in a browser.