### PR TITLE
fix(whatsapp): preserve phone conversations for mixed BSUID payloads

### DIFF
--- a/app/services/whatsapp/identity_source_id_orderer.rb
+++ b/app/services/whatsapp/identity_source_id_orderer.rb
@@ -1,0 +1,25 @@
+class Whatsapp::IdentitySourceIdOrderer
+  pattr_initialize [:inbox!, :phone_source_id, :source_ids!]
+
+  def perform
+    identifiers = source_ids.compact_blank
+    default_order = [phone_source_id, *identifiers].compact_blank.uniq
+    return default_order unless addressable_identifiers? && phone_source_id.present?
+    return default_order if contact_inbox_has_conversations?(phone_source_id)
+
+    existing_identifier = identifiers.find { |source_id| contact_inbox_has_conversations?(source_id) }
+    return default_order if existing_identifier.blank?
+
+    [existing_identifier, *(identifiers - [existing_identifier]), phone_source_id].compact_blank.uniq
+  end
+
+  private
+
+  def addressable_identifiers?
+    inbox.channel.try(:provider) == 'whatsapp_cloud'
+  end
+
+  def contact_inbox_has_conversations?(source_id)
+    inbox.contact_inboxes.joins(:conversations).exists?(source_id: source_id)
+  end
+end

--- a/app/services/whatsapp/incoming_message_identifier_helper.rb
+++ b/app/services/whatsapp/incoming_message_identifier_helper.rb
@@ -41,40 +41,30 @@ module Whatsapp::IncomingMessageIdentifierHelper
     ).perform
   end
 
-  # Parent business scoped user id, then the regular one, then the phone number. The parent is the
-  # identifier that survives across the payload shapes Meta sends: an event carrying both and a
-  # later parent-only event describe the same sender, so leading with it keeps them on one
-  # ContactInbox instead of anchoring each on a row of its own. It is addressable in its own right,
-  # through `recipient`, for messages and for calls alike.
-  #
-  # Only the Cloud provider can address an identifier back: 360Dialog always sends to `to`, so there
-  # the phone number stays the identity a conversation anchors to and a reply keeps working.
+  # Preserve existing conversation history: phone history wins for mixed payloads, BSUID history
+  # wins if the caller was first seen BSUID-only, and new mixed callers start on the phone.
   def incoming_message_source_ids(contact_params)
     phone_source_id = whatsapp_phone_source_id(contact_params[:wa_id].presence || messages_data.first[:from].presence)
     identifiers = [
       whatsapp_source_id(contact_params[:parent_user_id].presence || messages_data.first[:from_parent_user_id].presence),
       whatsapp_source_id(contact_params[:user_id].presence || messages_data.first[:from_user_id].presence)
     ]
-    ordered = addressable_identifiers? ? [*identifiers, phone_source_id] : [phone_source_id, *identifiers]
 
-    ordered.compact_blank.uniq
+    Whatsapp::IdentitySourceIdOrderer.new(inbox: inbox, phone_source_id: phone_source_id, source_ids: identifiers).perform
   end
 
   def addressable_identifiers?
     inbox.channel.try(:provider) == 'whatsapp_cloud'
   end
 
-  # An echo has to land on the same alias an inbound message would, otherwise the two entry
-  # points anchor the same contact on different rows and split the thread in half.
   def outgoing_message_source_ids(message)
     phone_source_id = whatsapp_phone_source_id(message[:to].presence)
     identifiers = [
       whatsapp_source_id(message[:to_parent_user_id].presence),
       whatsapp_source_id(message[:to_user_id].presence)
     ]
-    ordered = addressable_identifiers? ? [*identifiers, phone_source_id] : [phone_source_id, *identifiers]
 
-    ordered.compact_blank.uniq
+    Whatsapp::IdentitySourceIdOrderer.new(inbox: inbox, phone_source_id: phone_source_id, source_ids: identifiers).perform
   end
 
   def whatsapp_phone_source_id(identifier)

