### PR TITLE
feat(auth): trusted proxy header authentication (AuthZ Proxy like Cloudflare Access, Oathkeeper etc. auto-login)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,6 +190,18 @@ GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
 GOOGLE_OAUTH_CALLBACK_URL=
 
+# Trusted proxy authentication
+# Enable this ONLY when Chatwoot is reachable exclusively through a trusted
+# authenticating proxy (e.g. Cloudflare Access) that sets the header below and
+# strips any client-supplied value for it. When enabled, visiting the login page
+# with the header present signs the matching user in automatically.
+# ENABLE_TRUSTED_PROXY_AUTH=false
+# TRUSTED_PROXY_AUTH_HEADER=Cf-Access-Authenticated-User-Email
+# While the feature is enabled, logout redirects to the proxy's logout endpoint
+# instead of LOGOUT_REDIRECT_LINK, since the login page would sign the user
+# straight back in. Defaults to Cloudflare Access's logout URL.
+# TRUSTED_PROXY_LOGOUT_REDIRECT_LINK=/cdn-cgi/access/logout
+
 ### Change this env variable only if you are using a custom build mobile app
 ## Mobile app env variables
 IOS_APP_ID=L7YLMN4634.com.chatwoot.app

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -35,6 +35,7 @@ class DashboardController < ActionController::Base
   around_action :switch_locale
   before_action :ensure_installation_onboarding, only: [:index]
   before_action :render_hc_if_custom_domain, only: [:index]
+  before_action :process_trusted_proxy_auth, only: [:index]
   before_action :ensure_html_format
   layout 'vueapp'
 
@@ -48,6 +49,9 @@ class DashboardController < ActionController::Base
 
   def set_global_config
     @global_config = GlobalConfig.get(*GLOBAL_CONFIG_KEYS).merge(app_config)
+    # Behind a trusted proxy the default post-logout target (/app/login) would sign the
+    # user straight back in, so logout must land on the proxy's own logout endpoint.
+    @global_config['LOGOUT_REDIRECT_LINK'] = trusted_proxy_logout_redirect_link if trusted_proxy_auth_enabled?
   end
 
   def set_dashboard_scripts
@@ -56,6 +60,39 @@ class DashboardController < ActionController::Base
 
   def ensure_installation_onboarding
     redirect_to '/installation/onboarding' if ::Redis::Alfred.get(::Redis::Alfred::CHATWOOT_INSTALLATION_ONBOARDING)
+  end
+
+  # Auto-login for installations running behind a trusted authenticating proxy
+  # (e.g. Cloudflare Access sets Cf-Access-Authenticated-User-Email). The proxy is
+  # trusted to strip client-supplied values for this header, so its presence alone
+  # proves the user's identity; we exchange it for a short-lived SSO auth token that
+  # the login page submits automatically.
+  def process_trusted_proxy_auth
+    return unless request.path == '/app/login'
+    return if params[:sso_auth_token].present?
+    return unless trusted_proxy_auth_enabled?
+
+    email = request.headers[trusted_proxy_auth_header]
+    return if email.blank?
+
+    user = User.from_email(email.strip)
+    return if user.blank?
+
+    redirect_to "/app/login?email=#{ERB::Util.url_encode(user.email)}&sso_auth_token=#{user.generate_sso_auth_token}"
+  end
+
+  # Plain ENV reads (no InstallationConfig): the env var stays authoritative on every
+  # boot instead of being frozen into the DB by the first request that reads it.
+  def trusted_proxy_auth_enabled?
+    ENV.fetch('ENABLE_TRUSTED_PROXY_AUTH', 'false') == 'true'
+  end
+
+  def trusted_proxy_auth_header
+    ENV.fetch('TRUSTED_PROXY_AUTH_HEADER', 'Cf-Access-Authenticated-User-Email')
+  end
+
+  def trusted_proxy_logout_redirect_link
+    ENV.fetch('TRUSTED_PROXY_LOGOUT_REDIRECT_LINK', '/cdn-cgi/access/logout')
   end
 
   def render_hc_if_custom_domain


### PR DESCRIPTION
Adds trusted proxy authentication as a login method. When Chatwoot runs behind an authenticating proxy such as Cloudflare Access, enabling the `ENABLE_TRUSTED_PROXY_AUTH` flag makes the login page read the authenticated user's email from a configurable request header (`TRUSTED_PROXY_AUTH_HEADER`, defaulting to Cloudflare's `Cf-Access-Authenticated-User-Email`) and sign the matching user in automatically — no password entry needed. Logging out sends the user to the proxy's logout endpoint (`TRUSTED_PROXY_LOGOUT_REDIRECT_LINK`, defaulting to Cloudflare's `/cdn-cgi/access/logout`) so the proxy session actually ends instead of auto-logging back in.

## Type of change

- New feature (non-breaking change which adds functionality)

## How to test

1. Set `ENABLE_TRUSTED_PROXY_AUTH=true` (and optionally `TRUSTED_PROXY_AUTH_HEADER` — it defaults to `Cf-Access-Authenticated-User-Email`) and restart the server.
2. Visit `/app/login` with the header set to an existing agent's email (e.g. `curl -H "Cf-Access-Authenticated-User-Email: agent@example.com"` or via Cloudflare Access in front of the install). You are redirected with a one-time SSO token and land in the dashboard signed in as that user.
3. Visit `/app/login` with the header set to an email that has no Chatwoot user, or without the header — the regular login form renders as before.
4. Log out from the dashboard — you are redirected to `/cdn-cgi/access/logout` (or the URL in `TRUSTED_PROXY_LOGOUT_REDIRECT_LINK`), ending the Cloudflare Access session, instead of bouncing back to the login page and being signed straight back in.
5. With the flag unset (default), behavior is unchanged everywhere, including the existing `LOGOUT_REDIRECT_LINK` behavior on logout.

## What changed

- `DashboardController` gets a `process_trusted_proxy_auth` before_action on the login page: when the feature is enabled and the configured header carries an email matching an existing user, it generates the existing short-lived (5 min, single-use, Redis-backed) SSO auth token and redirects to `/app/login?email=…&sso_auth_token=…`. The existing v3 login page auto-submits that token and `DeviseOverrides::SessionsController` completes the sign-in, so session-limit enforcement and token handling are all reused.
- While the feature is enabled, `set_global_config` overrides the `LOGOUT_REDIRECT_LINK` value delivered to the frontend with `TRUSTED_PROXY_LOGOUT_REDIRECT_LINK` (default `/cdn-cgi/access/logout`), since the stored default (`/app/login`) would immediately re-authenticate the user. The frontend logout flow already honors `LOGOUT_REDIRECT_LINK`, so no frontend changes are needed.
- All three settings are read via `GlobalConfigService` (env var or super-admin installation config), consistent with the other login-method flags.
- `.env.example` documents the new variables.

**Security note**: this trusts the header by design, so it must only be enabled when the app is reachable exclusively through the proxy and the proxy strips client-supplied values for that header (Cloudflare Access does this for `Cf-Access-Authenticated-User-Email`). The `.env.example` comment calls this out.