### PR TITLE
fix: preserve email signature separator with empty line

### DIFF
--- a/app/services/messages/markdown_renderer_service.rb
+++ b/app/services/messages/markdown_renderer_service.rb
@@ -42,7 +42,7 @@ class Messages::MarkdownRendererService
 
   def render_html
     markdown_renderer = BaseMarkdownRenderer.new
-    doc = CommonMarker.render_doc(@content, :DEFAULT, [:strikethrough])
+    doc = CommonMarker.render_doc(MarkdownSetextEscape.call(@content), :DEFAULT, [:strikethrough])
     markdown_renderer.render(doc)
   end
 

--- a/lib/chatwoot_markdown_renderer.rb
+++ b/lib/chatwoot_markdown_renderer.rb
@@ -5,7 +5,7 @@ class ChatwootMarkdownRenderer
 
   def render_message(hardbreaks: false)
     markdown_renderer = BaseMarkdownRenderer.new(options: hardbreaks ? [:HARDBREAKS] : :DEFAULT)
-    doc = CommonMarker.render_doc(@content, :DEFAULT, [:strikethrough, :autolink])
+    doc = CommonMarker.render_doc(MarkdownSetextEscape.call(@content), :DEFAULT, [:strikethrough, :autolink])
     html = markdown_renderer.render(doc)
     render_as_html_safe(html)
   end

--- a/lib/markdown_setext_escape.rb
+++ b/lib/markdown_setext_escape.rb
@@ -1,0 +1,15 @@
+# cmark parses a dashes/equals line sitting directly under a hard-break
+# backslash ("\" + newline) as a setext heading underline: the dashes vanish
+# into markup and the stray "\" renders as heading text. The reply editor
+# serializes an empty line above the "--" signature delimiter exactly that
+# way. Escaping the underline keeps it literal text (matching the dashboard,
+# which disables setext parsing), while intentional setext headings — no
+# trailing backslash — stay untouched. Stored content can be CRLF, so both
+# line endings are handled.
+module MarkdownSetextEscape
+  UNDERLINE_AFTER_HARD_BREAK = /\\\r?\n(?=(?:-+|=+)[ \t]*\r?(?:\n|\z))/
+
+  def self.call(content)
+    content.gsub(UNDERLINE_AFTER_HARD_BREAK) { |hard_break| "#{hard_break}\\" }
+  end
+end

--- a/spec/lib/chatwoot_markdown_renderer_spec.rb
+++ b/spec/lib/chatwoot_markdown_renderer_spec.rb
@@ -84,6 +84,14 @@ RSpec.describe ChatwootMarkdownRenderer do
         expect(renderer.render_message.to_s).to eq("<p>Visit <a href=\"https://example.com\">https://example.com</a> for details</p>\n")
       end
     end
+
+    context 'with an empty line above the signature delimiter' do
+      let(:markdown_content) { "Answer\n\n\\\n--\n\nRegards" }
+
+      it 'keeps the delimiter and the empty line instead of rendering a setext heading' do
+        expect(rendered_message.to_s).to eq("<p>Answer</p>\n<p><br />\n--</p>\n<p>Regards</p>\n")
+      end
+    end
   end
 
   describe '#render_markdown_to_plain_text' do

--- a/spec/lib/markdown_setext_escape_spec.rb
+++ b/spec/lib/markdown_setext_escape_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe MarkdownSetextEscape do
+  describe '.call' do
+    it 'escapes the delimiter when an empty line sits directly above it' do
+      content = "Answer\n\n\\\n--\n\nRegards"
+      expect(described_class.call(content)).to eq("Answer\n\n\\\n\\--\n\nRegards")
+    end
+
+    it 'handles CRLF line endings' do
+      content = "Answer\r\n\r\n\\\r\n--\r\n\r\nRegards"
+      expect(described_class.call(content)).to eq("Answer\r\n\r\n\\\r\n\\--\r\n\r\nRegards")
+    end
+
+    it 'escapes equals underlines the same way' do
+      expect(described_class.call("Answer\n\n\\\n==\n\nRegards")).to eq("Answer\n\n\\\n\\==\n\nRegards")
+    end
+
+    it 'escapes only the underline when several empty lines precede the delimiter' do
+      content = "Answer\n\n\\\n\\\n--\n\nRegards"
+      expect(described_class.call(content)).to eq("Answer\n\n\\\n\\\n\\--\n\nRegards")
+    end
+
+    it 'escapes a delimiter at the end of the content' do
+      expect(described_class.call("Answer\n\n\\\n--")).to eq("Answer\n\n\\\n\\--")
+    end
+
+    it 'leaves a plain delimiter without a preceding empty line untouched' do
+      content = "Answer\n\n--\n\nRegards"
+      expect(described_class.call(content)).to eq(content)
+    end
+
+    it 'leaves hard breaks followed by regular text untouched' do
+      content = "Thanks \\\nSivin | Chatwoot"
+      expect(described_class.call(content)).to eq(content)
+    end
+
+    it 'leaves intentional setext headings untouched' do
+      content = "Title\n---\n\nBody"
+      expect(described_class.call(content)).to eq(content)
+    end
+
+    it 'leaves thematic breaks untouched' do
+      content = "para\n\n---\n\npara2"
+      expect(described_class.call(content)).to eq(content)
+    end
+  end
+end

--- a/spec/services/messages/markdown_renderer_service_spec.rb
+++ b/spec/services/messages/markdown_renderer_service_spec.rb
@@ -362,6 +362,13 @@ RSpec.describe Messages::MarkdownRendererService, type: :service do
         result = described_class.new(content, channel_type).render
         expect(result).to include('<del>strikethrough text</del>')
       end
+
+      it 'keeps the signature delimiter when an empty line sits above it' do
+        content = "Answer\n\n\\\n--\n\nRegards"
+        result = described_class.new(content, channel_type).render
+        expect(result).to include("<p><br />\n--</p>")
+        expect(result).not_to include('<h2>')
+      end
     end
 
     context 'when channel is Channel::WebWidget' do


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where leaving an empty line above the `--` email signature separator caused the delivered email to show a stray `\` and the separator to disappear. Emails now render the separator with the empty line preserved, matching the reply editor and dashboard.



#### What changed

The editor serializes the empty line as a hard-break backslash, and cmark parses `\` + `--` as a setext heading underline (`<h2>\</h2>`), swallowing the separator. The frontend already avoids this by disabling setext parsing in markdown-it (#14134), but cmark-gfm has no equivalent option.

* Added `MarkdownSetextEscape`, which escapes a dashes/equals underline only when it sits directly under a hard-break backslash, turning it back into literal text (`<br />` + `--`). Intentional setext headings, ATX headings, and thematic breaks are untouched.
* Applied it to the two email render paths: `ChatwootMarkdownRenderer#render_message` for stored email HTML and mailers, and `Messages::MarkdownRendererService#render_html` for outgoing email bodies. Other channel renderers are unaffected.
* Handles both LF and CRLF content.

Fixes https://linear.app/chatwoot/issue/CW-8062/email-replies-show-a-stray-backslash-instead-of-the-signature

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### How to reproduce

1. On an email inbox with a signature enabled, write a reply and press Enter so an empty line sits directly above the `--` separator
2. Send the reply
3. The received email and email bubble show `\` instead of the separator

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
