### PR TITLE
fix: include conversation labels in Captain state

### DIFF
--- a/enterprise/app/services/captain/assistant/runner_state_helper.rb
+++ b/enterprise/app/services/captain/assistant/runner_state_helper.rb
@@ -31,6 +31,7 @@ module Captain::Assistant::RunnerStateHelper
 
   def build_conversation_state(state)
     state[:conversation] = slice_attrs(@conversation, CONVERSATION_STATE_ATTRIBUTES)
+    state[:conversation][:label_list] = @conversation.label_list.to_a
     state[:channel_type] = @conversation.inbox&.channel_type
     state[:message_length_limit] = Captain::MessageLengthLimit.for(@conversation)
     state[:contact] = slice_attrs(@conversation.contact, CONTACT_STATE_ATTRIBUTES) if @conversation.contact

--- a/spec/enterprise/services/captain/assistant/agent_runner_service_spec.rb
+++ b/spec/enterprise/services/captain/assistant/agent_runner_service_spec.rb
@@ -770,6 +770,16 @@ RSpec.describe Captain::Assistant::AgentRunnerService do
       expect(state[:channel_type]).to eq(inbox.channel_type)
     end
 
+    it 'includes labels from a persisted conversation' do
+      conversation.label_list.add('lang_en')
+      conversation.save!
+      conversation.reload
+
+      state = service.send(:build_state)
+
+      expect(state.dig(:conversation, :label_list)).to contain_exactly('lang_en')
+    end
+
     it 'includes contact inbox attributes when conversation is present' do
       state = service.send(:build_state)
 


### PR DESCRIPTION
## Summary

Captain now reads the conversation label list through the model accessor when it builds runner state. The regression coverage reloads a labeled conversation before building state, which matches the background job path.

## Why

`label_list` is a virtual attribute backed by conversation tags. The runner previously sliced it from `record.attributes`, where it is nil on a persisted and reloaded conversation. Captain therefore omitted active conversation labels from the model prompt even though the labels were present on the conversation.

The change keeps the existing runner state shape and ensures the current label list reaches the prompt.

## Testing

- `bundle exec rspec spec/enterprise/services/captain/assistant/agent_runner_service_spec.rb`
- `bundle exec rubocop --cache-root /tmp/codex-rubocop-aa05 enterprise/app/services/captain/assistant/runner_state_helper.rb spec/enterprise/services/captain/assistant/agent_runner_service_spec.rb`