### PR TITLE
fix(instagram): restore business login authorization

### DIFF
--- a/app/controllers/api/v1/accounts/instagram/authorizations_controller.rb
+++ b/app/controllers/api/v1/accounts/instagram/authorizations_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::Accounts::Instagram::AuthorizationsController < Api::V1::Accounts
         redirect_uri: "#{base_url}/instagram/callback",
         scope: REQUIRED_SCOPES.join(','),
         enable_fb_login: '0',
-        force_authentication: '1',
+        force_reauth: 'true',
         response_type: 'code',
         state: generate_instagram_token(Current.account.id, params[:return_to])
       }

--- a/app/controllers/concerns/instagram_concern.rb
+++ b/app/controllers/concerns/instagram_concern.rb
@@ -7,7 +7,7 @@ module InstagramConcern
       client_secret,
       {
         site: 'https://api.instagram.com',
-        authorize_url: 'https://api.instagram.com/oauth/authorize',
+        authorize_url: 'https://www.instagram.com/oauth/authorize',
         token_url: 'https://api.instagram.com/oauth/access_token',
         auth_scheme: :request_body,
         token_method: :post

--- a/spec/controllers/api/v1/accounts/instagram/authorizations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/instagram/authorizations_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Instagram Authorization API', type: :request do
             redirect_uri: "#{frontend_url}/instagram/callback",
             scope: Instagram::IntegrationHelper::REQUIRED_SCOPES.join(','),
             enable_fb_login: '0',
-            force_authentication: '1',
+            force_reauth: 'true',
             response_type: 'code',
             state: instagram_service.generate_instagram_token(account.id)
           }

--- a/spec/controllers/concerns/instagram_concern_spec.rb
+++ b/spec/controllers/concerns/instagram_concern_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe InstagramConcern do
       expect(client.id).to eq(client_id)
       expect(client.secret).to eq(client_secret)
       expect(client.site).to eq('https://api.instagram.com')
-      expect(client.options[:authorize_url]).to eq('https://api.instagram.com/oauth/authorize')
+      expect(client.options[:authorize_url]).to eq('https://www.instagram.com/oauth/authorize')
       expect(client.options[:token_url]).to eq('https://api.instagram.com/oauth/access_token')
       expect(client.options[:auth_scheme]).to eq(:request_body)
       expect(client.options[:token_method]).to eq(:post)


### PR DESCRIPTION
Meta deprecated part of the existing Instagram Business Login flow, which could prevent customers from reaching the login page even when their app configuration was correct. This hotfix updates the authorization flow to use Metas current endpoint and reauthentication parameter.

The callback URL, requested permissions, and token exchange remain unchanged.

### How to reproduce

1. Configure an Instagram app with valid credentials and callback URL.
2. Start the Instagram inbox connection flow.
3. Observe that the previous authorization flow can show a page unavailable error before login.

### How to test

1. As an administrator, start connecting a new Instagram inbox.
2. Confirm the browser opens the current Instagram Business Login page.
3. Complete authorization and confirm the callback returns to Chatwoot successfully.

### Things to know

This is limited to the Instagram authorization endpoint and reauthentication parameter.