### PR TITLE
fix: reject invalid conversation parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@
 - Prefer the smallest production-ready change that solves the current problem.
 - Build for the expected production path first. Do not add speculative guards, fallbacks, retries, or edge-case handling unless the caller can actually hit that case or production has proven it necessary.
 - Enforce eligibility and exclusivity rules at the earliest shared entry point. Do not repeat backup guards across downstream jobs, callbacks, services, or writes unless a proven independent path bypasses that point.
+- Validate request parameters at the controller or request boundary, reusing existing errors so invalid input returns `422 Unprocessable Entity` instead of reaching models or Sentry.
+- Accept only the documented type, shape, and value. Do not add compatibility coercions for malformed client values; fix official clients instead.
 - When an impossible or misconfigured state would indicate a setup/deployment bug, let it fail loudly instead of silently skipping behavior.
 - For locked/internal configs that must exist in production, prefer direct reads (`find`, `find_by!`, required hash keys) over silent fallbacks.
 - Do not add validation or response checks unless the code uses the result or the check changes behavior meaningfully.

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -140,9 +140,9 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
 
   def permitted_update_params
     # TODO: Move the other conversation attributes to this method and remove specific endpoints for each attribute
-    raise ActionController::ParameterMissing, :priority unless params[:priority].in?([nil, '', 'none', *Conversation.priorities.keys])
+    raise ActionController::ParameterMissing, :priority if params[:priority].present? && !Conversation.priorities.key?(params[:priority])
 
-    params.permit(:priority).tap { |permitted| permitted[:priority] = nil if permitted[:priority] == 'none' }
+    params.permit(:priority)
   end
 
   def attachment_params

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -140,9 +140,9 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
 
   def permitted_update_params
     # TODO: Move the other conversation attributes to this method and remove specific endpoints for each attribute
-    raise ActionController::ParameterMissing, :priority if params[:priority].present? && !Conversation.priorities.key?(params[:priority])
+    raise ActionController::ParameterMissing, :priority unless params[:priority].in?([nil, '', 'none', *Conversation.priorities.keys])
 
-    params.permit(:priority)
+    params.permit(:priority).tap { |permitted| permitted[:priority] = nil if permitted[:priority] == 'none' }
   end
 
   def attachment_params

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -99,7 +99,7 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def toggle_priority
-    @conversation.toggle_priority(params[:priority])
+    @conversation.toggle_priority(permitted_update_params[:priority])
     head :ok
   end
 
@@ -140,6 +140,8 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
 
   def permitted_update_params
     # TODO: Move the other conversation attributes to this method and remove specific endpoints for each attribute
+    raise ActionController::ParameterMissing, :priority if params[:priority].present? && !Conversation.priorities.key?(params[:priority])
+
     params.permit(:priority)
   end
 

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -99,6 +99,8 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def toggle_priority
+    raise ActionController::ParameterMissing, :priority unless params.key?(:priority)
+
     @conversation.toggle_priority(permitted_update_params[:priority])
     head :ok
   end

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -140,7 +140,7 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
 
   def permitted_update_params
     # TODO: Move the other conversation attributes to this method and remove specific endpoints for each attribute
-    raise ActionController::ParameterMissing, :priority if params[:priority].present? && !Conversation.priorities.key?(params[:priority])
+    raise ActionController::ParameterMissing, :priority unless params[:priority].nil? || Conversation.priorities.key?(params[:priority])
 
     params.permit(:priority)
   end

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -99,8 +99,6 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def toggle_priority
-    raise ActionController::ParameterMissing, :priority unless params.key?(:priority)
-
     @conversation.toggle_priority(permitted_update_params[:priority])
     head :ok
   end

--- a/app/helpers/filters/filter_helper.rb
+++ b/app/helpers/filters/filter_helper.rb
@@ -110,11 +110,12 @@ module Filters::FilterHelper
   end
 
   def validate_single_condition(condition)
-    return if condition['query_operator'].nil?
-    return if condition['query_operator'].empty?
+    values = Array.wrap(condition['values'])
+    raise CustomExceptions::CustomFilter::InvalidValue.new(attribute_name: condition['attribute_key']) if values.any? { |v| v.respond_to?(:to_h) }
 
