### PR TITLE
fix: bound IMAP validation timeout

### DIFF
--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -129,7 +129,7 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   def validate_and_update_email_channel(channel_attributes)
     validate_email_channel(channel_attributes)
   rescue StandardError => e
-    render json: { message: e }, status: :unprocessable_entity and return
+    render json: { message: e.message }, status: :unprocessable_entity and raise ActiveRecord::Rollback
   end
 
   def reauthorize_and_update_channel(channel_attributes)

--- a/app/helpers/api/v1/inboxes_helper.rb
+++ b/app/helpers/api/v1/inboxes_helper.rb
@@ -1,4 +1,7 @@
 module Api::V1::InboxesHelper
+  IMAP_VALIDATION_TIMEOUT = 10
+  private_constant :IMAP_VALIDATION_TIMEOUT
+
   def inbox_name(channel)
     return channel.try(:bot_name) if channel.is_a?(Channel::Telegram)
 
@@ -35,14 +38,18 @@ module Api::V1::InboxesHelper
   end
 
   def check_imap_connection(channel_data, authentication)
-    imap = open_imap_connection(channel_data, authentication)
+    # Net::IMAP only applies open_timeout to TCP/TLS establishment. Bound the complete validation so greeting or authentication
+    # stalls finish before Rack's request timeout and can be returned as a validation error.
+    Timeout.timeout(IMAP_VALIDATION_TIMEOUT) do
+      authenticate_imap_connection(channel_data, authentication)
+    end
   rescue SocketError => e
     raise StandardError, I18n.t('errors.inboxes.imap.socket_error')
   rescue Net::IMAP::NoResponseError => e
     raise StandardError, I18n.t('errors.inboxes.imap.no_response_error')
   rescue Errno::EHOSTUNREACH => e
     raise StandardError, I18n.t('errors.inboxes.imap.host_unreachable_error')
-  rescue Net::OpenTimeout => e
+  rescue Timeout::Error => e
     raise StandardError,
           I18n.t('errors.inboxes.imap.connection_timed_out_error', address: channel_data[:imap_address], port: channel_data[:imap_port])
   rescue Net::IMAP::Error => e
@@ -50,18 +57,19 @@ module Api::V1::InboxesHelper
   rescue StandardError => e
     raise StandardError, e.message
   ensure
-    imap.disconnect if imap.present? && !imap.disconnected?
     Rails.logger.error "[Api::V1::InboxesHelper] check_imap_connection failed with #{e.message}" if e.present?
   end
 
-  def open_imap_connection(channel_data, authentication)
+  def authenticate_imap_connection(channel_data, authentication)
     imap = build_imap_connection(channel_data)
     Imap::Authentication.authenticate!(imap, authentication, channel_data[:imap_login], channel_data[:imap_password])
-    imap
+  ensure
+    imap.disconnect if imap.present? && !imap.disconnected?
   end
 
   def build_imap_connection(channel_data)
-    Net::IMAP.new(channel_data[:imap_address], port: channel_data[:imap_port], ssl: channel_data[:imap_enable_ssl], open_timeout: 10)
+    Net::IMAP.new(channel_data[:imap_address], port: channel_data[:imap_port], ssl: channel_data[:imap_enable_ssl],
+                                               open_timeout: IMAP_VALIDATION_TIMEOUT)
   end
 
   def check_smtp_connection(channel_data, smtp)

--- a/app/helpers/api/v1/inboxes_helper.rb
+++ b/app/helpers/api/v1/inboxes_helper.rb
@@ -61,7 +61,7 @@ module Api::V1::InboxesHelper
   end
 
   def build_imap_connection(channel_data)
-    Net::IMAP.new(channel_data[:imap_address], port: channel_data[:imap_port], ssl: channel_data[:imap_enable_ssl])
+    Net::IMAP.new(channel_data[:imap_address], port: channel_data[:imap_port], ssl: channel_data[:imap_enable_ssl], open_timeout: 10)
   end
 
   def check_smtp_connection(channel_data, smtp)


### PR DESCRIPTION
IMAP configuration updates now validate the complete connection and authentication flow within 10 seconds. Unreachable or unresponsive servers return the existing actionable validation error instead of surfacing a generic Internal Server Error.

## How to reproduce

1. Configure a custom email inbox with an IMAP endpoint that does not complete its connection, greeting, or authentication response.
2. Save the configuration.
3. Observe the request reach Rack's 15-second service timeout before IMAP validation finishes.
4. The UI receives a generic HTTP 500 instead of the IMAP timeout validation message.

## What changed

- Apply a 10-second deadline to the complete synchronous IMAP validation, including TCP/TLS establishment, the server greeting, and authentication.
- Use the same value for Net::IMAP's native TCP/TLS open timeout and always disconnect the validation session.
- Return the translated timeout as HTTP 422 and roll back the rejected channel update.
- Leave background IMAP fetching unchanged.

Net::IMAP's `open_timeout` only covers TCP and TLS establishment; it does not limit the time spent waiting for the server greeting or an authentication response. The complete validation therefore needs an application-level deadline: https://ruby.github.io/net-imap/Net/IMAP.html

That deadline must remain below Rack's 15-second request limit. Any value of 15 seconds or more is ineffective on this request path because Rack aborts first. Ten seconds matches the existing SMTP validation timeout and preserves five seconds for exception translation, transaction rollback, and response serialization.
