### PR TITLE
fix(inboxes): hide opaque social identifiers

### DIFF
--- a/app/javascript/dashboard/helper/inbox.js
+++ b/app/javascript/dashboard/helper/inbox.js
@@ -111,14 +111,14 @@ const INBOX_ICON_MAP_LINE = {
 
 const DEFAULT_ICON_LINE = 'i-ri-chat-1-line';
 
+// Instagram and TikTok already use the provider account name as the inbox name;
+// their IDs are opaque routing keys and should not be shown as identifiers.
 const INBOX_IDENTIFIER_RESOLVERS = {
   [INBOX_TYPES.WEB]: inbox => inbox.website_url,
   [INBOX_TYPES.EMAIL]: inbox => inbox.email,
   [INBOX_TYPES.WHATSAPP]: inbox => inbox.phone_number,
   [INBOX_TYPES.SMS]: inbox => inbox.phone_number,
   [INBOX_TYPES.FB]: inbox => inbox.page_id,
-  [INBOX_TYPES.INSTAGRAM]: inbox => inbox.instagram_id,
-  [INBOX_TYPES.TIKTOK]: inbox => inbox.business_id,
   [INBOX_TYPES.TWITTER]: inbox => inbox.profile_id,
   [INBOX_TYPES.LINE]: inbox => inbox.line_channel_id,
   [INBOX_TYPES.API]: inbox => inbox.inbox_identifier,

--- a/app/javascript/dashboard/helper/specs/inbox.spec.js
+++ b/app/javascript/dashboard/helper/specs/inbox.spec.js
@@ -26,12 +26,6 @@ describe('#Inbox Helpers', () => {
       [INBOX_TYPES.WHATSAPP, { phone_number: '+15555550100' }, '+15555550100'],
       [INBOX_TYPES.SMS, { phone_number: '+15555550101' }, '+15555550101'],
       [INBOX_TYPES.FB, { page_id: 'page-123' }, 'page-123'],
-      [
-        INBOX_TYPES.INSTAGRAM,
-        { instagram_id: 'instagram-123' },
-        'instagram-123',
-      ],
-      [INBOX_TYPES.TIKTOK, { business_id: 'business-123' }, 'business-123'],
       [INBOX_TYPES.TWITTER, { profile_id: 'profile-123' }, 'profile-123'],
       [INBOX_TYPES.TELEGRAM, { bot_name: 'support_bot' }, '@support_bot'],
       [INBOX_TYPES.LINE, { line_channel_id: 'line-123' }, 'line-123'],
@@ -69,10 +63,22 @@ describe('#Inbox Helpers', () => {
       ).toBe('@support_bot');
     });
 
-    it('returns an empty identifier for missing and unknown inboxes', () => {
+    it('returns an empty identifier for missing, unknown, and opaque social identifiers', () => {
       expect(getInboxIdentifier()).toBe('');
       expect(getInboxIdentifier({ channel_type: 'Channel::Unknown' })).toBe('');
       expect(getInboxIdentifier({ channel_type: INBOX_TYPES.EMAIL })).toBe('');
+      expect(
+        getInboxIdentifier({
+          channel_type: INBOX_TYPES.INSTAGRAM,
+          instagram_id: 'instagram-123',
+        })
+      ).toBe('');
+      expect(
+        getInboxIdentifier({
+          channel_type: INBOX_TYPES.TIKTOK,
+          business_id: 'business-123',
+        })
+      ).toBe('');
     });
   });
 


### PR DESCRIPTION
Instagram and TikTok inboxes now keep their provider account name as the visible label without appending opaque provider IDs in the sidebar or inbox settings. This is a follow-up to [#15527](https://github.com/chatwoot/chatwoot/pull/15527) and [#15528](https://github.com/chatwoot/chatwoot/pull/15528).

## Closes

[CW-7245](https://linear.app/chatwoot/issue/CW-7245/show-phone-numberchannel-identifier-consistently-in-inbox-ui)

## How to reproduce

1. Open a workspace with connected Instagram and TikTok inboxes.
2. Check the Channels section in the conversation sidebar.
3. Open Settings → Inboxes, then open either inbox settings page.
4. On `develop`, the provider account name is followed by a large opaque Instagram or TikTok ID. On this branch, the account name remains visible without the opaque ID.

## What changed

- Stop resolving Instagram account IDs and TikTok business IDs as display identifiers.
- Keep both IDs in the inbox payload for matching, reauthorization, and provider operations.
- Preserve identifier display and search behavior for every other supported channel.