### PR TITLE
fix: read FRONTEND_URL from global config for SAML ACS URL

### DIFF
--- a/app/javascript/dashboard/api/captain/customTools.js
+++ b/app/javascript/dashboard/api/captain/customTools.js
@@ -37,6 +37,28 @@ class CaptainCustomTools extends ApiClient {
       custom_tool: data,
     });
   }
+
+  previewImport(file, { signal } = {}) {
+    const formData = new FormData();
+    formData.append('file', file);
+    return axios.post(`${this.url}/preview_import`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+      signal,
+    });
+  }
+
+  importToolset(file, configuration) {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('configuration', JSON.stringify(configuration));
+    return axios.post(`${this.url}/import`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+  }
+
+  exportToolset(id) {
+    return axios.get(`${this.url}/${id}/export`, { responseType: 'blob' });
+  }
 }
 
 export default new CaptainCustomTools();

--- a/app/javascript/dashboard/api/captain/customTools.js
+++ b/app/javascript/dashboard/api/captain/customTools.js
@@ -38,18 +38,20 @@ class CaptainCustomTools extends ApiClient {
     });
   }
 
-  previewImport(file, { signal } = {}) {
+  previewImport({ file, source }, { signal } = {}) {
     const formData = new FormData();
-    formData.append('file', file);
+    if (file) formData.append('file', file);
+    if (source) formData.append('source', source);
     return axios.post(`${this.url}/preview_import`, formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
       signal,
     });
   }
 
