### PR TITLE
perf: avoid per-membership queries in user auth payload

### DIFF
--- a/app/views/api/v1/models/_user.json.jbuilder
+++ b/app/views/api/v1/models/_user.json.jbuilder
@@ -1,7 +1,8 @@
 # loaded once here; per-row lookups below would otherwise cost a query per membership
 account_users = resource.account_users.includes(:account)
 account_users = account_users.includes(:custom_role) if ChatwootApp.enterprise?
-active_account_user = account_users.max_by { |account_user| account_user.active_at&.to_i || 0 }
+# full-precision timestamps, nils last, matching ORDER BY active_at DESC NULLS LAST
+active_account_user = account_users.max_by { |account_user| [account_user.active_at ? 1 : 0, account_user.active_at || Time.at(0).utc] }
 
 json.access_token resource.accounts.any?(&:api_and_webhooks_enabled?) ? resource.access_token.token : ''
 json.account_id active_account_user&.account_id

--- a/app/views/api/v1/models/_user.json.jbuilder
+++ b/app/views/api/v1/models/_user.json.jbuilder
@@ -1,5 +1,10 @@
+# loaded once here; per-row lookups below would otherwise cost a query per membership
+account_users = resource.account_users.includes(:account)
+account_users = account_users.includes(:custom_role) if ChatwootApp.enterprise?
+active_account_user = account_users.max_by { |account_user| account_user.active_at&.to_i || 0 }
+
 json.access_token resource.accounts.any?(&:api_and_webhooks_enabled?) ? resource.access_token.token : ''
-json.account_id resource.active_account_user&.account_id
+json.account_id active_account_user&.account_id
 json.available_name resource.available_name
 json.avatar_url resource.avatar_url
 json.confirmed resource.confirmed?
@@ -8,17 +13,17 @@ json.message_signature resource.message_signature
 json.email resource.email
 json.hmac_identifier resource.hmac_identifier if GlobalConfig.get('CHATWOOT_INBOX_HMAC_KEY')['CHATWOOT_INBOX_HMAC_KEY'].present?
 json.id resource.id
-json.inviter_id resource.active_account_user&.inviter_id
+json.inviter_id active_account_user&.inviter_id
 json.name resource.name
 json.provider resource.provider
 json.pubsub_token resource.pubsub_token
 json.custom_attributes resource.custom_attributes if resource.custom_attributes.present?
-json.role resource.active_account_user&.role
+json.role active_account_user&.role
 json.ui_settings resource.ui_settings
 json.uid resource.uid
 json.type resource.type
 json.accounts do
-  json.array! resource.account_users do |account_user|
+  json.array! account_users do |account_user|
     json.id account_user.account_id
     json.name account_user.account.name
     json.status account_user.account.status

--- a/spec/controllers/devise/token_validations_controller_spec.rb
+++ b/spec/controllers/devise/token_validations_controller_spec.rb
@@ -22,5 +22,39 @@ RSpec.describe 'Token Validation API', type: :request do
         expect(response.body).to include('payload')
       end
     end
+
+    context 'when the user belongs to many accounts' do
+      def count_sql_queries
+        queries = []
+        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |_name, _started, _finished, _id, payload|
+          next if payload[:cached] || %w[SCHEMA TRANSACTION].include?(payload[:name])
+
+          queries << payload[:sql]
+        end
+        yield
+        queries.length
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      def user_with_accounts(count)
+        user = create(:user)
+        count.times { create(:account_user, user: user, account: create(:account)) }
+        user
+      end
+
+      it 'does not run additional queries per account membership' do
+        few_headers = user_with_accounts(2).create_new_auth_token
+        many_headers = user_with_accounts(15).create_new_auth_token
+
+        few_queries = count_sql_queries { get '/auth/validate_token', headers: few_headers }
+        expect(response).to have_http_status(:success)
+
+        many_queries = count_sql_queries { get '/auth/validate_token', headers: many_headers }
+        expect(response).to have_http_status(:success)
+
+        expect(many_queries).to eq(few_queries)
+      end
+    end
   end
 end

--- a/spec/controllers/devise/token_validations_controller_spec.rb
+++ b/spec/controllers/devise/token_validations_controller_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe 'Token Validation API', type: :request do
         few_headers = user_with_accounts(2).create_new_auth_token
         many_headers = user_with_accounts(15).create_new_auth_token
 
+        # warmup so one-time app initialization queries don't skew the first measured request
+        get '/auth/validate_token', headers: few_headers
+
         few_queries = count_sql_queries { get '/auth/validate_token', headers: few_headers }
         expect(response).to have_http_status(:success)
 


### PR DESCRIPTION
# Pull Request Template

## Description

The user payload rendered by `api/v1/models/_user.json.jbuilder` (shared by sign-in, token validation, and profile endpoints) iterates the user's account memberships and previously issued one `accounts` lookup per membership, one `custom_role` lookup per membership on enterprise, and re-ran the unmemoized `active_account_user` ordering query three times per render. For users belonging to many accounts this makes the auth response cost linear in membership count and can push `/auth/sign_in` and `/auth/validate_token` past the request timeout.

This change preloads the memberships once (`includes(:account)`, plus `:custom_role` on enterprise) and derives the active account in memory from the preloaded rows, keeping full timestamp precision and `NULLS LAST` semantics.

Measured by counting SQL queries per request at increasing membership counts:

| Memberships | `GET /auth/validate_token` on develop | with this change |
|---|---|---|
| 1 | 10 | 9 |
| 10 | 19 | 9 |
| 100 | 109 | 9 |
| 500 | 509 | 9 |

`POST /auth/sign_in` drops from 2016 to 1516 queries at 500 memberships; its remaining growth comes from the per-account audit writes addressed in #15572. With both changes applied, sign-in settles at 19 queries and token validation at 9, independent of membership count.

Fixes https://linear.app/chatwoot/issue/INF-103

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested locally with users in 1, 10, 100, and 500 accounts; the query counts above are from those runs.
- New request spec asserts the SQL query count for `/auth/validate_token` does not grow with the number of account memberships (fails on develop, passes with this change).
- Existing specs covering all render sites of the partial (devise sessions/token validations, profiles, enterprise profiles) pass locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