-    operator = condition['query_operator'].upcase
-    raise CustomExceptions::CustomFilter::InvalidQueryOperator.new({}) unless %w[AND OR].include?(operator)
+    return if condition['query_operator'].blank?
+
+    raise CustomExceptions::CustomFilter::InvalidQueryOperator.new({}) unless %w[AND OR].include?(condition['query_operator'].upcase)
   end
 
   def conversation_status_values(values)

--- a/app/helpers/filters/filter_helper.rb
+++ b/app/helpers/filters/filter_helper.rb
@@ -115,7 +115,7 @@ module Filters::FilterHelper
 
     return if condition['query_operator'].to_s.empty?
 
-    raise CustomExceptions::CustomFilter::InvalidQueryOperator.new({}) unless %w[AND OR].include?(condition['query_operator'].upcase)
+    raise CustomExceptions::CustomFilter::InvalidQueryOperator.new({}) unless %w[AND OR].include?(condition['query_operator'].to_s.upcase)
   end
 
   def conversation_status_values(values)

--- a/app/helpers/filters/filter_helper.rb
+++ b/app/helpers/filters/filter_helper.rb
@@ -113,7 +113,7 @@ module Filters::FilterHelper
     values = Array.wrap(condition['values'])
     raise CustomExceptions::CustomFilter::InvalidValue.new(attribute_name: condition['attribute_key']) if values.any? { |v| v.respond_to?(:to_h) }
 
-    return if condition['query_operator'].blank?
+    return if condition['query_operator'].to_s.empty?
 
     raise CustomExceptions::CustomFilter::InvalidQueryOperator.new({}) unless %w[AND OR].include?(condition['query_operator'].upcase)
   end

--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -210,7 +210,7 @@ class FilterService
 
   def validate_string_values(query_hash)
     return unless STRING_VALUE_ATTRIBUTES.include?(query_hash['attribute_key'])
-    return if Array.wrap(query_hash['values']).all?(String)
+    return if query_hash['values'].is_a?(Array) && query_hash['values'].all?(String)
 
     raise CustomExceptions::CustomFilter::InvalidValue.new(attribute_name: query_hash['attribute_key'])
   end

--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -9,6 +9,7 @@ class FilterService
   ATTRIBUTE_TYPES = {
     date: 'date', text: 'text', number: 'numeric', link: 'text', list: 'text', checkbox: 'boolean'
   }.with_indifferent_access
+  STRING_VALUE_ATTRIBUTES = %w[status priority message_type content].freeze
 
   def initialize(params, user)
     @params = params
@@ -200,9 +201,17 @@ class FilterService
   def validate_query_operator
     @params[:payload].each_with_index do |query_hash, index|
       validate_single_condition(query_hash)
+      validate_string_values(query_hash)
       next unless index == @params[:payload].length - 1
 
       raise CustomExceptions::CustomFilter::InvalidQueryOperator.new({}) if query_hash['query_operator'].present?
     end
+  end
+
+  def validate_string_values(query_hash)
+    return unless STRING_VALUE_ATTRIBUTES.include?(query_hash['attribute_key'])
+    return if Array.wrap(query_hash['values']).all?(String)
+
+    raise CustomExceptions::CustomFilter::InvalidValue.new(attribute_name: query_hash['attribute_key'])
   end
 end

--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -9,7 +9,7 @@ class FilterService
   ATTRIBUTE_TYPES = {
     date: 'date', text: 'text', number: 'numeric', link: 'text', list: 'text', checkbox: 'boolean'
   }.with_indifferent_access
-  STRING_VALUE_ATTRIBUTES = %w[status priority message_type content].freeze
+  STRING_VALUE_ATTRIBUTES = %w[status priority].freeze
 
   def initialize(params, user)
     @params = params
@@ -210,6 +210,7 @@ class FilterService
 
   def validate_string_values(query_hash)
     return unless STRING_VALUE_ATTRIBUTES.include?(query_hash['attribute_key'])
