### PR TITLE
feat: add Captain scenario and tool toggles

### DIFF
--- a/app/javascript/dashboard/components-next/captain/assistant/ScenariosCard.vue
+++ b/app/javascript/dashboard/components-next/captain/assistant/ScenariosCard.vue
@@ -12,6 +12,8 @@ import Editor from 'dashboard/components-next/Editor/Editor.vue';
 import CardLayout from 'dashboard/components-next/CardLayout.vue';
 import Checkbox from 'dashboard/components-next/checkbox/Checkbox.vue';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
+import Switch from 'dashboard/components-next/switch/Switch.vue';
+import Policy from 'dashboard/components/policy.vue';
 
 const props = defineProps({
   id: {
@@ -34,6 +36,14 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+  isUpdating: {
+    type: Boolean,
+    default: false,
+  },
   selectable: {
     type: Boolean,
     default: false,
@@ -44,7 +54,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['select', 'hover', 'delete', 'update']);
+const emit = defineEmits(['select', 'hover', 'delete', 'update', 'toggle']);
 
 const { t } = useI18n();
 const { formatMessage } = useMessageFormatter();
@@ -53,6 +63,17 @@ const modelValue = computed({
   get: () => props.isSelected,
   set: () => emit('select', props.id),
 });
+
+const enabledState = computed({
+  get: () => props.enabled,
+  set: enabled => emit('toggle', { id: props.id, enabled }),
+});
+
+const statusLabel = computed(() =>
+  props.enabled
+    ? t('CAPTAIN.ASSISTANTS.SCENARIOS.STATUS.ENABLED')
+    : t('CAPTAIN.ASSISTANTS.SCENARIOS.STATUS.DISABLED')
+);
 
 const state = reactive({
   id: '',
@@ -151,6 +172,24 @@ const renderInstruction = instruction => () =>
           </span>
         </div>
         <div class="flex items-center gap-2">
+          <span class="text-xs text-n-slate-11">
+            {{ statusLabel }}
+          </span>
+          <Policy
+            as="span"
+            :permissions="['administrator']"
+            class="inline-flex items-center"
+          >
+            <Switch
+              v-model="enabledState"
+              :disabled="isUpdating"
+              :aria-label="
+                t('CAPTAIN.ASSISTANTS.SCENARIOS.STATUS.TOGGLE', { title })
+              "
+              :class="{ 'opacity-50 cursor-not-allowed': isUpdating }"
+            />
+          </Policy>
+          <span class="w-px h-4 bg-n-weak" />
           <!-- <Button label="Test" slate xs ghost class="!text-sm" />
           <span class="w-px h-4 bg-n-weak" /> -->
           <Button icon="i-lucide-pen" slate xs ghost @click="startEdit" />

--- a/app/javascript/dashboard/components-next/captain/pageComponents/customTool/CustomToolCard.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/customTool/CustomToolCard.vue
@@ -7,6 +7,7 @@ import { dynamicTime } from 'shared/helpers/timeHelper';
 import CardLayout from 'dashboard/components-next/CardLayout.vue';
 import DropdownMenu from 'dashboard/components-next/dropdown-menu/DropdownMenu.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
+import Switch from 'dashboard/components-next/switch/Switch.vue';
 import Policy from 'dashboard/components/policy.vue';
 
 const props = defineProps({
@@ -26,6 +27,14 @@ const props = defineProps({
     type: String,
     default: 'none',
   },
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+  isUpdating: {
+    type: Boolean,
+    default: false,
+  },
   updatedAt: {
     type: Number,
     required: true,
@@ -36,11 +45,22 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['action']);
+const emit = defineEmits(['action', 'toggle']);
 
 const { t } = useI18n();
 
 const [showActionsDropdown, toggleDropdown] = useToggle();
+
+const enabledState = computed({
+  get: () => props.enabled,
+  set: enabled => emit('toggle', { id: props.id, enabled }),
+});
+
+const statusLabel = computed(() =>
+  props.enabled
+    ? t('CAPTAIN.CUSTOM_TOOLS.STATUS.ENABLED')
+    : t('CAPTAIN.CUSTOM_TOOLS.STATUS.DISABLED')
+);
 
 const menuItems = computed(() => [
   {
@@ -80,6 +100,21 @@ const authTypeLabel = computed(() => {
         {{ title }}
       </span>
       <div class="flex items-center gap-2">
+        <span class="text-xs text-n-slate-11">
+          {{ statusLabel }}
+        </span>
+        <Policy
+          as="span"
+          :permissions="['administrator']"
+          class="inline-flex items-center"
+        >
+          <Switch
+            v-model="enabledState"
+            :disabled="isUpdating"
+            :aria-label="t('CAPTAIN.CUSTOM_TOOLS.STATUS.TOGGLE', { title })"
+            :class="{ 'opacity-50 cursor-not-allowed': isUpdating }"
+          />
+        </Policy>
         <Policy
           v-on-clickaway="() => toggleDropdown(false)"
           :permissions="['administrator']"

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -875,6 +875,11 @@
           "CANCEL": "Cancel",
           "UPDATE": "Update changes"
         },
+        "STATUS": {
+          "ENABLED": "Enabled",
+          "DISABLED": "Disabled",
+          "TOGGLE": "Toggle {title}"
+        },
         "LIST": {
           "SEARCH_PLACEHOLDER": "Search..."
         },
@@ -888,6 +893,11 @@
           "UPDATE": {
             "SUCCESS": "Scenarios updated successfully",
             "ERROR": "There was an error updating scenarios, please try again."
+          },
+          "TOGGLE": {
+            "ENABLED": "Scenario enabled successfully",
+            "DISABLED": "Scenario disabled successfully",
+            "ERROR": "There was an error updating the scenario status, please try again."
           },
           "DELETE": {
             "SUCCESS": "Scenarios deleted successfully",
@@ -1056,6 +1066,16 @@
       "OPTIONS": {
         "EDIT_TOOL": "Edit tool",
         "DELETE_TOOL": "Delete tool"
+      },
+      "STATUS": {
+        "ENABLED": "Enabled",
+        "DISABLED": "Disabled",
+        "TOGGLE": "Toggle {title}"
+      },
+      "TOGGLE": {
+        "ENABLED": "Tool enabled successfully",
+        "DISABLED": "Tool disabled successfully",
+        "ERROR": "Failed to update tool status"
       },
       "CREATE": {
         "TITLE": "Create Custom Tool",

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -1077,6 +1077,12 @@
         "DISABLED": "Tool disabled successfully",
         "ERROR": "Failed to update tool status"
       },
+      "DISABLE_CONFIRMATION": {
+        "TITLE": "Disable {title}?",
+        "DESCRIPTION_ONE": "This tool is used by {count} enabled scenario. Disabling it may cause that scenario to stop working as expected.",
+        "DESCRIPTION_OTHER": "This tool is used by {count} enabled scenarios. Disabling it may cause those scenarios to stop working as expected.",
+        "CONFIRM": "Disable tool"
+      },
       "CREATE": {
         "TITLE": "Create Custom Tool",
         "SUCCESS_MESSAGE": "Custom tool created successfully",

--- a/app/javascript/dashboard/routes/dashboard/captain/assistants/scenarios/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/assistants/scenarios/Index.vue
@@ -70,6 +70,17 @@ const closeSuggestedRules = () => {
 // Bulk selection & hover state
 const bulkSelectedIds = ref(new Set());
 const hoveredCard = ref(null);
+const pendingToggleIds = ref(new Set());
+
+const setTogglePending = (id, isPending) => {
+  const pendingIds = new Set(pendingToggleIds.value);
+  if (isPending) {
+    pendingIds.add(id);
+  } else {
+    pendingIds.delete(id);
+  }
+  pendingToggleIds.value = pendingIds;
+};
 
 const handleRuleSelect = id => {
   const selected = new Set(bulkSelectedIds.value);
@@ -115,6 +126,27 @@ const updateScenario = async scenario => {
       error?.response?.message ||
       t('CAPTAIN.ASSISTANTS.SCENARIOS.API.UPDATE.ERROR');
     useAlert(errorMessage);
+  }
+};
+
+const toggleScenario = async ({ id, enabled }) => {
+  if (pendingToggleIds.value.has(id)) return;
+
+  setTogglePending(id, true);
+  try {
+    await store.dispatch('captainScenarios/update', {
+      id,
+      assistantId: assistantId.value,
+      enabled,
+    });
+    const successMessage = enabled
+      ? t('CAPTAIN.ASSISTANTS.SCENARIOS.API.TOGGLE.ENABLED')
+      : t('CAPTAIN.ASSISTANTS.SCENARIOS.API.TOGGLE.DISABLED');
+    useAlert(successMessage);
+  } catch {
+    useAlert(t('CAPTAIN.ASSISTANTS.SCENARIOS.API.TOGGLE.ERROR'));
+  } finally {
+    setTogglePending(id, false);
   }
 };
 
@@ -286,6 +318,8 @@ onMounted(() => {
             :description="scenario.description"
             :instruction="scenario.instruction"
             :tools="scenario.tools"
+            :enabled="scenario.enabled"
+            :is-updating="pendingToggleIds.has(scenario.id)"
             :is-selected="bulkSelectedIds.has(scenario.id)"
             :selectable="
               hoveredCard === scenario.id || bulkSelectedIds.size > 0
@@ -293,6 +327,7 @@ onMounted(() => {
             @select="handleRuleSelect"
             @delete="deleteScenario(scenario.id)"
             @update="updateScenario"
+            @toggle="toggleScenario"
             @hover="isHovered => handleRuleHover(isHovered, scenario.id)"
           />
         </div>

--- a/app/javascript/dashboard/routes/dashboard/captain/tools/Index.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/captain/tools/Index.spec.js
@@ -1,0 +1,177 @@
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import Index from './Index.vue';
+
+const mocks = vi.hoisted(() => ({
+  alerts: vi.fn(),
+  dialogClose: vi.fn(),
+  dialogOpen: vi.fn(),
+  dispatch: vi.fn(),
+  getterValues: null,
+}));
+
+const translate = (key, params = {}) => {
+  if (key === 'CAPTAIN.CUSTOM_TOOLS.DISABLE_CONFIRMATION.DESCRIPTION_OTHER') {
+    return `This tool is used by ${params.count} enabled scenarios.`;
+  }
+  if (key === 'CAPTAIN.CUSTOM_TOOLS.DISABLE_CONFIRMATION.TITLE') {
+    return `Disable ${params.title}?`;
+  }
+  return key;
+};
+
+vi.mock('dashboard/composables/store', async () => {
+  const { ref } = await import('vue');
+  mocks.getterValues = {
+    'captainCustomTools/getRecords': ref([
+      {
+        id: 7,
+        title: 'Order lookup',
+        description: 'Looks up an order',
+        enabled: true,
+        created_at: 1_700_000_000,
+        updated_at: 1_700_000_000,
+      },
+    ]),
+    'captainCustomTools/getMeta': ref({ totalCount: 1, page: 1 }),
+    'captainCustomTools/getUIFlags': ref({ fetchingList: false }),
+  };
+
+  return {
+    useStore: () => ({ dispatch: mocks.dispatch }),
+    useMapGetter: key => mocks.getterValues[key],
+  };
+});
+
+vi.mock('dashboard/composables', () => ({ useAlert: mocks.alerts }));
+
+vi.mock('dashboard/composables/usePolicy', () => ({
+  usePolicy: () => ({
+    isFeatureFlagEnabled: () => true,
+    shouldShowPaywall: () => false,
+  }),
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: translate }),
+}));
+
+const PageLayoutStub = {
+  inheritAttrs: false,
+  emits: ['click'],
+  template: '<div><slot name="body" /></div>',
+};
+
+const CustomToolCardStub = {
+  props: ['id', 'enabled', 'isUpdating'],
+  emits: ['toggle'],
+  template: `
+    <button
+      data-test="toggle"
+      :disabled="isUpdating"
+      @click="$emit('toggle', { id, enabled: !enabled })"
+    />
+  `,
+};
+
+const DialogStub = {
+  props: ['title', 'description', 'confirmButtonLabel', 'isLoading'],
+  emits: ['confirm', 'close'],
+  methods: {
+    open() {
+      mocks.dialogOpen();
+    },
+    close() {
+      mocks.dialogClose();
+      this.$emit('close');
+    },
+  },
+  template: `
+    <div data-test="disable-dialog">
+      <button data-test="confirm" @click="$emit('confirm')" />
+    </div>
+  `,
+};
+
+const mountIndex = () =>
+  shallowMount(Index, {
+    global: {
+      mocks: { $t: translate },
+      stubs: {
+        PageLayout: PageLayoutStub,
+        CaptainPaywall: true,
+        CustomToolsPageEmptyState: true,
+        CreateCustomToolDialog: true,
+        CustomToolCard: CustomToolCardStub,
+        DeleteDialog: true,
+        Dialog: DialogStub,
+      },
+    },
+  });
+
+describe('Captain custom tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.dispatch.mockResolvedValue(undefined);
+  });
+
+  it('confirms before disabling a tool used by enabled scenarios', async () => {
+    mocks.dispatch.mockImplementation(action => {
+      if (action === 'captainCustomTools/show') {
+        return Promise.resolve({
+          id: 7,
+          title: 'Order lookup',
+          enabled_scenarios_count: 2,
+        });
+      }
+      return Promise.resolve();
+    });
+    const wrapper = mountIndex();
+
+    await flushPromises();
+    await wrapper.get('[data-test="toggle"]').trigger('click');
+    await flushPromises();
+
+    expect(mocks.dispatch).toHaveBeenCalledWith('captainCustomTools/show', 7);
+    expect(mocks.dispatch).not.toHaveBeenCalledWith(
+      'captainCustomTools/update',
+      expect.anything()
+    );
+    expect(mocks.dialogOpen).toHaveBeenCalledOnce();
+    expect(wrapper.findComponent(DialogStub).props('description')).toBe(
+      'This tool is used by 2 enabled scenarios.'
+    );
+
+    await wrapper.get('[data-test="confirm"]').trigger('click');
+    await flushPromises();
+
+    expect(mocks.dispatch).toHaveBeenCalledWith('captainCustomTools/update', {
+      id: 7,
+      enabled: false,
+    });
+    expect(mocks.dialogClose).toHaveBeenCalledOnce();
+  });
+
+  it('disables immediately when no enabled scenarios use the tool', async () => {
+    mocks.dispatch.mockImplementation(action => {
+      if (action === 'captainCustomTools/show') {
+        return Promise.resolve({
+          id: 7,
+          title: 'Order lookup',
+          enabled_scenarios_count: 0,
+        });
+      }
+      return Promise.resolve();
+    });
+    const wrapper = mountIndex();
+
+    await flushPromises();
+    await wrapper.get('[data-test="toggle"]').trigger('click');
+    await flushPromises();
+
+    expect(mocks.dispatch).toHaveBeenCalledWith('captainCustomTools/update', {
+      id: 7,
+      enabled: false,
+    });
+    expect(mocks.dialogOpen).not.toHaveBeenCalled();
+  });
+});

--- a/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
@@ -12,6 +12,7 @@ import CustomToolsPageEmptyState from 'dashboard/components-next/captain/pageCom
 import CreateCustomToolDialog from 'dashboard/components-next/captain/pageComponents/customTool/CreateCustomToolDialog.vue';
 import CustomToolCard from 'dashboard/components-next/captain/pageComponents/customTool/CustomToolCard.vue';
 import DeleteDialog from 'dashboard/components-next/captain/pageComponents/DeleteDialog.vue';
+import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
 
 const store = useStore();
 const { t } = useI18n();
@@ -31,9 +32,29 @@ const showSoftLimitWarning = computed(
 
 const createDialogRef = ref(null);
 const deleteDialogRef = ref(null);
+const disableDialogRef = ref(null);
 const selectedTool = ref(null);
 const dialogType = ref('');
 const pendingToggleIds = ref(new Set());
+const pendingDisable = ref(null);
+const isDisableSaving = ref(false);
+
+const disableConfirmationTitle = computed(() =>
+  t('CAPTAIN.CUSTOM_TOOLS.DISABLE_CONFIRMATION.TITLE', {
+    title: pendingDisable.value?.title,
+  })
+);
+
+const disableConfirmationDescription = computed(() => {
+  const count = pendingDisable.value?.enabledScenariosCount || 0;
+  return count === 1
+    ? t('CAPTAIN.CUSTOM_TOOLS.DISABLE_CONFIRMATION.DESCRIPTION_ONE', {
+        count,
+      })
+    : t('CAPTAIN.CUSTOM_TOOLS.DISABLE_CONFIRMATION.DESCRIPTION_OTHER', {
+        count,
+      });
+});
 
 const setTogglePending = (id, isPending) => {
   const pendingIds = new Set(pendingToggleIds.value);
@@ -77,21 +98,66 @@ const handleAction = ({ action, id }) => {
   }
 };
 
-const toggleCustomTool = async ({ id, enabled }) => {
-  if (pendingToggleIds.value.has(id)) return;
-
-  setTogglePending(id, true);
+const updateCustomToolStatus = async ({ id, enabled }) => {
   try {
     await store.dispatch('captainCustomTools/update', { id, enabled });
     const successMessage = enabled
       ? t('CAPTAIN.CUSTOM_TOOLS.TOGGLE.ENABLED')
       : t('CAPTAIN.CUSTOM_TOOLS.TOGGLE.DISABLED');
     useAlert(successMessage);
+    return true;
   } catch {
     useAlert(t('CAPTAIN.CUSTOM_TOOLS.TOGGLE.ERROR'));
-  } finally {
-    setTogglePending(id, false);
+    return false;
   }
+};
+
+const toggleCustomTool = async ({ id, enabled }) => {
+  if (pendingToggleIds.value.has(id)) return;
+
+  setTogglePending(id, true);
+
+  if (!enabled) {
+    try {
+      const tool = await store.dispatch('captainCustomTools/show', id);
+      if (tool.enabled_scenarios_count > 0) {
+        pendingDisable.value = {
+          id,
+          enabled,
+          title: tool.title,
+          enabledScenariosCount: tool.enabled_scenarios_count,
+        };
+        await nextTick();
+        disableDialogRef.value?.open();
+        return;
+      }
+    } catch {
+      useAlert(t('CAPTAIN.CUSTOM_TOOLS.TOGGLE.ERROR'));
+      setTogglePending(id, false);
+      return;
+    }
+  }
+
+  await updateCustomToolStatus({ id, enabled });
+  setTogglePending(id, false);
+};
+
+const handleDisableConfirm = async () => {
+  if (!pendingDisable.value) return;
+
+  isDisableSaving.value = true;
+  const updated = await updateCustomToolStatus(pendingDisable.value);
+  isDisableSaving.value = false;
+
+  if (updated) disableDialogRef.value?.close();
+};
+
+const handleDisableDialogClose = () => {
+  if (pendingDisable.value) {
+    setTogglePending(pendingDisable.value.id, false);
+  }
+  pendingDisable.value = null;
+  isDisableSaving.value = false;
 };
 
 const handleDialogClose = () => {
@@ -186,5 +252,18 @@ onMounted(() => {
     type="CustomTools"
     translation-key="CUSTOM_TOOLS"
     @delete-success="onDeleteSuccess"
+  />
+
+  <Dialog
+    ref="disableDialogRef"
+    type="alert"
+    :title="disableConfirmationTitle"
+    :description="disableConfirmationDescription"
+    :confirm-button-label="
+      t('CAPTAIN.CUSTOM_TOOLS.DISABLE_CONFIRMATION.CONFIRM')
+    "
+    :is-loading="isDisableSaving"
+    @confirm="handleDisableConfirm"
+    @close="handleDisableDialogClose"
   />
 </template>

--- a/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { computed, onMounted, ref, nextTick } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useMapGetter, useStore } from 'dashboard/composables/store';
+import { useAlert } from 'dashboard/composables';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import { usePolicy } from 'dashboard/composables/usePolicy';
 
@@ -12,6 +14,7 @@ import CustomToolCard from 'dashboard/components-next/captain/pageComponents/cus
 import DeleteDialog from 'dashboard/components-next/captain/pageComponents/DeleteDialog.vue';
 
 const store = useStore();
+const { t } = useI18n();
 const { isFeatureFlagEnabled, shouldShowPaywall } = usePolicy();
 
 const SOFT_LIMIT = 10;
@@ -30,6 +33,17 @@ const createDialogRef = ref(null);
 const deleteDialogRef = ref(null);
 const selectedTool = ref(null);
 const dialogType = ref('');
+const pendingToggleIds = ref(new Set());
+
+const setTogglePending = (id, isPending) => {
+  const pendingIds = new Set(pendingToggleIds.value);
+  if (isPending) {
+    pendingIds.add(id);
+  } else {
+    pendingIds.delete(id);
+  }
+  pendingToggleIds.value = pendingIds;
+};
 
 const fetchCustomTools = (page = 1) => {
   store.dispatch('captainCustomTools/get', { page });
@@ -55,11 +69,28 @@ const handleDelete = tool => {
 };
 
 const handleAction = ({ action, id }) => {
-  const tool = customTools.value.find(t => t.id === id);
+  const tool = customTools.value.find(item => item.id === id);
   if (action === 'edit') {
     handleEdit(tool);
   } else if (action === 'delete') {
     handleDelete(tool);
+  }
+};
+
+const toggleCustomTool = async ({ id, enabled }) => {
+  if (pendingToggleIds.value.has(id)) return;
+
+  setTogglePending(id, true);
+  try {
+    await store.dispatch('captainCustomTools/update', { id, enabled });
+    const successMessage = enabled
+      ? t('CAPTAIN.CUSTOM_TOOLS.TOGGLE.ENABLED')
+      : t('CAPTAIN.CUSTOM_TOOLS.TOGGLE.DISABLED');
+    useAlert(successMessage);
+  } catch {
+    useAlert(t('CAPTAIN.CUSTOM_TOOLS.TOGGLE.ERROR'));
+  } finally {
+    setTogglePending(id, false);
   }
 };
 
@@ -130,9 +161,11 @@ onMounted(() => {
           :auth-type="tool.auth_type"
           :param-schema="tool.param_schema"
           :enabled="tool.enabled"
+          :is-updating="pendingToggleIds.has(tool.id)"
           :created-at="tool.created_at"
           :updated-at="tool.updated_at"
           @action="handleAction"
+          @toggle="toggleCustomTool"
         />
       </div>
     </template>

--- a/enterprise/app/controllers/api/v1/accounts/captain/scenarios_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/scenarios_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Accounts::Captain::ScenariosController < Api::V1::Accounts::BaseC
   before_action :set_scenario, only: [:show, :update, :destroy]
 
   def index
-    @scenarios = assistant_scenarios.enabled
+    @scenarios = assistant_scenarios
   end
 
   def show; end

--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -134,6 +134,8 @@ class Captain::Assistant < ApplicationRecord
     tools
   end
 
+  def available_tool_ids = available_agent_tools.pluck(:id)
+
   def known_tool_ids
     self.class.built_in_tool_ids + account.captain_custom_tools.pluck(:slug)
   end

--- a/enterprise/app/models/captain/assistant.rb
+++ b/enterprise/app/models/captain/assistant.rb
@@ -134,8 +134,8 @@ class Captain::Assistant < ApplicationRecord
     tools
   end
 
-  def available_tool_ids
-    available_agent_tools.pluck(:id)
+  def known_tool_ids
+    self.class.built_in_tool_ids + account.captain_custom_tools.pluck(:slug)
   end
 
   def push_event_data

--- a/enterprise/app/models/captain/custom_tool.rb
+++ b/enterprise/app/models/captain/custom_tool.rb
@@ -80,6 +80,10 @@ class Captain::CustomTool < ApplicationRecord
     }
   end
 
+  def enabled_scenarios_count
+    Captain::Scenario.enabled.where(account_id: account_id).where('tools @> ?', [slug].to_json).count
+  end
+
   private
 
   def ensure_within_limit

--- a/enterprise/app/models/captain/scenario.rb
+++ b/enterprise/app/models/captain/scenario.rb
@@ -149,8 +149,7 @@ class Captain::Scenario < ApplicationRecord
     tool_ids = extract_tool_ids_from_text(instruction)
     return if tool_ids.empty?
 
-    all_available_tool_ids = assistant.available_tool_ids
-    invalid_tools = tool_ids - all_available_tool_ids
+    invalid_tools = tool_ids - assistant.known_tool_ids
 
     return unless invalid_tools.any?
 

--- a/enterprise/app/views/api/v1/accounts/captain/custom_tools/show.json.jbuilder
+++ b/enterprise/app/views/api/v1/accounts/captain/custom_tools/show.json.jbuilder
@@ -1,1 +1,2 @@
 json.partial! 'api/v1/models/captain/custom_tool', custom_tool: @custom_tool
+json.enabled_scenarios_count @custom_tool.enabled_scenarios_count

--- a/spec/enterprise/controllers/api/v1/accounts/captain/custom_tools_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/custom_tools_controller_spec.rb
@@ -85,6 +85,21 @@ RSpec.describe 'Api::V1::Accounts::Captain::CustomTools', type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    it 'returns the number of enabled scenarios referencing the tool' do
+      custom_tool.update!(slug: 'custom_fetch-order')
+      assistant = create(:captain_assistant, account: account)
+      instruction = 'Use [@Fetch Order](tool://custom_fetch-order) to get order details'
+      create(:captain_scenario, assistant: assistant, account: account, instruction: instruction, enabled: true)
+      create(:captain_scenario, assistant: assistant, account: account, instruction: instruction, enabled: false)
+
+      get "/api/v1/accounts/#{account.id}/captain/custom_tools/#{custom_tool.id}",
+          headers: admin.create_new_auth_token,
+          as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(json_response[:enabled_scenarios_count]).to eq(1)
+    end
   end
 
   describe 'POST /api/v1/accounts/{account.id}/captain/custom_tools' do

--- a/spec/enterprise/controllers/api/v1/accounts/captain/custom_tools_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/custom_tools_controller_spec.rb
@@ -218,6 +218,7 @@ RSpec.describe 'Api::V1::Accounts::Captain::CustomTools', type: :request do
         expect(response).to have_http_status(:success)
         expect(json_response[:title]).to eq('Updated Tool Title')
         expect(json_response[:enabled]).to be(false)
+        expect(custom_tool.reload.enabled).to be(false)
       end
 
       context 'with invalid parameters' do

--- a/spec/enterprise/controllers/api/v1/accounts/captain/scenarios_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/captain/scenarios_controller_spec.rb
@@ -41,16 +41,18 @@ RSpec.describe 'Api::V1::Accounts::Captain::Scenarios', type: :request do
         expect(json_response[:payload].length).to eq(5)
       end
 
-      it 'returns only enabled scenarios' do
-        create(:captain_scenario, assistant: assistant, account: account, enabled: true)
-        create(:captain_scenario, assistant: assistant, account: account, enabled: false)
+      it 'returns enabled and disabled scenarios' do
+        enabled_scenario = create(:captain_scenario, assistant: assistant, account: account, enabled: true)
+        disabled_scenario = create(:captain_scenario, assistant: assistant, account: account, enabled: false)
         get "/api/v1/accounts/#{account.id}/captain/assistants/#{assistant.id}/scenarios",
             headers: admin.create_new_auth_token,
             as: :json
 
         expect(response).to have_http_status(:success)
-        expect(json_response[:payload].length).to eq(1)
-        expect(json_response[:payload].first[:enabled]).to be(true)
+        expect(json_response[:payload]).to contain_exactly(
+          hash_including(id: enabled_scenario.id, enabled: true),
+          hash_including(id: disabled_scenario.id, enabled: false)
+        )
       end
     end
   end
@@ -194,6 +196,7 @@ RSpec.describe 'Api::V1::Accounts::Captain::Scenarios', type: :request do
         expect(response).to have_http_status(:success)
         expect(json_response[:title]).to eq('Updated Scenario Title')
         expect(json_response[:enabled]).to be(false)
+        expect(scenario.reload.enabled).to be(false)
       end
 
       context 'with invalid parameters' do

--- a/spec/enterprise/models/captain/assistant_spec.rb
+++ b/spec/enterprise/models/captain/assistant_spec.rb
@@ -302,6 +302,24 @@ RSpec.describe Captain::Assistant, type: :model do
     end
   end
 
+  describe '#available_tool_ids' do
+    it 'excludes disabled custom tools' do
+      enabled_tool = create(:captain_custom_tool, account: account)
+      disabled_tool = create(:captain_custom_tool, :disabled, account: account)
+
+      expect(assistant.available_tool_ids).to include(enabled_tool.slug)
+      expect(assistant.available_tool_ids).not_to include(disabled_tool.slug)
+    end
+  end
+
+  describe '#known_tool_ids' do
+    it 'includes disabled custom tools as valid references' do
+      disabled_tool = create(:captain_custom_tool, :disabled, account: account)
+
+      expect(assistant.known_tool_ids).to include(disabled_tool.slug)
+    end
+  end
+
   describe '#agent_instructions' do
     it 'keeps the Assistant human handoff prompt unchanged' do
       instructions = assistant.agent_instructions

--- a/spec/enterprise/models/captain/scenario_spec.rb
+++ b/spec/enterprise/models/captain/scenario_spec.rb
@@ -164,15 +164,14 @@ RSpec.describe Captain::Scenario, type: :model do
         expect(scenario.errors[:instruction]).to include('contains invalid tools: custom_fetch-order')
       end
 
-      it 'is invalid with disabled custom tool' do
+      it 'is valid with disabled custom tool' do
         create(:captain_custom_tool, account: account, slug: 'custom_fetch-order', enabled: false)
         scenario = build(:captain_scenario,
                          assistant: assistant,
                          account: account,
                          instruction: 'Use [@Fetch Order](tool://custom_fetch-order) to get order details')
 
-        expect(scenario).not_to be_valid
-        expect(scenario.errors[:instruction]).to include('contains invalid tools: custom_fetch-order')
+        expect(scenario).to be_valid
       end
 
       it 'is valid with mixed static and custom tool references' do


### PR DESCRIPTION
## Description

Administrators can now enable or disable Captain scenarios and custom tools directly from their cards, while agents retain read-only visibility of each item's status. Disabled records remain available for management, but are excluded from Captain prompts, handoff agents, editor tool selection, and runtime execution as appropriate.

## Closes

- [CW-7770](https://linear.app/chatwoot/issue/CW-7770/enable-or-disable-scenario-and-tools)

## What changed

- Return enabled and disabled scenarios from the management API so disabled scenarios can be searched, edited, deleted, and re-enabled.
- Add localized status labels and administrator-only inline switches for scenarios and custom tools, with per-record saving states and success or failure feedback.
- Keep disabled custom tools valid as saved scenario references while excluding them from runtime-enabled tool collections.
- Cover management visibility, toggle persistence, and disabled custom-tool reference validation in request and model specs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How to test

1. As an administrator, open Captain scenarios and disable a scenario. Confirm its status changes, remains visible, and stays disabled after reload.
2. Re-enable the scenario and confirm it becomes available to Captain again.
3. Open Captain custom tools and disable a custom tool referenced by a scenario. Confirm the scenario remains editable and enabled while the tool disappears from the scenario editor picker and Captain runtime toolset.
4. Re-enable the custom tool and confirm it becomes available again.
5. Sign in as an agent and confirm scenario and custom-tool statuses are visible without interactive switches.
6. Simulate a failed update request and confirm the previous state is preserved with an error alert.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing focused tests pass locally with my changes
