### PR TITLE
chore: bump mail gem to 2.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,7 +533,8 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.8.1)
+    mail (2.9.1)
+      logger
       mini_mime (>= 0.1.1)
       net-imap
       net-pop


### PR DESCRIPTION
## Description

Bumps the `mail` gem from 2.8.1 to 2.9.1 to resolve [GHSA-mvxr-6m87-mv2q](https://github.com/mikel/mail/security/advisories/GHSA-mvxr-6m87-mv2q) (email address spoofing via malformed RFC 2047 encoded-words), which is currently failing the bundle-audit CI check on develop ([example failing run](https://github.com/chatwoot/chatwoot/actions/runs/32226134705/job/95986093102?pr=15521)).

`mail` is a transitive dependency (via actionmailer), so this is a lockfile-only change done with `bundle update mail --conservative`. The only dependency change is the new explicit `logger` dependency, which is already in the bundle.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `bundle exec bundle-audit check --update` passes (no vulnerabilities found)
- Verified mail 2.9.1 loads and renders a basic message correctly
- All email specs pass

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
