### PR TITLE
feat(tiktok): add inbox access request

### DIFF
--- a/app/controllers/api/v1/accounts/tiktok/authorizations_controller.rb
+++ b/app/controllers/api/v1/accounts/tiktok/authorizations_controller.rb
@@ -1,6 +1,8 @@
 class Api::V1::Accounts::Tiktok::AuthorizationsController < Api::V1::Accounts::OauthAuthorizationController
   include Tiktok::IntegrationHelper
 
+  before_action :ensure_tiktok_enabled
+
   def create
     redirect_url = Tiktok::AuthClient.authorize_url(
       state: generate_tiktok_token(Current.account.id, params[:return_to])
@@ -11,5 +13,11 @@ class Api::V1::Accounts::Tiktok::AuthorizationsController < Api::V1::Accounts::O
     else
       render json: { success: false }, status: :unprocessable_entity
     end
+  end
+
+  private
+
+  def ensure_tiktok_enabled
+    raise Pundit::NotAuthorizedError unless Current.account.feature_enabled?('channel_tiktok')
   end
 end

--- a/app/javascript/dashboard/components/widgets/ChannelItem.vue
+++ b/app/javascript/dashboard/components/widgets/ChannelItem.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed } from 'vue';
+import { useAccount } from 'dashboard/composables/useAccount';
 import ChannelSelector from '../ChannelSelector.vue';
 
 const props = defineProps({
@@ -14,6 +15,7 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['channelItemClick']);
+const { isOnChatwootCloud } = useAccount();
 
 const hasFbConfigured = computed(() => {
   return window.chatwootConfig?.fbAppId;
@@ -81,6 +83,16 @@ const isBeta = computed(() => {
   return ['tiktok', 'voice', 'whatsapp_call'].includes(props.channel.key);
 });
 
+const canRequestTiktokAccess = computed(() => {
+  return (
+    props.channel.key === 'tiktok' &&
+    isOnChatwootCloud.value &&
+    hasTiktokConfigured.value &&
+    Object.keys(props.enabledFeatures).length > 0 &&
+    !props.enabledFeatures.channel_tiktok
+  );
+});
+
 const hasVoiceBadge = computed(() => {
   return (
     ['voice', 'whatsapp_call'].includes(props.channel.key) &&
@@ -89,6 +101,11 @@ const hasVoiceBadge = computed(() => {
 });
 
 const onItemClick = () => {
+  if (canRequestTiktokAccess.value) {
+    window.$chatwoot?.toggle();
+    return;
+  }
+
   if (isActive.value) {
     emit('channelItemClick', props.channel.key);
   }
@@ -103,7 +120,7 @@ const onItemClick = () => {
     :is-coming-soon="isComingSoon"
     :is-beta="isBeta"
     :has-voice-badge="hasVoiceBadge"
-    :disabled="!isActive"
+    :disabled="!isActive && !canRequestTiktokAccess"
     @click="onItemClick"
   />
 </template>

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -611,7 +611,8 @@
           },
           "TIKTOK": {
             "TITLE": "TikTok",
-            "DESCRIPTION": "Connect your TikTok account"
+            "DESCRIPTION": "Connect your TikTok account",
+            "ACCESS_REQUEST_DESCRIPTION": "Contact our support team to request TikTok access"
           },
           "VOICE": {
             "TITLE": "Voice",

--- a/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/InboxChannelsDialog.vue
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/InboxChannelsDialog.vue
@@ -20,7 +20,7 @@ const emit = defineEmits(['connected']);
 
 const { t } = useI18n();
 const { connectViaOAuth, connectWhatsapp } = useChannelConnect();
-const { isConfigured } = useChannelConfig();
+const { isConfigured, isEnabled } = useChannelConfig();
 
 // Maps the dialog's display types to the OAuth client key the flow expects.
 // Types without an entry (manual-setup channels) are no-ops for now.
@@ -38,8 +38,11 @@ const OAUTH_PROVIDERS = {
 // (see channelCards), so they never reach this state.
 // `connected` (a real inbox already backs it) is orthogonal and tracked
 // separately, since a connected channel can still be in any of these states.
-const channelAvailability = channel =>
-  channel.setupLater ? 'setupLater' : 'available';
+const channelAvailability = channel => {
+  return channel.setupLater || !isEnabled(channel.type)
+    ? 'setupLater'
+    : 'available';
+};
 
 const CARD_CLASS = {
   available: 'bg-n-solid-1 hover:outline-n-slate-6 cursor-pointer',

--- a/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
@@ -39,9 +39,7 @@ export function useChannelConfig() {
 
   const isConfigured = type => CHANNEL_CONFIGURED[type]?.() ?? true;
   const isEnabled = type =>
-    type !== 'tiktok' ||
-    !isOnChatwootCloud.value ||
-    isCloudFeatureEnabled(FEATURE_FLAGS.CHANNEL_TIKTOK);
+    type !== 'tiktok' || isCloudFeatureEnabled(FEATURE_FLAGS.CHANNEL_TIKTOK);
 
   return { isConfigured, isEnabled };
 }

--- a/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
@@ -32,15 +32,16 @@ export function useChannelConfig() {
       !isMetaInboxCreationDisabled.value &&
       Boolean(installationConfig.instagramAppId) &&
       isCloudFeatureEnabled(FEATURE_FLAGS.CHANNEL_INSTAGRAM),
-    tiktok: () =>
-      Boolean(installationConfig.tiktokAppId) &&
-      (!isOnChatwootCloud.value ||
-        isCloudFeatureEnabled(FEATURE_FLAGS.CHANNEL_TIKTOK)),
+    tiktok: () => Boolean(installationConfig.tiktokAppId),
     gmail: () => Boolean(installationConfig.googleOAuthClientId),
     outlook: () => Boolean(globalConfig.value.azureAppId),
   };
 
   const isConfigured = type => CHANNEL_CONFIGURED[type]?.() ?? true;
+  const isEnabled = type =>
+    type !== 'tiktok' ||
+    !isOnChatwootCloud.value ||
+    isCloudFeatureEnabled(FEATURE_FLAGS.CHANNEL_TIKTOK);
 
-  return { isConfigured };
+  return { isConfigured, isEnabled };
 }

--- a/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
@@ -32,7 +32,10 @@ export function useChannelConfig() {
       !isMetaInboxCreationDisabled.value &&
       Boolean(installationConfig.instagramAppId) &&
       isCloudFeatureEnabled(FEATURE_FLAGS.CHANNEL_INSTAGRAM),
-    tiktok: () => Boolean(installationConfig.tiktokAppId),
+    tiktok: () =>
+      Boolean(installationConfig.tiktokAppId) &&
+      (!isOnChatwootCloud.value ||
+        isCloudFeatureEnabled(FEATURE_FLAGS.CHANNEL_TIKTOK)),
     gmail: () => Boolean(installationConfig.googleOAuthClientId),
     outlook: () => Boolean(globalConfig.value.azureAppId),
   };

--- a/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useChannelConfig.js
@@ -39,7 +39,9 @@ export function useChannelConfig() {
 
   const isConfigured = type => CHANNEL_CONFIGURED[type]?.() ?? true;
   const isEnabled = type =>
-    type !== 'tiktok' || isCloudFeatureEnabled(FEATURE_FLAGS.CHANNEL_TIKTOK);
+    type !== 'tiktok' ||
+    !isOnChatwootCloud.value ||
+    isCloudFeatureEnabled(FEATURE_FLAGS.CHANNEL_TIKTOK);
 
   return { isConfigured, isEnabled };
 }

--- a/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useDetectedChannels.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/inbox-setup/useDetectedChannels.js
@@ -35,7 +35,7 @@ const extractHandle = ({ type, url }) => {
 export function useDetectedChannels() {
   const { currentAccount } = useAccount();
   const inboxes = useMapGetter('inboxes/getInboxes');
-  const { isConfigured } = useChannelConfig();
+  const { isConfigured, isEnabled } = useChannelConfig();
 
   const brandSocials = computed(
     () => currentAccount.value?.custom_attributes?.brand_info?.socials || []
@@ -88,6 +88,8 @@ export function useDetectedChannels() {
       // Hide channels whose installation OAuth credentials are missing — their
       // connect flow would only error.
       .filter(channel => isConfigured(channel.type))
+      // Account-gated channels stay in the secondary catalog until enabled.
+      .filter(channel => isEnabled(channel.type))
   );
 
   const defaultChannels = computed(() =>

--- a/app/javascript/dashboard/routes/dashboard/onboarding/specs/inbox-setup/InboxChannelsDialog.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/specs/inbox-setup/InboxChannelsDialog.spec.js
@@ -2,10 +2,12 @@ import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import InboxChannelsDialog from '../../inbox-setup/InboxChannelsDialog.vue';
 
-const { isOnChatwootCloud, isMetaInboxCreationDisabled } = vi.hoisted(() => ({
-  isOnChatwootCloud: { value: false },
-  isMetaInboxCreationDisabled: { value: false },
-}));
+const { isOnChatwootCloud, isMetaInboxCreationDisabled, isTiktokEnabled } =
+  vi.hoisted(() => ({
+    isOnChatwootCloud: { value: false },
+    isMetaInboxCreationDisabled: { value: false },
+    isTiktokEnabled: { value: true },
+  }));
 
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: key => key }) }));
 vi.mock('dashboard/composables/store', () => ({
@@ -16,7 +18,8 @@ vi.mock('dashboard/composables/store', () => ({
 }));
 vi.mock('dashboard/composables/useAccount', () => ({
   useAccount: () => ({
-    isCloudFeatureEnabled: () => true,
+    isCloudFeatureEnabled: feature =>
+      feature !== 'channel_tiktok' || isTiktokEnabled.value,
     isOnChatwootCloud,
     isMetaInboxCreationDisabled,
   }),
@@ -45,11 +48,12 @@ const mountDialog = () =>
     },
   });
 
-describe('InboxChannelsDialog Facebook gating', () => {
+describe('InboxChannelsDialog channel availability', () => {
   afterEach(() => {
     delete window.chatwootConfig;
     isOnChatwootCloud.value = false;
     isMetaInboxCreationDisabled.value = false;
+    isTiktokEnabled.value = true;
   });
 
   it('opens the Facebook page picker when fbAppId is configured', async () => {
@@ -85,5 +89,19 @@ describe('InboxChannelsDialog Facebook gating', () => {
 
     expect(wrapper.find('[data-test="fb-form"]').exists()).toBe(false);
     expect(wrapper.find('button').exists()).toBe(true);
+  });
+
+  it('shows TikTok as disabled when account access is disabled on Chatwoot Cloud', () => {
+    isOnChatwootCloud.value = true;
+    isTiktokEnabled.value = false;
+    window.chatwootConfig = { tiktokAppId: 'tiktok-app' };
+    const wrapper = mountDialog();
+
+    const tiktokButton = wrapper
+      .findAll('button')
+      .find(button => button.text().includes('TIKTOK.TITLE'));
+
+    expect(tiktokButton.attributes('disabled')).toBeDefined();
+    expect(tiktokButton.text()).toContain('SETUP_LATER');
   });
 });

--- a/app/javascript/dashboard/routes/dashboard/onboarding/specs/inbox-setup/useDetectedChannels.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/specs/inbox-setup/useDetectedChannels.spec.js
@@ -13,7 +13,7 @@ vi.mock('vue-router');
 // channel_type, social ordering) derived from CHANNEL_LIST.
 const mountComposable = ({
   brandInfo,
-  features = { channel_instagram: true },
+  features = { channel_instagram: true, channel_tiktok: true },
   inboxes = [],
   isOnChatwootCloud = false,
   disableMetaInboxCreation = false,
@@ -260,6 +260,23 @@ describe('useDetectedChannels', () => {
       const { displayedChannels, remainingChannels } = mountComposable({
         features: { channel_instagram: true, channel_tiktok: false },
         isOnChatwootCloud: true,
+        brandInfo: {
+          socials: [{ type: 'tiktok', url: 'https://tiktok.com/@acme' }],
+        },
+      });
+
+      expect(
+        displayedChannels.value.map(channel => channel.type)
+      ).not.toContain('tiktok');
+      expect(remainingChannels.value.map(channel => channel.type)).toContain(
+        'tiktok'
+      );
+    });
+
+    it('keeps disabled TikTok out of detected channels on self-hosted installations', () => {
+      const { displayedChannels, remainingChannels } = mountComposable({
+        features: { channel_tiktok: false },
+        isOnChatwootCloud: false,
         brandInfo: {
           socials: [{ type: 'tiktok', url: 'https://tiktok.com/@acme' }],
         },

--- a/app/javascript/dashboard/routes/dashboard/onboarding/specs/inbox-setup/useDetectedChannels.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/onboarding/specs/inbox-setup/useDetectedChannels.spec.js
@@ -219,6 +219,7 @@ describe('useDetectedChannels', () => {
       const { displayedChannels } = mountComposable({
         features: {
           channel_instagram: true,
+          channel_tiktok: true,
           whatsapp_embedded_signup_inbox_creation: true,
         },
         isOnChatwootCloud: true,
@@ -240,7 +241,7 @@ describe('useDetectedChannels', () => {
 
     it('hides Instagram when disabled for the account', () => {
       const { displayedChannels } = mountComposable({
-        features: { channel_instagram: false },
+        features: { channel_instagram: false, channel_tiktok: true },
         isOnChatwootCloud: true,
         brandInfo: {
           socials: [
@@ -253,6 +254,23 @@ describe('useDetectedChannels', () => {
       expect(displayedChannels.value.map(channel => channel.type)).toEqual([
         'tiktok',
       ]);
+    });
+
+    it('keeps disabled TikTok in the secondary channel catalog on Chatwoot Cloud', () => {
+      const { displayedChannels, remainingChannels } = mountComposable({
+        features: { channel_instagram: true, channel_tiktok: false },
+        isOnChatwootCloud: true,
+        brandInfo: {
+          socials: [{ type: 'tiktok', url: 'https://tiktok.com/@acme' }],
+        },
+      });
+
+      expect(
+        displayedChannels.value.map(channel => channel.type)
+      ).not.toContain('tiktok');
+      expect(remainingChannels.value.map(channel => channel.type)).toContain(
+        'tiktok'
+      );
     });
   });
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/ChannelList.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/ChannelList.vue
@@ -10,7 +10,7 @@ import ChannelItem from 'dashboard/components/widgets/ChannelItem.vue';
 
 const { t } = useI18n();
 const router = useRouter();
-const { accountId, currentAccount } = useAccount();
+const { accountId, currentAccount, isOnChatwootCloud } = useAccount();
 
 const globalConfig = useMapGetter('globalConfig/get');
 
@@ -83,7 +83,12 @@ const channelList = computed(() => {
     channels.push({
       key: 'tiktok',
       title: t('INBOX_MGMT.ADD.AUTH.CHANNEL.TIKTOK.TITLE'),
-      description: t('INBOX_MGMT.ADD.AUTH.CHANNEL.TIKTOK.DESCRIPTION'),
+      description:
+        currentAccount.value &&
+        isOnChatwootCloud.value &&
+        !enabledFeatures.value.channel_tiktok
+          ? t('INBOX_MGMT.ADD.AUTH.CHANNEL.TIKTOK.ACCESS_REQUEST_DESCRIPTION')
+          : t('INBOX_MGMT.ADD.AUTH.CHANNEL.TIKTOK.DESCRIPTION'),
       icon: 'i-woot-tiktok',
     });
   }

--- a/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
+++ b/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
@@ -11,7 +11,6 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
     channel_facebook
     channel_email
     channel_instagram
-    channel_tiktok
     captain_integration
     captain_document_auto_sync
     advanced_search_indexing

--- a/spec/controllers/api/v1/accounts/tiktok/authorizations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/tiktok/authorizations_controller_spec.rb
@@ -31,7 +31,21 @@ RSpec.describe 'TikTok Authorization API', type: :request do
         expect(response).to have_http_status(:unauthorized)
       end
 
+      it 'returns unauthorized when TikTok is disabled for the account' do
+        account.disable_features!('channel_tiktok')
+
+        with_modified_env TIKTOK_APP_ID: 'tiktok-app-id', TIKTOK_APP_SECRET: 'tiktok-app-secret' do
+          post "/api/v1/accounts/#{account.id}/tiktok/authorization",
+               headers: administrator.create_new_auth_token,
+               as: :json
+        end
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
       it 'creates a new authorization and returns the redirect url' do
+        account.enable_features!('channel_tiktok')
+
         travel_to Time.zone.parse('2025-01-01 00:00:00 UTC') do
           with_modified_env TIKTOK_APP_ID: 'tiktok-app-id', TIKTOK_APP_SECRET: 'tiktok-app-secret' do
             post "/api/v1/accounts/#{account.id}/tiktok/authorization",


### PR DESCRIPTION
Chatwoot Cloud accounts without TikTok access can now contact support directly from the TikTok channel card. Accounts with the existing `channel_tiktok` feature continue through the current connection flow.

Related: https://github.com/chatwoot/chatwoot/pull/13628

## Why

TikTok access is being reviewed manually for now. Paid plans should not enable it automatically while this temporary process is in place.

## What this change does

- Removes TikTok from automatic paid-plan feature reconciliation.
- Keeps the channel card available as a support-chat entry point when `channel_tiktok` is disabled.
- Hides TikTok from onboarding until the existing feature is enabled.
- Leaves self-hosted and enabled-account OAuth behavior unchanged.

## How to test

1. On Chatwoot Cloud, open Settings → Inboxes → Add inbox with `channel_tiktok` disabled.
2. Confirm the TikTok card asks the customer to contact support.
3. Select the card and confirm the support chat opens.
4. Enable `channel_tiktok` and reload.
5. Confirm the card opens the existing TikTok connection flow.
6. Confirm TikTok is hidden from onboarding while disabled and visible when enabled.