### PR TITLE
feat: collect email after unassigned Captain handoff

### DIFF
--- a/app/services/message_templates/template/email_collect.rb
+++ b/app/services/message_templates/template/email_collect.rb
@@ -1,6 +1,35 @@
 class MessageTemplates::Template::EmailCollect
   pattr_initialize [:conversation!]
 
+  def self.perform_after_handoff_if_applicable(conversation)
+    # Assignment can finish in the handoff commit callback. Read and lock a fresh row so
+    # the prompt uses the final assignee and concurrent handoff paths cannot create duplicates.
+    Conversation.transaction do
+      locked_conversation = Conversation.lock.find_by(id: conversation.id)
+      next unless locked_conversation && collectable_after_handoff?(locked_conversation)
+
+      new(conversation: locked_conversation).perform
+    end
+  rescue StandardError => e
+    ChatwootExceptionTracker.new(e, account: conversation.account).capture_exception
+    true
+  end
+
+  def self.collectable_after_handoff?(conversation)
+    conversation.assignee_id.blank? &&
+      conversation.campaign.blank? &&
+      email_collectable?(conversation)
+  end
+  private_class_method :collectable_after_handoff?
+
+  def self.email_collectable?(conversation)
+    conversation.inbox.web_widget? &&
+      conversation.inbox.enable_email_collect? &&
+      conversation.contact.email.blank? &&
+      !conversation.messages.exists?(content_type: :input_email)
+  end
+  private_class_method :email_collectable?
+
   def perform
     ActiveRecord::Base.transaction do
       conversation.messages.create!(ways_to_reach_you_message_params)

--- a/enterprise/app/jobs/captain/conversation/response_builder_job.rb
+++ b/enterprise/app/jobs/captain/conversation/response_builder_job.rb
@@ -146,6 +146,7 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
       @conversation.bot_handoff!
       report_v1_handoff_not_executed if conversation_pending?
       send_out_of_office_message_if_applicable
+      ::MessageTemplates::Template::EmailCollect.perform_after_handoff_if_applicable(@conversation)
     end
   end
 
@@ -154,6 +155,7 @@ class Captain::Conversation::ResponseBuilderJob < ApplicationJob
     # waiting_since so this message doesn't clear the timestamp it left in place.
     I18n.with_locale(@assistant.account.locale) do
       create_handoff_message(preserve_waiting_since: true)
+      ::MessageTemplates::Template::EmailCollect.perform_after_handoff_if_applicable(@conversation)
     end
   end
 

--- a/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
+++ b/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
@@ -133,7 +133,7 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
       reason_category: :pending_clarification,
       at: Time.current
     )
-    send_out_of_office_message_if_applicable(conversation.reload)
+    send_handoff_follow_up_messages(conversation.reload)
   rescue ActiveRecord::RecordNotFound
     nil
   end
@@ -154,6 +154,11 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
 
   def send_out_of_office_message_if_applicable(conversation)
     ::MessageTemplates::Template::OutOfOffice.perform_if_applicable(conversation) if conversation.campaign.blank?
+  end
+
+  def send_handoff_follow_up_messages(conversation)
+    send_out_of_office_message_if_applicable(conversation)
+    ::MessageTemplates::Template::EmailCollect.perform_after_handoff_if_applicable(conversation)
   end
 
   def create_private_note(conversation, content)

--- a/enterprise/app/services/enterprise/message_templates/hook_execution_service.rb
+++ b/enterprise/app/services/enterprise/message_templates/hook_execution_service.rb
@@ -65,6 +65,7 @@ module Enterprise::MessageTemplates::HookExecutionService
       at: Time.current
     )
     send_out_of_office_message_after_handoff
+    send_email_collect_message_after_handoff
   end
 
   def send_out_of_office_message_after_handoff
@@ -73,6 +74,10 @@ module Enterprise::MessageTemplates::HookExecutionService
     return if conversation.campaign.present?
 
     ::MessageTemplates::Template::OutOfOffice.perform_if_applicable(conversation)
+  end
+
+  def send_email_collect_message_after_handoff
+    ::MessageTemplates::Template::EmailCollect.perform_after_handoff_if_applicable(conversation)
   end
 
   def captain_handling_conversation?

--- a/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
+++ b/spec/enterprise/jobs/captain/conversation/response_builder_job_spec.rb
@@ -300,6 +300,23 @@ RSpec.describe Captain::Conversation::ResponseBuilderJob, type: :job do
           expect(account.reload.usage_limits[:captain][:responses][:consumed]).to eq(0)
         end
 