-  importToolset(file, configuration) {
+  importToolset({ file, source }, configuration) {
     const formData = new FormData();
-    formData.append('file', file);
+    if (file) formData.append('file', file);
+    if (source) formData.append('source', source);
     formData.append('configuration', JSON.stringify(configuration));
     return axios.post(`${this.url}/import`, formData, {
       headers: { 'Content-Type': 'multipart/form-data' },

--- a/app/javascript/dashboard/components-next/captain/pageComponents/customTool/AuthConfig.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/customTool/AuthConfig.vue
@@ -31,6 +31,7 @@ watch(
     <Input
       v-if="authType === 'bearer'"
       v-model="authConfig.token"
+      type="password"
       :label="t('CAPTAIN.CUSTOM_TOOLS.FORM.AUTH_CONFIG.BEARER_TOKEN')"
       :placeholder="
         t('CAPTAIN.CUSTOM_TOOLS.FORM.AUTH_CONFIG.BEARER_TOKEN_PLACEHOLDER')
@@ -63,6 +64,7 @@ watch(
       />
       <Input
         v-model="authConfig.key"
+        type="password"
         :label="t('CAPTAIN.CUSTOM_TOOLS.FORM.AUTH_CONFIG.API_VALUE')"
         :placeholder="
           t('CAPTAIN.CUSTOM_TOOLS.FORM.AUTH_CONFIG.API_VALUE_PLACEHOLDER')

--- a/app/javascript/dashboard/components-next/captain/pageComponents/customTool/CustomToolCard.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/customTool/CustomToolCard.vue
@@ -50,6 +50,12 @@ const menuItems = computed(() => [
     icon: 'i-lucide-pencil-line',
   },
   {
+    label: t('CAPTAIN.CUSTOM_TOOLS.OPTIONS.DOWNLOAD_TOOL'),
+    value: 'download',
+    action: 'download',
+    icon: 'i-lucide-download',
+  },
+  {
     label: t('CAPTAIN.CUSTOM_TOOLS.OPTIONS.DELETE_TOOL'),
     value: 'delete',
     action: 'delete',

--- a/app/javascript/dashboard/components-next/captain/pageComponents/customTool/CustomToolCard.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/customTool/CustomToolCard.vue
@@ -43,6 +43,10 @@ const props = defineProps({
     type: Number,
     required: true,
   },
+  sourceMetadata: {
+    type: Object,
+    default: null,
+  },
 });
 
 const emit = defineEmits(['action', 'toggle']);
@@ -95,6 +99,18 @@ const handleAction = ({ action, value }) => {
 const authTypeLabel = computed(() => {
   return t(
     `CAPTAIN.CUSTOM_TOOLS.FORM.AUTH_TYPES.${props.authType.toUpperCase()}`
+  );
+});
+
+const sourceLabel = computed(() => {
+  if (!props.sourceMetadata) return '';
+  if (props.sourceMetadata.type === 'github') {
+    const path = props.sourceMetadata.path?.replace(/\/toolset\.ya?ml$/, '');
+    return [props.sourceMetadata.repository, path].filter(Boolean).join('/');
+  }
+
+  return (
+    props.sourceMetadata.filename || t('CAPTAIN.CUSTOM_TOOLS.SOURCE.UPLOAD')
   );
 });
 </script>
@@ -153,6 +169,20 @@ const authTypeLabel = computed(() => {
         >
           <i class="i-lucide-lock text-base" />
           {{ authTypeLabel }}
+        </span>
+        <span
+          v-if="sourceLabel"
+          class="text-sm shrink-0 text-n-slate-11 inline-flex items-center gap-1"
+        >
+          <i
+            :class="
+              sourceMetadata.type === 'github'
+                ? 'i-lucide-github'
+                : 'i-lucide-file-up'
+            "
+            class="text-base"
+          />
+          {{ sourceLabel }}
         </span>
       </div>
       <span

--- a/app/javascript/dashboard/components-next/captain/pageComponents/customTool/CustomToolCard.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/customTool/CustomToolCard.vue
@@ -47,6 +47,10 @@ const props = defineProps({
     type: Object,
     default: null,
   },
+  showSource: {
+    type: Boolean,
+    default: true,
+  },
 });
 
 const emit = defineEmits(['action', 'toggle']);
@@ -171,7 +175,7 @@ const sourceLabel = computed(() => {
           {{ authTypeLabel }}
         </span>
         <span
-          v-if="sourceLabel"
+          v-if="showSource && sourceLabel"
           class="text-sm shrink-0 text-n-slate-11 inline-flex items-center gap-1"
         >
           <i

--- a/app/javascript/dashboard/components-next/captain/pageComponents/customTool/ImportToolsetDialog.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/customTool/ImportToolsetDialog.vue
@@ -308,13 +308,12 @@ defineExpose({ dialogRef, open });
         <span class="text-heading-3 text-n-slate-12">
           {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.TOOLS_LABEL') }}
         </span>
-        <ul class="flex flex-col gap-2 list-none">
+        <ul class="flex flex-col gap-2 pe-1 overflow-y-auto list-none max-h-80">
           <li
             v-for="tool in preview.tools"
             :key="tool.title"
-            class="flex items-start gap-2 px-3 py-2 rounded-lg bg-n-alpha-2"
+            class="px-3 py-2 rounded-lg bg-n-alpha-2"
           >
-            <span class="i-lucide-wrench size-4 mt-0.5 text-n-slate-10" />
             <div class="flex flex-col min-w-0">
               <span class="text-sm font-medium text-n-slate-12">
                 {{ tool.title }}

--- a/app/javascript/dashboard/components-next/captain/pageComponents/customTool/ImportToolsetDialog.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/customTool/ImportToolsetDialog.vue
@@ -8,13 +8,24 @@ import CustomToolsAPI from 'dashboard/api/captain/customTools';
 
 import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
 import Input from 'dashboard/components-next/input/Input.vue';
+import Button from 'dashboard/components-next/button/Button.vue';
 
 const emit = defineEmits(['imported', 'close']);
+
+const STEPS = {
+  SOURCE: 'source',
+  TOOLSET: 'toolset',
+  CONFIGURATION: 'configuration',
+};
 
 const { t } = useI18n();
 const dialogRef = ref(null);
 const fileInputRef = ref(null);
+const currentStep = ref(STEPS.SOURCE);
 const selectedFile = ref(null);
+const selectedSource = ref('');
+const source = ref('');
+const repositoryToolsets = ref([]);
 const preview = ref(null);
 const isImporting = ref(false);
 const configuration = reactive({ inputs: {}, secrets: {} });
@@ -24,6 +35,22 @@ const {
   isPending: isPreviewing,
 } = useAbortableRequest();
 
+const stepTitles = computed(() => ({
+  [STEPS.SOURCE]: t('CAPTAIN.CUSTOM_TOOLS.IMPORT.TITLE'),
+  [STEPS.TOOLSET]: t('CAPTAIN.CUSTOM_TOOLS.IMPORT.REPOSITORY_TOOLS_LABEL'),
+  [STEPS.CONFIGURATION]: preview.value?.name,
+}));
+const dialogTitle = computed(() => stepTitles.value[currentStep.value]);
+
+const stepDescriptions = computed(() => ({
+  [STEPS.SOURCE]: t('CAPTAIN.CUSTOM_TOOLS.IMPORT.STEPS.SOURCE'),
+  [STEPS.TOOLSET]: t('CAPTAIN.CUSTOM_TOOLS.IMPORT.STEPS.TOOLSET'),
+  [STEPS.CONFIGURATION]: preview.value?.description,
+}));
+const dialogDescription = computed(
+  () => stepDescriptions.value[currentStep.value]
+);
+
 const isConfigurationComplete = computed(() =>
   (preview.value?.fields || []).every(field => {
     if (!field.required) return true;
@@ -31,12 +58,20 @@ const isConfigurationComplete = computed(() =>
   })
 );
 
-const reset = () => {
-  abortPreviewRequest();
-  selectedFile.value = null;
+const resetConfiguration = () => {
   preview.value = null;
   configuration.inputs = {};
   configuration.secrets = {};
+};
+
+const reset = () => {
+  abortPreviewRequest();
+  currentStep.value = STEPS.SOURCE;
+  selectedFile.value = null;
+  selectedSource.value = '';
+  source.value = '';
+  repositoryToolsets.value = [];
+  resetConfiguration();
   if (fileInputRef.value) fileInputRef.value.value = '';
 };
 
@@ -49,40 +84,81 @@ const showError = error => {
   useAlert(message);
 };
 
-const handleFileChange = async event => {
-  const [file] = event.target.files;
-  abortPreviewRequest();
-  selectedFile.value = null;
-  preview.value = null;
-  configuration.inputs = {};
-  configuration.secrets = {};
-  if (!file) return;
+const initializeConfiguration = data => {
+  preview.value = data;
+  data.fields.forEach(field => {
+    configuration[field.section][field.name] = '';
+  });
+  currentStep.value = STEPS.CONFIGURATION;
+};
 
-  selectedFile.value = file;
+const loadPreview = async ({ file, source: githubSource }) => {
+  abortPreviewRequest();
+  resetConfiguration();
+
   try {
     const response = await runPreviewRequest(signal =>
-      CustomToolsAPI.previewImport(file, { signal })
+      CustomToolsAPI.previewImport({ file, source: githubSource }, { signal })
     );
     if (!response) return;
 
-    const { data } = response;
-    preview.value = data;
-    data.fields.forEach(field => {
-      configuration[field.section][field.name] = '';
-    });
+    if (response.data.toolsets) {
+      repositoryToolsets.value = response.data.toolsets;
+      currentStep.value = STEPS.TOOLSET;
+      return;
+    }
+
+    selectedFile.value = file || null;
+    selectedSource.value = githubSource || '';
+    initializeConfiguration(response.data);
   } catch (error) {
     showError(error);
-    reset();
+    if (fileInputRef.value) fileInputRef.value.value = '';
   }
 };
 
+const handleFileChange = event => {
+  const [file] = event.target.files;
+  if (!file) return;
+
+  repositoryToolsets.value = [];
+  loadPreview({ file });
+};
+
+const previewSource = () => {
+  const githubSource = source.value.trim();
+  if (!githubSource) return;
+
+  repositoryToolsets.value = [];
+  loadPreview({ source: githubSource });
+};
+
+const selectRepositoryToolset = toolset => {
+  loadPreview({ source: toolset.source });
+};
+
+const goBack = () => {
+  resetConfiguration();
+  if (
+    currentStep.value === STEPS.CONFIGURATION &&
+    repositoryToolsets.value.length
+  ) {
+    currentStep.value = STEPS.TOOLSET;
+    return;
+  }
+
+  currentStep.value = STEPS.SOURCE;
+  selectedFile.value = null;
+  selectedSource.value = '';
+};
+
 const handleImport = async () => {
-  if (!selectedFile.value || !isConfigurationComplete.value) return;
+  if (!preview.value || !isConfigurationComplete.value) return;
 
   isImporting.value = true;
   try {
     const { data } = await CustomToolsAPI.importToolset(
-      selectedFile.value,
+      { file: selectedFile.value, source: selectedSource.value },
       configuration
     );
     useAlert(
@@ -104,24 +180,61 @@ const handleClose = () => {
   emit('close');
 };
 
-defineExpose({ dialogRef });
+const open = async initialSource => {
+  reset();
+  source.value = initialSource || '';
+  dialogRef.value.open();
+  if (source.value) await previewSource();
+};
+
+defineExpose({ dialogRef, open });
 </script>
 
 <template>
   <Dialog
     ref="dialogRef"
     width="xl"
-    :title="t('CAPTAIN.CUSTOM_TOOLS.IMPORT.TITLE')"
-    :description="t('CAPTAIN.CUSTOM_TOOLS.IMPORT.DESCRIPTION')"
-    :confirm-button-label="t('CAPTAIN.CUSTOM_TOOLS.IMPORT.CONFIRM')"
-    :disable-confirm-button="
-      !preview || !isConfigurationComplete || isPreviewing
-    "
-    :is-loading="isImporting"
-    @confirm="handleImport"
+    :title="dialogTitle"
+    :description="dialogDescription"
+    :show-confirm-button="false"
+    :show-cancel-button="false"
     @close="handleClose"
   >
-    <div class="flex flex-col gap-5">
+    <div v-if="isPreviewing" class="flex flex-col items-center gap-3 py-10">
+      <span class="i-lucide-loader-circle size-6 animate-spin text-n-brand" />
+      <span class="text-sm text-n-slate-11">
+        {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.PREVIEWING') }}
+      </span>
+    </div>
+
+    <div v-else-if="currentStep === STEPS.SOURCE" class="flex flex-col gap-5">
+      <div class="flex flex-col gap-1">
+        <Input
+          v-model="source"
+          :label="t('CAPTAIN.CUSTOM_TOOLS.IMPORT.GITHUB_LABEL')"
+          :placeholder="t('CAPTAIN.CUSTOM_TOOLS.IMPORT.GITHUB_PLACEHOLDER')"
+          @keyup.enter="previewSource"
+        />
+        <span class="text-xs text-n-slate-11">
+          {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.GITHUB_HINT') }}
+        </span>
+        <Button
+          class="self-start mt-2"
+          variant="faded"
+          color="slate"
+          size="sm"
+          :label="t('CAPTAIN.CUSTOM_TOOLS.IMPORT.LOAD_GITHUB')"
+          :disabled="!source.trim()"
+          @click="previewSource"
+        />
+      </div>
+
+      <div class="flex items-center gap-3 text-xs text-n-slate-10">
+        <span class="h-px grow bg-n-weak" />
+        {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.OR_UPLOAD') }}
+        <span class="h-px grow bg-n-weak" />
+      </div>
+
       <div class="flex flex-col gap-1">
         <label
           for="captain-toolset-file"
@@ -141,60 +254,105 @@ defineExpose({ dialogRef });
           {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.FILE_HINT') }}
         </span>
       </div>
+    </div>
 
-      <div
-        v-if="isPreviewing"
-        class="flex items-center gap-2 text-sm text-n-slate-11"
+    <div v-else-if="currentStep === STEPS.TOOLSET" class="flex flex-col gap-2">
+      <button
+        v-for="toolset in repositoryToolsets"
+        :key="toolset.source"
+        type="button"
+        class="flex items-center justify-between w-full gap-3 px-4 py-3 text-start rounded-lg bg-n-alpha-2 hover:bg-n-alpha-3"
+        @click="selectRepositoryToolset(toolset)"
       >
-        <span class="i-lucide-loader-circle size-4 animate-spin" />
-        {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.PREVIEWING') }}
+        <div class="flex flex-col min-w-0 gap-1">
+          <span class="text-sm font-medium text-n-slate-12">
+            {{ toolset.name }}
+          </span>
+          <span
+            v-if="toolset.description"
+            class="text-xs text-n-slate-11 line-clamp-1"
+          >
+            {{ toolset.description }}
+          </span>
+          <div
+            class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-n-slate-10"
+          >
+            <span>
+              {{ toolset.tool_count }}
+              {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.TOOL_COUNT_LABEL') }}
+            </span>
+            <span v-if="toolset.required_configuration.length">
+              {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.REQUIRES') }}
+              {{ toolset.required_configuration.join(', ') }}
+            </span>
+          </div>
+        </div>
+        <span class="i-lucide-chevron-right size-5 shrink-0 text-n-slate-10" />
+      </button>
+    </div>
+
+    <div v-else-if="preview" class="flex flex-col gap-5">
+      <div v-if="preview.fields.length" class="flex flex-col gap-3">
+        <Input
+          v-for="field in preview.fields"
+          :key="`${field.section}-${field.name}`"
+          v-model="configuration[field.section][field.name]"
+          :type="field.secret ? 'password' : 'text'"
+          :label="field.label"
+          :placeholder="field.placeholder || ''"
+          :required="field.required"
+        />
       </div>
 
-      <template v-if="preview">
-        <div class="flex flex-col gap-1">
-          <span class="text-base font-medium text-n-slate-12">
-            {{ preview.name }}
-          </span>
-          <span v-if="preview.description" class="text-sm text-n-slate-11">
-            {{ preview.description }}
-          </span>
-        </div>
-
-        <div v-if="preview.fields.length" class="flex flex-col gap-3">
-          <Input
-            v-for="field in preview.fields"
-            :key="`${field.section}-${field.name}`"
-            v-model="configuration[field.section][field.name]"
-            :type="field.secret ? 'password' : 'text'"
-            :label="field.label"
-            :placeholder="field.placeholder || ''"
-            :required="field.required"
-          />
-        </div>
-
-        <div class="flex flex-col gap-2">
-          <span class="text-heading-3 text-n-slate-12">
-            {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.TOOLS_LABEL') }}
-          </span>
-          <ul class="flex flex-col gap-2 list-none">
-            <li
-              v-for="tool in preview.tools"
-              :key="tool.title"
-              class="flex items-start gap-2 px-3 py-2 rounded-lg bg-n-alpha-2"
-            >
-              <span class="i-lucide-wrench size-4 mt-0.5 text-n-slate-10" />
-              <div class="flex flex-col min-w-0">
-                <span class="text-sm font-medium text-n-slate-12">
-                  {{ tool.title }}
-                </span>
-                <span v-if="tool.description" class="text-xs text-n-slate-11">
-                  {{ tool.description }}
-                </span>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </template>
+      <div class="flex flex-col gap-2">
+        <span class="text-heading-3 text-n-slate-12">
+          {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.TOOLS_LABEL') }}
+        </span>
+        <ul class="flex flex-col gap-2 list-none">
+          <li
+            v-for="tool in preview.tools"
+            :key="tool.title"
+            class="flex items-start gap-2 px-3 py-2 rounded-lg bg-n-alpha-2"
+          >
+            <span class="i-lucide-wrench size-4 mt-0.5 text-n-slate-10" />
+            <div class="flex flex-col min-w-0">
+              <span class="text-sm font-medium text-n-slate-12">
+                {{ tool.title }}
+              </span>
+              <span v-if="tool.description" class="text-xs text-n-slate-11">
+                {{ tool.description }}
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>
     </div>
+
+    <template #footer>
+      <div
+        v-if="!isPreviewing"
+        class="flex items-center justify-between w-full gap-3"
+      >
+        <Button
+          variant="faded"
+          color="slate"
+          class="w-full"
+          :label="
+            currentStep === STEPS.SOURCE
+              ? t('DIALOG.BUTTONS.CANCEL')
+              : t('CAPTAIN.CUSTOM_TOOLS.IMPORT.BACK')
+          "
+          @click="currentStep === STEPS.SOURCE ? dialogRef.close() : goBack()"
+        />
+        <Button
+          v-if="currentStep === STEPS.CONFIGURATION"
+          class="w-full"
+          :label="t('CAPTAIN.CUSTOM_TOOLS.IMPORT.CONFIRM')"
+          :is-loading="isImporting"
+          :disabled="!isConfigurationComplete || isImporting"
+          @click="handleImport"
+        />
+      </div>
+    </template>
   </Dialog>
 </template>

--- a/app/javascript/dashboard/components-next/captain/pageComponents/customTool/ImportToolsetDialog.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/customTool/ImportToolsetDialog.vue
@@ -1,0 +1,200 @@
+<script setup>
+import { computed, reactive, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useAlert } from 'dashboard/composables';
+import { parseAPIErrorResponse } from 'dashboard/store/utils/api';
+import { useAbortableRequest } from 'dashboard/composables/useAbortableRequest';
+import CustomToolsAPI from 'dashboard/api/captain/customTools';
+
+import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
+import Input from 'dashboard/components-next/input/Input.vue';
+
+const emit = defineEmits(['imported', 'close']);
+
+const { t } = useI18n();
+const dialogRef = ref(null);
+const fileInputRef = ref(null);
+const selectedFile = ref(null);
+const preview = ref(null);
+const isImporting = ref(false);
+const configuration = reactive({ inputs: {}, secrets: {} });
+const {
+  run: runPreviewRequest,
+  abort: abortPreviewRequest,
+  isPending: isPreviewing,
+} = useAbortableRequest();
+
+const isConfigurationComplete = computed(() =>
+  (preview.value?.fields || []).every(field => {
+    if (!field.required) return true;
+    return configuration[field.section][field.name]?.trim();
+  })
+);
+
+const reset = () => {
+  abortPreviewRequest();
+  selectedFile.value = null;
+  preview.value = null;
+  configuration.inputs = {};
+  configuration.secrets = {};
+  if (fileInputRef.value) fileInputRef.value.value = '';
+};
+
+const showError = error => {
+  const parsedError = parseAPIErrorResponse(error);
+  const message =
+    typeof parsedError === 'string'
+      ? parsedError
+      : t('CAPTAIN.CUSTOM_TOOLS.IMPORT.ERROR_MESSAGE');
+  useAlert(message);
+};
+
+const handleFileChange = async event => {
+  const [file] = event.target.files;
+  abortPreviewRequest();
+  selectedFile.value = null;
+  preview.value = null;
+  configuration.inputs = {};
+  configuration.secrets = {};
+  if (!file) return;
+
+  selectedFile.value = file;
+  try {
+    const response = await runPreviewRequest(signal =>
+      CustomToolsAPI.previewImport(file, { signal })
+    );
+    if (!response) return;
+
+    const { data } = response;
+    preview.value = data;
+    data.fields.forEach(field => {
+      configuration[field.section][field.name] = '';
+    });
+  } catch (error) {
+    showError(error);
+    reset();
+  }
+};
+
+const handleImport = async () => {
+  if (!selectedFile.value || !isConfigurationComplete.value) return;
+
+  isImporting.value = true;
+  try {
+    const { data } = await CustomToolsAPI.importToolset(
+      selectedFile.value,
+      configuration
+    );
+    useAlert(
+      t('CAPTAIN.CUSTOM_TOOLS.IMPORT.SUCCESS_MESSAGE', {
+        count: data.imported_count,
+      })
+    );
+    emit('imported');
+    dialogRef.value.close();
+  } catch (error) {
+    showError(error);
+  } finally {
+    isImporting.value = false;
+  }
+};
+
+const handleClose = () => {
+  reset();
+  emit('close');
+};
+
+defineExpose({ dialogRef });
+</script>
+
+<template>
+  <Dialog
+    ref="dialogRef"
+    width="xl"
+    :title="t('CAPTAIN.CUSTOM_TOOLS.IMPORT.TITLE')"
+    :description="t('CAPTAIN.CUSTOM_TOOLS.IMPORT.DESCRIPTION')"
+    :confirm-button-label="t('CAPTAIN.CUSTOM_TOOLS.IMPORT.CONFIRM')"
+    :disable-confirm-button="
+      !preview || !isConfigurationComplete || isPreviewing
+    "
+    :is-loading="isImporting"
+    @confirm="handleImport"
+    @close="handleClose"
+  >
+    <div class="flex flex-col gap-5">
+      <div class="flex flex-col gap-1">
+        <label
+          for="captain-toolset-file"
+          class="text-heading-3 text-n-slate-12"
+        >
+          {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.FILE_LABEL') }}
+        </label>
+        <input
+          id="captain-toolset-file"
+          ref="fileInputRef"
+          type="file"
+          accept=".yml,.yaml,application/yaml,text/yaml"
+          class="block w-full h-10 px-3 py-2 text-sm rounded-lg outline outline-1 outline-offset-[-1px] outline-n-weak bg-n-alpha-black2 text-n-slate-12 file:me-3 file:border-0 file:bg-transparent file:text-sm file:font-medium"
+          @change="handleFileChange"
+        />
+        <span class="text-xs text-n-slate-11">
+          {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.FILE_HINT') }}
+        </span>
+      </div>
+
+      <div
+        v-if="isPreviewing"
+        class="flex items-center gap-2 text-sm text-n-slate-11"
+      >
+        <span class="i-lucide-loader-circle size-4 animate-spin" />
+        {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.PREVIEWING') }}
+      </div>
+
+      <template v-if="preview">
+        <div class="flex flex-col gap-1">
+          <span class="text-base font-medium text-n-slate-12">
+            {{ preview.name }}
+          </span>
+          <span v-if="preview.description" class="text-sm text-n-slate-11">
+            {{ preview.description }}
+          </span>
+        </div>
+
+        <div v-if="preview.fields.length" class="flex flex-col gap-3">
+          <Input
+            v-for="field in preview.fields"
+            :key="`${field.section}-${field.name}`"
+            v-model="configuration[field.section][field.name]"
+            :type="field.secret ? 'password' : 'text'"
+            :label="field.label"
+            :placeholder="field.placeholder || ''"
+            :required="field.required"
+          />
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <span class="text-heading-3 text-n-slate-12">
+            {{ t('CAPTAIN.CUSTOM_TOOLS.IMPORT.TOOLS_LABEL') }}
+          </span>
+          <ul class="flex flex-col gap-2 list-none">
+            <li
+              v-for="tool in preview.tools"
+              :key="tool.title"
+              class="flex items-start gap-2 px-3 py-2 rounded-lg bg-n-alpha-2"
+            >
+              <span class="i-lucide-wrench size-4 mt-0.5 text-n-slate-10" />
+              <div class="flex flex-col min-w-0">
+                <span class="text-sm font-medium text-n-slate-12">
+                  {{ tool.title }}
+                </span>
+                <span v-if="tool.description" class="text-xs text-n-slate-11">
+                  {{ tool.description }}
+                </span>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </template>
+    </div>
+  </Dialog>
+</template>

--- a/app/javascript/dashboard/components-next/captain/pageComponents/customTool/ToolsetCard.vue
+++ b/app/javascript/dashboard/components-next/captain/pageComponents/customTool/ToolsetCard.vue
@@ -1,0 +1,97 @@
+<script setup>
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import CardLayout from 'dashboard/components-next/CardLayout.vue';
+import CustomToolCard from './CustomToolCard.vue';
+
+const props = defineProps({
+  tools: {
+    type: Array,
+    required: true,
+  },
+  pendingToggleIds: {
+    type: Set,
+    default: () => new Set(),
+  },
+});
+
+const emit = defineEmits(['action', 'toggle']);
+
+const { t } = useI18n();
+const isExpanded = ref(false);
+
+const metadata = computed(() => props.tools[0].source_metadata);
+const sourceLabel = computed(() => {
+  if (metadata.value.type === 'github') {
+    const path = metadata.value.path.replace(/\/toolset\.ya?ml$/, '');
+    return [metadata.value.repository, path].filter(Boolean).join('/');
+  }
+
+  return metadata.value.filename;
+});
+
+const toolCountLabel = computed(() =>
+  t('CAPTAIN.CUSTOM_TOOLS.TOOLSET.TOOL_COUNT', {
+    n: props.tools.length,
+  })
+);
+
+const sourceDetails = computed(() =>
+  t('CAPTAIN.CUSTOM_TOOLS.TOOLSET.SOURCE_DETAILS', {
+    source: sourceLabel.value,
+    version: metadata.value.toolset_version,
+  })
+);
+</script>
+
+<template>
+  <CardLayout class="overflow-hidden">
+    <button
+      type="button"
+      class="flex flex-col w-full gap-3 p-0 text-start"
+      :aria-expanded="isExpanded"
+      @click="isExpanded = !isExpanded"
+    >
+      <div class="flex items-center justify-between w-full gap-4">
+        <span class="text-base font-medium text-n-slate-12 line-clamp-1">
+          {{ metadata.toolset_name }}
+        </span>
+        <div class="flex items-center gap-3 shrink-0">
+          <span class="text-sm text-n-slate-11">{{ toolCountLabel }}</span>
+          <i
+            class="size-5 text-n-slate-10 transition-transform i-lucide-chevron-down"
+            :class="{ 'rotate-180': isExpanded }"
+          />
+        </div>
+      </div>
+      <span class="text-sm truncate text-n-slate-11">
+        {{ sourceDetails }}
+      </span>
+    </button>
+
+    <template #after>
+      <div
+        v-if="isExpanded"
+        class="flex flex-col gap-2 p-3 overflow-y-auto border-y max-h-96 border-n-weak bg-n-alpha-1"
+      >
+        <CustomToolCard
+          v-for="tool in tools"
+          :id="tool.id"
+          :key="tool.id"
+          :title="tool.title"
+          :description="tool.description"
+          :auth-type="tool.auth_type"
+          :enabled="tool.enabled"
+          :is-updating="pendingToggleIds.has(tool.id)"
+          :created-at="tool.created_at"
+          :updated-at="tool.updated_at"
+          :source-metadata="tool.source_metadata"
+          :show-source="false"
+          @action="emit('action', $event)"
+          @toggle="emit('toggle', $event)"
+        />
+      </div>
+    </template>
+  </CardLayout>
+</template>

--- a/app/javascript/dashboard/helper/downloadHelper.js
+++ b/app/javascript/dashboard/helper/downloadHelper.js
@@ -1,8 +1,11 @@
 import fromUnixTime from 'date-fns/fromUnixTime';
 import format from 'date-fns/format';
 
-export const downloadCsvFile = (fileName, content) => {
-  const contentType = 'data:text/csv;charset=utf-8;';
+export const downloadFile = (
+  fileName,
+  content,
+  contentType = 'application/octet-stream'
+) => {
   const blob = new Blob([content], { type: contentType });
   const url = URL.createObjectURL(blob);
 
@@ -10,8 +13,12 @@ export const downloadCsvFile = (fileName, content) => {
   link.setAttribute('download', fileName);
   link.setAttribute('href', url);
   link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
   return link;
 };
+
+export const downloadCsvFile = (fileName, content) =>
+  downloadFile(fileName, content, 'data:text/csv;charset=utf-8;');
 
 export const generateFileName = ({ type, to, businessHours = false }) => {
   let name = `${type}-report-${format(fromUnixTime(to), 'dd-MM-yyyy')}`;

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -1147,7 +1147,23 @@
       "FORM_DESCRIPTION": "Configure your custom tool to connect with external APIs",
       "OPTIONS": {
         "EDIT_TOOL": "Edit tool",
+        "DOWNLOAD_TOOL": "Download YAML",
         "DELETE_TOOL": "Delete tool"
+      },
+      "IMPORT": {
+        "BUTTON": "Import YAML",
+        "TITLE": "Import toolset",
+        "DESCRIPTION": "Upload a Captain toolset and provide the configuration it requires.",
+        "FILE_LABEL": "Toolset file",
+        "FILE_HINT": "Choose a .yml or .yaml file up to 256 KB.",
+        "PREVIEWING": "Checking toolset…",
+        "TOOLS_LABEL": "Tools to import",
+        "CONFIRM": "Import tools",
+        "SUCCESS_MESSAGE": "Imported {count} tool successfully | Imported {count} tools successfully",
+        "ERROR_MESSAGE": "Could not import this toolset"
+      },
+      "EXPORT": {
+        "ERROR_MESSAGE": "Could not download this tool"
       },
       "CREATE": {
         "TITLE": "Create Custom Tool",

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -1158,6 +1158,10 @@
       "SOURCE": {
         "UPLOAD": "Uploaded toolset"
       },
+      "TOOLSET": {
+        "TOOL_COUNT": "{n} tool | {n} tools",
+        "SOURCE_DETAILS": "{source} · v{version}"
+      },
       "OPTIONS": {
         "EDIT_TOOL": "Edit tool",
         "DOWNLOAD_TOOL": "Download YAML",

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -1155,6 +1155,9 @@
         }
       },
       "FORM_DESCRIPTION": "Configure your custom tool to connect with external APIs",
+      "SOURCE": {
+        "UPLOAD": "Uploaded toolset"
+      },
       "OPTIONS": {
         "EDIT_TOOL": "Edit tool",
         "DOWNLOAD_TOOL": "Download YAML",

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -1161,9 +1161,23 @@
         "DELETE_TOOL": "Delete tool"
       },
       "IMPORT": {
-        "BUTTON": "Import YAML",
+        "BUTTON": "Import toolset",
         "TITLE": "Import toolset",
-        "DESCRIPTION": "Upload a Captain toolset and provide the configuration it requires.",
+        "DESCRIPTION": "Import a Captain toolset from GitHub or upload a YAML file, then provide the configuration it requires.",
+        "GITHUB_LABEL": "GitHub URL",
+        "GITHUB_PLACEHOLDER": "https://github.com/owner/repository/tree/main/shopify",
+        "GITHUB_HINT": "Enter a repository, tool folder, or direct toolset.yml URL from GitHub.",
+        "LOAD_GITHUB": "Load from GitHub",
+        "REPOSITORY_TOOLS_LABEL": "Choose a toolset",
+        "TOOL_COUNT_LABEL": "tools",
+        "REQUIRES": "Requires:",
+        "STEPS": {
+          "SOURCE": "Choose a GitHub repository or upload a Captain toolset file.",
+          "TOOLSET": "Choose the toolset you want to install from this repository.",
+          "CONFIGURATION": "Review the tools and provide the information required to install them."
+        },
+        "BACK": "Back",
+        "OR_UPLOAD": "or upload a file",
         "FILE_LABEL": "Toolset file",
         "FILE_HINT": "Choose a .yml or .yaml file up to 256 KB.",
         "PREVIEWING": "Checking toolset…",
@@ -1171,6 +1185,15 @@
         "CONFIRM": "Import tools",
         "SUCCESS_MESSAGE": "Imported {count} tool successfully | Imported {count} tools successfully",
         "ERROR_MESSAGE": "Could not import this toolset"
+      },
+      "INSTALL": {
+        "TITLE": "Install toolset",
+        "SELECT_TITLE": "Choose a Captain assistant",
+        "SELECT_DESCRIPTION": "Select the assistant whose Tools page you want to install this toolset from.",
+        "PLACEHOLDER": "Select an assistant",
+        "CONTINUE": "Continue to install",
+        "NO_ASSISTANTS": "Create a Captain assistant before installing this toolset.",
+        "CREATE_ASSISTANT": "Create an assistant"
       },
       "EXPORT": {
         "ERROR_MESSAGE": "Could not download this tool"

--- a/app/javascript/dashboard/routes/dashboard/captain/captain.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/captain/captain.routes.js
@@ -24,6 +24,7 @@ import DocumentsIndex from './documents/Index.vue';
 import ResponsesIndex from './responses/Index.vue';
 import FaqSuggestionsIndex from './responses/FaqSuggestions.vue';
 import CustomToolsIndex from './tools/Index.vue';
+import ToolsetInstall from './tools/Install.vue';
 
 const meta = {
   permissions: ['administrator', 'agent'],
@@ -49,6 +50,12 @@ const metaV2 = {
 };
 
 const assistantRoutes = [
+  {
+    path: frontendURL('accounts/:accountId/captain/toolsets/install'),
+    component: ToolsetInstall,
+    name: 'captain_toolset_install',
+    meta: metaCustomTools,
+  },
   {
     path: frontendURL('accounts/:accountId/captain/:assistantId/overview'),
     component: AssistantOverviewIndex,

--- a/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, onMounted, ref, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useRoute, useRouter } from 'vue-router';
 import { useMapGetter, useStore } from 'dashboard/composables/store';
 import { useAlert } from 'dashboard/composables';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
@@ -20,6 +21,8 @@ import Policy from 'dashboard/components/policy.vue';
 import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
 
 const store = useStore();
+const route = useRoute();
+const router = useRouter();
 const { t } = useI18n();
 const { isFeatureFlagEnabled, shouldShowPaywall } = usePolicy();
 
@@ -104,7 +107,8 @@ const handleDownload = async tool => {
   }
 };
 
-const openImportDialog = () => importDialogRef.value.dialogRef.open();
+const openImportDialog = source =>
+  importDialogRef.value.open(typeof source === 'string' ? source : '');
 
 const handleAction = ({ action, id }) => {
   const tool = customTools.value.find(item => item.id === id);
@@ -196,9 +200,17 @@ const onDeleteSuccess = () => {
   }
 };
 
-onMounted(() => {
+onMounted(async () => {
   if (!shouldShowPaywall(FEATURE_FLAGS.CAPTAIN_CUSTOM_TOOLS)) {
     fetchCustomTools();
+  }
+
+  if (route.query.source) {
+    await nextTick();
+    openImportDialog(route.query.source);
+    const query = { ...route.query };
+    delete query.source;
+    router.replace({ query });
   }
 });
 </script>

--- a/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
@@ -14,6 +14,7 @@ import CaptainPaywall from 'dashboard/components-next/captain/pageComponents/Pay
 import CustomToolsPageEmptyState from 'dashboard/components-next/captain/pageComponents/emptyStates/CustomToolsPageEmptyState.vue';
 import CreateCustomToolDialog from 'dashboard/components-next/captain/pageComponents/customTool/CreateCustomToolDialog.vue';
 import CustomToolCard from 'dashboard/components-next/captain/pageComponents/customTool/CustomToolCard.vue';
+import ToolsetCard from 'dashboard/components-next/captain/pageComponents/customTool/ToolsetCard.vue';
 import DeleteDialog from 'dashboard/components-next/captain/pageComponents/DeleteDialog.vue';
 import ImportToolsetDialog from 'dashboard/components-next/captain/pageComponents/customTool/ImportToolsetDialog.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
@@ -37,6 +38,34 @@ const customToolsMeta = useMapGetter('captainCustomTools/getMeta');
 const showSoftLimitWarning = computed(
   () => !isV2.value && customToolsMeta.value.totalCount > SOFT_LIMIT
 );
+
+const toolEntries = computed(() => {
+  const entries = [];
+  const toolsets = new Map();
+
+  customTools.value.forEach(tool => {
+    const installationKey =
+      tool.source_metadata?.installation_id ||
+      tool.source_metadata?.manifest_digest;
+    if (!installationKey) {
+      entries.push({ type: 'tool', key: `tool-${tool.id}`, tool });
+      return;
+    }
+
+    if (!toolsets.has(installationKey)) {
+      const entry = {
+        type: 'toolset',
+        key: `toolset-${installationKey}`,
+        tools: [],
+      };
+      toolsets.set(installationKey, entry);
+      entries.push(entry);
+    }
+    toolsets.get(installationKey).tools.push(tool);
+  });
+
+  return entries;
+});
 
 const createDialogRef = ref(null);
 const deleteDialogRef = ref(null);
@@ -262,24 +291,29 @@ onMounted(async () => {
           <span class="i-lucide-triangle-alert size-4 shrink-0" />
           {{ $t('CAPTAIN.CUSTOM_TOOLS.SOFT_LIMIT_WARNING') }}
         </div>
-        <CustomToolCard
-          v-for="tool in customTools"
-          :id="tool.id"
-          :key="tool.id"
-          :title="tool.title"
-          :description="tool.description"
-          :endpoint-url="tool.endpoint_url"
-          :http-method="tool.http_method"
-          :auth-type="tool.auth_type"
-          :param-schema="tool.param_schema"
-          :enabled="tool.enabled"
-          :is-updating="pendingToggleIds.has(tool.id)"
-          :created-at="tool.created_at"
-          :updated-at="tool.updated_at"
-          :source-metadata="tool.source_metadata"
-          @action="handleAction"
-          @toggle="toggleCustomTool"
-        />
+        <template v-for="entry in toolEntries" :key="entry.key">
+          <ToolsetCard
+            v-if="entry.type === 'toolset'"
+            :tools="entry.tools"
+            :pending-toggle-ids="pendingToggleIds"
+            @action="handleAction"
+            @toggle="toggleCustomTool"
+          />
+          <CustomToolCard
+            v-else
+            :id="entry.tool.id"
+            :title="entry.tool.title"
+            :description="entry.tool.description"
+            :auth-type="entry.tool.auth_type"
+            :enabled="entry.tool.enabled"
+            :is-updating="pendingToggleIds.has(entry.tool.id)"
+            :created-at="entry.tool.created_at"
+            :updated-at="entry.tool.updated_at"
+            :source-metadata="entry.tool.source_metadata"
+            @action="handleAction"
+            @toggle="toggleCustomTool"
+          />
+        </template>
       </div>
     </template>
   </PageLayout>

--- a/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
@@ -3,6 +3,10 @@ import { computed, onMounted, ref, nextTick } from 'vue';
 import { useMapGetter, useStore } from 'dashboard/composables/store';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import { usePolicy } from 'dashboard/composables/usePolicy';
+import { useAlert } from 'dashboard/composables';
+import { useI18n } from 'vue-i18n';
+import CustomToolsAPI from 'dashboard/api/captain/customTools';
+import { downloadFile } from 'dashboard/helper/downloadHelper';
 
 import PageLayout from 'dashboard/components-next/captain/PageLayout.vue';
 import CaptainPaywall from 'dashboard/components-next/captain/pageComponents/Paywall.vue';
@@ -10,8 +14,12 @@ import CustomToolsPageEmptyState from 'dashboard/components-next/captain/pageCom
 import CreateCustomToolDialog from 'dashboard/components-next/captain/pageComponents/customTool/CreateCustomToolDialog.vue';
 import CustomToolCard from 'dashboard/components-next/captain/pageComponents/customTool/CustomToolCard.vue';
 import DeleteDialog from 'dashboard/components-next/captain/pageComponents/DeleteDialog.vue';
+import ImportToolsetDialog from 'dashboard/components-next/captain/pageComponents/customTool/ImportToolsetDialog.vue';
+import Button from 'dashboard/components-next/button/Button.vue';
+import Policy from 'dashboard/components/policy.vue';
 
 const store = useStore();
+const { t } = useI18n();
 const { isFeatureFlagEnabled, shouldShowPaywall } = usePolicy();
 
 const SOFT_LIMIT = 10;
@@ -28,6 +36,7 @@ const showSoftLimitWarning = computed(
 
 const createDialogRef = ref(null);
 const deleteDialogRef = ref(null);
+const importDialogRef = ref(null);
 const selectedTool = ref(null);
 const dialogType = ref('');
 
@@ -54,10 +63,23 @@ const handleDelete = tool => {
   nextTick(() => deleteDialogRef.value.dialogRef.open());
 };
 
+const handleDownload = async tool => {
+  try {
+    const { data } = await CustomToolsAPI.exportToolset(tool.id);
+    downloadFile(`${tool.slug}.yml`, data, 'application/yaml');
+  } catch {
+    useAlert(t('CAPTAIN.CUSTOM_TOOLS.EXPORT.ERROR_MESSAGE'));
+  }
+};
+
+const openImportDialog = () => importDialogRef.value.dialogRef.open();
+
 const handleAction = ({ action, id }) => {
-  const tool = customTools.value.find(t => t.id === id);
+  const tool = customTools.value.find(item => item.id === id);
   if (action === 'edit') {
     handleEdit(tool);
+  } else if (action === 'download') {
+    handleDownload(tool);
   } else if (action === 'delete') {
     handleDelete(tool);
   }
@@ -102,6 +124,21 @@ onMounted(() => {
     @update:current-page="onPageChange"
     @click="openCreateDialog"
   >
+    <template #headerActions>
+      <Policy
+        v-if="!shouldShowPaywall(FEATURE_FLAGS.CAPTAIN_CUSTOM_TOOLS)"
+        :permissions="['administrator']"
+      >
+        <Button
+          variant="faded"
+          color="slate"
+          size="sm"
+          icon="i-lucide-upload"
+          :label="$t('CAPTAIN.CUSTOM_TOOLS.IMPORT.BUTTON')"
+          @click="openImportDialog"
+        />
+      </Policy>
+    </template>
     <template #paywall>
       <CaptainPaywall feature-prefix="CAPTAIN.CUSTOM_TOOLS" />
     </template>
@@ -154,4 +191,6 @@ onMounted(() => {
     translation-key="CUSTOM_TOOLS"
     @delete-success="onDeleteSuccess"
   />
+
+  <ImportToolsetDialog ref="importDialogRef" @imported="fetchCustomTools()" />
 </template>

--- a/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
@@ -276,6 +276,7 @@ onMounted(async () => {
           :is-updating="pendingToggleIds.has(tool.id)"
           :created-at="tool.created_at"
           :updated-at="tool.updated_at"
+          :source-metadata="tool.source_metadata"
           @action="handleAction"
           @toggle="toggleCustomTool"
         />

--- a/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/tools/Index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, ref, nextTick } from 'vue';
+import { computed, onMounted, ref, nextTick, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import { useMapGetter, useStore } from 'dashboard/composables/store';
@@ -29,6 +29,9 @@ const { isFeatureFlagEnabled, shouldShowPaywall } = usePolicy();
 
 const SOFT_LIMIT = 10;
 const isV2 = computed(() => isFeatureFlagEnabled(FEATURE_FLAGS.CAPTAIN_V2));
+const showPaywall = computed(() =>
+  shouldShowPaywall(FEATURE_FLAGS.CAPTAIN_CUSTOM_TOOLS)
+);
 
 const uiFlags = useMapGetter('captainCustomTools/getUIFlags');
 const customTools = useMapGetter('captainCustomTools/getRecords');
@@ -76,6 +79,7 @@ const dialogType = ref('');
 const pendingToggleIds = ref(new Set());
 const pendingDisable = ref(null);
 const isDisableSaving = ref(false);
+const hasRequestedTools = ref(false);
 
 const disableConfirmationTitle = computed(() =>
   t('CAPTAIN.CUSTOM_TOOLS.DISABLE_CONFIRMATION.TITLE', {
@@ -105,6 +109,7 @@ const setTogglePending = (id, isPending) => {
 };
 
 const fetchCustomTools = (page = 1) => {
+  hasRequestedTools.value = true;
   store.dispatch('captainCustomTools/get', { page });
 };
 
@@ -229,11 +234,17 @@ const onDeleteSuccess = () => {
   }
 };
 
-onMounted(async () => {
-  if (!shouldShowPaywall(FEATURE_FLAGS.CAPTAIN_CUSTOM_TOOLS)) {
-    fetchCustomTools();
-  }
+watch(
+  showPaywall,
+  isPaywallVisible => {
+    if (!isPaywallVisible && !hasRequestedTools.value) {
+      fetchCustomTools();
+    }
+  },
+  { immediate: true }
+);
 
+onMounted(async () => {
   if (route.query.source) {
     await nextTick();
     openImportDialog(route.query.source);

--- a/app/javascript/dashboard/routes/dashboard/captain/tools/Install.vue
+++ b/app/javascript/dashboard/routes/dashboard/captain/tools/Install.vue
@@ -1,0 +1,98 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRoute, useRouter } from 'vue-router';
+import { useMapGetter, useStore } from 'dashboard/composables/store';
+
+import PageLayout from 'dashboard/components-next/captain/PageLayout.vue';
+import ComboBox from 'dashboard/components-next/combobox/ComboBox.vue';
+import Button from 'dashboard/components-next/button/Button.vue';
+
+const store = useStore();
+const route = useRoute();
+const router = useRouter();
+const { t } = useI18n();
+
+const selectedAssistantId = ref('');
+const assistants = useMapGetter('captainAssistants/getRecords');
+const uiFlags = useMapGetter('captainAssistants/getUIFlags');
+
+const assistantOptions = computed(() =>
+  assistants.value.map(assistant => ({
+    value: assistant.id,
+    label: assistant.name,
+  }))
+);
+const isFetching = computed(() => uiFlags.value.fetchingList);
+const hasAssistants = computed(() => assistantOptions.value.length > 0);
+
+const continueInstall = () => {
+  if (!selectedAssistantId.value || !route.query.source) return;
+
+  router.push({
+    name: 'captain_tools_index',
+    params: {
+      accountId: route.params.accountId,
+      assistantId: selectedAssistantId.value,
+    },
+    query: { source: route.query.source },
+  });
+};
+
+const createAssistant = () => {
+  router.push({
+    name: 'captain_assistants_create_index',
+    params: { accountId: route.params.accountId },
+  });
+};
+
+onMounted(() => store.dispatch('captainAssistants/get'));
+</script>
+
+<template>
+  <PageLayout
+    :header-title="t('CAPTAIN.CUSTOM_TOOLS.INSTALL.TITLE')"
+    :show-assistant-switcher="false"
+    :show-pagination-footer="false"
+    :is-fetching="isFetching"
+    container-class="max-w-[40rem]"
+  >
+    <template #body>
+      <div class="flex flex-col gap-5 p-6 rounded-xl bg-n-alpha-2">
+        <div class="flex flex-col gap-1">
+          <h2 class="text-heading-2 text-n-slate-12">
+            {{ t('CAPTAIN.CUSTOM_TOOLS.INSTALL.SELECT_TITLE') }}
+          </h2>
+          <p class="text-body-2 text-n-slate-11">
+            {{ t('CAPTAIN.CUSTOM_TOOLS.INSTALL.SELECT_DESCRIPTION') }}
+          </p>
+        </div>
+
+        <template v-if="hasAssistants">
+          <ComboBox
+            v-model="selectedAssistantId"
+            :options="assistantOptions"
+            :placeholder="t('CAPTAIN.CUSTOM_TOOLS.INSTALL.PLACEHOLDER')"
+          />
+          <Button
+            class="self-end"
+            :label="t('CAPTAIN.CUSTOM_TOOLS.INSTALL.CONTINUE')"
+            :disabled="!selectedAssistantId"
+            @click="continueInstall"
+          />
+        </template>
+
+        <template v-else-if="!isFetching">
+          <p class="text-body-2 text-n-slate-11">
+            {{ t('CAPTAIN.CUSTOM_TOOLS.INSTALL.NO_ASSISTANTS') }}
+          </p>
+          <Button
+            class="self-start"
+            :label="t('CAPTAIN.CUSTOM_TOOLS.INSTALL.CREATE_ASSISTANT')"
+            @click="createAssistant"
+          />
+        </template>
+      </div>
+    </template>
+  </PageLayout>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/dashboard.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/dashboard.routes.js
@@ -14,9 +14,15 @@ import Suspended from './suspended/Index.vue';
 import NoAccounts from './noAccounts/Index.vue';
 import OnboardingAccountDetails from './onboarding/Index.vue';
 import OnboardingInboxSetup from './onboarding/InboxSetup.vue';
+import ToolsetInstall from './captain/tools/Install.vue';
 
 export default {
   routes: [
+    {
+      path: frontendURL('captain/toolsets/install'),
+      name: 'captain_toolset_install_entry',
+      component: ToolsetInstall,
+    },
     {
       path: frontendURL('accounts/:accountId'),
       component: AppContainer,

--- a/app/javascript/dashboard/routes/index.js
+++ b/app/javascript/dashboard/routes/index.js
@@ -41,6 +41,14 @@ export const validateAuthenticateRoutePermission = async (to, next) => {
     isAdmin &&
     isActive;
 
+  if (to.name === 'captain_toolset_install_entry') {
+    return next({
+      name: 'captain_toolset_install',
+      params: { accountId: routeAccountId },
+      query: to.query,
+    });
+  }
+
   if (to.name === 'no_accounts' || !to.name) {
     const target = needsOnboarding
       ? onboardingPath(userAccount?.onboarding_step)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   }, via: [:get, :post]
 
   post 'resend_confirmation', to: 'auth/resend_confirmations#create'
+  get '/captain/toolsets/install', to: 'captain/toolset_installs#show', as: :captain_toolset_install
 
   ## renders the frontend paths only if its not an api only server
   if ActiveModel::Type::Boolean.new.cast(ENV.fetch('CW_API_ONLY_SERVER', false))
@@ -99,11 +100,11 @@ Rails.application.routes.draw do
             resources :custom_tools do
               collection do
                 post :test
-                post :preview_import
-                post :import
               end
               get :export, on: :member
             end
+            post 'custom_tools/preview_import', to: 'toolset_imports#preview_import', as: :preview_import_custom_tools
+            post 'custom_tools/import', to: 'toolset_imports#import', as: :import_custom_tools
             resources :documents, only: [:index, :show, :create, :destroy] do
               post :sync, on: :member
               get :drilldown, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,7 +97,12 @@ Rails.application.routes.draw do
               resources :copilot_messages, only: [:index, :create]
             end
             resources :custom_tools do
-              post :test, on: :collection
+              collection do
+                post :test
+                post :preview_import
+                post :import
+              end
+              get :export, on: :member
             end
             resources :documents, only: [:index, :show, :create, :destroy] do
               post :sync, on: :member

--- a/db/migrate/20260829162252_add_source_metadata_to_captain_custom_tools.rb
+++ b/db/migrate/20260829162252_add_source_metadata_to_captain_custom_tools.rb
@@ -1,0 +1,5 @@
+class AddSourceMetadataToCaptainCustomTools < ActiveRecord::Migration[7.2]
+  def change
+    add_column :captain_custom_tools, :source_metadata, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_29_162252) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -450,6 +450,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
     t.boolean "enabled", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "source_metadata"
     t.index ["account_id", "slug"], name: "index_captain_custom_tools_on_account_id_and_slug", unique: true
     t.index ["account_id"], name: "index_captain_custom_tools_on_account_id"
   end

--- a/enterprise/app/controllers/api/v1/accounts/captain/custom_tools_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/custom_tools_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::Accounts::Captain::CustomToolsController < Api::V1::Accounts::BaseController
   before_action :ensure_custom_tools_enabled
   before_action -> { check_authorization(Captain::CustomTool) }
-  before_action :set_custom_tool, only: [:show, :update, :destroy]
+  before_action :set_custom_tool, only: [:show, :update, :destroy, :export]
 
   def index
     @custom_tools = account_custom_tools
@@ -32,6 +32,27 @@ class Api::V1::Accounts::Captain::CustomToolsController < Api::V1::Accounts::Bas
     render json: { error: e.message }, status: :unprocessable_content
   end
 
+  def preview_import
+    render json: toolset_service.preview
+  rescue Captain::ToolsetService::InvalidManifestError => e
+    render json: { error: e.message }, status: :unprocessable_content
+  end
+
+  def import
+    tools = toolset_service.import!(toolset_configuration)
+    render json: { imported_count: tools.size }, status: :created
+  rescue Captain::ToolsetService::InvalidManifestError, Captain::CustomTool::LimitExceededError => e
+    render_could_not_create_error(e.message)
+  end
+
+  def export
+    send_data(
+      Captain::ToolsetService.export(@custom_tool),
+      filename: "#{@custom_tool.slug}.yml",
+      type: 'application/yaml'
+    )
+  end
+
   private
 
   def ensure_custom_tools_enabled
@@ -51,6 +72,24 @@ class Api::V1::Accounts::Captain::CustomToolsController < Api::V1::Accounts::Bas
   def execute_test_request(tool)
     http_tool = Captain::Tools::HttpTool.new(nil, tool)
     http_tool.send(:execute_http_request, tool.endpoint_url, nil, nil)
+  end
+
+  def toolset_service
+    @toolset_service ||= Captain::ToolsetService.new(account: Current.account, source: toolset_source)
+  end
+
+  def toolset_source
+    file = params[:file]
+    raise Captain::ToolsetService::InvalidManifestError, 'Select a YAML toolset file' unless file.respond_to?(:read)
+    raise Captain::ToolsetService::InvalidManifestError, 'Toolset file is too large' if file.size > Captain::ToolsetService::MAX_FILE_SIZE
+
+    file.read
+  end
+
+  def toolset_configuration
+    JSON.parse(params[:configuration].presence || '{}')
+  rescue JSON::ParserError
+    raise Captain::ToolsetService::InvalidManifestError, 'Toolset configuration must be valid JSON'
   end
 
   def custom_tool_params

--- a/enterprise/app/controllers/api/v1/accounts/captain/custom_tools_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/custom_tools_controller.rb
@@ -32,19 +32,6 @@ class Api::V1::Accounts::Captain::CustomToolsController < Api::V1::Accounts::Bas
     render json: { error: e.message }, status: :unprocessable_content
   end
 
-  def preview_import
-    render json: toolset_service.preview
-  rescue Captain::ToolsetService::InvalidManifestError => e
-    render json: { error: e.message }, status: :unprocessable_content
-  end
-
-  def import
-    tools = toolset_service.import!(toolset_configuration)
-    render json: { imported_count: tools.size }, status: :created
-  rescue Captain::ToolsetService::InvalidManifestError, Captain::CustomTool::LimitExceededError => e
-    render_could_not_create_error(e.message)
-  end
-
   def export
     send_data(
       Captain::ToolsetService.export(@custom_tool),
@@ -72,24 +59,6 @@ class Api::V1::Accounts::Captain::CustomToolsController < Api::V1::Accounts::Bas
   def execute_test_request(tool)
     http_tool = Captain::Tools::HttpTool.new(nil, tool)
     http_tool.send(:execute_http_request, tool.endpoint_url, nil, nil)
-  end
-
-  def toolset_service
-    @toolset_service ||= Captain::ToolsetService.new(account: Current.account, source: toolset_source)
-  end
-
-  def toolset_source
-    file = params[:file]
-    raise Captain::ToolsetService::InvalidManifestError, 'Select a YAML toolset file' unless file.respond_to?(:read)
-    raise Captain::ToolsetService::InvalidManifestError, 'Toolset file is too large' if file.size > Captain::ToolsetService::MAX_FILE_SIZE
-
-    file.read
-  end
-
-  def toolset_configuration
-    JSON.parse(params[:configuration].presence || '{}')
-  rescue JSON::ParserError
-    raise Captain::ToolsetService::InvalidManifestError, 'Toolset configuration must be valid JSON'
   end
 
   def custom_tool_params

--- a/enterprise/app/controllers/api/v1/accounts/captain/toolset_imports_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/toolset_imports_controller.rb
@@ -1,0 +1,161 @@
+class Api::V1::Accounts::Captain::ToolsetImportsController < Api::V1::Accounts::BaseController
+  before_action :ensure_custom_tools_enabled
+  before_action -> { check_authorization(Captain::CustomTool) }
+
+  def preview_import
+    return render json: { toolsets: github_toolsets } if github_repository_url?
+
+    render json: toolset_service.preview
+  rescue Captain::ToolsetService::InvalidManifestError => e
+    render json: { error: e.message }, status: :unprocessable_content
+  end
+
+  def import
+    tools = toolset_service.import!(toolset_configuration)
+    render json: { imported_count: tools.size }, status: :created
+  rescue Captain::ToolsetService::InvalidManifestError, Captain::CustomTool::LimitExceededError => e
+    render_could_not_create_error(e.message)
+  end
+
+  private
+
+  def ensure_custom_tools_enabled
+    return if Current.account.feature_enabled?('custom_tools') || Current.account.feature_enabled?('captain_integration_v2')
+
+    render json: { error: 'Custom tools are not enabled for this account' }, status: :forbidden
+  end
+
+  def toolset_service
+    @toolset_service ||= Captain::ToolsetService.new(account: Current.account, source: toolset_source)
+  end
+
+  def toolset_source
+    file = params[:file]
+    return source_from_url if params[:source].present?
+
+    raise Captain::ToolsetService::InvalidManifestError, 'Select a YAML toolset file or enter a GitHub URL' unless file.respond_to?(:read)
+    raise Captain::ToolsetService::InvalidManifestError, 'Toolset file is too large' if file.size > Captain::ToolsetService::MAX_FILE_SIZE
+
+    file.read
+  end
+
+  def source_from_url
+    fetch_toolset_source(params[:source])
+  rescue SafeFetch::Error => e
+    raise Captain::ToolsetService::InvalidManifestError, "Could not fetch the GitHub toolset: #{e.message}"
+  end
+
+  def github_repository_url?
+    return false if params[:source].blank?
+
+    uri = URI.parse(normalized_github_source)
+    uri.scheme == 'https' && uri.host == 'github.com' && uri.path.split('/').count(&:present?) == 2
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def github_toolsets
+    uri = URI.parse(normalized_github_source)
+    owner, repository = uri.path.split('/').reject(&:blank?)
+    repository = repository.delete_suffix('.git')
+    repository_data = fetch_github_json("https://api.github.com/repos/#{owner}/#{repository}")
+    branch = repository_data.fetch('default_branch')
+    contents = fetch_github_json("https://api.github.com/repos/#{owner}/#{repository}/git/trees/#{branch}?recursive=1")
+
+    contents.fetch('tree').filter_map do |item|
+      next unless item['type'] == 'blob' && item['path'].match?(%r{\A[^/]+/toolset\.ya?ml\z})
+
+      folder = item['path'].split('/').first
+      source = "https://github.com/#{owner}/#{repository}/blob/#{branch}/#{item['path']}"
+      toolset_metadata(source, folder)
+    end
+  rescue SafeFetch::Error, JSON::ParserError, KeyError => e
+    raise Captain::ToolsetService::InvalidManifestError, "Could not read the GitHub repository: #{e.message}"
+  end
+
+  def fetch_github_json(url)
+    SafeFetch.fetch(url, max_bytes: Captain::ToolsetService::MAX_FILE_SIZE, validate_content_type: false) do |result|
+      return JSON.parse(result.tempfile.read)
+    end
+  end
+
+  def toolset_metadata(source, folder)
+    preview = Captain::ToolsetService.new(account: Current.account, source: fetch_toolset_source(source)).preview
+    {
+      name: preview[:name],
+      folder: folder,
+      description: preview[:description],
+      tool_count: preview[:tools].size,
+      required_configuration: preview[:fields].filter_map { |field| field[:label] if field[:required] },
+      source: source
+    }
+  end
+
+  def fetch_toolset_source(source)
+    SafeFetch.fetch(github_raw_url(source), max_bytes: Captain::ToolsetService::MAX_FILE_SIZE, validate_content_type: false) do |result|
+      return result.tempfile.read
+    end
+  end
+
+  def github_raw_url(source)
+    uri = URI.parse(normalized_github_source(source))
+    return uri.to_s if uri.scheme == 'https' && uri.host == 'raw.githubusercontent.com'
+
+    validate_github_uri!(uri)
+
+    segments = uri.path.split('/').reject(&:blank?)
+    validate_github_path!(segments)
+
+    owner, repository, = segments
+    repository = repository.delete_suffix('.git')
+    ref, path = github_ref_and_path(segments.drop(2))
+    "https://raw.githubusercontent.com/#{owner}/#{repository}/#{ref}/#{path.join('/')}"
+  rescue URI::InvalidURIError
+    raise Captain::ToolsetService::InvalidManifestError, 'Enter a valid GitHub URL'
+  end
+
+  def normalized_github_source(source = params[:source])
+    value = source.to_s.strip
+    return value if value.start_with?('https://')
+
+    segments = value.split('/')
+    validate_github_shorthand!(segments)
+
+    owner, repository, *path = segments
+    view = path.last&.match?(/toolset\.ya?ml\z/) ? 'blob' : 'tree'
+    suffix = path.any? ? "/#{view}/HEAD/#{path.join('/')}" : ''
+    "https://github.com/#{owner}/#{repository}#{suffix}"
+  end
+
+  def validate_github_uri!(uri)
+    return if uri.scheme == 'https' && uri.host == 'github.com'
+
+    raise Captain::ToolsetService::InvalidManifestError, 'Enter a valid GitHub URL'
+  end
+
+  def validate_github_path!(segments)
+    return if segments.size >= 2
+
+    raise Captain::ToolsetService::InvalidManifestError, 'Enter a GitHub repository, folder, or toolset.yml URL'
+  end
+
+  def validate_github_shorthand!(segments)
+    return if segments.size.between?(2, 10) && segments.all? { |segment| segment.match?(/\A[\w.-]+\z/) }
+
+    raise Captain::ToolsetService::InvalidManifestError, 'Enter a valid GitHub URL or owner/repository/tool path'
+  end
+
+  def github_ref_and_path(location)
+    view, ref, *path = location
+    return ['HEAD', ['toolset.yml']] unless %w[blob tree].include?(view)
+
+    path << 'toolset.yml' if view == 'tree'
+    [ref, path]
+  end
+
+  def toolset_configuration
+    JSON.parse(params[:configuration].presence || '{}')
+  rescue JSON::ParserError
+    raise Captain::ToolsetService::InvalidManifestError, 'Toolset configuration must be valid JSON'
+  end
+end

--- a/enterprise/app/controllers/api/v1/accounts/captain/toolset_imports_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/toolset_imports_controller.rb
@@ -26,7 +26,11 @@ class Api::V1::Accounts::Captain::ToolsetImportsController < Api::V1::Accounts::
   end
 
   def toolset_service
-    @toolset_service ||= Captain::ToolsetService.new(account: Current.account, source: toolset_source)
+    @toolset_service ||= Captain::ToolsetService.new(
+      account: Current.account,
+      source: toolset_source,
+      source_metadata: toolset_source_metadata
+    )
   end
 
   def toolset_source
@@ -37,6 +41,31 @@ class Api::V1::Accounts::Captain::ToolsetImportsController < Api::V1::Accounts::
     raise Captain::ToolsetService::InvalidManifestError, 'Toolset file is too large' if file.size > Captain::ToolsetService::MAX_FILE_SIZE
 
     file.read
+  end
+
+  def toolset_source_metadata
+    return github_source_metadata if params[:source].present?
+
+    {
+      'type' => 'upload',
+      'filename' => params[:file].original_filename
+    }
+  end
+
+  def github_source_metadata
+    uri = URI.parse(github_raw_url(params[:source]))
+    owner, repository, ref, *path = uri.path.split('/').reject(&:blank?)
+    revision = fetch_github_json("https://api.github.com/repos/#{owner}/#{repository}/commits/#{ref}").fetch('sha')
+
+    {
+      'type' => 'github',
+      'repository' => "#{owner}/#{repository}",
+      'path' => path.join('/'),
+      'ref' => ref,
+      'revision' => revision
+    }
+  rescue SafeFetch::Error, JSON::ParserError, KeyError => e
+    raise Captain::ToolsetService::InvalidManifestError, "Could not resolve the GitHub toolset revision: #{e.message}"
   end
 
   def source_from_url

--- a/enterprise/app/controllers/api/v1/accounts/captain/toolset_imports_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/toolset_imports_controller.rb
@@ -48,6 +48,7 @@ class Api::V1::Accounts::Captain::ToolsetImportsController < Api::V1::Accounts::
 
     {
       'type' => 'upload',
+      'installation_id' => SecureRandom.uuid,
       'filename' => params[:file].original_filename
     }
   end
@@ -59,6 +60,7 @@ class Api::V1::Accounts::Captain::ToolsetImportsController < Api::V1::Accounts::
 
     {
       'type' => 'github',
+      'installation_id' => SecureRandom.uuid,
       'repository' => "#{owner}/#{repository}",
       'path' => path.join('/'),
       'ref' => ref,

--- a/enterprise/app/controllers/captain/toolset_installs_controller.rb
+++ b/enterprise/app/controllers/captain/toolset_installs_controller.rb
@@ -1,0 +1,6 @@
+class Captain::ToolsetInstallsController < ApplicationController
+  def show
+    query = { source: params.require(:source) }.to_query
+    redirect_to "/app/captain/toolsets/install?#{query}"
+  end
+end

--- a/enterprise/app/models/captain/custom_tool.rb
+++ b/enterprise/app/models/captain/custom_tool.rb
@@ -13,6 +13,7 @@
 #  request_template  :text
 #  response_template :text
 #  slug              :string           not null
+#  source_metadata   :jsonb
 #  title             :string           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
@@ -26,7 +27,7 @@
 class Captain::CustomTool < ApplicationRecord
   class LimitExceededError < StandardError; end
 
-  MAX_PER_ACCOUNT = 15
+  MAX_PER_ACCOUNT = 100
 
   include Concerns::Toolable
   include Concerns::SafeEndpointValidatable
@@ -39,6 +40,7 @@ class Captain::CustomTool < ApplicationRecord
   # verbatim as the tool name in LLM requests, so it must fit within this limit.
   MAX_SLUG_LENGTH = 64
   COLLISION_SUFFIX_LENGTH = 7 # "_" + 6 random alphanumeric chars
+  TOOLSET_VERSION_PATTERN = '^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$'.freeze
   PARAM_SCHEMA_VALIDATION = {
     'type': 'array',
     'items': {
@@ -52,6 +54,38 @@ class Captain::CustomTool < ApplicationRecord
       'required': %w[name type description],
       'additionalProperties': false
     }
+  }.to_json.freeze
+  SOURCE_METADATA_VALIDATION = {
+    'oneOf': [
+      { 'type': 'null' },
+      {
+        'type': 'object',
+        'properties': {
+          'type': { 'const': 'upload' },
+          'filename': { 'type': 'string', 'minLength': 1 },
+          'toolset_name': { 'type': 'string', 'minLength': 1 },
+          'toolset_version': { 'type': 'string', 'pattern': TOOLSET_VERSION_PATTERN },
+          'manifest_digest': { 'type': 'string', 'pattern': '^sha256:[0-9a-f]{64}$' }
+        },
+        'required': %w[type filename toolset_name toolset_version manifest_digest],
+        'additionalProperties': false
+      },
+      {
+        'type': 'object',
+        'properties': {
+          'type': { 'const': 'github' },
+          'repository': { 'type': 'string', 'pattern': '^[\\w.-]+/[\\w.-]+$' },
+          'path': { 'type': 'string', 'minLength': 1 },
+          'ref': { 'type': 'string', 'minLength': 1 },
+          'revision': { 'type': 'string', 'pattern': '^[0-9a-f]{40}$' },
+          'toolset_name': { 'type': 'string', 'minLength': 1 },
+          'toolset_version': { 'type': 'string', 'pattern': TOOLSET_VERSION_PATTERN },
+          'manifest_digest': { 'type': 'string', 'pattern': '^sha256:[0-9a-f]{64}$' }
+        },
+        'required': %w[type repository path ref revision toolset_name toolset_version manifest_digest],
+        'additionalProperties': false
+      }
+    ]
   }.to_json.freeze
 
   belongs_to :account
@@ -68,6 +102,9 @@ class Captain::CustomTool < ApplicationRecord
   validates_with JsonSchemaValidator,
                  schema: PARAM_SCHEMA_VALIDATION,
                  attribute_resolver: ->(record) { record.param_schema }
+  validates_with JsonSchemaValidator,
+                 schema: SOURCE_METADATA_VALIDATION,
+                 attribute_resolver: ->(record) { record.source_metadata }
 
   scope :enabled, -> { where(enabled: true) }
 

--- a/enterprise/app/models/captain/custom_tool.rb
+++ b/enterprise/app/models/captain/custom_tool.rb
@@ -62,18 +62,20 @@ class Captain::CustomTool < ApplicationRecord
         'type': 'object',
         'properties': {
           'type': { 'const': 'upload' },
+          'installation_id': { 'type': 'string', 'format': 'uuid' },
           'filename': { 'type': 'string', 'minLength': 1 },
           'toolset_name': { 'type': 'string', 'minLength': 1 },
           'toolset_version': { 'type': 'string', 'pattern': TOOLSET_VERSION_PATTERN },
           'manifest_digest': { 'type': 'string', 'pattern': '^sha256:[0-9a-f]{64}$' }
         },
-        'required': %w[type filename toolset_name toolset_version manifest_digest],
+        'required': %w[type installation_id filename toolset_name toolset_version manifest_digest],
         'additionalProperties': false
       },
       {
         'type': 'object',
         'properties': {
           'type': { 'const': 'github' },
+          'installation_id': { 'type': 'string', 'format': 'uuid' },
           'repository': { 'type': 'string', 'pattern': '^[\\w.-]+/[\\w.-]+$' },
           'path': { 'type': 'string', 'minLength': 1 },
           'ref': { 'type': 'string', 'minLength': 1 },
@@ -82,7 +84,7 @@ class Captain::CustomTool < ApplicationRecord
           'toolset_version': { 'type': 'string', 'pattern': TOOLSET_VERSION_PATTERN },
           'manifest_digest': { 'type': 'string', 'pattern': '^sha256:[0-9a-f]{64}$' }
         },
-        'required': %w[type repository path ref revision toolset_name toolset_version manifest_digest],
+        'required': %w[type installation_id repository path ref revision toolset_name toolset_version manifest_digest],
         'additionalProperties': false
       }
     ]

--- a/enterprise/app/policies/captain/custom_tool_policy.rb
+++ b/enterprise/app/policies/captain/custom_tool_policy.rb
@@ -15,6 +15,18 @@ class Captain::CustomToolPolicy < ApplicationPolicy
     @account_user.administrator?
   end
 
+  def preview_import?
+    @account_user.administrator?
+  end
+
+  def import?
+    @account_user.administrator?
+  end
+
+  def export?
+    @account_user.administrator?
+  end
+
   def update?
     @account_user.administrator?
   end

--- a/enterprise/app/services/captain/toolset_exporter.rb
+++ b/enterprise/app/services/captain/toolset_exporter.rb
@@ -1,0 +1,66 @@
+class Captain::ToolsetExporter
+  def initialize(tool)
+    @tool = tool
+  end
+
+  def to_yaml
+    YAML.dump(manifest)
+  end
+
+  private
+
+  attr_reader :tool
+
+  def manifest
+    auth_config, inputs, secrets = authentication
+    {
+      'version' => Captain::ToolsetService::VERSION,
+      'kind' => Captain::ToolsetService::KIND,
+      'name' => tool.title,
+      'description' => tool.description,
+      'inputs' => inputs,
+      'secrets' => secrets,
+      'tools' => [tool_definition(auth_config)]
+    }.compact
+  end
+
+  def tool_definition(auth_config)
+    {
+      'title' => tool.title,
+      'description' => tool.description,
+      'http_method' => tool.http_method,
+      'endpoint_url' => tool.endpoint_url,
+      'auth_type' => tool.auth_type,
+      'auth_config' => auth_config,
+      'param_schema' => tool.param_schema,
+      'request_template' => tool.request_template,
+      'response_template' => tool.response_template,
+      'enabled' => tool.enabled
+    }.compact
+  end
+
+  def authentication
+    case tool.auth_type
+    when 'bearer'
+      [{ 'token' => '${{ secrets.bearer_token }}' }, {}, definition('bearer_token', 'Bearer token')]
+    when 'basic'
+      basic_authentication
+    when 'api_key'
+      [{ 'name' => tool.auth_config['name'], 'key' => '${{ secrets.api_key }}' }, {}, definition('api_key', 'API key')]
+    else
+      [{}, {}, {}]
+    end
+  end
+
+  def basic_authentication
+    [
+      { 'username' => '${{ inputs.username }}', 'password' => '${{ secrets.password }}' },
+      definition('username', 'Username'),
+      definition('password', 'Password')
+    ]
+  end
+
+  def definition(name, label)
+    { name => { 'label' => label, 'required' => true } }
+  end
+end

--- a/enterprise/app/services/captain/toolset_exporter.rb
+++ b/enterprise/app/services/captain/toolset_exporter.rb
@@ -14,7 +14,7 @@ class Captain::ToolsetExporter
   def manifest
     auth_config, inputs, secrets = authentication
     {
-      'version' => Captain::ToolsetService::VERSION,
+      'version' => Captain::ToolsetService::DEFAULT_VERSION,
       'kind' => Captain::ToolsetService::KIND,
       'name' => tool.title,
       'description' => tool.description,
@@ -26,6 +26,7 @@ class Captain::ToolsetExporter
 
   def tool_definition(auth_config)
     {
+      'id' => tool.slug,
       'title' => tool.title,
       'description' => tool.description,
       'http_method' => tool.http_method,

--- a/enterprise/app/services/captain/toolset_service.rb
+++ b/enterprise/app/services/captain/toolset_service.rb
@@ -1,0 +1,217 @@
+class Captain::ToolsetService
+  class InvalidManifestError < StandardError; end
+
+  VERSION = 1
+  KIND = 'captain_toolset'.freeze
+  MAX_FILE_SIZE = 256.kilobytes
+  VARIABLE_PATTERN = /\$\{\{\s*(inputs|secrets)\.([a-z][a-z0-9_]*)\s*\}\}/i
+  VARIABLE_NAME_PATTERN = /\A[a-z][a-z0-9_]*\z/i
+  ROOT_KEYS = %w[version kind name description inputs secrets tools].freeze
+  CONFIG_KEYS = %w[label type placeholder required].freeze
+  TOOL_KEYS = %w[title description endpoint_url http_method request_template response_template auth_type auth_config param_schema enabled].freeze
+
+  def self.export(tool) = Captain::ToolsetExporter.new(tool).to_yaml
+
+  def initialize(account:, source:)
+    @account = account
+    @manifest = parse(source)
+  end
+
+  def preview
+    validate_manifest!
+    validate_tools!(preview_configuration)
+
+    {
+      name: manifest['name'],
+      description: manifest['description'],
+      fields: configuration_fields,
+      tools: tool_definitions.map { |tool| tool.slice('title', 'description', 'http_method', 'endpoint_url') }
+    }
+  end
+
+  def import!(configuration)
+    validate_manifest!
+    raise InvalidManifestError, 'Toolset configuration must be an object' unless configuration.is_a?(Hash)
+
+    configuration = configuration.deep_stringify_keys
+    validate_configuration!(configuration)
+    resolved_tools = resolve_tools(configuration)
+    validate_tools!(configuration)
+    ensure_capacity!(resolved_tools.size)
+
+    ApplicationRecord.transaction do
+      resolved_tools.map { |attributes| account.captain_custom_tools.create!(tool_attributes(attributes)) }
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    raise InvalidManifestError, e.record.errors.full_messages.join(', ')
+  end
+
+  private
+
+  attr_reader :account, :manifest
+
+  def parse(source)
+    parsed = YAML.safe_load(source, permitted_classes: [], permitted_symbols: [], aliases: false)
+    raise InvalidManifestError, 'Toolset must contain a YAML object' unless parsed.is_a?(Hash)
+
+    parsed.deep_stringify_keys
+  rescue Psych::Exception => e
+    raise InvalidManifestError, "Invalid YAML: #{e.message}"
+  end
+
+  def validate_manifest!
+    reject_unknown_keys!(manifest, ROOT_KEYS, 'toolset')
+    validate_metadata!
+    validate_tool_collection!
+    validate_configuration_definitions!
+    tool_definitions.each_with_index { |tool, index| validate_tool_definition!(tool, index) }
+    validate_placeholders!
+  end
+
+  def validate_metadata!
+    raise InvalidManifestError, "Toolset version must be #{VERSION}" unless manifest['version'] == VERSION
+    raise InvalidManifestError, "Toolset kind must be #{KIND}" unless manifest['kind'] == KIND
+    raise InvalidManifestError, 'Toolset name is required' if manifest['name'].blank?
+  end
+
+  def validate_tool_collection!
+    raise InvalidManifestError, 'Tools must be a YAML list' unless manifest['tools'].is_a?(Array)
+    raise InvalidManifestError, 'Toolset must contain at least one tool' if tool_definitions.empty?
+    return unless tool_definitions.size > Captain::CustomTool::MAX_PER_ACCOUNT
+
+    raise InvalidManifestError, "Toolset cannot contain more than #{Captain::CustomTool::MAX_PER_ACCOUNT} tools"
+  end
+
+  def validate_configuration_definitions!
+    %w[inputs secrets].each do |section|
+      definitions = manifest[section] || {}
+      raise InvalidManifestError, "#{section.capitalize} must be a YAML object" unless definitions.is_a?(Hash)
+
+      definitions.each do |name, definition|
+        raise InvalidManifestError, "Invalid #{section.singularize} name: #{name}" unless name.match?(VARIABLE_NAME_PATTERN)
+        raise InvalidManifestError, "Definition for #{name} must be a YAML object" unless definition.is_a?(Hash)
+
+        reject_unknown_keys!(definition, CONFIG_KEYS, "#{section.singularize} #{name}")
+      end
+    end
+  end
+
+  def validate_tool_definition!(tool, index)
+    raise InvalidManifestError, "Tool #{index + 1} must be a YAML object" unless tool.is_a?(Hash)
+
+    reject_unknown_keys!(tool, TOOL_KEYS, "tool #{index + 1}")
+  end
+
+  def validate_placeholders!
+    serialized_tools = tool_definitions.to_json
+    serialized_tools.scan(VARIABLE_PATTERN).each do |section, name|
+      next if manifest.fetch(section, {}).key?(name)
+
+      raise InvalidManifestError, "Unknown #{section.singularize} placeholder: #{name}"
+    end
+  end
+
+  def validate_configuration!(configuration)
+    %w[inputs secrets].each do |section|
+      values = configuration[section] || {}
+      validate_configuration_section!(section, values)
+    end
+  end
+
+  def validate_configuration_section!(section, values)
+    raise InvalidManifestError, "#{section.capitalize} must be an object" unless values.is_a?(Hash)
+
+    manifest.fetch(section, {}).each do |name, definition|
+      next if !definition.fetch('required', true) || values[name].present?
+
+      raise InvalidManifestError, "#{definition['label'].presence || name.humanize} is required"
+    end
+  end
+
+  def validate_tools!(configuration)
+    resolve_tools(configuration).each_with_index do |attributes, index|
+      tool = account.captain_custom_tools.new(tool_attributes(attributes))
+      next if tool.valid?
+
+      raise InvalidManifestError, "#{tool_definitions[index]['title'].presence || "Tool #{index + 1}"}: #{tool.errors.full_messages.join(', ')}"
+    end
+  rescue ArgumentError, NoMethodError => e
+    raise InvalidManifestError, "Invalid tool definition: #{e.message}"
+  end
+
+  def ensure_capacity!(tool_count)
+    current_count = account.captain_custom_tools.count
+    return if current_count + tool_count <= Captain::CustomTool::MAX_PER_ACCOUNT
+
+    raise Captain::CustomTool::LimitExceededError,
+          I18n.t('captain.custom_tool.limit_exceeded', limit: Captain::CustomTool::MAX_PER_ACCOUNT)
+  end
+
+  def resolve_tools(configuration) = interpolate(tool_definitions, configuration)
+
+  def interpolate(value, configuration)
+    case value
+    when String
+      interpolated = value.gsub(VARIABLE_PATTERN) do
+        configuration.fetch(Regexp.last_match(1), {}).fetch(Regexp.last_match(2), '').to_s
+      end
+      raise InvalidManifestError, "Invalid placeholder: #{value}" if interpolated.include?('${{')
+
+      interpolated
+    when Array
+      value.map { |item| interpolate(item, configuration) }
+    when Hash
+      value.transform_values { |item| interpolate(item, configuration) }
+    else
+      value
+    end
+  end
+
+  def preview_configuration
+    {
+      'inputs' => manifest.fetch('inputs', {}).transform_values { |definition| definition['placeholder'].presence || 'preview' },
+      'secrets' => manifest.fetch('secrets', {}).transform_values { 'preview' }
+    }
+  end
+
+  def configuration_fields
+    input_fields = manifest.fetch('inputs', {}).map { |name, definition| field_definition(name, definition, 'inputs', false) }
+    secret_fields = manifest.fetch('secrets', {}).map { |name, definition| field_definition(name, definition, 'secrets', true) }
+    input_fields + secret_fields
+  end
+
+  def field_definition(name, definition, section, secret)
+    {
+      name: name,
+      label: definition['label'].presence || name.humanize,
+      placeholder: definition['placeholder'],
+      required: definition.fetch('required', true),
+      section: section,
+      secret: secret
+    }
+  end
+
+  def tool_definitions = (@tool_definitions ||= manifest['tools'].is_a?(Array) ? manifest['tools'] : [])
+
+  def tool_attributes(attributes)
+    {
+      title: attributes['title'],
+      description: attributes['description'],
+      endpoint_url: attributes['endpoint_url'],
+      http_method: attributes['http_method'].presence || 'GET',
+      request_template: attributes['request_template'],
+      response_template: attributes['response_template'],
+      auth_type: attributes['auth_type'].presence || 'none',
+      auth_config: attributes['auth_config'] || {},
+      param_schema: attributes['param_schema'] || [],
+      enabled: attributes.fetch('enabled', true)
+    }
+  end
+
+  def reject_unknown_keys!(object, allowed_keys, context)
+    unknown_keys = object.keys - allowed_keys
+    return if unknown_keys.empty?
+
+    raise InvalidManifestError, "Unknown #{context} fields: #{unknown_keys.join(', ')}"
+  end
+end

--- a/enterprise/app/services/captain/toolset_service.rb
+++ b/enterprise/app/services/captain/toolset_service.rb
@@ -1,14 +1,15 @@
 class Captain::ToolsetService
   class InvalidManifestError < StandardError; end
 
-  VERSION = 1
+  DEFAULT_VERSION = '1.0.0'.freeze
   KIND = 'captain_toolset'.freeze
   MAX_FILE_SIZE = 256.kilobytes
+  VERSION_PATTERN = /\A\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\z/
   VARIABLE_PATTERN = /\$\{\{\s*(inputs|secrets)\.([a-z][a-z0-9_]*)\s*\}\}/i
   VARIABLE_NAME_PATTERN = /\A[a-z][a-z0-9_]*\z/i
   ROOT_KEYS = %w[version kind name description inputs secrets tools].freeze
   CONFIG_KEYS = %w[label type placeholder required].freeze
-  TOOL_KEYS = %w[title description endpoint_url http_method request_template response_template auth_type auth_config param_schema enabled].freeze
+  TOOL_KEYS = %w[id title description endpoint_url http_method request_template response_template auth_type auth_config param_schema enabled].freeze
 
   def self.export(tool) = Captain::ToolsetExporter.new(tool).to_yaml
 
@@ -24,6 +25,7 @@ class Captain::ToolsetService
     {
       name: manifest['name'],
       description: manifest['description'],
+      version: manifest['version'],
       fields: configuration_fields,
       tools: tool_definitions.map { |tool| tool.slice('title', 'description', 'http_method', 'endpoint_url') }
     }
@@ -69,7 +71,8 @@ class Captain::ToolsetService
   end
 
   def validate_metadata!
-    raise InvalidManifestError, "Toolset version must be #{VERSION}" unless manifest['version'] == VERSION
+    raise InvalidManifestError, 'Toolset version must be a semantic version' unless VERSION_PATTERN.match?(manifest['version'].to_s)
+
     raise InvalidManifestError, "Toolset kind must be #{KIND}" unless manifest['kind'] == KIND
     raise InvalidManifestError, 'Toolset name is required' if manifest['name'].blank?
   end
@@ -100,6 +103,7 @@ class Captain::ToolsetService
     raise InvalidManifestError, "Tool #{index + 1} must be a YAML object" unless tool.is_a?(Hash)
 
     reject_unknown_keys!(tool, TOOL_KEYS, "tool #{index + 1}")
+    raise InvalidManifestError, "Invalid tool ID: #{tool['id']}" unless tool['id'].is_a?(String) && VARIABLE_NAME_PATTERN.match?(tool['id'])
   end
 
   def validate_placeholders!
@@ -194,18 +198,13 @@ class Captain::ToolsetService
   def tool_definitions = (@tool_definitions ||= manifest['tools'].is_a?(Array) ? manifest['tools'] : [])
 
   def tool_attributes(attributes)
-    {
-      title: attributes['title'],
-      description: attributes['description'],
-      endpoint_url: attributes['endpoint_url'],
+    attributes.slice(*(TOOL_KEYS - ['id'])).symbolize_keys.merge(
       http_method: attributes['http_method'].presence || 'GET',
-      request_template: attributes['request_template'],
-      response_template: attributes['response_template'],
       auth_type: attributes['auth_type'].presence || 'none',
       auth_config: attributes['auth_config'] || {},
       param_schema: attributes['param_schema'] || [],
       enabled: attributes.fetch('enabled', true)
-    }
+    )
   end
 
   def reject_unknown_keys!(object, allowed_keys, context)

--- a/enterprise/app/services/captain/toolset_service.rb
+++ b/enterprise/app/services/captain/toolset_service.rb
@@ -13,9 +13,13 @@ class Captain::ToolsetService
 
   def self.export(tool) = Captain::ToolsetExporter.new(tool).to_yaml
 
-  def initialize(account:, source:)
+  def initialize(account:, source:, source_metadata: nil)
     @account = account
     @manifest = parse(source)
+    @source_metadata = source_metadata&.merge(
+      'toolset_name' => @manifest['name'], 'toolset_version' => @manifest['version'],
+      'manifest_digest' => "sha256:#{Digest::SHA256.hexdigest(source)}"
+    )
   end
 
   def preview
@@ -42,7 +46,7 @@ class Captain::ToolsetService
     ensure_capacity!(resolved_tools.size)
 
     ApplicationRecord.transaction do
-      resolved_tools.map { |attributes| account.captain_custom_tools.create!(tool_attributes(attributes)) }
+      resolved_tools.map { |attributes| account.captain_custom_tools.create!(tool_attributes(attributes).merge(source_metadata: source_metadata)) }
     end
   rescue ActiveRecord::RecordInvalid => e
     raise InvalidManifestError, e.record.errors.full_messages.join(', ')
@@ -50,7 +54,7 @@ class Captain::ToolsetService
 
   private
 
-  attr_reader :account, :manifest
+  attr_reader :account, :manifest, :source_metadata
 
   def parse(source)
     parsed = YAML.safe_load(source, permitted_classes: [], permitted_symbols: [], aliases: false)
@@ -179,9 +183,8 @@ class Captain::ToolsetService
   end
 
   def configuration_fields
-    input_fields = manifest.fetch('inputs', {}).map { |name, definition| field_definition(name, definition, 'inputs', false) }
-    secret_fields = manifest.fetch('secrets', {}).map { |name, definition| field_definition(name, definition, 'secrets', true) }
-    input_fields + secret_fields
+    manifest.fetch('inputs', {}).map { |name, definition| field_definition(name, definition, 'inputs', false) } +
+      manifest.fetch('secrets', {}).map { |name, definition| field_definition(name, definition, 'secrets', true) }
   end
 
   def field_definition(name, definition, section, secret)

--- a/enterprise/app/views/api/v1/models/captain/_custom_tool.json.jbuilder
+++ b/enterprise/app/views/api/v1/models/captain/_custom_tool.json.jbuilder
@@ -10,6 +10,7 @@ json.auth_type custom_tool.auth_type
 json.auth_config custom_tool.auth_config if Current.user&.administrator?
 json.param_schema custom_tool.param_schema
 json.enabled custom_tool.enabled
+json.source_metadata custom_tool.source_metadata
 json.account_id custom_tool.account_id
 json.created_at custom_tool.created_at.to_i
 json.updated_at custom_tool.updated_at.to_i

--- a/enterprise/config/initializers/omniauth_saml.rb
+++ b/enterprise/config/initializers/omniauth_saml.rb
@@ -23,7 +23,8 @@ SAML_SETUP_PROC = proc do |env|
     if settings
       # Configure the strategy options dynamically
       env['omniauth.strategy'].options[:idp_sso_service_url_runtime_params] = { RelayState: :RelayState }
-      env['omniauth.strategy'].options[:assertion_consumer_service_url] = "#{ENV.fetch('FRONTEND_URL', 'http://localhost:3000')}/omniauth/saml/callback?account_id=#{account_id}"
+      base_url = GlobalConfigService.load('FRONTEND_URL', 'http://localhost:3000')
+      env['omniauth.strategy'].options[:assertion_consumer_service_url] = "#{base_url}/omniauth/saml/callback?account_id=#{account_id}"
       env['omniauth.strategy'].options[:sp_entity_id] = settings.sp_entity_id
       env['omniauth.strategy'].options[:idp_entity_id] = settings.idp_entity_id
       env['omniauth.strategy'].options[:idp_sso_service_url] = settings.sso_url

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,313 @@
+# Captain Toolsets
+
+## Status
+
+Draft product and technical specification.
+
+## Summary
+
+Captain Toolsets is an open, GitHub-backed ecosystem for sharing and installing custom Captain tools. Publishers keep toolsets in any public GitHub repository. A static Astro catalog discovers repositories through the `captain-toolsets` GitHub topic, validates their manifests, and renders searchable documentation.
+
+GitHub is the source of truth for published toolsets. Chatwoot stores only installed tool definitions, account-specific configuration, credentials, and enough source metadata to check for updates safely.
+
+Users can also upload a YAML manifest directly. Manually imported toolsets do not require GitHub and are not linked to upstream updates.
+
+## Goals
+
+- Let anyone publish Captain toolsets from a GitHub repository.
+- Let users browse toolsets through a fast, static catalog.
+- Let users install a toolset from GitHub or import its YAML manually.
+- Preserve the repository and commit from which a GitHub toolset was installed.
+- Prevent upstream changes from silently changing an installed tool.
+- Support explicit, reviewable updates.
+- Avoid operating a package registry or hosting package artifacts.
+
+## Non-goals
+
+- Hosting toolset manifests outside their source repositories.
+- Automatically applying upstream updates.
+- Executing code from a toolset repository.
+- Listing private repositories in the public catalog.
+- Providing ratings, reviews, payments, or publisher analytics in the first version.
+- Providing installation-count rankings in the first version.
+
+## Terminology
+
+- **Repository**: A GitHub repository containing one or more toolsets.
+- **Toolset**: A folder containing a `toolset.yml` manifest and `README.md`.
+- **Tool**: One HTTP action declared inside a toolset manifest.
+- **Catalog**: The static Astro site generated from discovered repositories.
+- **Installation**: An account-specific, locally materialized copy of a toolset.
+- **Publisher**: The GitHub owner of the source repository.
+
+## Repository contract
+
+Publishers may use any repository name. A compatible repository has a root `README.md` and one direct child folder per toolset.
+
+```text
+customer-support-tools/
+├── README.md
+├── shopify/
+│   ├── README.md
+│   └── toolset.yml
+└── linear/
+    ├── README.md
+    └── toolset.yml
+```
+
+Requirements:
+
+- The repository must have the `captain-toolsets` GitHub topic to appear in the public catalog.
+- The root `README.md` describes the collection.
+- Toolset folders must be direct children of the repository root.
+- Each toolset folder must contain `toolset.yml` and `README.md` using those exact names.
+- The folder name is the toolset ID and must be URL-safe.
+- Unrelated files and folders are ignored.
+- A repository may contain any number of valid toolset folders within catalog limits.
+
+The human-readable source coordinate includes the owner, repository, and folder:
+
+```text
+chatwoot/customer-support-tools/shopify
+scmmishra/integration-tools/linear
+```
+
+A tool within a toolset has a stable coordinate:
+
+```text
+chatwoot/customer-support-tools/shopify#find_order
+```
+
+The GitHub owner controls the publisher namespace. A repository cannot claim another owner's namespace through manifest metadata.
+
+## Manifest format
+
+`toolset.yml` is a declarative manifest. It does not contain executable code.
+
+```yaml
+version: 1.2.0
+kind: captain_toolset
+name: Shopify Support Tools
+description: Look up Shopify customers and orders.
+
+inputs:
+  shop_domain:
+    label: Shop domain
+    type: string
+    placeholder: example.myshopify.com
+    required: true
+
+secrets:
+  access_token:
+    label: Admin API access token
+    type: password
+    required: true
+
+tools:
+  - id: find_order
+    title: Find order
+    description: Find a Shopify order by its order number.
+    http_method: GET
+    endpoint_url: https://${{ inputs.shop_domain }}/admin/api/orders.json
+    auth_type: api_key
+    auth_config:
+      name: X-Shopify-Access-Token
+      key: ${{ secrets.access_token }}
+    param_schema:
+      - name: order_number
+        type: string
+        required: true
+        description: Order number supplied by the customer.
+    enabled: true
+```
+
+Manifest rules:
+
+- `version` is the publisher-controlled toolset release version.
+- `kind` must be `captain_toolset`.
+- The current manifest schema is implicitly version 1.
+- Each tool must have an ID that remains stable across releases.
+- Inputs use `${{ inputs.name }}` and secrets use `${{ secrets.name }}`.
+- Runtime tool parameters use Liquid placeholders such as `{{ order_number }}`.
+- Secret values must never be committed to a manifest.
+- Unknown fields are rejected.
+- YAML aliases and arbitrary object deserialization are disabled.
+
+## Discovery
+
+The catalog discovers public repositories using GitHub repository search and the `captain-toolsets` topic. A scheduled GitHub Actions workflow rebuilds the site approximately once per hour.
+
+For each discovered repository, the builder:
+
+1. Resolves the repository ID, default branch, and current commit SHA.
+2. Fetches the root directory and root `README.md`.
+3. Finds direct child directories containing `toolset.yml` and `README.md`.
+4. Parses and validates each manifest.
+5. Sanitizes each README.
+6. Produces static toolset pages and a client-side search index.
+7. Publishes the Astro build only when catalog generation succeeds.
+
+The builder should use authenticated GitHub requests, pagination, and conditional requests. A transient GitHub failure must not replace the currently deployed catalog with an empty or partial build.
+
+Invalid repositories or toolsets are excluded and reported in build output. Discovery through a topic is permissionless; inclusion does not imply endorsement.
+
+## Catalog
+
+Each toolset page should show:
+
+- Name and description.
+- Sanitized toolset README.
+- GitHub owner and repository.
+- Toolset folder and source link.
+- Toolset version and indexed commit.
+- Included tools and their declared capabilities.
+- Required inputs and secrets without their values.
+- Publisher verification status, when available.
+- An install action that identifies the repository and manifest path.
+
+The catalog may maintain small moderation files for verified publishers and blocked repositories. Verification provides a badge; unverified valid toolsets remain installable.
+
+The catalog must never receive or proxy a user's tool credentials.
+
+## Installation paths
+
+### Install from GitHub
+
+Users may start from the catalog or enter a GitHub repository URL directly in Chatwoot.
+
+Chatwoot independently fetches and validates the manifest from GitHub. It must not trust manifest content copied from the catalog build.
+
+The flow is:
+
+1. Resolve the repository and selected toolset folder.
+2. Fetch `toolset.yml` at a specific commit SHA.
+3. Show a preview of tools, endpoints, authentication requirements, and requested inputs.
+4. Collect required input and secret values.
+5. Materialize the toolset and its tools locally in one atomic operation.
+6. Record the source repository, path, commit, release version, and manifest digest.
+
+### Manual import
+
+Users may upload or paste a `toolset.yml` file.
+
+The same parser, validation, preview, and credential collection flow is used. The resulting toolset has no upstream source and cannot check for GitHub updates. Manually imported tools remain editable and may be exported as YAML.
+
+## Persistence
+
+GitHub remains the source of truth for published documentation and manifests. Chatwoot persists installation state because credentials and account configuration are local, and because an installed toolset must continue working if its repository becomes unavailable.
+
+Each GitHub installation records at least:
+
+```text
+provider                 github
+repository_id            GitHub's immutable repository ID
+repository_full_name     owner/repository
+toolset_id               folder name
+manifest_path            folder/toolset.yml
+installed_commit         resolved commit SHA
+installed_version        manifest version
+manifest_digest          SHA-256 of normalized manifest content
+```
+
+Chatwoot also persists:
+
+- Materialized tool definitions and stable tool IDs.
+- Encrypted secret values.
+- Input values.
+- Per-tool enabled state.
+- The association between tools and their toolset installation.
+
+Directory listings and README content do not require durable persistence. They may be fetched on demand or cached temporarily.
+
+## Editing and ownership
+
+GitHub-installed manifest fields are managed by their source and are read-only in Chatwoot. Users may change local credentials, input values, and enabled state.
+
+A **Customize** or **Detach from source** action converts the toolset to manual ownership. Detached tools become editable and stop receiving upstream update checks.
+
+Manual imports are locally owned and editable from installation onward.
+
+## Updates
+
+Updates are explicit and user-initiated in the first version. No scheduled update polling or automatic application is required.
+
+When the user selects **Check for updates**, Chatwoot:
+
+1. Fetches the manifest from the source repository's default branch.
+2. Compares its normalized digest and release version with the installed values.
+3. Shows changes to tools, endpoints, methods, authentication, parameters, inputs, and secrets.
+4. Requests any newly required configuration.
+5. Applies the complete update atomically after confirmation.
+6. Records the new commit, version, and digest.
+
+Removed tools must be called out explicitly. Existing credentials may be reused only for secret IDs that remain unchanged. An upstream change must never take effect merely because a branch moved.
+
+## Security and trust
+
+Toolsets describe outbound HTTP requests and therefore require a strong trust boundary.
+
+- Display the publisher, repository, commit, endpoints, and authentication behavior before installation.
+- Sanitize all rendered Markdown and reject embedded scripts or unsafe HTML.
+- Parse YAML using safe loading with aliases disabled.
+- Enforce manifest, README, repository, and tool-count size limits.
+- Validate supported HTTP methods, authentication types, schemas, and templates.
+- Prevent manifests from supplying secret values.
+- Encrypt account credentials at rest and never expose them to the catalog.
+- Protect server-side requests against private-network and metadata-service access.
+- Require confirmation when an update changes a destination host or authentication behavior.
+- Distinguish verified publishers from merely valid manifests.
+- Support blocking abusive repositories without making approval a prerequisite for publication.
+
+## Private repositories
+
+Private repositories are not included in the public Astro catalog. A user may install directly from a private GitHub repository when Chatwoot has user-authorized read access.
+
+Private and public installations follow the same commit pinning, validation, preview, and update rules. Repository credentials must not be stored in the toolset manifest.
+
+## Availability and failure behavior
+
+- Installed tools run from their local materialized definitions and do not depend on GitHub availability.
+- Catalog downtime does not prevent direct GitHub installation or manual import.
+- Repository deletion does not delete an installed toolset.
+- A failed import or update leaves the previous installation unchanged.
+- An hourly indexing failure leaves the last successful catalog deployed.
+- Repository renames are tracked using the immutable GitHub repository ID where possible.
+
+## Initial delivery
+
+### Phase 1: Manifest portability
+
+- Import and export toolsets as YAML.
+- Validate manifests and collect required inputs and secrets.
+
+### Phase 2: GitHub installation
+
+- Browse a supplied repository.
+- Install a selected toolset at a resolved commit.
+- Persist source provenance and group installed tools.
+- Support detaching a GitHub-installed toolset.
+
+### Phase 3: Static catalog
+
+- Discover repositories through the `captain-toolsets` topic.
+- Build the Astro catalog hourly.
+- Render sanitized documentation and searchable toolset metadata.
+- Link catalog installation into Chatwoot.
+
+### Phase 4: Managed updates
+
+- Check for updates on demand.
+- Show a security-relevant manifest diff.
+- Apply confirmed updates atomically.
+
+## Acceptance criteria
+
+- A publisher can expose multiple toolsets from an arbitrarily named public GitHub repository.
+- Adding the `captain-toolsets` topic makes valid toolsets eligible for the next catalog build.
+- Invalid manifests are excluded without breaking the deployed catalog.
+- A user can install from the catalog, a GitHub repository URL, or a local YAML file.
+- GitHub installations retain their repository, path, commit, and digest.
+- Installed tools continue working when GitHub or the catalog is unavailable.
+- Upstream changes do not affect installed tools until explicitly reviewed and applied.
+- Manual imports work without GitHub and remain locally editable.
+- Secrets never appear in manifests, catalog output, logs, exports, or update diffs.


### PR DESCRIPTION
On installations that override `FRONTEND_URL` through installation config, SAML login broke: the SP entity ID was built from the overridden value while the assertion consumer service URL was built from the raw env var, so the two pointed at different hosts and the IdP posted its assertion to the wrong place.

The SAML setup proc now reads `FRONTEND_URL` via `GlobalConfigService`, matching how `AccountSamlSettings#set_sp_entity_id` builds the SP entity ID.

## How to reproduce

1. Set `FRONTEND_URL` in the environment, then override it with a different value in Super Admin installation config.
2. Configure SAML for an account and compare the generated SP entity ID with the ACS URL sent to the IdP. Before this change they use different hosts.

## Note

`sp_entity_id` is only generated on create, so accounts that configured SAML under an older `FRONTEND_URL` keep a stale value and still need a re-save. `OmniAuth.config.full_host` in `config/initializers/omniauth.rb` also reads the raw env var, but that affects OSS Google OAuth too and is left alone here.