### PR TITLE
fix: moved learn more hyperlink below the description

### DIFF
--- a/app/javascript/dashboard/helper/featureHelper.js
+++ b/app/javascript/dashboard/helper/featureHelper.js
@@ -17,6 +17,8 @@ const FEATURE_HELP_URLS = {
   sla: 'https://chwt.app/hc/sla',
   team_management: 'https://chwt.app/hc/teams',
   webhook: 'https://chwt.app/hc/webhooks',
+  whatsapp_templates:
+    'https://www.chatwoot.com/hc/user-guide/articles/1754940076-whatsapp-templates',
   billing: 'https://chwt.app/pricing',
   saml: 'https://chwt.app/hc/saml',
   captain: 'https://chwt.app/captain-docs',

--- a/app/javascript/dashboard/i18n/locale/en/whatsappTemplateMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/whatsappTemplateMgmt.json
@@ -3,7 +3,7 @@
     "TITLE": "Templates",
     "DESCRIPTION": "View the message templates synced from your WhatsApp inboxes. To create or edit a template, manage it with your provider.",
     "COUNT": "{n} template | {n} templates",
-    "KNOW_MORE": "Know more",
+    "LEARN_MORE": "Learn more about WhatsApp templates",
     "SYNC_TEMPLATES": "Sync templates",
     "SYNC_SUCCESS": "Template sync started for all WhatsApp inboxes. Updates may take a couple of minutes.",
     "PARTIAL_SYNC_ERROR": "Template sync started for some WhatsApp inboxes, but others could not be synced.",

--- a/app/javascript/dashboard/routes/dashboard/settings/components/BaseSettingsHeader.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/components/BaseSettingsHeader.vue
@@ -59,7 +59,9 @@ const helpURL = getHelpUrlForFeature(props.featureName);
       </slot>
     </div>
     <div
-      v-if="description || $slots.description || linkText || helpURL"
+      v-if="
+        description || $slots.description || linkText || helpURL || $slots.meta
+      "
       class="flex flex-col w-full gap-1.5 text-n-slate-11"
     >
       <p
@@ -83,6 +85,7 @@ const helpURL = getHelpUrlForFeature(props.featureName);
           />
         </a>
       </CustomBrandPolicyWrapper>
+      <slot name="meta" />
     </div>
   </div>
   <div

--- a/app/javascript/dashboard/routes/dashboard/settings/templates/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/templates/Index.vue
@@ -32,9 +32,6 @@ const FUZZY_SEARCH_KEYS = [
   'searchableContent',
 ];
 
-const TEMPLATE_LEARN_MORE_URL =
-  'https://www.chatwoot.com/hc/user-guide/articles/1754940076-whatsapp-templates';
-
 const store = useStore();
 const { t } = useI18n();
 
@@ -342,24 +339,15 @@ onDeactivated(abortTemplateRequest);
       <BaseSettingsHeader
         v-model:search-query="searchQuery"
         :title="$t('WHATSAPP_TEMPLATE_MGMT.TITLE')"
+        :description="$t('WHATSAPP_TEMPLATE_MGMT.DESCRIPTION')"
+        :link-text="$t('WHATSAPP_TEMPLATE_MGMT.LEARN_MORE')"
+        feature-name="whatsapp_templates"
         :search-placeholder="
           showSearch ? $t('WHATSAPP_TEMPLATE_MGMT.SEARCH_PLACEHOLDER') : ''
         "
       >
-        <template #description>
-          {{ $t('WHATSAPP_TEMPLATE_MGMT.DESCRIPTION') }}
-          <a
-            :href="TEMPLATE_LEARN_MORE_URL"
-            class="text-sm font-medium text-n-blue-11 hover:underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {{ $t('WHATSAPP_TEMPLATE_MGMT.KNOW_MORE') }}
-          </a>
-          <span
-            v-if="lastSyncAttemptAt"
-            class="block mt-1 text-xs text-n-slate-10"
-          >
+        <template v-if="lastSyncAttemptAt" #meta>
+          <span class="text-xs text-n-slate-10">
             {{
               $t('WHATSAPP_TEMPLATE_MGMT.LAST_SYNC_ATTEMPT', {
                 date: formatTemplateDate(lastSyncAttemptAt),


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the Templates page using different "Know more" link copy and a hardcoded chatwoot.com URL, which also remained visible on custom-branded installs. It now uses the shared settings header link, matching the copy used across the product ("Learn more about WhatsApp templates") and automatically hiding the link on custom-branded instances.

It also fixes the "Last sync attempt" line appearing between the description and the link. It now renders below the link as a secondary line.

Fixes https://linear.app/chatwoot/issue/CW-8056/remove-hyperlink-from-templates-page-header

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**
<img width="1249" height="338" alt="image" src="https://github.com/user-attachments/assets/23bc3b21-07c8-45c4-843e-d64928a5171b" />

**After**
<img width="1249" height="338" alt="image" src="https://github.com/user-attachments/assets/8c5878f9-44c2-4fe4-837e-c7b57bb26aec" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
