### PR TITLE
feat(whatsapp): recover phone information for BSUID contacts

### DIFF
--- a/app/controllers/api/v1/accounts/contacts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/conversations_controller.rb
@@ -2,8 +2,11 @@ class Api::V1::Accounts::Contacts::ConversationsController < Api::V1::Accounts::
   def index
     # Start with all conversations for this contact
     conversations = Current.account.conversations.includes(
-      :assignee, :contact, :inbox, :taggings
-    ).preload(ai_assignee: { avatar_attachment: [:blob] }).where(contact_id: @contact.id)
+      :assignee, :contact, :taggings, :contact_inbox
+    ).preload(
+      inbox: :channel,
+      ai_assignee: { avatar_attachment: [:blob] }
+    ).where(contact_id: @contact.id)
 
     # Apply permission-based filtering using the existing service
     conversations = Conversations::PermissionFilterService.new(

--- a/app/controllers/api/v1/accounts/conversations/contact_info_requests_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/contact_info_requests_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Accounts::Conversations::ContactInfoRequestsController < Api::V1::Accounts::Conversations::BaseController
+  def create
+    @message = Whatsapp::ContactInfoRequestService.new(conversation: @conversation, sender: Current.user).perform
+    render 'api/v1/accounts/conversations/messages/create'
+  rescue CustomExceptions::WhatsappContactInfoRequestError => e
+    render json: { error: e.message }, status: e.http_status
+  end
+end

--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -70,7 +70,7 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
 
       Messages::StatusUpdateService.new(message, 'sent').perform
       previous_source_id = message.source_id
-      retry_attributes = { content_attributes: {} }
+      retry_attributes = { content_attributes: retry_content_attributes }
       retry_attributes[:source_id] = nil unless @conversation.inbox.api? || @conversation.inbox.web_widget?
       message.update!(retry_attributes)
       if retry_attributes.key?(:source_id) && previous_source_id.present?
@@ -78,6 +78,12 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
       end
       true
     end
+  end
+
+  def retry_content_attributes
+    return message.content_attributes if message.content_attributes.dig('whatsapp_contact_info', 'type') == 'request'
+
+    {}
   end
 
   def permitted_params

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -210,8 +210,8 @@ class ConversationFinder
 
   def conversations_base_query
     @conversations.includes(
-      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox
-    ).preload(ai_assignee: { avatar_attachment: [:blob] })
+      :taggings, :team, :contact_inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }
+    ).preload(inbox: :channel, ai_assignee: { avatar_attachment: [:blob] })
   end
 
   def conversations

--- a/app/javascript/dashboard/api/inbox/conversation.js
+++ b/app/javascript/dashboard/api/inbox/conversation.js
@@ -114,6 +114,10 @@ class ConversationApi extends ApiClient {
     return axios.post(`${this.url}/${conversationId}/transcript`, { email });
   }
 
