### PR TITLE
feat(whatsapp): expose scoped identity metadata

### DIFF
--- a/app/models/contact_inbox.rb
+++ b/app/models/contact_inbox.rb
@@ -41,7 +41,7 @@ class ContactInbox < ApplicationRecord
   }
 
   def webhook_data
-    {
+    data = {
       id: id,
       contact: contact.try(:webhook_data),
       inbox: inbox.webhook_data,
@@ -49,6 +49,9 @@ class ContactInbox < ApplicationRecord
       current_conversation: current_conversation.try(:webhook_data),
       source_id: source_id
     }
+    whatsapp_identity = Whatsapp::IdentityPresenter.new(self).identity
+    data[:whatsapp_identity] = whatsapp_identity if whatsapp_identity.present?
+    data
   end
 
   def current_conversation

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -192,10 +192,15 @@ class Message < ApplicationRecord
       message_type: message_type,
       private: private,
       sender: sender.try(:webhook_data),
-      source_id: source_id
+      source_id: source_id,
+      whatsapp_identity: whatsapp_identity
     }
     data[:attachments] = attachments.map(&:push_event_data) if attachments.present?
     data
+  end
+
+  def whatsapp_identity
+    Whatsapp::IdentityPresenter.new(conversation.contact_inbox).identity
   end
 
   # Method to get content with survey URL for outgoing channel delivery

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -23,9 +23,16 @@ class Conversations::EventDataPresenter < SimpleDelegator
 
   # Like #push_data but with message text normalized for external integrations (webhooks).
   def webhook_data