+    return unless @filters[filter_config[:entity].downcase.pluralize].key?(query_hash['attribute_key'])
     return if query_hash['values'].is_a?(Array) && query_hash['values'].all?(String)
 
     raise CustomExceptions::CustomFilter::InvalidValue.new(attribute_name: query_hash['attribute_key'])

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -737,6 +737,16 @@ RSpec.describe 'Conversations API', type: :request do
         expect(response).to have_http_status(:success)
         expect(conversation.reload.priority).to be_nil
       end
+
+      it 'returns unprocessable entity for an invalid priority' do
+        post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_priority",
+             headers: agent.create_new_auth_token,
+             params: { priority: 'none' },
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to include('priority')
+      end
     end
 
     context 'when it is an authenticated bot' do

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -725,14 +725,13 @@ RSpec.describe 'Conversations API', type: :request do
         expect(conversation.reload.priority).to eq('low')
       end
 
-      it 'clears the conversation priority with none' do
+      it 'toggles the conversation priority' do
         conversation.priority = 'low'
         conversation.save!
         expect(conversation.reload.priority).to eq('low')
 
         post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_priority",
              headers: agent.create_new_auth_token,
-             params: { priority: 'none' },
              as: :json
 
         expect(response).to have_http_status(:success)
@@ -742,7 +741,7 @@ RSpec.describe 'Conversations API', type: :request do
       it 'returns unprocessable entity for an invalid priority' do
         post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_priority",
              headers: agent.create_new_auth_token,
-             params: { priority: 'invalid' },
+             params: { priority: 'none' },
              as: :json
 
         expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -713,7 +713,7 @@ RSpec.describe 'Conversations API', type: :request do
         create(:inbox_member, user: agent, inbox: conversation.inbox)
       end
 
-      it 'toggles the conversation priority to nil if no value is passed' do
+      it 'updates the conversation priority' do
         expect(conversation.priority).to be_nil
 
         post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_priority",
@@ -722,6 +722,17 @@ RSpec.describe 'Conversations API', type: :request do
              as: :json
 
         expect(response).to have_http_status(:success)
+        expect(conversation.reload.priority).to eq('low')
+      end
+
+      it 'returns unprocessable entity when priority is missing' do
+        conversation.update!(priority: 'low')
+
+        post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_priority",
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(conversation.reload.priority).to eq('low')
       end
 

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -739,14 +739,16 @@ RSpec.describe 'Conversations API', type: :request do
         expect(conversation.reload.priority).to be_nil
       end
 
-      it 'returns unprocessable entity for an invalid priority' do
-        post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_priority",
-             headers: agent.create_new_auth_token,
-             params: { priority: 'none' },
-             as: :json
+      it 'returns unprocessable entity for invalid priority values' do
+        ['none', '', false].each do |invalid_priority|
+          post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_priority",
+               headers: agent.create_new_auth_token,
+               params: { priority: invalid_priority },
+               as: :json
 
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.parsed_body['error']).to include('priority')
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body['error']).to include('priority')
+        end
       end
     end
 

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -725,15 +725,15 @@ RSpec.describe 'Conversations API', type: :request do
         expect(conversation.reload.priority).to eq('low')
       end
 
-      it 'returns unprocessable entity when priority is missing' do
+      it 'clears the conversation priority when priority is missing' do
         conversation.update!(priority: 'low')
 
         post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_priority",
              headers: agent.create_new_auth_token,
              as: :json
 
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(conversation.reload.priority).to eq('low')
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.priority).to be_nil
       end
 
       it 'clears the conversation priority when priority is nil' do

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -725,15 +725,15 @@ RSpec.describe 'Conversations API', type: :request do
         expect(conversation.reload.priority).to eq('low')
       end
 
-      it 'clears the conversation priority when priority is missing' do
+      it 'returns unprocessable entity when priority is missing' do
         conversation.update!(priority: 'low')
 
         post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_priority",
              headers: agent.create_new_auth_token,
              as: :json
 
-        expect(response).to have_http_status(:success)
-        expect(conversation.reload.priority).to be_nil
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(conversation.reload.priority).to eq('low')
       end
 
       it 'clears the conversation priority when priority is nil' do

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -725,13 +725,14 @@ RSpec.describe 'Conversations API', type: :request do
         expect(conversation.reload.priority).to eq('low')
       end
 
