### PR TITLE
feat(slack): add alerts only mode for the Slack integration

### DIFF
--- a/app/controllers/api/v1/accounts/integrations/slack_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/slack_controller.rb
@@ -16,6 +16,8 @@ class Api::V1::Accounts::Integrations::SlackController < Api::V1::Accounts::Base
   end
 
   def update
+    return update_message_mode if permitted_params[:message_mode].present?
+
     @hook = channel_builder.update(permitted_params[:reference_id])
     render json: { error: I18n.t('errors.slack.invalid_channel_id') }, status: :unprocessable_entity if @hook.blank?
   end
@@ -35,7 +37,11 @@ class Api::V1::Accounts::Integrations::SlackController < Api::V1::Accounts::Base
     Integrations::Slack::ChannelBuilder.new(hook: @hook)
   end
 
+  def update_message_mode
+    @hook.update!(settings: @hook.settings.merge('message_mode' => permitted_params[:message_mode]))
+  end
+
   def permitted_params
-    params.permit(:reference_id)
+    params.permit(:reference_id, :message_mode)
   end
 end

--- a/app/javascript/dashboard/api/integrations.js
+++ b/app/javascript/dashboard/api/integrations.js
@@ -11,9 +11,10 @@ class IntegrationsAPI extends ApiClient {
     return axios.post(`${this.baseUrl()}/integrations/slack`, { code });
   }
 
-  updateSlack({ referenceId }) {
+  updateSlack({ referenceId, messageMode }) {
     return axios.patch(`${this.baseUrl()}/integrations/slack`, {
       reference_id: referenceId,
+      message_mode: messageMode,
     });
   }
 

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -135,7 +135,23 @@
       "HELP_TEXT": {
         "TITLE": "How to use the Slack Integration?",
         "BODY": "With this integration, all of your incoming conversations will be synced to the ***{selectedChannelName}*** channel in your Slack workspace. You can manage all your customer conversations right within the channel and never miss a message.\n\nHere are the main features of the integration:\n\n**Respond to conversations from within Slack:** To respond to a conversation in the ***{selectedChannelName}*** Slack channel, simply type out your message and send it as a thread. This will create a response back to the customer through Chatwoot. It's that simple!\n\n **Create private notes:** If you want to create private notes instead of replies, start your message with ***`note:`***. This ensures that your message is kept private and won't be visible to the customer.\n\n**Associate an agent profile:** If the person who replied on Slack has an agent profile in Chatwoot under the same email, the replies will be associated with that agent profile automatically. This means you can easily track who said what and when. On the other hand, when the replier doesn't have an associated agent profile, the replies will appear from the bot profile to the customer.",
+        "BODY_ALERT": "With this integration, all of your incoming conversations will be synced to the ***{selectedChannelName}*** channel in your Slack workspace, so your team can pick them up as soon as they come in.\n\nThis integration is set to **Alerts only**, which means the Slack thread is a safe space for internal discussion. Anything your team posts there stays in Slack and is never sent to the customer.\n\n**Respond to the customer from Chatwoot:** Open the conversation from the link shared in the thread and reply from the Chatwoot dashboard. Replies and private notes added in Chatwoot keep appearing in the Slack thread, so everyone stays in the loop.",
         "SELECTED": "selected"
+      },
+      "MESSAGE_MODE": {
+        "TITLE": "Slack thread behaviour",
+        "DESCRIPTION": "Choose what happens when your team replies inside the Slack thread of a conversation.",
+        "OPTIONS": {
+          "TWO_WAY": {
+            "LABEL": "Two-way sync",
+            "DESCRIPTION": "Replies posted in the Slack thread are sent to the customer. Start a message with `note:` to keep it as a private note."
+          },
+          "ALERT": {
+            "LABEL": "Alerts only",
+            "DESCRIPTION": "Conversations are posted to Slack for internal discussion. Nothing your team writes in the thread reaches the customer, so replies must be sent from the Chatwoot dashboard."
+          }
+        },
+        "UPDATE_SUCCESS": "The Slack thread behaviour is updated successfully"
       },
       "SELECT_CHANNEL": {
         "OPTION_LABEL": "Select a channel",

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -140,15 +140,15 @@
       },
       "MESSAGE_MODE": {
         "TITLE": "Slack thread behaviour",
-        "DESCRIPTION": "Choose what happens when your team replies inside the Slack thread of a conversation.",
+        "DESCRIPTION": "Decide whether replies in the Slack thread reach the customer or stay internal.",
         "OPTIONS": {
           "TWO_WAY": {
             "LABEL": "Two-way sync",
-            "DESCRIPTION": "Replies posted in the Slack thread are sent to the customer. Start a message with `note:` to keep it as a private note."
+            "DESCRIPTION": "Replies in the Slack thread are sent to the customer. Start a message with `note:` to keep it internal."
           },
           "ALERT": {
             "LABEL": "Alerts only",
-            "DESCRIPTION": "Conversations are posted to Slack for internal discussion. Nothing your team writes in the thread reaches the customer, so replies must be sent from the Chatwoot dashboard."
+            "DESCRIPTION": "Conversations are posted to Slack for internal discussion only. Nothing in the thread reaches the customer."
           }
         },
         "UPDATE_SUCCESS": "The Slack thread behaviour is updated successfully"

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Slack.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Slack.vue
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n';
 import Integration from './Integration.vue';
 import SelectChannelWarning from './Slack/SelectChannelWarning.vue';
 import SlackIntegrationHelpText from './Slack/SlackIntegrationHelpText.vue';
+import SlackMessageMode from './Slack/SlackMessageMode.vue';
 import SettingsLayout from '../SettingsLayout.vue';
 import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';
 
@@ -41,6 +42,11 @@ const isIntegrationHookEnabled = computed(() => {
 
 const hasConnectedAChannel = computed(() => {
   return !!hook.value.reference_id;
+});
+
+const messageMode = computed(() => {
+  const { settings: { message_mode: mode = '' } = {} } = hook.value;
+  return mode || 'two_way';
 });
 
 const selectedChannelName = computed(() => {
@@ -108,8 +114,13 @@ onMounted(() => {
             v-if="!isIntegrationHookEnabled"
             :has-connected-a-channel="hasConnectedAChannel"
           />
+          <SlackMessageMode
+            v-if="isIntegrationHookEnabled"
+            :message-mode="messageMode"
+          />
           <SlackIntegrationHelpText
             :selected-channel-name="selectedChannelName"
+            :message-mode="messageMode"
           />
         </div>
       </div>

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Slack/SlackIntegrationHelpText.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Slack/SlackIntegrationHelpText.vue
@@ -2,9 +2,14 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useMessageFormatter } from 'shared/composables/useMessageFormatter';
+import { useBranding } from 'shared/composables/useBranding';
 
 const props = defineProps({
   selectedChannelName: {
+    type: String,
+    required: true,
+  },
+  messageMode: {
     type: String,
     required: true,
   },
@@ -12,12 +17,17 @@ const props = defineProps({
 
 const { t } = useI18n();
 const { formatMessage } = useMessageFormatter();
+const { replaceInstallationName } = useBranding();
 
 const formattedHelpText = computed(() => {
+  const bodyKey =
+    props.messageMode === 'alert'
+      ? 'INTEGRATION_SETTINGS.SLACK.HELP_TEXT.BODY_ALERT'
+      : 'INTEGRATION_SETTINGS.SLACK.HELP_TEXT.BODY';
   return formatMessage(
-    t('INTEGRATION_SETTINGS.SLACK.HELP_TEXT.BODY', {
-      selectedChannelName: props.selectedChannelName,
-    }),
+    replaceInstallationName(
+      t(bodyKey, { selectedChannelName: props.selectedChannelName })
+    ),
     false
   );
 });

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Slack/SlackMessageMode.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Slack/SlackMessageMode.vue
@@ -1,0 +1,65 @@
+<script setup>
+import { useStore } from 'vuex';
+import { useI18n } from 'vue-i18n';
+import { useAlert } from 'dashboard/composables';
+import { useBranding } from 'shared/composables/useBranding';
+import RadioCard from 'dashboard/components-next/radioCard/RadioCard.vue';
+
+defineProps({
+  messageMode: {
+    type: String,
+    required: true,
+  },
+});
+
+const MESSAGE_MODES = [
+  { id: 'two_way', key: 'TWO_WAY' },
+  { id: 'alert', key: 'ALERT' },
+];
+
+const store = useStore();
+const { t } = useI18n();
+const { replaceInstallationName } = useBranding();
+
+const onSelect = async messageMode => {
+  try {
+    await store.dispatch('integrations/updateSlack', { messageMode });
+    useAlert(t('INTEGRATION_SETTINGS.SLACK.MESSAGE_MODE.UPDATE_SUCCESS'));
+  } catch (error) {
+    useAlert(error.message || t('INTEGRATION_SETTINGS.SLACK.UPDATE_ERROR'));
+  }
+};
+</script>
+
+<template>
+  <div
+    class="flex-1 w-full px-6 py-5 mb-4 outline outline-n-container outline-1 bg-n-card rounded-xl"
+  >
+    <h5 class="text-n-slate-12 text-heading-1 tracking-tight">
+      {{ t('INTEGRATION_SETTINGS.SLACK.MESSAGE_MODE.TITLE') }}
+    </h5>
+    <p class="mt-1 mb-4 text-n-slate-11 text-body-main">
+      {{ t('INTEGRATION_SETTINGS.SLACK.MESSAGE_MODE.DESCRIPTION') }}
+    </p>
+    <div class="grid gap-3 sm:grid-cols-2">
+      <RadioCard
+        v-for="mode in MESSAGE_MODES"
+        :id="mode.id"
+        :key="mode.id"
+        name="slack-message-mode"
+        :label="
+          t(`INTEGRATION_SETTINGS.SLACK.MESSAGE_MODE.OPTIONS.${mode.key}.LABEL`)
+        "
+        :description="
+          replaceInstallationName(
+            t(
+              `INTEGRATION_SETTINGS.SLACK.MESSAGE_MODE.OPTIONS.${mode.key}.DESCRIPTION`
+            )
+          )
+        "
+        :is-active="messageMode === mode.id"
+        @select="onSelect"
+      />
+    </div>
+  </div>
+</template>

--- a/app/models/integrations/hook.rb
+++ b/app/models/integrations/hook.rb
@@ -54,6 +54,12 @@ class Integrations::Hook < ApplicationRecord
     app_id == 'slack'
   end
 
+  # Alert mode makes the Slack integration one way. Conversations are pushed to Slack,
+  # but replies posted in the Slack thread are never synced back to the customer.
+  def slack_alert_mode?
+    slack? && settings['message_mode'] == 'alert'
+  end
+
   def dialogflow?
     app_id == 'dialogflow'
   end

--- a/config/integration/apps.yml
+++ b/config/integration/apps.yml
@@ -79,7 +79,16 @@ slack:
   action: https://slack.com/oauth/v2/authorize?scope=commands,chat:write,channels:read,channels:manage,channels:join,groups:read,groups:write,im:write,mpim:write,users:read,users:read.email,chat:write.customize,channels:history,groups:history,mpim:history,im:history,files:read,files:write
   hook_type: account
   allow_multiple_hooks: false
-  visible_properties: ['channel_name']
+  visible_properties: ['channel_name', 'message_mode']
+  settings_json_schema:
+    {
+      'type': 'object',
+      'properties':
+        {
+          'channel_name': { 'type': 'string' },
+          'message_mode': { 'type': 'string', 'enum': ['two_way', 'alert'] },
+        },
+    }
 dialogflow:
   id: dialogflow
   logo: dialogflow.png

--- a/lib/integrations/slack/channel_builder.rb
+++ b/lib/integrations/slack/channel_builder.rb
@@ -64,7 +64,7 @@ class Integrations::Slack::ChannelBuilder
     return if channel.blank?
 
     slack_client.conversations_join(channel: channel[:id]) if channel[:is_private] == false
-    @hook.update!(reference_id: channel[:id], settings: { channel_name: channel[:name] }, status: 'enabled')
-    @hook
+    hook.update!(reference_id: channel[:id], settings: hook.settings.merge('channel_name' => channel[:name]), status: 'enabled')
+    hook
   end
 end

--- a/lib/integrations/slack/incoming_message_builder.rb
+++ b/lib/integrations/slack/incoming_message_builder.rb
@@ -68,7 +68,7 @@ class Integrations::Slack::IncomingMessageBuilder
   end
 
   def process_message_payload?
-    thread_timestamp_available? && supported_message? && integration_hook
+    thread_timestamp_available? && supported_message? && integration_hook.present? && !integration_hook.slack_alert_mode?
   end
 
   def link_shared?


### PR DESCRIPTION
Earlier, every reply posted there was delivered to the customer. Teams that use the channel for alerts had to remember a `note:` prefix on every message, and a single slip reached the customer.

The integration now has a thread behavior setting. 2-way sync keeps the current behavior and stays the default, so existing installs are untouched. Alerts only makes the integration one way: conversations are still pushed to Slack, but nothing posted in the thread is synced back, leaving the thread free for internal discussion.
