### PR TITLE
chore: clean up resolved conversation guard in widget

### DIFF
--- a/app/controllers/api/v1/widget/messages_controller.rb
+++ b/app/controllers/api/v1/widget/messages_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::Widget::MessagesController < Api::V1::Widget::BaseController
+  before_action :prevent_reply_to_resolved_conversation, only: [:create]
   before_action :set_conversation, only: [:create]
   before_action :set_message, only: [:update]
 
@@ -42,18 +43,20 @@ class Api::V1::Widget::MessagesController < Api::V1::Widget::BaseController
     end
   end
 
-  def set_conversation
-    if conversation.nil?
-      @conversation = create_conversation
-      apply_labels if permitted_params[:labels].present?
-      return
-    end
-
-    # Hiding the reply box does not stop requests reaching this endpoint, so the setting is
-    # enforced here.
-    return if inbox.allow_messages_after_resolved || !conversation.resolved?
+  # Hiding the reply box does not stop requests reaching this endpoint, so the setting is
+  # enforced here.
+  def prevent_reply_to_resolved_conversation
+    return unless conversation&.resolved?
+    return if inbox.allow_messages_after_resolved
 
     render json: { error: I18n.t('errors.conversations.resolved') }, status: :forbidden
+  end
+
+  def set_conversation
+    return if conversation.present?
+
+    @conversation = create_conversation
+    apply_labels if permitted_params[:labels].present?
   end
 
   def apply_labels


### PR DESCRIPTION
# Pull Request Template

## Description

This PR cleans up the resolved-conversation guard in the widget messages controller by separating the authorization check from the conversation creation logic. This makes `set_conversation` responsible only for lazily creating the conversation, while the resolved-conversation check is handled by a dedicated before-action.

No behavior change.

### What changed

* Moved the resolved-conversation check from `set_conversation` to a dedicated `prevent_reply_to_resolved_conversation` before-action.
* Moved the hardcoded error message to `errors.conversations.resolved` in `en.yml`.

Fixes https://github.com/chatwoot/chatwoot/pull/15529#discussion_r3816102329

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
