### PR TITLE
fix: render activity messages as text

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/Activity.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Activity.vue
@@ -17,6 +17,6 @@ const readableTime = computed(() =>
     class="px-3 py-1 !rounded-xl flex min-w-0 items-center gap-2"
     data-bubble-name="activity"
   >
-    <span v-dompurify-html="content" :title="content" />
+    <span :title="content">{{ content }}</span>
   </BaseBubble>
 </template>

--- a/app/javascript/dashboard/components-next/message/bubbles/specs/Activity.spec.js
+++ b/app/javascript/dashboard/components-next/message/bubbles/specs/Activity.spec.js
@@ -1,0 +1,43 @@
+import { defineComponent, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import Activity from '../Activity.vue';
+import { provideMessageContext } from '../../provider.js';
+
+const mountActivity = content => {
+  const TestHost = defineComponent({
+    components: { Activity },
+    setup() {
+      provideMessageContext({
+        content: ref(content),
+        createdAt: ref(1724054400),
+      });
+    },
+    template: '<Activity />',
+  });
+
+  return mount(TestHost, {
+    global: {
+      stubs: {
+        BaseBubble: {
+          template: '<div data-bubble-name="activity"><slot /></div>',
+        },
+      },
+    },
+  });
+};
+
+describe('Activity', () => {
+  it('renders activity content as text instead of HTML', () => {
+    const content =
+      'Conversation was marked resolved by x <font color="red"><img src="https://placehold.co/80x24/red/white?text=SERA7C">SERA-HTMLi-7CM1XT2P</font>';
+    const wrapper = mountActivity(content);
+
+    expect(wrapper.text()).toContain(content);
+    expect(wrapper.find('font').exists()).toBe(false);
+    expect(wrapper.find('img').exists()).toBe(false);
+    expect(wrapper.find('span').element.innerHTML).toContain(
+      '&lt;font color="red"&gt;'
+    );
+    expect(wrapper.find('span').attributes('title')).toBe(content);
+  });
+});


### PR DESCRIPTION
# Pull Request Template

## Description

Activity messages in the dashboard now render their content as text instead of sanitized HTML. This prevents stored markup from profile names or other activity-message inputs from being interpreted in conversation activity bubbles, while preserving the visible activity text.

Fixes [CW-7979](https://linear.app/chatwoot/issue/CW-7979/stored-html-injection-via-agent-profile-name-in-conversation-activity)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `pnpm exec vitest --no-watch --no-cache --no-coverage app/javascript/dashboard/components-next/message/bubbles/specs/Activity.spec.js`
- `pnpm exec eslint app/javascript/dashboard/components-next/message/bubbles/Activity.vue app/javascript/dashboard/components-next/message/bubbles/specs/Activity.spec.js`
- `git diff --check`
- `bundle exec rspec spec/controllers/api/v1/profiles_controller_spec.rb:90 spec/controllers/api/v1/accounts/conversations_controller_spec.rb:570 spec/models/conversation_spec.rb:270`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