-    push_data.merge(
+    data = push_data.merge(
       account: account.webhook_data,
       messages: webhook_push_messages
+    )
+    identity_presenter = Whatsapp::IdentityPresenter.new(contact_inbox)
+    return data if identity_presenter.identity.blank?
+
+    data.merge(
+      whatsapp_identity: identity_presenter.identity,
+      whatsapp_username: identity_presenter.username
     )
   end
 

--- a/app/presenters/whatsapp/identity_presenter.rb
+++ b/app/presenters/whatsapp/identity_presenter.rb
@@ -1,0 +1,42 @@
+class Whatsapp::IdentityPresenter
+  include RegexHelper
+
+  def initialize(contact_inbox)
+    @contact_inbox = contact_inbox
+  end
+
+  def identity
+    return if @contact_inbox.blank?
+
+    provider = provider_for(@contact_inbox.inbox.channel)
+    type = type_for(@contact_inbox.source_id)
+    return if provider.blank? || type.blank?
+
+    {
+      type: type,
+      value: @contact_inbox.source_id,
+      provider: provider,
+      inbox_id: @contact_inbox.inbox_id
+    }
+  end
+
+  def username
+    return if identity.blank?
+
+    @contact_inbox.contact.additional_attributes['social_whatsapp_user_name'].presence
+  end
+
+  private
+
+  def provider_for(channel)
+    return 'whatsapp_cloud' if channel.is_a?(Channel::Whatsapp) && channel.provider == 'whatsapp_cloud'
+    return 'twilio' if channel.is_a?(Channel::TwilioSms) && channel.whatsapp?
+  end
+
+  def type_for(source_id)
+    identifier = source_id.to_s.delete_prefix('whatsapp:')
+    return 'phone_number' if identifier.match?(/\A\+?\d{1,15}\z/)
+    return 'parent_bsuid' if identifier.match?(/\A[A-Z]{2}\.ENT\./)
+    return 'bsuid' if identifier.match?(WHATSAPP_BSUID_REGEX)
+  end
+end

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -27,6 +27,12 @@ json.meta do
 end
 
 json.id conversation.display_id
+whatsapp_identity_presenter = Whatsapp::IdentityPresenter.new(conversation.contact_inbox)
+whatsapp_identity = whatsapp_identity_presenter.identity
+if whatsapp_identity.present?
+  json.whatsapp_identity whatsapp_identity
+  json.whatsapp_username whatsapp_identity_presenter.username
+end
 # The dashboard seeds the message thread from this array and then paginates BACKWARD
 # by id (before: messages[0].id). Keep the seed as the chronologically latest message,
 # but add an id tiebreaker: without it, same-second siblings (e.g. the input_csat survey

--- a/app/views/api/v1/models/_contact_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_contact_inbox.json.jbuilder
@@ -1,4 +1,6 @@
 json.source_id resource.source_id
+whatsapp_identity = Whatsapp::IdentityPresenter.new(resource).identity
+json.whatsapp_identity whatsapp_identity if whatsapp_identity.present?
 json.inbox do
   json.partial! 'api/v1/models/inbox_slim', formats: [:json], resource: resource.inbox
 end

--- a/app/views/api/v1/models/_message.json.jbuilder
+++ b/app/views/api/v1/models/_message.json.jbuilder
@@ -10,6 +10,8 @@ json.content_attributes message.content_attributes
 json.created_at message.created_at.to_i
 json.private message.private
 json.source_id message.source_id
+whatsapp_identity = message.whatsapp_identity
+json.whatsapp_identity whatsapp_identity if whatsapp_identity.present?
 json.sender message.sender.push_event_data if message.sender
 json.attachments message.attachments.map(&:push_event_data) if message.attachments.present?
 

--- a/docs/whatsapp_identity_contract.md
+++ b/docs/whatsapp_identity_contract.md
@@ -1,0 +1,17 @@
+# WhatsApp identity contract
+
+Chatwoot exposes a typed `whatsapp_identity` alongside the existing `source_id` wherever a response is already scoped to an exact WhatsApp `ContactInbox`. `source_id` is not deprecated or rewritten, so existing integrations can continue using it unchanged.
+
+The identity contains `type` (`phone_number`, `bsuid`, or `parent_bsuid`), `value`, `provider`, and `inbox_id`. Meta Cloud values remain unprefixed. Twilio values retain their provider-shaped `whatsapp:` prefix so they can round-trip without guessing or normalization.
+
+Conversation responses and outgoing webhooks also expose `whatsapp_username` when the provider supplied one. These fields are additive and are omitted or returned as `null` for non-WhatsApp and unsupported providers.
+
+## Scope and permissions
+
+The typed identity never expands the existing response scope: it describes the same `source_id` already attached to the authorized contact inbox, conversation, or message. Cross-inbox aliases are intentionally not emitted. A merged contact may own identifiers from unrelated WhatsApp inboxes or business portfolios, and contact ownership alone is not permission to expose those aliases together.
+
+Contact exports and generic contact webhooks therefore remain unchanged until their cross-inbox permission, masking, retention, and deletion behavior is agreed. The stable Chatwoot contact `id` remains the recommended downstream join key; phone number is not guaranteed for BSUID-only contacts.
+
+## Sending
+
+Provider-aware send paths continue to use the selected conversation or contact inbox. Meta Cloud sends BSUID destinations using the `recipient` contract, while Twilio uses its `whatsapp:<BSUID>` destination. Authentication templates cannot be sent to BSUID recipients.

--- a/swagger/definitions/index.yml
+++ b/swagger/definitions/index.yml
@@ -54,6 +54,8 @@ agent_bot:
   $ref: ./resource/agent_bot.yml
 contact_inboxes:
   $ref: ./resource/contact_inboxes.yml
+whatsapp_identity:
+  $ref: ./resource/whatsapp_identity.yml
 contactable_inboxes:
   $ref: ./resource/contactable_inboxes.yml
 custom_filter:

--- a/swagger/definitions/resource/contact_inboxes.yml
+++ b/swagger/definitions/resource/contact_inboxes.yml
@@ -2,6 +2,8 @@ type: object
 properties:
   source_id:
     type: string
-    description: Contact Inbox Source Id
+    description: Contact Inbox Source Id. This field remains unchanged for backward compatibility.
+  whatsapp_identity:
+    $ref: '#/components/schemas/whatsapp_identity'
   inbox:
     $ref: '#/components/schemas/inbox_contact'

--- a/swagger/definitions/resource/conversation.yml
+++ b/swagger/definitions/resource/conversation.yml
@@ -34,6 +34,13 @@ properties:
   inbox_id:
     type: number
     description: ID of the inbox
+  whatsapp_identity:
+    $ref: '#/components/schemas/whatsapp_identity'
+  whatsapp_username:
+    type:
+      - string
+      - 'null'
+    description: The latest WhatsApp username reported for the contact.
   labels:
     type: array
     items:
@@ -99,4 +106,3 @@ properties:
     items:
       type: object
       description: SLA event objects
-

--- a/swagger/definitions/resource/message.yml
+++ b/swagger/definitions/resource/message.yml
@@ -41,6 +41,8 @@ properties:
       - string
       - 'null'
     description: The source ID of the message
+  whatsapp_identity:
+    $ref: '#/components/schemas/whatsapp_identity'
   content_type:
     type:
       - string

--- a/swagger/definitions/resource/whatsapp_identity.yml
+++ b/swagger/definitions/resource/whatsapp_identity.yml
@@ -1,0 +1,21 @@
+type: object
+required:
+  - type
+  - value
+  - provider
+  - inbox_id
+properties:
+  type:
+    type: string
+    enum: [phone_number, bsuid, parent_bsuid]
+    description: The explicit WhatsApp identifier type.
+  value:
+    type: string
+    description: The provider-shaped destination value. Twilio values retain the `whatsapp:` prefix.
+  provider:
+    type: string
+    enum: [whatsapp_cloud, twilio]
+    description: The provider that owns and validates this identifier.
+  inbox_id:
+    type: integer
+    description: The Chatwoot inbox that scopes this identifier.


### PR DESCRIPTION
API and webhook consumers currently have to infer whether a WhatsApp `source_id` is a phone number, BSUID, or parent BSUID. This PR adds a typed `whatsapp_identity` alongside the existing source value on responses already scoped to an exact contact inbox, conversation, or message.

Meta Cloud and Twilio identities retain the provider-shaped value used for outbound routing. Existing `source_id` fields and phone-backed integrations remain unchanged.

### Closes

Related: https://linear.app/chatwoot/issue/CW-7803/expose-typed-whatsapp-identifiers-in-apis-webhooks-and-exports

### Things to know

- This PR is stacked on #15614.
- `whatsapp_identity` contains `type`, `value`, `provider`, and `inbox_id`; conversation payloads also expose `whatsapp_username` when available.
- Meta Cloud values remain unprefixed and Twilio values retain the `whatsapp:` prefix.
- 360Dialog is not supported.
- The existing `source_id` contract is unchanged.
- Cross-inbox aliases, generic contact webhooks, and contact exports are intentionally not changed here. A merged contact can own unrelated WhatsApp identities, so their permission, masking, retention, and deletion behavior needs explicit API review before those identifiers are aggregated.

### How to test

1. Open a Meta Cloud conversation whose exact ContactInbox uses a phone number, regular BSUID, or parent BSUID.
2. Fetch the conversation and its messages through the account API; confirm `whatsapp_identity.type` matches the source and the value matches the existing ContactInbox `source_id`.
3. Trigger a conversation or message webhook and confirm it contains the same typed identity.
4. Repeat with a Twilio WhatsApp conversation and confirm the value retains the `whatsapp:` prefix and the provider is `twilio`.
5. Fetch a non-WhatsApp conversation and confirm no typed WhatsApp identity is exposed.
6. Confirm the existing `source_id` values are unchanged on every response.
