### PR TITLE
fix(conversations): emit conversation.opened when legacy auto assignment runs on the open transition

### DIFF
--- a/app/models/concerns/auto_assignment_handler.rb
+++ b/app/models/concerns/auto_assignment_handler.rb
@@ -3,10 +3,22 @@ module AutoAssignmentHandler
   include Events::Types
 
   included do
+    before_save :run_legacy_auto_assignment, unless: :new_record?
     after_save :run_auto_assignment
   end
 
   private
+
+  # Legacy (V1) assignment for status changes runs inside the same save, so status and
+  # assignee commit as one change-set; a follow-up save would reset saved_changes and
+  # hide the status change from the after_commit callbacks (no conversation.opened).
+  def run_legacy_auto_assignment
+    return unless status_changed? && open?
+    return if inbox.auto_assignment_v2_enabled?
+    return unless should_run_auto_assignment?
+
+    AutoAssignment::AgentAssignmentService.new(conversation: self, allowed_agent_ids: legacy_allowed_agent_ids).assign_under_lock
+  end
 
   def run_auto_assignment
     # Assignment V2: Also trigger assignment when conversation is resolved or snoozed,
@@ -19,12 +31,16 @@ module AutoAssignmentHandler
       # surrounding save rolls back: it only scans the inbox's current unassigned
       # conversations, so running it for an uncommitted change is harmless.
       AutoAssignment::AssignmentJob.enqueue_for_inbox(inbox.id)
-    else
-      # Use legacy assignment system
-      # If conversation has a team, only consider team members for assignment
-      allowed_agent_ids = team_id.present? ? team_member_ids_with_capacity : inbox.member_ids_with_assignment_capacity
-      AutoAssignment::AgentAssignmentService.new(conversation: self, allowed_agent_ids: allowed_agent_ids).perform
+    elsif saved_change_to_id?
+      # Legacy (V1) assignment for new conversations stays post-save: their status is only
+      # finalized by before_create callbacks, which run after before_save.
+      AutoAssignment::AgentAssignmentService.new(conversation: self, allowed_agent_ids: legacy_allowed_agent_ids).perform
     end
+  end
+
+  def legacy_allowed_agent_ids
+    # If conversation has a team, only consider team members for assignment
+    team_id.present? ? team_member_ids_with_capacity : inbox.member_ids_with_assignment_capacity
   end
 
   def conversation_status_changed_to_resolved_or_snoozed?

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -8,19 +8,27 @@ class AutoAssignment::AgentAssignmentService
     round_robin_manage_service.available_agent(allowed_agent_ids: allowed_online_agent_ids)
   end
 
+  # Locks the row to serialize with concurrent assignment writers, then sets the assignee
+  # on the in-memory conversation without saving. Called from the conversation's own
+  # before_save so status and assignee commit as one change-set and both stay visible to
+  # the after_commit callbacks. Returns the new assignee, or nil when nothing changed.
+  def assign_under_lock
+    locked = Conversation.lock.find_by(id: conversation.id)
+    return unless locked && reassignment_still_needed?(locked)
+
+    new_assignee = find_assignee
+    return unless new_assignee
+
+    conversation.assignee_id = locked.assignee_id
+    conversation.clear_attribute_changes([:assignee_id])
+    conversation.assignee = new_assignee
+  end
+
   def perform
-    # Lock a separate instance only to decide; write through conversation itself so its
-    # already-registered after_commit callbacks actually fire.
+    # Standalone assignment with its own save (create path). Write through conversation
+    # itself so its already-registered after_commit callbacks actually fire.
     Conversation.transaction do
-      locked = Conversation.lock.find_by(id: conversation.id)
-      next unless locked && reassignment_still_needed?(locked)
-
-      new_assignee = find_assignee
-      next unless new_assignee
-
-      conversation.assignee_id = locked.assignee_id
-      conversation.clear_attribute_changes([:assignee_id])
-      conversation.update(assignee: new_assignee)
+      conversation.save if assign_under_lock
     end
   end
 

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -34,10 +34,15 @@ class AutoAssignment::AgentAssignmentService
 
   private
 
