### PR TITLE
fix(contacts): coerce numeric values to strings in text custom attribute filters

### DIFF
--- a/app/services/contacts/filter_service.rb
+++ b/app/services/contacts/filter_service.rb
@@ -18,6 +18,11 @@ class Contacts::FilterService < FilterService
     }
   end
 
+  def filter_operation(query_hash, current_index)
+    coerce_text_attribute_values(query_hash) if @custom_attribute_type.present? && @attribute_data_type == 'text'
+    super
+  end
+
   def filter_values(query_hash)
     current_val = query_hash['values'][0]
     if query_hash['attribute_key'] == 'phone_number'

--- a/app/services/conversations/filter_service.rb
+++ b/app/services/conversations/filter_service.rb
@@ -42,6 +42,11 @@ class Conversations::FilterService < FilterService
     @params[:page] || 1
   end
 
+  def filter_operation(query_hash, current_index)
+    coerce_text_attribute_values(query_hash) if @custom_attribute_type.present? && @attribute_data_type == 'text'
+    super
+  end
+
   def filter_config
     {
       entity: 'Conversation',

--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -70,9 +70,9 @@ class FilterService
   def values_for_ilike(query_hash)
     if query_hash['values'].is_a?(Array)
       query_hash['values']
-        .map { |item| "%#{item.strip}%" }
+        .map { |item| "%#{item.to_s.strip}%" }
     else
-      ["%#{query_hash['values'].strip}%"]
+      ["%#{query_hash['values'].to_s.strip}%"]
     end
   end
 
@@ -204,5 +204,9 @@ class FilterService
 
       raise CustomExceptions::CustomFilter::InvalidQueryOperator.new({}) if query_hash['query_operator'].present?
     end
+  end
+
+  def coerce_text_attribute_values(query_hash)
+    query_hash['values'] = Array(query_hash['values']).map { |v| v.is_a?(String) ? v : v.to_s }
   end
 end

--- a/spec/services/contacts/filter_service_spec.rb
+++ b/spec/services/contacts/filter_service_spec.rb
@@ -519,6 +519,38 @@ describe Contacts::FilterService do
 
         expect { filter_service.new(account, first_user, params).perform }.to raise_error(CustomExceptions::CustomFilter::InvalidValue)
       end
+
+      it 'filters text custom attributes with numeric JSON values' do
+        en_contact.update!(custom_attributes: { contact_additional_information: '12345678901' })
+        params[:payload] = [
+          {
+            attribute_key: 'contact_additional_information',
+            filter_operator: 'equal_to',
+            values: [12_345_678_901],
+            query_operator: nil
+          }.with_indifferent_access
+        ]
+
+        result = filter_service.new(account, first_user, params).perform
+        expect(result[:count]).to be 1
+        expect(result[:contacts].first.id).to eq(en_contact.id)
+      end
+
+      it 'filters text custom attributes with numeric JSON values using contains' do
+        en_contact.update!(custom_attributes: { contact_additional_information: '12345678901' })
+        params[:payload] = [
+          {
+            attribute_key: 'contact_additional_information',
+            filter_operator: 'contains',
+            values: [12_345_678_901],
+            query_operator: nil
+          }.with_indifferent_access
+        ]
+
+        result = filter_service.new(account, first_user, params).perform
+        expect(result[:count]).to be 1
+        expect(result[:contacts].first.id).to eq(en_contact.id)
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

When a numeric JSON value (e.g. `12345678901`) is sent for a text custom attribute, PostgreSQL receives an integer bind param for a `::text` cast, causing a type mismatch → HTTP 500.

This affects both the contacts filter (`POST /api/v1/accounts/{id}/contacts/filter`) and the conversations filter (`POST /api/v1/accounts/{id}/conversations/filter`).

Closes #15519

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added 2 new specs in `spec/services/contacts/filter_service_spec.rb`:
  - `equal_to` filter with integer value on text custom attribute
  - `contains` filter with integer value on text custom attribute
- All 27 specs in the filter service spec pass

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes