### PR TITLE
feat: SAML back-channel single logout

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -660,6 +660,11 @@
         "HELP": "The URL where SAML authentication requests will be sent",
         "PLACEHOLDER": "https://sso.example.com/saml/sso"
       },
+      "SLS_URL": {
+        "LABEL": "Identity Provider SLS URL",
+        "HELP": "The URL where SAML logout responses will be sent. Leave blank to keep single logout disabled.",
+        "PLACEHOLDER": "https://sso.example.com/saml/slo"
+      },
       "CERTIFICATE": {
         "LABEL": "Signing certificate in PEM format",
         "HELP": "The public certificate from your identity provider used to verify SAML responses",
@@ -674,6 +679,10 @@
         "LABEL": "SP Entity ID",
         "HELP": "Unique identifier for this application as a service provider (auto-generated).",
         "TOOLTIP": "Unique identifier for Chatwoot as the Service Provider - Configure this in your IdP settings"
+      },
+      "SP_SLS_URL": {
+        "LABEL": "SP SLS URL",
+        "TOOLTIP": "Configure this URL in your identity provider as the destination for SAML logout requests"
       },
       "IDP_ENTITY_ID": {
         "LABEL": "Identity Provider Entity ID",
@@ -690,6 +699,7 @@
       "VALIDATION": {
         "REQUIRED_FIELDS": "SSO URL, Identity Provider Entity ID, and Certificate are required fields",
         "SSO_URL_ERROR": "Please enter a valid SSO URL",
+        "SLS_URL_ERROR": "Please enter a valid HTTP or HTTPS SLS URL",
         "CERTIFICATE_ERROR": "Certificate is required",
         "IDP_ENTITY_ID_ERROR": "Identity Provider Entity ID is required"
       },

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -662,7 +662,7 @@
       },
       "SLS_URL": {
         "LABEL": "Identity Provider SLS URL",
-        "HELP": "The URL where SAML logout responses will be sent. Leave blank to keep single logout disabled.",
+        "HELP": "The URL where SAML logout responses will be sent. After saving, configure the generated SP SLS URL and certificate in your identity provider. Leave blank to keep single logout disabled.",
         "PLACEHOLDER": "https://sso.example.com/saml/slo"
       },
       "CERTIFICATE": {
@@ -683,6 +683,10 @@
       "SP_SLS_URL": {
         "LABEL": "SP SLS URL",
         "TOOLTIP": "Configure this URL in your identity provider as the destination for SAML logout requests"
+      },
+      "SP_CERTIFICATE": {
+        "LABEL": "SP Certificate",
+        "TOOLTIP": "Install this public certificate in your identity provider so it can verify signed SAML logout responses"
       },
       "IDP_ENTITY_ID": {
         "LABEL": "Identity Provider Entity ID",

--- a/app/javascript/dashboard/routes/dashboard/settings/security/components/SamlInfoSection.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/security/components/SamlInfoSection.vue
@@ -19,6 +19,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  spCertificate: {
+    type: String,
+    default: '',
+  },
 });
 
 const { t } = useI18n();
@@ -50,6 +54,13 @@ const allInfoItems = computed(() => [
     value: props.spSlsUrl,
     tooltip: t('SECURITY_SETTINGS.SAML.SP_SLS_URL.TOOLTIP'),
     show: !!props.spSlsUrl,
+  },
+  {
+    key: 'SP_CERTIFICATE',
+    label: t('SECURITY_SETTINGS.SAML.SP_CERTIFICATE.LABEL'),
+    value: props.spCertificate,
+    tooltip: t('SECURITY_SETTINGS.SAML.SP_CERTIFICATE.TOOLTIP'),
+    show: !!props.spCertificate,
   },
   {
     key: 'FINGERPRINT',

--- a/app/javascript/dashboard/routes/dashboard/settings/security/components/SamlInfoSection.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/security/components/SamlInfoSection.vue
@@ -15,6 +15,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  spSlsUrl: {
+    type: String,
+    default: '',
+  },
 });
 
 const { t } = useI18n();
