### PR TITLE
perf: batch sign-in and sign-out audit inserts

### DIFF
--- a/enterprise/app/controllers/enterprise/devise_overrides/sessions_controller.rb
+++ b/enterprise/app/controllers/enterprise/devise_overrides/sessions_controller.rb
@@ -27,14 +27,32 @@ module Enterprise::DeviseOverrides::SessionsController
   def create_audit_event(action)
     return unless @resource
 
-    associated_type = 'Account'
-    @resource.accounts.each do |account|
-      @resource.audits.create(
-        action: action,
+    account_ids = @resource.accounts.ids
+    return if account_ids.empty?
+
+    Enterprise::AuditLog.insert_all!(audit_event_rows(action, account_ids)) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def audit_event_rows(action, account_ids)
+    base_version = Enterprise::AuditLog.unscoped.auditable_finder(@resource.id, 'User').maximum(:version) || 0
+    request_uuid = ::Audited.store[:current_request_uuid] || SecureRandom.uuid
+    created_at = Time.zone.now
+
+    account_ids.each_with_index.map do |account_id, index|
+      {
+        auditable_id: @resource.id,
+        auditable_type: 'User',
         user_id: @resource.id,
-        associated_id: account.id,
-        associated_type: associated_type
-      )
+        user_type: 'User',
+        username: @resource.email,
+        action: action,
+        associated_id: account_id,
+        associated_type: 'Account',
+        version: base_version + index + 1,
+        request_uuid: request_uuid,
+        remote_address: ::Audited.store[:current_remote_address],
+        created_at: created_at
+      }
     end
   end
 end

--- a/spec/enterprise/controllers/enterprise/devise_overrides/session_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/devise_overrides/session_controller_spec.rb
@@ -68,6 +68,33 @@ RSpec.describe 'Enterprise Audit API', type: :request do
       end
     end
 
+    context 'with a user belonging to multiple accounts' do
+      before do
+        create_list(:account, 3).each { |extra_account| create(:account_user, account: extra_account, user: user) }
+      end
+
+      it 'creates one audit per account using a single insert statement' do
+        audit_insert_count = 0
+        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |_name, _started, _finished, _id, payload|
+          audit_insert_count += 1 if payload[:sql].to_s.include?('INSERT INTO "audits"')
+        end
+
+        expect do
+          post new_user_session_url, params: { email: user.email, password: 'Password1!' }, as: :json
+        end.to change(Enterprise::AuditLog, :count).by(4)
+        expect(response).to have_http_status(:success)
+        expect(audit_insert_count).to eq(1)
+
+        audits = user.reload.audits.where(action: 'sign_in').order(:version)
+        expect(audits.map(&:associated_id)).to match_array(user.accounts.ids)
+        expect(audits.map { |audit| [audit.associated_type, audit.username] }.uniq).to eq([['Account', user.email]])
+        expect(audits.map(&:version)).to eq((audits.first.version..audits.last.version).to_a)
+        expect(audits.map(&:request_uuid).uniq.length).to eq(1)
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+    end
+
     context 'with blank email' do
       it 'skips SAML check and processes normally' do
         params = { email: '', password: 'Password1!' }


### PR DESCRIPTION
# Pull Request Template

## Description

Enterprise sign-in and sign-out create one audit event per account the user belongs to. Each of those went through a separate `create`, costing three queries per account (a version lookup, the insert, and a username update from the after_save hook). For users belonging to many accounts this makes authentication cost scale linearly with membership count and contributes to request timeouts.

This change writes the same audit rows with a single bulk insert. Row contents are unchanged: sequential versions continue from the current max, username and user attribution are identical, and all rows share the request uuid and remote address as before.

Measured by counting SQL queries per request at increasing membership counts:

| Memberships | `POST /auth/sign_in` on develop | with this change |
|---|---|---|
| 1 | 21 | 21 |
| 10 | 56 | 29 |
| 100 | 416 | 119 |
| 500 | 2016 | 519 |

The remaining growth is the response rendering addressed in #15570. With both changes applied, sign-in settles at 19 queries and token validation at 9, independent of membership count.

Fixes https://linear.app/chatwoot/issue/INF-103

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested locally with users in 1, 10, 100, and 500 accounts; the query counts above are from those runs.
- New request spec: sign-in for a user in multiple accounts creates one audit per account using a single insert statement, with sequential versions, correct association fields, username, and a shared request uuid.
- Existing enterprise session specs (single account sign-in, sign-out, SAML, invalid credentials) pass unchanged: 7 examples, 0 failures.
- Old and new attribution compared empirically on develop: rows produced by the previous per-account loop match the batched rows column for column.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
