### PR TITLE
fix: send the event's own message in the webhook conversation payload

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -185,7 +185,9 @@ class Message < ApplicationRecord
       content_attributes: content_attributes,
       content_type: content_type,
       content: webhook_content,
-      conversation: conversation.webhook_data,
+      # conversation.webhook_data re-queries the conversation for its newest chat message,
+      # which is not this message when the payload is built in a background job.
+      conversation: conversation.webhook_data.merge(messages: [webhook_push_event_data]),
       created_at: created_at,
       id: id,
       inbox: inbox.webhook_data,

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -415,6 +415,16 @@ RSpec.describe Message do
 
       expect(message.webhook_data[:content]).to include('survey/responses/')
     end
+
+    it 'embeds the event message in the nested conversation payload instead of the latest message' do
+      conversation = create(:conversation)
+      message = create(:message, conversation: conversation, account: conversation.account, created_at: 2.minutes.ago)
+      newer_message = create(:message, conversation: conversation, account: conversation.account, created_at: 1.minute.ago)
+
+      expect(conversation.webhook_data[:messages].first[:id]).to eq(newer_message.id)
+      expect(message.webhook_data[:conversation][:messages].first[:id]).to eq(message.id)
+      expect(newer_message.webhook_data[:conversation][:messages].first[:id]).to eq(newer_message.id)
+    end
   end
 
   context 'when message is created' do


### PR DESCRIPTION
## Description

`message_created` and `message_updated` webhook payloads carry the wrong message inside `conversation.messages`. When messages are created in quick succession, several payloads repeat the newest message and the intermediate ones never appear in that field. The reporter traced this in the #11901 thread: messages 1 2 3 4 5 produced webhooks carrying 1 2 3 5 5, and the webhook count was correct.

The payload's top level `id`, `content` and `source_id` are correct on every event. Only the nested `conversation.messages` array carries the wrong message.

`Message#webhook_data` embeds `conversation.webhook_data`, and `Conversations::EventDataPresenter#webhook_push_messages` builds that array with a fresh query:

```ruby
[messages.where(account_id: account_id).chat.last&.webhook_push_event_data].compact
```

`WebhookListener` is registered on `AsyncDispatcher`, whose `dispatch` calls `EventDispatcherJob.perform_later`, so the payload is built when the job runs rather than when the message is created. Each job runs that query after the later messages already exist, and they all resolve to the same newest message.

This is not the same change as #14148. That PR changes `webhook_push_messages` for #14023, and it still re-queries the conversation for its latest message, so it does not address the timing above. This change does not touch `webhook_push_messages`. The two do not conflict in the tree, and this still applies if #14148 lands first.

The change builds the nested array from the message the event is about. `Conversations::EventDataPresenter` is unchanged, so `conversation_created`, `conversation_updated` and `conversation_status_changed` keep the behaviour they have today. `push_messages` and the ActionCable path are also unchanged.

One thing worth flagging for review: private notes now appear in the nested array, where the `chat` scope's `private: false` filter previously excluded them. The note's body and its `private` flag are already in the payload's top level fields, so a consumer that was already receiving the event sees nothing it could not see before.

I posted the diagnosis on #11901 before opening this.

Fixes #11901

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added one example to `spec/models/message_spec.rb`. It creates a message, then a newer message in the same conversation, and asserts that each message's payload embeds itself. Its first assertion is a control: it checks that `conversation.webhook_data` still reports the newer message, which proves the newer message is visible to the presenter's account scoped query rather than being filtered out of it.

On develop with only the spec added, it fails:

```
  1) Message with webhook_data embeds the event message in the nested conversation payload instead of the latest message
     Failure/Error: expect(message.webhook_data[:conversation][:messages].first[:id]).to eq(message.id)

       expected: 5
            got: 6

1 example, 1 failure
```

With the change it passes. Run locally on Ruby 3.4.4 against Postgres with pgvector:

```
$ bundle exec rspec spec/models/message_spec.rb spec/models/conversation_spec.rb \
    spec/presenters/conversations/event_data_presenter_spec.rb \
    spec/listeners/webhook_listener_spec.rb spec/listeners/agent_bot_listener_spec.rb \
    spec/listeners/installation_webhook_listener_spec.rb \
    spec/jobs/event_dispatcher_job_spec.rb spec/dispatchers/async_dispatcher_spec.rb
286 examples, 0 failures

$ bundle exec rspec spec/enterprise/presenters/conversations/event_data_presenter_spec.rb \
    spec/enterprise/models/message_spec.rb spec/services/automation_rules/action_service_spec.rb \
    spec/services/macros/execution_service_spec.rb
39 examples, 0 failures

$ bundle exec rubocop app/models/message.rb spec/models/message_spec.rb
2 files inspected, no offenses detected
```

`spec/models spec/listeners spec/presenters spec/jobs spec/dispatchers` gives 1687 examples with one failure, in `spec/listeners/reporting_event_listener_spec.rb:410`. That failure is pre-existing: the same run on develop without this change gives 1686 examples and the same one failure, and the file passes on its own in both cases.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