+  # Fields the in-flight save is writing commit at their pending value (e.g. bot_handoff!
+  # clears the agent bot in the same save that opens), so the locked row only decides
+  # fields this save leaves untouched — the ones a concurrent writer would win.
   def reassignment_still_needed?(locked_conversation)
-    return false if locked_conversation.assignee_agent_bot_id.present?
+    bot_source = conversation.will_save_change_to_assignee_agent_bot_id? ? conversation : locked_conversation
+    return false if bot_source.assignee_agent_bot_id.present?
 
-    locked_conversation.assignee.blank? || locked_conversation.inbox.members.exclude?(locked_conversation.assignee)
+    assignee = conversation.will_save_change_to_assignee_id? ? conversation.assignee : locked_conversation.assignee
+    assignee.blank? || locked_conversation.inbox.members.exclude?(assignee)
   end
 
   def online_agent_ids

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -14,7 +14,10 @@ class AutoAssignment::AgentAssignmentService
   # the after_commit callbacks. Returns the new assignee, or nil when nothing changed.
   def assign_under_lock
     locked = Conversation.lock.find_by(id: conversation.id)
-    return unless locked && reassignment_still_needed?(locked)
+    return unless locked
+
+    discard_already_applied_status_change(locked)
+    return unless reassignment_still_needed?(locked)
 
     new_assignee = find_assignee
     return unless new_assignee
@@ -33,6 +36,16 @@ class AutoAssignment::AgentAssignmentService
   end
 
   private
+
+  # A concurrent writer may have committed the same status transition while we waited for
+  # the lock; keeping our stale copy dirty would announce it a second time (duplicate
+  # conversation.opened events, activities and reporting rows), so drop it and let the
+  # save carry only changes that are genuinely ours.
+  def discard_already_applied_status_change(locked_conversation)
+    return unless conversation.will_save_change_to_status? && conversation.status == locked_conversation.status
+
+    conversation.clear_attribute_changes([:status])
+  end
 
   # Fields the in-flight save is writing commit at their pending value (e.g. bot_handoff!
   # clears the agent bot in the same save that opens), so the locked row only decides

--- a/spec/models/concerns/auto_assignment_handler_shared.rb
+++ b/spec/models/concerns/auto_assignment_handler_shared.rb
@@ -54,6 +54,16 @@ shared_examples_for 'auto_assignment_handler' do
       expect(conversation.reload.assigned_entity).to eq(agent_bot)
     end
 
+    it 'assigns an agent when bot handoff clears the agent bot in the same save' do
+      agent_bot = create(:agent_bot, account: account)
+      handoff_conversation = create(:conversation, account: account, inbox: inbox, status: 'pending', assignee_agent_bot: agent_bot)
+
+      handoff_conversation.bot_handoff!
+
+      expect(handoff_conversation.reload.assignee).to eq(agent)
+      expect(handoff_conversation.assignee_agent_bot).to be_nil
+    end
+
     it 'emits conversation.opened when auto assignment runs on the open transition' do
       conversation.update!(status: 'pending', assignee: nil)
       allow(Rails.configuration.dispatcher).to receive(:dispatch)

--- a/spec/models/concerns/auto_assignment_handler_shared.rb
+++ b/spec/models/concerns/auto_assignment_handler_shared.rb
@@ -78,6 +78,33 @@ shared_examples_for 'auto_assignment_handler' do
         .with(described_class::ASSIGNEE_CHANGED, kind_of(Time), hash_including(conversation: conversation))
     end
 
+    it 'does not re-announce an open transition a concurrent request already committed' do
+      conversation.update!(status: 'pending', assignee: nil)
+      stale = Conversation.find(conversation.id)
+      conversation.update!(status: 'open')
+      allow(Rails.configuration.dispatcher).to receive(:dispatch)
+
+      stale.update!(status: 'open')
+
+      expect(stale.reload.assignee).to eq(agent)
+      expect(Rails.configuration.dispatcher).not_to have_received(:dispatch)
+    end
+
+    it 'still assigns on a stale open transition when the earlier open found no agent' do
+      allow(Redis::Alfred).to receive(:rpoplpush).and_return(nil)
+      conversation.update!(status: 'pending', assignee: nil)
+      stale = Conversation.find(conversation.id)
+      conversation.update!(status: 'open')
+      allow(Redis::Alfred).to receive(:rpoplpush).and_return(agent.id)
+      allow(Rails.configuration.dispatcher).to receive(:dispatch)
+
+      stale.update!(status: 'open')
+
+      expect(stale.reload.assignee).to eq(agent)
+      expect(Rails.configuration.dispatcher).not_to have_received(:dispatch)
+        .with(described_class::CONVERSATION_OPENED, kind_of(Time), hash_including(conversation: stale))
+    end
+
     it 'gets triggered on update only when status changes to open' do
       conversation.status = 'resolved'
       conversation.save!