+  requestContactInfo(conversationId) {
+    return axios.post(`${this.url}/${conversationId}/contact_info_request`);
+  }
+
   updateCustomAttributes({ conversationId, customAttributes }) {
     return axios.post(`${this.url}/${conversationId}/custom_attributes`, {
       custom_attributes: customAttributes,

--- a/app/javascript/dashboard/components-next/message/bubbles/Contact.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Contact.vue
@@ -38,6 +38,10 @@ const rawPhoneNumber = computed(() => {
   return phoneNumber.value.replace(/\D/g, '');
 });
 
+const isContactInfoResponse = computed(() => {
+  return attachment.value?.meta?.isContactInfoResponse;
+});
+
 function getContactObject() {
   const contactItem = {
     name: contactName.value,
@@ -103,6 +107,6 @@ const action = computed(() => ({
     sender-translation-key="CONVERSATION.SHARED_ATTACHMENT.CONTACT"
     :title="contactName"
     :content="phoneNumber"
-    :action="formattedPhoneNumber ? action : null"
+    :action="formattedPhoneNumber && !isContactInfoResponse ? action : null"
   />
 </template>

--- a/app/javascript/dashboard/components-next/message/bubbles/Text/Index.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Text/Index.vue
@@ -5,10 +5,11 @@ import FormattedContent from './FormattedContent.vue';
 import AttachmentChips from 'next/message/chips/AttachmentChips.vue';
 import TranslationToggle from 'dashboard/components-next/message/TranslationToggle.vue';
 import { MESSAGE_TYPES } from '../../constants';
+import { MESSAGE_STATUS } from 'shared/constants/messages';
 import { useMessageContext } from '../../provider.js';
 import { useTranslations } from 'dashboard/composables/useTranslations';
 
-const { content, attachments, contentAttributes, messageType } =
+const { content, attachments, contentAttributes, messageType, status } =
   useMessageContext();
 
 const { hasTranslations, translationContent } =
@@ -32,6 +33,12 @@ const isTemplate = computed(() => {
   return messageType.value === MESSAGE_TYPES.TEMPLATE;
 });
 
+const contactInfoRequestState = computed(() => {
+  if (status.value === MESSAGE_STATUS.FAILED) return null;
+
+  return contentAttributes.value?.whatsappContactInfo?.state;
+});
+
 const isEmpty = computed(() => {
   return !content.value && !attachments.value?.length;
 });
@@ -48,6 +55,24 @@ const handleSeeOriginal = () => {
         {{ $t('CONVERSATION.NO_CONTENT') }}
       </span>
       <FormattedContent v-if="renderContent" :content="renderContent" />
+      <span
+        v-if="contactInfoRequestState === 'pending'"
+        class="text-xs font-medium text-n-slate-11"
+      >
+        {{ $t('CONVERSATION.REQUEST_CONTACT_INFO.STATES.PENDING') }}
+      </span>
+      <span
+        v-else-if="contactInfoRequestState === 'shared'"
+        class="text-xs font-medium text-n-slate-11"
+      >
+        {{ $t('CONVERSATION.REQUEST_CONTACT_INFO.STATES.SHARED') }}
+      </span>
+      <span
+        v-else-if="contactInfoRequestState === 'identity_conflict'"
+        class="text-xs font-medium text-n-slate-11"
+      >
+        {{ $t('CONVERSATION.REQUEST_CONTACT_INFO.STATES.IDENTITY_CONFLICT') }}
+      </span>
       <TranslationToggle
         v-if="hasTranslations"
         class="-mt-3"

--- a/app/javascript/dashboard/components-next/message/provider.js
+++ b/app/javascript/dashboard/components-next/message/provider.js
@@ -78,6 +78,7 @@ const MessageControl = Symbol('MessageControl');
  * @property {string} [referral.videoUrl] - Video URL of a Cloud API referral
  * @property {string} [referral.mediaUrl] - Media URL of a Twilio referral
  * @property {string} [referral.mediaContentType] - Media content type of a Twilio referral
+ * @property {{type: 'request', state: 'pending'|'shared'|'identity_conflict'}} [whatsappContactInfo] - WhatsApp contact information request state
  */
 
 /**

--- a/app/javascript/dashboard/components/widgets/RequestContactInfoButton.vue
+++ b/app/javascript/dashboard/components/widgets/RequestContactInfoButton.vue
@@ -1,0 +1,89 @@
+<script setup>
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useAlert } from 'dashboard/composables';
+import { useStore, useMapGetter } from 'dashboard/composables/store';
+import NextButton from 'dashboard/components-next/button/Button.vue';
+
+const emit = defineEmits(['requestTemplate']);
+
+const store = useStore();
+const { t } = useI18n();
+
+const currentChat = useMapGetter('getSelectedChat');
+const contactById = useMapGetter('contacts/getContact');
+
+const isRequesting = ref(false);
+
+const capability = computed(
+  () => currentChat.value?.contact_info_request || {}
+);
+
+const currentContact = computed(() => {
+  const senderId = currentChat.value?.meta?.sender?.id;
+  if (!senderId) return {};
+  return contactById.value(senderId);
+});
+
+const hasPendingRequest = computed(() =>
+  (currentChat.value?.messages || []).some(message => {
+    const contactInfo = message.content_attributes?.whatsapp_contact_info || {};
+    return (
+      contactInfo.type === 'request' &&
+      contactInfo.state === 'pending' &&
+      message.status !== 'failed'
+    );
+  })
+);
+
+const showButton = computed(
+  () =>
+    !currentContact.value.phone_number &&
+    (capability.value.available ||
+      capability.value.reason === 'pending_request')
+);
+
+const isDisabled = computed(
+  () =>
+    isRequesting.value ||
+    hasPendingRequest.value ||
+    capability.value.reason === 'pending_request'
+);
+
+const tooltip = computed(() =>
+  hasPendingRequest.value
+    ? t('CONVERSATION.REQUEST_CONTACT_INFO.PENDING_ACTION')
+    : t('CONVERSATION.REQUEST_CONTACT_INFO.ACTION')
+);
+
+const requestContactInfo = async () => {
+  if (capability.value.delivery_mode === 'template') {
+    emit('requestTemplate');
+    return;
+  }
+
+  isRequesting.value = true;
+  try {
+    await store.dispatch('requestContactInfo', currentChat.value.id);
+  } catch (error) {
+    useAlert(error?.response?.data?.error || t('CONVERSATION.MESSAGE_ERROR'));
+  } finally {
+    isRequesting.value = false;
+  }
+};
+</script>
+
+<template>
+  <NextButton
+    v-if="showButton"
+    v-tooltip.top-end="tooltip"
+    icon="i-ph-address-book"
+    slate
+    faded
+    sm
+    :disabled="isDisabled"
+    :is-loading="isRequesting"
+    @click="requestContactInfo"
+  />
+  <template v-else />
+</template>

--- a/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
@@ -8,13 +8,19 @@ import inboxMixin from 'shared/mixins/inboxMixin';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import { getAllowedFileTypesByChannel } from '@chatwoot/utils';
 import VideoCallButton from '../VideoCallButton.vue';
+import RequestContactInfoButton from '../RequestContactInfoButton.vue';
 import { INBOX_TYPES } from 'dashboard/helper/inbox';
 import { mapGetters } from 'vuex';
 import NextButton from 'dashboard/components-next/button/Button.vue';
 
 export default {
   name: 'ReplyBottomPanel',
-  components: { NextButton, FileUpload, VideoCallButton },
+  components: {
+    NextButton,
+    FileUpload,
+    VideoCallButton,
+    RequestContactInfoButton,
+  },
   mixins: [inboxMixin],
   props: {
     isNote: {
@@ -131,6 +137,7 @@ export default {
     'selectWhatsappTemplate',
     'selectContentTemplate',
     'toggleQuotedReply',
+    'requestContactInfoTemplate',
   ],
   setup(props) {
     const { setSignatureFlagForInbox, fetchSignatureFlagFromUISettings } =
@@ -357,6 +364,10 @@ export default {
         faded
         sm
         @click="$emit('selectWhatsappTemplate')"
+      />
+      <RequestContactInfoButton
+        v-if="!isOnPrivateNote"
+        @request-template="$emit('requestContactInfoTemplate')"
       />
       <NextButton
         v-if="enableContentTemplates"

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -168,6 +168,7 @@ export default {
       toEmails: '',
       doAutoSaveDraft: () => {},
       showWhatsAppTemplatesModal: false,
+      requestContactInfoTemplatesOnly: false,
       showContentTemplatesModal: false,
       updateEditorSelectionWith: '',
       undefinedVariableMessage: '',
@@ -639,6 +640,10 @@ export default {
     emitter.off(CMD_AI_ASSIST, this.executeCopilotAction);
   },
   methods: {
+    openContactInfoTemplateModal() {
+      this.requestContactInfoTemplatesOnly = true;
+      this.showWhatsAppTemplatesModal = true;
+    },
     getDraftKey(
       conversationId = this.conversationIdByRoute,
       replyType = this.effectiveReplyMode
@@ -843,10 +848,12 @@ export default {
       }
     },
     openWhatsappTemplateModal() {
+      this.requestContactInfoTemplatesOnly = false;
       this.showWhatsAppTemplatesModal = true;
     },
     hideWhatsappTemplatesModal() {
       this.showWhatsAppTemplatesModal = false;
+      this.requestContactInfoTemplatesOnly = false;
     },
     openContentTemplateModal() {
       this.showContentTemplatesModal = true;
@@ -1521,6 +1528,7 @@ export default {
         @select-content-template="openContentTemplateModal"
         @toggle-insert-article="toggleInsertArticle"
         @toggle-quoted-reply="toggleQuotedReply"
+        @request-contact-info-template="openContactInfoTemplateModal"
       />
     </Transition>
 
@@ -1528,6 +1536,7 @@ export default {
       :inbox-id="inbox.id"
       :show="showWhatsAppTemplatesModal"
       :send-rendered-content="isAPIInbox"
+      :request-contact-info-only="requestContactInfoTemplatesOnly"
       @close="hideWhatsappTemplatesModal"
       @on-send="onSendWhatsAppReply"
       @cancel="hideWhatsappTemplatesModal"

--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/Modal.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/Modal.vue
@@ -19,6 +19,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    requestContactInfoOnly: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ['onSend', 'cancel', 'update:show'],
   data() {
@@ -41,6 +45,14 @@ export default {
             templateName: this.selectedWaTemplate.name,
           })
         : this.$t('WHATSAPP_TEMPLATES.MODAL.SUBTITLE');
+    },
+  },
+  watch: {
+    show(value) {
+      if (!value) this.selectedWaTemplate = null;
+    },
+    requestContactInfoOnly() {
+      this.selectedWaTemplate = null;
     },
   },
   methods: {
@@ -70,6 +82,7 @@ export default {
       <TemplatesPicker
         v-if="!selectedWaTemplate"
         :inbox-id="inboxId"
+        :request-contact-info-only="requestContactInfoOnly"
         @on-select="pickTemplate"
       />
       <WhatsAppTemplateReply

--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplatesPicker.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplatesPicker.vue
@@ -15,6 +15,10 @@ const props = defineProps({
     type: Number,
     default: undefined,
   },
+  requestContactInfoOnly: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits(['onSelect']);
@@ -29,8 +33,20 @@ const whatsAppTemplateMessages = useFunctionGetter(
   toRef(props, 'inboxId')
 );
 
+const hasRequestContactInfoButton = template => {
+  const buttons = findComponentByType(template, COMPONENT_TYPES.BUTTONS);
+  return buttons?.buttons?.some(
+    button => button.type?.toUpperCase() === 'REQUEST_CONTACT_INFO'
+  );
+};
+
+const availableTemplateMessages = computed(() => {
+  if (!props.requestContactInfoOnly) return whatsAppTemplateMessages.value;
+  return whatsAppTemplateMessages.value.filter(hasRequestContactInfoButton);
+});
+
 const filteredTemplateMessages = computed(() =>
-  whatsAppTemplateMessages.value.filter(template =>
+  availableTemplateMessages.value.filter(template =>
     template.name.toLowerCase().includes(query.value.toLowerCase())
   )
 );
@@ -189,13 +205,13 @@ const refreshTemplates = async () => {
         />
       </div>
       <div v-if="!filteredTemplateMessages.length" class="py-8 text-center">
-        <div v-if="query && whatsAppTemplateMessages.length">
+        <div v-if="query && availableTemplateMessages.length">
           <p>
             {{ t('WHATSAPP_TEMPLATES.PICKER.NO_TEMPLATES_FOUND') }}
             <strong>{{ query }}</strong>
           </p>
         </div>
-        <div v-else-if="!whatsAppTemplateMessages.length" class="space-y-4">
+        <div v-else-if="!availableTemplateMessages.length" class="space-y-4">
           <p class="text-n-slate-11">
             {{ t('WHATSAPP_TEMPLATES.PICKER.NO_TEMPLATES_AVAILABLE') }}
           </p>

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -80,6 +80,15 @@
     "SUCCESS_DELETE_MESSAGE": "Message deleted successfully",
     "FAIL_DELETE_MESSSAGE": "Couldn't delete message! Try again",
     "NO_RESPONSE": "No response",
+    "REQUEST_CONTACT_INFO": {
+      "ACTION": "Ask the customer to share their WhatsApp phone number",
+      "PENDING_ACTION": "Contact information request pending",
+      "STATES": {
+        "PENDING": "Waiting for contact information",
+        "SHARED": "Phone number shared",
+        "IDENTITY_CONFLICT": "Phone number needs review"
+      }
+    },
     "RESPONSE": "Response",
     "RATING_TITLE": "Rating",
     "FEEDBACK_TITLE": "Feedback",

--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -19,6 +19,31 @@ import {
   syncConversationCallVisibility,
 } from 'dashboard/helper/voice';
 
+const TERMINAL_CONTACT_INFO_REQUEST_STATES = ['shared', 'identity_conflict'];
+
+const contactInfoSourceId = message =>
+  message.conversation?.contact_inbox?.source_id;
+
+const hasContactInfoSource = (conversation, sourceId) => {
+  return (conversation.messages || []).some(message => {
+    return contactInfoSourceId(message) === sourceId;
+  });
+};
+
+const contactInfoRefreshConversationIds = (state, message) => {
+  const conversationIds = new Set([message.conversation_id].filter(Boolean));
+  const sourceId = contactInfoSourceId(message);
+  if (!sourceId) return [...conversationIds];
+
+  (state.allConversations || []).forEach(conversation => {
+    if (hasContactInfoSource(conversation, sourceId)) {
+      conversationIds.add(conversation.id);
+    }
+  });
+
+  return [...conversationIds];
+};
+
 export const hasMessageFailedWithExternalError = pendingMessage => {
   // This helper is used to check if the message has failed with an external error.
   // We have two cases
@@ -329,6 +354,12 @@ const actions = {
     }
   },
 
+  requestContactInfo: async ({ commit }, conversationId) => {
+    const { data } = await ConversationApi.requestContactInfo(conversationId);
+    commit(types.ADD_MESSAGE, data);
+    return data;
+  },
+
   addMessage({ commit, rootGetters }, message) {
     commit(types.ADD_MESSAGE, message);
     if (message.message_type === MESSAGE_TYPE.INCOMING) {
@@ -345,8 +376,25 @@ const actions = {
     );
   },
 
-  updateMessage({ commit, rootGetters }, message) {
+  updateMessage({ commit, dispatch, rootGetters, state }, message) {
     commit(types.ADD_MESSAGE, message);
+
+    const contactInfoRequest =
+      message.content_attributes?.whatsapp_contact_info;
+    const isTerminalContactInfoRequest =
+      contactInfoRequest?.type === 'request' &&
+      (message.status === MESSAGE_STATUS.FAILED ||
+        TERMINAL_CONTACT_INFO_REQUEST_STATES.includes(
+          contactInfoRequest.state
+        ));
+    if (isTerminalContactInfoRequest) {
+      contactInfoRefreshConversationIds(state, message).forEach(
+        conversationId => {
+          dispatch('getConversation', conversationId);
+        }
+      );
+    }
+
     handleVoiceCallUpdated(
       commit,
       message,

--- a/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
@@ -290,6 +290,68 @@ describe('#actions', () => {
     });
   });
 
+  describe('#updateMessage', () => {
+    it('refreshes loaded conversations sharing the same contact inbox source after terminal contact info updates', () => {
+      const localCommit = vi.fn();
+      const localDispatch = vi.fn();
+      const message = {
+        id: 1,
+        conversation_id: 10,
+        status: 'sent',
+        content_attributes: {
+          whatsapp_contact_info: {
+            type: 'request',
+            state: 'identity_conflict',
+          },
+        },
+        conversation: {
+          contact_inbox: { source_id: 'IN.2081978709342942' },
+        },
+      };
+      const state = {
+        allConversations: [
+          { id: 10, messages: [message] },
+          {
+            id: 20,
+            messages: [
+              {
+                conversation: {
+                  contact_inbox: { source_id: 'IN.2081978709342942' },
+                },
+              },
+            ],
+          },
+          {
+            id: 30,
+            messages: [
+              {
+                conversation: {
+                  contact_inbox: { source_id: 'IN.3109889333218546' },
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      actions.updateMessage(
+        {
+          commit: localCommit,
+          dispatch: localDispatch,
+          rootGetters: {},
+          state,
+        },
+        message
+      );
+
+      expect(localCommit.mock.calls).toEqual([[types.ADD_MESSAGE, message]]);
+      expect(localDispatch.mock.calls).toEqual([
+        ['getConversation', 10],
+        ['getConversation', 20],
+      ]);
+    });
+  });
+
   describe('#markMessagesRead', () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -136,6 +136,12 @@ class Channel::Whatsapp < ApplicationRecord
   delegate :media_url, to: :provider_service
   delegate :api_headers, to: :provider_service
 
+  def send_contact_info_request(identifier, message)
+    raise NotImplementedError, 'Contact information requests require a WhatsApp Cloud provider' unless provider == 'whatsapp_cloud'
+
+    Whatsapp::Providers::WhatsappCloudContactInfoRequestService.perform(self, identifier, message)
+  end
+
   def setup_webhooks(is_coexistence: nil)
     perform_webhook_setup(is_coexistence: is_coexistence)
   rescue StandardError => e

--- a/app/services/conversations/filter_service.rb
+++ b/app/services/conversations/filter_service.rb
@@ -27,8 +27,12 @@ class Conversations::FilterService < FilterService
     # :messages is deliberately not preloaded: the list payload fetches messages through
     # scoped queries (last message, last_non_activity_message), which bypass the preload.
     conversations = @account.conversations.includes(
-      :taggings, :inbox, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team, :contact_inbox
-    ).preload(ai_assignee: { avatar_attachment: [:blob] })
+      :taggings, { assignee: { avatar_attachment: [:blob] } }, { contact: { avatar_attachment: [:blob] } }, :team,
+      :contact_inbox
+    ).preload(
+      inbox: :channel,
+      ai_assignee: { avatar_attachment: [:blob] }
+    )
 
     Conversations::PermissionFilterService.new(
       conversations,

--- a/app/services/whatsapp/contact_info_request_eligibility_service.rb
+++ b/app/services/whatsapp/contact_info_request_eligibility_service.rb
@@ -1,0 +1,130 @@
+class Whatsapp::ContactInfoRequestEligibilityService
+  pattr_initialize [:conversation!, :message, { delivery_mode: :any, template_params: nil, pending_request: nil, can_reply: nil }]
+
+  class << self
+    def availability_by_conversation(conversations)
+      conversations = conversations.to_a
+      pending_contact_inbox_ids = pending_request_contact_inbox_ids(conversations)
+
+      conversations.to_h do |conversation|
+        availability = new(
+          conversation: conversation,
+          pending_request: pending_contact_inbox_ids.include?(conversation.contact_inbox_id)
+        ).availability
+        [conversation.id, availability]
+      end
+    end
+
+    private
+
+    def pending_request_contact_inbox_ids(conversations)
+      contact_inbox_ids = conversations.filter_map(&:contact_inbox_id).uniq
+      return [] if contact_inbox_ids.empty?
+
+      Message.outgoing.joins(:conversation)
+             .where(conversations: { contact_inbox_id: contact_inbox_ids })
+             .where.not(status: :failed)
+             .where("(content_attributes #>> '{}')::jsonb -> 'whatsapp_contact_info' ->> 'type' = ?", 'request')
+             .where("(content_attributes #>> '{}')::jsonb -> 'whatsapp_contact_info' ->> 'state' = ?", 'pending')
+             .reorder(nil)
+             .distinct
+             .pluck('conversations.contact_inbox_id')
+    end
+  end
+
+  def ensure_available!
+    return if reason.blank?
+
+    raise CustomExceptions::WhatsappContactInfoRequestError, { reason: reason }
+  end
+
+  def availability
+    unavailable_reason = reason
+    {
+      available: unavailable_reason.blank?,
+      reason: unavailable_reason&.to_s,
+      delivery_mode: unavailable_reason.blank? ? available_delivery_mode : nil
+    }
+  end
+
+  def reason
+    request_reason || delivery_mode_reason
+  end
+
+  def request_contact_info_template?(params)
+    request_contact_info_template(params).present?
+  end
+
+  private
+
+  def request_reason
+    return :unsupported_provider unless whatsapp_cloud_channel?
+    return :phone_already_available if conversation.contact.phone_number.present?
+    return :invalid_identifier unless bsuid_contact?
+    return :pending_request if pending_request?
+  end
+
+  def delivery_mode_reason
+    return :outside_messaging_window if delivery_mode == :interactive && !can_reply?
+    return :template_not_configured if delivery_mode == :template && !request_contact_info_template?(template_params)
+    return :template_not_configured if delivery_mode == :any && available_delivery_mode.blank?
+  end
+
+  def available_delivery_mode
+    return @available_delivery_mode if defined?(@available_delivery_mode)
+
+    @available_delivery_mode = if can_reply?
+                                 'interactive'
+                               elsif request_contact_info_templates.any?
+                                 'template'
+                               end
+  end
+
+  def can_reply?
+    return can_reply unless can_reply.nil?
+
+    conversation.can_reply?
+  end
+
+  def whatsapp_cloud_channel?
+    conversation.inbox.channel_type == 'Channel::Whatsapp' && conversation.inbox.channel.provider == 'whatsapp_cloud'
+  end
+
+  def bsuid_contact?
+    conversation.contact_inbox.source_id.to_s.match?(RegexHelper::WHATSAPP_BSUID_REGEX)
+  end
+
+  def request_contact_info_template(params)
+    return if params.blank?
+
+    request_contact_info_templates.find do |template|
+      template['name'] == params['name'] && template['language']&.casecmp?(params['language'])
+    end
+  end
+
+  def request_contact_info_templates
+    Array(conversation.inbox.channel.message_templates).select { |template| request_contact_info_template_definition?(template) }
+  end
+
+  def request_contact_info_template_definition?(template)
+    return false unless template['status'].to_s.casecmp?('approved')
+
+    request_contact_info_buttons(template).any? { |button| button['type'].to_s.casecmp?('request_contact_info') }
+  end
+
+  def request_contact_info_buttons(template)
+    buttons = Array(template['components']).find { |component| component['type'].to_s.casecmp?('buttons') }
+    Array(buttons&.dig('buttons'))
+  end
+
+  def pending_request?
+    return pending_request unless pending_request.nil?
+
+    scope = Message.outgoing.where(conversation_id: conversation.contact_inbox.conversations.select(:id))
+                   .where.not(status: :failed)
+                   .where("(content_attributes #>> '{}')::jsonb -> 'whatsapp_contact_info' ->> 'type' = ?", 'request')
+                   .where("(content_attributes #>> '{}')::jsonb -> 'whatsapp_contact_info' ->> 'state' = ?", 'pending')
+    scope = scope.where.not(id: message.id) if message&.persisted?
+    scope.exists?
+  end
+end

--- a/app/services/whatsapp/contact_info_request_service.rb
+++ b/app/services/whatsapp/contact_info_request_service.rb
@@ -1,0 +1,26 @@
+class Whatsapp::ContactInfoRequestService
+  pattr_initialize [:conversation!, :sender!]
+
+  def perform
+    conversation.contact_inbox.with_lock do
+      Whatsapp::ContactInfoRequestEligibilityService.new(conversation: conversation, delivery_mode: :interactive).ensure_available!
+
+      Messages::MessageBuilder.new(sender, conversation, message_params).perform
+    end
+  end
+
+  private
+
+  def message_params
+    {
+      content: I18n.t('conversations.messages.whatsapp.request_contact_info'),
+      content_attributes: {
+        whatsapp_contact_info: {
+          type: 'request',
+          state: 'pending',
+          delivery_mode: 'interactive'
+        }
+      }
+    }
+  end
+end

--- a/app/services/whatsapp/contact_info_response_service.rb
+++ b/app/services/whatsapp/contact_info_response_service.rb
@@ -1,0 +1,130 @@
+class Whatsapp::ContactInfoResponseService
+  pattr_initialize [:contact_inbox!, :message_payload!]
+
+  def perform
+    return unless processable_response?
+
+    request_message = pending_request_message
+    return if request_message.blank? || response_predates_request?(request_message)
+
+    phone_identity = shared_phone_identity
+    return if phone_identity.blank?
+
+    request_message.with_lock do
+      return unless pending_request?(request_message)
+
+      state = sync_contact_info_response(phone_identity)
+      update_request_state(request_message, state)
+      state
+    end
+  end
+
+  private
+
+  def processable_response?
+    contact_payload[:origin] == 'contact_request' && matching_bsuid? && !response_already_processed?
+  end
+
+  def inbox
+    contact_inbox.inbox
+  end
+
+  def contact
+    contact_inbox.contact
+  end
+
+  def contact_payload
+    Array(message_payload[:contacts]).first&.with_indifferent_access || {}.with_indifferent_access
+  end
+
+  def matching_bsuid?
+    return false if sender_ids.blank?
+    return false unless matching_contact_inboxes.exists?
+
+    sender_ids.include?(contact_inbox.source_id)
+  end
+
+  def sender_ids
+    [message_payload[:from_user_id], message_payload[:from_parent_user_id]].compact_blank.map(&:to_s).uniq
+  end
+
+  def matching_contact_inboxes
+    inbox.contact_inboxes.where(contact: contact, source_id: sender_ids)
+  end
+
+  def response_already_processed?
+    source_id = message_payload[:id].to_s
+    return false if source_id.blank?
+
+    contact_info_request_messages.exists?(
+      ["(content_attributes #>> '{}')::jsonb -> 'whatsapp_contact_info' ->> 'response_source_id' = ?", source_id]
+    )
+  end
+
+  def pending_request_message
+    contact_info_request_messages.where.not(status: :failed)
+                                 .where("(content_attributes #>> '{}')::jsonb -> 'whatsapp_contact_info' ->> 'type' = ?", 'request')
+                                 .where("(content_attributes #>> '{}')::jsonb -> 'whatsapp_contact_info' ->> 'state' = ?", 'pending')
+                                 .order(created_at: :desc, id: :desc)
+                                 .first
+  end
+
+  def contact_info_request_messages
+    Message.outgoing.where(
+      conversation_id: Conversation.where(contact_inbox: matching_contact_inboxes).select(:id)
+    )
+  end
+
+  def pending_request?(message)
+    message.content_attributes.dig('whatsapp_contact_info', 'type') == 'request' &&
+      message.content_attributes.dig('whatsapp_contact_info', 'state') == 'pending' && !message.failed?
+  end
+
+  def response_predates_request?(request_message)
+    response_timestamp = message_payload[:timestamp].to_i
+    response_timestamp.positive? && response_timestamp < request_message.created_at.to_i
+  end
+
+  def shared_phone_identity
+    phone = Array(contact_payload[:phones]).first&.with_indifferent_access || {}.with_indifferent_access
+    wa_id = phone[:wa_id].to_s
+    return { phone_number: "+#{wa_id}", source_id: wa_id } if wa_id.match?(/\A\d{1,15}\z/)
+
+    parsed_number = TelephoneNumber.parse(phone[:phone].to_s)
+    return unless parsed_number.valid?
+
+    phone_number = parsed_number.e164_number
+    { phone_number: phone_number, source_id: phone_number.delete_prefix('+') }
+  end
+
+  def identity_conflict?(phone_identity)
+    phone_number = phone_identity[:phone_number]
+    return true if contact.phone_number.present? && contact.phone_number != phone_number
+    return true if inbox.contact_inboxes.where(source_id: phone_identity[:source_id]).where.not(contact_id: contact.id).exists?
+
+    contact.account.contacts.where(phone_number: phone_number).where.not(id: contact.id).exists?
+  end
+
+  def sync_contact_info_response(phone_identity)
+    contact.account.with_lock do
+      contact.with_lock do
+        contact.reload
+        identity_conflict?(phone_identity) ? 'identity_conflict' : sync_phone_identity(phone_identity)
+      end
+    end
+  end
+
+  def sync_phone_identity(phone_identity)
+    Whatsapp::IdentifierSyncService.new(contact_inbox: contact_inbox, contact: contact).perform(
+      source_ids: [phone_identity[:source_id]], phone_number: phone_identity[:phone_number]
+    )
+    contact.reload.phone_number == phone_identity[:phone_number] ? 'shared' : 'identity_conflict'
+  end
+
+  def update_request_state(request_message, state)
+    content_attributes = request_message.content_attributes.deep_dup
+    content_attributes['whatsapp_contact_info']['state'] = state
+    content_attributes['whatsapp_contact_info']['response_source_id'] = message_payload[:id].to_s
+    request_message.update!(content_attributes: content_attributes)
+  end
+end

--- a/app/services/whatsapp/incoming_contact_message_handler.rb
+++ b/app/services/whatsapp/incoming_contact_message_handler.rb
@@ -1,0 +1,44 @@
+module Whatsapp::IncomingContactMessageHandler
+  def create_contact_messages(message)
+    message = process_contact_info_response(message)
+    Array(message[:contacts]).each do |contact|
+      # Pass source_id from parent message since contact objects don't have :id
+      create_message(contact, source_id: message[:id], content_attributes_source: message)
+      attach_contact(contact, contact_info_response_handled: message[:contact_info_response_handled])
+      @message.save!
+    end
+  end
+
+  def process_contact_info_response(message)
+    contact_params = @processed_params[:contacts]&.first || {}
+    response_payload = message.merge(
+      from_user_id: message[:from_user_id].presence || contact_params[:user_id],
+      from_parent_user_id: message[:from_parent_user_id].presence || contact_params[:parent_user_id]
+    )
+    handled_state = Whatsapp::ContactInfoResponseService.new(
+      contact_inbox: @contact_inbox, message_payload: response_payload
+    ).perform
+
+    message.merge(contact_info_response_handled: handled_state == 'shared')
+  end
+
+  def attach_contact(contact, contact_info_response_handled: false)
+    phones = contact[:phones].presence || [{ phone: 'Phone number is not available' }]
+
+    name_info = contact['name'] || {}
+    contact_meta = {
+      firstName: name_info['first_name'],
+      lastName: name_info['last_name']
+    }.compact
+    contact_meta[:isContactInfoResponse] = true if contact_info_response_handled
+
+    phones.each do |phone|
+      @message.attachments.new(
+        account_id: @message.account_id,
+        file_type: file_content_type(message_type),
+        fallback_title: phone[:phone].to_s,
+        meta: contact_meta
+      )
+    end
+  end
+end

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -4,6 +4,7 @@
 class Whatsapp::IncomingMessageBaseService
   include ::Whatsapp::IncomingMessageServiceHelpers
   include ::Whatsapp::IncomingMessageIdentifierHelper
+  include ::Whatsapp::IncomingContactMessageHandler
 
   pattr_initialize [:inbox!, :params!, :outgoing_echo, { locked_sender_id: nil }]
 
@@ -87,15 +88,6 @@ class Whatsapp::IncomingMessageBaseService
     @message.content = I18n.t('conversations.messages.whatsapp.unsupported_message')
     @message.content_attributes = @message.content_attributes.merge(is_unsupported: true)
     @message.save!
-  end
-
-  def create_contact_messages(message)
-    message['contacts'].each do |contact|
-      # Pass source_id from parent message since contact objects don't have :id
-      create_message(contact, source_id: message[:id], content_attributes_source: message)
-      attach_contact(contact)
-      @message.save!
-    end
   end
 
   def create_regular_message(message)
@@ -200,26 +192,6 @@ class Whatsapp::IncomingMessageBaseService
     end
 
     content_attrs
-  end
-
-  def attach_contact(contact)
-    phones = contact[:phones]
-    phones = [{ phone: 'Phone number is not available' }] if phones.blank?
-
-    name_info = contact['name'] || {}
-    contact_meta = {
-      firstName: name_info['first_name'],
-      lastName: name_info['last_name']
-    }.compact
-
-    phones.each do |phone|
-      @message.attachments.new(
-        account_id: @message.account_id,
-        file_type: file_content_type(message_type),
-        fallback_title: phone[:phone].to_s,
-        meta: contact_meta
-      )
-    end
   end
 
   def update_contact_with_profile_name(contact_params)

--- a/app/services/whatsapp/providers/whatsapp_cloud_contact_info_request_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_contact_info_request_service.rb
@@ -1,0 +1,41 @@
+class Whatsapp::Providers::WhatsappCloudContactInfoRequestService < Whatsapp::Providers::BaseService
+  def self.perform(whatsapp_channel, identifier, message)
+    new(whatsapp_channel: whatsapp_channel).perform(identifier, message)
+  end
+
+  def perform(identifier, message)
+    response = HTTParty.post(
+      "#{phone_id_path}/messages",
+      headers: api_headers,
+      body: {
+        messaging_product: 'whatsapp',
+        recipient_type: 'individual',
+        **recipient_params(identifier),
+        type: 'interactive',
+        interactive: {
+          type: 'request_contact_info',
+          body: { text: message.outgoing_content },
+          action: { name: 'request_contact_info' }
+        }
+      }.to_json
+    )
+
+    process_response(response, message)
+  end
+
+  private
+
+  def phone_id_path
+    api_version = GlobalConfigService.load('WHATSAPP_API_VERSION', 'v22.0')
+    base_url = ENV.fetch('WHATSAPP_CLOUD_BASE_URL', 'https://graph.facebook.com')
+    "#{base_url}/#{api_version}/#{whatsapp_channel.provider_config['phone_number_id']}"
+  end
+
+  def api_headers
+    { 'Authorization' => "Bearer #{whatsapp_channel.provider_config['api_key']}", 'Content-Type' => 'application/json' }
+  end
+
+  def error_message(response)
+    response.parsed_response.dig('error', 'message') if response.parsed_response.is_a?(Hash)
+  end
+end

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -6,10 +6,25 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
   end
 
   def perform_reply
-    return send_template_message if template_params.present?
+    if template_params.present?
+      tag_contact_info_template_request
+      return send_template_message
+    end
+    return send_contact_info_request if contact_info_request?
+
     return send_session_message if message.conversation.can_reply?
 
     message.update!(status: :failed, external_error: I18n.t('errors.whatsapp.message_outside_messaging_window'))
+  rescue CustomExceptions::WhatsappContactInfoRequestError => e
+    message.update!(status: :failed, external_error: e.message)
+  end
+
+  def send_contact_info_request
+    Whatsapp::ContactInfoRequestEligibilityService.new(
+      conversation: message.conversation, message: message, delivery_mode: :interactive
+    ).ensure_available!
+    message_id = channel.send_contact_info_request(message.conversation.contact_inbox.source_id, message)
+    message.update!(source_id: message_id) if message_id.present?
   end
 
   def send_template_message
@@ -42,5 +57,23 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
 
   def template_params
     message.additional_attributes && message.additional_attributes['template_params']
+  end
+
+  def contact_info_request?
+    message.content_attributes.dig('whatsapp_contact_info', 'type') == 'request'
+  end
+
+  def tag_contact_info_template_request
+    eligibility = Whatsapp::ContactInfoRequestEligibilityService.new(
+      conversation: message.conversation, message: message, delivery_mode: :template, template_params: template_params
+    )
+    return unless eligibility.request_contact_info_template?(template_params)
+
+    message.conversation.contact_inbox.with_lock do
+      eligibility.ensure_available!
+      content_attributes = message.content_attributes.deep_dup
+      content_attributes['whatsapp_contact_info'] = { 'type' => 'request', 'state' => 'pending', 'delivery_mode' => 'template' }
+      message.update!(content_attributes: content_attributes)
+    end
   end
 end

--- a/app/views/api/v1/accounts/contacts/conversations/index.json.jbuilder
+++ b/app/views/api/v1/accounts/contacts/conversations/index.json.jbuilder
@@ -1,5 +1,10 @@
+contact_info_requests = Whatsapp::ContactInfoRequestEligibilityService.availability_by_conversation(@conversations)
+
 json.payload do
   json.array! @conversations do |conversation|
-    json.partial! 'api/v1/conversations/partials/conversation', formats: [:json], conversation: conversation
+    json.partial! 'api/v1/conversations/partials/conversation',
+                  formats: [:json],
+                  conversation: conversation,
+                  contact_info_request: contact_info_requests.fetch(conversation.id)
   end
 end

--- a/app/views/api/v1/accounts/conversations/filter.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/filter.json.jbuilder
@@ -1,3 +1,5 @@
+contact_info_requests = Whatsapp::ContactInfoRequestEligibilityService.availability_by_conversation(@conversations)
+
 json.meta do
   json.mine_count @conversations_count[:mine_count]
   json.unassigned_count @conversations_count[:unassigned_count]
@@ -5,6 +7,9 @@ json.meta do
 end
 json.payload do
   json.array! @conversations do |conversation|
-    json.partial! 'api/v1/conversations/partials/conversation', formats: [:json], conversation: conversation
+    json.partial! 'api/v1/conversations/partials/conversation',
+                  formats: [:json],
+                  conversation: conversation,
+                  contact_info_request: contact_info_requests.fetch(conversation.id)
   end
 end

--- a/app/views/api/v1/accounts/conversations/index.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/index.json.jbuilder
@@ -1,3 +1,5 @@
+contact_info_requests = Whatsapp::ContactInfoRequestEligibilityService.availability_by_conversation(@conversations)
+
 json.data do
   json.meta do
     json.mine_count @conversations_count[:mine_count]
@@ -7,7 +9,10 @@ json.data do
   end
   json.payload do
     json.array! @conversations do |conversation|
-      json.partial! 'api/v1/conversations/partials/conversation', formats: [:json], conversation: conversation
+      json.partial! 'api/v1/conversations/partials/conversation',
+                    formats: [:json],
+                    conversation: conversation,
+                    contact_info_request: contact_info_requests.fetch(conversation.id)
     end
   end
 end

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -47,7 +47,15 @@ json.uuid conversation.uuid
 json.additional_attributes conversation.additional_attributes
 json.agent_last_seen_at conversation.agent_last_seen_at.to_i
 json.assignee_last_seen_at conversation.assignee_last_seen_at.to_i
-json.can_reply conversation.can_reply?
+can_reply = conversation.can_reply?
+json.can_reply can_reply
+contact_info_request = local_assigns[:contact_info_request] ||
+                       Whatsapp::ContactInfoRequestEligibilityService.new(conversation: conversation, can_reply: can_reply).availability
+json.contact_info_request do
+  json.available contact_info_request[:available]
+  json.reason contact_info_request[:reason]
+  json.delivery_mode contact_info_request[:delivery_mode]
+end
 json.contact_last_seen_at conversation.contact_last_seen_at.to_i
 json.custom_attributes conversation.custom_attributes
 json.inbox_id conversation.inbox_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,13 @@ en:
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'
       phone_number_already_exists: 'Channel already exists for this phone number: %{phone_number}, please contact support if the error persists'
       message_outside_messaging_window: 'Message not sent because the WhatsApp 24-hour customer service window is closed and no template parameters were provided. Send an approved template message instead.'
+      contact_info_request:
+        unsupported_provider: 'Contact information requests are currently available only for WhatsApp Cloud inboxes.'
+        phone_already_available: 'This contact already has a phone number.'
+        invalid_identifier: 'Contact information can only be requested from a business-scoped WhatsApp user.'
+        outside_messaging_window: 'Contact information can only be requested within the WhatsApp 24-hour customer service window.'
+        template_not_configured: 'An approved WhatsApp template with a Request contact info button is required outside the 24-hour customer service window.'
+        pending_request: 'A contact information request is already pending.'
       reauthorization:
         generic: 'Failed to reauthorize WhatsApp. Please try again.'
         not_supported: 'Reauthorization is not supported for this type of WhatsApp channel.'
@@ -306,6 +313,7 @@ en:
         list_button_label: 'Choose an item'
         call_permission_request_body: 'We would like to call you regarding your conversation.'
         flow_response: 'Submitted a flow response'
+        request_contact_info: 'Would you like to share your phone number with us?'
         unsupported_message: 'This message is unavailable.'
       voice_call:
         twilio: 'Voice Call'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,6 +171,7 @@ Rails.application.routes.draw do
                   post :retry
                 end
               end
+              resource :contact_info_request, only: [:create]
               resources :assignments, only: [:create]
               resources :labels, only: [:create, :index]
               resource :participants, only: [:show, :create, :update, :destroy]

--- a/lib/custom_exceptions/whatsapp_contact_info_request_error.rb
+++ b/lib/custom_exceptions/whatsapp_contact_info_request_error.rb
@@ -1,0 +1,9 @@
+class CustomExceptions::WhatsappContactInfoRequestError < CustomExceptions::Base
+  def message
+    I18n.t("errors.whatsapp.contact_info_request.#{@data[:reason]}")
+  end
+
+  def http_status
+    :unprocessable_entity
+  end
+end

--- a/spec/services/whatsapp/contact_info_request_eligibility_service_spec.rb
+++ b/spec/services/whatsapp/contact_info_request_eligibility_service_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::ContactInfoRequestEligibilityService do
+  subject(:availability) { described_class.new(conversation: conversation).availability }
+
+  let(:whatsapp_channel) do
+    create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false)
+  end
+  let(:inbox) { whatsapp_channel.inbox }
+  let(:contact) { create(:contact, account: inbox.account, phone_number: nil) }
+  let(:contact_inbox) do
+    create(:contact_inbox, inbox: inbox, contact: contact, source_id: 'AE.2109889333218546')
+  end
+  let(:conversation) do
+    create(:conversation, account: inbox.account, inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+  end
+
+  before do
+    create(:message, account: inbox.account, inbox: inbox, conversation: conversation, message_type: :incoming)
+  end
+
+  it 'finds a pending request from another conversation on the same BSUID contact inbox' do
+    previous_conversation = create(
+      :conversation, account: inbox.account, inbox: inbox, contact: contact, contact_inbox: contact_inbox, status: :resolved
+    )
+    create(
+      :message,
+      account: inbox.account,
+      inbox: inbox,
+      conversation: previous_conversation,
+      message_type: :outgoing,
+      status: :sent,
+      content_attributes: { whatsapp_contact_info: { type: 'request', state: 'pending' } }
+    )
+
+    expect(availability).to include(available: false, reason: 'pending_request', delivery_mode: nil)
+  end
+
+  it 'ignores pending requests from another BSUID contact inbox on the merged contact' do
+    other_contact_inbox = create(:contact_inbox, inbox: inbox, contact: contact, source_id: 'AE.3109889333218546')
+    other_conversation = create(
+      :conversation, account: inbox.account, inbox: inbox, contact: contact, contact_inbox: other_contact_inbox
+    )
+    create(
+      :message,
+      account: inbox.account,
+      inbox: inbox,
+      conversation: other_conversation,
+      message_type: :outgoing,
+      status: :sent,
+      content_attributes: { whatsapp_contact_info: { type: 'request', state: 'pending' } }
+    )
+
+    expect(availability).to include(available: true, reason: nil, delivery_mode: 'interactive')
+  end
+
+  it 'reuses a supplied reply-window result' do
+    allow(conversation).to receive(:can_reply?).and_raise('should use the provided can_reply value')
+
+    result = described_class.new(conversation: conversation, can_reply: true).availability
+
+    expect(result).to include(available: true, reason: nil, delivery_mode: 'interactive')
+  end
+end

--- a/spec/services/whatsapp/contact_info_response_service_spec.rb
+++ b/spec/services/whatsapp/contact_info_response_service_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::ContactInfoResponseService do
+  subject(:perform) do
+    described_class.new(contact_inbox: contact_inbox, message_payload: message_payload).perform
+  end
+
+  let(:whatsapp_channel) do
+    create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false)
+  end
+  let(:inbox) { whatsapp_channel.inbox }
+  let(:contact) { create(:contact, account: inbox.account, phone_number: nil) }
+  let(:bsuid) { 'AE.2109889333218546' }
+  let(:contact_inbox) { create(:contact_inbox, inbox: inbox, contact: contact, source_id: bsuid) }
+  let(:request_conversation) do
+    create(:conversation, account: inbox.account, inbox: inbox, contact: contact, contact_inbox: contact_inbox, status: :resolved)
+  end
+  let(:response_conversation) do
+    create(:conversation, account: inbox.account, inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+  end
+  let!(:request_message) do
+    create(
+      :message,
+      account: inbox.account,
+      inbox: inbox,
+      conversation: request_conversation,
+      message_type: :outgoing,
+      status: :sent,
+      created_at: 1.hour.ago,
+      content_attributes: {
+        whatsapp_contact_info: { type: 'request', state: 'pending', delivery_mode: 'interactive' }
+      }
+    )
+  end
+  let(:message_payload) do
+    {
+      id: 'wamid.contact-info-response',
+      from_user_id: bsuid,
+      timestamp: Time.current.to_i.to_s,
+      contacts: [{
+        origin: 'contact_request',
+        phones: [{ phone: '+971 54 529 6927', wa_id: '971545296927' }]
+      }]
+    }.with_indifferent_access
+  end
+
+  it 'updates a pending request from a resolved conversation on the same BSUID contact inbox' do
+    expect(response_conversation).not_to eq(request_conversation)
+
+    expect(perform).to eq('shared')
+
+    expect(request_message.reload.content_attributes['whatsapp_contact_info']).to include(
+      'state' => 'shared',
+      'response_source_id' => 'wamid.contact-info-response'
+    )
+    expect(contact.reload.phone_number).to eq('+971545296927')
+    expect(contact_inbox.inbox.contact_inboxes.find_by!(source_id: '971545296927').contact).to eq(contact)
+  end
+
+  it 'marks a conflict when the contact was already updated with a different phone' do
+    contact.update!(phone_number: '+971500000000')
+
+    expect(perform).to eq('identity_conflict')
+
+    expect(request_message.reload.content_attributes['whatsapp_contact_info']).to include(
+      'state' => 'identity_conflict',
+      'response_source_id' => 'wamid.contact-info-response'
+    )
+    expect(contact.reload.phone_number).to eq('+971500000000')
+  end
+
+  it 'accepts a parent-only BSUID response' do
+    message_payload.delete(:from_user_id)
+    message_payload[:from_parent_user_id] = bsuid
+
+    expect(perform).to eq('shared')
+
+    expect(request_message.reload.content_attributes['whatsapp_contact_info']).to include(
+      'state' => 'shared',
+      'response_source_id' => 'wamid.contact-info-response'
+    )
+    expect(contact.reload.phone_number).to eq('+971545296927')
+  end
+
+  it 'does not use a newer pending request from another BSUID contact inbox on the merged contact' do
+    other_contact_inbox = create(:contact_inbox, inbox: inbox, contact: contact, source_id: 'AE.3109889333218546')
+    other_conversation = create(
+      :conversation, account: inbox.account, inbox: inbox, contact: contact, contact_inbox: other_contact_inbox
+    )
+    other_request = create(
+      :message,
+      account: inbox.account,
+      inbox: inbox,
+      conversation: other_conversation,
+      message_type: :outgoing,
+      status: :sent,
+      created_at: 30.minutes.ago,
+      content_attributes: { whatsapp_contact_info: { type: 'request', state: 'pending' } }
+    )
+
+    perform
+
+    expect(request_message.reload.content_attributes.dig('whatsapp_contact_info', 'state')).to eq('shared')
+    expect(other_request.reload.content_attributes.dig('whatsapp_contact_info', 'state')).to eq('pending')
+  end
+
+  it 'ignores an ordinary shared contact' do
+    message_payload[:contacts].first[:origin] = 'other'
+
+    perform
+
+    expect(request_message.reload.content_attributes.dig('whatsapp_contact_info', 'state')).to eq('pending')
+    expect(contact.reload.phone_number).to be_nil
+  end
+
+  it 'ignores a response that predates the request' do
+    message_payload[:timestamp] = (request_message.created_at - 1.minute).to_i.to_s
+
+    perform
+
+    expect(request_message.reload.content_attributes.dig('whatsapp_contact_info', 'state')).to eq('pending')
+    expect(contact.reload.phone_number).to be_nil
+  end
+
+  it 'does not process the same response twice' do
+    service = described_class.new(contact_inbox: contact_inbox, message_payload: message_payload)
+    service.perform
+
+    expect { service.perform }.not_to raise_error
+    expect(contact_inbox.inbox.contact_inboxes.where(source_id: '971545296927').count).to eq(1)
+    expect(request_message.reload.content_attributes['whatsapp_contact_info']).to include(
+      'state' => 'shared',
+      'response_source_id' => 'wamid.contact-info-response'
+    )
+  end
+
+  it 'marks the request as an identity conflict without changing the contact' do
+    create(:contact, account: inbox.account, phone_number: '+971545296927')
+
+    perform
+
+    expect(request_message.reload.content_attributes['whatsapp_contact_info']).to include(
+      'state' => 'identity_conflict',
+      'response_source_id' => 'wamid.contact-info-response'
+    )
+    expect(contact.reload.phone_number).to be_nil
+    expect(contact_inbox.inbox.contact_inboxes.find_by(source_id: '971545296927')).to be_nil
+  end
+
+  it 'locks the account while assigning the shared phone identity' do
+    account = contact.account
+    expect(account).to receive(:with_lock).and_call_original
+
+    perform
+
+    expect(contact.reload.phone_number).to eq('+971545296927')
+  end
+end

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -57,6 +57,110 @@ describe Whatsapp::IncomingMessageService do
         expect(parent_conversation.contact_inbox.source_id).to eq('IN.ENT.9081726354')
         expect(parent_conversation.messages.pluck(:content)).to contain_exactly('second')
       end
+
+      it 'keeps Save Contact available for contact-request responses without a Chatwoot pending request' do
+        contact = create(:contact, account: cloud_channel.account, phone_number: nil)
+        contact_inbox = create(:contact_inbox, inbox: cloud_channel.inbox, contact: contact, source_id: 'IN.2081978709342942')
+        create(:conversation, account: cloud_channel.account, inbox: cloud_channel.inbox, contact: contact, contact_inbox: contact_inbox)
+        params = {
+          'contacts' => [{ 'profile' => { 'name' => 'Muhsin' }, 'user_id' => 'IN.2081978709342942' }],
+          'messages' => [{
+            'from_user_id' => 'IN.2081978709342942',
+            'id' => 'wamid.external-contact-request-response',
+            'timestamp' => Time.current.to_i.to_s,
+            'type' => 'contacts',
+            'contacts' => [{
+              'origin' => 'contact_request',
+              'name' => { 'first_name' => 'Muhsin', 'formatted_name' => 'Muhsin' },
+              'phones' => [{ 'phone' => '+91 97457 86257', 'wa_id' => '919745786257' }]
+            }]
+          }]
+        }.with_indifferent_access
+
+        described_class.new(inbox: cloud_channel.inbox, params: params).perform
+
+        attachment = cloud_channel.inbox.messages.find_by!(source_id: 'wamid.external-contact-request-response').attachments.first
+        expect(attachment.meta).to include('firstName' => 'Muhsin')
+        expect(attachment.meta).not_to include('isContactInfoResponse')
+        expect(contact.reload.phone_number).to be_nil
+      end
+
+      it 'hides Save Contact only after handling a Chatwoot pending request' do
+        contact = create(:contact, account: cloud_channel.account, phone_number: nil)
+        contact_inbox = create(:contact_inbox, inbox: cloud_channel.inbox, contact: contact, source_id: 'IN.2081978709342942')
+        conversation = create(
+          :conversation, account: cloud_channel.account, inbox: cloud_channel.inbox, contact: contact, contact_inbox: contact_inbox
+        )
+        create(
+          :message,
+          account: cloud_channel.account,
+          inbox: cloud_channel.inbox,
+          conversation: conversation,
+          message_type: :outgoing,
+          status: :sent,
+          content_attributes: { whatsapp_contact_info: { type: 'request', state: 'pending' } }
+        )
+        params = {
+          'contacts' => [{ 'profile' => { 'name' => 'Muhsin' }, 'user_id' => 'IN.2081978709342942' }],
+          'messages' => [{
+            'from_user_id' => 'IN.2081978709342942',
+            'id' => 'wamid.handled-contact-request-response',
+            'timestamp' => Time.current.to_i.to_s,
+            'type' => 'contacts',
+            'contacts' => [{
+              'origin' => 'contact_request',
+              'name' => { 'first_name' => 'Muhsin', 'formatted_name' => 'Muhsin' },
+              'phones' => [{ 'phone' => '+91 97457 86257', 'wa_id' => '919745786257' }]
+            }]
+          }]
+        }.with_indifferent_access
+
+        described_class.new(inbox: cloud_channel.inbox, params: params).perform
+
+        attachment = cloud_channel.inbox.messages.find_by!(source_id: 'wamid.handled-contact-request-response').attachments.first
+        expect(attachment.meta).to include('isContactInfoResponse' => true)
+        expect(contact.reload.phone_number).to eq('+919745786257')
+      end
+
+      it 'keeps Save Contact available when a Chatwoot pending request hits an identity conflict' do
+        contact = create(:contact, account: cloud_channel.account, phone_number: nil)
+        create(:contact, account: cloud_channel.account, phone_number: '+919745786257')
+        contact_inbox = create(:contact_inbox, inbox: cloud_channel.inbox, contact: contact, source_id: 'IN.2081978709342942')
+        conversation = create(
+          :conversation, account: cloud_channel.account, inbox: cloud_channel.inbox, contact: contact, contact_inbox: contact_inbox
+        )
+        request_message = create(
+          :message,
+          account: cloud_channel.account,
+          inbox: cloud_channel.inbox,
+          conversation: conversation,
+          message_type: :outgoing,
+          status: :sent,
+          content_attributes: { whatsapp_contact_info: { type: 'request', state: 'pending' } }
+        )
+        params = {
+          'contacts' => [{ 'profile' => { 'name' => 'Muhsin' }, 'user_id' => 'IN.2081978709342942' }],
+          'messages' => [{
+            'from_user_id' => 'IN.2081978709342942',
+            'id' => 'wamid.conflicted-contact-request-response',
+            'timestamp' => Time.current.to_i.to_s,
+            'type' => 'contacts',
+            'contacts' => [{
+              'origin' => 'contact_request',
+              'name' => { 'first_name' => 'Muhsin', 'formatted_name' => 'Muhsin' },
+              'phones' => [{ 'phone' => '+91 97457 86257', 'wa_id' => '919745786257' }]
+            }]
+          }]
+        }.with_indifferent_access
+
+        described_class.new(inbox: cloud_channel.inbox, params: params).perform
+
+        attachment = cloud_channel.inbox.messages.find_by!(source_id: 'wamid.conflicted-contact-request-response').attachments.first
+        expect(attachment.meta).to include('firstName' => 'Muhsin')
+        expect(attachment.meta).not_to include('isContactInfoResponse')
+        expect(request_message.reload.content_attributes.dig('whatsapp_contact_info', 'state')).to eq('identity_conflict')
+        expect(contact.reload.phone_number).to be_nil
+      end
     end
 
     context 'when valid text message params' do

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -396,6 +396,74 @@ describe Whatsapp::SendOnWhatsappService do
       end
     end
 
+    context 'when a contact information template becomes ineligible before delivery' do
+      let(:request_template) do
+        {
+          'name' => 'request_contact_info',
+          'status' => 'APPROVED',
+          'language' => 'en_US',
+          'components' => [
+            { 'type' => 'BODY', 'text' => 'Would you like to share your phone number with us?' },
+            { 'type' => 'BUTTONS', 'buttons' => [{ 'type' => 'REQUEST_CONTACT_INFO' }] }
+          ]
+        }
+      end
+      let(:whatsapp_channel) do
+        create(
+          :channel_whatsapp,
+          provider: 'whatsapp_cloud',
+          message_templates: [request_template],
+          sync_templates: false,
+          validate_provider_config: false
+        )
+      end
+      let(:inbox) { whatsapp_channel.inbox }
+      let(:contact) { create(:contact, account: inbox.account, phone_number: nil) }
+      let(:contact_inbox) do
+        create(:contact_inbox, inbox: inbox, contact: contact, source_id: 'AE.2109889333218546')
+      end
+      let(:conversation) do
+        create(:conversation, account: inbox.account, inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+      end
+
+      it 'marks the message failed when another request is already pending' do
+        previous_conversation = create(
+          :conversation, account: inbox.account, inbox: inbox, contact: contact, contact_inbox: contact_inbox, status: :resolved
+        )
+        create(
+          :message,
+          account: inbox.account,
+          inbox: inbox,
+          conversation: previous_conversation,
+          message_type: :outgoing,
+          status: :sent,
+          content_attributes: { whatsapp_contact_info: { type: 'request', state: 'pending' } }
+        )
+        message = create(
+          :message,
+          account: inbox.account,
+          inbox: inbox,
+          conversation: conversation,
+          message_type: :outgoing,
+          additional_attributes: {
+            template_params: {
+              name: request_template['name'],
+              language: request_template['language'],
+              processed_params: {}
+            }
+          }
+        )
+        expect(Whatsapp::TemplateProcessorService).not_to receive(:new)
+
+        expect { described_class.new(message: message).perform }.not_to raise_error
+
+        expect(message.reload).to have_attributes(
+          status: 'failed',
+          external_error: I18n.t('errors.whatsapp.contact_info_request.pending_request')
+        )
+      end
+    end
+
     context 'when a merged contact owns multiple Meta Cloud identities' do
       let!(:whatsapp_channel) do
         create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false)


### PR DESCRIPTION
BSUID-only WhatsApp contacts can now share their phone information without agents having to ask manually or move the conversation away from its active BSUID identity. Eligible WhatsApp Cloud conversations expose a Request Contact Info action, track the request separately from message delivery, and safely add a valid returned phone identity to the existing contact.

The flow is limited to contacts whose active inbox identity is a BSUID and who do not already have a phone number. Phone-backed conversations, Twilio WhatsApp inboxes, and ordinary shared-contact messages keep their existing behavior.

### Closes

Fixes https://linear.app/chatwoot/issue/CW-7809/recover-phone-information-for-bsuid-only-whatsapp-contacts

Note: CW-7810 and CW-7811 were merged into CW-7809 as duplicate scope, so response-processing and agent-UX requirements are now tracked under CW-7809.

### Things to know

- This first delivery supports WhatsApp Cloud only. Twilio remains unavailable until its request-and-response contract is verified end to end.
- Inside the customer service window, Chatwoot sends Meta's interactive contact-information request. Outside the window, agents can use an approved template containing a `request_contact_info` button.
- A conflicting phone identity is surfaced as an identity conflict and is never merged automatically.
- The generic Save Contact action is hidden only when the contact card is the response to Chatwoot's contact-information request. It remains available for ordinary shared contacts.

### What changed

- Added backend-controlled eligibility, delivery, and request-state handling for BSUID-only WhatsApp Cloud conversations.
- Added safe processing for `origin: contact_request` responses while preserving the active BSUID conversation and existing aliases.
- Added the agent action, template filtering, pending/shared/conflict status display, and contact-panel refresh behavior.

### How to test

1. Open a WhatsApp Cloud conversation whose active contact inbox uses a BSUID and whose contact has no phone number.
2. Select **Request Contact Info** and confirm that the outgoing message shows **Waiting for contact information**.
3. In WhatsApp, select **Share Contact Info** and share the current user's contact.
4. Confirm that Chatwoot adds the phone identity to the existing contact, keeps the conversation on its BSUID contact inbox, and updates the request state.
5. Confirm that the requested-response contact card does not show **Save Contact**, while an ordinary shared-contact message still does.
6. Outside the customer service window, confirm that only approved templates containing a Request Contact Info button are offered.

### Screenshots

**Chatwoot — BSUID-only contact and pending request**

<img width="2068" height="2086" alt="CleanShot 2026-08-21 at 14 04 43@2x" src="https://github.com/user-attachments/assets/80a957cd-d8d5-489b-96a4-353a46af4ab3" />

**WhatsApp — Share Contact Info request and response**

<img width="1170" height="2532" alt="Screenshot 2026-08-21 at 15 05 00" src="https://github.com/user-attachments/assets/a8feff39-d265-4658-8ac4-dcbb6b5858eb" />