### PR TITLE
fix(business-hours): include the full closing minute in working hours

### DIFF
--- a/app/javascript/widget/helpers/availabilityHelpers.js
+++ b/app/javascript/widget/helpers/availabilityHelpers.js
@@ -54,8 +54,11 @@ const getTodayConfig = (time, utcOffset, workingHours) => {
 };
 
 /**
- * Check if current time is within working range, handling midnight crossing
+ * Check if current time is within working range, handling midnight crossing.
  * @private
+ * The closing minute is inclusive, matching `WorkingHour#open_at?` on the server:
+ * hours are configured with minute precision, so a day closing at 11:59 PM stays
+ * open until midnight.
  * @param {number} currentMinutes
  * @param {number} openMinutes
  * @param {number} closeMinutes
@@ -65,8 +68,8 @@ const isTimeWithinRange = (currentMinutes, openMinutes, closeMinutes) => {
   const crossesMidnight = closeMinutes <= openMinutes;
 
   return crossesMidnight
-    ? currentMinutes >= openMinutes || currentMinutes < closeMinutes
-    : currentMinutes >= openMinutes && currentMinutes < closeMinutes;
+    ? currentMinutes >= openMinutes || currentMinutes <= closeMinutes
+    : currentMinutes >= openMinutes && currentMinutes <= closeMinutes;
 };
 
 /**

--- a/app/javascript/widget/helpers/specs/availabilityHelpers.spec.js
+++ b/app/javascript/widget/helpers/specs/availabilityHelpers.spec.js
@@ -181,6 +181,46 @@ describe('availabilityHelpers', () => {
       expect(isInWorkingHours(new Date(), 'UTC', workingHours)).toBe(true);
     });
 
+    it('should stay open through the closing minute', () => {
+      const mockDate = new Date('2024-01-15T23:59:00.000Z');
+      mockDate.getDay = vi.fn().mockReturnValue(1);
+      mockDate.getHours = vi.fn().mockReturnValue(23);
+      mockDate.getMinutes = vi.fn().mockReturnValue(59);
+      vi.mocked(utcToZonedTime).mockReturnValue(mockDate);
+
+      const workingHours = [
+        {
+          dayOfWeek: 1,
+          openHour: 0,
+          openMinutes: 0,
+          closeHour: 23,
+          closeMinutes: 59,
+        },
+      ];
+
+      expect(isInWorkingHours(new Date(), 'UTC', workingHours)).toBe(true);
+    });
+
+    it('should return false once the closing minute has passed', () => {
+      const mockDate = new Date('2024-01-15T17:01:00.000Z');
+      mockDate.getDay = vi.fn().mockReturnValue(1);
+      mockDate.getHours = vi.fn().mockReturnValue(17);
+      mockDate.getMinutes = vi.fn().mockReturnValue(1);
+      vi.mocked(utcToZonedTime).mockReturnValue(mockDate);
+
+      const workingHours = [
+        {
+          dayOfWeek: 1,
+          openHour: 9,
+          openMinutes: 0,
+          closeHour: 17,
+          closeMinutes: 0,
+        },
+      ];
+
+      expect(isInWorkingHours(new Date(), 'UTC', workingHours)).toBe(false);
+    });
+
     it('should return false when no config for current day', () => {
       const mockDate = new Date('2024-01-15T10:00:00.000Z');
       mockDate.getDay = vi.fn().mockReturnValue(1);
@@ -555,14 +595,14 @@ describe('availabilityHelpers', () => {
 
       expect(isInWorkingHours(new Date(), 'UTC', workingHours)).toBe(true);
 
-      // Test at exact closing time
+      // Test at exact closing time, the closing minute itself is still open
       const mockDate2 = new Date('2024-01-15T17:00:00.000Z');
       mockDate2.getDay = vi.fn().mockReturnValue(1);
       mockDate2.getHours = vi.fn().mockReturnValue(17);
       mockDate2.getMinutes = vi.fn().mockReturnValue(0);
       vi.mocked(utcToZonedTime).mockReturnValue(mockDate2);
 
-      expect(isInWorkingHours(new Date(), 'UTC', workingHours)).toBe(false);
+      expect(isInWorkingHours(new Date(), 'UTC', workingHours)).toBe(true);
     });
 
     it('should handle one minute before closing', () => {

--- a/app/javascript/widget/helpers/specs/availabilityHelpers.timezone.spec.js
+++ b/app/javascript/widget/helpers/specs/availabilityHelpers.timezone.spec.js
@@ -1,0 +1,121 @@
+import {
+  isInWorkingHours,
+  isOpenAllDay,
+  isClosedAllDay,
+} from '../availabilityHelpers';
+
+// The sibling `availabilityHelpers.spec.js` mocks `date-fns-tz` and stubs the
+// date getters, so it never exercises a real timezone conversion. These specs
+// deliberately leave `date-fns-tz` unmocked and drive the helpers with real UTC
+// instants, which is the only way to cover the day-of-week selection and the
+// closing-minute boundary as they actually behave in the widget.
+//
+// Everything here depends solely on the inbox timezone that is passed in, never
+// on the timezone of the machine running the suite, so the results are stable in
+// CI and locally. `findNextAvailableSlotDetails` is intentionally left out: it
+// converts to the *viewer's* timezone via `Intl`, so it cannot be asserted
+// without pinning the runner's timezone.
+
+const SEOUL = 'Asia/Seoul'; // UTC+9, no DST
+const NEW_YORK = 'America/New_York'; // UTC-5 in January
+
+const MONDAY = 1;
+const SUNDAY = 0;
+
+describe('availabilityHelpers with real timezone conversion', () => {
+  describe('closing minute boundary', () => {
+    // A full-day schedule is stored as 00:00-23:59 because 24:00 is not
+    // representable, so the closing minute has to be inclusive to cover the day.
+    const fullDay = [
+      {
+        dayOfWeek: MONDAY,
+        openHour: 0,
+        openMinutes: 0,
+        closeHour: 23,
+        closeMinutes: 59,
+      },
+    ];
+
+    it('stays open for the whole of the last minute of the day', () => {
+      // Mon 2024-01-15 23:59:30 in Seoul
+      const time = new Date('2024-01-15T14:59:30.000Z');
+      expect(isInWorkingHours(time, SEOUL, fullDay)).toBe(true);
+    });
+
+    it('closes at the next midnight in the inbox timezone', () => {
+      // Tue 2024-01-16 00:00:00 in Seoul, so Monday's slot no longer applies
+      const time = new Date('2024-01-15T15:00:00.000Z');
+      expect(isInWorkingHours(time, SEOUL, fullDay)).toBe(false);
+    });
+
+    it('keeps a regular day open through its closing minute', () => {
+      const nineToFive = [
+        {
+          dayOfWeek: MONDAY,
+          openHour: 9,
+          openMinutes: 0,
+          closeHour: 17,
+          closeMinutes: 0,
+        },
+      ];
+
+      // Mon 2024-01-15 17:00:30 in Seoul
+      expect(
+        isInWorkingHours(
+          new Date('2024-01-15T08:00:30.000Z'),
+          SEOUL,
+          nineToFive
+        )
+      ).toBe(true);
+      // Mon 2024-01-15 17:01:00 in Seoul
+      expect(
+        isInWorkingHours(
+          new Date('2024-01-15T08:01:00.000Z'),
+          SEOUL,
+          nineToFive
+        )
+      ).toBe(false);
+    });
+
+    it('keeps an open all day slot open for the last minute of the day', () => {
+      const openAllDay = [{ dayOfWeek: MONDAY, openAllDay: true }];
+
+      // Mon 2024-01-15 23:59:30 in Seoul
+      expect(
+        isInWorkingHours(
+          new Date('2024-01-15T14:59:30.000Z'),
+          SEOUL,
+          openAllDay
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('day selection when the inbox timezone is on another date', () => {
+    const mondayOnly = [
+      {
+        dayOfWeek: MONDAY,
+        openHour: 8,
+        openMinutes: 0,
+        closeHour: 17,
+        closeMinutes: 0,
+      },
+    ];
+    const sundayClosed = [{ dayOfWeek: SUNDAY, closedAllDay: true }];
+    const sundayOpenAllDay = [{ dayOfWeek: SUNDAY, openAllDay: true }];
+
+    it('uses the day that is ahead of UTC', () => {
+      // Sun 2024-01-14 23:00 UTC is already Mon 2024-01-15 08:00 in Seoul
+      const time = new Date('2024-01-14T23:00:00.000Z');
+      expect(isInWorkingHours(time, SEOUL, mondayOnly)).toBe(true);
+    });
+
+    it('uses the day that is behind UTC', () => {
+      // Mon 2024-01-15 02:00 UTC is still Sun 2024-01-14 21:00 in New York
+      const time = new Date('2024-01-15T02:00:00.000Z');
+      expect(isInWorkingHours(time, NEW_YORK, mondayOnly)).toBe(false);
+      expect(isClosedAllDay(time, NEW_YORK, sundayClosed)).toBe(true);
+      expect(isOpenAllDay(time, NEW_YORK, sundayOpenAllDay)).toBe(true);
+    });
+  });
+});

--- a/app/models/working_hour.rb
+++ b/app/models/working_hour.rb
@@ -46,13 +46,18 @@ class WorkingHour < ApplicationRecord
     find_by(day_of_week: Time.zone.now.in_time_zone(inbox.timezone).to_date.wday)
   end
 
+  # Working hours are configured with minute precision, so the closing minute is
+  # inclusive: a day closing at 11:59 PM stays open until midnight, not until
+  # 11:59:00 PM. The window is [open_time, close_time + 1.minute).
   def open_at?(time)
     return false if closed_all_day?
+    return true if open_all_day?
 
-    open_time = Time.zone.now.in_time_zone(inbox.timezone).change({ hour: open_hour, min: open_minutes })
-    close_time = Time.zone.now.in_time_zone(inbox.timezone).change({ hour: close_hour, min: close_minutes })
+    local_time = time.in_time_zone(inbox.timezone)
+    open_time = local_time.change({ hour: open_hour, min: open_minutes })
+    close_time = local_time.change({ hour: close_hour, min: close_minutes }) + 1.minute
 
-    time.between?(open_time, close_time)
+    local_time >= open_time && local_time < close_time
   end
 
   def open_now?
@@ -76,6 +81,9 @@ class WorkingHour < ApplicationRecord
     errors.add(:close_hour, 'Closing time cannot be before opening time')
   end
 
+  # 24:00 is not representable with the hour/minute columns, so an all-day record is
+  # stored as 00:00-23:59. `open_at?` treats the closing minute as inclusive, which
+  # makes that range cover the full calendar day.
   def ensure_open_all_day_hours
     return unless open_all_day?
 

--- a/spec/models/working_hour_spec.rb
+++ b/spec/models/working_hour_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe WorkingHour do
       expect(described_class.today.close_hour).to be 23
       expect(described_class.today.close_minutes).to be 59
     end
+
+    it 'is considered open for the entire calendar day' do
+      working_hour = described_class.today
+      expect(working_hour.open_at?('18.02.2022 00:00:00'.to_datetime)).to be true
+      expect(working_hour.open_at?('18.02.2022 23:59:30'.to_datetime)).to be true
+      expect(working_hour.open_at?('18.02.2022 23:59:59'.to_datetime)).to be true
+    end
   end
 
   context 'when open_all_day and closed_all_day true at the same time' do
@@ -86,6 +93,42 @@ RSpec.describe WorkingHour do
         working_hour.save!
       end.to raise_error(ActiveRecord::RecordInvalid,
                          'Validation failed: open_all_day and closed_all_day cannot be true at the same time')
+    end
+  end
+
+  context 'when the day closes at 11:59 PM' do
+    let(:inbox) { create(:inbox) }
+    let(:working_hour) { inbox.working_hours.find_by(day_of_week: 1) }
+
+    before do
+      Time.zone = 'UTC'
+      working_hour.update(open_hour: 9, open_minutes: 0, close_hour: 23, close_minutes: 59)
+    end
+
+    it 'is considered open for the whole of the closing minute' do
+      expect(working_hour.open_at?('26.10.2020 23:59:30'.to_datetime)).to be true
+      expect(working_hour.open_at?('26.10.2020 23:59:59'.to_datetime)).to be true
+    end
+
+    it 'is considered closed at midnight' do
+      expect(working_hour.open_at?('27.10.2020 00:00:00'.to_datetime)).to be false
+    end
+  end
+
+  context 'when the day closes at 5 PM' do
+    before do
+      Time.zone = 'UTC'
+      create(:working_hour)
+    end
+
+    it 'is considered open until the end of the closing minute' do
+      travel_to '26.10.2020 17:00:59'.to_datetime
+      expect(described_class.today.open_now?).to be true
+    end
+
+    it 'is considered closed once the closing minute has passed' do
+      travel_to '26.10.2020 17:01:00'.to_datetime
+      expect(described_class.today.closed_now?).to be true
     end
   end
 


### PR DESCRIPTION
Business hours configured to end at `11:59 PM` no longer close 59 seconds early, and an inbox marked **Open all day** now stays open for the entire day on the server, matching what the widget already showed.

The closing time is picked from a minute-precision dropdown, so it is now interpreted as covering the whole minute you selected. A day set to `12:00 AM – 11:59 PM` covers the full calendar day and closes at the next day's midnight, and a day set to `09:00 AM – 05:00 PM` stays open through `05:00:59 PM`. The server and the widget use the same boundary, so the availability shown in the widget and the out-of-office decision on an incoming message agree.

## Closes

Closes #15638

## How to reproduce

1. Enable business hours on a website inbox and set today to **Open all day** (or `12:00 AM – 11:59 PM`).
2. At `11:59:30 PM` in the inbox timezone, send an incoming message.
3. Before this change the inbox was treated as out of office and the out-of-office message was sent, while the widget still showed the inbox as online. After it, the inbox stays open until midnight.

## What changed

- `WorkingHour#open_at?` treats the closing minute as inclusive: the window is `[open_time, close_time + 1.minute)` instead of an inclusive `between?` against `HH:MM:00`.
- `open_at?` returns `true` for `open_all_day?` records directly, rather than relying on the normalised `00:00–23:59` range.
- `open_at?` anchors the window to the date of the time it is given instead of `Time.zone.now`, so the boundary can be evaluated for any instant.
- The widget's `isTimeWithinRange` compares with `<=` on the closing minute, so it matches the server instead of closing at the start of that minute.
- Adds `availabilityHelpers.timezone.spec.js`. The existing widget spec mocks `date-fns-tz` and stubs the date getters, so no spec exercised a real timezone conversion — the stubbed getters decided the answer before `getTodayConfig` ran. The new file leaves `date-fns-tz` unmocked and covers the closing-minute boundary plus two cases where the inbox timezone sits on a different calendar day than UTC.

## Scope

This changes availability only — "is the inbox reachable at this instant". It deliberately does not touch the two consumers that compute business-hour *durations*, `Sla::BusinessHoursService` and `ReportingEventHelper`, because aligning them would redefine a 09:00–17:00 business day as 8h 1m instead of 8h, shifting existing SLA deadlines and historical reporting metrics by 60s per business day. That leaves a bounded overlap of at most 60s between "reachable" and "counted", which seemed the better trade in a bugfix; details in the review threads.

Note that for `open_all_day` this PR *removes* a pre-existing divergence: `Sla::BusinessHoursService#day_close_time_for` already treats an all-day inbox as open until midnight, while `open_at?` reported it closed for the final 59 seconds.
