### PR TITLE
Chatwood Optimization

### DIFF
--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -54,8 +54,24 @@ class WidgetsController < ActionController::Base
   def build_contact
     return if @contact.present?
 
-    @contact_inbox, @token = build_contact_inbox_with_token(@web_widget, additional_attributes)
+    @contact_inbox, @token = build_contact_inbox_with_token(@web_widget, additional_attributes, identifier: verified_identifier)
     @contact = @contact_inbox.contact
+  end
+
+  # Allows the host site to identify the visitor on the very first widget request,
+  # so an existing contact is found/reused instead of creating a throwaway one
+  # that would later need to be merged via set_user.
+  def verified_identifier
+    identifier = permitted_params[:identifier]
+    return if identifier.blank?
+    return if @web_widget.hmac_mandatory && !valid_identifier_hmac?(identifier)
+
+    identifier
+  end
+
+  def valid_identifier_hmac?(identifier)
+    permitted_params[:identifier_hash].present? &&
+      permitted_params[:identifier_hash] == OpenSSL::HMAC.hexdigest('sha256', @web_widget.hmac_token, identifier.to_s)
   end
 
   def ensure_account_is_active
@@ -73,7 +89,7 @@ class WidgetsController < ActionController::Base
   end
 
   def permitted_params
-    params.permit(:website_token, :cw_conversation)
+    params.permit(:website_token, :cw_conversation, :identifier, :identifier_hash)
   end
 
   def allow_iframe_requests

--- a/app/helpers/widget_helper.rb
+++ b/app/helpers/widget_helper.rb
@@ -1,6 +1,6 @@
 module WidgetHelper
-  def build_contact_inbox_with_token(web_widget, additional_attributes = {})
-    contact_inbox = web_widget.create_contact_inbox(additional_attributes)
+  def build_contact_inbox_with_token(web_widget, additional_attributes = {}, identifier: nil)
+    contact_inbox = web_widget.create_contact_inbox(additional_attributes, identifier: identifier)
     payload = { source_id: contact_inbox.source_id, inbox_id: web_widget.inbox.id }
     token = ::Widget::TokenService.new(payload: payload).generate_token
 

