### PR TITLE
fix(whatsapp): keep one thread when a contact replies under a BSUID

### DIFF
--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -113,17 +113,8 @@ class Whatsapp::IncomingMessageBaseService
   end
 
   def set_conversation
-    # Reuse is scoped to the contact inbox that resolved this message, never to the contact. A contact
-    # can hold unrelated WhatsApp identities in the same inbox, either from coexistence or from a
-    # dashboard merge, and a contact wide lookup cannot tell them apart: it would answer one identity
-    # through another one's source id. The conversation opened under a previous identity stays where it
-    # is and remains reachable under previous conversations.
-    #
-    # Only where an identifier can be replied to, though. 360Dialog always sends the destination in
-    # `to` and has no way to address one, so anchoring a thread there would produce a conversation
-    # nobody can answer. That provider keeps the contact wide reuse it had, which lands every message
-    # on the phone backed thread it can actually reply through.
-    conversations = addressable_identifiers? ? @contact_inbox.conversations : @contact.conversations.where(inbox_id: @inbox.id)
+    conversations = Whatsapp::ReusableConversationsResolver.new(inbox: @inbox, contact: @contact, contact_inbox: @contact_inbox,
+                                                                addressable_identifiers: addressable_identifiers?).perform
     # if lock to single conversation is disabled, we will create a new conversation if previous conversation is resolved
     @conversation = if @inbox.lock_to_single_conversation
                       conversations.last

--- a/app/services/whatsapp/reusable_conversations_resolver.rb
+++ b/app/services/whatsapp/reusable_conversations_resolver.rb
@@ -1,0 +1,27 @@
+# Picks the conversations an incoming WhatsApp payload is allowed to land on.
+#
+# Reuse spans the resolved contact inbox plus the contact's phone backed rows. That pair is one person
+# under two aliases, which is how a thread opened by an outbound message or a campaign — always keyed on
+# the phone number — gets answered once Meta starts identifying the sender by a business scoped user id.
+# Two identifier rows on one contact are different people brought together by a dashboard merge, so they
+# never share a thread and a reply is never addressed through the other one's source id.
+#
+# 360Dialog always sends the destination in `to` and cannot address an identifier, so it keeps plain
+# contact wide reuse, which lands every message on the phone backed thread it can actually reply through.
+class Whatsapp::ReusableConversationsResolver
+  pattr_initialize [:inbox!, :contact!, :contact_inbox!, { addressable_identifiers: false }]
+
+  def perform
+    conversations = contact.conversations.where(inbox_id: inbox.id)
+    return conversations unless addressable_identifiers
+
+    conversations.where(contact_inbox_id: [contact_inbox.id, *phone_contact_inbox_ids])
+  end
+
+  private
+
+  def phone_contact_inbox_ids
+    inbox.contact_inboxes.where(contact_id: contact.id).pluck(:id, :source_id)
+         .filter_map { |id, source_id| id unless source_id.match?(RegexHelper::WHATSAPP_BSUID_REGEX) }
+  end
+end

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -394,7 +394,7 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
         expect(whatsapp_channel.inbox.messages.pluck(:content)).to contain_exactly('phone and bsuid', 'echo reply')
       end
 
