### PR TITLE
fix: treat empty labels as absent in filters

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/helpers/filterHelpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers/filterHelpers.js
@@ -242,6 +242,11 @@ const matchesCondition = (conversationValue, filter) => {
 
   const isNullish =
     conversationValue === null || conversationValue === undefined;
+  const isEmptyLabels =
+    filter.attribute_key === 'labels' &&
+    Array.isArray(conversationValue) &&
+    conversationValue.length === 0;
+  const isAbsent = isNullish || isEmptyLabels;
 
   const filterValue = Array.isArray(values)
     ? values.map(resolveValue)
@@ -261,10 +266,10 @@ const matchesCondition = (conversationValue, filter) => {
       return !contains(filterValue, conversationValue);
 
     case 'is_present':
-      return !isNullish;
+      return !isAbsent;
 
     case 'is_not_present':
-      return isNullish;
+      return isAbsent;
 
     case 'is_greater_than':
       return compareDates(conversationValue, filterValue, (a, b) => a > b);

--- a/app/javascript/dashboard/store/modules/conversations/helpers/specs/filterHelpers.spec.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers/specs/filterHelpers.spec.js
@@ -1170,14 +1170,14 @@ describe('filterHelpers', () => {
       expect(matchesFilters(conversation, filters)).toBe(true);
     });
 
-    it('should handle empty arrays in conversation', () => {
+    it('should treat an empty labels array as not present', () => {
       const conversation = {
         labels: [],
       };
       const filters = [
         {
           attribute_key: 'labels',
-          filter_operator: 'is_present',
+          filter_operator: 'is_not_present',
           values: [],
           query_operator: 'and',
         },


### PR DESCRIPTION
Fixes an issue where filtering conversations using **Labels → Is not present** caused the conversation list to remain empty and repeatedly reload. This affected both the Conversations view and saved folders, preventing teams from reliably finding unlabeled conversations for supervision and quality assurance.

## Closes

- [CW-7861](https://linear.app/chatwoot/issue/CW-7861/bug-labels-is-not-present-filter-triggers-an-infinite-flickering)

## How to reproduce

1. Open the Conversations page.
2. Open advanced filters.
3. Select **Labels**.
4. Select **Is not present**.
5. Apply the filter.
6. Observe that no conversations are displayed and the conversation list repeatedly flickers while loading additional pages.

The same behavior can be reproduced by creating or opening a folder that uses this filter.

## What caused the issue

The backend correctly returned unlabeled conversations with `labels: []`. The frontend then reapplied the filter locally but only treated `null` and `undefined` as absent.

As a result, an empty labels array was incorrectly considered present, and every conversation returned by the backend was removed from the displayed list. The empty list kept the infinite-scroll observer visible, causing it to request additional pages repeatedly and produce the flickering reload loop.

## What changed

The frontend filter matcher now treats an empty labels array as absent when evaluating label presence operators. This aligns frontend filtering with the backend:

- `labels: []` matches **Is not present**
- A non-empty labels array matches **Is present**

The change is scoped specifically to labels, preserving the existing presence semantics for other attributes and custom fields.