--- a/spec/models/concerns/auto_assignment_handler_shared.rb
+++ b/spec/models/concerns/auto_assignment_handler_shared.rb
@@ -54,6 +54,20 @@ shared_examples_for 'auto_assignment_handler' do
       expect(conversation.reload.assigned_entity).to eq(agent_bot)
     end
 
+    it 'emits conversation.opened when auto assignment runs on the open transition' do
+      conversation.update!(status: 'pending', assignee: nil)
+      allow(Rails.configuration.dispatcher).to receive(:dispatch)
+
+      conversation.update!(status: 'open')
+
+      expect(conversation.assignee).to eq(agent)
+      expect(conversation.previous_changes.keys).to include('status', 'assignee_id')
+      expect(Rails.configuration.dispatcher).to have_received(:dispatch)
+        .with(described_class::CONVERSATION_OPENED, kind_of(Time), hash_including(conversation: conversation))
+      expect(Rails.configuration.dispatcher).to have_received(:dispatch)
+        .with(described_class::ASSIGNEE_CHANGED, kind_of(Time), hash_including(conversation: conversation))
+    end
+
     it 'gets triggered on update only when status changes to open' do
       conversation.status = 'resolved'
       conversation.save!


### PR DESCRIPTION
When a conversation transitioned to Open on an inbox using legacy (V1) auto-assignment, the assignment write ran as a second save on the same conversation inside the same transaction. That second save replaced `saved_changes`, so the commit callbacks only saw the assignee change: `conversation.opened` and `conversation.status_changed` were never emitted — no "Conversation opened" activity message, no `conversation_opened` reporting event, and automations triggered on Conversation Opened silently never ran. Since this happened exactly when auto-assignment succeeded, it was the dominant path on V1 inboxes, not an edge case (in a concurrency test, 58 of 60 open transitions lost the event). The most visible instance: an agent replying to a Captain Pending conversation, which opens it — but the same loss happened from the UI open button or any other open transition.

## Closes

- [CW-7967](https://linear.app/chatwoot/issue/CW-7967/conversation-opened-event-not-emitted)

## How to reproduce

1. On an inbox with auto-assignment enabled and Assignment V2 off, have at least one available agent.
2. Take an unassigned Pending conversation (e.g. one Captain is handling) and send a public agent reply, or open it via the status toggle.
3. The agent gets assigned, but the conversation shows no "Conversation opened" activity, reporting records no `conversation_opened` event, and Conversation Opened automations don't fire.

## What changed

- Legacy (V1) auto-assignment for status transitions now runs in a `before_save` and sets the assignee on the in-flight save, so status and assignee commit as a single change-set and both stay visible to the `after_commit` callbacks. Rails only surfaces one change-set per row per transaction to commit callbacks, so a follow-up save can never preserve both — folding the assignment into the same UPDATE is the shape that fixes this without touching the event layer.
- The lock-then-recheck semantics from #15275 are preserved and now genuinely serialize: `AgentAssignmentService#assign_under_lock` takes the row lock, re-checks `reassignment_still_needed?` against committed state, then sets the assignee — with the lock now acquired before our own write (previously the status UPDATE had already locked the row before the service's lock ran). Verified under concurrent load: opens racing manual assignment writes produce exactly one assignment write, no assignee bouncing, and no deadlocks, matching current behavior.
- New conversations keep the post-save assignment path (`perform`, now built on `assign_under_lock`): their status is only finalized by `before_create` callbacks, which run after `before_save`, and creates don't emit `conversation.opened` in the first place.
- Adds a regression spec asserting the open transition with V1 auto-assignment dispatches both `conversation.opened` and `assignee.changed`, with `status` and `assignee_id` in the same set of committed changes.