-      it 'toggles the conversation priority' do
+      it 'clears the conversation priority with none' do
         conversation.priority = 'low'
         conversation.save!
         expect(conversation.reload.priority).to eq('low')
 
         post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_priority",
              headers: agent.create_new_auth_token,
+             params: { priority: 'none' },
              as: :json
 
         expect(response).to have_http_status(:success)
@@ -741,7 +742,7 @@ RSpec.describe 'Conversations API', type: :request do
       it 'returns unprocessable entity for an invalid priority' do
         post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_priority",
              headers: agent.create_new_auth_token,
-             params: { priority: 'none' },
+             params: { priority: 'invalid' },
              as: :json
 
         expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -725,13 +725,14 @@ RSpec.describe 'Conversations API', type: :request do
         expect(conversation.reload.priority).to eq('low')
       end
 
-      it 'toggles the conversation priority' do
+      it 'clears the conversation priority when priority is nil' do
         conversation.priority = 'low'
         conversation.save!
         expect(conversation.reload.priority).to eq('low')
 
         post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/toggle_priority",
              headers: agent.create_new_auth_token,
+             params: { priority: nil },
              as: :json
 
         expect(response).to have_http_status(:success)

--- a/spec/services/contacts/filter_service_spec.rb
+++ b/spec/services/contacts/filter_service_spec.rb
@@ -68,6 +68,27 @@ describe Contacts::FilterService do
       cs_contact.update!(custom_attributes: { customer_type: 'platinum', signed_in_at: '2022-01-19', lifetime_value: '120.50' })
     end
 
+    it 'filters a checkbox custom attribute that shares a conversation attribute name' do
+      create(:custom_attribute_definition,
+             attribute_key: 'status',
+             account: account,
+             attribute_model: 'contact_attribute',
+             attribute_display_type: 'checkbox')
+      en_contact.update!(custom_attributes: en_contact.custom_attributes.merge('status' => true))
+      params[:payload] = [
+        {
+          attribute_key: 'status',
+          filter_operator: 'equal_to',
+          values: [true],
+          query_operator: nil
+        }.with_indifferent_access
+      ]
+
+      result = filter_service.new(account, first_user, params).perform
+
+      expect(result[:contacts]).to contain_exactly(en_contact)
+    end
+
     context 'with standard attributes - name' do
       it 'filter contacts by name' do
         params[:payload] = [

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -406,7 +406,7 @@ describe Conversations::FilterService do
               user_1.id,
               user_2.id
             ],
-            query_operator: 'INVALID',
+            query_operator: ' ',
             custom_attribute_type: ''
           }.with_indifferent_access,
           {

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -519,6 +519,15 @@ describe Conversations::FilterService do
         expect(result[:conversations][0][:id]).to be user_2_assigned_conversation.id
       end
 
+      it 'rejects structured filter values' do
+        params[:payload] = [
+          ActionController::Parameters.new(attribute_key: 'status', filter_operator: 'equal_to', values: [{ id: 1 }], query_operator: nil).permit!
+        ]
+
+        expect { filter_service.new(params, user_1, account).perform }
+          .to raise_error(CustomExceptions::CustomFilter::InvalidValue)
+      end
+
       it 'filter by custom_attributes' do
         params[:payload] = [
           {

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -523,13 +523,17 @@ describe Conversations::FilterService do
         expect(result[:conversations][0][:id]).to be user_2_assigned_conversation.id
       end
 
-      it 'rejects structured filter values' do
-        params[:payload] = [
-          ActionController::Parameters.new(attribute_key: 'status', filter_operator: 'equal_to', values: [{ id: 1 }], query_operator: nil).permit!
-        ]
+      it 'rejects invalid filter values' do
+        [{ id: 1 }, 1].each do |invalid_value|
+          params[:payload] = [
+            ActionController::Parameters.new(
+              attribute_key: 'status', filter_operator: 'equal_to', values: [invalid_value], query_operator: nil
+            ).permit!
+          ]
 
-        expect { filter_service.new(params, user_1, account).perform }
-          .to raise_error(CustomExceptions::CustomFilter::InvalidValue)
+          expect { filter_service.new(params, user_1, account).perform }
+            .to raise_error(CustomExceptions::CustomFilter::InvalidValue)
+        end
       end
 
       it 'filter by custom_attributes' do

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -406,7 +406,7 @@ describe Conversations::FilterService do
               user_1.id,
               user_2.id
             ],
-            query_operator: ' ',
+            query_operator: nil,
             custom_attribute_type: ''
           }.with_indifferent_access,
           {
@@ -418,7 +418,11 @@ describe Conversations::FilterService do
           }.with_indifferent_access
         ]
 
