### PR TITLE
fix(sdk): refresh users when contact details change

### DIFF
--- a/app/javascript/sdk/cookieHelpers.js
+++ b/app/javascript/sdk/cookieHelpers.js
@@ -3,6 +3,23 @@ import Cookies from 'js-cookie';
 
 const REQUIRED_USER_KEYS = ['avatar_url', 'email', 'name'];
 const ALLOWED_USER_ATTRIBUTES = [...REQUIRED_USER_KEYS, 'identifier_hash'];
+const CONTACT_INFORMATION_ATTRIBUTES = [
+  'phone_number',
+  'company_name',
+  'city',
+  'country_code',
+  'description',
+  'social_profiles',
+];
+
+const serializeUserAttribute = value => {
+  if (!value || typeof value !== 'object') return value || '';
+
+  const sortedEntries = Object.keys(value)
+    .sort()
+    .map(key => [key, value[key]]);
+  return JSON.stringify(sortedEntries);
+};
 
 export const getUserCookieName = () => {
   const SET_USER_COOKIE_PREFIX = 'cw_user_';
@@ -15,7 +32,15 @@ export const getUserString = ({ identifier = '', user }) => {
     (acc, key) => `${acc}${key}${user[key] || ''}`,
     ''
   );
-  return `${userStringWithSortedKeys}identifier${identifier}`;
+  const contactInformationString = CONTACT_INFORMATION_ATTRIBUTES.reduce(
+    (acc, key) => {
+      if (user[key] === undefined) return acc;
+
+      return `${acc}${key}${serializeUserAttribute(user[key])}`;
+    },
+    ''
+  );
+  return `${userStringWithSortedKeys}${contactInformationString}identifier${identifier}`;
 };
 
 export const computeHashForUserData = (...args) => md5(getUserString(...args));

--- a/app/javascript/sdk/cookieHelpers.js
+++ b/app/javascript/sdk/cookieHelpers.js
@@ -12,13 +12,12 @@ const CONTACT_INFORMATION_ATTRIBUTES = [
   'social_profiles',
 ];
 
-const serializeUserAttribute = value => {
+const normalizeUserAttribute = value => {
   if (!value || typeof value !== 'object') return value || '';
 
-  const sortedEntries = Object.keys(value)
+  return Object.keys(value)
     .sort()
     .map(key => [key, value[key]]);
-  return JSON.stringify(sortedEntries);
 };
 
 export const getUserCookieName = () => {
@@ -28,19 +27,14 @@ export const getUserCookieName = () => {
 };
 
 export const getUserString = ({ identifier = '', user }) => {
-  const userStringWithSortedKeys = ALLOWED_USER_ATTRIBUTES.reduce(
-    (acc, key) => `${acc}${key}${user[key] || ''}`,
-    ''
-  );
-  const contactInformationString = CONTACT_INFORMATION_ATTRIBUTES.reduce(
-    (acc, key) => {
-      if (user[key] === undefined) return acc;
-
-      return `${acc}${key}${serializeUserAttribute(user[key])}`;
-    },
-    ''
-  );
-  return `${userStringWithSortedKeys}${contactInformationString}identifier${identifier}`;
+  const userAttributes = [
+    ...ALLOWED_USER_ATTRIBUTES.map(key => [key, user[key] || '']),
+    ...CONTACT_INFORMATION_ATTRIBUTES.filter(
+      key => user[key] !== undefined
+    ).map(key => [key, normalizeUserAttribute(user[key])]),
+    ['identifier', String(identifier)],
+  ];
+  return JSON.stringify(userAttributes);
 };
 
 export const computeHashForUserData = (...args) => md5(getUserString(...args));

--- a/app/javascript/sdk/specs/cookieHelpers.spec.js
+++ b/app/javascript/sdk/specs/cookieHelpers.spec.js
@@ -1,5 +1,6 @@
 import Cookies from 'js-cookie';
 import {
+  computeHashForUserData,
   getUserCookieName,
   getUserString,
   hasUserKeys,
@@ -39,6 +40,78 @@ describe('#getUserString', () => {
     ).toBe(
       'avatar_urlhttps://images.chatwoot.com/placeholderemailpranav@example.comnameidentifier_hashidentifier'
     );
+  });
+});
+
+describe('#computeHashForUserData', () => {
+  const identifier = 'user-123';
+  const user = {
+    name: 'Pranav',
+    email: 'pranav@example.com',
+  };
+
+  it.each([
+    ['phone_number', '+15555550100', '+15555550101'],
+    ['company_name', 'Chatwoot', 'Acme'],
+    ['city', 'Bengaluru', 'Kochi'],
+    ['country_code', 'IN', 'US'],
+    ['description', 'Chatwoot user', 'Acme user'],
+  ])('changes when %s changes', (attribute, currentValue, updatedValue) => {
+    const currentHash = computeHashForUserData({
+      identifier,
+      user: { ...user, [attribute]: currentValue },
+    });
+    const updatedHash = computeHashForUserData({
+      identifier,
+      user: { ...user, [attribute]: updatedValue },
+    });
+
+    expect(updatedHash).not.toBe(currentHash);
+  });
+
+  it('changes when a social profile changes', () => {
+    const currentHash = computeHashForUserData({
+      identifier,
+      user: { ...user, social_profiles: { github: 'chatwoot' } },
+    });
+    const updatedHash = computeHashForUserData({
+      identifier,
+      user: { ...user, social_profiles: { github: 'chatwoot-app' } },
+    });
+
+    expect(updatedHash).not.toBe(currentHash);
+  });
+
+  it('is independent of social profile property order', () => {
+    const firstHash = computeHashForUserData({
+      identifier,
+      user: {
+        ...user,
+        social_profiles: { github: 'chatwoot', twitter: 'chatwootapp' },
+      },
+    });
+    const secondHash = computeHashForUserData({
+      identifier,
+      user: {
+        ...user,
+        social_profiles: { twitter: 'chatwootapp', github: 'chatwoot' },
+      },
+    });
+
+    expect(secondHash).toBe(firstHash);
+  });
+
+  it('ignores custom attributes managed by setCustomAttributes', () => {
+    const currentHash = computeHashForUserData({
+      identifier,
+      user: { ...user, custom_attributes: { plan: 'starter' } },
+    });
+    const updatedHash = computeHashForUserData({
+      identifier,
+      user: { ...user, custom_attributes: { plan: 'business' } },
+    });
+
+    expect(updatedHash).toBe(currentHash);
   });
 });
 

