### PR TITLE
docs: fix typo in message provider JSDoc

### DIFF
--- a/app/javascript/dashboard/components-next/message/provider.js
+++ b/app/javascript/dashboard/components-next/message/provider.js
@@ -112,7 +112,7 @@ const MessageControl = Symbol('MessageControl');
  * @property {import('vue').ComputedRef<MessageVariant>} variant - The visual variant of the message
  * @property {import('vue').ComputedRef<boolean>} isBotOrAgentMessage - Does the message belong to the current user
  * @property {import('vue').ComputedRef<boolean>} isPrivate - Proxy computed value for private
- * @property {import('vue').ComputedRef<boolean>} shouldGroupWithNext - Should group with the next message or not, it is differnt from groupWithNext, this has a bypass for a failed message
+ * @property {import('vue').ComputedRef<boolean>} shouldGroupWithNext - Should group with the next message or not, it is different from groupWithNext, this has a bypass for a failed message
  */
 
 /**


### PR DESCRIPTION
Corrects `differnt` to `different` in the `shouldGroupWithNext` JSDoc description in `app/javascript/dashboard/components-next/message/provider.js`.

Comment-only change; no runtime behavior changes.