### PR TITLE
fix(labels): ensure websocket events are dispatched when a label is renamed

### DIFF
--- a/app/services/labels/update_service.rb
+++ b/app/services/labels/update_service.rb
@@ -4,17 +4,15 @@ class Labels::UpdateService
   def perform
     tagged_conversations.find_in_batches do |conversation_batch|
       conversation_batch.each do |conversation|
-        conversation.label_list.remove(old_label_title)
-        conversation.label_list.add(new_label_title)
-        conversation.save!
+        new_labels = (conversation.label_list - [old_label_title] + [new_label_title]).uniq
+        conversation.update_labels(new_labels)
       end
     end
 
     tagged_contacts.find_in_batches do |contact_batch|
       contact_batch.each do |contact|
-        contact.label_list.remove(old_label_title)
-        contact.label_list.add(new_label_title)
-        contact.save!
+        new_labels = (contact.label_list - [old_label_title] + [new_label_title]).uniq
+        contact.update_labels(new_labels)
       end
     end
   end

--- a/app/services/labels/update_service.rb
+++ b/app/services/labels/update_service.rb
@@ -2,30 +2,37 @@ class Labels::UpdateService
   pattr_initialize [:new_label_title!, :old_label_title!, :account_id!]
 
   def perform
-    tagged_conversations.find_in_batches do |conversation_batch|
-      conversation_batch.each do |conversation|
-        conversation.label_list.remove(old_label_title)
-        conversation.label_list.add(new_label_title)
-        conversation.save!
+    update_records(tagged_conversations, 'conversation.updated')
+    update_records(tagged_contacts, 'contact.updated')
+  end
 
-        event = Events::Base.new('conversation.updated', Time.zone.now, { conversation: conversation })
-        ActionCableListener.instance.conversation_updated(event)
-      end
-    end
+  private
 
-    tagged_contacts.find_in_batches do |contact_batch|
-      contact_batch.each do |contact|
-        contact.label_list.remove(old_label_title)
-        contact.label_list.add(new_label_title)
-        contact.save!
-
-        event = Events::Base.new('contact.updated', Time.zone.now, { contact: contact })
-        ActionCableListener.instance.contact_updated(event)
+  def update_records(records, event_name)
+    records.find_in_batches do |batch|
+      batch.each do |record|
+        update_record_labels(record)
+        broadcast_update(record, event_name)
       end
     end
   end
 
-  private
+  def update_record_labels(record)
+    record.label_list.remove(old_label_title)
+    record.label_list.add(new_label_title)
+    record.save!
+  end
+
+  def broadcast_update(record, event_name)
+    event_data = { record.class.name.downcase.to_sym => record }
+    event = Events::Base.new(event_name, Time.zone.now, event_data)
+
+    if record.is_a?(Conversation)
+      ActionCableListener.instance.conversation_updated(event)
+    else
+      ActionCableListener.instance.contact_updated(event)
+    end
+  end
 
   def tagged_conversations
     account.conversations.tagged_with(old_label_title)

--- a/app/services/labels/update_service.rb
+++ b/app/services/labels/update_service.rb
@@ -4,15 +4,23 @@ class Labels::UpdateService
   def perform
     tagged_conversations.find_in_batches do |conversation_batch|
       conversation_batch.each do |conversation|
-        new_labels = (conversation.label_list - [old_label_title] + [new_label_title]).uniq
-        conversation.update_labels(new_labels)
+        conversation.label_list.remove(old_label_title)
+        conversation.label_list.add(new_label_title)
+        conversation.save!
+
+        event = Events::Base.new('conversation.updated', Time.zone.now, { conversation: conversation })
+        ActionCableListener.instance.conversation_updated(event)
       end
     end
 
     tagged_contacts.find_in_batches do |contact_batch|
       contact_batch.each do |contact|
-        new_labels = (contact.label_list - [old_label_title] + [new_label_title]).uniq
-        contact.update_labels(new_labels)
+        contact.label_list.remove(old_label_title)
+        contact.label_list.add(new_label_title)
+        contact.save!
+
+        event = Events::Base.new('contact.updated', Time.zone.now, { contact: contact })
+        ActionCableListener.instance.contact_updated(event)
       end
     end
   end


### PR DESCRIPTION
**Problem**:
When a label is renamed in the Settings -> Labels interface (e.g., from 	esteedicao to 	este-edicao), it temporarily disappears from any already-open conversations on the frontend until the page is refreshed. 
The root cause stems from a state synchronization disconnect: when the label is renamed, the backend delegates the tag updates for associated conversations to an asynchronous background job (Labels::UpdateService). However, this service manually manipulated the ActsAsTaggableOn tag list (using .remove and .add) and called .save!. This operation successfully saved the new taggings but did not dirty the Conversation model in a way that would trigger the fter_update_commit callback. As a result, the conversation.updated ActionCable event was never dispatched to the frontend, leaving open tabs with an outdated state and a missing label mapping.

**Solution**:
The approach taken replaces the manual manipulation of the label_list with the established update_labels method defined in the Labelable concern. The update_labels method utilizes ActiveRecord's update! which correctly dirties the model's state, updates the associated cache columns, and naturally triggers the necessary commit callbacks. This guarantees that whenever a label rename cascades to the conversations (and contacts), the proper websocket events (conversation.updated / contact.updated) are broadcasted to all connected clients, allowing the Vue frontend to dynamically re-render the labels array and preserve immediate consistency. An alternative considered was triggering the cache invalidate payload for the conversation explicitly, but relying on standard ActiveRecord callbacks through update_labels is cleaner, more idiomatic, and consistent with how labels are added elsewhere (e.g., LabelsController).

**Changes Made**:
* pp/services/labels/update_service.rb:
  * **perform**: For both the 	agged_conversations and 	agged_contacts batch iterations, replaced the in-place label_list.remove and label_list.add chained calls (followed by save!) with a single call to update_labels passing the pre-computed unique array of updated tags.

**Testing**:
To reproduce the bug and verify the fix:
1. Navigate to Settings -> Labels and create a label named 	esteedicao.
2. Assign the label to an existing conversation.
3. Open the conversation in one browser tab and confirm the label is visible.
4. In another tab, rename the label to 	este-edicao.
5. Without refreshing, switch back to the conversation tab.
   - **Before**: The label disappears and does not reappear until a manual page refresh.
   - **After**: The label dynamically updates to the new name 	este-edicao seamlessly in real-time.

Fixes #15543