### PR TITLE
fix(campaigns): clarify pending whatsapp campaign statuses

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/campaign.json
+++ b/app/javascript/dashboard/i18n/locale/en/campaign.json
@@ -222,7 +222,16 @@
             "DESCRIPTION": "No delivery data was recorded for this campaign. This can happen for campaigns sent before campaign analytics were introduced."
           }
         },
-        "PROCESSING_BANNER": "This campaign is still processing. Analytics will update as messages are sent and delivery statuses are received.",
+        "PROCESSING_BANNER": {
+          "DEFAULT": "This campaign is still processing. Analytics will update automatically.",
+          "BOTH": "This campaign is still processing. {queued} messages are queued, and {awaitingUpdate} are awaiting a delivery update from WhatsApp.",
+          "BOTH_SINGLE": "This campaign is still processing. {queued} message is queued, and {awaitingUpdate} is awaiting a delivery update from WhatsApp.",
+          "BOTH_QUEUED_SINGLE": "This campaign is still processing. {queued} message is queued, and {awaitingUpdate} are awaiting a delivery update from WhatsApp.",
+          "BOTH_AWAITING_SINGLE": "This campaign is still processing. {queued} messages are queued, and {awaitingUpdate} is awaiting a delivery update from WhatsApp.",
+          "QUEUED": "This campaign is still processing. {count} message is queued. | This campaign is still processing. {count} messages are queued.",
+          "AWAITING_UPDATE": "This campaign is still processing. {count} message is awaiting a delivery update from WhatsApp. | This campaign is still processing. {count} messages are awaiting a delivery update from WhatsApp.",
+          "COMPLETING": "This campaign is completing. Analytics will update automatically."
+        },
         "RATE": "{value}% of audience",
         "SENT_ON": "Sent on {date}",
         "PAGE_INFO": "Showing {startItem} - {endItem} of {totalItems} contact | Showing {startItem} - {endItem} of {totalItems} contacts",
@@ -239,7 +248,7 @@
             "HINT": "Contacts included in this campaign."
           },
           "SENT": {
-            "LABEL": "Sent",
+            "LABEL": "Submitted to WhatsApp",
             "HINT": "Messages accepted by WhatsApp for delivery."
           },
           "DELIVERED": {
@@ -261,7 +270,7 @@
         },
         "STATUS": {
           "QUEUED": "Queued",
-          "SENT": "Sent",
+          "SENT": "Awaiting delivery update",
           "DELIVERED": "Delivered",
           "READ": "Read",
           "FAILED": "Failed",
@@ -275,7 +284,7 @@
             "DELIVERED": "Delivered",
             "FAILED": "Failed",
             "SKIPPED": "Skipped",
-            "PENDING": "Pending"
+            "PENDING": "Queued or awaiting update"
           }
         },
         "TABLE": {

--- a/app/javascript/dashboard/routes/dashboard/campaigns/pages/WhatsAppCampaignAnalyticsPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/campaigns/pages/WhatsAppCampaignAnalyticsPage.vue
@@ -91,6 +91,56 @@ const breadcrumbItems = computed(() => [
 
 const metricCount = key => Number(state.metrics?.[key] || 0);
 const audience = computed(() => metricCount('audience'));
+const processingBanner = computed(() => {
+  if (!state.metrics || !audience.value) {
+    return t('CAMPAIGN.WHATSAPP.ANALYTICS.PROCESSING_BANNER.DEFAULT');
+  }
+
+  const queued = Number(state.metrics.status_counts?.queued || 0);
+  const awaitingUpdate = Number(state.metrics.status_counts?.sent || 0);
+
+  if (queued && awaitingUpdate) {
+    const values = { queued, awaitingUpdate };
+    if (queued === 1 && awaitingUpdate === 1) {
+      return t(
+        'CAMPAIGN.WHATSAPP.ANALYTICS.PROCESSING_BANNER.BOTH_SINGLE',
+        values
+      );
+    }
+    if (queued === 1) {
+      return t(
+        'CAMPAIGN.WHATSAPP.ANALYTICS.PROCESSING_BANNER.BOTH_QUEUED_SINGLE',
+        values
+      );
+    }
+    if (awaitingUpdate === 1) {
+      return t(
+        'CAMPAIGN.WHATSAPP.ANALYTICS.PROCESSING_BANNER.BOTH_AWAITING_SINGLE',
+        values
+      );
+    }
+
+    return t('CAMPAIGN.WHATSAPP.ANALYTICS.PROCESSING_BANNER.BOTH', values);
+  }
+
+  if (queued) {
+    return t(
+      'CAMPAIGN.WHATSAPP.ANALYTICS.PROCESSING_BANNER.QUEUED',
+      { count: queued },
+      queued
+    );
+  }
+
+  if (awaitingUpdate) {
+    return t(
+      'CAMPAIGN.WHATSAPP.ANALYTICS.PROCESSING_BANNER.AWAITING_UPDATE',
+      { count: awaitingUpdate },
+      awaitingUpdate
+    );
+  }
+
+  return t('CAMPAIGN.WHATSAPP.ANALYTICS.PROCESSING_BANNER.COMPLETING');
+});
 const analyticsEmptyState = computed(() => {
   if (state.isFetchingMetrics || audience.value > 0) return null;
 
@@ -342,7 +392,7 @@ onBeforeUnmount(stopPolling);
             class="flex-shrink-0 mt-0.5 size-4 animate-spin"
           />
           <span>
-            {{ t('CAMPAIGN.WHATSAPP.ANALYTICS.PROCESSING_BANNER') }}
+            {{ processingBanner }}
           </span>
         </div>
       </Banner>


### PR DESCRIPTION
WhatsApp campaign analytics currently groups queued recipients and messages awaiting a WhatsApp delivery update under “Pending,” which makes it difficult to understand whether those messages have been submitted.

This change makes the processing state explicit. The summary now uses “Submitted to WhatsApp,” sent recipients are labeled “Awaiting delivery update,” and the processing banner shows the live queued and awaiting-update counts.

Related: https://linear.app/chatwoot/issue/CW-4627/ee-basic-analytics-for-whatsapp-campaigns

### Things to know

- This only changes the analytics presentation; delivery states and API calculations remain unchanged.
- The banner continues to refresh with the existing analytics polling.
- Singular, queued-only, awaiting-only, initial-loading, and completing states have dedicated copy.

### How to test

1. Open analytics for a processing WhatsApp campaign with queued and sent recipients.
2. Confirm the banner shows both counts: “X messages are queued, and Y are awaiting a delivery update from WhatsApp.”
3. Confirm the summary says “Submitted to WhatsApp,” the sent filter says “Awaiting delivery update,” and the breakdown says “Queued or awaiting update.”
4. Confirm the banner adapts when either count reaches zero and updates as campaign statuses change.