### PR TITLE
fix: show Initiated at in the agent's timezone

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/ConversationInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ConversationInfo.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { computed } from 'vue';
+import { getUnixTime } from 'date-fns';
 import { getLanguageName } from 'dashboard/components/widgets/conversation/advancedFilterItems/languages';
+import { useExactTimestamp } from 'shared/composables/useExactTimestamp';
 import ContactDetailsItem from './ContactDetailsItem.vue';
 import CustomAttributes from './customAttributes/CustomAttributes.vue';
 
@@ -16,9 +18,21 @@ const props = defineProps({
 });
 
 const referer = computed(() => props.conversationAttributes.referer);
-const initiatedAt = computed(
-  () => props.conversationAttributes.initiated_at?.timestamp
-);
+
+const exactTimestamp = useExactTimestamp({ showTimeZone: true });
+
+// Stored as a raw string: the visitor's `Date.toString()` for widget
+// conversations and a UTC time for email ones. Re-render it in the agent's
+// own timezone and locale; fall back to the raw value when unparseable.
+const initiatedAt = computed(() => {
+  const timestamp = props.conversationAttributes.initiated_at?.timestamp;
+  if (!timestamp) return '';
+
+  const initiatedDate = new Date(timestamp);
+  if (Number.isNaN(initiatedDate.getTime())) return timestamp;
+
+  return exactTimestamp(getUnixTime(initiatedDate));
+});
 
 const browserInfo = computed(() => props.conversationAttributes.browser);
 

--- a/app/javascript/shared/composables/specs/useExactTimestamp.spec.js
+++ b/app/javascript/shared/composables/specs/useExactTimestamp.spec.js
@@ -1,5 +1,5 @@
 import messages from 'dashboard/i18n';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useExactTimestamp } from '../useExactTimestamp';
