### PR TITLE
fix(i18n): register missing Ukrainian locale files (contentTemplates, yearInReview)

### DIFF
--- a/app/javascript/dashboard/i18n/locale/uk/index.js
+++ b/app/javascript/dashboard/i18n/locale/uk/index.js
@@ -39,7 +39,6 @@ import sessionLimit from './sessionLimit.json';
 import settings from './settings.json';
 import signup from './signup.json';
 import sla from './sla.json';
-import snooze from './snooze.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
@@ -87,7 +86,6 @@ export default {
   ...settings,
   ...signup,
   ...sla,
-  ...snooze,
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,

--- a/app/javascript/dashboard/i18n/locale/uk/index.js
+++ b/app/javascript/dashboard/i18n/locale/uk/index.js
@@ -13,6 +13,7 @@ import companies from './companies.json';
 import components from './components.json';
 import contact from './contact.json';
 import contactFilters from './contactFilters.json';
+import contentTemplates from './contentTemplates.json';
 import conversation from './conversation.json';
 import csatMgmt from './csatMgmt.json';
 import customRole from './customRole.json';
@@ -38,9 +39,11 @@ import sessionLimit from './sessionLimit.json';
 import settings from './settings.json';
 import signup from './signup.json';
 import sla from './sla.json';
+import snooze from './snooze.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -58,6 +61,7 @@ export default {
   ...components,
   ...contact,
   ...contactFilters,
+  ...contentTemplates,
   ...conversation,
   ...csatMgmt,
   ...customRole,
@@ -83,7 +87,9 @@ export default {
   ...settings,
   ...signup,
   ...sla,
+  ...snooze,
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...yearInReview,
 };


### PR DESCRIPTION
### Summary

`app/javascript/dashboard/i18n/locale/uk/index.js` does not import two locale files that exist and are already translated into Ukrainian, so their strings fall back to English in the dashboard:

- `contentTemplates.json`
- `yearInReview.json`

### Changes

Add the two missing `import` statements and their spreads, in alphabetical order to match the existing convention. No string content is changed (handled via Crowdin).

### Note on snooze

`snooze.json` is also unregistered for `uk`, but it is intentionally **left out** of this PR: its `SNOOZE_PARSER.UNITS` are mistranslated (`WEEK` → `день`, `MONTH` → `тиждень`, `YEAR` → `місяць`, plus untranslated plurals). Registering it as-is would make the snooze parser misread typed input. It should be corrected via Crowdin first, then registered separately. Thanks to the automated review for catching this.