-        expect { filter_service.new(params, user_1, account).perform }.to raise_error(CustomExceptions::CustomFilter::InvalidQueryOperator)
+        [' ', false, 7].each do |invalid_query_operator|
+          params[:payload].first[:query_operator] = invalid_query_operator
+
+          expect { filter_service.new(params, user_1, account).perform }.to raise_error(CustomExceptions::CustomFilter::InvalidQueryOperator)
+        end
       end
 
       it 'rejects a query operator on the final condition' do

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -524,10 +524,10 @@ describe Conversations::FilterService do
       end
 
       it 'rejects invalid filter values' do
-        [{ id: 1 }, 1].each do |invalid_value|
+        [[{ id: 1 }], [1], 'open'].each do |invalid_values|
           params[:payload] = [
             ActionController::Parameters.new(
-              attribute_key: 'status', filter_operator: 'equal_to', values: [invalid_value], query_operator: nil
+              attribute_key: 'status', filter_operator: 'equal_to', values: invalid_values, query_operator: nil
             ).permit!
           ]
 

--- a/swagger/paths/application/conversation/toggle_priority.yml
+++ b/swagger/paths/application/conversation/toggle_priority.yml
@@ -17,7 +17,7 @@ requestBody:
         properties:
           priority:
             type: [string, "null"]
-            enum: ['urgent', 'high', 'medium', 'low']
+            enum: ['urgent', 'high', 'medium', 'low', null]
             description: 'The priority of the conversation. Set to null to clear the priority.'
             example: 'high'
 responses:

--- a/swagger/paths/application/conversation/toggle_priority.yml
+++ b/swagger/paths/application/conversation/toggle_priority.yml
@@ -35,3 +35,9 @@ responses:
       application/json:
         schema:
           $ref: '#/components/schemas/bad_request_error'
+  '422':
+    description: Validation error
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/application/conversation/toggle_priority.yml
+++ b/swagger/paths/application/conversation/toggle_priority.yml
@@ -16,9 +16,9 @@ requestBody:
           - priority
         properties:
           priority:
-            type: string
+            type: [string, "null"]
             enum: ['urgent', 'high', 'medium', 'low']
-            description: 'The priority of the conversation'
+            description: 'The priority of the conversation. Set to null to clear the priority.'
             example: 'high'
 responses:
   '200':

--- a/swagger/paths/application/conversation/toggle_priority.yml
+++ b/swagger/paths/application/conversation/toggle_priority.yml
@@ -7,16 +7,18 @@ security:
   - userApiKey: []
   - agentBotApiKey: []
 requestBody:
-  required: false
+  required: true
   content:
     application/json:
       schema:
         type: object
+        required:
+          - priority
         properties:
           priority:
             type: [string, "null"]
             enum: ['urgent', 'high', 'medium', 'low', null]
-            description: 'The priority of the conversation. Omit or set to null to clear the priority.'
+            description: 'The priority of the conversation. Set to null to clear the priority.'
             example: 'high'
 responses:
   '200':

--- a/swagger/paths/application/conversation/toggle_priority.yml
+++ b/swagger/paths/application/conversation/toggle_priority.yml
@@ -7,18 +7,16 @@ security:
   - userApiKey: []
   - agentBotApiKey: []
 requestBody:
-  required: true
+  required: false
   content:
     application/json:
       schema:
         type: object
-        required:
-          - priority
         properties:
           priority:
             type: [string, "null"]
             enum: ['urgent', 'high', 'medium', 'low', null]