+        it 'asks for an email after the handoff message when no agent is assigned' do
+          conversation.contact.update!(email: nil)
+          inbox.update!(enable_email_collect: true)
+          allow(mock_action_classifier_service).to receive(:classify).and_return({
+                                                                                   'action' => 'handoff',
+                                                                                   'action_reason' => 'explicit_human_request',
+                                                                                   'model' => 'gpt-4.1'
+                                                                                 })
+
+          described_class.perform_now(conversation, assistant)
+
+          handoff_message = conversation.messages.outgoing.where(private: false).last
+          email_prompt = conversation.messages.find_by(content_type: :input_email)
+          expect(email_prompt).to be_present
+          expect(email_prompt.id).to be > handoff_message.id
+        end
+
         it 'skips the classifier when the legacy handoff token is returned' do
           allow(mock_llm_chat_service).to receive(:generate_response).and_return({ 'response' => 'conversation_handoff' })
           expect(Captain::Llm::AssistantActionClassifierService).not_to receive(:new)
@@ -771,6 +788,36 @@ RSpec.describe Captain::Conversation::ResponseBuilderJob, type: :job do
         expect(conversation).not_to receive(:bot_handoff!)
 
         described_class.perform_now(conversation, assistant)
+      end
+
+      it 'asks for an email after the handoff message when no agent is assigned' do
+        conversation.contact.update!(email: nil)
+        inbox.update!(enable_email_collect: true)
+        allow(mock_agent_runner_service).to receive(:generate_response) do
+          conversation.update!(status: :open)
+          { 'response' => 'Let me connect you', 'handoff_tool_called' => true }
+        end
+
+        described_class.perform_now(conversation, assistant)
+
+        handoff_message = conversation.messages.outgoing.where(private: false).last
+        email_prompt = conversation.messages.find_by(content_type: :input_email)
+        expect(email_prompt).to be_present
+        expect(email_prompt.id).to be > handoff_message.id
+      end
+
+      it 'does not ask for an email when an agent is assigned during handoff' do
+        conversation.contact.update!(email: nil)
+        inbox.update!(enable_email_collect: true)
+        agent = create(:user, account: account)
+        allow(mock_agent_runner_service).to receive(:generate_response) do
+          conversation.update!(status: :open, assignee: agent)
+          { 'response' => 'Let me connect you', 'handoff_tool_called' => true }
+        end
+
+        described_class.perform_now(conversation, assistant)
+
+        expect(conversation.messages.where(content_type: :input_email)).to be_empty
       end
 
       it 'does not create a duplicate out of office message' do

--- a/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
+++ b/spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb
@@ -260,6 +260,15 @@ RSpec.describe Captain::InboxPendingConversationsResolutionJob, type: :job do
       expect(resolvable_pending_conversation.reload.status).to eq('open')
     end
 
+    it 'asks for an email when the handed-off conversation remains unassigned' do
+      resolvable_pending_conversation.contact.update!(email: nil)
+      inbox.update!(enable_email_collect: true)
+
+      described_class.perform_now(inbox)
+
+      expect(resolvable_pending_conversation.messages.where(content_type: :input_email)).to exist
+    end
+
     it 'creates a private note with the reason' do
       described_class.perform_now(inbox)
 

--- a/spec/enterprise/services/enterprise/message_templates/hook_execution_service_spec.rb
+++ b/spec/enterprise/services/enterprise/message_templates/hook_execution_service_spec.rb
@@ -524,6 +524,15 @@ RSpec.describe MessageTemplates::HookExecutionService do
       )
     end
 
+    it 'asks for an email when the handed-off conversation remains unassigned' do
+      contact.update!(email: nil)
+      inbox.update!(enable_email_collect: true)
+
+      create(:message, conversation: conversation, message_type: :incoming, account: account)
+
+      expect(conversation.messages.where(content_type: :input_email)).to exist
+    end
+
     context 'when outside business hours' do
       before do
         inbox.update!(

--- a/spec/services/message_templates/template/email_collect_spec.rb
+++ b/spec/services/message_templates/template/email_collect_spec.rb
@@ -1,12 +1,88 @@
 require 'rails_helper'
 
-describe MessageTemplates::Template::EmailCollect do
-  context 'when this hook is called' do
+RSpec.describe MessageTemplates::Template::EmailCollect do
+  describe '#perform' do
     let(:conversation) { create(:conversation) }
 
     it 'creates the email collect messages' do
-      described_class.new(conversation: conversation).perform
-      expect(conversation.messages.count).to eq(2)
+      expect do
+        described_class.new(conversation: conversation).perform
+      end.to change { conversation.messages.count }.by(2)
+    end
+  end
+
+  describe '.perform_after_handoff_if_applicable' do
+    let(:account) { create(:account) }
+    let(:inbox) { create(:inbox, account: account, enable_email_collect: true) }
+    let(:contact) { create(:contact, account: account, email: nil) }
+    let(:conversation) { create(:conversation, account: account, inbox: inbox, contact: contact, status: :open) }
+
+    it 'asks for an email when the handed-off conversation is unassigned' do
+      expect do
+        described_class.perform_after_handoff_if_applicable(conversation)
+      end.to change { conversation.messages.template.count }.by(2)
+
+      expect(conversation.messages.template.order(:id).pluck(:content_type)).to eq(%w[text input_email])
+    end
+
+    it 'does not ask for an email when an agent is assigned' do
+      conversation.update!(assignee: create(:user, account: account))
+
+      expect do
+        described_class.perform_after_handoff_if_applicable(conversation)
+      end.not_to(change { conversation.messages.count })
+    end
+
+    it 'does not ask for an email when collection is disabled' do
+      inbox.update!(enable_email_collect: false)
+
+      expect do
+        described_class.perform_after_handoff_if_applicable(conversation)
+      end.not_to(change { conversation.messages.count })
+    end
+
+    it 'does not ask for an email outside the web widget' do
+      email_inbox = create(:inbox, :with_email, account: account, enable_email_collect: true)
+      email_conversation = create(:conversation, account: account, inbox: email_inbox, contact: contact, status: :open)
+
+      expect do
+        described_class.perform_after_handoff_if_applicable(email_conversation)
+      end.not_to(change { email_conversation.messages.count })
+    end
+
+    it 'does not ask for an email when the contact already has one' do
+      contact.update!(email: 'customer@example.com')
+
+      expect do
+        described_class.perform_after_handoff_if_applicable(conversation)
+      end.not_to(change { conversation.messages.count })
+    end
+
+    it 'does not ask for an email more than once' do
+      described_class.perform_after_handoff_if_applicable(conversation)
+
+      expect do
+        described_class.perform_after_handoff_if_applicable(conversation)
+      end.not_to(change { conversation.messages.count })
+    end
+
+    it 'does not ask for an email on campaign conversations' do
+      conversation.update!(campaign: create(:campaign, account: account, inbox: inbox))
+
+      expect do
+        described_class.perform_after_handoff_if_applicable(conversation)
+      end.not_to(change { conversation.messages.count })
+    end
+
+    it 'does not interrupt a completed handoff when the eligibility check fails' do
+      error = StandardError.new('database unavailable')
+      exception_tracker = instance_double(ChatwootExceptionTracker, capture_exception: true)
+      allow(Conversation).to receive(:transaction).and_raise(error)
+      expect(ChatwootExceptionTracker).to receive(:new).with(error, account: account).and_return(exception_tracker)
+
+      expect do
+        described_class.perform_after_handoff_if_applicable(conversation)
+      end.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## Summary

Collect the visitor's email after Captain hands off a web widget conversation and no agent was assigned.

The email prompt appears only when email collection is enabled, the contact has no email, and no earlier email prompt exists. Assigned conversations, campaigns, and other channel types keep their current behavior.

Captain still hands off immediately. This PR does not change handoff copy or assignment.

## Dependency

This PR must merge after [PR #15554](https://github.com/chatwoot/chatwoot/pull/15554), which assigns an eligible available agent during handoff. This PR reads the final assignee from that change. If the conversation remains unassigned, the existing widget email form lets the team follow up.

Linear issue: https://linear.app/chatwoot/issue/AI-199/captain-should-handoff-to-an-online-agent-whenever-possible

## Validation

1. 182 focused RSpec examples passed. The run covered Captain V1 and V2 handoffs, inactivity handoffs, usage limit handoffs, email prompt eligibility, and widget email submission.
2. RuboCop passed for all eight changed files.
3. No frontend code changed. The PR reuses the existing widget email form and contact update path.