### PR TITLE
fix(contacts): show BSUID-only WhatsApp contacts

### DIFF
--- a/app/finders/whatsapp/contact_ids_finder.rb
+++ b/app/finders/whatsapp/contact_ids_finder.rb
@@ -1,0 +1,15 @@
+class Whatsapp::ContactIdsFinder
+  def perform
+    ContactInbox.joins(:inbox)
+                .joins(<<~SQL.squish)
+                  LEFT JOIN channel_twilio_sms
+                    ON channel_twilio_sms.id = inboxes.channel_id
+                    AND inboxes.channel_type = 'Channel::TwilioSms'
+                SQL
+                .where(
+                  'inboxes.channel_type = :cloud OR (inboxes.channel_type = :twilio AND channel_twilio_sms.medium = :whatsapp)',
+                  cloud: 'Channel::Whatsapp', twilio: 'Channel::TwilioSms', whatsapp: Channel::TwilioSms.media.fetch('whatsapp')
+                )
+                .select(:contact_id)
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -181,9 +181,8 @@ class Contact < ApplicationRecord
   end
 
   def self.resolved_contacts(use_crm_v2: false)
-    return where(contact_type: 'lead') if use_crm_v2
-
-    where("contacts.email <> '' OR contacts.phone_number <> '' OR contacts.identifier <> ''")
+    resolved = use_crm_v2 ? where(contact_type: 'lead') : where("contacts.email <> '' OR contacts.phone_number <> '' OR contacts.identifier <> ''")
+    resolved.or(where(id: Whatsapp::ContactIdsFinder.new.perform))
   end
 
   def discard_invalid_attrs

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe 'Contacts API', type: :request do
         expect(contact_inboxes_source_ids).to include(contact_inbox.source_id)
       end
 
+      it 'returns a contact identified only by a WhatsApp BSUID' do
+        channel = create(:channel_whatsapp, provider: 'whatsapp_cloud', account: account,
+                                            validate_provider_config: false, sync_templates: false)
+        bsuid_contact = create(:contact, account: account, name: 'BSUID customer', email: nil, phone_number: nil, identifier: nil)
+        create(:contact_inbox, contact: bsuid_contact, inbox: channel.inbox, source_id: 'IN.2081978709342942')
+
+        get "/api/v1/accounts/#{account.id}/contacts", headers: admin.create_new_auth_token, as: :json
+
+        expect(response.parsed_body['payload'].pluck('id')).to include(bsuid_contact.id)
+      end
+
       it 'returns all contacts without contact inboxes' do
         get "/api/v1/accounts/#{account.id}/contacts?include_contact_inboxes=false",
             headers: admin.create_new_auth_token,
@@ -357,6 +368,18 @@ RSpec.describe 'Contacts API', type: :request do
         expect(response).to have_http_status(:success)
         expect(response.body).to include(contact2.email)
         expect(response.body).not_to include(contact1.email)
+      end
+
+      it 'finds a BSUID-only contact by name' do
+        channel = create(:channel_whatsapp, provider: 'whatsapp_cloud', account: account,
+                                            validate_provider_config: false, sync_templates: false)
+        bsuid_contact = create(:contact, account: account, name: 'Private Username Contact', email: nil, phone_number: nil, identifier: nil)
+        create(:contact_inbox, contact: bsuid_contact, inbox: channel.inbox, source_id: 'IN.2081978709342942')
+
+        get "/api/v1/accounts/#{account.id}/contacts/search",
+            params: { q: 'Private Username' }, headers: admin.create_new_auth_token, as: :json
+
+        expect(response.parsed_body['payload'].pluck('id')).to include(bsuid_contact.id)
       end
 
       it 'matches the resolved contact respecting the identifier character casing' do

--- a/spec/jobs/account/contacts_export_job_spec.rb
+++ b/spec/jobs/account/contacts_export_job_spec.rb
@@ -148,6 +148,18 @@ RSpec.describe Account::ContactsExportJob do
       expect(csv_data.length).to eq(account.contacts.resolved_contacts.count)
     end
 
+    it 'exports a contact identified only by a WhatsApp BSUID' do
+      channel = create(:channel_whatsapp, provider: 'whatsapp_cloud', account: account,
+                                          validate_provider_config: false, sync_templates: false)
+      contact = create(:contact, account: account, name: 'BSUID export contact', email: nil, phone_number: nil, identifier: nil)
+      create(:contact_inbox, contact: contact, inbox: channel.inbox, source_id: 'IN.2081978709342942')
+
+      described_class.perform_now(account.id, user.id, %w[id name], {})
+
+      csv_data = CSV.parse(account.contacts_export.download, headers: true)
+      expect(csv_data.pluck('name')).to include(contact.name)
+    end
+
     it 'returns resolved contacts filtered if labels are provided' do
       # Adding label to a resolved contact
       Contact.last.add_labels(['spec-billing'])

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -131,6 +131,25 @@ RSpec.describe Contact do
         expect(resolved).to include(contact_with_email, contact_with_phone, contact_with_identifier)
         expect(resolved).not_to include(contact_without_details)
       end