--- a/app/javascript/sdk/specs/cookieHelpers.spec.js
+++ b/app/javascript/sdk/specs/cookieHelpers.spec.js
@@ -27,7 +27,13 @@ describe('#getUserString', () => {
         identifier: '12345',
       })
     ).toBe(
-      'avatar_urlhttps://images.chatwoot.com/placeholderemailpranav@example.comnamePranavidentifier_hash12345identifier12345'
+      JSON.stringify([
+        ['avatar_url', 'https://images.chatwoot.com/placeholder'],
+        ['email', 'pranav@example.com'],
+        ['name', 'Pranav'],
+        ['identifier_hash', '12345'],
+        ['identifier', '12345'],
+      ])
     );
 
     expect(
@@ -38,7 +44,13 @@ describe('#getUserString', () => {
         },
       })
     ).toBe(
-      'avatar_urlhttps://images.chatwoot.com/placeholderemailpranav@example.comnameidentifier_hashidentifier'
+      JSON.stringify([
+        ['avatar_url', 'https://images.chatwoot.com/placeholder'],
+        ['email', 'pranav@example.com'],
+        ['name', ''],
+        ['identifier_hash', ''],
+        ['identifier', ''],
+      ])
     );
   });
 });
@@ -49,6 +61,19 @@ describe('#computeHashForUserData', () => {
     name: 'Pranav',
     email: 'pranav@example.com',
   };
+
+  it('normalizes numeric identifiers', () => {
+    const numericIdentifierHash = computeHashForUserData({
+      identifier: 123,
+      user,
+    });
+    const stringIdentifierHash = computeHashForUserData({
+      identifier: '123',
+      user,
+    });
+
+    expect(numericIdentifierHash).toBe(stringIdentifierHash);
+  });
 
   it.each([
     ['phone_number', '+15555550100', '+15555550101'],
@@ -80,6 +105,19 @@ describe('#computeHashForUserData', () => {
     });
 
     expect(updatedHash).not.toBe(currentHash);
+  });
+
+  it('preserves contact information field boundaries', () => {
+    const companyNameHash = computeHashForUserData({
+      identifier,
+      user: { ...user, company_name: 'cityParis' },
+    });
+    const companyNameAndCityHash = computeHashForUserData({
+      identifier,
+      user: { ...user, company_name: '', city: 'Paris' },
+    });
+
+    expect(companyNameAndCityHash).not.toBe(companyNameHash);
   });
 
   it('is independent of social profile property order', () => {


### PR DESCRIPTION
Updates the web widget user fingerprint to include contact information supported by setUser. Existing contacts now sync when phone, company, location, description, or social profiles change, while custom attributes remain handled separately.

## Closes

Closes chatwoot/chatwoot#13448

## How to reproduce

1. Identify a contact with setUser.
2. Change only phone_number, country_code, city, company_name, description, or social_profiles.
3. Call setUser again and confirm the existing contact is updated.