### PR TITLE
fix: clear browser storage when sessions end

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::ProfilesController < Api::BaseController
+  include ClearSiteData
+
   before_action :set_user
 
   def show; end
@@ -13,6 +15,7 @@ class Api::V1::ProfilesController < Api::BaseController
     @user.assign_attributes(profile_params)
     @user.custom_attributes.merge!(custom_attributes_params)
     @user.save!
+    clear_site_data if @user.saved_change_to_email? || @user.saved_change_to_unconfirmed_email?
   end
 
   def avatar

--- a/app/controllers/concerns/clear_site_data.rb
+++ b/app/controllers/concerns/clear_site_data.rb
@@ -1,0 +1,9 @@
+module ClearSiteData
+  private
+
+  def clear_site_data
+    # Browser-owned cleanup clears origin storage across tabs and avoids
+    # per-database deletion being blocked by another open connection.
+    response.set_header('Clear-Site-Data', '"storage"')
+  end
+end

--- a/app/controllers/devise_overrides/sessions_controller.rb
+++ b/app/controllers/devise_overrides/sessions_controller.rb
@@ -1,4 +1,6 @@
 class DeviseOverrides::SessionsController < DeviseTokenAuth::SessionsController
+  include ClearSiteData
+
   MAX_SESSIONS = ENV.fetch('MAX_USER_SESSIONS', 25).to_i
 
   # Prevent session parameter from being passed
@@ -25,6 +27,11 @@ class DeviseOverrides::SessionsController < DeviseTokenAuth::SessionsController
   def render_create_success
     track_user_session unless @impersonation
     render partial: 'devise/auth', formats: [:json], locals: { resource: @resource }
+  end
+
+  def destroy
+    clear_site_data
+    super
   end
 
   private

--- a/app/controllers/devise_overrides/token_validations_controller.rb
+++ b/app/controllers/devise_overrides/token_validations_controller.rb
@@ -1,9 +1,12 @@
 class DeviseOverrides::TokenValidationsController < DeviseTokenAuth::TokenValidationsController
+  include ClearSiteData
+
   def validate_token
     # @resource will have been set by set_user_by_token concern
     if @resource
       render 'devise/token', formats: [:json]
     else
+      clear_site_data if request.headers['access-token'].present?
       render_validate_token_error
     end
   end

--- a/app/javascript/dashboard/App.vue
+++ b/app/javascript/dashboard/App.vue
@@ -16,6 +16,7 @@ import { isOnOnboardingView } from 'v3/helpers/RouteHelper';
 import { useAccount } from 'dashboard/composables/useAccount';
 import { useFontSize } from 'dashboard/composables/useFontSize';
 import {
+  hasPushPermissions,
   registerSubscription,
   verifyServiceWorkerExistence,
 } from './helper/pushHelper';
@@ -123,9 +124,8 @@ export default {
 
       verifyServiceWorkerExistence(registration =>
         registration.pushManager.getSubscription().then(subscription => {
-          if (subscription) {
-            registerSubscription();
-          }
+          // Clear-Site-Data removes the subscription but preserves permission.
+          if (subscription || hasPushPermissions()) registerSubscription();
         })
       );
     },

--- a/app/javascript/dashboard/api/auth.js
+++ b/app/javascript/dashboard/api/auth.js
@@ -2,10 +2,7 @@
 
 import Cookies from 'js-cookie';
 import endPoints from './endPoints';