+
+      it 'includes contacts identified only by a WhatsApp contact inbox' do
+        cloud_channel = create(:channel_whatsapp, provider: 'whatsapp_cloud', account: account,
+                                                  validate_provider_config: false, sync_templates: false)
+        twilio_channel = create(:channel_twilio_sms, medium: :whatsapp, account: account)
+        cloud_contact = create(:contact, account: account, name: 'Cloud BSUID', email: nil, phone_number: nil, identifier: nil)
+        twilio_contact = create(:contact, account: account, name: 'Twilio BSUID', email: nil, phone_number: nil, identifier: nil)
+        create(:contact_inbox, contact: cloud_contact, inbox: cloud_channel.inbox, source_id: 'IN.2081978709342942')
+        create(:contact_inbox, contact: twilio_contact, inbox: twilio_channel.inbox, source_id: 'whatsapp:IN.2166217060865430')
+
+        expect(account.contacts.resolved_contacts(use_crm_v2: false)).to include(cloud_contact, twilio_contact)
+      end
+
+      it 'does not include an unidentified web widget visitor' do
+        visitor = create(:contact, account: account, name: 'Anonymous', email: nil, phone_number: nil, identifier: nil)
+        create(:contact_inbox, contact: visitor, inbox: create(:channel_widget, account: account).inbox)
+
+        expect(account.contacts.resolved_contacts(use_crm_v2: false)).not_to include(visitor)
+      end
     end
 
     context 'when crm_v2 feature flag is enabled' do
@@ -170,6 +189,16 @@ RSpec.describe Contact do
         expect(resolved).to include(lead_contact)
         expect(resolved).not_to include(customer_contact)
         expect(resolved).not_to include(visitor_contact)
+      end
+
+      it 'includes an existing BSUID-only visitor contact' do
+        channel = create(:channel_whatsapp, provider: 'whatsapp_cloud', account: account,
+                                            validate_provider_config: false, sync_templates: false)
+        contact = create(:contact, account: account, name: 'BSUID only', email: nil, phone_number: nil, identifier: nil)
+        create(:contact_inbox, contact: contact, inbox: channel.inbox, source_id: 'IN.2081978709342942')
+
+        expect(contact.contact_type).to eq('visitor')
+        expect(account.contacts.resolved_contacts(use_crm_v2: true)).to include(contact)
       end
 
       it 'returns contacts with email, phone_number, or identifier when explicitly passing use_crm_v2: false' do


### PR DESCRIPTION
When WhatsApp provides only a BSUID, the Chatwoot contact may have no phone number, email address, or external identifier. The conversation remains accessible, but the contact is excluded by the resolved-contact scope and consequently disappears from Contacts, search results, filters, and exports.

This PR treats an attached WhatsApp `ContactInbox` as a valid contact identity. BSUID-only customers therefore remain visible across the contact-management surfaces for both Meta Cloud and Twilio WhatsApp.

### What changed

- Include contacts with a Meta Cloud WhatsApp `ContactInbox` in the resolved-contact scope.
- Include contacts from Twilio inboxes whose medium is WhatsApp.
- Apply the same behavior to existing visitor records when CRM v2 is enabled.
- Reuse the shared scope so Contacts, search, filters, and exports remain consistent.
- Continue excluding unidentified contacts from unrelated channels, such as anonymous web-widget visitors.

### Things to know

- This changes contact visibility only. It does not merge contacts, promote anonymous visitors, or alter conversation routing.
- This PR is stacked on [#15546](https://github.com/chatwoot/chatwoot/pull/15546), which is based on [#15175](https://github.com/chatwoot/chatwoot/pull/15175). Review and merge #15546 first; after the earlier PRs merge, this PR can be retargeted to `develop`.

### How to test

1. Receive a Meta Cloud WhatsApp message that contains a BSUID but no customer phone number.
2. Confirm the resulting contact appears in the Contacts list.
3. Search for the contact by name and apply contact filters.
4. Export contacts and confirm the BSUID-only contact is included.
5. Repeat the flow with a Twilio WhatsApp `ExternalUserId` and no phone number.
6. Confirm an unidentified web-widget visitor remains excluded.

### Fixes

Fixes https://linear.app/chatwoot/issue/CW-7982
