### PR TITLE
feat: render media previews in the article diff panel

### DIFF
--- a/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleDiffPanel.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleDiffPanel.vue
@@ -68,25 +68,14 @@ const applyColumnWidths = (doc, widths) => {
   table.style.width = `${sized.reduce((sum, width) => sum + width, 0)}px`;
 };
 
-// Match the portal renderer: solo video links become players, and media
-// resized in the editor (cw_image_width / cw_video_width) keeps its size.
+// Match the portal renderer: solo video links become players, sized by their
+// cw_video_width param. (Images are sized by MessageFormatter itself.)
 const videoEmbeds = embeds.filter(embed => embed.hideSource);
-const DEFAULT_VIDEO_WIDTH = '640px';
+const DEFAULT_VIDEO_WIDTH = 640;
 
-const savedMediaWidth = (src, key) => {
-  const width = Number(
-    (src || '').match(new RegExp(`[?&]${key}=(\\d+)px(?:[&#]|$)`))?.[1]
-  );
-  return width >= 1 && width <= 2000 ? `${width}px` : null;
-};
-
-const applyImageSizes = doc => {
-  doc.body.querySelectorAll('img').forEach(image => {
-    const width = savedMediaWidth(image.getAttribute('src'), 'cw_image_width');
-    if (width) {
-      image.style.cssText = `width: ${width}; max-width: 100%; height: auto;`;
-    }
-  });
+const savedVideoWidth = href => {
+  const width = Number(href.match(/[?&]cw_video_width=(\d+)px(?:[&#]|$)/)?.[1]);
+  return width >= 1 && width <= 2000 ? width : null;
 };
 
 const applyVideoPreviews = doc => {
@@ -100,12 +89,10 @@ const applyVideoPreviews = doc => {
       controls: true,
       preload: 'metadata',
       src: href,
+      width: savedVideoWidth(href) || DEFAULT_VIDEO_WIDTH,
+      className: 'max-w-full h-auto',
     });
-    video.style.cssText = 'width: 100%; height: auto;';
-    const wrapper = doc.createElement('div');
-    wrapper.style.cssText = `width: ${savedMediaWidth(href, 'cw_video_width') || DEFAULT_VIDEO_WIDTH}; max-width: 100%;`;
-    wrapper.append(video);
-    paragraph.replaceWith(wrapper);
+    paragraph.replaceWith(video);
   });
 };
 
@@ -115,7 +102,6 @@ const renderMarkdown = markdown => {
   const doc = new DOMParser().parseFromString(html, 'text/html');
   const match = markdown.match(COLWIDTHS_RE);
   if (match) applyColumnWidths(doc, match[1].split(',').map(Number));
-  applyImageSizes(doc);
   applyVideoPreviews(doc);
   return doc.body.innerHTML;
 };

--- a/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleDiffPanel.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleDiffPanel.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import MessageFormatter from 'shared/helpers/MessageFormatter';
+import { embeds } from 'dashboard/helper/markdownEmbeds';
 import {
   renderInlineDiff,
   buildDiffBlocks,
@@ -50,10 +51,9 @@ const contentChanged = computed(() =>
 const COLWIDTHS_RE = /<!--cw-colwidths:([\d,]+)-->/;
 const DEFAULT_COL_WIDTH = 50;
 
-const applyColumnWidths = (html, widths) => {
-  const doc = new DOMParser().parseFromString(html, 'text/html');
+const applyColumnWidths = (doc, widths) => {
   const table = doc.body.querySelector('table');
-  if (!table) return html;
+  if (!table) return;
 
   const sized = widths.map(width => (width > 0 ? width : DEFAULT_COL_WIDTH));
   const colgroup = doc.createElement('colgroup');
@@ -66,16 +66,58 @@ const applyColumnWidths = (html, widths) => {
 
   table.style.tableLayout = 'fixed';
   table.style.width = `${sized.reduce((sum, width) => sum + width, 0)}px`;
-  return doc.body.innerHTML;
+};
+
+// Match the portal renderer: solo video links become players, and media
+// resized in the editor (cw_image_width / cw_video_width) keeps its size.
+const videoEmbeds = embeds.filter(embed => embed.hideSource);
+const DEFAULT_VIDEO_WIDTH = '640px';
+
+const savedMediaWidth = (src, key) => {
+  const width = Number(
+    (src || '').match(new RegExp(`[?&]${key}=(\\d+)px(?:[&#]|$)`))?.[1]
+  );
+  return width >= 1 && width <= 2000 ? `${width}px` : null;
+};
+
+const applyImageSizes = doc => {
+  doc.body.querySelectorAll('img').forEach(image => {
+    const width = savedMediaWidth(image.getAttribute('src'), 'cw_image_width');
+    if (width) {
+      image.style.cssText = `width: ${width}; max-width: 100%; height: auto;`;
+    }
+  });
+};
+
+const applyVideoPreviews = doc => {
+  doc.body.querySelectorAll('p > a:only-child').forEach(link => {
+    const href = link.getAttribute('href');
+    if (!href || !videoEmbeds.some(({ regex }) => regex.test(href))) return;
+    const paragraph = link.parentElement;
+    if (paragraph.textContent.trim() !== link.textContent.trim()) return;
+
+    const video = Object.assign(doc.createElement('video'), {
+      controls: true,
+      preload: 'metadata',
+      src: href,
+    });
+    video.style.cssText = 'width: 100%; height: auto;';
+    const wrapper = doc.createElement('div');
+    wrapper.style.cssText = `width: ${savedMediaWidth(href, 'cw_video_width') || DEFAULT_VIDEO_WIDTH}; max-width: 100%;`;
+    wrapper.append(video);
+    paragraph.replaceWith(wrapper);
+  });
 };
 
 const renderMarkdown = markdown => {
   if (!markdown) return '';
   const html = new MessageFormatter(markdown).formattedMessage;
+  const doc = new DOMParser().parseFromString(html, 'text/html');
   const match = markdown.match(COLWIDTHS_RE);
-  return match
-    ? applyColumnWidths(html, match[1].split(',').map(Number))
-    : html;
+  if (match) applyColumnWidths(doc, match[1].split(',').map(Number));
+  applyImageSizes(doc);
+  applyVideoPreviews(doc);
+  return doc.body.innerHTML;
 };
 
 const blockClass = type => {

--- a/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
@@ -60,6 +60,14 @@ const editorRef = useTemplateRef('editorRef');
 
 const hasPendingUploads = () => !!editorRef.value?.hasPendingUploads();
 
+// Files picked between the create dispatch and its redirect would die with
+// this editor instance; hold them off for that window.
+const uploadsBlockedMessage = computed(() =>
+  isNewArticle.value && props.isUpdating
+    ? t('HELP_CENTER.EDIT_ARTICLE_PAGE.HEADER.CREATE_IN_PROGRESS')
+    : ''
+);
+
 onBeforeRouteLeave(() => {
   if (!hasPendingUploads()) return true;
   useAlert(t('HELP_CENTER.EDIT_ARTICLE_PAGE.HEADER.UPLOAD_IN_PROGRESS'));
@@ -228,6 +236,7 @@ const handleCreateArticle = event => {
           t('HELP_CENTER.EDIT_ARTICLE_PAGE.EDIT_ARTICLE.EDITOR_PLACEHOLDER')
         "
         :enabled-menu-options="ARTICLE_EDITOR_MENU_OPTIONS"
+        :uploads-blocked-message="uploadsBlockedMessage"
         :autofocus="!isNewArticle"
       />
     </template>

--- a/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
@@ -69,6 +69,9 @@ const uploadsBlockedMessage = computed(() =>
 );
 
 onBeforeRouteLeave(() => {
+  // Always let the post-create redirect through: blocking it strands a "new"
+  // page whose article already exists, and the next blur would duplicate it.
+  if (isNewArticle.value && props.isUpdating) return true;
   if (!hasPendingUploads()) return true;
   useAlert(t('HELP_CENTER.EDIT_ARTICLE_PAGE.HEADER.UPLOAD_IN_PROGRESS'));
   return false;

--- a/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.spec.js
+++ b/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.spec.js
@@ -946,6 +946,14 @@ describe('FullEditor', () => {
       expect(alerts).toHaveLength(1);
     });
 
+    it('holds files back with an alert while the parent blocks uploads', async () => {
+      mountEditor({ uploadsBlockedMessage: 'article is being created' });
+      await selectFile(fileOfSize(1));
+
+      expect(attachImage).not.toHaveBeenCalled();
+      expect(alerts).toEqual(['article is being created']);
+    });
+
     it('keeps the preview with retry and remove controls when the upload fails', async () => {
       mountEditor();
       attachImage.mockRejectedValue(new Error('nope'));

--- a/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/FullEditor.vue
@@ -84,6 +84,7 @@ export default {
     editorId: { type: String, default: '' },
     placeholder: { type: String, default: '' },
     enabledMenuOptions: { type: Array, default: () => [] },
+    uploadsBlockedMessage: { type: String, default: '' },
     autofocus: {
       type: Boolean,
       default: true,
@@ -398,6 +399,10 @@ export default {
     },
     handleFiles(files) {
       if (!editorView || !files.length) return;
+      if (this.uploadsBlockedMessage) {
+        useAlert(this.uploadsBlockedMessage);
+        return;
+      }
       const buckets = { images: [], videos: [] };
       files.forEach(file => {
         const bucket = this.bucketFor(file);

--- a/app/javascript/dashboard/i18n/locale/en/helpCenter.json
+++ b/app/javascript/dashboard/i18n/locale/en/helpCenter.json
@@ -807,6 +807,7 @@
         "PUBLISH_CHANGES_ERROR": "Could not publish changes",
         "SAVE_IN_PROGRESS": "Still saving your latest changes. Please try again in a moment.",
         "UPLOAD_IN_PROGRESS": "A file upload is unfinished. Wait for it to finish or remove it first.",
+        "CREATE_IN_PROGRESS": "The article is still being created. Add files again in a moment.",
         "DISCARD_CHANGES": "Discard changes",
         "DISCARD_CHANGES_SUCCESS": "Changes discarded",
         "DISCARD_CHANGES_ERROR": "Could not discard changes",

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesNewPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesNewPage.vue
@@ -72,7 +72,7 @@ const createNewArticle = async ({ title, content }) => {
     )?.slug;
     const startedFromCategorySlug = route.params.categorySlug;
 
-    router.replace({
+    await router.replace({
       name: isCategoryArticles.value
         ? 'portals_categories_articles_edit'
         : 'portals_articles_edit',


### PR DESCRIPTION
# Pull Request Template

## Description

This PR is a follow-up to #15593 and adds media previews to the "Unpublished changes" panel so media is rendered the same way as in the article instead of showing raw links or full-size images. Uploaded videos now render as players, and resized images or videos use their saved dimensions, so the diff reflects how the content will appear when published.

It also prevents files added while creating a new article from being lost during the redirect to the edit page.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Screenshot

**Before**
<img width="1484" height="1173" alt="image" src="https://github.com/user-attachments/assets/760ea761-9a33-415f-ae9b-1e2b6f6fbd33" />



**After**
<img width="1484" height="1173" alt="image" src="https://github.com/user-attachments/assets/47249801-aea9-439d-9a80-6d33e08c7bf8" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