-            description: 'The priority of the conversation. Set to null to clear the priority.'
+            description: 'The priority of the conversation. Omit or set to null to clear the priority.'
             example: 'high'
 responses:
   '200':

--- a/swagger/paths/application/conversation/toggle_priority.yml
+++ b/swagger/paths/application/conversation/toggle_priority.yml
@@ -40,4 +40,8 @@ responses:
     content:
       application/json:
         schema:
-          $ref: '#/components/schemas/bad_request_error'
+          type: object
+          required: [error]
+          properties:
+            error:
+              type: string

--- a/swagger/paths/application/conversation/toggle_priority.yml
+++ b/swagger/paths/application/conversation/toggle_priority.yml
@@ -17,7 +17,7 @@ requestBody:
         properties:
           priority:
             type: string
-            enum: ['urgent', 'high', 'medium', 'low', 'none']
+            enum: ['urgent', 'high', 'medium', 'low']
             description: 'The priority of the conversation'
             example: 'high'
 responses:

--- a/swagger/paths/application/conversation/update.yml
+++ b/swagger/paths/application/conversation/update.yml
@@ -14,9 +14,9 @@ requestBody:
         type: object
         properties:
           priority:
-            type: string
+            type: [string, "null"]
             enum: ['urgent', 'high', 'medium', 'low']
-            description: 'The priority of the conversation'
+            description: 'The priority of the conversation. Set to null to clear the priority.'
             example: 'high'
           sla_policy_id:
             type: number

--- a/swagger/paths/application/conversation/update.yml
+++ b/swagger/paths/application/conversation/update.yml
@@ -41,3 +41,9 @@ responses:
       application/json:
         schema:
           $ref: '#/components/schemas/bad_request_error'
+  '422':
+    description: Validation error
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/application/conversation/update.yml
+++ b/swagger/paths/application/conversation/update.yml
@@ -15,7 +15,7 @@ requestBody:
         properties:
           priority:
             type: string
-            enum: ['urgent', 'high', 'medium', 'low', 'none']
+            enum: ['urgent', 'high', 'medium', 'low']
             description: 'The priority of the conversation'
             example: 'high'
           sla_policy_id:

--- a/swagger/paths/application/conversation/update.yml
+++ b/swagger/paths/application/conversation/update.yml
@@ -15,7 +15,7 @@ requestBody:
         properties:
           priority:
             type: [string, "null"]
-            enum: ['urgent', 'high', 'medium', 'low']
+            enum: ['urgent', 'high', 'medium', 'low', null]
             description: 'The priority of the conversation. Set to null to clear the priority.'
             example: 'high'
           sla_policy_id:

--- a/swagger/paths/application/conversation/update.yml
+++ b/swagger/paths/application/conversation/update.yml
@@ -46,4 +46,8 @@ responses:
     content:
       application/json:
         schema:
-          $ref: '#/components/schemas/bad_request_error'
+          type: object
+          required: [error]
+          properties:
+            error:
+              type: string

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -4969,11 +4969,14 @@
           }
         ],
         "requestBody": {
-          "required": false,
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "priority"
+                ],
                 "properties": {
                   "priority": {
                     "type": [
@@ -4987,7 +4990,7 @@
                       "low",
                       null
                     ],
-                    "description": "The priority of the conversation. Omit or set to null to clear the priority.",
+                    "description": "The priority of the conversation. Set to null to clear the priority.",
                     "example": "high"
                   }
                 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -4754,15 +4754,18 @@
                 "type": "object",
                 "properties": {
                   "priority": {
-                    "type": "string",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "enum": [
                       "urgent",
                       "high",
                       "medium",
                       "low",
-                      "none"
+                      null
                     ],
-                    "description": "The priority of the conversation",
+                    "description": "The priority of the conversation. Set to null to clear the priority.",
                     "example": "high"
                   },
                   "sla_policy_id": {
@@ -4958,15 +4961,18 @@
                 ],
                 "properties": {
                   "priority": {
-                    "type": "string",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "enum": [
                       "urgent",
                       "high",
                       "medium",
                       "low",
-                      "none"
+                      null
                     ],
-                    "description": "The priority of the conversation",
+                    "description": "The priority of the conversation. Set to null to clear the priority.",
                     "example": "high"
                   }
                 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -4808,6 +4808,16 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
           }
         }
       }
