### PR TITLE
fix: prevent reopening resolved conversations from widget

### DIFF
--- a/app/controllers/api/v1/widget/messages_controller.rb
+++ b/app/controllers/api/v1/widget/messages_controller.rb
@@ -43,10 +43,17 @@ class Api::V1::Widget::MessagesController < Api::V1::Widget::BaseController
   end
 
   def set_conversation
-    return unless conversation.nil?
+    if conversation.nil?
+      @conversation = create_conversation
+      apply_labels if permitted_params[:labels].present?
+      return
+    end
 
-    @conversation = create_conversation
-    apply_labels if permitted_params[:labels].present?
+    # Hiding the reply box does not stop requests reaching this endpoint, so the setting is
+    # enforced here.
+    return if inbox.allow_messages_after_resolved || !conversation.resolved?
+
+    render json: { error: 'Conversation is resolved and does not accept new messages' }, status: :forbidden
   end
 
   def apply_labels

--- a/app/controllers/api/v1/widget/messages_controller.rb
+++ b/app/controllers/api/v1/widget/messages_controller.rb
@@ -53,7 +53,7 @@ class Api::V1::Widget::MessagesController < Api::V1::Widget::BaseController
     # enforced here.
     return if inbox.allow_messages_after_resolved || !conversation.resolved?
 
-    render json: { error: 'Conversation is resolved and does not accept new messages' }, status: :forbidden
+    render json: { error: I18n.t('errors.conversations.resolved') }, status: :forbidden
   end
 
   def apply_labels

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,6 +113,7 @@ en:
       sso_not_enabled: SAML SSO is not enabled for this installation
       multi_account_invitation_not_allowed: Users associated with another account cannot be added while SAML is enabled
     conversations:
+      resolved: Conversation is resolved and does not accept new messages
       unread_counts:
         feature_not_enabled: Conversation unread counts feature not enabled for this account
     data_import:

--- a/spec/controllers/api/v1/widget/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/messages_controller_spec.rb
@@ -42,6 +42,39 @@ RSpec.describe '/api/v1/widget/messages', type: :request do
   end
 
   describe 'POST /api/v1/widget/messages' do
+    context 'when the conversation is resolved and the inbox does not allow messages after resolved' do
+      before do
+        web_widget.inbox.update!(allow_messages_after_resolved: false)
+        conversation.resolved!
+      end
+
+      it 'rejects the message and does not create a new conversation' do
+        expect do
+          post api_v1_widget_messages_url,
+               params: { website_token: web_widget.website_token, message: { content: 'hello world' } },
+               headers: { 'X-Auth-Token' => token },
+               as: :json
+        end.to not_change(Conversation, :count).and not_change(Message, :count)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.parsed_body['error']).to eq('Conversation is resolved and does not accept new messages')
+      end
+
+      it 'accepts the message when the inbox allows messages after resolved' do
+        web_widget.inbox.update!(allow_messages_after_resolved: true)
+
+        expect do
+          post api_v1_widget_messages_url,
+               params: { website_token: web_widget.website_token, message: { content: 'hello world' } },
+               headers: { 'X-Auth-Token' => token },
+               as: :json
+        end.not_to change(Conversation, :count)
+
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.messages.last.content).to eq('hello world')
+      end
+    end
+
     context 'when post request is made' do
       it 'creates message in conversation' do
         conversation.destroy! # Test all params

--- a/spec/controllers/api/v1/widget/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/messages_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe '/api/v1/widget/messages', type: :request do
         end.to not_change(Conversation, :count).and not_change(Message, :count)
 
         expect(response).to have_http_status(:forbidden)
-        expect(response.parsed_body['error']).to eq('Conversation is resolved and does not accept new messages')
+        expect(response.parsed_body['error']).to eq(I18n.t('errors.conversations.resolved'))
       end
 
       it 'accepts the message when the inbox allows messages after resolved' do


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes resolved conversations being reopened by customers through the live chat widget when **Allow messages after conversation resolved** is disabled.

The check is now enforced on the server. If a conversation is resolved and replies are not allowed, the message endpoint returns `403 Forbidden` instead of adding the message and reopening the conversation. The widget already hides the reply box for resolved conversations, so this closes the paths that bypass it. The visitor sees the message marked as failed.

Customers can still use the widget's **Start a new conversation** button to reach out again.


### What changed

* `Api::V1::Widget::MessagesController#set_conversation` now returns `403 Forbidden` when the conversation is resolved and `allow_messages_after_resolved` is disabled.
* This covers both text messages and attachments since they use the same endpoint.
* First messages and inboxes where the setting is enabled behave exactly as before.



Fixes https://linear.app/chatwoot/issue/CW-7846/known-issue-with-customers-being-able-to-open-resolved-chats

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?


### Screencast

**Before**

https://github.com/user-attachments/assets/92617b37-2ec0-42fe-a208-98f9a8dfbab7


**After**


https://github.com/user-attachments/assets/2b508962-b4c7-4f09-a640-ed38933669b8



### How to reproduce

The reply box is already hidden for resolved conversations, so we need a path that bypasses it. The retry button on a failed message is the simplest way to reproduce this.

1. Go to Inbox settings and disable **Allow messages after conversation resolved**.
2. Open the widget, start a conversation, and send a message.
3. Open DevTools → Network and set the network to **Offline**.
4. Send another message. It fails and shows the **Send message again** retry icon.
5. Set the network back to **Online**.
6. Resolve the conversation from the dashboard.
7. Click the retry icon on the failed message.

**Before:** The message is added to the resolved conversation and reopens it.

**After:** The request is rejected, the message stays marked as failed, and the conversation remains resolved. The customer can start a new conversation from the widget instead.



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
