### PR TITLE
feat: assign Captain handoffs to available agents

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -139,10 +139,12 @@ class Conversation < ApplicationRecord
   before_create :ensure_waiting_since
 
   after_update_commit :execute_after_update_commit_callbacks
+  after_update_commit :assign_agent_after_bot_handoff
   after_create_commit :notify_conversation_creation
   after_create_commit :load_attributes_created_by_db_triggers
   before_destroy :set_unread_count_deletion_data
   after_destroy_commit :notify_conversation_deletion
+  after_rollback :clear_bot_handoff_assignment
 
   delegate :auto_resolve_after, to: :account
 
@@ -183,6 +185,7 @@ class Conversation < ApplicationRecord
   def bot_handoff!(dispatch_event: true)
     update(waiting_since: Time.current) if waiting_since.blank?
     self.ai_assignee = nil
+    @assign_agent_after_bot_handoff = inbox.auto_assignment_v2_enabled?
     open!
     dispatch_bot_handoff_event if dispatch_event
   end
@@ -270,6 +273,19 @@ class Conversation < ApplicationRecord
   end
 
   private
+
+  def assign_agent_after_bot_handoff
+    return unless @assign_agent_after_bot_handoff
+
+    @assign_agent_after_bot_handoff = false
+    AutoAssignment::AssignmentService.new(inbox: inbox).perform_assignment(self)
+  rescue StandardError => e
+    ChatwootExceptionTracker.new(e, account: account).capture_exception
+  end
+
+  def clear_bot_handoff_assignment
+    @assign_agent_after_bot_handoff = false
+  end
 
   def execute_after_update_commit_callbacks
     handle_resolved_status_change

--- a/app/services/auto_assignment/assignment_service.rb
+++ b/app/services/auto_assignment/assignment_service.rb
@@ -16,6 +16,14 @@ class AutoAssignment::AssignmentService
     assigned_count
   end
 
+  def perform_assignment(conversation)
+    return false unless inbox.auto_assignment_v2_enabled?
+    return false unless inbox.enable_auto_assignment?
+    return false unless unassigned_conversations(1).exists?(id: conversation.id)
+
+    perform_for_conversation(conversation)
+  end
+
   private
 
   def perform_for_conversation(conversation)

--- a/spec/enterprise/lib/captain/tools/handoff_tool_spec.rb
+++ b/spec/enterprise/lib/captain/tools/handoff_tool_spec.rb
@@ -65,6 +65,17 @@ RSpec.describe Captain::Tools::HandoffTool, type: :model do
           expect(tool_context.state[:captain_v2_handoff_tool_completed]).to be true
         end
 
+        it 'assigns the conversation to an available inbox member during handoff' do
+          account.enable_features!(:assignment_v2)
+          create(:inbox_member, user: user, inbox: inbox)
+          allow(OnlineStatusTracker).to receive(:get_available_users).and_return(user.id.to_s => 'online')
+
+          result = tool.perform(tool_context, reason: 'Customer asked for a human', reason_category: 'customer_request')
+
+          expect(result).to include('Conversation handed off')
+          expect(conversation.reload).to have_attributes(status: 'open', assignee: user)
+        end
+
         it 'dispatches the handoff event after leaving the lock transaction' do
           found_conversation = Conversation.find(conversation.id)
           scoped_conversations = Conversation.where(account_id: assistant.account_id)

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -433,6 +433,55 @@ RSpec.describe Conversation do
         .with(described_class::CONVERSATION_BOT_HANDOFF, anything, hash_including(conversation: conversation))
       conversation.bot_handoff!
     end
+
+    context 'when Assignment V2 is enabled' do
+      let(:account) { create(:account) }
+      let(:inbox) { create(:inbox, account: account, enable_auto_assignment: true) }
+      let(:agent) { create(:user, account: account, role: :agent) }
+      let(:conversation) { create(:conversation, account: account, inbox: inbox, status: :pending, assignee: nil) }
+
+      before do
+        account.enable_features('assignment_v2')
+        create(:inbox_member, inbox: inbox, user: agent)
+        allow(OnlineStatusTracker).to receive(:get_available_users).and_return(agent.id.to_s => 'online')
+      end
+
+      it 'assigns the handed-off conversation before returning' do
+        older_conversation = create(:conversation, account: account, inbox: inbox, status: :open, assignee: nil, created_at: 1.hour.ago)
+
+        conversation.bot_handoff!
+
+        expect(conversation.reload).to have_attributes(status: 'open', assignee: agent)
+        expect(older_conversation.reload.assignee).to be_nil
+      end
+
+      it 'leaves the handed-off conversation unassigned when no agent is online' do
+        allow(OnlineStatusTracker).to receive(:get_available_users).and_return({})
+
+        conversation.bot_handoff!
+
+        expect(conversation.reload).to have_attributes(status: 'open', assignee: nil)
+      end
+
+      it 'leaves the handed-off conversation unassigned when auto assignment is disabled' do
+        inbox.update!(enable_auto_assignment: false)
+
+        conversation.bot_handoff!
+
+        expect(conversation.reload).to have_attributes(status: 'open', assignee: nil)
+      end
+
+      it 'completes the handoff when immediate assignment fails' do
+        tracker = instance_double(ChatwootExceptionTracker, capture_exception: nil)
+        allow(AutoAssignment::AssignmentService).to receive(:new).and_raise(StandardError, 'assignment failed')
+        allow(ChatwootExceptionTracker).to receive(:new).and_return(tracker)
+
+        conversation.bot_handoff!
+
+        expect(conversation.reload).to have_attributes(status: 'open', assignee: nil)
+        expect(tracker).to have_received(:capture_exception)
+      end
+    end
   end
 
   describe '#toggle_priority' do


### PR DESCRIPTION
## Summary

* Assign the exact Captain handed-off conversation to an eligible online agent immediately when Assignment V2 is enabled.
* Keep the conversation unassigned when no eligible agent is available or assignment fails, while preserving the completed handoff.
* Reuse the existing assignment rules for teams, rate limits, exclusions, round robin selection, and Enterprise capacity.
* Leave handoff messages and email collection unchanged.

## Test plan

* `bundle exec rspec spec/models/conversation_spec.rb` (123 examples)
* `bundle exec rspec spec/services/auto_assignment/assignment_service_spec.rb spec/enterprise/services/enterprise/auto_assignment/assignment_service_spec.rb spec/enterprise/lib/captain/tools/handoff_tool_spec.rb` (66 examples)
* `bundle exec rubocop app/models/conversation.rb app/services/auto_assignment/assignment_service.rb spec/models/conversation_spec.rb spec/enterprise/lib/captain/tools/handoff_tool_spec.rb`

Part of [AI-199](https://linear.app/chatwoot/issue/AI-199/captain-should-handoff-to-an-online-agent-whenever-possible).