-import {
-  clearCookiesOnLogout,
-  deleteIndexedDBOnLogout,
-} from '../store/utils/api';
+import { clearCookiesOnLogout } from '../store/utils/api';
 
 export default {
   validityCheck() {
@@ -18,7 +15,6 @@ export default {
       axios
         .delete(urlData.url)
         .then(response => {
-          deleteIndexedDBOnLogout();
           clearCookiesOnLogout();
           resolve(response);
         })

--- a/app/javascript/dashboard/helper/CacheHelper/DataManager.js
+++ b/app/javascript/dashboard/helper/CacheHelper/DataManager.js
@@ -10,7 +10,6 @@ export class DataManager {
 
   async initDb() {
     if (this.db) return this.db;
-    const dbName = `cw-store-${this.accountId}`;
     this.db = await openDB(`cw-store-${this.accountId}`, DATA_VERSION, {
       upgrade(db) {
         // Existing databases already carry the stores added in earlier versions,
@@ -27,13 +26,6 @@ export class DataManager {
         createStore('canned_response', { keyPath: 'id' });
       },
     });
-
-    // Store the database name in LocalStorage
-    const dbNames = JSON.parse(localStorage.getItem('cw-idb-names') || '[]');
-    if (!dbNames.includes(dbName)) {
-      dbNames.push(dbName);
-      localStorage.setItem('cw-idb-names', JSON.stringify(dbNames));
-    }
 
     return this.db;
   }

--- a/app/javascript/dashboard/store/utils/api.js
+++ b/app/javascript/dashboard/store/utils/api.js
@@ -50,32 +50,6 @@ export const clearSessionStorageOnLogout = () => {
   SessionStorage.remove(SESSION_STORAGE_KEYS.IMPERSONATION_USER);
 };
 
-export const deleteIndexedDBOnLogout = async () => {
-  let dbs = [];
-  try {
-    dbs = await window.indexedDB.databases();
-    dbs = dbs.map(db => db.name);
-  } catch (e) {
-    dbs = JSON.parse(localStorage.getItem('cw-idb-names') || '[]');
-  }
-
-  dbs.forEach(dbName => {
-    const deleteRequest = window.indexedDB.deleteDatabase(dbName);
-
-    deleteRequest.onerror = event => {
-      // eslint-disable-next-line no-console
-      console.error(`Error deleting database ${dbName}.`, event);
-    };
-
-    deleteRequest.onsuccess = () => {
-      // eslint-disable-next-line no-console
-      console.log(`Database ${dbName} deleted successfully.`);
-    };
-  });
-
-  localStorage.removeItem('cw-idb-names');
-};
-
 export const clearCookiesOnLogout = () => {
   emitter.emit(CHATWOOT_RESET);
   emitter.emit(ANALYTICS_RESET);

--- a/spec/controllers/api/v1/profiles_controller_spec.rb
+++ b/spec/controllers/api/v1/profiles_controller_spec.rb
@@ -213,6 +213,7 @@ RSpec.describe 'Profile API', type: :request do
         agent.reload
 
         expect(agent.unconfirmed_email).to eq(new_email)
+        expect(response.headers['Clear-Site-Data']).to eq('"storage"')
       end
     end
   end

--- a/spec/controllers/devise/token_validations_controller_spec.rb
+++ b/spec/controllers/devise/token_validations_controller_spec.rb
@@ -5,9 +5,22 @@ RSpec.describe 'Token Validation API', type: :request do
     let(:account) { create(:account) }
 
     context 'when it is an invalid token' do
-      it 'returns unauthorized' do
+      it 'does not clear storage for a request without session credentials' do
         get '/auth/validate_token'
+
         expect(response).to have_http_status(:unauthorized)
+        expect(response.headers['Clear-Site-Data']).to be_nil
+      end
+
+      it 'clears storage for a revoked dashboard session' do
+        agent = create(:user, account: account, role: :agent)
+        stale_headers = agent.create_new_auth_token
+        agent.update!(tokens: {})
+
+        get '/auth/validate_token', headers: stale_headers
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.headers['Clear-Site-Data']).to eq('"storage"')
       end
     end
 
@@ -20,6 +33,7 @@ RSpec.describe 'Token Validation API', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(response.body).to include('payload')
+        expect(response.headers['Clear-Site-Data']).to be_nil
       end
     end
 

--- a/spec/controllers/devise_overrides/sessions_controller_spec.rb
+++ b/spec/controllers/devise_overrides/sessions_controller_spec.rb
@@ -164,6 +164,18 @@ RSpec.describe DeviseOverrides::SessionsController, type: :controller do
     end
   end
 
+  describe 'DELETE /auth/sign_out' do
+    let(:user) { create(:user) }
+
+    it 'asks the browser to clear origin storage' do
+      request.headers.merge!(user.create_new_auth_token)
+      delete :destroy
+
+      expect(response).to have_http_status(:success)
+      expect(response.headers['Clear-Site-Data']).to eq('"storage"')
+    end
+  end
+
   describe 'session limit enforcement' do
     let(:user) { create(:user, password: 'Test@123456') }
     let(:session_limit) { described_class::MAX_SESSIONS }


### PR DESCRIPTION
Signing out now delegates origin storage cleanup to the browser so account data cached by one dashboard session does not survive into the next session. This supersedes #12220.

## Why

The earlier approach discovered and deleted each cw-store-* IndexedDB database from JavaScript. IndexedDB deletion is cooperative, which made cleanup depend on connection timing:

- Another dashboard tab could keep a database connection open and block deleteDatabase.
- A blocked deletion cannot be cancelled and can queue later database opens, delaying logout or cache reads.
- Clearing stores before a best-effort deletion reduced the immediate exposure but introduced ordering races with writes from stale tabs.
- Handling database discovery fallbacks, blocking callbacks, pending requests, and timeouts added significant client-side lifecycle code for an operation the browser already owns.

## What changed

- Session-ending server responses now return Clear-Site-Data: "storage" for explicit sign-out, a rejected validation request carrying a stale access token, and a successful email change that logs the user out.
- Anonymous validation failures do not return the header, preventing an unauthenticated cross-site request from being used to wipe browser storage.
- The application-managed IndexedDB enumeration, name tracking, and deletion code has been removed.
- Since clearing storage unregisters the service worker and removes its push subscription, account initialization recreates the subscription when notification permission is still granted.

## Multi-tab and browser behavior

The storage directive operates at the origin boundary and clears localStorage, sessionStorage, IndexedDB, and service-worker registrations across the origin. This avoids coordinating individual database handles between tabs or introducing a separate BroadcastChannel logout protocol.

Running tabs are not forcibly reloaded because the executionContexts directive is not consistently supported across browsers. Their storage connections are cleared by the browser, and their next request with stale credentials receives the same cleanup header. Authentication cookies continue to be cleared by the existing logout flow; the header is deliberately limited to browser storage.

Clear-Site-Data is honored only on secure origins and is supported for storage cleanup in Chrome 61+, Firefox 63+, and Safari 17+. On older or unsupported clients, the existing authentication and JavaScript session cleanup still runs, but the browser cannot perform the origin-wide storage clear.
