### PR TITLE
fix(conversation): always show TO field in email reply composer

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyEmailHead.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyEmailHead.vue
@@ -88,7 +88,7 @@ export default {
 
 <template>
   <div>
-    <div v-if="toEmails">
+    <div>
       <div class="input-group small" :class="{ error: v$.toEmailsVal.$error }">
         <label class="input-group-label">
           {{ $t('CONVERSATION.REPLYBOX.EMAIL_HEAD.TO') }}


### PR DESCRIPTION
When an agent or integration replies to an email conversation with an empty TO address, the TO field disappears from the reply composer permanently. `ReplyEmailHead.vue` only rendered the TO row when `toEmails` was truthy, so after `setCCAndToEmailsFromLastChat` left it empty there was no way to re-add a recipient — every subsequent reply went out without a TO.

This renders the TO row unconditionally, matching the always-visible CC row. Empty values already pass `validEmailsByComma`, so no other behavior changes.

Closes #15588