### PR TITLE
fix(i18n): wire snooze, contentTemplates and yearInReview into locale indexes

### DIFF
--- a/app/javascript/dashboard/i18n/locale/am/index.js
+++ b/app/javascript/dashboard/i18n/locale/am/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ar/index.js
+++ b/app/javascript/dashboard/i18n/locale/ar/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/az/index.js
+++ b/app/javascript/dashboard/i18n/locale/az/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/bg/index.js
+++ b/app/javascript/dashboard/i18n/locale/bg/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ca/index.js
+++ b/app/javascript/dashboard/i18n/locale/ca/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/cs/index.js
+++ b/app/javascript/dashboard/i18n/locale/cs/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/da/index.js
+++ b/app/javascript/dashboard/i18n/locale/da/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/de/index.js
+++ b/app/javascript/dashboard/i18n/locale/de/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/el/index.js
+++ b/app/javascript/dashboard/i18n/locale/el/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/es/index.js
+++ b/app/javascript/dashboard/i18n/locale/es/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/fa/index.js
+++ b/app/javascript/dashboard/i18n/locale/fa/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/fi/index.js
+++ b/app/javascript/dashboard/i18n/locale/fi/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/fr/index.js
+++ b/app/javascript/dashboard/i18n/locale/fr/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/he/index.js
+++ b/app/javascript/dashboard/i18n/locale/he/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/hi/index.js
+++ b/app/javascript/dashboard/i18n/locale/hi/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/hr/index.js
+++ b/app/javascript/dashboard/i18n/locale/hr/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/hu/index.js
+++ b/app/javascript/dashboard/i18n/locale/hu/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/hy/index.js
+++ b/app/javascript/dashboard/i18n/locale/hy/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/id/index.js
+++ b/app/javascript/dashboard/i18n/locale/id/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/is/index.js
+++ b/app/javascript/dashboard/i18n/locale/is/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/it/index.js
+++ b/app/javascript/dashboard/i18n/locale/it/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ja/index.js
+++ b/app/javascript/dashboard/i18n/locale/ja/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ka/index.js
+++ b/app/javascript/dashboard/i18n/locale/ka/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ko/index.js
+++ b/app/javascript/dashboard/i18n/locale/ko/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/lt/index.js
+++ b/app/javascript/dashboard/i18n/locale/lt/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/lv/index.js
+++ b/app/javascript/dashboard/i18n/locale/lv/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ml/index.js
+++ b/app/javascript/dashboard/i18n/locale/ml/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ms/index.js
+++ b/app/javascript/dashboard/i18n/locale/ms/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ne/index.js
+++ b/app/javascript/dashboard/i18n/locale/ne/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/nl/index.js
+++ b/app/javascript/dashboard/i18n/locale/nl/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/no/index.js
+++ b/app/javascript/dashboard/i18n/locale/no/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/pl/index.js
+++ b/app/javascript/dashboard/i18n/locale/pl/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/pt/index.js
+++ b/app/javascript/dashboard/i18n/locale/pt/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ro/index.js
+++ b/app/javascript/dashboard/i18n/locale/ro/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ru/index.js
+++ b/app/javascript/dashboard/i18n/locale/ru/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/sh/index.js
+++ b/app/javascript/dashboard/i18n/locale/sh/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/sk/index.js
+++ b/app/javascript/dashboard/i18n/locale/sk/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/sl/index.js
+++ b/app/javascript/dashboard/i18n/locale/sl/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/sq/index.js
+++ b/app/javascript/dashboard/i18n/locale/sq/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/sr/index.js
+++ b/app/javascript/dashboard/i18n/locale/sr/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/sv/index.js
+++ b/app/javascript/dashboard/i18n/locale/sv/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ta/index.js
+++ b/app/javascript/dashboard/i18n/locale/ta/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/th/index.js
+++ b/app/javascript/dashboard/i18n/locale/th/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/tl/index.js
+++ b/app/javascript/dashboard/i18n/locale/tl/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/tr/index.js
+++ b/app/javascript/dashboard/i18n/locale/tr/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/uk/index.js
+++ b/app/javascript/dashboard/i18n/locale/uk/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ur/index.js
+++ b/app/javascript/dashboard/i18n/locale/ur/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/ur_IN/index.js
+++ b/app/javascript/dashboard/i18n/locale/ur_IN/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/vi/index.js
+++ b/app/javascript/dashboard/i18n/locale/vi/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/zh_CN/index.js
+++ b/app/javascript/dashboard/i18n/locale/zh_CN/index.js
@@ -41,6 +41,9 @@ import sla from './sla.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import snooze from './snooze.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -86,4 +89,7 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...snooze,
+  ...contentTemplates,
+  ...yearInReview,
 };

