### PR TITLE
fix(channels): wrap conversation + message save in transaction for Telegram, Twilio, Line

### DIFF
--- a/app/services/line/incoming_message_service.rb
+++ b/app/services/line/incoming_message_service.rb
@@ -23,12 +23,14 @@ class Line::IncomingMessageService
       next if @line_contact_info['userId'].blank?
 
       set_contact
-      set_conversation
+      ActiveRecord::Base.transaction do
+        set_conversation
 
-      next unless message_created? event
+        next unless message_created? event
 
-      attach_files event['message']
-      @message.save!
+        attach_files event['message']
+        @message.save!
+      end
     end
   end
 

--- a/app/services/telegram/incoming_message_service.rb
+++ b/app/services/telegram/incoming_message_service.rb
@@ -13,26 +13,28 @@ class Telegram::IncomingMessageService
 
     set_contact
     update_contact_avatar
-    set_conversation
-    # TODO: Since the recent Telegram Business update, we need to explicitly mark messages as read using an additional request.
-    # Otherwise, the client will see their messages as unread.
-    # Chatwoot defines a 'read' status in its enum but does not currently update this status for Telegram conversations.
-    # We have two options:
-    # 1. Send the read request to Telegram here, immediately when the message is created.
-    # 2. Properly update the read status in the Chatwoot UI and trigger the Telegram request when the agent actually reads the message.
-    # See: https://core.telegram.org/bots/api#readbusinessmessage
-    @message = @conversation.messages.build(
-      content: telegram_params_message_content,
-      account_id: @inbox.account_id,
-      inbox_id: @inbox.id,
-      message_type: message_type,
-      sender: message_sender,
-      content_attributes: telegram_params_content_attributes,
-      source_id: telegram_params_message_id.to_s
-    )
+    ActiveRecord::Base.transaction do
+      set_conversation
+      # TODO: Since the recent Telegram Business update, we need to explicitly mark messages as read using an additional request.
+      # Otherwise, the client will see their messages as unread.
+      # Chatwoot defines a 'read' status in its enum but does not currently update this status for Telegram conversations.
+      # We have two options:
+      # 1. Send the read request to Telegram here, immediately when the message is created.
+      # 2. Properly update the read status in the Chatwoot UI and trigger the Telegram request when the agent actually reads the message.
+      # See: https://core.telegram.org/bots/api#readbusinessmessage
+      @message = @conversation.messages.build(
+        content: telegram_params_message_content,
+        account_id: @inbox.account_id,
+        inbox_id: @inbox.id,
+        message_type: message_type,
+        sender: message_sender,
+        content_attributes: telegram_params_content_attributes,
+        source_id: telegram_params_message_id.to_s
+      )
 
-    process_message_attachments if message_params?
-    @message.save!
+      process_message_attachments if message_params?
+      @message.save!
+    end
   end
 
   private

--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -9,19 +9,21 @@ class Twilio::IncomingMessageService
     return if twilio_channel.blank?
 
     set_contact
-    set_conversation
-    @message = @conversation.messages.build(
-      content: message_body,
-      account_id: @inbox.account_id,
-      inbox_id: @inbox.id,
-      message_type: :incoming,
-      sender: @contact,
-      source_id: params[:SmsSid],
-      content_attributes: message_content_attributes
-    )
-    attach_files
-    attach_location if location_message?
-    @message.save!
+    ActiveRecord::Base.transaction do
+      set_conversation
+      @message = @conversation.messages.build(
+        content: message_body,
+        account_id: @inbox.account_id,
+        inbox_id: @inbox.id,
+        message_type: :incoming,
+        sender: @contact,
+        source_id: params[:SmsSid],
+        content_attributes: message_content_attributes
+      )
+      attach_files
+      attach_location if location_message?
+      @message.save!
+    end
   end
 
   private


### PR DESCRIPTION
## Description

`set_conversation` creates and commits a `Conversation` row immediately. If `process_message_attachments` raises (e.g. `Down::Error` on network timeout), the conversation exists with zero messages — a ghost conversation.

WhatsApp already wraps this in `ActiveRecord::Base.transaction`. Apply the same pattern to Telegram, Twilio, and Line services.

Closes #15449

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- All 72 existing specs in the three affected service specs pass
- Telegram: `spec/services/telegram/incoming_message_service_spec.rb`
- Twilio: `spec/services/twilio/incoming_message_service_spec.rb`
- Line: `spec/services/line/incoming_message_service_spec.rb`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes