### PR TITLE
fix(inboxes): hide Facebook and X identifiers

### DIFF
--- a/app/javascript/dashboard/helper/inbox.js
+++ b/app/javascript/dashboard/helper/inbox.js
@@ -111,15 +111,13 @@ const INBOX_ICON_MAP_LINE = {
 
 const DEFAULT_ICON_LINE = 'i-ri-chat-1-line';
 
-// Instagram and TikTok already use the provider account name as the inbox name;
-// their IDs are opaque routing keys and should not be shown as identifiers.
+// Facebook, Instagram, TikTok, and X initialize the editable inbox name from
+// the provider account name; their opaque routing IDs should not be displayed.
 const INBOX_IDENTIFIER_RESOLVERS = {
   [INBOX_TYPES.WEB]: inbox => inbox.website_url,
   [INBOX_TYPES.EMAIL]: inbox => inbox.email,
   [INBOX_TYPES.WHATSAPP]: inbox => inbox.phone_number,
   [INBOX_TYPES.SMS]: inbox => inbox.phone_number,
-  [INBOX_TYPES.FB]: inbox => inbox.page_id,
-  [INBOX_TYPES.TWITTER]: inbox => inbox.profile_id,
   [INBOX_TYPES.LINE]: inbox => inbox.line_channel_id,
   [INBOX_TYPES.API]: inbox => inbox.inbox_identifier,
   [INBOX_TYPES.TWILIO]: inbox =>

--- a/app/javascript/dashboard/helper/specs/inbox.spec.js
+++ b/app/javascript/dashboard/helper/specs/inbox.spec.js
@@ -25,8 +25,6 @@ describe('#Inbox Helpers', () => {
       ],
       [INBOX_TYPES.WHATSAPP, { phone_number: '+15555550100' }, '+15555550100'],
       [INBOX_TYPES.SMS, { phone_number: '+15555550101' }, '+15555550101'],
-      [INBOX_TYPES.FB, { page_id: 'page-123' }, 'page-123'],
-      [INBOX_TYPES.TWITTER, { profile_id: 'profile-123' }, 'profile-123'],
       [INBOX_TYPES.TELEGRAM, { bot_name: 'support_bot' }, '@support_bot'],
       [INBOX_TYPES.LINE, { line_channel_id: 'line-123' }, 'line-123'],
       [INBOX_TYPES.API, { inbox_identifier: 'api-123' }, 'api-123'],
@@ -69,6 +67,12 @@ describe('#Inbox Helpers', () => {
       expect(getInboxIdentifier({ channel_type: INBOX_TYPES.EMAIL })).toBe('');
       expect(
         getInboxIdentifier({
+          channel_type: INBOX_TYPES.FB,
+          page_id: 'page-123',
+        })
+      ).toBe('');
+      expect(
+        getInboxIdentifier({
           channel_type: INBOX_TYPES.INSTAGRAM,
           instagram_id: 'instagram-123',
         })
@@ -77,6 +81,12 @@ describe('#Inbox Helpers', () => {
         getInboxIdentifier({
           channel_type: INBOX_TYPES.TIKTOK,
           business_id: 'business-123',
+        })
+      ).toBe('');
+      expect(
+        getInboxIdentifier({
+          channel_type: INBOX_TYPES.TWITTER,
+          profile_id: 'profile-123',
         })
       ).toBe('');
     });


### PR DESCRIPTION
Facebook and X inboxes now keep the editable inbox name as the visible label without appending opaque provider IDs in the sidebar or inbox settings. This follows the same behavior introduced for Instagram and TikTok in [#15611](https://github.com/chatwoot/chatwoot/pull/15611).

## Closes

[CW-7245](https://linear.app/chatwoot/issue/CW-7245/show-phone-numberchannel-identifier-consistently-in-inbox-ui)

## How to reproduce

1. Open a workspace with connected Facebook and X inboxes.
2. Check the Channels section in the conversation sidebar.
3. Open Settings → Inboxes, then open either inbox settings page.
4. On `develop`, the inbox name is followed by an opaque page or profile ID. On this branch, only the inbox name remains visible.

## What changed

- Stop resolving Facebook page IDs and X profile IDs as display identifiers.
- Keep both IDs in the inbox payload for routing and provider operations.
- Preserve identifier display and search behavior for every other supported channel.