@@ -74,5 +74,140 @@ describe('useExactTimestamp', () => {
     expect(exactTimestamp(null)).toBe('');
     expect(exactTimestamp(undefined)).toBe('');
     expect(exactTimestamp('')).toBe('');
+  });
+
+  describe('with showTimeZone', () => {
+    // Nov 27 2025, 15:35:53 UTC — late November keeps northern zones on
+    // standard time.
+    const WINTER_TIMESTAMP = 1764257753;
+    // Jul 15 2025, 12:00:00 UTC — the same zones' daylight-saving half.
+    const SUMMER_TIMESTAMP = 1752580800;
+
+    const RealDateTimeFormat = Intl.DateTimeFormat;
+    let dateTimeFormatSpy;
+
+    afterEach(() => {
+      dateTimeFormatSpy?.mockRestore();
+      dateTimeFormatSpy = undefined;
+    });
+
+    // Browsers default Intl to the agent's zone, but vitest workers cannot
+    // switch the process zone at runtime, so simulate the agent's zone by
+    // injecting an explicit timeZone into the formatters the composable
+    // builds. Fresh module per case, as its formatter cache is locale-keyed.
+    const exactTimestampIn = async (timeZone, options) => {
+      dateTimeFormatSpy = vi
+        .spyOn(Intl, 'DateTimeFormat')
+        .mockImplementation(
+          (locale, formatOptions) =>
+            new RealDateTimeFormat(locale, { ...formatOptions, timeZone })
+        );
+      vi.resetModules();
+      const { useExactTimestamp: freshComposable } = await import(
+        '../useExactTimestamp'
+      );
+      return freshComposable(options);
+    };
+
+    it('appends the UTC label for a UTC user', async () => {
+      const exactTimestamp = await exactTimestampIn('UTC', {
+        showTimeZone: true,
+      });
+      expect(exactTimestamp(WINTER_TIMESTAMP)).toMatch(
+        /^Nov 27, 2025, 3:35\sPM \(UTC\)$/
+      );
+    });
+
+    it('uses the named abbreviation where the locale has one', async () => {
+      const exactTimestamp = await exactTimestampIn('America/Los_Angeles', {
+        showTimeZone: true,
+      });
+      expect(exactTimestamp(WINTER_TIMESTAMP)).toMatch(
+        /^Nov 27, 2025, 7:35\sAM \(PST\)$/
+      );
+    });
+
+    it('follows daylight saving for the formatted instant', async () => {
+      const exactTimestamp = await exactTimestampIn('America/Los_Angeles', {
+        showTimeZone: true,
+      });
+      expect(exactTimestamp(SUMMER_TIMESTAMP)).toMatch(
+        /^Jul 15, 2025, 5:00\sAM \(PDT\)$/
+      );
+    });
+
+    it('renders whole-hour offsets as a GMT label', async () => {
+      const exactTimestamp = await exactTimestampIn('Europe/Berlin', {
+        showTimeZone: true,
+      });
+      expect(exactTimestamp(WINTER_TIMESTAMP)).toMatch(
+        /^Nov 27, 2025, 4:35\sPM \(GMT\+1\)$/
+      );
+    });
+
+    it.each([
+      ['Asia/Kolkata', /^Nov 27, 2025, 9:05\sPM \(GMT\+5:30\)$/],
+      ['Asia/Kathmandu', /^Nov 27, 2025, 9:20\sPM \(GMT\+5:45\)$/],
+      ['America/St_Johns', /^Nov 27, 2025, 12:05\sPM \(GMT-3:30\)$/],
+    ])(
+      'keeps the fractional offset exact in %s',
+      async (timeZone, expected) => {
+        const exactTimestamp = await exactTimestampIn(timeZone, {
+          showTimeZone: true,
+        });
+        expect(exactTimestamp(WINTER_TIMESTAMP)).toMatch(expected);
+      }
+    );
+
+    it('crosses the date line for extreme offsets', async () => {
+      const exactTimestamp = await exactTimestampIn('Pacific/Kiritimati', {
+        showTimeZone: true,
+      });
+      expect(exactTimestamp(WINTER_TIMESTAMP)).toMatch(
+        /^Nov 28, 2025, 5:35\sAM \(GMT\+14\)$/
+      );
+    });
+
+    it('localizes the zone label with the dashboard language', async () => {
+      vi.mocked(useI18n).mockReturnValue({ locale: ref('fr') });
+      const exactTimestamp = await exactTimestampIn('Asia/Kolkata', {
+        showTimeZone: true,
+      });
+      expect(exactTimestamp(WINTER_TIMESTAMP)).toBe(
+        '27 nov. 2025, 21:05 (UTC+5:30)'
+      );
+    });
+
+    it('keeps the parenthesized zone label at the end for RTL languages', async () => {
+      vi.mocked(useI18n).mockReturnValue({ locale: ref('ar') });
+      const exactTimestamp = await exactTimestampIn('Asia/Kolkata', {
+        showTimeZone: true,
+      });
+      const formatted = exactTimestamp(WINTER_TIMESTAMP);
+      expect(formatted).toContain('9:05 م');
+      expect(formatted).toMatch(/\(غرينتش\+5:30\)$/);
+    });
+
+    it('leaves the default format without a zone label', async () => {
+      dateTimeFormatSpy = vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(
+        (locale, formatOptions) =>
+          new RealDateTimeFormat(locale, {
+            ...formatOptions,
+            timeZone: 'Asia/Kolkata',
+          })
+      );
+      vi.resetModules();
+      const { useExactTimestamp: freshComposable } = await import(
+        '../useExactTimestamp'
+      );
+      // Both variants from the same module instance, so this also proves the
+      // formatter cache keeps the two apart.
+      expect(freshComposable()(WINTER_TIMESTAMP)).toMatch(
+        /^Nov 27, 2025, 9:05\sPM$/
+      );
+      expect(freshComposable({ showTimeZone: true })(WINTER_TIMESTAMP)).toMatch(
+        /^Nov 27, 2025, 9:05\sPM \(GMT\+5:30\)$/
+      );
+    });
   });
 });

