### PR TITLE
fix: render team metadata for agent bot requests

### DIFF
--- a/app/views/api/v1/models/_team.json.jbuilder
+++ b/app/views/api/v1/models/_team.json.jbuilder
@@ -5,4 +5,4 @@ json.allow_auto_assign resource.allow_auto_assign
 json.icon resource.icon
 json.icon_color resource.icon_color
 json.account_id resource.account_id
-json.is_member Current.user.teams.include?(resource)
+json.is_member Current.user.is_a?(User) && Current.user.teams.include?(resource)

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -343,6 +343,22 @@ RSpec.describe 'Conversations API', type: :request do
         expect(JSON.parse(response.body, symbolize_names: true)[:id]).to eq(conversation.display_id)
       end
     end
+
+    context 'when it is an authenticated bot' do
+      let(:agent_bot) { create(:agent_bot, account: account) }
+      let(:team) { create(:team, account: account) }
+
+      it 'shows a team-assigned conversation' do
+        conversation.update!(team: team)
+
+        get "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}",
+            headers: { api_access_token: agent_bot.access_token.token },
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body.dig('meta', 'team', 'is_member')).to be(false)
+      end
+    end
   end
 
   describe 'PATCH /api/v1/accounts/{account.id}/conversations/:id' do


### PR DESCRIPTION
Agent bots can now fetch team-assigned conversations without the response failing while rendering team membership metadata.

## Closes

https://linear.app/chatwoot/issue/CW-8042/actionviewtemplateerror-undefined-method-teams-for-an-instance-of

## Why

Agent-bot access tokens are allowed to fetch conversation details. When the conversation had a team, the shared team serializer assumed the authenticated resource was always a user and called `teams` on the agent bot, returning a 500 response.

## What this change does

- Reports `is_member` only for authenticated users.
- Returns `is_member: false` for agent-bot requests.
- Covers fetching a team-assigned conversation with an agent-bot token.

## How to test

1. Assign a conversation to a team.
2. Fetch the conversation details using an agent-bot access token.
3. Confirm the request succeeds and the team metadata includes `is_member: false`.
