### PR TITLE
feat(whatsapp): enable embedded signup for paid plans

### DIFF
--- a/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
+++ b/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
@@ -18,6 +18,7 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
     advanced_search
     linear_integration
     channel_voice
+    whatsapp_embedded_signup_inbox_creation
     api_and_webhooks
     data_import
   ].freeze

--- a/enterprise/app/services/internal/accounts/internal_attributes_service.rb
+++ b/enterprise/app/services/internal/accounts/internal_attributes_service.rb
@@ -54,7 +54,7 @@ class Internal::Accounts::InternalAttributesService
   def valid_feature_list
     Enterprise::Billing::ReconcilePlanFeaturesService::BUSINESS_PLAN_FEATURES +
       Enterprise::Billing::ReconcilePlanFeaturesService::ENTERPRISE_PLAN_FEATURES +
-      %w[inbound_emails api_and_webhooks]
+      %w[inbound_emails api_and_webhooks whatsapp_embedded_signup_inbox_creation]
   end
 
   # Account notes functionality removed for now

--- a/spec/enterprise/services/enterprise/billing/reconcile_plan_features_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/reconcile_plan_features_service_spec.rb
@@ -49,5 +49,16 @@ describe Enterprise::Billing::ReconcilePlanFeaturesService do
         expect(account.reload).to be_feature_enabled('api_and_webhooks')
       end
     end
+
+    context 'with whatsapp_embedded_signup_inbox_creation feature' do
+      it 'keeps the feature enabled on the default plan when manually managed' do
+        account.update!(custom_attributes: { 'plan_name' => 'Hacker', 'subscription_status' => 'active' })
+        Internal::Accounts::InternalAttributesService.new(account).manually_managed_features = ['whatsapp_embedded_signup_inbox_creation']
+
+        described_class.new(account: account).perform
+
+        expect(account.reload).to be_feature_enabled('whatsapp_embedded_signup_inbox_creation')
+      end
+    end
   end
 end


### PR DESCRIPTION
Paid Chatwoot Cloud accounts now receive access to WhatsApp Embedded Signup automatically when their plan features are reconciled. This removes the support approval step for Startups, Business, and Enterprise plans while leaving the Hacker plan's automatic entitlement unchanged.

The installation-wide Meta inbox creation switch remains independent of plan entitlement, so the existing incident control continues to take precedence in the product UI.

### Things to know

- This PR does not include a data migration. Existing paid accounts require a one-time manual backfill.
- Hacker accounts are not granted the feature automatically. Support-approved exceptions can be recorded as manually managed and will survive plan reconciliation.
- Existing Hacker accounts approved through a direct feature toggle must be recorded as manually managed before their next reconciliation.

### How to test

1. Reconcile features for a Startups, Business, or Enterprise account.
2. Open Settings -> Inboxes -> Add Inbox -> WhatsApp.
3. Confirm WhatsApp Embedded Signup is available without requesting support access.
4. Reconcile a Hacker account and confirm it does not receive Embedded Signup automatically.
5. Add Embedded Signup as a manually managed feature for a Hacker account, reconcile it, and confirm access remains enabled.
6. Enable `DISABLE_META_INBOX_CREATION` and confirm the existing Meta inbox creation restriction remains active in the UI.