--- a/app/javascript/dashboard/i18n/locale/zh_TW/index.js
+++ b/app/javascript/dashboard/i18n/locale/zh_TW/index.js
@@ -42,6 +42,8 @@ import snooze from './snooze.json';
 import teamsSettings from './teamsSettings.json';
 import whatsappTemplates from './whatsappTemplates.json';
 import whatsappTemplateMgmt from './whatsappTemplateMgmt.json';
+import contentTemplates from './contentTemplates.json';
+import yearInReview from './yearInReview.json';
 
 export default {
   ...advancedFilters,
@@ -88,4 +90,6 @@ export default {
   ...teamsSettings,
   ...whatsappTemplates,
   ...whatsappTemplateMgmt,
+  ...contentTemplates,
+  ...yearInReview,
 };


### PR DESCRIPTION
## Problem

`locale/en/index.js` imports and spreads `snooze.json`, `contentTemplates.json` and
`yearInReview.json`. **52 of the 56 non-English locale indexes never import them.**

The translations exist and ship in the repo, but because the locale's `index.js` never
spreads them, the keys are absent from the locale object at runtime and vue-i18n falls
back to English. The Snooze menu, Content Templates and Year in Review screens therefore
render in English in almost every language — regardless of how complete the translation is.

Reproduce on `develop`:

```bash
grep -c '^import' app/javascript/dashboard/i18n/locale/en/index.js   # 46
grep -c '^import' app/javascript/dashboard/i18n/locale/ar/index.js   # 43
grep -n 'snooze\|contentTemplates\|yearInReview' \
     app/javascript/dashboard/i18n/locale/ar/index.js                # no matches
```

## Fix

Adds the three missing `import` statements and their matching spreads to the **51 locales
that already ship the corresponding JSON files**, appended in the same relative order
`en/index.js` uses.

This unlocks roughly **132 already-translated strings per locale** — about **6,676 strings**
in total, of which **39 locales are wired into `dashboard/i18n/index.js`** and ship to users
today.

## Scope and exclusions

- **`zh` is deliberately untouched.** It does not ship `snooze.json`, `contentTemplates.json`
  or `yearInReview.json`, so importing them there would break the build. (Separately, `zh`
  already imports 21 JSON files that are not present in its directory — it survives only
  because `zh` is not imported by `dashboard/i18n/index.js`. Out of scope here.)
- **No translation content is modified** — imports and spreads only. Nothing here touches
  files in a way that conflicts with the Crowdin sync (`crowdin.yml` manages the `*.json`
  content; `index.js` is source code and is not Crowdin-managed).

## Verification

For every one of the 51 changed files:

- `node --check` passes
- `import` count == spread count
- no duplicate imports introduced
- every imported path resolves to a file that exists in that locale directory

Additionally built and ran the result end to end (Chatwoot v4.17.0, account locale `ar`,
production Vite build): module count rose by exactly 3, the previously-dead strings now
render, and the dashboard loads with no console or page errors.

## Related observations (not addressed here)

- 14 locale directories exist but are not imported by `dashboard/i18n/index.js`:
  `am az bn hr hy ka ms ne sh sq tl ur ur_IN zh`. This PR still fixes 12 of them for
  consistency, so they are correct whenever they do get wired.
- `bn/` ships 47 JSON files but has no `index.js` at all.