-      it 'leaves a conversation opened under the phone identity untouched' do
+      it 'reuses the conversation opened under the phone identity' do
         phone_contact_inbox = create(:contact_inbox, inbox: whatsapp_channel.inbox, source_id: '919745786257')
         contact = phone_contact_inbox.contact
         phone_conversation = create(:conversation, inbox: whatsapp_channel.inbox, contact_inbox: phone_contact_inbox,
@@ -404,7 +404,8 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
         described_class.new(inbox: whatsapp_channel.inbox, params: bsuid_only_params).perform
 
         expect(phone_conversation.reload.contact_inbox).to eq(phone_contact_inbox)
-        expect(contact.conversations.count).to eq(2)
+        expect(contact.conversations.count).to eq(1)
+        expect(phone_conversation.messages.pluck(:content)).to contain_exactly('bsuid only')
       end
 
       it 'names a contact created by an echo after the phone number, not the identifier' do
@@ -435,31 +436,32 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
         expect(whatsapp_channel.inbox.conversations.first.contact_inbox.source_id).to eq('IN.2081978709342942')
       end
 
-      it 'moves a phone-backed contact on the first payload that carries an identifier' do
+      it 'records the identifier without splitting the phone-backed conversation' do
         phone_contact_inbox = create(:contact_inbox, inbox: whatsapp_channel.inbox, source_id: '919745786257')
         contact = phone_contact_inbox.contact
-        create(:conversation, inbox: whatsapp_channel.inbox, contact_inbox: phone_contact_inbox,
-                              contact: contact, account: whatsapp_channel.inbox.account)
+        phone_conversation = create(:conversation, inbox: whatsapp_channel.inbox, contact_inbox: phone_contact_inbox,
+                                                   contact: contact, account: whatsapp_channel.inbox.account)
 
         described_class.new(inbox: whatsapp_channel.inbox, params: phone_with_bsuid_params).perform
 
         bsuid_contact_inbox = whatsapp_channel.inbox.contact_inboxes.find_by!(source_id: 'IN.2081978709342942')
 
         expect(bsuid_contact_inbox.contact).to eq(contact)
-        expect(contact.conversations.count).to eq(2)
-        expect(whatsapp_channel.inbox.messages.last.conversation.contact_inbox).to eq(bsuid_contact_inbox)
+        expect(contact.conversations.count).to eq(1)
+        expect(whatsapp_channel.inbox.messages.last.conversation).to eq(phone_conversation)
       end
 
-      it 'does not open a third conversation on the payload after that' do
+      it 'keeps an identifier-only payload after that on the same conversation' do
         phone_contact_inbox = create(:contact_inbox, inbox: whatsapp_channel.inbox, source_id: '919745786257')
         contact = phone_contact_inbox.contact
-        create(:conversation, inbox: whatsapp_channel.inbox, contact_inbox: phone_contact_inbox,
-                              contact: contact, account: whatsapp_channel.inbox.account)
+        phone_conversation = create(:conversation, inbox: whatsapp_channel.inbox, contact_inbox: phone_contact_inbox,
+                                                   contact: contact, account: whatsapp_channel.inbox.account)
 
         described_class.new(inbox: whatsapp_channel.inbox, params: phone_with_bsuid_params).perform
         described_class.new(inbox: whatsapp_channel.inbox, params: bsuid_only_params).perform
 
-        expect(contact.conversations.count).to eq(2)
+        expect(contact.conversations.count).to eq(1)
+        expect(phone_conversation.messages.pluck(:content)).to contain_exactly('phone and bsuid', 'bsuid only')
       end
 
       context 'when a merged contact owns multiple WhatsApp identities' do


### PR DESCRIPTION
A WhatsApp Cloud contact who already has a conversation opened under their phone number now keeps that conversation when they reply, instead of having a second one opened under their business scoped user id (BSUID). Outbound messages — the dashboard's "new conversation", the API and campaigns — always key a contact inbox on the phone number, while Meta identifies a replying sender by a BSUID. Since #15175 the two directions anchored on different `ContactInbox` rows, so a thread started by an outbound message or a broadcast was orphaned the moment the contact answered, and the answer arrived in a new thread with none of the original context, assignee or team. Inboxes with *lock to single conversation* enabled were affected too, because that lock is scoped to a contact inbox.

The orphaned thread is also unreplyable: having no incoming message it falls outside the 24 hour service window, so only templates can be sent from the very thread an automation keeps writing to.

## Closes

Follow-up to #15175. <!-- add the issue / Linear ticket for the duplicate-conversation reports -->

## How to reproduce

1. On a Meta Cloud inbox, start a conversation with a contact from the dashboard, the API, or a campaign. The conversation is created against the phone backed `ContactInbox`.
2. Have that contact reply from WhatsApp, with Meta sending `contacts[].user_id` in the payload.

**Before:** a second conversation opens on the BSUID `ContactInbox`; the first is orphaned and can no longer be replied to outside a template.

**After:** the reply lands on the existing conversation.

## What changed

`Whatsapp::ReusableConversationsResolver` decides which conversations an incoming payload may land on. Reuse spans the resolved contact inbox **plus the contact's phone backed rows** — that pair is one person under two aliases, which is exactly the outbound/inbound mismatch above.

Two *identifier* rows on one contact are still kept apart. Those come from a dashboard merge and are different people, so they never share a thread and a reply is never addressed through the other one's `source_id` — the guarantee #15175 added for merged contacts is unchanged, and its specs still pin it.

360Dialog is untouched: it cannot address an identifier, so it keeps plain contact wide reuse on the phone backed thread it can actually reply through.

Three specs that asserted the split (`contact.conversations.count == 2`) now assert the reuse. `Whatsapp::CallConversationBuilder` already looked up conversations contact wide and needed no change.