--- a/enterprise/app/services/whatsapp/inbound_call_identity_builder.rb
+++ b/enterprise/app/services/whatsapp/inbound_call_identity_builder.rb
@@ -2,9 +2,10 @@ class Whatsapp::InboundCallIdentityBuilder
   pattr_initialize [:inbox!, :params!]
 
   # Build the message path's source_id set plus contact attributes, so the resolver lands a call
-  # on the same ContactInbox a message would: on Cloud the parent BSUID leads, then the regular
-  # one, and the phone trails; anywhere else the phone still leads. BSUIDs ride in
-  # from_user_id/from_parent_user_id (or the contact's user_id/parent_user_id), never in `from`.
+  # on the identity that preserves conversation continuity. If the phone row already has history,
+  # mixed phone+BSUID call webhooks should stay there; if only the BSUID row has history, keep that
+  # continuity. Brand-new callers use the phone when Meta still provides it and the BSUID when it
+  # does not.
   def perform(payload)
     contact = caller_contact(payload)
     phone = contact[:wa_id].presence || payload[:from].presence
@@ -12,20 +13,12 @@ class Whatsapp::InboundCallIdentityBuilder
       payload[:from_parent_user_id].presence || contact[:parent_user_id].presence,
       payload[:from_user_id].presence || contact[:user_id].presence
     ]
-    ordered = addressable_identifiers? ? [*identifiers, phone_source_id(phone)] : [phone_source_id(phone), *identifiers]
-    source_ids = ordered.compact_blank.uniq
+    source_ids = Whatsapp::IdentitySourceIdOrderer.new(inbox: inbox, phone_source_id: phone_source_id(phone), source_ids: identifiers).perform
 
     { source_ids: source_ids, contact_attributes: contact_attributes(contact, phone, source_ids.first) }
   end
 
   private
-
-  # Same rule the message path uses: the BSUID leads only where it can be answered. Cloud is the
-  # only provider that addresses one, so anchoring a call on it anywhere else would open a
-  # conversation nobody can reply to.
-  def addressable_identifiers?
-    inbox.channel.try(:provider) == 'whatsapp_cloud'
-  end
 
   # Normalize the wa_id the same way messaging does so a call matches its stored source_id.
   def phone_source_id(phone)
@@ -34,8 +27,8 @@ class Whatsapp::InboundCallIdentityBuilder
     Whatsapp::PhoneNumberNormalizationService.new(inbox).normalize_and_find_contact_by_provider(phone.to_s, :cloud)
   end
 
-  # The fallback name prefers the phone over the leading source_id: with the BSUID first, a caller
-  # who sends no profile name would otherwise be displayed as a machine-readable value. The
+  # The fallback name prefers the phone over the leading source_id: when an identifier leads, a
+  # caller who sends no profile name would otherwise be displayed as a machine-readable value. The
   # identifier still serves as the last resort, so a BSUID-only caller is not left unnamed.
   def contact_attributes(contact, phone, fallback_identifier)
     name = contact.dig(:profile, :name).presence || phone.presence || fallback_identifier

--- a/spec/enterprise/services/voice/inbound_call_builder_spec.rb
+++ b/spec/enterprise/services/voice/inbound_call_builder_spec.rb
@@ -148,9 +148,9 @@ RSpec.describe Voice::InboundCallBuilder do
       expect(phone_conversation.reload.contact_inbox_id).to eq(phone_contact_inbox.id)
     end
 
-    # The caller reached us before under the phone alone; the BSUID row has to be created so the
-    # call lands on the same identity a message would, instead of answering through the old one.
-    it 'creates the preferred BSUID contact inbox when the caller only had a phone one' do
+    # The lower-level builder honors the leading source_id it is given. The WhatsApp-specific
+    # identity builder decides whether that should be the phone or BSUID for a real webhook.
+    it 'creates the preferred contact inbox when the caller only had a secondary alias' do
       legacy_contact = create(:contact, account: account)
       create(:contact_inbox, contact: legacy_contact, inbox: whatsapp_inbox, source_id: '5541966665555')
 
@@ -170,8 +170,7 @@ RSpec.describe Voice::InboundCallBuilder do
     # Matching across every source_id reuses the contact instead of forking on the phone.
     #
     # The order matters and is the caller's contract: the builder trusts the leading source_id as
-    # the identity to land on. Whatsapp::InboundCallIdentityBuilder puts the BSUID there on Cloud,
-    # which is what this reproduces — passing the phone first would ask for the phone alias.
+    # the identity to land on.
     it 'reuses the contact by matching any source_id, not just the first' do
       call = described_class.perform!(
         inbox: whatsapp_inbox,

--- a/spec/enterprise/services/whatsapp/inbound_call_identity_builder_spec.rb
+++ b/spec/enterprise/services/whatsapp/inbound_call_identity_builder_spec.rb
@@ -13,35 +13,41 @@ RSpec.describe Whatsapp::InboundCallIdentityBuilder do
 
   describe '#perform' do
     context 'when the inbox addresses identifiers' do
-      it 'leads with the business scoped user id and trails the phone' do
+      it 'leads with the phone when Meta still provides it' do
+        identity = described_class.new(inbox: cloud_inbox, params: params)
+                                  .perform({ from: '5541988887777', from_user_id: 'IN.2081978709342942' })
+
+        expect(identity[:source_ids]).to eq(['5541988887777', 'IN.2081978709342942'])
+      end
+
+      it 'keeps identifiers behind the phone when all are present' do
+        identity = described_class.new(inbox: cloud_inbox, params: params).perform(
+          { from: '5541988887777', from_user_id: 'IN.2081978709342942', from_parent_user_id: 'IN.ENT.2081978709342942' }
+        )
+
+        expect(identity[:source_ids]).to eq(['5541988887777', 'IN.ENT.2081978709342942', 'IN.2081978709342942'])
+      end
+
+      it 'uses the parent identifier first when the phone is absent' do
+        parent_only = described_class.new(inbox: cloud_inbox, params: params).perform(
+          { from_user_id: 'IN.2081978709342942', from_parent_user_id: 'IN.ENT.2081978709342942' }
+        )
+
+        expect(parent_only[:source_ids]).to eq(['IN.ENT.2081978709342942', 'IN.2081978709342942'])
+      end
+
+      it 'keeps a BSUID-only conversation as the leading identity when the phone appears later' do
+        contact = create(:contact, account: account)
+        contact_inbox = create(:contact_inbox, contact: contact, inbox: cloud_inbox, source_id: 'IN.2081978709342942')
+        create(:conversation, account: account, inbox: cloud_inbox, contact: contact, contact_inbox: contact_inbox)
+
         identity = described_class.new(inbox: cloud_inbox, params: params)
                                   .perform({ from: '5541988887777', from_user_id: 'IN.2081978709342942' })
 
         expect(identity[:source_ids]).to eq(['IN.2081978709342942', '5541988887777'])
       end
 
-      # The parent leads: a payload carrying both identifiers and a later parent-only payload
-      # describe the same caller, so anchoring on the parent keeps them on one ContactInbox.
-      it 'places the parent identifier ahead of the personal one and of the phone' do
-        identity = described_class.new(inbox: cloud_inbox, params: params).perform(
-          { from: '5541988887777', from_user_id: 'IN.2081978709342942', from_parent_user_id: 'IN.ENT.2081978709342942' }
-        )
-
-        expect(identity[:source_ids]).to eq(['IN.ENT.2081978709342942', 'IN.2081978709342942', '5541988887777'])
-      end
-
-      it 'resolves a parent-only call onto the identifier a mixed payload led with' do
-        mixed = described_class.new(inbox: cloud_inbox, params: params).perform(
-          { from: '5541988887777', from_user_id: 'IN.2081978709342942', from_parent_user_id: 'IN.ENT.2081978709342942' }
-        )
-        parent_only = described_class.new(inbox: cloud_inbox, params: params).perform(
-          { from_parent_user_id: 'IN.ENT.2081978709342942' }
-        )
-
-        expect(parent_only[:source_ids].first).to eq(mixed[:source_ids].first)
-      end
-
-      it 'keeps the phone as the display name even though it no longer leads' do
+      it 'keeps the phone as the display name' do
         identity = described_class.new(inbox: cloud_inbox, params: params)
                                   .perform({ from: '5541988887777', from_user_id: 'IN.2081978709342942' })
 

--- a/spec/enterprise/services/whatsapp/incoming_call_service_spec.rb
+++ b/spec/enterprise/services/whatsapp/incoming_call_service_spec.rb
@@ -81,7 +81,7 @@ describe Whatsapp::IncomingCallService do
 
     before { create(:inbox_member, inbox: inbox, user: agent) }
 
-    it 'keys a caller by the BSUID when one is present, matching messaging' do
+    it 'keys a caller by the phone when Meta still provides it' do
       allow(ActionCable.server).to receive(:broadcast)
 
       params = {
@@ -93,7 +93,7 @@ describe Whatsapp::IncomingCallService do
         .to change(Call, :count).by(1).and change(Conversation, :count).by(1)
 
       contact_inbox = Call.last.conversation.contact_inbox
-      expect(contact_inbox.source_id).to eq(bsuid)
+      expect(contact_inbox.source_id).to eq(from_number)
       expect(contact_inbox.contact.name).to eq('Ada Lovelace')
     end
 
@@ -113,24 +113,26 @@ describe Whatsapp::IncomingCallService do
       expect(contact_inbox.contact.name).to eq('Ada Lovelace')
     end
 
-    it 'keeps the contact messaging created by phone but answers on its BSUID ContactInbox' do
+    it 'keeps the contact messaging created by phone on its phone ContactInbox when both identifiers are present' do
       allow(ActionCable.server).to receive(:broadcast)
       contact = create(:contact, account: account)
       phone_contact_inbox = create(:contact_inbox, inbox: inbox, contact: contact, source_id: from_number)
+      phone_conversation = create(:conversation, account: account, inbox: inbox, contact: contact, contact_inbox: phone_contact_inbox)
 
       params = {
         calls: [{ id: provider_call_id, from: from_number, from_user_id: bsuid, event: 'connect',
                   session: { sdp: sdp_offer, sdp_type: 'offer' } }],
         contacts: [{ wa_id: from_number, user_id: bsuid }]
       }
-      # The contact is the same one messaging created; the call lands on the BSUID row, the
-      # identity a message would resolve, rather than answering through the phone alias.
+      # The contact is the same one messaging created; the call stays on the phone conversation
+      # because Meta still supplied the phone and the phone identity already has history.
       expect { described_class.new(inbox: inbox, params: params).perform }
-        .to change(Call, :count).by(1).and change(ContactInbox, :count).by(1)
+        .to change(Call, :count).by(1).and change(ContactInbox, :count).by(1).and not_change(Conversation, :count)
 
       expect(Call.last.contact).to eq(contact)
-      expect(Call.last.conversation.contact_inbox.source_id).to eq(bsuid)
-      expect(Call.last.conversation.contact_inbox).not_to eq(phone_contact_inbox)
+      expect(Call.last.conversation).to eq(phone_conversation)
+      expect(Call.last.conversation.contact_inbox).to eq(phone_contact_inbox)
+      expect(inbox.contact_inboxes.find_by(source_id: bsuid).contact).to eq(contact)
     end
 
     it 'reuses a phone ContactInbox via the same wa_id normalization messaging uses' do
@@ -166,13 +168,13 @@ describe Whatsapp::IncomingCallService do
       expect(Call.last.conversation.contact_inbox).to eq(existing)
     end
 
-    # The gap: messaging created the contact username-only (BSUID-keyed), and the call now
-    # also exposes a phone. Matching across every source_id reuses the BSUID thread instead
-    # of forking a new phone-keyed contact.
-    it 'reuses a BSUID-keyed ContactInbox even when the call also carries a phone and backfills the phone alias' do
+    # The caller was first seen username-only, so the BSUID row already owns the conversation.
+    # When Meta later exposes the phone, keep that thread and only backfill the phone alias.
+    it 'reuses a BSUID-keyed ContactInbox when that is the only identity with conversation history' do
       allow(ActionCable.server).to receive(:broadcast)
       contact = create(:contact, account: account)
       existing = create(:contact_inbox, inbox: inbox, contact: contact, source_id: bsuid)
+      create(:conversation, account: account, inbox: inbox, contact: contact, contact_inbox: existing)
 
       params = {
         calls: [{ id: provider_call_id, from: from_number, from_user_id: bsuid, event: 'connect',
@@ -188,12 +190,12 @@ describe Whatsapp::IncomingCallService do
       expect(inbox.contact_inboxes.find_by(source_id: from_number).contact).to eq(contact)
     end
 
-    it 'reuses the BSUID conversation when a later call carries both phone and BSUID' do
+    it 'reuses the phone conversation when a later call carries both phone and BSUID' do
       allow(ActionCable.server).to receive(:broadcast)
       contact = create(:contact, account: account)
       phone_contact_inbox = create(:contact_inbox, inbox: inbox, contact: contact, source_id: from_number)
       bsuid_contact_inbox = create(:contact_inbox, inbox: inbox, contact: contact, source_id: bsuid)
-      conversation = create(:conversation, account: account, inbox: inbox, contact: contact, contact_inbox: bsuid_contact_inbox)
+      conversation = create(:conversation, account: account, inbox: inbox, contact: contact, contact_inbox: phone_contact_inbox)
 
       params = {
         calls: [{ id: provider_call_id, from: from_number, from_user_id: bsuid, event: 'connect',
@@ -205,7 +207,8 @@ describe Whatsapp::IncomingCallService do
         .to change(Call, :count).by(1).and not_change(Conversation, :count)
 
       expect(Call.last.conversation).to eq(conversation)
-      expect(Call.last.conversation.contact_inbox).to eq(bsuid_contact_inbox)
+      expect(Call.last.conversation.contact_inbox).to eq(phone_contact_inbox)
+      expect(bsuid_contact_inbox.reload.contact).to eq(contact)
       expect(phone_contact_inbox.reload.contact).to eq(contact)
     end
 

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -24,16 +24,14 @@ describe Whatsapp::IncomingMessageService do
       }.with_indifferent_access
     end
 
-    # The parent-first ordering is Cloud-only, so this needs its own channel: the shared
-    # `whatsapp_channel` above is a default/360Dialog one, where the phone still leads.
+    # Phone-first ordering is Cloud-only when Meta still includes the phone. The shared
+    # `whatsapp_channel` above is a default/360Dialog one, where the phone has always led.
     context 'when a Cloud payload carries the parent identifier' do
       let!(:cloud_channel) do
         create(:channel_whatsapp, provider: 'whatsapp_cloud', validate_provider_config: false, sync_templates: false)
       end
 
-      # Meta sends the parent identifier alone in some payloads. Leading with it keeps the mixed
-      # event and the parent-only follow-up on one ContactInbox, so the thread is not split.
-      it 'reuses the conversation when a parent-only payload follows one carrying both identifiers' do
+      it 'uses the parent identifier only when the phone is absent' do
         mixed = {
           'contacts' => [{ 'profile' => { 'name' => 'Muhsin' }, 'wa_id' => '919745786257',
                            'user_id' => 'IN.2081978709342942', 'parent_user_id' => 'IN.ENT.9081726354' }],
@@ -48,12 +46,16 @@ describe Whatsapp::IncomingMessageService do
         }.with_indifferent_access
 
         described_class.new(inbox: cloud_channel.inbox, params: mixed).perform
-        expect { described_class.new(inbox: cloud_channel.inbox, params: parent_only).perform }
-          .not_to(change { cloud_channel.inbox.conversations.count })
+        phone_conversation = cloud_channel.inbox.conversations.last
 
-        conversation = cloud_channel.inbox.conversations.last
-        expect(conversation.contact_inbox.source_id).to eq('IN.ENT.9081726354')
-        expect(conversation.messages.pluck(:content)).to include('first', 'second')
+        expect { described_class.new(inbox: cloud_channel.inbox, params: parent_only).perform }
+          .to change { cloud_channel.inbox.conversations.count }.by(1)
+
+        parent_conversation = cloud_channel.inbox.conversations.last
+        expect(phone_conversation.contact_inbox.source_id).to eq('919745786257')
+        expect(phone_conversation.messages.pluck(:content)).to contain_exactly('first')
+        expect(parent_conversation.contact_inbox.source_id).to eq('IN.ENT.9081726354')
+        expect(parent_conversation.messages.pluck(:content)).to contain_exactly('second')
       end
     end
 

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -348,20 +348,25 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
         expect(bsuid_contact_inbox.contact).to eq(contact_inbox.contact)
       end
 
-      it 'opens the conversation on the BSUID contact inbox when a payload carries both identities' do
+      it 'opens the conversation on the phone contact inbox when a payload carries both identities' do
         described_class.new(inbox: whatsapp_channel.inbox, params: phone_with_bsuid_params).perform
 
-        bsuid_contact_inbox = whatsapp_channel.inbox.contact_inboxes.find_by!(source_id: 'IN.2081978709342942')
+        phone_contact_inbox = whatsapp_channel.inbox.contact_inboxes.find_by!(source_id: '919745786257')
 
         expect(whatsapp_channel.inbox.conversations.count).to eq(1)
-        expect(whatsapp_channel.inbox.conversations.first.contact_inbox).to eq(bsuid_contact_inbox)
+        expect(whatsapp_channel.inbox.conversations.first.contact_inbox).to eq(phone_contact_inbox)
       end
 
-      it 'reuses that conversation on a BSUID only follow-up' do
+      it 'moves to the BSUID contact inbox only when a follow-up omits the phone' do
         described_class.new(inbox: whatsapp_channel.inbox, params: phone_with_bsuid_params).perform
         described_class.new(inbox: whatsapp_channel.inbox, params: bsuid_only_params).perform
 
-        expect(whatsapp_channel.inbox.conversations.count).to eq(1)
+        phone_contact_inbox = whatsapp_channel.inbox.contact_inboxes.find_by!(source_id: '919745786257')
+        bsuid_contact_inbox = whatsapp_channel.inbox.contact_inboxes.find_by!(source_id: 'IN.2081978709342942')
+
+        expect(whatsapp_channel.inbox.conversations.count).to eq(2)
+        expect(phone_contact_inbox.conversations.first.messages.pluck(:content)).to contain_exactly('phone and bsuid')
+        expect(bsuid_contact_inbox.conversations.first.messages.pluck(:content)).to contain_exactly('bsuid only')
         expect(whatsapp_channel.inbox.messages.pluck(:content)).to contain_exactly('phone and bsuid', 'bsuid only')
       end
 
@@ -432,10 +437,10 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
         described_class.new(inbox: whatsapp_channel.inbox, params: echo_params, outgoing_echo: true).perform
 
         expect(Contact.last.name).to eq('+919745786257')
-        expect(whatsapp_channel.inbox.conversations.first.contact_inbox.source_id).to eq('IN.2081978709342942')
+        expect(whatsapp_channel.inbox.conversations.first.contact_inbox.source_id).to eq('919745786257')
       end
 
-      it 'moves a phone-backed contact on the first payload that carries an identifier' do
+      it 'keeps a phone-backed contact on the phone conversation when a payload carries an identifier' do
         phone_contact_inbox = create(:contact_inbox, inbox: whatsapp_channel.inbox, source_id: '919745786257')
         contact = phone_contact_inbox.contact
         create(:conversation, inbox: whatsapp_channel.inbox, contact_inbox: phone_contact_inbox,
@@ -446,8 +451,8 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
         bsuid_contact_inbox = whatsapp_channel.inbox.contact_inboxes.find_by!(source_id: 'IN.2081978709342942')
 
         expect(bsuid_contact_inbox.contact).to eq(contact)
-        expect(contact.conversations.count).to eq(2)
-        expect(whatsapp_channel.inbox.messages.last.conversation.contact_inbox).to eq(bsuid_contact_inbox)
+        expect(contact.conversations.count).to eq(1)
+        expect(whatsapp_channel.inbox.messages.last.conversation.contact_inbox).to eq(phone_contact_inbox)
       end
 
       it 'does not open a third conversation on the payload after that' do
@@ -574,7 +579,7 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
                 contacts: [{ profile: { name: 'Conflicting identifiers' }, wa_id: '971501234567', user_id: 'AE.QACONFLICT' }],
                 messages: [{
                   from: '971501234567', from_user_id: 'AE.QACONFLICT', id: 'wamid.cloud-conflicting-identifiers',
-                  text: { body: 'route by exact BSUID' }, timestamp: '1778579800', type: 'text'
+                  text: { body: 'route by phone when present' }, timestamp: '1778579800', type: 'text'
                 }]
               }
             }]
@@ -583,8 +588,8 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
 
         described_class.new(inbox: whatsapp_channel.inbox, params: conflicting_params).perform
 
-        expect(bsuid_conversation.reload.messages.pluck(:content)).to contain_exactly('route by exact BSUID')
-        expect(phone_conversation.reload.messages).to be_empty
+        expect(phone_conversation.reload.messages.pluck(:content)).to contain_exactly('route by phone when present')
+        expect(bsuid_conversation.reload.messages).to be_empty
         expect(bsuid_contact_inbox.reload.contact).to eq(bsuid_contact)
         expect(phone_contact_inbox.reload.contact).to eq(phone_contact)
       end


### PR DESCRIPTION
WhatsApp can send both the customer phone number and BSUID in the same webhook. When the phone-backed conversation already exists, agents and customers expect that conversation to continue instead of seeing a second BSUID-backed conversation created only because the webhook also carried an identifier.

This PR routes mixed phone+BSUID webhook payloads to the identity that preserves existing conversation history. Phone-backed history wins when present, BSUID-only history is preserved when that is the only existing thread, and brand-new mixed customers still start on the phone identity. BSUID-only webhooks continue to create or reuse the BSUID ContactInbox. The same ordering is shared by Meta Cloud messages, message echoes, and inbound WhatsApp calls.

Related: https://github.com/chatwoot/chatwoot/pull/15175
Related: https://github.com/chatwoot/chatwoot/pull/15546

### Things to know

- This does not repoint existing conversations or merge conflicting ContactInbox rows.
- BSUID aliases are still synced to the same contact when a mixed payload resolves through the phone identity.
- If the phone is absent, Chatwoot still routes through the BSUID identity.
- This directly covers the production shape where Meta sent both `from` and `from_user_id` for an inbound WhatsApp call.

### How to test

1. Receive a Meta Cloud WhatsApp message or inbound call webhook that includes both `from`/`wa_id` and `from_user_id` for a contact with an existing phone-backed conversation.
2. Confirm the new message/call is added to the existing phone-backed conversation and no new BSUID-backed conversation is created.
3. Confirm a BSUID ContactInbox is still created for the same contact.
4. Send a BSUID-only follow-up and confirm it creates or reuses the BSUID-backed conversation.
5. Start with a BSUID-only conversation, then receive a mixed phone+BSUID webhook, and confirm Chatwoot keeps the existing BSUID conversation instead of creating a new phone thread.
6. Repeat with conflicting phone and BSUID ContactInbox records and confirm Chatwoot does not merge or repoint either contact.

### What changed

- Added a shared WhatsApp source-ID orderer for message and call routing.
- Updated Meta Cloud message and echo routing to prefer existing conversation continuity.
- Updated inbound WhatsApp call identity ordering to use the same rule.
- Updated specs for mixed phone+BSUID, BSUID-only, existing phone history, existing BSUID-only history, and conflict safety.

Validation:

```bash
bundle exec rspec spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb spec/enterprise/services/whatsapp/inbound_call_identity_builder_spec.rb spec/enterprise/services/whatsapp/incoming_call_service_spec.rb spec/enterprise/services/voice/inbound_call_builder_spec.rb
bundle exec rubocop --cache false app/services/whatsapp/identity_source_id_orderer.rb app/services/whatsapp/incoming_message_identifier_helper.rb enterprise/app/services/whatsapp/inbound_call_identity_builder.rb spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb spec/enterprise/services/whatsapp/inbound_call_identity_builder_spec.rb spec/enterprise/services/whatsapp/incoming_call_service_spec.rb spec/enterprise/services/voice/inbound_call_builder_spec.rb
```