### PR TITLE
feat(whatsapp): route campaigns to BSUID recipients

### DIFF
--- a/app/services/whatsapp/authentication_template_guard.rb
+++ b/app/services/whatsapp/authentication_template_guard.rb
@@ -1,0 +1,29 @@
+class Whatsapp::AuthenticationTemplateGuard
+  pattr_initialize [:channel!, :recipient!, :template_params!]
+
+  def error
+    return unless bsuid_recipient?
+    return I18n.t('errors.whatsapp.template_category_required_for_bsuid') if template.blank?
+    return I18n.t('errors.whatsapp.authentication_template_requires_phone') if authentication_template?
+  end
+
+  private
+
+  def bsuid_recipient?
+    recipient.to_s.delete_prefix('whatsapp:').match?(RegexHelper::WHATSAPP_BSUID_REGEX)
+  end
+
+  def authentication_template?
+    template['category'].to_s.casecmp?('authentication')
+  end
+
+  def template
+    Array(channel.message_templates).find do |item|
+      item['name'] == param('name') && item['language']&.casecmp?(param('language').to_s)
+    end
+  end
+
+  def param(key)
+    template_params[key] || template_params[key.to_sym]
+  end
+end

--- a/app/services/whatsapp/oneoff_campaign_service.rb
+++ b/app/services/whatsapp/oneoff_campaign_service.rb
@@ -25,7 +25,7 @@ class Whatsapp::OneoffCampaignService
   end
 
   def validate_provider!
-    raise 'WhatsApp Cloud provider required' if channel.provider != 'whatsapp_cloud'
+    raise 'WhatsApp Cloud provider required' unless whatsapp_cloud_channel?
   end
 
   def validate_feature_flag!
@@ -47,8 +47,9 @@ class Whatsapp::OneoffCampaignService
   def process_contact(contact)
     Rails.logger.info "Processing contact: #{contact.name} (#{contact.phone_number})"
 
-    if contact.phone_number.blank?
-      Rails.logger.info "Skipping contact #{contact.name} - no phone number"
+    recipient, recipient_error = campaign_destination(contact)
+    if recipient.blank?
+      Rails.logger.warn "Skipping campaign recipient contact_id=#{contact.id}: #{recipient_error}"
       return
     end
 
@@ -60,7 +61,7 @@ class Whatsapp::OneoffCampaignService
     processed_template_params = process_liquid_template_params(contact)
     return if processed_template_params.nil?
 
-    send_whatsapp_template_message(to: contact.phone_number, template_params: processed_template_params)
+    send_whatsapp_template_message(to: recipient, template_params: processed_template_params)
   end
 
   def process_audience(audience_labels)
@@ -85,6 +86,8 @@ class Whatsapp::OneoffCampaignService
   end
 
   def send_whatsapp_template_message(to:, template_params:)
