### PR TITLE
fix: allow-list img/iframe embeds in raw HTML Help Center articles (#14602)

### DIFF
--- a/app/javascript/dashboard/helper/markdownEmbeds.js
+++ b/app/javascript/dashboard/helper/markdownEmbeds.js
@@ -3,7 +3,7 @@ import config from '../../../../config/markdown_embeds.yml';
 // Gists rely on document.write() and can't render inline in the editor.
 const NON_PREVIEWABLE_EMBEDS = new Set(['github_gist']);
 
-export const embeds = Object.entries(config)
+export const embeds = Object.entries(config.embeds)
   .filter(([key]) => !NON_PREVIEWABLE_EMBEDS.has(key))
   .map(([, { regex, template }]) => ({
     regex: new RegExp(regex),

--- a/config/markdown_embeds.yml
+++ b/config/markdown_embeds.yml
@@ -1,14 +1,18 @@
 # Markdown Embed Configuration
 #
 # This file defines patterns and templates for converting URLs into embedded content
-# in markdown rendering. Each embed type has:
+# in markdown rendering. Each embed type under `embeds:` has:
 #   - regex: Pattern with named capture groups (?<name>...)
 #   - template: HTML template with %{capture_group_name} placeholders
 #
 # To add a new embed type:
-# 1. Add a new top-level key
+# 1. Add a new key under `embeds:`
 # 2. Define the regex pattern with named capture groups: (?<name>pattern)
 # 3. Create an HTML template using %{name} placeholders matching the capture groups
+#
+# `trusted_iframe_hosts` below is metadata, not an embed — it must stay outside `embeds:`
+# so consumers that map every embed entry to `{ regex, template }` (e.g.
+# app/javascript/dashboard/helper/markdownEmbeds.js) never see it.
 
 # Hosts allowed as a raw `<iframe src="...">` destination when an article is created/updated
 # with raw HTML (e.g. via the Portal Articles API) instead of a markdown link. This list only
@@ -32,150 +36,151 @@ trusted_iframe_hosts:
   - codepen.io
   - www.codepen.io
 
-youtube:
-  regex: 'https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)(?<video_id>[^&/]+)'
-  template: |
-    <div style="position: relative; padding-bottom: 62.5%; height: 0;">
-     <iframe
-      src="https://www.youtube-nocookie.com/embed/%{video_id}"
-      frameborder="0"
-      style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-      allowfullscreen></iframe>
-    </div>
-
-loom:
-  regex: 'https?://(?:www\.)?loom\.com/share/(?<video_id>[^&/]+)'
-  template: |
-    <div style="position: relative; padding-bottom: 62.5%; height: 0;">
-      <iframe
-       src="https://www.loom.com/embed/%{video_id}"
-       frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen
-       style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
-    </div>
-
-vimeo:
-  regex: 'https?://(?:www\.)?vimeo\.com/(?<video_id>\d+)'
-  template: |
-    <div style="position: relative; padding-bottom: 62.5%; height: 0;">
-     <iframe
-      src="https://player.vimeo.com/video/%{video_id}?dnt=true"
-      frameborder="0"
-      allow="autoplay; fullscreen; picture-in-picture"
-      allowfullscreen
-      style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
-     </div>
-
-mp4:
-  regex: '(?<link_url>https?://(?:www\.)?.+\.mp4)'
-  template: |
-    <video width="640" height="360" controls>
-      <source src="%{link_url}" type="video/mp4">
-      Your browser does not support the video tag.
-    </video>
-
-arcade_tab:
-  regex: 'https?://(?:www\.)?app\.arcade\.software/share/(?<video_id>[^&/?]+)\?(?:[^&#]*&)*embed_mobile=tab(?:[&#?][^ ]*)?'
-  template: |
-    <div style="position: relative; padding-bottom: calc(62.793% + 41px); height: 0px; width: 100%;">
-      <iframe
-        src="https://app.arcade.software/embed/%{video_id}?embed&embed_mobile=tab"
+embeds:
+  youtube:
+    regex: 'https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)(?<video_id>[^&/]+)'
+    template: |
+      <div style="position: relative; padding-bottom: 62.5%; height: 0;">
+       <iframe
+        src="https://www.youtube-nocookie.com/embed/%{video_id}"
         frameborder="0"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen
-        allow="fullscreen"
-        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
-      </iframe>
-    </div>
-
-arcade:
-  regex: 'https?://(?:www\.)?app\.arcade\.software/share/(?<video_id>[^&/]+)'
-  template: |
-    <div style="position: relative; padding-bottom: calc(62.793% + 41px); height: 0px; width: 100%;">
-      <iframe
-        src="https://app.arcade.software/embed/%{video_id}"
-        frameborder="0"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen
-        allow="fullscreen"
-        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
-      </iframe>
-    </div>
-
-wistia:
-  regex: 'https?://(?:www\.)?[^/]+\.wistia\.com/medias/(?<video_id>[^&/]+)'
-  template: |
-    <div style="position: relative; padding-bottom: 56.25%; height: 0;">
-      <script src="https://fast.wistia.com/player.js" async></script>
-      <script src="https://fast.wistia.com/embed/%{video_id}.js" async type="module"></script>
-      <style>
-        wistia-player[media-id='%{video_id}']:not(:defined) {
-          background: center / contain no-repeat url('https://fast.wistia.com/embed/medias/%{video_id}/swatch');
-          display: block;
-          filter: blur(5px);
-          padding-top:56.25%;
-        }
-      </style>
-      <wistia-player
-        media-id="%{video_id}"
-        aspect="1.7777777777777777"
-        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
-      </wistia-player>
-    </div>
-
-bunny:
-  regex: 'https?://(?:iframe|player)\.mediadelivery\.net/(?:play|embed)/(?<library_id>\d+)/(?<video_id>[^&/?]+)'
-  template: |
-    <div style="position: relative; padding-top: 56.25%;">
-      <iframe
-        src="https://player.mediadelivery.net/embed/%{library_id}/%{video_id}?autoplay=false&loop=false&muted=false&preload=true&responsive=true"
-        title="Bunny video player"
-        loading="lazy"
-        style="border: 0; position: absolute; top: 0; height: 100%; width: 100%;"
-        allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
-        allowfullscreen>
-      </iframe>
-    </div>
-
-codepen:
-  regex: 'https?://(?:www\.)?codepen\.io/(?<user>[^/]+)/pen/(?<pen_id>[^/?]+)'
-  template: |
-    <div style="height: 400px; box-sizing: border-box; display: flex; align-items: center; justify-content: center;">
-      <iframe
-        height="400"
-        style="width: 100%;"
-        scrolling="no"
-        title="CodePen Embed"
-        src="https://codepen.io/%{user}/embed/%{pen_id}?default-tab=result"
-        frameborder="no"
-        loading="lazy"
-        allowtransparency="true"
-        allowfullscreen="true">
-      </iframe>
-    </div>
-
-guidejar:
-  regex: 'https?://(?:www\.)?guidejar\.com/(?:embed|guides)/(?<guide_id>[^&/?]+)'
-  template: |
-    <div style="position: relative; padding-bottom: 62.5%; height: 0;">
-      <iframe
-        src="https://www.guidejar.com/embed/%{guide_id}?type=1&controls=on"
-        frameborder="0"
+        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen></iframe>
+      </div>
+
+  loom:
+    regex: 'https?://(?:www\.)?loom\.com/share/(?<video_id>[^&/]+)'
+    template: |
+      <div style="position: relative; padding-bottom: 62.5%; height: 0;">
+        <iframe
+         src="https://www.loom.com/embed/%{video_id}"
+         frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen
+         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+      </div>
+
+  vimeo:
+    regex: 'https?://(?:www\.)?vimeo\.com/(?<video_id>\d+)'
+    template: |
+      <div style="position: relative; padding-bottom: 62.5%; height: 0;">
+       <iframe
+        src="https://player.vimeo.com/video/%{video_id}?dnt=true"
+        frameborder="0"
+        allow="autoplay; fullscreen; picture-in-picture"
         allowfullscreen
         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
-    </div>
+       </div>
 
-github_gist:
-  regex: 'https?://gist\.github\.com/(?<username>[^/]+)/(?<gist_id>[a-f0-9]+)'
-  template: |
-    <script src="https://gist.github.com/%{username}/%{gist_id}.js"></script>
-    <noscript>
-      <div style="border: 1px solid #d1d9e0; border-radius: 6px; padding: 16px; margin: 16px 0; background: #f6f8fa;">
-        <a href="https://gist.github.com/%{username}/%{gist_id}" target="_blank" style="color: #0969da; text-decoration: none;">
-          View this gist on GitHub
-        </a>
+  mp4:
+    regex: '(?<link_url>https?://(?:www\.)?.+\.mp4)'
+    template: |
+      <video width="640" height="360" controls>
+        <source src="%{link_url}" type="video/mp4">
+        Your browser does not support the video tag.
+      </video>
+
+  arcade_tab:
+    regex: 'https?://(?:www\.)?app\.arcade\.software/share/(?<video_id>[^&/?]+)\?(?:[^&#]*&)*embed_mobile=tab(?:[&#?][^ ]*)?'
+    template: |
+      <div style="position: relative; padding-bottom: calc(62.793% + 41px); height: 0px; width: 100%;">
+        <iframe
+          src="https://app.arcade.software/embed/%{video_id}?embed&embed_mobile=tab"
+          frameborder="0"
+          webkitallowfullscreen
+          mozallowfullscreen
+          allowfullscreen
+          allow="fullscreen"
+          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+        </iframe>
       </div>
-    </noscript>
+
+  arcade:
+    regex: 'https?://(?:www\.)?app\.arcade\.software/share/(?<video_id>[^&/]+)'
+    template: |
+      <div style="position: relative; padding-bottom: calc(62.793% + 41px); height: 0px; width: 100%;">
+        <iframe
+          src="https://app.arcade.software/embed/%{video_id}"
+          frameborder="0"
+          webkitallowfullscreen
+          mozallowfullscreen
+          allowfullscreen
+          allow="fullscreen"
+          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+        </iframe>
+      </div>
+
+  wistia:
+    regex: 'https?://(?:www\.)?[^/]+\.wistia\.com/medias/(?<video_id>[^&/]+)'
+    template: |
+      <div style="position: relative; padding-bottom: 56.25%; height: 0;">
+        <script src="https://fast.wistia.com/player.js" async></script>
+        <script src="https://fast.wistia.com/embed/%{video_id}.js" async type="module"></script>
+        <style>
+          wistia-player[media-id='%{video_id}']:not(:defined) {
+            background: center / contain no-repeat url('https://fast.wistia.com/embed/medias/%{video_id}/swatch');
+            display: block;
+            filter: blur(5px);
+            padding-top:56.25%;
+          }
+        </style>
+        <wistia-player
+          media-id="%{video_id}"
+          aspect="1.7777777777777777"
+          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+        </wistia-player>
+      </div>
+
+  bunny:
+    regex: 'https?://(?:iframe|player)\.mediadelivery\.net/(?:play|embed)/(?<library_id>\d+)/(?<video_id>[^&/?]+)'
+    template: |
+      <div style="position: relative; padding-top: 56.25%;">
+        <iframe
+          src="https://player.mediadelivery.net/embed/%{library_id}/%{video_id}?autoplay=false&loop=false&muted=false&preload=true&responsive=true"
+          title="Bunny video player"
+          loading="lazy"
+          style="border: 0; position: absolute; top: 0; height: 100%; width: 100%;"
+          allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
+          allowfullscreen>
+        </iframe>
+      </div>
+
+  codepen:
+    regex: 'https?://(?:www\.)?codepen\.io/(?<user>[^/]+)/pen/(?<pen_id>[^/?]+)'
+    template: |
+      <div style="height: 400px; box-sizing: border-box; display: flex; align-items: center; justify-content: center;">
+        <iframe
+          height="400"
+          style="width: 100%;"
+          scrolling="no"
+          title="CodePen Embed"
+          src="https://codepen.io/%{user}/embed/%{pen_id}?default-tab=result"
+          frameborder="no"
+          loading="lazy"
+          allowtransparency="true"
+          allowfullscreen="true">
+        </iframe>
+      </div>
+
+  guidejar:
+    regex: 'https?://(?:www\.)?guidejar\.com/(?:embed|guides)/(?<guide_id>[^&/?]+)'
+    template: |
+      <div style="position: relative; padding-bottom: 62.5%; height: 0;">
+        <iframe
+          src="https://www.guidejar.com/embed/%{guide_id}?type=1&controls=on"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+      </div>
+
+  github_gist:
+    regex: 'https?://gist\.github\.com/(?<username>[^/]+)/(?<gist_id>[a-f0-9]+)'
+    template: |
+      <script src="https://gist.github.com/%{username}/%{gist_id}.js"></script>
+      <noscript>
+        <div style="border: 1px solid #d1d9e0; border-radius: 6px; padding: 16px; margin: 16px 0; background: #f6f8fa;">
+          <a href="https://gist.github.com/%{username}/%{gist_id}" target="_blank" style="color: #0969da; text-decoration: none;">
+            View this gist on GitHub
+          </a>
+        </div>
+      </noscript>

--- a/config/markdown_embeds.yml
+++ b/config/markdown_embeds.yml
@@ -10,6 +10,28 @@
 # 2. Define the regex pattern with named capture groups: (?<name>pattern)
 # 3. Create an HTML template using %{name} placeholders matching the capture groups
 
+# Hosts allowed as a raw `<iframe src="...">` destination when an article is created/updated
+# with raw HTML (e.g. via the Portal Articles API) instead of a markdown link. This list only
+# mirrors the iframe destinations the embed templates below already point traffic to — it does
+# not grant any new trust. CustomMarkdownRenderer#trusted_iframe_host? requires an exact,
+# case-insensitive host match (no subdomain/suffix matching) before a raw iframe is re-rendered.
+trusted_iframe_hosts:
+  - www.youtube.com
+  - youtube.com
+  - www.youtube-nocookie.com
+  - youtube-nocookie.com
+  - www.loom.com
+  - loom.com
+  - player.vimeo.com
+  - vimeo.com
+  - app.arcade.software
+  - player.mediadelivery.net
+  - iframe.mediadelivery.net
+  - www.guidejar.com
+  - guidejar.com
+  - codepen.io
+  - www.codepen.io
+
 youtube:
   regex: 'https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)(?<video_id>[^&/]+)'
   template: |

--- a/lib/custom_markdown_renderer.rb
+++ b/lib/custom_markdown_renderer.rb
@@ -6,7 +6,15 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
   end
 
   def self.embed_regexes
-    @embed_regexes ||= config.transform_values { |embed_config| Regexp.new(embed_config['regex']) }
+    @embed_regexes ||= config.each_with_object({}) do |(key, embed_config), acc|
+      next unless embed_config.is_a?(Hash) && embed_config['regex']
+
+      acc[key] = Regexp.new(embed_config['regex'])
+    end
+  end
+
+  def self.trusted_iframe_hosts
+    @trusted_iframe_hosts ||= Array(config['trusted_iframe_hosts']).map(&:downcase).to_set.freeze
   end
 
   # Matches columnResizing({ cellMinWidth: 50 }) in @chatwoot/prosemirror-schema
@@ -17,11 +25,32 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
   # The article editor serializes column widths as a `<!--cw-colwidths:...-->` HTML
   # comment immediately before each resized table. Capture it (emitting nothing) so the
   # next `table` can size itself; any other raw HTML keeps its default rendering.
+  # `html`/`inline_html` are where CommonMarker delivers raw HTML nodes. Without passing the
+  # `:UNSAFE` render option, its own default behavior would blank ALL raw HTML out to
+  # `<!-- raw HTML omitted -->` here — including the `<img>`/`<iframe>` embeds from
+  # https://github.com/chatwoot/chatwoot/issues/14602. We deliberately do NOT enable `:UNSAFE`
+  # anywhere in this renderer; instead both node types are routed through
+  # EmbeddedHtmlSanitizer's narrow allow-list, which re-renders only `img`/`iframe` and drops
+  # everything else exactly as before.
   def html(node)
     match = node.string_content.match(COLWIDTHS_COMMENT)
-    return super unless match
+    if match
+      @pending_colwidths = match[1].split(',').map(&:to_i)
+      return
+    end
 
-    @pending_colwidths = match[1].split(',').map(&:to_i)
+    safe_html = embed_sanitizer.sanitize(node.string_content)
+    return if safe_html.blank?
+
+    block { out(safe_html) }
+  end
+
+  # Raw inline HTML (e.g. a bare `<img ...>` or `<iframe ...>` tag written directly in the
+  # article body rather than as a markdown image/link) reaches this node type instead of `html`
+  # above.
+  def inline_html(node)
+    safe_html = embed_sanitizer.sanitize(node.string_content)
+    out(safe_html) if safe_html.present?
   end
 
   def table(node)
@@ -69,6 +98,10 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
   end
 
   private
+
+  def embed_sanitizer
+    @embed_sanitizer ||= EmbeddedHtmlSanitizer.new(self.class.trusted_iframe_hosts)
+  end
 
   def sized_widths?(widths)
     widths.is_a?(Array) && widths.any? { |w| w.to_i.positive? }

--- a/lib/custom_markdown_renderer.rb
+++ b/lib/custom_markdown_renderer.rb
@@ -6,7 +6,7 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
   end
 
   def self.embeds_config
-    @embeds_config ||= config['embeds'] || {}
+    @embeds_config ||= config.fetch('embeds')
   end
 
   def self.embed_regexes
@@ -18,7 +18,7 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
   end
 
   def self.trusted_iframe_hosts
-    @trusted_iframe_hosts ||= Array(config['trusted_iframe_hosts']).map(&:downcase).to_set.freeze
+    @trusted_iframe_hosts ||= config.fetch('trusted_iframe_hosts').to_set(&:downcase).freeze
   end
 
   # Matches columnResizing({ cellMinWidth: 50 }) in @chatwoot/prosemirror-schema

--- a/lib/custom_markdown_renderer.rb
+++ b/lib/custom_markdown_renderer.rb
@@ -11,9 +11,7 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
 
   def self.embed_regexes
     @embed_regexes ||= embeds_config.each_with_object({}) do |(key, embed_config), acc|
-      next unless embed_config.is_a?(Hash) && embed_config['regex']
-
-      acc[key] = Regexp.new(embed_config['regex'])
+      acc[key] = Regexp.new(embed_config.fetch('regex'))
     end
   end
 

--- a/lib/custom_markdown_renderer.rb
+++ b/lib/custom_markdown_renderer.rb
@@ -5,8 +5,12 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
     @config ||= YAML.load_file(CONFIG_PATH)
   end
 
+  def self.embeds_config
+    @embeds_config ||= config['embeds'] || {}
+  end
+
   def self.embed_regexes
-    @embed_regexes ||= config.each_with_object({}) do |(key, embed_config), acc|
+    @embed_regexes ||= embeds_config.each_with_object({}) do |(key, embed_config), acc|
       next unless embed_config.is_a?(Hash) && embed_config['regex']
 
       acc[key] = Regexp.new(embed_config['regex'])
@@ -207,7 +211,7 @@ class CustomMarkdownRenderer < CommonMarker::HtmlRenderer
   end
 
   def render_embed_from_match(embed_key, match_data)
-    embed_config = self.class.config[embed_key]
+    embed_config = self.class.embeds_config[embed_key]
     return nil unless embed_config
 
     template = embed_config['template']

--- a/lib/embedded_html_sanitizer.rb
+++ b/lib/embedded_html_sanitizer.rb
@@ -1,0 +1,93 @@
+# Sanitizes a raw HTML fragment down to a narrow allow-list of `<img>`/`<iframe>` tags.
+#
+# Used by CustomMarkdownRenderer to support articles created via the Portal Articles API with
+# raw HTML `<img>`/`<iframe>` embeds (see https://github.com/chatwoot/chatwoot/issues/14602).
+# CommonMarker's default (non-`:UNSAFE`) rendering replaces ALL raw HTML — block or inline —
+# with an opaque placeholder comment. This class is deliberately NOT a general raw-HTML
+# passthrough: it re-renders only `img`/`iframe` elements that pass strict validation, rebuilt
+# attribute-by-attribute from scratch (never copying any raw attribute string from the input).
+# Everything else in the fragment — any other tag, any other attribute, any bare text — is
+# dropped, matching CommonMarker's existing default behavior for unrecognized raw HTML.
+class EmbeddedHtmlSanitizer
+  ALLOWED_TAGS = %w[img iframe].freeze
+  SAFE_DIMENSION = /\A\d{1,4}\z/
+
+  def initialize(trusted_iframe_hosts)
+    @trusted_iframe_hosts = trusted_iframe_hosts
+  end
+
+  # Nokogiri only builds a DOM tree here; it never executes anything, so parsing
+  # attacker-controlled markup is safe.
+  def sanitize(raw_html)
+    fragment = Nokogiri::HTML5.fragment(raw_html)
+    fragment.css(ALLOWED_TAGS.join(', ')).filter_map { |element| render_safe_embed(element) }.join
+  rescue Nokogiri::SyntaxError, ArgumentError
+    ''
+  end
+
+  private
+
+  def render_safe_embed(element)
+    case element.name
+    when 'img' then render_safe_img(element)
+    when 'iframe' then render_safe_iframe(element)
+    end
+  end
+
+  def render_safe_img(element)
+    src = safe_http_url(element['src'])
+    return nil unless src
+
+    tag = +%(<img src="#{CGI.escapeHTML(src)}")
+    tag << %( alt="#{CGI.escapeHTML(element['alt'])}") if element['alt'].present?
+    tag << %( title="#{CGI.escapeHTML(element['title'])}") if element['title'].present?
+    tag << %( width="#{element['width']}") if safe_dimension?(element['width'])
+    tag << %( height="#{element['height']}") if safe_dimension?(element['height'])
+    tag << ' />'
+    tag
+  end
+
+  def render_safe_iframe(element)
+    src = safe_http_url(element['src'])
+    return nil unless src && trusted_iframe_host?(src)
+
+    tag = +%(<iframe src="#{CGI.escapeHTML(src)}" frameborder="0")
+    tag << %( width="#{element['width']}") if safe_dimension?(element['width'])
+    tag << %( height="#{element['height']}") if safe_dimension?(element['height'])
+    tag << %( title="#{CGI.escapeHTML(element['title'])}") if element['title'].present?
+    tag << ' allowfullscreen' if element.key?('allowfullscreen')
+    tag << '></iframe>'
+    tag
+  end
+
+  # Only an absolute http/https URL is accepted — `URI.parse` classifies any other scheme
+  # (javascript:, data:, vbscript:, file:, protocol-relative //, etc.) as something other than
+  # a `URI::HTTP` instance, and malformed/illegal-character URLs raise and are rejected too.
+  # Nokogiri has already HTML-entity-decoded the attribute value by this point, so there is no
+  # separate decode step that could be bypassed with double-encoding.
+  def safe_http_url(value)
+    return nil if value.blank?
+
+    uri = URI.parse(value.strip)
+    return nil unless uri.is_a?(URI::HTTP) && uri.host.present?
+
+    uri.to_s
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  # Exact, case-insensitive host match only — no subdomain/suffix matching — so
+  # "evilyoutube.com" or "youtube.com.attacker.com" cannot pass as "youtube.com". Also defeats
+  # userinfo tricks like "https://youtube.com@evil.com/x" since `URI#host` only ever returns
+  # the actual host ("evil.com" there), never the userinfo segment.
+  def trusted_iframe_host?(url)
+    host = URI.parse(url).host&.downcase
+    @trusted_iframe_hosts.include?(host)
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def safe_dimension?(value)
+    value.present? && SAFE_DIMENSION.match?(value)
+  end
+end

--- a/lib/embedded_html_sanitizer.rb
+++ b/lib/embedded_html_sanitizer.rb
@@ -38,7 +38,7 @@ class EmbeddedHtmlSanitizer
     src = safe_http_url(element['src'])
     return nil unless src
 
-    tag = +%(<img src="#{CGI.escapeHTML(src)}")
+    tag = %(<img src="#{CGI.escapeHTML(src)}")
     tag << %( alt="#{CGI.escapeHTML(element['alt'])}") if element['alt'].present?
     tag << %( title="#{CGI.escapeHTML(element['title'])}") if element['title'].present?
     tag << %( width="#{element['width']}") if safe_dimension?(element['width'])
@@ -51,7 +51,7 @@ class EmbeddedHtmlSanitizer
     src = safe_http_url(element['src'])
     return nil unless src && trusted_iframe_host?(src)
 
-    tag = +%(<iframe src="#{CGI.escapeHTML(src)}" frameborder="0")
+    tag = %(<iframe src="#{CGI.escapeHTML(src)}" frameborder="0")
     tag << %( width="#{element['width']}") if safe_dimension?(element['width'])
     tag << %( height="#{element['height']}") if safe_dimension?(element['height'])
     tag << %( title="#{CGI.escapeHTML(element['title'])}") if element['title'].present?

--- a/spec/config/markdown_embeds_spec.rb
+++ b/spec/config/markdown_embeds_spec.rb
@@ -5,14 +5,25 @@ describe 'Markdown Embeds Configuration' do
   # rubocop:enable RSpec/DescribeClass
   let(:config) { YAML.load_file(Rails.root.join('config/markdown_embeds.yml')) }
 
+  let(:embeds) { config['embeds'] }
+
   describe 'YAML structure' do
     it 'loads valid YAML' do
       expect(config).to be_a(Hash)
       expect(config).not_to be_empty
     end
 
+    it 'keeps the trusted iframe host allow-list outside the embeds map' do
+      expect(config).to have_key('trusted_iframe_hosts')
+      expect(config['trusted_iframe_hosts']).to be_an(Array)
+      expect(embeds).not_to have_key('trusted_iframe_hosts')
+    end
+
     it 'has required keys for each embed type' do
-      config.each do |embed_type, embed_config|
+      expect(embeds).to be_a(Hash)
+      expect(embeds).not_to be_empty
+
+      embeds.each do |embed_type, embed_config|
         expect(embed_config).to have_key('regex'), "#{embed_type} missing regex"
         expect(embed_config).to have_key('template'), "#{embed_type} missing template"
         expect(embed_config['regex']).to be_a(String), "#{embed_type} regex should be string"
@@ -22,7 +33,7 @@ describe 'Markdown Embeds Configuration' do
 
     it 'contains expected embed types' do
       expected_types = %w[youtube loom vimeo mp4 arcade_tab arcade wistia bunny codepen guidejar github_gist]
-      expect(config.keys).to match_array(expected_types)
+      expect(embeds.keys).to match_array(expected_types)
     end
   end
 
@@ -89,7 +100,7 @@ describe 'Markdown Embeds Configuration' do
 
     it 'correctly captures named groups for all embed types' do
       test_cases.each do |embed_type, cases|
-        regex = Regexp.new(config[embed_type]['regex'])
+        regex = Regexp.new(embeds[embed_type]['regex'])
 
         cases.each do |test_case|
           match = regex.match(test_case[:url])
@@ -101,7 +112,7 @@ describe 'Markdown Embeds Configuration' do
     end
 
     it 'validates that template variables match capture group names' do
-      config.each do |embed_type, embed_config|
+      embeds.each do |embed_type, embed_config|
         regex = Regexp.new(embed_config['regex'])
         template = embed_config['template']
 

--- a/spec/lib/custom_markdown_renderer_spec.rb
+++ b/spec/lib/custom_markdown_renderer_spec.rb
@@ -311,6 +311,146 @@ describe CustomMarkdownRenderer do
     end
   end
 
+  describe 'raw HTML embeds (img/iframe allow-list)' do
+    # These exercise the `html`/`inline_html` node types, which is what raw HTML submitted via
+    # the Portal Articles API parses into (as opposed to markdown image/link syntax, which uses
+    # the `image`/`link` node types tested elsewhere in this file).
+    def render_html(html)
+      doc = CommonMarker.render_doc(html, :DEFAULT)
+      renderer.render(doc)
+    end
+
+    context 'with the exact payload from the reported issue' do
+      it 'renders the trusted YouTube iframe and the image, dropping the surrounding raw markup' do
+        html = '<p>This article has a video and an image.</p>' \
+               '<div><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allowfullscreen></iframe></div>' \
+               '<p>And here is an image:</p><img src="https://example.com/screenshot.png" width="600">' \
+               '<p>End of article.</p>'
+        output = render_html(html)
+
+        expect(output).to include('<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ"')
+        expect(output).to include('allowfullscreen')
+        expect(output).to include('<img src="https://example.com/screenshot.png" width="600" />')
+      end
+    end
+
+    context 'with a trusted iframe host' do
+      it 'renders a bare Loom iframe' do
+        html = '<iframe src="https://www.loom.com/embed/VIDEO_ID" allowfullscreen></iframe>'
+        expect(render_html(html)).to include('<iframe src="https://www.loom.com/embed/VIDEO_ID" frameborder="0" allowfullscreen></iframe>')
+      end
+    end
+
+    context 'with an untrusted iframe host' do
+      it 'drops the iframe entirely' do
+        html = '<iframe src="https://evil.com/phish"></iframe>'
+        output = render_html(html)
+        expect(output).not_to include('<iframe')
+        expect(output).not_to include('evil.com')
+      end
+    end
+
+    context 'with a plain http(s) image' do
+      it 'renders the image' do
+        html = '<img src="https://example.com/pic.png" alt="A pic" title="Nice">'
+        output = render_html(html)
+        expect(output).to include('<img src="https://example.com/pic.png" alt="A pic" title="Nice" />')
+      end
+    end
+
+    describe 'XSS regression coverage' do
+      it 'strips a raw <script> tag' do
+        output = render_html('<script>alert(1)</script>')
+        expect(output).not_to include('<script')
+        expect(output).not_to include('alert(1)')
+      end
+
+      it 'drops an <img> with a relative/non-URL src (classic onerror payload)' do
+        output = render_html('<img src=x onerror=alert(1)>')
+        expect(output).not_to include('onerror')
+        expect(output).not_to include('alert(1)')
+        expect(output).not_to include('<img')
+      end
+
+      it 'drops an <img> with a javascript: src' do
+        output = render_html('<img src="javascript:alert(1)">')
+        expect(output).not_to include('javascript:')
+        expect(output).not_to include('<img')
+      end
+
+      it 'drops an <iframe> with a javascript: src' do
+        output = render_html('<iframe src="javascript:alert(1)"></iframe>')
+        expect(output).not_to include('javascript:')
+        expect(output).not_to include('<iframe')
+      end
+
+      it 'drops an <iframe> with a data: src' do
+        output = render_html('<iframe src="data:text/html,<script>alert(1)</script>"></iframe>')
+        expect(output).not_to include('<iframe')
+        expect(output).not_to include('<script')
+      end
+
+      it 'drops an <img> with a data: src (no data URIs allowed for images either)' do
+        output = render_html('<img src="data:image/png;base64,AAAA">')
+        expect(output).not_to include('<img')
+        expect(output).not_to include('data:')
+      end
+
+      it 'drops an <iframe> with a protocol-relative src' do
+        output = render_html('<iframe src="//evil.com/x"></iframe>')
+        expect(output).not_to include('<iframe')
+        expect(output).not_to include('evil.com')
+      end
+
+      it 'drops an <iframe> whose src uses userinfo to disguise the real host' do
+        output = render_html('<iframe src="https://www.youtube.com@evil.com/x"></iframe>')
+        expect(output).not_to include('<iframe')
+        expect(output).not_to include('evil.com')
+      end
+
+      it 'does not allow a look-alike host to pass as a trusted host' do
+        output = render_html('<iframe src="https://evilyoutube.com/embed/x"></iframe>')
+        expect(output).not_to include('<iframe')
+      end
+
+      it 'does not allow a trusted-looking suffix host to pass as trusted' do
+        output = render_html('<iframe src="https://www.youtube.com.evil.com/embed/x"></iframe>')
+        expect(output).not_to include('<iframe')
+      end
+
+      it 'strips a raw <a href="javascript:..."> tag entirely (anchor is not on the allow-list)' do
+        output = render_html('<a href="javascript:alert(1)">click me</a>')
+        expect(output).not_to include('<a ')
+        expect(output).not_to include('javascript:')
+      end
+
+      it 'ignores an iframe srcdoc attribute even when no usable src is present' do
+        output = render_html('<iframe srcdoc="<script>alert(1)</script>"></iframe>')
+        expect(output).not_to include('<script')
+        expect(output).not_to include('<iframe')
+      end
+
+      it 'does not let a malicious width/height value inject extra attributes onto a safe image' do
+        html = %(<img src="https://example.com/pic.png" width="1&quot; onerror=&quot;alert(1)">)
+        output = render_html(html)
+        expect(output).to include('<img src="https://example.com/pic.png" />')
+        expect(output).not_to include('onerror')
+      end
+
+      it 'is not fooled by uppercase tag/attribute names' do
+        output = render_html('<IFRAME SRC="javascript:alert(1)"></IFRAME>')
+        expect(output).not_to include('<iframe')
+        expect(output.downcase).not_to include('javascript:')
+      end
+
+      it 'still omits unrelated raw HTML (e.g. a div wrapper) as a bare comment-free no-op' do
+        output = render_html('<div class="foo">hello</div>')
+        expect(output).not_to include('<div')
+        expect(output).not_to include('class="foo"')
+      end
+    end
+  end
+
   describe '#image' do
     it 'renders width in px with responsive cap and auto height' do
       markdown = '![Sample](https://example.com/image.jpg?cw_image_width=400px)'


### PR DESCRIPTION
Fixes #14602

## Problem

Articles created via the Portal Articles API (`POST /api/v1/accounts/{id}/portals/{slug}/articles`) with HTML content containing raw `<img>`/`<iframe>` tags had those elements silently disappear on the public Help Center.

Root cause: the public Help Center renders article content through `ChatwootMarkdownRenderer#render_article`, which parses the stored HTML/markdown with CommonMarker and renders it with `CustomMarkdownRenderer` (a `CommonMarker::HtmlRenderer` subclass). CommonMarker's default rendering mode (i.e. the `:UNSAFE` render option is **not** passed anywhere in this renderer) replaces *all* raw HTML block/inline nodes with an opaque `<!-- raw HTML omitted -->` comment — that's the built-in default from the `commonmarker` gem itself (see `html`/`inline_html` in `commonmarker`'s `HtmlRenderer`). Any raw `<img>`/`<iframe>` tag submitted via the API (as opposed to markdown image syntax `![alt](src)`, which the existing `#image` method already supports) gets swallowed by this.

## Fix

Adds a new `EmbeddedHtmlSanitizer` (`lib/embedded_html_sanitizer.rb`), used from `CustomMarkdownRenderer#html` and the previously-unhandled `#inline_html` node type, that re-renders **only**:

- `<img>` tags whose `src` is an absolute `http://`/`https://` URL
- `<iframe>` tags whose `src` is an absolute `http://`/`https://` URL **and** whose host is an exact, case-insensitive match against a new `trusted_iframe_hosts` allow-list added to `config/markdown_embeds.yml`. That list only mirrors the iframe destinations the *existing* markdown-link embed templates in that same file already point traffic to (YouTube, Loom, Vimeo, Arcade, Bunny, GuideJar, CodePen) — it grants no new trust.

Every other tag, attribute, and bare text in a raw HTML fragment is dropped exactly as it was before this change (still routed to nothing, matching the previous `<!-- raw HTML omitted -->` behavior net effect). **`:UNSAFE` is not enabled anywhere** — this is a narrow, explicit allow-list layered on top of CommonMarker's existing safe-mode suppression, not a bypass of it.

### Security design (please scrutinize)

- Every emitted `<img>`/`<iframe>` tag is **rebuilt from scratch**, attribute-by-attribute, from validated + `CGI.escapeHTML`-escaped values. No raw attribute string from user input is ever copied into the output — so even if Nokogiri's parser produced an attacker-controlled attribute we didn't intend to read (e.g. `onerror`, `srcdoc`, `style`), it's structurally impossible for it to reach the output, because we never re-serialize the parsed element — we only ever read `src`/`alt`/`title`/`width`/`height`/`allowfullscreen` off of it into a fresh string.
- `src` validation (`safe_http_url`): `URI.parse` the (already HTML-entity-decoded, by Nokogiri) value and require it to be a `URI::HTTP` instance (covers both `http`/`https` — `javascript:`, `data:`, `vbscript:`, `file:`, and protocol-relative `//host/path` all fail this check) with a non-blank host. Malformed/illegal-character URLs raise `URI::InvalidURIError` and are rejected (fail closed).
- iframe host validation (`trusted_iframe_host?`): exact, case-insensitive match only — no subdomain/suffix matching — so `evilyoutube.com` or `youtube.com.evil.com` cannot pass as `youtube.com`. `URI#host` also correctly ignores userinfo, so `https://youtube.com@evil.com/x` resolves to host `evil.com` and is rejected.
- `width`/`height` are only forwarded if they match `\A\d{1,4}\z` (bare digits, 1-4 of them) — no unit suffixes, no CSS, no attribute-injection payloads smuggled through a dimension value.
- Parsing itself (`Nokogiri::HTML5.fragment`) never executes anything — it only builds a DOM tree, so it's safe to run over fully attacker-controlled markup.

### What is intentionally still blocked (unchanged)

- `<script>` and any other tag not on the two-tag allow-list (dropped, not re-rendered)
- `<img>`/`<iframe>` with `javascript:`, `data:`, `vbscript:`, `file:`, or protocol-relative `src`
- `<iframe>` pointing at any host not on `trusted_iframe_hosts`
- `<iframe srcdoc="...">` (only `src` is ever read)
- Raw `<a href="javascript:...">` (anchor isn't on the allow-list, so it's dropped entirely along with its content)

### Out of scope / follow-up worth a maintainer look

While tracing how `node.url` is rendered for **markdown-syntax** links/images (`[text](url)`, `![alt](url)` — a *different* code path from the one this PR touches), I could not find any scheme/protocol filtering in `commonmarker` 0.23.12's pure-Ruby `HtmlRenderer#link`/`#image`/`escape_href` (it appears to only percent/entity-encode, not reject `javascript:`/`data:` schemes) once a custom Ruby renderer subclass is used instead of the C `cmark_render_html` writer's own safe-mode link-sanitization path. I have **not** verified this empirically (no Ruby/Bundler available in my environment to execute a repro), and it is unrelated to and unaffected by this PR's `html`/`inline_html`-only change, so I've deliberately left it out of scope here rather than bundle two different security concerns into one PR. If confirmed, `[xss](javascript:alert(1))` markdown syntax could render as a clickable unsafe anchor in both `CustomMarkdownRenderer` (Help Center articles) and `BaseMarkdownRenderer` (messages). Flagging for a maintainer to confirm/triage separately.

## Test plan

Added regression coverage to `spec/lib/custom_markdown_renderer_spec.rb`:
- The exact reproduction payload from the issue (mixed `<p>`/`<div>`/`<iframe>`/`<img>` on one line) renders the trusted iframe and the image
- Trusted-host iframe renders; untrusted-host iframe is dropped entirely
- Plain `http(s)` image renders with `alt`/`title`
- XSS regression coverage: `<script>`, `<img src=x onerror=...>`, `<img>`/`<iframe>` with `javascript:`/`data:` src, protocol-relative iframe src, userinfo-disguised host, look-alike/suffix host tricks, raw `<a href="javascript:...">`, `iframe srcdoc`, dimension-attribute-injection attempt, uppercase tag/attribute names, and confirmation that unrelated raw HTML (e.g. a bare `<div>`) is still a no-op

**I was not able to run this test suite** — this environment has no Ruby/Bundler installed, so I could not execute `bundle exec rspec spec/lib/custom_markdown_renderer_spec.rb` or run Rubocop. I manually traced CommonMarker's node-type/html-block parsing behavior and Nokogiri's HTML5 fragment-parsing/attribute-decoding semantics against every test case above, and checked the diff for `Layout/LineLength` (150) and `Metrics/ClassLength` (175) compliance by hand, but the tests are **written and reasoned through, not verified green**. Please run CI/rspec before merging and treat this disclosure as a hard gate — flagging this explicitly per this being a security-relevant sanitizer change.
