### PR TITLE
fix(email): accept semicolon and space separated recipients

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -99,12 +99,6 @@ class Messages::MessageBuilder
     @message.content_attributes[:email] = email_attributes
   end
 
-  def process_email_string(email_string)
-    return [] if email_string.blank?
-
-    email_string.gsub(/\s+/, '').split(',')
-  end
-
   def message_type
     if @conversation.inbox.channel_type != 'Channel::Api' && @message_type == 'incoming'
       raise StandardError, 'Incoming messages are only allowed in Api inboxes'

--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -10,6 +10,18 @@ module EmailHelper
     ChatwootMarkdownRenderer.new(content).render_message(hardbreaks: true).to_s
   end
 
+  # Recipient lists reach us comma, semicolon or space separated. Mail::AddressList handles the
+  # first two along with display name forms such as `Jane Smith <jane@example.com>`, but not a
+  # plain space separated list, so collapse the separators unless a display name needs its spaces.
+  def process_email_string(email_string)
+    return [] if email_string.blank?
+
+    normalized = email_string.match?(/[<"]/) ? email_string : email_string.strip.gsub(/[\s,;]+/, ',')
+    Mail::AddressList.new(normalized).addresses.map(&:address)
+  rescue Mail::Field::ParseError
+    raise StandardError, 'Invalid email address'
+  end
+
   # Raise a standard error if any email address is invalid
   def validate_email_addresses(emails_to_test)
     emails_to_test&.each do |email|

--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -17,7 +17,12 @@ module EmailHelper
     return [] if email_string.blank?
 
     normalized = email_string.match?(/[<"]/) ? email_string : email_string.strip.gsub(/[\s,;]+/, ',')
-    Mail::AddressList.new(normalized).addresses.map(&:address)
+    addresses = Mail::AddressList.new(normalized).addresses
+    # `a@example.com Jane Doe <b@example.com>` parses as one recipient with the first address
+    # swallowed into the display name. Reject that rather than dropping a recipient silently.
+    raise StandardError, 'Invalid email address' if addresses.any? { |address| address.display_name.to_s.include?('@') }
+
+    addresses.map(&:address)
   rescue Mail::Field::ParseError
     raise StandardError, 'Invalid email address'
   end

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -252,6 +252,21 @@ describe Messages::MessageBuilder do
         expect { described_class.new(user, conversation, params).perform }.to raise_error 'Invalid email address'
       end
 
+      it 'accepts semicolon separated display name forms' do
+        cc_emails = 'Jane Smith <jane@test.com>; John Doe <john@test.com>'
+        params = ActionController::Parameters.new({ cc_emails: cc_emails })
+
+        message = described_class.new(user, conversation, params).perform
+
+        expect(message.content_attributes[:cc_emails]).to eq ['jane@test.com', 'john@test.com']
+      end
+
+      it 'rejects a bare address followed by a display name instead of dropping the first one' do
+        params = ActionController::Parameters.new({ cc_emails: 'jane@test.com John Doe <john@test.com>' })
+
+        expect { described_class.new(user, conversation, params).perform }.to raise_error 'Invalid email address'
+      end
+
       context 'when custom email content is provided' do
         it 'creates message with custom HTML email content' do
           params = ActionController::Parameters.new({

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -209,6 +209,49 @@ describe Messages::MessageBuilder do
         expect(message.content_attributes[:bcc_emails]).to eq ['test1@test.com', 'test2@test.com', 'test3@test.com']
       end
 
+      it 'accepts semicolon separated cc_emails and bcc_emails' do
+        params = ActionController::Parameters.new({ cc_emails: 'test1@test.com;test2@test.com',
+                                                    bcc_emails: 'test3@test.com; test4@test.com' })
+
+        message = described_class.new(user, conversation, params).perform
+
+        expect(message.content_attributes[:cc_emails]).to eq ['test1@test.com', 'test2@test.com']
+        expect(message.content_attributes[:bcc_emails]).to eq ['test3@test.com', 'test4@test.com']
+      end
+
+      it 'accepts space separated cc_emails and bcc_emails' do
+        params = ActionController::Parameters.new({ cc_emails: 'test1@test.com test2@test.com',
+                                                    bcc_emails: 'test3@test.com  test4@test.com' })
+
+        message = described_class.new(user, conversation, params).perform
+
+        expect(message.content_attributes[:cc_emails]).to eq ['test1@test.com', 'test2@test.com']
+        expect(message.content_attributes[:bcc_emails]).to eq ['test3@test.com', 'test4@test.com']
+      end
+
+      it 'extracts the address from display name forms without splitting on the name' do
+        cc_emails = 'Jane Smith <jane@test.com>, John Doe <john@test.com>'
+        params = ActionController::Parameters.new({ cc_emails: cc_emails })
+
+        message = described_class.new(user, conversation, params).perform
+
+        expect(message.content_attributes[:cc_emails]).to eq ['jane@test.com', 'john@test.com']
+      end
+
+      it 'keeps a comma inside a quoted display name intact' do
+        params = ActionController::Parameters.new({ cc_emails: '"Doe, John" <john@test.com>, jane@test.com' })
+
+        message = described_class.new(user, conversation, params).perform
+
+        expect(message.content_attributes[:cc_emails]).to eq ['john@test.com', 'jane@test.com']
+      end
+
+      it 'rejects an unparseable recipient instead of dropping it' do
+        params = ActionController::Parameters.new({ cc_emails: 'Jane <' })
+
+        expect { described_class.new(user, conversation, params).perform }.to raise_error 'Invalid email address'
+      end
+
       context 'when custom email content is provided' do
         it 'creates message with custom HTML email content' do
           params = ActionController::Parameters.new({


### PR DESCRIPTION
Recipient fields on email conversations now accept the separators people actually paste. Semicolon separated lists (the default when copying out of Outlook), space separated lists, and display name forms like `Jane Smith <jane@example.com>` are all parsed correctly instead of being rejected as one invalid address. Malformed input is still rejected.

## Closes

Closes #15609

## How to reproduce

1. Open a conversation in an email inbox.
2. In the CC field, enter two valid addresses separated by a space: `a@example.com b@example.com`.
3. Send.

**Before:** the send fails with `Invalid email address` and the message is never created. Same for `a@example.com;b@example.com`, and for `Jane Smith <jane@example.com>`.

**After:** both recipients are stored and the reply sends. Comma separated lists behave exactly as before.

One correction to the original report: it describes this as a *silent* drop. On the dashboard and API send path it is not silent — `validate_email_addresses` raises, and `MessagesController#create` rescues it into a 422, so the agent does see an error and no message is created. It *is* silent when the same reply is sent from an automation rule or a macro, because `AutomationRules::ActionService` and `Macros::ExecutionService` capture the exception and move on to the next action.

## What changed

`process_email_string` stripped all whitespace and then split on commas only, so any other separator fused adjacent addresses into a single unusable token.

It now builds a `Mail::AddressList`, which already understands comma and semicolon separated lists, display names, and commas inside quoted names such as `"Doe, John" <john@example.com>`. The one thing it cannot parse is a plain space separated list, so the separators are collapsed beforehand — but only when the string carries no display name, whose internal spaces have to survive. A parse failure raises the existing `Invalid email address` error, so malformed recipients are still rejected rather than silently passed through.

The method moved from `Messages::MessageBuilder` to `EmailHelper`, alongside `validate_email_addresses`. `MessageBuilder` already includes that helper and was sitting exactly on its `Metrics/ClassLength` limit, so the parsing sits better with the other email string helpers.

## Not covered

Two forms are rejected with `Invalid email address` rather than parsed, both of which use whitespace as the separator *and* inside a display name in the same string:

- `Jane Smith <jane@example.com> John Doe <john@example.com>`
- `jane@example.com John Doe <john@example.com>`

Resolving those needs a character scanner tracking quote and angle-bracket depth, which seemed a poor trade against `Mail::AddressList` for input no mainstream client emits — Outlook separates with semicolons, Gmail and Apple Mail with commas, and hand-typed lists are bare addresses. All three are covered.

The second form is worth calling out: before this change it parsed to `["john@example.com"]`, silently discarding the first recipient. Rejecting is a deliberate improvement on that, and it satisfies the issue's requirement that malformed input not be passed through silently. Happy to add the scanner if you would rather have full coverage.