--- a/app/javascript/shared/composables/useExactTimestamp.js
+++ b/app/javascript/shared/composables/useExactTimestamp.js
@@ -20,11 +20,28 @@ const formatterFor = locale => {
   return formatters.get(locale);
 };
 
+// Only used to pick out the localized zone label; `dateStyle`/`timeStyle`
+// cannot be combined with `timeZoneName` in a single formatter.
+const zoneFormatterFor = locale => {
+  const key = `${locale}/zone`;
+  if (!formatters.has(key)) {
+    formatters.set(
+      key,
+      new Intl.DateTimeFormat(locale, { timeZoneName: 'short' })
+    );
+  }
+  return formatters.get(key);
+};
+
 /**
  * Composable for the full, unambiguous date and time shown on hover next to a
  * relative timestamp (e.g. "2 days ago"). Formats in the user's dashboard
  * language, so the month name, field order and clock convention read natively.
  *
+ * @param {Object} [options]
+ * @param {boolean} [options.showTimeZone=false] - Append the user's timezone
+ *   label in parentheses, e.g. "(GMT+5:30)", for values whose zone would
+ *   otherwise be ambiguous.
  * @returns {(time: number) => string} Formatter for a Unix timestamp; returns
  *   an empty string when there is no timestamp.
  *
@@ -32,12 +49,19 @@ const formatterFor = locale => {
  * const exactTimestamp = useExactTimestamp();
  * exactTimestamp(1770000000); // "Feb 2, 2026, 8:10 AM" / "2 févr. 2026, 08:10"
  */
-export function useExactTimestamp() {
+export function useExactTimestamp({ showTimeZone = false } = {}) {
   const { resolvedLocale } = useLocale();
 
   return time => {
     if (!time) return '';
 
-    return formatterFor(resolvedLocale.value).format(fromUnixTime(time));
+    const date = fromUnixTime(time);
+    const formatted = formatterFor(resolvedLocale.value).format(date);
+    if (!showTimeZone) return formatted;
+
+    const zone = zoneFormatterFor(resolvedLocale.value)
+      .formatToParts(date)
+      .find(part => part.type === 'timeZoneName').value;
+    return `${formatted} (${zone})`;
   };
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the "Initiated at" field in the conversation sidebar showing the visitor's local time for website conversations and UTC for email conversations. It now shows the time in the agent's timezone and dashboard language, with the timezone label included to avoid ambiguity.

For example: `Nov 27, 2025, 9:05 PM (GMT+5:30)` or `27/11/2025، 9:05 م (غرينتش+5:30)`.

## How to reproduce

1. Start a conversation from the live-chat widget with the visitor's timezone different from the agent's, or use an email conversation.
2. Open the conversation in the dashboard and check Conversation Information → Initiated at.
3. Before: the visitor's local time or UTC. After: the agent's local time with the timezone label.

## What changed

* `ConversationInfo.vue` now parses and formats the stored timestamp instead of displaying it as-is.
* `useExactTimestamp` now supports an opt-in `showTimeZone` flag. The existing default formatting is reused, with the localized timezone label appended in parentheses.
* Specs cover UTC, DST abbreviations (PST/PDT), whole and fractional offsets, date-line rollover, localized and RTL timezone labels, and the default format.


Fixes https://linear.app/chatwoot/issue/CW-7983/initiated-at-in-conversation-information-is-not-shown-in-the-agents

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screenshots

**Before**

<img width="357" height="125" alt="image" src="https://github.com/user-attachments/assets/5861d67d-d802-4938-8c35-7e7874fb2e84" />
<img width="357" height="125" alt="image" src="https://github.com/user-attachments/assets/2039da42-d152-4043-b5c3-847e2b9fdb1e" />



**After**
<img width="357" height="125" alt="image" src="https://github.com/user-attachments/assets/13c538ba-a2b2-4982-940a-fbe5514c262f" />
<img width="357" height="125" alt="image" src="https://github.com/user-attachments/assets/dbcc145e-10a0-4683-8e8d-03e39ba4ef41" />



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