@@ -39,6 +43,13 @@ const allInfoItems = computed(() => [
     value: props.spEntityId,
     tooltip: t('SECURITY_SETTINGS.SAML.SP_ENTITY_ID.TOOLTIP'),
     show: !!props.spEntityId,
+  },
+  {
+    key: 'SP_SLS_URL',
+    label: t('SECURITY_SETTINGS.SAML.SP_SLS_URL.LABEL'),
+    value: props.spSlsUrl,
+    tooltip: t('SECURITY_SETTINGS.SAML.SP_SLS_URL.TOOLTIP'),
+    show: !!props.spSlsUrl,
   },
   {
     key: 'FINGERPRINT',
@@ -78,15 +89,17 @@ const handleCopy = async text => {
         :key="item.key"
         class="ps-4 pe-1 py-1 flex justify-between items-center"
       >
-        <div class="flex items-center gap-2">
-          <span class="text-n-slate-11 w-32 flex items-center gap-1">
+        <div class="flex items-center gap-2 min-w-0">
+          <span class="text-n-slate-11 w-32 shrink-0 flex items-center gap-1">
             {{ item.label }}
             <i
               v-tooltip.top="item.tooltip"
               class="i-lucide-info text-n-slate-9 w-3 h-3 cursor-help"
             />
           </span>
-          <span class="flex-1">{{ item.value }}</span>
+          <span class="flex-1 truncate" :title="item.value">
+            {{ item.value }}
+          </span>
         </div>
         <NextButton
           type="button"

--- a/app/javascript/dashboard/routes/dashboard/settings/security/components/SamlSettings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/security/components/SamlSettings.vue
@@ -23,6 +23,7 @@ const id = ref(null);
 const fingerprint = ref('');
 const spEntityId = ref('');
 const spSlsUrl = ref('');
+const spCertificate = ref('');
 const isEnabled = ref(false);
 const isSubmitting = ref(false);
 const isLoading = ref(true);
@@ -99,6 +100,7 @@ const loadSamlSettings = async () => {
       formState.certificate = settings.certificate || '';
       spEntityId.value = settings.sp_entity_id || '';
       spSlsUrl.value = settings.sp_sls_url || '';
+      spCertificate.value = settings.sp_certificate || '';
       formState.idpEntityId = settings.idp_entity_id || '';
       fingerprint.value = settings.fingerprint || '';
       isEnabled.value = formState.ssoUrl !== '';
@@ -132,6 +134,7 @@ const saveSamlSettings = async settings => {
         fingerprint.value = response.data.fingerprint || '';
         spEntityId.value = response.data.sp_entity_id || '';
         spSlsUrl.value = response.data.sp_sls_url || '';
+        spCertificate.value = response.data.sp_certificate || '';
       }
 
       useAlert(t('SECURITY_SETTINGS.SAML.API.SUCCESS'));
@@ -179,6 +182,7 @@ const handleDisable = async () => {
   formState.certificate = '';
   spEntityId.value = '';
   spSlsUrl.value = '';
+  spCertificate.value = '';
   formState.idpEntityId = '';
   fingerprint.value = '';
 
@@ -220,6 +224,7 @@ onMounted(() => {
       :fingerprint="fingerprint"
       :sp-entity-id="spEntityId"
       :sp-sls-url="spSlsUrl"
+      :sp-certificate="spCertificate"
     />
     <SamlAttributeMap class="mb-5" />
 

--- a/app/javascript/dashboard/routes/dashboard/settings/security/components/SamlSettings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/security/components/SamlSettings.vue
@@ -22,18 +22,36 @@ const { isCloudFeatureEnabled } = useAccount();
 const id = ref(null);
 const fingerprint = ref('');
 const spEntityId = ref('');
+const spSlsUrl = ref('');
 const isEnabled = ref(false);
 const isSubmitting = ref(false);
 const isLoading = ref(true);
 
 const formState = reactive({
   ssoUrl: '',
+  slsUrl: '',
   certificate: '',
   idpEntityId: '',
 });
 
+const httpUrl = value => {
+  if (!value) return true;
+
+  try {
+    const parsedUrl = new URL(value);
+    return (
+      ['http:', 'https:'].includes(parsedUrl.protocol) &&
+      Boolean(parsedUrl.hostname) &&
+      !/\s/.test(value)
+    );
+  } catch {
+    return false;
+  }
+};
+
 const validations = {
   ssoUrl: { required },
+  slsUrl: { httpUrl },
   certificate: { required },
   idpEntityId: { required },
 };
@@ -45,6 +63,12 @@ const hasFeature = computed(() => isCloudFeatureEnabled('saml'));
 const ssoUrlError = computed(() =>
   v$.value.ssoUrl.$error
     ? t('SECURITY_SETTINGS.SAML.VALIDATION.SSO_URL_ERROR')
+    : ''
+);
+
+const slsUrlError = computed(() =>
+  v$.value.slsUrl.$error
+    ? t('SECURITY_SETTINGS.SAML.VALIDATION.SLS_URL_ERROR')
     : ''
 );
 
@@ -71,8 +95,10 @@ const loadSamlSettings = async () => {
     if (settings.sso_url) {
       id.value = settings.id;
       formState.ssoUrl = settings.sso_url;
+      formState.slsUrl = settings.sls_url || '';
       formState.certificate = settings.certificate || '';
       spEntityId.value = settings.sp_entity_id || '';
+      spSlsUrl.value = settings.sp_sls_url || '';
       formState.idpEntityId = settings.idp_entity_id || '';
       fingerprint.value = settings.fingerprint || '';
       isEnabled.value = formState.ssoUrl !== '';
@@ -105,6 +131,7 @@ const saveSamlSettings = async settings => {
         id.value = response.data.id;
         fingerprint.value = response.data.fingerprint || '';
         spEntityId.value = response.data.sp_entity_id || '';
+        spSlsUrl.value = response.data.sp_sls_url || '';
       }
 
       useAlert(t('SECURITY_SETTINGS.SAML.API.SUCCESS'));
@@ -136,6 +163,7 @@ const handleSubmit = async () => {
 
   const settings = {
     sso_url: formState.ssoUrl,
+    sls_url: formState.slsUrl,
     certificate: formState.certificate,
     idp_entity_id: formState.idpEntityId,
     role_mappings: {},
@@ -147,8 +175,10 @@ const handleSubmit = async () => {
 const handleDisable = async () => {
   id.value = null;
   formState.ssoUrl = '';
+  formState.slsUrl = '';
   formState.certificate = '';
   spEntityId.value = '';
+  spSlsUrl.value = '';
   formState.idpEntityId = '';
   fingerprint.value = '';
 
@@ -189,6 +219,7 @@ onMounted(() => {
       class="mb-5"
       :fingerprint="fingerprint"
       :sp-entity-id="spEntityId"
+      :sp-sls-url="spSlsUrl"
     />
     <SamlAttributeMap class="mb-5" />
 
@@ -206,6 +237,21 @@ onMounted(() => {
           class="w-full"
           type="url"
           :placeholder="t('SECURITY_SETTINGS.SAML.SSO_URL.PLACEHOLDER')"
+        />
+      </WithLabel>
+
+      <WithLabel
+        name="slsUrl"
+        :label="t('SECURITY_SETTINGS.SAML.SLS_URL.LABEL')"
+        :help-message="t('SECURITY_SETTINGS.SAML.SLS_URL.HELP')"
+        :has-error="v$.slsUrl.$error"
+        :error-message="slsUrlError"
+      >
+        <TextInput
+          v-model="formState.slsUrl"
+          class="w-full"
+          type="url"
+          :placeholder="t('SECURITY_SETTINGS.SAML.SLS_URL.PLACEHOLDER')"
         />
       </WithLabel>
 

--- a/app/javascript/dashboard/routes/dashboard/settings/security/components/specs/SamlSettings.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/security/components/specs/SamlSettings.spec.js
@@ -1,0 +1,96 @@
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import NextButton from 'next/button/Button.vue';
+import SamlInfoSection from '../SamlInfoSection.vue';
+import SamlSettings from '../SamlSettings.vue';
+
+const mocks = vi.hoisted(() => ({
+  copyTextToClipboard: vi.fn(),
+  samlSettingsAPI: {
+    get: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  useAlert: vi.fn(),
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: key => key }),
+}));
+
+vi.mock('dashboard/composables', () => ({
+  useAlert: mocks.useAlert,
+}));
+
+vi.mock('dashboard/composables/useAccount', () => ({
+  useAccount: () => ({
+    accountId: { value: 1 },
+    isCloudFeatureEnabled: () => true,
+  }),
+}));
+
+vi.mock('dashboard/api/samlSettings', () => ({
+  default: mocks.samlSettingsAPI,
+}));
+
+vi.mock('shared/helpers/clipboard', () => ({
+  copyTextToClipboard: mocks.copyTextToClipboard,
+}));
+
+describe('SamlSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the SP certificate returned after saving', async () => {
+    mocks.samlSettingsAPI.get.mockResolvedValue({
+      data: {
+        id: 1,
+        sso_url: 'https://idp.example.com/saml/sso',
+        sls_url: 'https://idp.example.com/saml/slo',
+        certificate: 'idp-certificate',
+        idp_entity_id: 'https://idp.example.com/saml',
+        sp_certificate: 'initial-sp-certificate',
+      },
+    });
+    mocks.samlSettingsAPI.update.mockResolvedValue({
+      data: {
+        id: 1,
+        sp_certificate: 'generated-sp-certificate',
+      },
+    });
+
+    const wrapper = shallowMount(SamlSettings, {
+      global: {
+        stubs: {
+          SectionLayout: {
+            template: '<div><slot name="headerActions" /><slot /></div>',
+          },
+        },
+      },
+    });
+    await flushPromises();
+
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mocks.samlSettingsAPI.update).toHaveBeenCalledOnce();
+    expect(wrapper.findComponent(SamlInfoSection).props('spCertificate')).toBe(
+      'generated-sp-certificate'
+    );
+  });
+
+  it('displays and copies the SP certificate', async () => {
+    const spCertificate = '-----BEGIN CERTIFICATE----- SP data';
+    const wrapper = shallowMount(SamlInfoSection, {
+      props: { spCertificate },
+    });
+
+    expect(wrapper.text()).toContain(spCertificate);
+
+    const copyButtons = wrapper.findAllComponents(NextButton);
+    await copyButtons.at(-1).trigger('click');
+
+    expect(mocks.copyTextToClipboard).toHaveBeenCalledWith(spCertificate);
+  });
+});

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,7 +3,7 @@
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [
   :password, :secret, :_key, :auth, :crypt, :salt, :certificate, :otp, :access, :private, :protected, :ssn,
-  :otp_secret, :otp_code, :backup_code, :mfa_token, :otp_backup_codes
+  :otp_secret, :otp_code, :backup_code, :mfa_token, :otp_backup_codes, :SAMLRequest, :SAMLResponse
 ]
 
 # Regex to filter all occurrences of 'token' in keys except for 'website_token'

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -74,6 +74,10 @@ class Rack::Attack
   ###-----Authentication Related Throttling---------###
   ###-----------------------------------------------###
 
+  throttle('saml_slo/ip', limit: 30, period: 1.minute) do |req|
+    req.ip if req.path.start_with?('/saml/slo/')
+  end
+
   ### Prevent Brute-Force Super Admin Login Attacks ###
   throttle('super_admin_login/ip', limit: 5, period: 5.minutes) do |req|
     req.ip if req.path_without_extensions == '/super_admin/sign_in' && req.post?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,6 +221,7 @@ en:
       disabled: MFA disabled successfully
     account_saml_settings:
       invalid_certificate: must be a valid X.509 certificate in PEM format
+      invalid_sp_signing_credentials: must contain a matching X.509 certificate and private key
   reports:
     period: Reporting period %{since} to %{until}
     utc_warning: The report generated is in UTC timezone

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  post '/saml/slo/:settings_token', to: 'saml/single_logout#create', as: :saml_single_logout if ChatwootApp.enterprise?
+
   # AUTH STARTS
   mount_devise_token_auth_for 'User', at: 'auth', controllers: {
     confirmations: 'devise_overrides/confirmations',

--- a/db/migrate/20260824090000_add_single_logout_to_account_saml_settings.rb
+++ b/db/migrate/20260824090000_add_single_logout_to_account_saml_settings.rb
@@ -1,0 +1,7 @@
+class AddSingleLogoutToAccountSamlSettings < ActiveRecord::Migration[7.1]
+  def change
+    add_column :account_saml_settings, :sls_url, :string
+    add_column :account_saml_settings, :sp_certificate, :text
+    add_column :account_saml_settings, :sp_private_key, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_24_090000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -37,6 +37,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
     t.json "role_mappings", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "sls_url"
+    t.text "sp_certificate"
+    t.text "sp_private_key"
     t.index ["account_id"], name: "index_account_saml_settings_on_account_id"
   end
 

--- a/enterprise/app/controllers/api/v1/accounts/saml_settings_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/saml_settings_controller.rb
@@ -41,6 +41,7 @@ class Api::V1::Accounts::SamlSettingsController < Api::V1::Accounts::BaseControl
       :certificate,
       :idp_entity_id,
       :sp_entity_id,
+      :sls_url,
       role_mappings: {}
     )
   end

--- a/enterprise/app/controllers/saml/single_logout_controller.rb
+++ b/enterprise/app/controllers/saml/single_logout_controller.rb
@@ -2,7 +2,8 @@ class Saml::SingleLogoutController < ActionController::Base # rubocop:disable Ra
   skip_forgery_protection
 
   def create
-    return head :not_found unless saml_available?
+    unavailable_reason = saml_unavailable_reason
+    return reject_request(:not_found, unavailable_reason) if unavailable_reason
 
     @service = Saml::SingleLogoutService.new(
       saml_settings: saml_settings,
@@ -11,14 +12,10 @@ class Saml::SingleLogoutController < ActionController::Base # rubocop:disable Ra
     )
     request_id = @service.perform
     redirect_with_logout_response(request_id, Saml::SingleLogoutService::STATUS_SUCCESS, 'Successfully signed out')
-  rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
-    head :not_found
-  rescue Saml::SingleLogoutService::ConfigurationError
-    head :unprocessable_entity
-  rescue Saml::SingleLogoutService::ReplayDetected, Saml::SingleLogoutService::UnknownPrincipal => e
-    redirect_with_logout_response(e.request_id, Saml::SingleLogoutService::STATUS_REQUESTER, e.message)
-  rescue Saml::SingleLogoutService::InvalidRequest
-    head :bad_request
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound,
+         Saml::SingleLogoutService::ConfigurationError, Saml::SingleLogoutService::ReplayDetected,
+         Saml::SingleLogoutService::UnknownPrincipal, Saml::SingleLogoutService::InvalidRequest, Redis::BaseError => e
+    handle_rejection(e)
   end
 
   private
@@ -30,14 +27,43 @@ class Saml::SingleLogoutController < ActionController::Base # rubocop:disable Ra
     )
   end
 
-  def saml_available?
-    return false unless GlobalConfigService.load('ENABLE_SAML_SSO_LOGIN', 'true').to_s == 'true'
+  def saml_unavailable_reason
+    return 'SAML SSO is globally disabled' unless GlobalConfigService.load('ENABLE_SAML_SSO_LOGIN', 'true').to_s == 'true'
+    return 'SAML feature is disabled for tenant' unless saml_settings.account.feature_enabled?('saml')
 
-    saml_settings.account.feature_enabled?('saml')
+    nil
   end
 
   def redirect_with_logout_response(request_id, status_code, message)
     response_url = @service.logout_response_url(request_id: request_id, status_code: status_code, message: message)
     redirect_to response_url, allow_other_host: true
+  end
+
+  def handle_rejection(error)
+    case error
+    when ActiveSupport::MessageVerifier::InvalidSignature
+      reject_request(:not_found, 'settings token is invalid')
+    when ActiveRecord::RecordNotFound
+      reject_request(:not_found, 'SAML settings were not found')
+    when Saml::SingleLogoutService::ConfigurationError
+      reject_request(:unprocessable_entity, error.message)
+    when Saml::SingleLogoutService::ReplayDetected, Saml::SingleLogoutService::UnknownPrincipal
+      log_rejection(error.message)
+      redirect_with_logout_response(error.request_id, Saml::SingleLogoutService::STATUS_REQUESTER, error.message)
+    when Saml::SingleLogoutService::InvalidRequest
+      reject_request(:bad_request, error.message)
+    when Redis::BaseError
+      reject_request(:service_unavailable, "replay store unavailable: #{error.class.name}")
+    end
+  end
+
+  def reject_request(status, reason)
+    log_rejection(reason)
+    head status
+  end
+
+  def log_rejection(reason)
+    safe_reason = reason.to_s.squish
+    Rails.logger.warn("[SAML SLO] Rejected request saml_settings_id=#{@saml_settings&.id || 'unknown'} reason=#{safe_reason}")
   end
 end

--- a/enterprise/app/controllers/saml/single_logout_controller.rb
+++ b/enterprise/app/controllers/saml/single_logout_controller.rb
@@ -1,0 +1,43 @@
+class Saml::SingleLogoutController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  skip_forgery_protection
+
+  def create
+    return head :not_found unless saml_available?
+
+    @service = Saml::SingleLogoutService.new(
+      saml_settings: saml_settings,
+      encoded_request: params[:SAMLRequest],
+      relay_state: params[:RelayState]
+    )
+    request_id = @service.perform
+    redirect_with_logout_response(request_id, Saml::SingleLogoutService::STATUS_SUCCESS, 'Successfully signed out')
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
+    head :not_found
+  rescue Saml::SingleLogoutService::ConfigurationError
+    head :unprocessable_entity
+  rescue Saml::SingleLogoutService::ReplayDetected, Saml::SingleLogoutService::UnknownPrincipal => e
+    redirect_with_logout_response(e.request_id, Saml::SingleLogoutService::STATUS_REQUESTER, e.message)
+  rescue Saml::SingleLogoutService::InvalidRequest
+    head :bad_request
+  end
+
+  private
+
+  def saml_settings
+    @saml_settings ||= AccountSamlSettings.find_signed!(
+      params[:settings_token],
+      purpose: AccountSamlSettings::SINGLE_LOGOUT_SIGNED_ID_PURPOSE
+    )
+  end
+
+  def saml_available?
+    return false unless GlobalConfigService.load('ENABLE_SAML_SSO_LOGIN', 'true').to_s == 'true'
+
+    saml_settings.account.feature_enabled?('saml')
+  end
+
+  def redirect_with_logout_response(request_id, status_code, message)
+    response_url = @service.logout_response_url(request_id: request_id, status_code: status_code, message: message)
+    redirect_to response_url, allow_other_host: true
+  end
+end

--- a/enterprise/app/models/account_saml_settings.rb
+++ b/enterprise/app/models/account_saml_settings.rb
@@ -31,7 +31,7 @@ class AccountSamlSettings < ApplicationRecord
   validates :sso_url, presence: true
   validates :certificate, presence: true
   validates :idp_entity_id, presence: true
-  validates :sls_url, format: URI::DEFAULT_PARSER.make_regexp(%w[http https]), allow_blank: true
+  validate :sls_url_must_be_http, if: -> { sls_url.present? }
   validate :certificate_must_be_valid_x509
   validate :sp_signing_credentials_must_match, if: :single_logout_configured?
 
@@ -69,6 +69,15 @@ class AccountSamlSettings < ApplicationRecord
   end
 
   private
+
+  def sls_url_must_be_http
+    uri = URI.parse(sls_url)
+    return if uri.is_a?(URI::HTTP) && uri.host.present?
+
+    errors.add(:sls_url, :invalid)
+  rescue URI::InvalidURIError
+    errors.add(:sls_url, :invalid)
+  end
 
   def set_sp_signing_credentials
     key = OpenSSL::PKey::RSA.new(2048)

--- a/enterprise/app/models/account_saml_settings.rb
+++ b/enterprise/app/models/account_saml_settings.rb
@@ -2,36 +2,58 @@
 #
 # Table name: account_saml_settings
 #
-#  id            :bigint           not null, primary key
-#  certificate   :text
-#  role_mappings :json
-#  sso_url       :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  account_id    :bigint           not null
-#  idp_entity_id :string
-#  sp_entity_id  :string
+#  id             :bigint           not null, primary key
+#  certificate    :text
+#  role_mappings  :json
+#  sls_url        :string
+#  sp_certificate :text
+#  sp_private_key :text
+#  sso_url        :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  account_id     :bigint           not null
+#  idp_entity_id  :string
+#  sp_entity_id   :string
 #
 # Indexes
 #
 #  index_account_saml_settings_on_account_id  (account_id)
 #
 class AccountSamlSettings < ApplicationRecord
+  SINGLE_LOGOUT_SIGNED_ID_PURPOSE = :saml_single_logout
+  SP_CERTIFICATE_VALIDITY = 10.years
+
   belongs_to :account
+
+  encrypts :sp_private_key if Chatwoot.encryption_configured?
 
   validates :account_id, presence: true
   validates :sso_url, presence: true
   validates :certificate, presence: true
   validates :idp_entity_id, presence: true
+  validates :sls_url, format: URI::DEFAULT_PARSER.make_regexp(%w[http https]), allow_blank: true
   validate :certificate_must_be_valid_x509
+  validate :sp_signing_credentials_must_match, if: :single_logout_configured?
 
   before_validation :set_sp_entity_id, if: :sp_entity_id_needs_generation?
+  before_validation :set_sp_signing_credentials, if: :sp_signing_credentials_need_generation?
 
   after_create_commit :update_account_users_provider
   after_destroy_commit :reset_account_users_provider
 
   def saml_enabled?
     sso_url.present? && certificate.present?
+  end
+
+  def single_logout_configured?
+    sls_url.present?
+  end
+
+  def sp_sls_url
+    return if new_record?
+
+    base_url = GlobalConfigService.load('FRONTEND_URL', 'http://localhost:3000')
+    "#{base_url}/saml/slo/#{signed_id(purpose: SINGLE_LOGOUT_SIGNED_ID_PURPOSE)}"
   end
 
   def certificate_fingerprint
@@ -48,6 +70,51 @@ class AccountSamlSettings < ApplicationRecord
 
   private
 
+  def set_sp_signing_credentials
+    key = OpenSSL::PKey::RSA.new(2048)
+    certificate = build_sp_certificate(key)
+
+    self.sp_private_key = key.to_pem
+    self.sp_certificate = certificate.to_pem
+  end
+
+  def build_sp_certificate(key)
+    certificate = OpenSSL::X509::Certificate.new
+    certificate.version = 2
+    certificate.serial = SecureRandom.random_number(2**159)
+    certificate.subject = OpenSSL::X509::Name.new([['CN', installation_name, OpenSSL::ASN1::UTF8STRING]])
+    certificate.issuer = certificate.subject
+    certificate.public_key = key.public_key
+    certificate.not_before = 1.minute.ago
+    certificate.not_after = SP_CERTIFICATE_VALIDITY.from_now
+    add_sp_certificate_extensions(certificate)
+    certificate.sign(key, OpenSSL::Digest.new('SHA256'))
+    certificate
+  end
+
+  def add_sp_certificate_extensions(certificate)
+    extension_factory = OpenSSL::X509::ExtensionFactory.new
+    extension_factory.subject_certificate = certificate
+    extension_factory.issuer_certificate = certificate
+    certificate.add_extension(extension_factory.create_extension('basicConstraints', 'CA:FALSE', true))
+    certificate.add_extension(extension_factory.create_extension('keyUsage', 'digitalSignature', true))
+    certificate.add_extension(extension_factory.create_extension('subjectKeyIdentifier', 'hash'))
+  end
+
+  def sp_signing_credentials_need_generation?
+    single_logout_configured? && (sp_private_key.blank? || sp_certificate.blank?)
+  end
+
+  def sp_signing_credentials_must_match
+    key = OpenSSL::PKey::RSA.new(sp_private_key)
+    certificate = OpenSSL::X509::Certificate.new(sp_certificate)
+    return if certificate.check_private_key(key)
+
+    errors.add(:sp_certificate, I18n.t('profile.account_saml_settings.invalid_sp_signing_credentials'))
+  rescue OpenSSL::PKey::PKeyError, OpenSSL::X509::CertificateError
+    errors.add(:sp_certificate, I18n.t('profile.account_saml_settings.invalid_sp_signing_credentials'))
+  end
+
   def set_sp_entity_id
     base_url = GlobalConfigService.load('FRONTEND_URL', 'http://localhost:3000')
     self.sp_entity_id = "#{base_url}/saml/sp/#{account_id}"
@@ -58,7 +125,7 @@ class AccountSamlSettings < ApplicationRecord
   end
 
   def installation_name
-    GlobalConfigService.load('INSTALLATION_NAME', 'Chatwoot')
+    GlobalConfigService.load('INSTALLATION_NAME', 'Chatwoot').to_s.first(64)
   end
 
   def update_account_users_provider

--- a/enterprise/app/services/saml/logout_request_validator.rb
+++ b/enterprise/app/services/saml/logout_request_validator.rb
@@ -1,0 +1,160 @@
+class Saml::LogoutRequestValidator
+  class InvalidRequest < StandardError
+    attr_reader :request_id
+
+    def initialize(message, request_id: nil)
+      @request_id = request_id
+      super(message)
+    end
+  end
+
+  PROTOCOL_NAMESPACE = 'urn:oasis:names:tc:SAML:2.0:protocol'.freeze
+  SIGNATURE_NAMESPACE = 'http://www.w3.org/2000/09/xmldsig#'.freeze
+  MAX_REQUEST_AGE = 5.minutes
+  ALLOWED_CLOCK_DRIFT = 1.minute
+  REPLAY_TTL = (MAX_REQUEST_AGE + ALLOWED_CLOCK_DRIFT).to_i
+  MAX_ENCODED_REQUEST_SIZE = 100.kilobytes
+  MAX_XML_REQUEST_SIZE = 64.kilobytes
+
+  ALLOWED_SIGNATURE_METHODS = [
+    XMLSecurity::Document::RSA_SHA256,
+    XMLSecurity::Document::RSA_SHA384,
+    XMLSecurity::Document::RSA_SHA512
+  ].freeze
+  ALLOWED_DIGEST_METHODS = [
+    XMLSecurity::Document::SHA256,
+    XMLSecurity::Document::SHA384,
+    XMLSecurity::Document::SHA512
+  ].freeze
+  ALLOWED_TRANSFORMS = [
+    XMLSecurity::Document::ENVELOPED_SIG,
+    XMLSecurity::BaseDocument::C14N
+  ].freeze
+
+  def initialize(saml_settings:, encoded_request:, ruby_saml_settings:)
+    @saml_settings = saml_settings
+    @encoded_request = encoded_request
+    @ruby_saml_settings = ruby_saml_settings
+  end
+
+  def perform
+    parse_request!
+    validate_signed_root!
+    validate_xml_signature!
+    validate_saml_request!
+    validate_destination!
+    validate_issue_instant!
+    logout_request
+  end
+
+  private
+
+  attr_reader :saml_settings, :encoded_request, :ruby_saml_settings, :logout_request, :xml_document
+
+  def parse_request!
+    raise InvalidRequest, 'SAMLRequest is missing' if encoded_request.blank?
+    raise InvalidRequest, 'SAMLRequest is too large' unless valid_encoded_size?
+
+    decoded_request = Base64.strict_decode64(encoded_request)
+    raise InvalidRequest, 'SAMLRequest is too large' if decoded_request.bytesize > MAX_XML_REQUEST_SIZE
+
+    @xml_document = XMLSecurity::BaseDocument.safe_load_xml(decoded_request)
+    @logout_request = OneLogin::RubySaml::SloLogoutrequest.new(
+      decoded_request,
+      settings: ruby_saml_settings,
+      allowed_clock_drift: ALLOWED_CLOCK_DRIFT
+    )
+  rescue StandardError => e
+    raise if e.is_a?(InvalidRequest)
+
+    raise InvalidRequest, e.message
+  end
+
+  def valid_encoded_size?
+    encoded_request.is_a?(String) && encoded_request.bytesize <= MAX_ENCODED_REQUEST_SIZE
+  end
+
+  def validate_signed_root!
+    root = xml_document.root
+    valid_root = root&.name == 'LogoutRequest' && root&.namespace&.href == PROTOCOL_NAMESPACE
+    raise InvalidRequest, 'SAML message is not a LogoutRequest' unless valid_root
+
+    signature = root_signature!(root)
+    validate_signature_algorithms!(signature)
+    validate_signature_reference!(root, signature)
+  end
+
+  def root_signature!(root)
+    root_signatures = root.xpath('./ds:Signature', 'ds' => SIGNATURE_NAMESPACE)
+    all_signatures = root.xpath('.//ds:Signature', 'ds' => SIGNATURE_NAMESPACE)
+    return root_signatures.first if root_signatures.one? && all_signatures.one?
+
+    raise InvalidRequest, 'LogoutRequest must contain one root XML signature'
+  end
+
+  def validate_signature_reference!(root, signature)
+    references = signature.xpath('./ds:SignedInfo/ds:Reference', 'ds' => SIGNATURE_NAMESPACE)
+    request_id = root['ID']
+    signed_id = references.first&.[]('URI')&.delete_prefix('#')
+    matching_nodes = request_id.present? ? xml_document.xpath('//*[@ID=$id]', nil, id: request_id) : []
+    validation_results = [references.one?, request_id.present?, signed_id == request_id, matching_nodes.one?, matching_nodes.first == root]
+    return if validation_results.all?
+
+    raise InvalidRequest, 'XML signature must reference the LogoutRequest root'
+  end
+
+  def validate_signature_algorithms!(signature)
+    canonicalization_method = signature.at_xpath(
+      './ds:SignedInfo/ds:CanonicalizationMethod', 'ds' => SIGNATURE_NAMESPACE
+    )&.[]('Algorithm')
+    signature_method = signature.at_xpath('./ds:SignedInfo/ds:SignatureMethod', 'ds' => SIGNATURE_NAMESPACE)&.[]('Algorithm')
+    digest_method = signature.at_xpath('./ds:SignedInfo/ds:Reference/ds:DigestMethod', 'ds' => SIGNATURE_NAMESPACE)&.[]('Algorithm')
+    transforms = signature.xpath(
+      './ds:SignedInfo/ds:Reference/ds:Transforms/ds:Transform', 'ds' => SIGNATURE_NAMESPACE
+    ).pluck('Algorithm')
+    validation_results = [
+      canonicalization_method == XMLSecurity::BaseDocument::C14N,
+      ALLOWED_SIGNATURE_METHODS.include?(signature_method),
+      ALLOWED_DIGEST_METHODS.include?(digest_method),
+      transforms == ALLOWED_TRANSFORMS
+    ]
+    return if validation_results.all?
+
+    raise InvalidRequest, 'LogoutRequest uses an unsupported signature algorithm'
+  end
+
+  def validate_xml_signature!
+    signed_document = XMLSecurity::SignedDocument.new(logout_request.request)
+    certificate = OpenSSL::X509::Certificate.new(saml_settings.certificate)
+    valid_signature = signed_document.validate_document_with_cert(certificate, false)
+    return if valid_signature && signed_document.signed_element_id == logout_request.id
+
+    raise InvalidRequest, 'Invalid LogoutRequest signature'
+  rescue OneLogin::RubySaml::ValidationError, OpenSSL::X509::CertificateError => e
+    raise InvalidRequest, e.message
+  end
+
+  def validate_saml_request!
+    raise InvalidRequest.new(logout_request.errors.join(', '), request_id: logout_request.id) unless logout_request.is_valid?
+    return if logout_request.issuer == saml_settings.idp_entity_id
+
+    raise InvalidRequest.new('LogoutRequest Issuer does not match this tenant', request_id: logout_request.id)
+  end
+
+  def validate_destination!
+    return if xml_document.root['Destination'] == saml_settings.sp_sls_url
+
+    raise InvalidRequest.new('LogoutRequest Destination does not match this tenant', request_id: logout_request.id)
+  end
+
+  def validate_issue_instant!
+    issue_instant = Time.iso8601(xml_document.root['IssueInstant'])
+    earliest = Time.current - MAX_REQUEST_AGE
+    latest = Time.current + ALLOWED_CLOCK_DRIFT
+    return if issue_instant.between?(earliest, latest)
+
+    raise InvalidRequest.new('LogoutRequest IssueInstant is outside the accepted time window', request_id: logout_request.id)
+  rescue ArgumentError, TypeError
+    raise InvalidRequest.new('LogoutRequest IssueInstant is invalid', request_id: logout_request.id)
+  end
+end

--- a/enterprise/app/services/saml/logout_request_validator.rb
+++ b/enterprise/app/services/saml/logout_request_validator.rb
@@ -12,6 +12,7 @@ class Saml::LogoutRequestValidator
   SIGNATURE_NAMESPACE = 'http://www.w3.org/2000/09/xmldsig#'.freeze
   MAX_REQUEST_AGE = 5.minutes
   ALLOWED_CLOCK_DRIFT = 1.minute
+  # Cache eviction can permit a replay only while the original request remains valid within this age-plus-drift window.
   REPLAY_TTL = (MAX_REQUEST_AGE + ALLOWED_CLOCK_DRIFT).to_i
   MAX_ENCODED_REQUEST_SIZE = 100.kilobytes
   MAX_XML_REQUEST_SIZE = 64.kilobytes
@@ -55,7 +56,7 @@ class Saml::LogoutRequestValidator
     raise InvalidRequest, 'SAMLRequest is missing' if encoded_request.blank?
     raise InvalidRequest, 'SAMLRequest is too large' unless valid_encoded_size?
 
-    decoded_request = Base64.strict_decode64(encoded_request)
+    decoded_request = Base64.strict_decode64(encoded_request.gsub(/\s/, ''))
     raise InvalidRequest, 'SAMLRequest is too large' if decoded_request.bytesize > MAX_XML_REQUEST_SIZE
 
     @xml_document = XMLSecurity::BaseDocument.safe_load_xml(decoded_request)
@@ -135,6 +136,8 @@ class Saml::LogoutRequestValidator
   end
 
   def validate_saml_request!
+    # ruby-saml skips signature validation without Redirect-binding query parameters.
+    # validate_xml_signature! must always run before this call.
     raise InvalidRequest.new(logout_request.errors.join(', '), request_id: logout_request.id) unless logout_request.is_valid?
     return if logout_request.issuer == saml_settings.idp_entity_id
 

--- a/enterprise/app/services/saml/single_logout_service.rb
+++ b/enterprise/app/services/saml/single_logout_service.rb
@@ -1,0 +1,152 @@
+class Saml::SingleLogoutService
+  class Error < StandardError
+    attr_reader :request_id
+
+    def initialize(message, request_id: nil)
+      @request_id = request_id
+      super(message)
+    end
+  end
+
+  class ConfigurationError < Error; end
+  class InvalidRequest < Error; end
+  class ReplayDetected < Error; end
+  class UnknownPrincipal < Error; end
+
+  NAME_ID_FORMAT_EMAIL = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'.freeze
+  MAX_RELAY_STATE_SIZE = 80
+  REPLAY_TTL = Saml::LogoutRequestValidator::REPLAY_TTL
+  STATUS_SUCCESS = 'urn:oasis:names:tc:SAML:2.0:status:Success'.freeze
+  STATUS_REQUESTER = 'urn:oasis:names:tc:SAML:2.0:status:Requester'.freeze
+
+  def initialize(saml_settings:, encoded_request:, relay_state: nil)
+    @saml_settings = saml_settings
+    @encoded_request = encoded_request
+    @relay_state = relay_state
+  end
+
+  def perform
+    validate_configuration!
+    validate_relay_state!
+    @logout_request = validate_logout_request!
+    claim_request_id!
+    revoke_user_sessions!
+    logout_request.id
+  end
+
+  def logout_response_url(request_id:, status_code:, message:)
+    validate_configuration!
+    OneLogin::RubySaml::SloLogoutresponse.new.create(
+      ruby_saml_settings,
+      request_id,
+      message,
+      response_parameters,
+      status_code
+    )
+  end
+
+  private
+
+  attr_reader :saml_settings, :encoded_request, :relay_state, :logout_request, :replay_claim_token
+
+  def validate_configuration!
+    raise ConfigurationError, 'SAML single logout is not configured' unless signing_credentials_present?
+
+    idp_certificate = OpenSSL::X509::Certificate.new(saml_settings.certificate)
+    sp_key = OpenSSL::PKey::RSA.new(saml_settings.sp_private_key)
+    sp_certificate = OpenSSL::X509::Certificate.new(saml_settings.sp_certificate)
+    return if valid_signing_credentials?(idp_certificate, sp_certificate, sp_key)
+
+    raise ConfigurationError, 'SAML signing credentials are invalid or expired'
+  rescue OpenSSL::PKey::PKeyError, OpenSSL::X509::CertificateError => e
+    raise ConfigurationError, e.message
+  end
+
+  def signing_credentials_present?
+    saml_settings.single_logout_configured? && saml_settings.sp_private_key.present? && saml_settings.sp_certificate.present?
+  end
+
+  def valid_signing_credentials?(idp_certificate, sp_certificate, sp_key)
+    certificates = [idp_certificate, sp_certificate]
+    certificates.all? { |certificate| OneLogin::RubySaml::Utils.is_cert_active(certificate) } &&
+      sp_key.private? && sp_key.n.num_bits >= 2048 && sp_certificate.check_private_key(sp_key)
+  end
+
+  def validate_relay_state!
+    return if relay_state.blank?
+    return if relay_state.is_a?(String) && relay_state.bytesize <= MAX_RELAY_STATE_SIZE
+
+    raise InvalidRequest, 'RelayState is too large'
+  end
+
+  def validate_logout_request!
+    Saml::LogoutRequestValidator.new(
+      saml_settings: saml_settings,
+      encoded_request: encoded_request,
+      ruby_saml_settings: ruby_saml_settings
+    ).perform
+  rescue Saml::LogoutRequestValidator::InvalidRequest => e
+    raise InvalidRequest.new(e.message, request_id: e.request_id)
+  end
+
+  def claim_request_id!
+    @replay_claim_token = SecureRandom.uuid
+    claimed = Redis::Alfred.set(replay_key, replay_claim_token, nx: true, ex: REPLAY_TTL)
+    return if claimed
+
+    raise ReplayDetected.new('LogoutRequest has already been processed', request_id: logout_request.id)
+  end
+
+  def revoke_user_sessions!
+    user = saml_user
+    raise UnknownPrincipal.new('SAML subject does not match an account user', request_id: logout_request.id) unless user
+
+    user.update!(tokens: {})
+  rescue ActiveRecord::ActiveRecordError
+    Redis::Alfred.delete_if_equals(replay_key, replay_claim_token)
+    raise
+  end
+
+  def saml_user
+    return unless logout_request.name_id_format == NAME_ID_FORMAT_EMAIL
+
+    saml_settings.account.users.find_by(email: logout_request.name_id&.downcase, provider: 'saml')
+  end
+
+  def replay_key
+    request_id_digest = Digest::SHA256.hexdigest(logout_request.id)
+    "saml:single_logout:#{saml_settings.id}:#{request_id_digest}"
+  end
+
+  def response_parameters
+    relay_state.present? ? { RelayState: relay_state } : {}
+  end
+
+  def ruby_saml_settings
+    @ruby_saml_settings ||= OneLogin::RubySaml::Settings.new.tap do |settings|
+      configure_identity_provider(settings)
+      configure_service_provider(settings)
+      configure_security(settings)
+    end
+  end
+
+  def configure_identity_provider(settings)
+    settings.idp_entity_id = saml_settings.idp_entity_id
+    settings.idp_cert = saml_settings.certificate
+    settings.idp_slo_service_url = saml_settings.sls_url
+    settings.idp_slo_service_binding = :redirect
+  end
+
+  def configure_service_provider(settings)
+    settings.sp_entity_id = saml_settings.sp_entity_id
+    settings.certificate = saml_settings.sp_certificate
+    settings.private_key = saml_settings.sp_private_key
+    settings.compress_response = true
+  end
+
+  def configure_security(settings)
+    settings.security[:logout_responses_signed] = true
+    settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
+    settings.security[:digest_method] = XMLSecurity::Document::SHA256
+  end
+end

--- a/enterprise/app/services/saml/single_logout_service.rb
+++ b/enterprise/app/services/saml/single_logout_service.rb
@@ -26,16 +26,18 @@ class Saml::SingleLogoutService
   end
 
   def perform
-    validate_configuration!
     validate_relay_state!
+    validate_identity_provider_configuration!
     @logout_request = validate_logout_request!
+    validate_response_signing_configuration!
     claim_request_id!
     revoke_user_sessions!
     logout_request.id
   end
 
   def logout_response_url(request_id:, status_code:, message:)
-    validate_configuration!
+    validate_response_signing_configuration!
+    configure_response_signing(ruby_saml_settings)
     OneLogin::RubySaml::SloLogoutresponse.new.create(
       ruby_saml_settings,
       request_id,
@@ -49,27 +51,34 @@ class Saml::SingleLogoutService
 
   attr_reader :saml_settings, :encoded_request, :relay_state, :logout_request, :replay_claim_token
 
-  def validate_configuration!
-    raise ConfigurationError, 'SAML single logout is not configured' unless signing_credentials_present?
+  def validate_identity_provider_configuration!
+    raise ConfigurationError, 'SAML single logout is not configured' unless saml_settings.single_logout_configured?
 
     idp_certificate = OpenSSL::X509::Certificate.new(saml_settings.certificate)
+    return if OneLogin::RubySaml::Utils.is_cert_active(idp_certificate)
+
+    raise ConfigurationError, 'SAML identity provider certificate is invalid or expired'
+  rescue OpenSSL::X509::CertificateError => e
+    raise ConfigurationError, e.message
+  end
+
+  def validate_response_signing_configuration!
+    unless saml_settings.sp_private_key.present? && saml_settings.sp_certificate.present?
+      raise ConfigurationError, 'SAML response signing credentials are not configured'
+    end
+
     sp_key = OpenSSL::PKey::RSA.new(saml_settings.sp_private_key)
     sp_certificate = OpenSSL::X509::Certificate.new(saml_settings.sp_certificate)
-    return if valid_signing_credentials?(idp_certificate, sp_certificate, sp_key)
+    return if valid_response_signing_credentials?(sp_certificate, sp_key)
 
-    raise ConfigurationError, 'SAML signing credentials are invalid or expired'
+    raise ConfigurationError, 'SAML response signing credentials are invalid or expired'
   rescue OpenSSL::PKey::PKeyError, OpenSSL::X509::CertificateError => e
     raise ConfigurationError, e.message
   end
 
-  def signing_credentials_present?
-    saml_settings.single_logout_configured? && saml_settings.sp_private_key.present? && saml_settings.sp_certificate.present?
-  end
-
-  def valid_signing_credentials?(idp_certificate, sp_certificate, sp_key)
-    certificates = [idp_certificate, sp_certificate]
-    certificates.all? { |certificate| OneLogin::RubySaml::Utils.is_cert_active(certificate) } &&
-      sp_key.private? && sp_key.n.num_bits >= 2048 && sp_certificate.check_private_key(sp_key)
+  def valid_response_signing_credentials?(certificate, key)
+    OneLogin::RubySaml::Utils.is_cert_active(certificate) &&
+      key.private? && key.n.num_bits >= 2048 && certificate.check_private_key(key)
   end
 
   def validate_relay_state!
@@ -101,7 +110,11 @@ class Saml::SingleLogoutService
     user = saml_user
     raise UnknownPrincipal.new('SAML subject does not match an account user', request_id: logout_request.id) unless user
 
-    user.update!(tokens: {})
+    User.transaction do
+      user.update!(tokens: {})
+      user.access_token&.regenerate_token
+    end
+    Rails.logger.info("[SAML SLO] Revoked sessions saml_settings_id=#{saml_settings.id} user_id=#{user.id}")
   rescue ActiveRecord::ActiveRecordError
     Redis::Alfred.delete_if_equals(replay_key, replay_claim_token)
     raise
@@ -139,9 +152,12 @@ class Saml::SingleLogoutService
 
   def configure_service_provider(settings)
     settings.sp_entity_id = saml_settings.sp_entity_id
+    settings.compress_response = true
+  end
+
+  def configure_response_signing(settings)
     settings.certificate = saml_settings.sp_certificate
     settings.private_key = saml_settings.sp_private_key
-    settings.compress_response = true
   end
 
   def configure_security(settings)

--- a/enterprise/app/views/api/v1/models/_account_saml_settings.json.jbuilder
+++ b/enterprise/app/views/api/v1/models/_account_saml_settings.json.jbuilder
@@ -5,6 +5,9 @@ json.certificate account_saml_settings.certificate
 json.fingerprint account_saml_settings.certificate_fingerprint
 json.idp_entity_id account_saml_settings.idp_entity_id
 json.sp_entity_id account_saml_settings.sp_entity_id
+json.sls_url account_saml_settings.sls_url
+json.sp_sls_url account_saml_settings.sp_sls_url
+json.sp_certificate account_saml_settings.sp_certificate
 json.role_mappings account_saml_settings.role_mappings || {}
 json.created_at account_saml_settings.created_at
 json.updated_at account_saml_settings.updated_at

--- a/enterprise/config/initializers/omniauth_saml.rb
+++ b/enterprise/config/initializers/omniauth_saml.rb
@@ -29,13 +29,6 @@ SAML_SETUP_PROC = proc do |env|
       env['omniauth.strategy'].options[:idp_sso_service_url] = settings.sso_url
       env['omniauth.strategy'].options[:idp_cert] = settings.certificate
       env['omniauth.strategy'].options[:name_identifier_format] = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
-      env['omniauth.strategy'].options[:certificate] = settings.sp_certificate
-      env['omniauth.strategy'].options[:private_key] = settings.sp_private_key
-      env['omniauth.strategy'].options[:security] = OneLogin::RubySaml::Settings::DEFAULTS[:security].merge(
-        authn_requests_signed: settings.sp_certificate.present? && settings.sp_private_key.present?,
-        signature_method: XMLSecurity::Document::RSA_SHA256,
-        digest_method: XMLSecurity::Document::SHA256
-      )
     else
       # Set a dummy certificate to avoid the error
       env['omniauth.strategy'].options[:idp_cert] = 'DUMMY'

--- a/enterprise/config/initializers/omniauth_saml.rb
+++ b/enterprise/config/initializers/omniauth_saml.rb
@@ -29,6 +29,13 @@ SAML_SETUP_PROC = proc do |env|
       env['omniauth.strategy'].options[:idp_sso_service_url] = settings.sso_url
       env['omniauth.strategy'].options[:idp_cert] = settings.certificate
       env['omniauth.strategy'].options[:name_identifier_format] = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
+      env['omniauth.strategy'].options[:certificate] = settings.sp_certificate
+      env['omniauth.strategy'].options[:private_key] = settings.sp_private_key
+      env['omniauth.strategy'].options[:security] = OneLogin::RubySaml::Settings::DEFAULTS[:security].merge(
+        authn_requests_signed: settings.sp_certificate.present? && settings.sp_private_key.present?,
+        signature_method: XMLSecurity::Document::RSA_SHA256,
+        digest_method: XMLSecurity::Document::SHA256
+      )
     else
       # Set a dummy certificate to avoid the error
       env['omniauth.strategy'].options[:idp_cert] = 'DUMMY'

--- a/spec/enterprise/config/initializers/omniauth_saml_spec.rb
+++ b/spec/enterprise/config/initializers/omniauth_saml_spec.rb
@@ -10,45 +10,12 @@ RSpec.describe 'SAML setup' do
     )
   end
 
-  it 'signs authentication requests with the SLO key when single logout is configured' do
-    settings = create(:account_saml_settings, account: account, sls_url: 'https://idp.example.com/saml/slo')
+  it 'does not start signing authentication requests when single logout is configured' do
+    create(:account_saml_settings, account: account, sls_url: 'https://idp.example.com/saml/slo')
 
     SAML_SETUP_PROC.call(env)
 
-    expect(strategy.options).to include(certificate: settings.sp_certificate, private_key: settings.sp_private_key)
-    expect(strategy.options[:security]).to include(
-      authn_requests_signed: true,
-      signature_method: XMLSecurity::Document::RSA_SHA256,
-      digest_method: XMLSecurity::Document::SHA256
-    )
-  end
-
-  it 'does not sign authentication requests when single logout is not configured' do
-    create(:account_saml_settings, account: account, sls_url: nil)
-    strategy.options.merge!(
-      certificate: 'another tenant certificate',
-      private_key: 'another tenant key',
-      security: { authn_requests_signed: true }
-    )
-
-    SAML_SETUP_PROC.call(env)
-
-    expect(strategy.options).to include(certificate: nil, private_key: nil)
-    expect(strategy.options[:security]).to include(
-      authn_requests_signed: false,
-      signature_method: XMLSecurity::Document::RSA_SHA256,
-      digest_method: XMLSecurity::Document::SHA256
-    )
-  end
-
-  it 'keeps authentication requests signed when SLO is disabled after its certificate was trusted' do
-    settings = create(:account_saml_settings, account: account, sls_url: 'https://idp.example.com/saml/slo')
-    settings.update!(sls_url: nil)
-
-    SAML_SETUP_PROC.call(env)
-
-    expect(strategy.options).to include(certificate: settings.sp_certificate, private_key: settings.sp_private_key)
-    expect(strategy.options[:security]).to include(authn_requests_signed: true)
+    expect(strategy.options).not_to include(:certificate, :private_key, :security)
   end
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/enterprise/config/initializers/omniauth_saml_spec.rb
+++ b/spec/enterprise/config/initializers/omniauth_saml_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'SAML setup' do
+  let(:account) { create(:account) }
+  let(:strategy) { Struct.new(:options).new({}) }
+  let(:env) do
+    Rack::MockRequest.env_for("/omniauth/saml?account_id=#{account.id}").merge(
+      'omniauth.strategy' => strategy
+    )
+  end
+
+  it 'signs authentication requests with the SLO key when single logout is configured' do
+    settings = create(:account_saml_settings, account: account, sls_url: 'https://idp.example.com/saml/slo')
+
+    SAML_SETUP_PROC.call(env)
+
+    expect(strategy.options).to include(certificate: settings.sp_certificate, private_key: settings.sp_private_key)
+    expect(strategy.options[:security]).to include(
+      authn_requests_signed: true,
+      signature_method: XMLSecurity::Document::RSA_SHA256,
+      digest_method: XMLSecurity::Document::SHA256
+    )
+  end
+
+  it 'does not sign authentication requests when single logout is not configured' do
+    create(:account_saml_settings, account: account, sls_url: nil)
+    strategy.options.merge!(
+      certificate: 'another tenant certificate',
+      private_key: 'another tenant key',
+      security: { authn_requests_signed: true }
+    )
+
+    SAML_SETUP_PROC.call(env)
+
+    expect(strategy.options).to include(certificate: nil, private_key: nil)
+    expect(strategy.options[:security]).to include(
+      authn_requests_signed: false,
+      signature_method: XMLSecurity::Document::RSA_SHA256,
+      digest_method: XMLSecurity::Document::SHA256
+    )
+  end
+
+  it 'keeps authentication requests signed when SLO is disabled after its certificate was trusted' do
+    settings = create(:account_saml_settings, account: account, sls_url: 'https://idp.example.com/saml/slo')
+    settings.update!(sls_url: nil)
+
+    SAML_SETUP_PROC.call(env)
+
+    expect(strategy.options).to include(certificate: settings.sp_certificate, private_key: settings.sp_private_key)
+    expect(strategy.options[:security]).to include(authn_requests_signed: true)
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/enterprise/controllers/api/v1/accounts/saml_settings_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/saml_settings_controller_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'Api::V1::Accounts::SamlSettings', type: :request do
           create(:account_saml_settings,
                  account: account,
                  sso_url: 'https://idp.example.com/saml/sso',
+                 sls_url: 'https://idp.example.com/saml/slo',
                  role_mappings: { 'Admins' => { 'role' => 1 } })
         end
 
@@ -44,6 +45,10 @@ RSpec.describe 'Api::V1::Accounts::SamlSettings', type: :request do
 
           expect(response).to have_http_status(:success)
           expect(json_response[:sso_url]).to eq('https://idp.example.com/saml/sso')
+          expect(json_response[:sls_url]).to eq('https://idp.example.com/saml/slo')
+          expect(json_response[:sp_sls_url]).to eq(saml_settings.sp_sls_url)
+          expect(json_response[:sp_certificate]).to eq(saml_settings.sp_certificate)
+          expect(json_response).not_to have_key(:sp_private_key)
           expect(json_response[:role_mappings]).to eq({ Admins: { role: 1 } })
         end
       end
@@ -100,6 +105,7 @@ RSpec.describe 'Api::V1::Accounts::SamlSettings', type: :request do
       {
         saml_settings: {
           sso_url: 'https://idp.example.com/saml/sso',
+          sls_url: 'https://idp.example.com/saml/slo',
           certificate: cert.to_pem,
           idp_entity_id: 'https://idp.example.com/saml/metadata',
           role_mappings: { 'Admins' => { 'role' => 1 }, 'Users' => { 'role' => 0 } }
@@ -127,8 +133,18 @@ RSpec.describe 'Api::V1::Accounts::SamlSettings', type: :request do
           expect(response).to have_http_status(:success)
 
           saml_settings = AccountSamlSettings.find_by(account: account)
-          expect(saml_settings.sso_url).to eq('https://idp.example.com/saml/sso')
-          expect(saml_settings.role_mappings).to eq({ 'Admins' => { 'role' => 1 }, 'Users' => { 'role' => 0 } })
+          expect(saml_settings).to have_attributes(
+            sso_url: 'https://idp.example.com/saml/sso',
+            sls_url: 'https://idp.example.com/saml/slo',
+            role_mappings: { 'Admins' => { 'role' => 1 }, 'Users' => { 'role' => 0 } }
+          )
+          expect(saml_settings.sp_private_key).to be_present
+          expect(json_response).to include(
+            sls_url: saml_settings.sls_url,
+            sp_sls_url: saml_settings.sp_sls_url,
+            sp_certificate: saml_settings.sp_certificate
+          )
+          expect(json_response).not_to have_key(:sp_private_key)
         end
       end
 
@@ -184,6 +200,7 @@ RSpec.describe 'Api::V1::Accounts::SamlSettings', type: :request do
       {
         saml_settings: {
           sso_url: 'https://new.example.com/saml/sso',
+          sls_url: 'https://idp.example.com/saml/slo',
           certificate: cert.to_pem,
           role_mappings: { 'NewGroup' => { 'custom_role_id' => 5 } }
         }
@@ -211,8 +228,18 @@ RSpec.describe 'Api::V1::Accounts::SamlSettings', type: :request do
         expect(response).to have_http_status(:success)
 
         saml_settings.reload
-        expect(saml_settings.sso_url).to eq('https://new.example.com/saml/sso')
-        expect(saml_settings.role_mappings).to eq({ 'NewGroup' => { 'custom_role_id' => 5 } })
+        expect(saml_settings).to have_attributes(
+          sso_url: 'https://new.example.com/saml/sso',
+          sls_url: 'https://idp.example.com/saml/slo',
+          role_mappings: { 'NewGroup' => { 'custom_role_id' => 5 } }
+        )
+        expect(saml_settings.sp_private_key).to be_present
+        expect(json_response).to include(
+          sls_url: saml_settings.sls_url,
+          sp_sls_url: saml_settings.sp_sls_url,
+          sp_certificate: saml_settings.sp_certificate
+        )
+        expect(json_response).not_to have_key(:sp_private_key)
       end
     end
 

--- a/spec/enterprise/controllers/saml/single_logout_controller_spec.rb
+++ b/spec/enterprise/controllers/saml/single_logout_controller_spec.rb
@@ -38,11 +38,18 @@ RSpec.describe Saml::SingleLogoutController, type: :request do
 
   describe 'POST /saml/slo/:settings_token' do
     it 'revokes every Chatwoot session' do
+      personal_access_token = saml_user.access_token.token
+      allow(Rails.logger).to receive(:info)
+
       post_logout_request
 
       expect(response).to have_http_status(:found)
       expect(saml_user.reload.tokens).to eq({})
       expect(saml_user.user_sessions).to be_empty
+      expect(saml_user.access_token.reload.token).not_to eq(personal_access_token)
+      expect(Rails.logger).to have_received(:info).with(
+        "[SAML SLO] Revoked sessions saml_settings_id=#{saml_settings.id} user_id=#{saml_user.id}"
+      )
     end
 
     it 'redirects the back-channel client with a signed LogoutResponse for the configured IdP' do
@@ -85,11 +92,105 @@ RSpec.describe Saml::SingleLogoutController, type: :request do
       expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
     end
 
+    it 'documents that ruby-saml considers an unsigned POST-binding LogoutRequest valid' do
+      unsigned_request = Base64.strict_decode64(build_logout_request(sign: false))
+      ruby_saml_settings = Saml::SingleLogoutService.new(
+        saml_settings: saml_settings,
+        encoded_request: nil
+      ).send(:ruby_saml_settings)
+      logout_request = OneLogin::RubySaml::SloLogoutrequest.new(
+        unsigned_request,
+        settings: ruby_saml_settings,
+        allowed_clock_drift: Saml::LogoutRequestValidator::ALLOWED_CLOCK_DRIFT
+      )
+
+      expect(logout_request.is_valid?).to be(true)
+    end
+
+    it 'rejects a signed LogoutRequest wrapped inside an unsigned attacker-controlled root' do
+      signed_request = decoded_logout_request.sub(/\A<\?xml.*?\?>/m, '')
+      wrapped_request = <<~XML
+        <samlp:LogoutRequest xmlns:samlp="#{Saml::LogoutRequestValidator::PROTOCOL_NAMESPACE}"
+          xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_attacker" Version="2.0"
+          IssueInstant="#{Time.current.utc.iso8601}" Destination="#{saml_settings.sp_sls_url}">
+          <saml:Issuer>#{saml_settings.idp_entity_id}</saml:Issuer>
+          <samlp:Extensions>#{signed_request}</samlp:Extensions>
+          <saml:NameID Format="#{Saml::SingleLogoutService::NAME_ID_FORMAT_EMAIL}">victim@example.com</saml:NameID>
+        </samlp:LogoutRequest>
+      XML
+
+      post_logout_request(encoded_request: Base64.strict_encode64(wrapped_request))
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects a root signature whose reference points to a wrapped LogoutRequest' do
+      signed_request = decoded_logout_request.sub(/\A<\?xml.*?\?>/m, '')
+      signature = signed_request[%r{<ds:Signature\b.*?</ds:Signature>}m]
+      unsigned_inner_request = signed_request.sub(signature, '')
+      wrapped_request = <<~XML
+        <samlp:LogoutRequest xmlns:samlp="#{Saml::LogoutRequestValidator::PROTOCOL_NAMESPACE}"
+          xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_attacker" Version="2.0"
+          IssueInstant="#{Time.current.utc.iso8601}" Destination="#{saml_settings.sp_sls_url}">
+          #{signature}
+          <saml:Issuer>#{saml_settings.idp_entity_id}</saml:Issuer>
+          <samlp:Extensions>#{unsigned_inner_request}</samlp:Extensions>
+          <saml:NameID Format="#{Saml::SingleLogoutService::NAME_ID_FORMAT_EMAIL}">victim@example.com</saml:NameID>
+        </samlp:LogoutRequest>
+      XML
+
+      post_logout_request(encoded_request: Base64.strict_encode64(wrapped_request))
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects duplicate ID attributes that make the signature reference ambiguous' do
+      signed_request = decoded_logout_request.sub(/\A<\?xml.*?\?>/m, '')
+      signature = signed_request[%r{<ds:Signature\b.*?</ds:Signature>}m]
+      unsigned_inner_request = signed_request.sub(signature, '')
+      wrapped_request = <<~XML
+        <samlp:LogoutRequest xmlns:samlp="#{Saml::LogoutRequestValidator::PROTOCOL_NAMESPACE}"
+          xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="#{request_id}" Version="2.0"
+          IssueInstant="#{Time.current.utc.iso8601}" Destination="#{saml_settings.sp_sls_url}">
+          #{signature}
+          <saml:Issuer>#{saml_settings.idp_entity_id}</saml:Issuer>
+          <samlp:Extensions>#{unsigned_inner_request}</samlp:Extensions>
+          <saml:NameID Format="#{Saml::SingleLogoutService::NAME_ID_FORMAT_EMAIL}">victim@example.com</saml:NameID>
+        </samlp:LogoutRequest>
+      XML
+
+      post_logout_request(encoded_request: Base64.strict_encode64(wrapped_request))
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects a second signature smuggled inside LogoutRequest Extensions' do
+      signed_request = decoded_logout_request
+      signature = signed_request[%r{<ds:Signature\b.*?</ds:Signature>}m]
+      request_with_two_signatures = signed_request.sub(
+        '</samlp:LogoutRequest>',
+        "<samlp:Extensions>#{signature}</samlp:Extensions></samlp:LogoutRequest>"
+      )
+
+      post_logout_request(encoded_request: Base64.strict_encode64(request_with_two_signatures))
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
     it 'rejects a signed LogoutRequest from a different issuer' do
+      allow(Rails.logger).to receive(:warn)
+
       post_logout_request(issuer: 'https://attacker.example.com/saml/metadata')
 
       expect(response).to have_http_status(:bad_request)
       expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+      expect(Rails.logger).to have_received(:warn).with(
+        a_string_including("saml_settings_id=#{saml_settings.id} reason=Doesn't match the issuer")
+      )
     end
 
     it 'rejects a signed LogoutRequest with a different Destination' do
@@ -104,6 +205,31 @@ RSpec.describe Saml::SingleLogoutController, type: :request do
 
       expect(response).to have_http_status(:bad_request)
       expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects an extra XML signature transform' do
+      signed_request = decoded_logout_request
+      enveloped_transform = signed_request[%r{<ds:Transform Algorithm=.http://www\.w3\.org/2000/09/xmldsig#enveloped-signature.\s*/?>}]
+      xpath_transform = <<~XML.squish
+        <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116">
+          <ds:XPath>true()</ds:XPath>
+        </ds:Transform>
+      XML
+      request_with_extra_transform = signed_request.sub(enveloped_transform, "#{enveloped_transform}#{xpath_transform}")
+
+      post_logout_request(encoded_request: Base64.strict_encode64(request_with_extra_transform))
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'accepts RFC 2045 line-wrapped base64' do
+      encoded_request = build_logout_request.scan(/.{1,64}/).join("\n")
+
+      post_logout_request(encoded_request: encoded_request)
+
+      expect(response).to have_http_status(:found)
+      expect(saml_user.reload.tokens).to eq({})
     end
 
     it 'rejects XML with a document type before parsing it with REXML' do
@@ -137,6 +263,21 @@ RSpec.describe Saml::SingleLogoutController, type: :request do
     it 'rejects a LogoutRequest signed by a different key' do
       attacker_key = OpenSSL::PKey::RSA.new(2048)
       attacker_certificate = build_certificate(attacker_key, 'attacker.example.com')
+      allow(Rails.logger).to receive(:warn)
+
+      post_logout_request(signing_key: attacker_key, signing_certificate: attacker_certificate)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+      expect(Rails.logger).to have_received(:warn).with(
+        a_string_including("saml_settings_id=#{saml_settings.id} reason=Certificate of the Signature element does not match")
+      )
+    end
+
+    it 'verifies the IdP signature before loading the SP private key' do
+      attacker_key = OpenSSL::PKey::RSA.new(2048)
+      attacker_certificate = build_certificate(attacker_key, 'attacker.example.com')
+      saml_settings.update_column(:sp_private_key, 'not-a-private-key') # rubocop:disable Rails/SkipsModelValidations
 
       post_logout_request(signing_key: attacker_key, signing_certificate: attacker_certificate)
 
@@ -182,12 +323,25 @@ RSpec.describe Saml::SingleLogoutController, type: :request do
       expect(response).to have_http_status(:found)
 
       saml_user.update!(tokens: { 'new-client' => { 'token' => 'new-token', 'expiry' => 1.month.from_now.to_i } })
+      allow(Rails.logger).to receive(:warn)
       post_logout_request(encoded_request: encoded_request)
 
       expect(response).to have_http_status(:found)
       expect(saml_user.reload.tokens.keys).to contain_exactly('new-client')
       expect(response_status_code).to eq(Saml::SingleLogoutService::STATUS_REQUESTER)
       expect(response_signature_valid?).to be(true)
+      expect(Rails.logger).to have_received(:warn).with(
+        a_string_including("saml_settings_id=#{saml_settings.id} reason=LogoutRequest has already been processed")
+      )
+    end
+
+    it 'fails closed when the replay store is unavailable' do
+      allow(Redis::Alfred).to receive(:set).and_raise(Redis::BaseError, 'Redis unavailable')
+
+      post_logout_request
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
     end
 
     it 'fails closed when the IdP SLS URL is not configured' do
@@ -200,10 +354,15 @@ RSpec.describe Saml::SingleLogoutController, type: :request do
     end
 
     it 'rejects a stale LogoutRequest' do
+      allow(Rails.logger).to receive(:warn)
+
       post_logout_request(issue_instant: 6.minutes.ago)
 
       expect(response).to have_http_status(:bad_request)
       expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+      expect(Rails.logger).to have_received(:warn).with(
+        a_string_including("saml_settings_id=#{saml_settings.id} reason=LogoutRequest IssueInstant is outside the accepted time window")
+      )
     end
 
     it 'rejects a LogoutRequest with an IssueInstant too far in the future' do
@@ -291,6 +450,10 @@ RSpec.describe Saml::SingleLogoutController, type: :request do
     sign_logout_request(document, options) if options[:sign]
 
     Base64.strict_encode64(document.to_s)
+  end
+
+  def decoded_logout_request
+    Base64.strict_decode64(build_logout_request)
   end
 
   def build_logout_request_document(options)

--- a/spec/enterprise/controllers/saml/single_logout_controller_spec.rb
+++ b/spec/enterprise/controllers/saml/single_logout_controller_spec.rb
@@ -1,0 +1,412 @@
+require 'rails_helper'
+
+RSpec.describe Saml::SingleLogoutController, type: :request do
+  let(:account) { create(:account) }
+  let(:idp_key) { OpenSSL::PKey::RSA.new(2048) }
+  let(:idp_certificate) { build_certificate(idp_key, 'idp.example.com') }
+  let(:request_id) { "_#{SecureRandom.uuid}" }
+  let(:saml_settings) do
+    create(
+      :account_saml_settings,
+      account: account,
+      certificate: idp_certificate.to_pem,
+      idp_entity_id: 'https://idp.example.com/saml/metadata',
+      sls_url: 'https://idp.example.com/saml/slo'
+    )
+  end
+  let(:saml_user) do
+    create(:user, account: account, email: 'agent@example.com', provider: 'saml').tap do |user|
+      user.update!(
+        tokens: {
+          'client-a' => { 'token' => 'token-a', 'expiry' => 1.month.from_now.to_i },
+          'client-b' => { 'token' => 'token-b', 'expiry' => 1.month.from_now.to_i }
+        }
+      )
+      user.user_sessions.create!(client_id: 'client-a', last_activity_at: Time.current)
+      user.user_sessions.create!(client_id: 'client-b', last_activity_at: Time.current)
+    end
+  end
+
+  before do
+    account.enable_features!('saml')
+    saml_user
+  end
+
+  after do
+    Redis::Alfred.delete(replay_key(saml_settings, request_id)) if saml_settings.persisted?
+  end
+
+  describe 'POST /saml/slo/:settings_token' do
+    it 'revokes every Chatwoot session' do
+      post_logout_request
+
+      expect(response).to have_http_status(:found)
+      expect(saml_user.reload.tokens).to eq({})
+      expect(saml_user.user_sessions).to be_empty
+    end
+
+    it 'redirects the back-channel client with a signed LogoutResponse for the configured IdP' do
+      post_logout_request
+
+      expect(response).to have_http_status(:found)
+      expect(response_redirect_params['SigAlg']).to eq(XMLSecurity::Document::RSA_SHA256)
+      expect(response_signature_valid?).to be(true)
+      expect(response_document.root['InResponseTo']).to eq(request_id)
+      expect(response_document.root['Destination']).to eq(saml_settings.sls_url)
+      expect(response_document.at_xpath('/samlp:LogoutResponse/saml:Issuer', response_namespaces).text).to eq(saml_settings.sp_entity_id)
+      expect(response_status_code).to eq(Saml::SingleLogoutService::STATUS_SUCCESS)
+    end
+
+    it 'echoes RelayState inside the signed redirect response' do
+      post_logout_request(relay_state: 'authentik-logout-state')
+
+      expect(response_redirect_params['RelayState']).to eq('authentik-logout-state')
+      expect(response_signature_valid?).to be(true)
+    end
+
+    it 'rejects RelayState longer than the SAML binding limit before revoking sessions' do
+      post_logout_request(relay_state: 'a' * 81)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects a request without SAMLRequest' do
+      post URI.parse(saml_settings.sp_sls_url).path
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects an unsigned LogoutRequest without revoking sessions' do
+      post_logout_request(sign: false)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects a signed LogoutRequest from a different issuer' do
+      post_logout_request(issuer: 'https://attacker.example.com/saml/metadata')
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects a signed LogoutRequest with a different Destination' do
+      post_logout_request(destination: "#{saml_settings.sp_sls_url}/other")
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects SHA-1 signature and digest algorithms' do
+      post_logout_request(signature_method: XMLSecurity::Document::RSA_SHA1, digest_method: XMLSecurity::Document::SHA1)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects XML with a document type before parsing it with REXML' do
+      encoded_request = Base64.strict_encode64('<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><foo>&xxe;</foo>')
+
+      post_logout_request(encoded_request: encoded_request)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects a compressed Redirect-binding payload on the POST endpoint' do
+      xml = Base64.strict_decode64(build_logout_request)
+      encoded_request = Base64.strict_encode64(deflate_request(xml))
+
+      post_logout_request(encoded_request: encoded_request)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects an oversized SAMLRequest before decoding it' do
+      encoded_request = 'A' * (Saml::LogoutRequestValidator::MAX_ENCODED_REQUEST_SIZE + 1)
+
+      post_logout_request(encoded_request: encoded_request)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects a LogoutRequest signed by a different key' do
+      attacker_key = OpenSSL::PKey::RSA.new(2048)
+      attacker_certificate = build_certificate(attacker_key, 'attacker.example.com')
+
+      post_logout_request(signing_key: attacker_key, signing_certificate: attacker_certificate)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'returns a signed failure for an unknown NameID without revoking another user' do
+      post_logout_request(name_id: 'unknown@example.com')
+
+      expect(response).to have_http_status(:found)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+      expect(response_status_code).to eq(Saml::SingleLogoutService::STATUS_REQUESTER)
+      expect(response_signature_valid?).to be(true)
+    end
+
+    it 'rejects a signed request sent to the wrong tenant endpoint' do
+      other_account = create(:account)
+      other_account.enable_features!('saml')
+      other_settings = create(
+        :account_saml_settings,
+        account: other_account,
+        certificate: idp_certificate.to_pem,
+        idp_entity_id: saml_settings.idp_entity_id,
+        sls_url: saml_settings.sls_url
+      )
+      other_user = create(:user, account: other_account, email: 'other@example.com', provider: 'saml')
+      other_user.update!(tokens: { 'other-client' => { 'token' => 'other-token', 'expiry' => 1.month.from_now.to_i } })
+      encoded_request = build_logout_request(destination: saml_settings.sp_sls_url)
+
+      post URI.parse(other_settings.sp_sls_url).path, params: { SAMLRequest: encoded_request }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+      expect(other_user.reload.tokens.keys).to contain_exactly('other-client')
+    ensure
+      Redis::Alfred.delete(replay_key(other_settings, request_id)) if other_settings&.persisted?
+    end
+
+    it 'rejects a replay without revoking a session created after the first request' do
+      encoded_request = build_logout_request
+      post_logout_request(encoded_request: encoded_request)
+      expect(response).to have_http_status(:found)
+
+      saml_user.update!(tokens: { 'new-client' => { 'token' => 'new-token', 'expiry' => 1.month.from_now.to_i } })
+      post_logout_request(encoded_request: encoded_request)
+
+      expect(response).to have_http_status(:found)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('new-client')
+      expect(response_status_code).to eq(Saml::SingleLogoutService::STATUS_REQUESTER)
+      expect(response_signature_valid?).to be(true)
+    end
+
+    it 'fails closed when the IdP SLS URL is not configured' do
+      saml_settings.update_columns(sls_url: nil, sp_certificate: nil, sp_private_key: nil) # rubocop:disable Rails/SkipsModelValidations
+
+      post_logout_request
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects a stale LogoutRequest' do
+      post_logout_request(issue_instant: 6.minutes.ago)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'rejects a LogoutRequest with an IssueInstant too far in the future' do
+      post_logout_request(issue_instant: 2.minutes.from_now)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'returns a signed failure when NameID is not an email identifier' do
+      post_logout_request(name_id_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent')
+
+      expect(response).to have_http_status(:found)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+      expect(response_signature_valid?).to be(true)
+    end
+
+    it 'does not revoke a non-SAML user with the same email address' do
+      saml_user.update!(provider: 'email')
+
+      post_logout_request
+
+      expect(response).to have_http_status(:found)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+      expect(response_status_code).to eq(Saml::SingleLogoutService::STATUS_REQUESTER)
+    end
+
+    it 'rejects a tampered settings token before processing the request' do
+      encoded_request = build_logout_request
+      path = URI.parse(saml_settings.sp_sls_url).path
+
+      post "#{path}tampered", params: { SAMLRequest: encoded_request }
+
+      expect(response).to have_http_status(:not_found)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'does not process logout when the account SAML feature is disabled' do
+      account.disable_features!('saml')
+
+      post_logout_request
+
+      expect(response).to have_http_status(:not_found)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'does not process logout when SAML is globally disabled' do
+      allow(GlobalConfigService).to receive(:load).and_call_original
+      allow(GlobalConfigService).to receive(:load).with('ENABLE_SAML_SSO_LOGIN', 'true').and_return('false')
+
+      post_logout_request
+
+      expect(response).to have_http_status(:not_found)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+
+    it 'does not expose the endpoint through GET binding' do
+      get URI.parse(saml_settings.sp_sls_url).path, params: { SAMLRequest: build_logout_request }
+
+      expect(response).to have_http_status(:not_found)
+      expect(saml_user.reload.tokens.keys).to contain_exactly('client-a', 'client-b')
+    end
+  end
+
+  def post_logout_request(encoded_request: nil, **request_options)
+    @response_document = nil
+    @response_redirect_params = nil
+    @response_raw_redirect_params = nil
+    relay_state = request_options.delete(:relay_state)
+    encoded_request ||= build_logout_request(**request_options)
+    post URI.parse(saml_settings.sp_sls_url).path, params: { SAMLRequest: encoded_request, RelayState: relay_state }.compact
+  end
+
+  def build_logout_request(options = {})
+    options.reverse_merge!(
+      name_id: saml_user.email,
+      name_id_format: Saml::SingleLogoutService::NAME_ID_FORMAT_EMAIL,
+      destination: saml_settings.sp_sls_url,
+      issue_instant: Time.current,
+      sign: true,
+      signing_key: idp_key,
+      signing_certificate: idp_certificate
+    )
+    document = build_logout_request_document(options)
+    sign_logout_request(document, options) if options[:sign]
+
+    Base64.strict_encode64(document.to_s)
+  end
+
+  def build_logout_request_document(options)
+    document = XMLSecurity::Document.new
+    document.uuid = request_id
+    root = add_logout_request_root(document, options)
+    add_logout_request_subject(root, options)
+    document
+  end
+
+  def add_logout_request_root(document, options)
+    root = document.add_element('samlp:LogoutRequest', logout_request_namespaces)
+    root.add_attributes(
+      'ID' => request_id,
+      'Version' => '2.0',
+      'IssueInstant' => options[:issue_instant].utc.iso8601,
+      'Destination' => options[:destination]
+    )
+    root.add_element('saml:Issuer').text = options.fetch(:issuer, saml_settings.idp_entity_id)
+    root
+  end
+
+  def add_logout_request_subject(root, options)
+    root.add_element('saml:NameID', 'Format' => options[:name_id_format]).text = options[:name_id]
+    root.add_element('samlp:SessionIndex').text = 'authentik-session-index'
+  end
+
+  def logout_request_namespaces
+    {
+      'xmlns:samlp' => Saml::LogoutRequestValidator::PROTOCOL_NAMESPACE,
+      'xmlns:saml' => 'urn:oasis:names:tc:SAML:2.0:assertion'
+    }
+  end
+
+  def sign_logout_request(document, options)
+    document.sign_document(
+      options[:signing_key],
+      options[:signing_certificate],
+      options.fetch(:signature_method, XMLSecurity::Document::RSA_SHA256),
+      options.fetch(:digest_method, XMLSecurity::Document::SHA256)
+    )
+  end
+
+  def build_certificate(key, common_name)
+    certificate = OpenSSL::X509::Certificate.new
+    certificate.version = 2
+    certificate.serial = SecureRandom.random_number(2**159)
+    certificate.subject = OpenSSL::X509::Name.parse("/CN=#{common_name}")
+    certificate.issuer = certificate.subject
+    certificate.public_key = key.public_key
+    certificate.not_before = 1.minute.ago
+    certificate.not_after = 1.year.from_now
+    certificate.sign(key, OpenSSL::Digest.new('SHA256'))
+    certificate
+  end
+
+  def response_status_code
+    response_document.at_xpath(
+      '/samlp:LogoutResponse/samlp:Status/samlp:StatusCode',
+      response_namespaces
+    )['Value']
+  end
+
+  def response_namespaces
+    {
+      'samlp' => Saml::LogoutRequestValidator::PROTOCOL_NAMESPACE,
+      'saml' => 'urn:oasis:names:tc:SAML:2.0:assertion'
+    }
+  end
+
+  def response_signature_valid?
+    parameters = response_redirect_params
+    raw_parameters = response_raw_redirect_params
+    query = OneLogin::RubySaml::Utils.build_query_from_raw_parts(
+      type: 'SAMLResponse',
+      raw_data: raw_parameters['SAMLResponse'],
+      raw_relay_state: raw_parameters['RelayState'],
+      raw_sig_alg: raw_parameters['SigAlg']
+    )
+    OneLogin::RubySaml::Utils.verify_signature(
+      cert: OpenSSL::X509::Certificate.new(saml_settings.sp_certificate),
+      sig_alg: parameters['SigAlg'],
+      signature: parameters['Signature'],
+      query_string: query
+    )
+  end
+
+  def response_document
+    @response_document ||= Nokogiri::XML(inflate_response(response_redirect_params['SAMLResponse']))
+  end
+
+  def response_redirect_params
+    @response_redirect_params ||= URI.decode_www_form(URI.parse(response.location).query).to_h
+  end
+
+  def response_raw_redirect_params
+    @response_raw_redirect_params ||= URI.parse(response.location).query.split('&').to_h do |parameter|
+      parameter.split('=', 2)
+    end
+  end
+
+  def inflate_response(encoded_response)
+    inflater = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+    inflater.inflate(Base64.strict_decode64(encoded_response))
+  ensure
+    inflater&.close
+  end
+
+  def deflate_request(xml)
+    deflater = Zlib::Deflate.new(Zlib::DEFAULT_COMPRESSION, -Zlib::MAX_WBITS)
+    deflater.deflate(xml, Zlib::FINISH)
+  ensure
+    deflater&.close
+  end
+
+  def replay_key(settings, id)
+    "saml:single_logout:#{settings.id}:#{Digest::SHA256.hexdigest(id)}"
+  end
+end

--- a/spec/enterprise/models/account_saml_settings_spec.rb
+++ b/spec/enterprise/models/account_saml_settings_spec.rb
@@ -56,6 +56,84 @@ RSpec.describe AccountSamlSettings, type: :model do
     end
   end
 
+  describe 'single logout configuration' do
+    it 'keeps SAML enabled when an SLS URL is not configured' do
+      settings = build(:account_saml_settings, account: account, sls_url: nil)
+
+      expect(settings).to be_valid
+      expect(settings).to be_saml_enabled
+      expect(settings).not_to be_single_logout_configured
+
+      settings.save!
+
+      expect(settings.sp_private_key).to be_nil
+      expect(settings.sp_certificate).to be_nil
+    end
+
+    it 'generates matching service provider signing credentials when an SLS URL is configured' do
+      settings = create(:account_saml_settings, account: account, sls_url: 'https://idp.example.com/saml/slo')
+
+      private_key = OpenSSL::PKey::RSA.new(settings.sp_private_key)
+      certificate = OpenSSL::X509::Certificate.new(settings.sp_certificate)
+
+      expect(certificate.check_private_key(private_key)).to be true
+    end
+
+    it 'rejects a non-HTTP SLS URL' do
+      settings = build(:account_saml_settings, account: account, sls_url: 'javascript:alert(1)')
+
+      expect(settings).not_to be_valid
+      expect(settings.errors[:sls_url]).to be_present
+    end
+
+    it 'exposes a signed service provider SLS URL that resolves to the settings record' do
+      allow(GlobalConfigService).to receive(:load).and_call_original
+      allow(GlobalConfigService).to receive(:load)
+        .with('FRONTEND_URL', 'http://localhost:3000')
+        .and_return('https://chatwoot.example.com')
+
+      settings = create(:account_saml_settings, account: account, sls_url: 'https://idp.example.com/saml/slo')
+      uri = URI.parse(settings.sp_sls_url)
+      route = Rails.application.routes.recognize_path(uri.path, method: :post)
+      settings_token = route.fetch(:settings_token)
+
+      expect("#{uri.scheme}://#{uri.host}").to eq('https://chatwoot.example.com')
+      expect(route).to include(controller: 'saml/single_logout', action: 'create')
+      expect(described_class.find_signed!(settings_token, purpose: described_class::SINGLE_LOGOUT_SIGNED_ID_PURPOSE)).to eq(settings)
+    end
+
+    it 'rejects malformed service provider signing credentials' do
+      settings = build(
+        :account_saml_settings,
+        account: account,
+        sls_url: 'https://idp.example.com/saml/slo',
+        sp_private_key: 'not-a-private-key',
+        sp_certificate: 'not-a-certificate'
+      )
+
+      expect(settings).not_to be_valid
+      expect(settings.errors[:sp_certificate]).to include(I18n.t('profile.account_saml_settings.invalid_sp_signing_credentials'))
+    end
+
+    it 'rejects service provider signing credentials that do not match' do
+      configured_settings = create(
+        :account_saml_settings,
+        account: create(:account),
+        sls_url: 'https://idp.example.com/saml/slo'
+      )
+      settings = build(
+        :account_saml_settings,
+        account: account,
+        sls_url: 'https://idp.example.com/saml/slo',
+        sp_private_key: OpenSSL::PKey::RSA.new(2048).to_pem,
+        sp_certificate: configured_settings.sp_certificate
+      )
+
+      expect(settings).not_to be_valid
+      expect(settings.errors[:sp_certificate]).to include(I18n.t('profile.account_saml_settings.invalid_sp_signing_credentials'))
+    end
+  end
+
   describe 'sp_entity_id auto-generation' do
     it 'automatically generates sp_entity_id when creating' do
       settings = build(:account_saml_settings, account: account, sp_entity_id: nil)

--- a/spec/enterprise/models/account_saml_settings_spec.rb
+++ b/spec/enterprise/models/account_saml_settings_spec.rb
@@ -79,11 +79,18 @@ RSpec.describe AccountSamlSettings, type: :model do
       expect(certificate.check_private_key(private_key)).to be true
     end
 
-    it 'rejects a non-HTTP SLS URL' do
-      settings = build(:account_saml_settings, account: account, sls_url: 'javascript:alert(1)')
+    [
+      'javascript:alert(1)/*http://a.com*/',
+      'javascript:https://a.com',
+      "http://a.com\nX-Injected: 1",
+      'data:text/html,<b>#https://a.com'
+    ].each do |sls_url|
+      it "rejects the non-HTTP SLS URL #{sls_url.inspect}" do
+        settings = build(:account_saml_settings, account: account, sls_url: sls_url)
 
-      expect(settings).not_to be_valid
-      expect(settings.errors[:sls_url]).to be_present
+        expect(settings).not_to be_valid
+        expect(settings.errors[:sls_url]).to be_present
+      end
     end
 
     it 'exposes a signed service provider SLS URL that resolves to the settings record' do


### PR DESCRIPTION
## What this does

Adds IdP-initiated **back-channel** SAML Single Logout. When an administrator deactivates a user in
the identity provider, the IdP POSTs a signed `<LogoutRequest>` to Chatwoot and that user's sessions
are revoked — with no browser involved.

Today, disabling a user in the IdP prevents future logins but leaves existing Chatwoot sessions alive
until their tokens expire, which is two months by default (`config/initializers/devise_token_auth.rb`).
For anyone using SAML for staff offboarding, that is the gap this closes.

Refs #11288. Supersedes the approach in the closed #12397.

## Why this differs from #12397

#12397 implemented **front-channel** logout: it resolved the user from `session["saml_uid"]`, which
requires the user's browser and cookie to be present. A back-channel LogoutRequest arrives
server-to-server with neither, so that approach cannot serve the deprovisioning case. It was closed
by its author as out of sync and its `SessionManageable` concern never shipped; this is a fresh
implementation built on what is in `develop` today.

## Security design

The endpoint is unauthenticated by necessity, multi-tenant, and destroys sessions — so the ordering
of checks is deliberate and load-bearing.

**Tenant is established before any attacker-controlled XML is parsed.** The IdP posts to a
per-settings URL carrying an `ActiveSupport::MessageVerifier` signed id (purpose-scoped, URL-safe,
constant-time comparison). The account is therefore known from a value Chatwoot itself issued, not
from the request body.

**The signature is verified against that tenant's configured IdP certificate before the SAML library
sees the document.** This matters: `OneLogin::RubySaml::SloLogoutrequest#validate_signature` returns
early when there are no `:get_params`, so for the HTTP-POST binding the gem performs *no* signature
validation at all. `Saml::LogoutRequestValidator#validate_xml_signature!` runs first and independently,
and an in-document `ds:X509Certificate` that does not match the configured certificate is rejected
rather than trusted.

**Structural guards run on the raw bytes**, before anything is trusted: exactly one signature, on the
document root; the signature `Reference` must point at that root; the transform chain must be exactly
`[enveloped-signature, exc-c14n]`; comment-preserving canonicalisation and SHA-1 are refused; DOCTYPE
is rejected. These specifically defeat signature-wrapping (XSW) variants.

**Binding is triple**: IdP certificate, exact `Issuer` match, and `Destination` equal to the signed
per-settings URL — so a request signed for one tenant cannot revoke sessions in another.

**Revocation covers both credential types.** Clearing `tokens` ends browser/mobile sessions, and the
user's personal API access token is rotated in the same transaction — otherwise a deprovisioned user
would keep full API access via `api_access_token` despite a successful logout.

**Rate limited** to 30 requests/minute per IP, and if the replay store is unavailable the request is
refused with `503` rather than processed without replay protection.

**Replay** requests are claimed atomically in Redis (`SET NX EX`) for longer than the acceptance
window, so a captured request cannot outlive its own `IssueInstant` check.

## Reviewing this

The specs drive real signed XML end-to-end through HTTP — nothing mocks the validator — and cover the
negatives: unsigned, wrong key, wrong issuer, wrong `Destination`, SHA-1 downgrade, comment-preserving
c14n, XSW variants, DOCTYPE/XXE, oversized payloads, replay, stale and future timestamps, cross-tenant
endpoint swap, feature disabled, unknown NameID.

## Deliberate constraints, and interop notes

These are stricter than SAML 2.0 core requires. Flagging them so they read as decisions rather than bugs:

- **`Destination` is mandatory.** Optional in the spec, but it is the cross-tenant guard here.
- **NameID `Format` must be `emailAddress`.** Note some IdPs default to `persistent` or `unspecified`.
- **Transform chain must be exactly `[enveloped-signature, exc-c14n]`**, in that order.
- **Only the HTTP-POST binding is accepted** for the request; the `LogoutResponse` is returned as a
  Redirect-binding URL.
- **Cross-account effect:** `User#tokens` is global, so revoking a user via one account's IdP ends
  that person's sessions in every account they belong to. That is arguably correct for a single human
  being deprovisioned, but it is a cross-account effect and worth being explicit about.

## Out of scope

SP-initiated logout (`/spslo`), and OIDC back-channel logout.

## Testing against a real IdP

1. Enable the `saml` feature for the account and configure SAML as usual.
2. Copy the SP single-logout URL exposed on the settings endpoint into the IdP's provider config, and
   set the IdP's own SLS URL in Chatwoot.
3. Sign in as an agent, then deactivate that user in the IdP.
4. The IdP posts a signed LogoutRequest; the agent's sessions are revoked and a signed
   `LogoutResponse` is returned.
