### PR TITLE
fix(captain): set cloud mode in reply suggestion specs

### DIFF
--- a/spec/enterprise/services/captain/copilot/reply_suggestion_service_spec.rb
+++ b/spec/enterprise/services/captain/copilot/reply_suggestion_service_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Captain::Copilot::ReplySuggestionService do
 
   before do
     incoming_message
+    allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
     allow(Captain::Assistant::AgentRunnerService).to receive(:new).with(
       hash_including(
         assistant: assistant,


### PR DESCRIPTION
Ensures Captain reply-suggestion usage tests run in cloud mode, matching the production guard introduced by #15465.

Related: https://github.com/chatwoot/chatwoot/pull/15465

## Why

Captain response usage is now intentionally disabled for self-hosted installations, but three cloud usage expectations were not updated. This left the backend test suite on `develop` failing.

## What this change does

Runs the reply-suggestion usage scenarios with Chatwoot Cloud enabled, consistent with the existing Copilot chat coverage.

## Validation

- Reproduced all three failures on a clean `develop` checkout before the change.
- All 18 reply-suggestion scenarios pass after the change.
- Ruby lint passes.