### PR TITLE
fix(auto-assignment): don't assign conversations outside their team

### DIFF
--- a/app/jobs/auto_assignment/assignment_job.rb
+++ b/app/jobs/auto_assignment/assignment_job.rb
@@ -2,6 +2,9 @@ class AutoAssignment::AssignmentJob < ApplicationJob
   queue_as :default
 
   IN_FLIGHT_TTL = 5.minutes
+  # Let automation rules (assign_team runs on its own async dispatcher) land first, so the
+  # batch snapshot already carries team_id and filter_agents_by_team can do its job.
+  ENQUEUE_DELAY = 15.seconds
 
   # Coalesce per inbox: at most one AssignmentJob per inbox is in-flight
   # (queued or running) at any time. The marker carries a token so a job only
@@ -11,7 +14,7 @@ class AutoAssignment::AssignmentJob < ApplicationJob
     token = SecureRandom.uuid
     return false unless ::Redis::Alfred.set(key, token, nx: true, ex: IN_FLIGHT_TTL)
 
-    return true if perform_later(inbox_id: inbox_id, token: token)
+    return true if set(wait: ENQUEUE_DELAY).perform_later(inbox_id: inbox_id, token: token)
 
     # Enqueue was halted; release our own claim so the inbox isn't gated until the TTL.
     ::Redis::Alfred.delete_if_equals(key, token)

--- a/app/services/auto_assignment/assignment_service.rb
+++ b/app/services/auto_assignment/assignment_service.rb
@@ -115,12 +115,24 @@ class AutoAssignment::AssignmentService
                     .lock('FOR UPDATE SKIP LOCKED')
                     .first
       next false unless locked
+      next false unless agent_allowed_for_team?(locked, agent)
 
       locked.update!(assignee: agent)
       true
     end
   ensure
     Current.executed_by = nil
+  end
+
+  # The batch snapshot in perform_bulk_assignment can predate an automation rule setting the
+  # team, so filter_agents_by_team may have seen a blank team_id. Re-check membership against
+  # the freshly locked row before claiming it.
+  def agent_allowed_for_team?(conversation, agent)
+    team = conversation.team
+    return true if team.blank?
+    return false if team.allow_auto_assign.blank?
+
+    team.members.exists?(agent.id)
   end
 
   def dispatch_assignment_event(conversation, agent)

--- a/spec/jobs/auto_assignment/assignment_job_spec.rb
+++ b/spec/jobs/auto_assignment/assignment_job_spec.rb
@@ -83,11 +83,32 @@ RSpec.describe AutoAssignment::AssignmentJob, type: :job do
     after { Redis::Alfred.delete(format(Redis::Alfred::AUTO_ASSIGNMENT_IN_FLIGHT_KEY, inbox_id: inbox.id)) }
 
     it 'enqueues one run per inbox and coalesces concurrent triggers' do
-      allow(described_class).to receive(:perform_later).and_return(true)
+      # enqueue_for_inbox delays the run, so the stub has to sit on the configured job
+      configured = double
+      allow(configured).to receive(:perform_later).and_return(true)
+      allow(described_class).to receive(:set).and_return(configured)
 
       expect(described_class.enqueue_for_inbox(inbox.id)).to be(true)
       expect(described_class.enqueue_for_inbox(inbox.id)).to be(false)
-      expect(described_class).to have_received(:perform_later).once
+      expect(configured).to have_received(:perform_later).once
+    end
+
+    it 'delays the run so automation rules can set the team first' do
+      allow(described_class).to receive(:set).and_call_original
+
+      described_class.enqueue_for_inbox(inbox.id)
+
+      expect(described_class).to have_received(:set).with(wait: described_class::ENQUEUE_DELAY)
+    end
+
+    it 'releases its own marker when the enqueue is halted' do
+      configured = double
+      allow(configured).to receive(:perform_later).and_return(false)
+      allow(described_class).to receive(:set).and_return(configured)
+      key = format(Redis::Alfred::AUTO_ASSIGNMENT_IN_FLIGHT_KEY, inbox_id: inbox.id)
+
+      expect(described_class.enqueue_for_inbox(inbox.id)).to be(false)
+      expect(Redis::Alfred.get(key)).to be_nil
     end
 
     it 'does not release a newer run marker when its own token is stale' do

--- a/spec/services/auto_assignment/assignment_service_spec.rb
+++ b/spec/services/auto_assignment/assignment_service_spec.rb
@@ -445,6 +445,56 @@ RSpec.describe AutoAssignment::AssignmentService do
 
         expect(conversation_with_team.reload.assignee).to be_nil
       end
+
+      # Regression: an automation rule can set the team after perform_bulk_assignment took its
+      # snapshot, so filter_agents_by_team sees a blank team_id and round robin runs over the
+      # whole inbox. The team write is injected during agent selection — i.e. after the snapshot
+      # and before claim_and_assign — which is exactly the production ordering. update_all keeps
+      # callbacks out of it so ensure_assignee_is_from_team cannot mask the bug.
+      context 'when the team was set after the batch snapshot was taken' do
+        let(:outsider) { create(:user, account: account, role: :agent, availability: :online) }
+
+        def selector_that_sets_team(conversation, team, picked_agent)
+          selector = instance_double(AutoAssignment::RoundRobinSelector)
+          allow(AutoAssignment::RoundRobinSelector).to receive(:new).and_return(selector)
+          allow(selector).to receive(:select_agent) do
+            Conversation.where(id: conversation.id).update_all(team_id: team.id) # rubocop:disable Rails/SkipsModelValidations
+            picked_agent
+          end
+          selector
+        end
+
+        it 'does not assign an agent who is not a member of the team' do
+          create(:inbox_member, inbox: inbox, user: outsider)
+          allow(OnlineStatusTracker).to receive(:get_available_users).and_return({ outsider.id.to_s => 'online' })
+          conversation_without_team = create(:conversation, inbox: inbox, team: nil, assignee: nil)
+          selector_that_sets_team(conversation_without_team, team, outsider)
+
+          service.perform_bulk_assignment(limit: 1)
+
+          expect(conversation_without_team.reload.assignee).to be_nil
+          expect(conversation_without_team.team_id).to eq(team.id)
+        end
+
+        it 'still assigns when the picked agent happens to be a team member' do
+          conversation_without_team = create(:conversation, inbox: inbox, team: nil, assignee: nil)
+          selector_that_sets_team(conversation_without_team, team, team_member)
+
+          service.perform_bulk_assignment(limit: 1)
+
+          expect(conversation_without_team.reload.assignee).to eq(team_member)
+        end
+
+        it 'does not assign when the team that landed disallows auto assignment' do
+          team.update!(allow_auto_assign: false)
+          conversation_without_team = create(:conversation, inbox: inbox, team: nil, assignee: nil)
+          selector_that_sets_team(conversation_without_team, team, team_member)
+
+          service.perform_bulk_assignment(limit: 1)
+
+          expect(conversation_without_team.reload.assignee).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

Auto-assignment can hand a conversation to an agent who is not a member of the
conversation's team, and the wrong assignee then sticks permanently. On a
self-hosted 4.16.1 instance, 46 of 67 automatic assignments were overwritten
within 0–6 seconds of being made, and one conversation kept an assignee from
outside its team until an admin unassigned it by hand.

No existing issue covers this — I did not find one when searching, so there is
nothing to link. Happy to open an issue first if you prefer that order.

**Why it happens.** Two assignment paths run concurrently for the same incoming
message: the assignment batch and an automation rule that sets the team.

1. `perform_bulk_assignment` snapshots the conversation list
   (`assignment_service.rb:8`, `unassigned_conversations(limit).to_a`).
2. `filter_agents_by_team` reads `conversation&.team_id` from that in-memory copy
   (`assignment_service.rb:79`). If the automation rule sets the team *after* the
   snapshot, this reads a blank `team_id` and round robin runs over the whole
   inbox instead of the team.
3. `claim_and_assign` writes only the assignee (`assignment_service.rb:109`),
   leaving `team_id` untouched.
4. `ensure_assignee_is_from_team` starts with `return unless team_id_changed?`
   (`app/models/concerns/assignment_handler.rb:13`), so the write in step 3 never
   goes through membership validation.

The result is an assignee who belongs to no team on the conversation, or to a
different one, with nothing downstream to correct it.

**What changed.** Two commits, deliberately separate because they carry very
different risk.

**1. `fix(auto-assignment): re-check team membership before claiming`**

Re-checks membership against the freshly locked row inside `claim_and_assign`,
before the assignee is written, and declines the claim when the team that landed
disallows auto assignment. This is the correctness fix and it stands on its own:
the row is already locked `FOR UPDATE SKIP LOCKED` at that point, so the check
sees the team as it is at write time rather than as it was at snapshot time.

Behaviour change: a conversation whose team landed mid-batch is left unassigned
instead of being assigned to the wrong agent. It is picked up by the next run.

**2. `fix(auto-assignment): let automation rules land before the batch runs`**

Delays the job enqueue so the automation rule has landed by the time the batch
takes its snapshot, which lets `filter_agents_by_team` do its job and the
conversation get assigned right away rather than on the next run.

This one is a timing choice, not a correctness fix, and it affects every install
— not only those running an `assign_team` rule. You may well want a different
value, a configurable setting, or no delay at all. **The first commit works
without it**, so it can be dropped without losing the fix. It is included because
with the guard alone, a conversation caught by the race waits for the next sweep,
and on an inbox with a periodic assignment policy that can be up to 30 minutes.

A cleaner alternative, if you prefer it: have the automation rule's `assign_team`
action and the assignment batch share one write path, so the team and the
assignee always land in a single update. That is a larger change than this PR
attempts, and it is your call on the design.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Automated.** Run against `develop` (`8d93d69e8`), Ruby 3.4.4, Postgres 16
(pgvector) and Redis 7, `RAILS_ENV=test`:

```
bundle exec rspec spec/services/auto_assignment/ spec/jobs/auto_assignment/
  => 65 examples, 0 failures

bundle exec rspec spec/services/automation_rules/ spec/models/conversation_spec.rb spec/models/concerns/
  => 213 examples, 0 failures

bundle exec rubocop app/services/auto_assignment/assignment_service.rb \
  app/jobs/auto_assignment/assignment_job.rb \
  spec/services/auto_assignment/assignment_service_spec.rb \
  spec/jobs/auto_assignment/assignment_job_spec.rb
  => 4 files inspected, no offenses detected
```

New coverage:

- `spec/services/auto_assignment/assignment_service_spec.rb` — a regression
  context that injects the team write *during* agent selection (a stub on
  `RoundRobinSelector#select_agent`), i.e. after the snapshot and before
  `claim_and_assign`, matching the production ordering. `update_all` keeps
  callbacks out of it so `ensure_assignee_is_from_team` cannot mask the bug.
  Three cases: outsider is not assigned, team member still is, and a team with
  `allow_auto_assign: false` blocks the claim.
- `spec/jobs/auto_assignment/assignment_job_spec.rb` — the delay is asserted, the
  existing coalescing test is adjusted to stub the configured job, and the
  marker-release path on a halted enqueue is now covered.

**Both commits were also run against unpatched code**, because a test asserting
"nothing happened" proves nothing unless it can fail:

- Guard reverted, spec kept: the regression context gives 2 failures out of 3.
  The middle case passes either way, correctly — there the picked agent happens
  to be a team member.
- Delay reverted, spec kept: the job spec gives 3 failures out of 11, including
  the adjusted coalescing test, so the `set` stub is not passing both ways.

One caveat worth stating plainly: the "delays the run" example asserts the
implementation (`set` received `wait: ENQUEUE_DELAY`) rather than behaviour. The
behavioural evidence for the delay is production, not that spec.

**Manual, on a production instance.** The patched build has been running on a
self-hosted instance since 2026-08-18. Before the patch, the activity log showed
the double write — `Assigned to <agent> by Default Policy`, then the team a
second or two later. After it, assignments arrive as a single write carrying both
the team and the assignee, and the counter of the old shape has not moved since.

**How to reproduce the original bug.**

1. Enable auto assignment on an inbox and add agents from more than one team.
2. Add an automation rule on `conversation_created` whose action is
   `assign_team`.
3. Send a message that creates a conversation.
4. Watch the activity log. When the batch wins the race you get two entries a
   second or two apart — the assignment first, the team second — and the
   assignee is frequently not a member of the team that landed.

The race is timing-dependent, so it does not reproduce on every conversation. It
gets more likely the more agents the inbox has, because agent selection takes
longer.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — not needed; no
      user-facing setting or documented behaviour changes. If you consider the
      enqueue delay worth documenting, tell me where and I will add it.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
      — n/a, no dependencies