--- a/app/javascript/entrypoints/sdk.js
+++ b/app/javascript/entrypoints/sdk.js
@@ -18,7 +18,12 @@ import {
 import { setCookieWithDomain } from '../sdk/cookieHelpers';
 import { SDK_SET_BUBBLE_VISIBILITY } from 'shared/constants/sharedFrameEvents';
 
-const runSDK = ({ baseUrl, websiteToken }) => {
+const runSDK = ({
+  baseUrl,
+  websiteToken,
+  identifier: bootIdentifier,
+  identifierHash: bootIdentifierHash,
+}) => {
   if (window.$chatwoot) {
     return;
   }
@@ -63,6 +68,8 @@ const runSDK = ({ baseUrl, websiteToken }) => {
     isOpen: false,
     position: chatwootSettings.position === 'left' ? 'left' : 'right',
     websiteToken,
+    identifier: bootIdentifier,
+    identifierHash: bootIdentifierHash,
     locale,
     useBrowserLanguage: chatwootSettings.useBrowserLanguage || false,
     type: getBubbleView(chatwootSettings.type),
@@ -213,6 +220,8 @@ const runSDK = ({ baseUrl, websiteToken }) => {
   IFrameHelper.createFrame({
     baseUrl,
     websiteToken,
+    identifier: bootIdentifier,
+    identifierHash: bootIdentifierHash,
   });
 };
 

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -51,10 +51,17 @@ const updateCampaignReadStatus = baseDomain => {
 };
 
 export const IFrameHelper = {
-  getUrl({ baseUrl, websiteToken }) {
-    return `${baseUrl}/widget?website_token=${websiteToken}`;
+  getUrl({ baseUrl, websiteToken, identifier, identifierHash }) {
+    let url = `${baseUrl}/widget?website_token=${websiteToken}`;
+    if (identifier) {
+      url += `&identifier=${encodeURIComponent(identifier)}`;
+    }
+    if (identifierHash) {
+      url += `&identifier_hash=${encodeURIComponent(identifierHash)}`;
+    }
+    return url;
   },
-  createFrame: ({ baseUrl, websiteToken }) => {
+  createFrame: ({ baseUrl, websiteToken, identifier, identifierHash }) => {
     if (IFrameHelper.getAppFrame()) {
       return;
     }
@@ -62,7 +69,12 @@ export const IFrameHelper = {
     loadCSS();
     const iframe = document.createElement('iframe');
     const cwCookie = Cookies.get('cw_conversation');
-    let widgetUrl = IFrameHelper.getUrl({ baseUrl, websiteToken });
+    let widgetUrl = IFrameHelper.getUrl({
+      baseUrl,
+      websiteToken,
+      identifier,
+      identifierHash,
+    });
     if (cwCookie) {
       widgetUrl = `${widgetUrl}&cw_conversation=${cwCookie}`;
     }

--- a/app/models/channel/web_widget.rb
+++ b/app/models/channel/web_widget.rb
@@ -100,10 +100,10 @@ class Channel::WebWidget < ApplicationRecord
     }
   end
 
-  def create_contact_inbox(additional_attributes = {})
+  def create_contact_inbox(additional_attributes = {}, identifier: nil)
     ::ContactInboxWithContactBuilder.new({
                                            inbox: inbox,
-                                           contact_attributes: { additional_attributes: additional_attributes }
+                                           contact_attributes: { identifier: identifier, additional_attributes: additional_attributes }
                                          }).perform
   end
 end


### PR DESCRIPTION
## Описание                                                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                        
  Убирает создание "пустышечных" анонимных контактов при загрузке виджета для уже идентифицированных (авторизованных на сайте) пользователей. Раньше при каждой загрузке страницы, если у браузера не было валидной cookie `cw_conversation`, Chatwoot безусловно создавал новый `contact`+`contact_inbox` — даже для уже зарегистрированных пользователей, до отправки любого сообщения. Идентификация происходила     
  вторым, отдельным шагом (`setUser()`), и найденный существующий контакт просто мёрджился с только что созданной пустышкой.                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## Проблема, которую это решает                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                        
  Обсуждали с Кириллом после его диагностики БД (`pg_stat_statements`, размеры таблиц, autovacuum-статистика): база раздута до 7.2М контактов / 14.3М contact_inboxes при ожидаемых ~500К, топ по объёму запросов — `INSERT INTO contacts`/`INSERT INTO contact_inboxes` (по 8.7М вызовов каждый), autovacuum не успевает за таким churn'ом, отсюда точечные лаги 5-70 секунд на ровном месте (подтверждено             
  `pg_stat_statements`: mean-время быстрое, но max доходит до 34-68 секунд). Независимо от анализа кода Кирилл пришёл к тому же выводу по метрикам БД — совпадение служит доп. подтверждением диагноза.                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## Что изменено                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                        
  - `Channel::WebWidget#create_contact_inbox` и `WidgetHelper#build_contact_inbox_with_token` — принимают опциональный `identifier`.                                                                                                                                                                                                                                                                                    
  - `WidgetsController` — читает `identifier`/`identifier_hash` из параметров запроса, проверяет HMAC (та же логика, что уже используется в `set_user`), передаёт identifier в уже существующий поиск (`ContactInboxWithContactBuilder#find_contact`), который находит существующий контакт вместо создания нового.                                                                                                     
  - `app/javascript/sdk/IFrameHelper.js` + `entrypoints/sdk.js` — `chatwootSDK.run()` теперь принимает `identifier`/`identifierHash` и включает их в URL iframe при загрузке виджета.                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                        
  Логика поиска/мёрджа контактов не менялась — используется как есть, ей просто передаются данные на шаг раньше. Другие каналы (WhatsApp, Telegram и т.д.) не используют этот код — не затронуты.                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## Локально протестировано                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                        
  - Известный identifier + верный HMAC → переиспользует существующий контакт, дубль не создаётся (добавляется только новый `contact_inbox` — новая браузерная сессия того же человека).                                                                                                                                                                                                                                 
  - Без identifier (обычный первый визит) → поведение не изменилось, создаётся новый анонимный контакт как раньше.                                                                                                                                                                                                                                                                                                      
  - Прогнан существующий тестовый набор Chatwoot (`widgets_controller_spec`, `web_widget_spec`, `contact_inbox_with_contact_builder_spec`) — 13 тестов, 0 упавших.                                                                                                                                                                                                                                                      
  - ESLint чист на обоих изменённых JS-файлах.                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## Как проверить                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                        
  1. Открыть виджет с известным `identifier`+`identifier_hash` в параметрах — убедиться, что не создаётся новый контакт, если такой identifier уже существует в базе.                                                                                                                                                                                                                                                   
  2. Открыть виджет без identifier (обычный анонимный визит) — убедиться, что поведение не изменилось.                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## Риски                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                        
  - **Нужна отдельная правка на сайте** (не в этом PR) — вызов `chatwootSDK.run()` должен передавать `identifier`+`identifierHash` для авторизованных пользователей. Без неё этот PR ничего не сломает, но и пользы не даст, пока обе стороны не обновлены.                                                                                                                                                             
  - Если `hmac_mandatory` включён на инбоксе, а hash не совпадёт/не передан — identifier молча игнорируется, включается прежнее поведение (безопасный fallback, не 500-ка).                                                                                                                                                                                                                                             
  - Не устраняет уже накопленные 7.2М контактов — отдельная задача чистки после того, как приток новых остановлен.                                                                                                                                                                                                                                                                                                      
  - Не устраняет насос от истинно анонимных посетителей (кто никогда не логинится) — закрывается отдельно решением не грузить виджет для неавторизованных.                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## Note по базовой ветке                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                        
.  