+    return if authentication_template_blocked?(to, template_params)
+
     processor = Whatsapp::TemplateProcessorService.new(
       channel: channel,
       template_params: template_params
@@ -106,6 +109,44 @@ class Whatsapp::OneoffCampaignService
     Rails.logger.error "Backtrace: #{e.backtrace.first(5).join('\n')}"
     # continue processing remaining contacts
     nil
+  end
+
+  def authentication_template_blocked?(recipient, params)
+    error = Whatsapp::AuthenticationTemplateGuard.new(channel: channel, recipient: recipient, template_params: params).error
+    return false unless error
+
+    Rails.logger.warn "Skipping BSUID campaign recipient: #{error}"
+    true
+  end
+
+  def campaign_destination(contact)
+    return [contact.phone_number, nil] if contact.phone_number.present?
+
+    bsuid_contact_inboxes = bsuid_contact_inboxes_for(contact)
+    return [nil, 'Phone number and BSUID are missing'] if bsuid_contact_inboxes.empty?
+
+    bsuid_recipient = preferred_bsuid_recipient(bsuid_contact_inboxes)
+    return [bsuid_recipient, nil] if bsuid_recipient.present?
+
+    [nil, 'Multiple WhatsApp identities found; refusing to choose a destination']
+  end
+
+  def bsuid_contact_inboxes_for(contact)
+    contact.contact_inboxes.where(inbox_id: inbox.id).select do |contact_inbox|
+      bsuid_source_id?(contact_inbox.source_id)
+    end
+  end
+
+  def preferred_bsuid_recipient(contact_inboxes)
+    return contact_inboxes.first.source_id if contact_inboxes.one?
+  end
+
+  def bsuid_source_id?(source_id)
+    source_id.to_s.delete_prefix('whatsapp:').match?(RegexHelper::WHATSAPP_BSUID_REGEX)
+  end
+
+  def whatsapp_cloud_channel?
+    channel.is_a?(Channel::Whatsapp) && channel.provider == 'whatsapp_cloud'
   end
 end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,8 @@ en:
       phone_info_fetch_failed: 'Failed to fetch phone number information. Please try again.'
       phone_number_already_exists: 'Channel already exists for this phone number: %{phone_number}, please contact support if the error persists'
       message_outside_messaging_window: 'Message not sent because the WhatsApp 24-hour customer service window is closed and no template parameters were provided. Send an approved template message instead.'
+      authentication_template_requires_phone: 'Authentication templates require a WhatsApp phone number and cannot be sent to a BSUID-only contact.'
+      template_category_required_for_bsuid: 'Template category could not be verified for this BSUID-only contact.'
       reauthorization:
         generic: 'Failed to reauthorize WhatsApp. Please try again.'
         not_supported: 'Reauthorization is not supported for this type of WhatsApp channel.'

--- a/enterprise/app/services/enterprise/whatsapp/oneoff_campaign_service.rb
+++ b/enterprise/app/services/enterprise/whatsapp/oneoff_campaign_service.rb
@@ -12,9 +12,9 @@ module Enterprise::Whatsapp::OneoffCampaignService
     contact = recipient.contact
     Rails.logger.info "Processing contact: #{contact.name} (#{contact.phone_number})"
 
-    if contact.phone_number.blank?
-      Rails.logger.info "Skipping contact #{contact.name} - no phone number"
-      recipient.mark_skipped!('Phone number is missing')
+    destination, destination_error = campaign_destination(contact)
+    if destination.blank?
+      recipient.mark_skipped!(destination_error)
       return
     end
 
@@ -32,7 +32,7 @@ module Enterprise::Whatsapp::OneoffCampaignService
 
     recipient.update!(message_content: rendered_message_content(contact))
 
-    send_whatsapp_template_message(recipient: recipient, to: contact.phone_number, template_params: processed_template_params)
+    send_whatsapp_template_message(recipient: recipient, to: destination, template_params: processed_template_params)
   end
 
   def create_recipients(audience_labels)
@@ -58,6 +58,8 @@ module Enterprise::Whatsapp::OneoffCampaignService
   end
 
   def send_whatsapp_template_message(recipient:, to:, template_params:)
+    return if authentication_template_blocked?(recipient, to, template_params)
+
     processor = Whatsapp::TemplateProcessorService.new(
       channel: channel,
       template_params: template_params
@@ -88,6 +90,14 @@ module Enterprise::Whatsapp::OneoffCampaignService
       lang_code: lang_code,
       parameters: processed_parameters
     }
+  end
+
+  def authentication_template_blocked?(campaign_recipient, recipient, params)
+    error = Whatsapp::AuthenticationTemplateGuard.new(channel: channel, recipient: recipient, template_params: params).error
+    return false unless error
+
+    campaign_recipient.mark_skipped!(error)
+    true
   end
 
   def update_recipient_from_provider_response(recipient, source_id)

--- a/spec/enterprise/services/enterprise/whatsapp/oneoff_campaign_service_spec.rb
+++ b/spec/enterprise/services/enterprise/whatsapp/oneoff_campaign_service_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe Enterprise::Whatsapp::OneoffCampaignService do
+  let(:account) { create(:account) }
+  let(:whatsapp_channel) do
+    create(:channel_whatsapp, account: account, provider: 'whatsapp_cloud', validate_provider_config: false, sync_templates: false)
+  end
+  let(:whatsapp_inbox) { whatsapp_channel.inbox }
+  let(:label) { create(:label, account: account) }
+  let(:template_params) do
+    {
+      'name' => 'ticket_status_updated',
+      'namespace' => '23423423_2342423_324234234_2343224',
+      'category' => 'UTILITY',
+      'language' => 'en',
+      'processed_params' => { 'body' => { 'name' => 'John', 'ticket_id' => '2332' } }
+    }
+  end
+  let(:campaign) do
+    create(
+      :campaign,
+      inbox: whatsapp_inbox,
+      account: account,
+      audience: [{ type: 'Label', id: label.id }],
+      template_params: template_params
+    )
+  end
+
+  before do
+    account.enable_features!(:whatsapp_campaign)
+    allow_any_instance_of(Whatsapp::OneoffCampaignService).to receive(:channel).and_return(whatsapp_channel) # rubocop:disable RSpec/AnyInstance
+  end
+
+  it 'marks contacts without phone or BSUID as skipped' do
+    contact = create(:contact, account: account, phone_number: nil)
+    contact.update_labels([label.title])
+
+    expect(whatsapp_channel).not_to receive(:send_template)
+
+    Whatsapp::OneoffCampaignService.new(campaign: campaign).perform
+
+    expect(CampaignRecipient.find_by!(campaign: campaign, contact: contact)).to be_skipped
+  end
+
+  it 'marks phone-less contacts with multiple WhatsApp identities as skipped' do
+    contact = create(:contact, account: account, phone_number: nil)
+    contact.update_labels([label.title])
+    create(:contact_inbox, contact: contact, inbox: whatsapp_inbox, source_id: 'IN.2081978709342942')
+    create(:contact_inbox, contact: contact, inbox: whatsapp_inbox, source_id: 'IN.2081978709342943')
+
+    expect(whatsapp_channel).not_to receive(:send_template)
+
+    Whatsapp::OneoffCampaignService.new(campaign: campaign).perform
+
+    expect(CampaignRecipient.find_by!(campaign: campaign, contact: contact)).to be_skipped
+  end
+
+  it 'marks blocked BSUID-only authentication-template recipients as skipped' do
+    contact = create(:contact, account: account, phone_number: nil)
+    contact.update_labels([label.title])
+    create(:contact_inbox, contact: contact, inbox: whatsapp_inbox, source_id: 'IN.2081978709342942')
+    whatsapp_channel.update!(
+      message_templates: [
+        {
+          'name' => 'ticket_status_updated',
+          'language' => 'en',
+          'category' => 'AUTHENTICATION'
+        }
+      ]
+    )
+
+    expect(whatsapp_channel).not_to receive(:send_template)
+
+    Whatsapp::OneoffCampaignService.new(campaign: campaign).perform
+
+    expect(CampaignRecipient.find_by!(campaign: campaign, contact: contact)).to be_skipped
+  end
+end

--- a/spec/services/whatsapp/authentication_template_guard_spec.rb
+++ b/spec/services/whatsapp/authentication_template_guard_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::AuthenticationTemplateGuard do
+  let(:account) { create(:account) }
+  let(:authentication_template) do
+    {
+      'name' => 'login_code',
+      'language' => 'en_US',
+      'category' => 'AUTHENTICATION'
+    }
+  end
+  let(:template_params) { { 'name' => 'login_code', 'language' => 'en_US' } }
+
+  it 'rejects a Meta authentication template for a BSUID recipient' do
+    channel = create(:channel_whatsapp, provider: 'whatsapp_cloud', account: account,
+                                        validate_provider_config: false, sync_templates: false)
+    channel.update!(message_templates: [authentication_template])
+
+    error = described_class.new(channel: channel, recipient: 'IN.2081978709342942', template_params: template_params).error
+
+    expect(error).to eq(I18n.t('errors.whatsapp.authentication_template_requires_phone'))
+  end
+
+  it 'rejects a BSUID recipient when only the saved template params carry a category' do
+    channel = create(:channel_whatsapp, provider: 'whatsapp_cloud', account: account,
+                                        validate_provider_config: false, sync_templates: false)
+    template_params = { 'name' => 'login_code', 'language' => 'en_US', 'category' => 'AUTHENTICATION' }
+
+    error = described_class.new(channel: channel, recipient: 'IN.2081978709342942', template_params: template_params).error
+
+    expect(error).to eq(I18n.t('errors.whatsapp.template_category_required_for_bsuid'))
+  end
+
+  it 'allows an authentication template for a phone recipient' do
+    channel = create(:channel_whatsapp, provider: 'whatsapp_cloud', account: account,
+                                        validate_provider_config: false, sync_templates: false)
+    channel.update!(message_templates: [authentication_template])
+
+    expect(described_class.new(channel: channel, recipient: '919745786257', template_params: template_params).error).to be_nil
+  end
+
+  it 'allows a non-authentication template for a BSUID recipient' do
+    channel = create(:channel_whatsapp, provider: 'whatsapp_cloud', account: account,
+                                        validate_provider_config: false, sync_templates: false)
+    channel.update!(message_templates: [authentication_template.merge('category' => 'UTILITY')])
+
+    expect(described_class.new(channel: channel, recipient: 'IN.2081978709342942', template_params: template_params).error).to be_nil
+  end
+
+  it 'rejects a BSUID recipient when template category cannot be verified' do
+    channel = create(:channel_whatsapp, provider: 'whatsapp_cloud', account: account,
+                                        validate_provider_config: false, sync_templates: false)
+
+    error = described_class.new(channel: channel, recipient: 'IN.2081978709342942', template_params: template_params).error
+
+    expect(error).to eq(I18n.t('errors.whatsapp.template_category_required_for_bsuid'))
+  end
+end

--- a/spec/services/whatsapp/oneoff_campaign_service_spec.rb
+++ b/spec/services/whatsapp/oneoff_campaign_service_spec.rb
@@ -116,6 +116,79 @@ describe Whatsapp::OneoffCampaignService do
         described_class.new(campaign: campaign).perform
       end
 
+      it 'sends to the contact BSUID when the contact has no phone number and exactly one WhatsApp identity' do
+        contact = create(:contact, account: account, phone_number: nil)
+        contact.update_labels([label1.title])
+        create(:contact_inbox, contact: contact, inbox: whatsapp_inbox, source_id: 'IN.2081978709342942')
+
+        expect(whatsapp_channel).to receive(:send_template).with(
+          'IN.2081978709342942',
+          hash_including(
+            name: 'ticket_status_updated',
+            namespace: '23423423_2342423_324234234_2343224',
+            lang_code: 'en'
+          ),
+          nil
+        )
+
+        described_class.new(campaign: campaign).perform
+      end
+
+      it 'does not send when the contact has parent and regular BSUID aliases' do
+        contact = create(:contact, account: account, phone_number: nil)
+        contact.update_labels([label1.title])
+        create(:contact_inbox, contact: contact, inbox: whatsapp_inbox, source_id: 'IN.ENT.9081726354')
+        create(:contact_inbox, contact: contact, inbox: whatsapp_inbox, source_id: 'IN.2081978709342942')
+
+        expect(whatsapp_channel).not_to receive(:send_template)
+
+        described_class.new(campaign: campaign).perform
+      end
+
+      it 'does not infer lifecycle rotation from conversation presence alone' do
+        contact = create(:contact, account: account, phone_number: nil)
+        contact.update_labels([label1.title])
+        previous_contact_inbox = create(:contact_inbox, contact: contact, inbox: whatsapp_inbox, source_id: 'IN.PREVIOUSBSUID')
+        create(:conversation, account: account, inbox: whatsapp_inbox, contact: contact, contact_inbox: previous_contact_inbox)
+        create(:contact_inbox, contact: contact, inbox: whatsapp_inbox, source_id: 'IN.CURRENTBSUID')
+
+        expect(whatsapp_channel).not_to receive(:send_template)
+
+        described_class.new(campaign: campaign).perform
+      end
+
+      it 'does not send when a phone-less contact has multiple WhatsApp identities in the campaign inbox' do
+        contact = create(:contact, account: account, phone_number: nil)
+        contact.update_labels([label1.title])
+        create(:contact_inbox, contact: contact, inbox: whatsapp_inbox, source_id: 'IN.2081978709342942')
+        create(:contact_inbox, contact: contact, inbox: whatsapp_inbox, source_id: 'IN.2081978709342943')
+
+        allow(Rails.logger).to receive(:info)
+        expect(whatsapp_channel).not_to receive(:send_template)
+
+        described_class.new(campaign: campaign).perform
+      end
+
+      it 'does not submit authentication templates for BSUID-only contacts' do
+        contact = create(:contact, account: account, phone_number: nil)
+        contact.update_labels([label1.title])
+        create(:contact_inbox, contact: contact, inbox: whatsapp_inbox, source_id: 'IN.2081978709342942')
+        whatsapp_channel.update!(
+          message_templates: [
+            {
+              'name' => 'ticket_status_updated',
+              'language' => 'en',
+              'category' => 'AUTHENTICATION'
+            }
+          ]
+        )
+
+        allow(Rails.logger).to receive(:info)
+        expect(whatsapp_channel).not_to receive(:send_template)
+
+        described_class.new(campaign: campaign).perform
+      end
+
       it 'uses template processor service to process templates' do
         contact = create(:contact, :with_phone_number, account: account)
         contact.update_labels([label1.title])


### PR DESCRIPTION
BSUID-only contacts can now be included in one-off WhatsApp campaigns for Meta Cloud inboxes instead of being skipped because the contact has no phone number. Campaign delivery resolves a unique BSUID for the selected inbox, sends supported templates through Meta's `recipient` contract, and keeps existing phone-number campaign delivery unchanged.

Fixes https://linear.app/chatwoot/issue/CW-7802/support-bsuid-recipients-in-whatsapp-campaigns-and-bulk-sends

### Things to know

- This PR is intentionally scoped to Meta Cloud WhatsApp campaigns.
- Twilio WhatsApp campaign support is deferred; this PR does not change Twilio campaign UI, template parsing, provider submission, or analytics.
- A phone number remains the preferred campaign destination when present.
- Phone-less recipients require exactly one BSUID on the selected inbox. Missing or ambiguous identities are skipped/failed per recipient instead of selecting another merged identity.
- Authentication templates are blocked for BSUID-only campaign recipients before provider submission.

### How to test

1. Create a one-off WhatsApp campaign using a Meta Cloud inbox and an audience containing a contact with no phone number but exactly one BSUID ContactInbox in that inbox.
2. Select an approved non-authentication template and start the campaign.
3. Confirm the provider request addresses that contact by BSUID and the recipient is not skipped for a missing phone number.
4. Add a phone number to the same contact and confirm the campaign still sends to the phone number.
5. Add two BSUID ContactInboxes for the same contact and selected inbox; confirm the recipient is not sent because Chatwoot refuses to choose an ambiguous destination.
6. Select an authentication template for a BSUID-only recipient; confirm Chatwoot blocks it before provider submission.
