### PR TITLE
fix(security): scope conversation source_id lookup to the current account

### DIFF
--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -207,7 +207,8 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
     # fallback for the old case where we do look up only using source id
     # In future we need to change this and make sure we do look up on combination of inbox_id and source_id
     # and deprecate the support of passing only source_id as the param
-    @contact_inbox ||= ::ContactInbox.find_by!(source_id: params[:source_id])
+    lookup_scope = @inbox ? @inbox.contact_inboxes : ContactInbox.joins(:inbox).where(inboxes: { account_id: Current.account.id })
+    @contact_inbox ||= lookup_scope.find_by!(source_id: params[:source_id])
     authorize @contact_inbox.inbox, :show?
   rescue ActiveRecord::RecordNotUnique
     render json: { error: 'source_id should be unique' }, status: :unprocessable_entity

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -506,6 +506,40 @@ RSpec.describe 'Conversations API', type: :request do
         end
       end
     end
+
+    context 'when it is an authenticated bot' do
+      let(:bot) { create(:agent_bot, account: account) }
+      let(:other_account) { create(:account) }
+      let(:other_inbox) { create(:inbox, account: other_account) }
+      let(:other_contact) { create(:contact, account: other_account) }
+      let!(:other_contact_inbox) do
+        create(:contact_inbox, contact: other_contact, inbox: other_inbox)
+      end
+
+      before { allow(Rails.configuration.dispatcher).to receive(:dispatch) }
+
+      it 'does not create a conversation in another account from its source_id' do
+        expect do
+          post "/api/v1/accounts/#{account.id}/conversations",
+               headers: { api_access_token: bot.access_token.token },
+               params: { source_id: other_contact_inbox.source_id, message: { content: 'hi' } },
+               as: :json
+        end.not_to change(other_account.conversations, :count)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'creates a conversation for a source_id in its own account' do
+        expect do
+          post "/api/v1/accounts/#{account.id}/conversations",
+               headers: { api_access_token: bot.access_token.token },
+               params: { source_id: contact_inbox.source_id },
+               as: :json
+        end.to change(account.conversations, :count).by(1)
+
+        expect(response).to have_http_status(:success)
+      end
+    end
   end
 
   describe 'POST /api/v1/accounts/{account.id}/conversations/:id/toggle_status' do


### PR DESCRIPTION
## Description

The source-only fallback in `Api::V1::Accounts::ConversationsController#contact_inbox`
resolved a `ContactInbox` globally by `source_id`, unlike the sibling lookups in the
controller which scope through an inbox or the current account. This scopes the fallback
to the current account's inboxes (and to the supplied inbox when `inbox_id` is present),
keeping it consistent with the rest of the controller and deterministic when the same
`source_id` exists in more than one inbox.

Fixes https://linear.app/chatwoot/issue/CW-7966

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added request specs for bot-authenticated conversation creation: a create for a
`source_id` that belongs to another account no longer resolves (returns 404), and a
create for a `source_id` in the bot's own account still succeeds. Full
conversations_controller_spec passes (93 examples, 0 failures); RuboCop clean.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
