### PR TITLE
fix(dev): keep tunnel vite watcher running

### DIFF
--- a/Procfile.tunnel
+++ b/Procfile.tunnel
@@ -1,4 +1,4 @@
 backend: DISABLE_MINI_PROFILER=true bin/rails s -p 3000
 # https://github.com/mperham/sidekiq/issues/3090#issuecomment-389748695
 worker: dotenv bundle exec sidekiq -C config/sidekiq.yml
-vite: bin/vite build --watch
+vite: bin/vite build --watch --force


### PR DESCRIPTION
Starting the tunnel workflow could immediately stop Rails and Sidekiq when Vite Ruby found the frontend build already up to date. This keeps the Vite build watcher alive so the Overmind tunnel stack remains available.

### How to reproduce

1. Ensure the Vite build is already current.
2. Run `make force_run_tunnel`.
3. Observe Vite skip the build and exit, which causes Overmind to stop the remaining processes.

### Things to know

The `--force` option is handled by Vite Ruby to bypass its freshness check. Vite still runs in build watch mode, so no development server port is exposed.

### How to test

1. Run `make force_run_tunnel` with an existing frontend build.
2. Confirm Vite completes the build and continues watching for changes.
3. Open the configured tunnel URL and confirm the Chatwoot login page renders while Rails and Sidekiq remain running.