### PR TITLE
fix(campaigns): preserve analytics during polling errors

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/campaigns/pages/WhatsAppCampaignAnalyticsPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/campaigns/pages/WhatsAppCampaignAnalyticsPage.vue
@@ -199,8 +199,10 @@ const fetchMetrics = async ({
   } catch {
     if (requestId !== metricsRequestId || id !== campaignId.value) return;
 
-    state.metrics = null;
-    state.metricsError = true;
+    if (showLoading) {
+      state.metrics = null;
+      state.metricsError = true;
+    }
   } finally {
     if (requestId === metricsRequestId && id === campaignId.value) {
       state.isFetchingMetrics = false;
@@ -231,9 +233,11 @@ const fetchDeliveries = async ({
   } catch {
     if (requestId !== deliveriesRequestId || id !== campaignId.value) return;
 
-    state.deliveries = [];
-    state.meta = {};
-    state.deliveriesError = true;
+    if (showLoading) {
+      state.deliveries = [];
+      state.meta = {};
+      state.deliveriesError = true;
+    }
   } finally {
     if (requestId === deliveriesRequestId && id === campaignId.value) {
       state.isFetchingDeliveries = false;


### PR DESCRIPTION
Processing campaigns refresh their analytics in the background. A temporary metrics or recipient request failure currently clears the last successful snapshot, causing the analytics cards or recipient table to disappear until the next successful poll.

This change keeps the last successful analytics visible when a silent background refresh fails. Initial loads and user-triggered foreground requests continue to clear invalid data and show the existing error state.

Related: https://github.com/chatwoot/chatwoot/pull/15369

### Things to know

- Only background polling failures preserve cached data.
- The next five-second poll still retries and replaces the snapshot when it succeeds.
- Foreground request failures retain the current explicit error behavior.

### How to test

1. Open analytics for a campaign that is still processing and already has metrics and recipients.
2. Make one background analytics request fail temporarily.
3. Confirm the last successful metrics and recipient rows remain visible.
4. Restore the request and confirm the next poll refreshes the analytics.