### PR TITLE
fix: read FRONTEND_URL from global config for SAML ACS URL

### DIFF
--- a/app/controllers/devise_overrides/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_overrides/omniauth_callbacks_controller.rb
@@ -52,11 +52,15 @@ class DeviseOverrides::OmniauthCallbacksController < DeviseTokenAuth::OmniauthCa
   end
 
   def login_page_url(error: nil, email: nil, sso_auth_token: nil)
-    frontend_url = ENV.fetch('FRONTEND_URL', nil)
+    frontend_url = omniauth_frontend_url
     params = { email: email, sso_auth_token: sso_auth_token }.compact
     params[:error] = error if error.present?
 
     "#{frontend_url}/app/login?#{params.to_query}"
+  end
+
+  def omniauth_frontend_url
+    ENV.fetch('FRONTEND_URL', nil)
   end
 
   def account_signup_allowed?

--- a/enterprise/app/controllers/api/v1/auth_controller.rb
+++ b/enterprise/app/controllers/api/v1/auth_controller.rb
@@ -66,7 +66,7 @@ class Api::V1::AuthController < Api::BaseController
   end
 
   def sso_login_page_url(error: nil)
-    frontend_url = ENV.fetch('FRONTEND_URL', nil)
+    frontend_url = GlobalConfigService.load('FRONTEND_URL', 'http://localhost:3000')
     params = { error: error }.compact
 
     query = params.to_query

--- a/enterprise/app/controllers/enterprise/devise_overrides/omniauth_callbacks_controller.rb
+++ b/enterprise/app/controllers/enterprise/devise_overrides/omniauth_callbacks_controller.rb
@@ -69,6 +69,12 @@ module Enterprise::DeviseOverrides::OmniauthCallbacksController
     request.env['omniauth.auth'] || super
   end
 
+  def omniauth_frontend_url
+    return super unless params[:provider] == 'saml' || params[:strategy] == 'saml'
+
+    GlobalConfigService.load('FRONTEND_URL', 'http://localhost:3000')
+  end
+
   def for_mobile?(relay_state)
     relay_state.to_s.casecmp('mobile').zero?
   end

--- a/enterprise/config/initializers/omniauth_saml.rb
+++ b/enterprise/config/initializers/omniauth_saml.rb
@@ -23,7 +23,8 @@ SAML_SETUP_PROC = proc do |env|
     if settings
       # Configure the strategy options dynamically
       env['omniauth.strategy'].options[:idp_sso_service_url_runtime_params] = { RelayState: :RelayState }
-      env['omniauth.strategy'].options[:assertion_consumer_service_url] = "#{ENV.fetch('FRONTEND_URL', 'http://localhost:3000')}/omniauth/saml/callback?account_id=#{account_id}"
+      base_url = GlobalConfigService.load('FRONTEND_URL', 'http://localhost:3000')
+      env['omniauth.strategy'].options[:assertion_consumer_service_url] = "#{base_url}/omniauth/saml/callback?account_id=#{account_id}"
       env['omniauth.strategy'].options[:sp_entity_id] = settings.sp_entity_id
       env['omniauth.strategy'].options[:idp_entity_id] = settings.idp_entity_id
       env['omniauth.strategy'].options[:idp_sso_service_url] = settings.sso_url

--- a/spec/enterprise/controllers/api/v1/auth_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/auth_controller_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'Api::V1::Auth', type: :request do
   before do
     account.enable_features('saml')
     account.save!
-    allow(ENV).to receive(:fetch).and_call_original
-    allow(ENV).to receive(:fetch).with('FRONTEND_URL', nil).and_return('http://www.example.com')
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load).with('FRONTEND_URL', 'http://localhost:3000').and_return('http://www.example.com')
   end
 
   describe 'POST /api/v1/auth/saml_login' do

--- a/spec/enterprise/controllers/enterprise/devise_overrides/omniauth_callbacks_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/devise_overrides/omniauth_callbacks_controller_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'Enterprise SAML OmniAuth Callbacks', type: :request do
 
   before do
     allow(ChatwootApp).to receive(:enterprise?).and_return(true)
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load).with('FRONTEND_URL', 'http://localhost:3000').and_return('http://www.example.com')
     account.enable_features!('saml')
     saml_settings
   end


### PR DESCRIPTION
On installations that override `FRONTEND_URL` through installation config, SAML login broke: the SP entity ID was built from the overridden value while the assertion consumer service URL was built from the raw env var, so the two pointed at different hosts and the IdP posted its assertion to the wrong place.

The SAML setup proc now reads `FRONTEND_URL` via `GlobalConfigService`, matching how `AccountSamlSettings#set_sp_entity_id` builds the SP entity ID.

## How to reproduce

1. Set `FRONTEND_URL` in the environment, then override it with a different value in Super Admin installation config.
2. Configure SAML for an account and compare the generated SP entity ID with the ACS URL sent to the IdP. Before this change they use different hosts.

## Note

`sp_entity_id` is only generated on create, so accounts that configured SAML under an older `FRONTEND_URL` keep a stale value and still need a re-save. `OmniAuth.config.full_host` in `config/initializers/omniauth.rb` also reads the raw env var, but that affects OSS Google OAuth too and is left alone here.