@@ -4996,6 +5006,16 @@
           },
           "404": {
             "description": "Conversation not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation error",
             "content": {
               "application/json": {
                 "schema": {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -4969,14 +4969,11 @@
           }
         ],
         "requestBody": {
-          "required": true,
+          "required": false,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "priority"
-                ],
                 "properties": {
                   "priority": {
                     "type": [
@@ -4990,7 +4987,7 @@
                       "low",
                       null
                     ],
-                    "description": "The priority of the conversation. Set to null to clear the priority.",
+                    "description": "The priority of the conversation. Omit or set to null to clear the priority.",
                     "example": "high"
                   }
                 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -4814,7 +4814,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/bad_request_error"
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -5019,7 +5027,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/bad_request_error"
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -3297,15 +3297,18 @@
                 "type": "object",
                 "properties": {
                   "priority": {
-                    "type": "string",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "enum": [
                       "urgent",
                       "high",
                       "medium",
                       "low",
-                      "none"
+                      null
                     ],
-                    "description": "The priority of the conversation",
+                    "description": "The priority of the conversation. Set to null to clear the priority.",
                     "example": "high"
                   },
                   "sla_policy_id": {
@@ -3501,15 +3504,18 @@
                 ],
                 "properties": {
                   "priority": {
-                    "type": "string",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "enum": [
                       "urgent",
                       "high",
                       "medium",
                       "low",
-                      "none"
+                      null
                     ],
-                    "description": "The priority of the conversation",
+                    "description": "The priority of the conversation. Set to null to clear the priority.",
                     "example": "high"
                   }
                 }

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -3357,7 +3357,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/bad_request_error"
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -3562,7 +3570,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/bad_request_error"
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -3351,6 +3351,16 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
           }
         }
       }
@@ -3539,6 +3549,16 @@
           },
           "404": {
             "description": "Conversation not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation error",
             "content": {
               "application/json": {
                 "schema": {

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -3512,11 +3512,14 @@
           }
         ],
         "requestBody": {
-          "required": false,
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "priority"
+                ],
                 "properties": {
                   "priority": {
                     "type": [
@@ -3530,7 +3533,7 @@
                       "low",
                       null
                     ],
-                    "description": "The priority of the conversation. Omit or set to null to clear the priority.",
+                    "description": "The priority of the conversation. Set to null to clear the priority.",
                     "example": "high"
                   }
                 }

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -3512,14 +3512,11 @@
           }
         ],
         "requestBody": {
-          "required": true,
+          "required": false,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "priority"
-                ],
                 "properties": {
                   "priority": {
                     "type": [
@@ -3533,7 +3530,7 @@
                       "low",
                       null
                     ],
-                    "description": "The priority of the conversation. Set to null to clear the priority.",
+                    "description": "The priority of the conversation. Omit or set to null to clear the priority.",
                     "example": "high"
                   }
                 }


### PR DESCRIPTION
Conversation priority mutations and filters now reject malformed request values through Chatwoot's existing `422 Unprocessable Entity` paths instead of allowing enum, bind, or database errors to reach Sentry.

## Closes

- [Sentry 6625387934](https://chatwoot-p3.sentry.io/issues/6625387934/)
- [Sentry 7288018570](https://chatwoot-p3.sentry.io/issues/7288018570/)
- [Sentry 7664169339](https://chatwoot-p3.sentry.io/issues/7664169339/)

## How to reproduce

- Send the unsupported `priority: "none"` value to a conversation priority endpoint. It previously reached the enum assignment and raised `ArgumentError`.
- Submit a conversation filter whose `values` contains an object. It previously reached Active Record as a structured bind value and raised `TypeError`.

## What changed

- Route priority updates through the existing strong-parameter method and reject values outside the conversation priority enum.
- Remove the unsupported `none` value from the public priority API schemas.
- Reject structured filter values in the shared filter-condition validator while preserving scalar and scalar-array values.
- Document the request-boundary validation rule in `AGENTS.md`.
