### PR TITLE
fix: keep super admin user action buttons on one row

### DIFF
--- a/app/views/super_admin/users/show.html.erb
+++ b/app/views/super_admin/users/show.html.erb
@@ -23,7 +23,7 @@ as well as a link to its edit page.
     <%= content_for(:title) %>
   </h1>
 
-  <div>
+  <div class="flex items-center gap-2">
     <%= link_to(
             t("administrate.actions.edit"),
             [:edit, namespace,  page.resource.becomes(User)],
@@ -34,6 +34,7 @@ as well as a link to its edit page.
             [:resend_confirmation, namespace, page.resource.becomes(User)],
             method: :post,
             class: "button",
+            form_class: "button_to contents",
           ) unless page.resource.confirmed? %>
   </div>
 </header>


### PR DESCRIPTION
## Description

On the super admin user show page, the actions area renders an Edit link next to a Resend confirmation email button. The resend control is a `button_to`, which Rails wraps in a block-level `<form>`. That form dropped onto its own line instead of sitting beside Edit, stretching the header and pushing the page content down. It only renders for unconfirmed users, so the confirmed-user view looked fine and the regression was easy to miss.

This makes the actions container a flex row and takes the form out of the box flow (`display: contents`) so its button aligns inline next to Edit. No behavior change.

Related to https://linear.app/chatwoot/issue/CW-7527

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified locally on the super admin user show page for an unconfirmed user (Edit + Resend now inline) and a confirmed user (Edit only, unchanged).
