### PR TITLE
fix: prevent team icon picker clipping

### DIFF
--- a/app/javascript/dashboard/components-next/popover/specs/Popover.spec.js
+++ b/app/javascript/dashboard/components-next/popover/specs/Popover.spec.js
@@ -1,0 +1,244 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { h, ref } from 'vue';
+import Popover from '../Popover.vue';
+
+const belowMd = ref(false);
+
+vi.mock('dashboard/composables/store', () => ({
+  useMapGetter: () => ref(false),
+}));
+
+vi.mock('@vueuse/core', async importOriginal => ({
+  ...(await importOriginal()),
+  useBreakpoints: () => ({ smaller: () => belowMd }),
+}));
+
+describe('Popover', () => {
+  let wrapper;
+
+  const mountPopover = (props = {}) => {
+    wrapper = mount(Popover, {
+      props,
+      slots: {
+        default: '<button data-test="trigger">Open</button>',
+        content: params =>
+          h(
+            'button',
+            { 'data-test': 'panel-action', onClick: params.hide },
+            'Panel'
+          ),
+      },
+      global: {
+        stubs: { teleport: true },
+      },
+      attachTo: document.body,
+    });
+    return wrapper;
+  };
+
+  const openPopover = async () => {
+    await wrapper.find('[data-test="trigger"]').trigger('click');
+    await flushPromises();
+  };
+
+  const desktopPopover = () => wrapper.find('.fixed[data-popover-content]');
+  const mobileBackdrop = () => wrapper.find('[data-popover-backdrop]');
+
+  beforeEach(() => {
+    belowMd.value = false;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    document.body.innerHTML = '';
+  });
+
+  describe('rendering and toggling', () => {
+    it('renders the trigger slot and keeps the content hidden initially', () => {
+      mountPopover();
+      expect(wrapper.find('[data-test="trigger"]').exists()).toBe(true);
+      expect(desktopPopover().exists()).toBe(false);
+      expect(mobileBackdrop().exists()).toBe(false);
+    });
+
+    it('opens on trigger click and emits show', async () => {
+      mountPopover();
+      await openPopover();
+      expect(desktopPopover().exists()).toBe(true);
+      expect(wrapper.emitted('show')).toHaveLength(1);
+      expect(wrapper.emitted('hide')).toBeUndefined();
+    });
+
+    it('renders the content slot inside the popover', async () => {
+      mountPopover();
+      await openPopover();
+      expect(desktopPopover().find('[data-test="panel-action"]').exists()).toBe(
+        true
+      );
+    });
+
+    it('closes on a second trigger click and emits hide exactly once', async () => {
+      mountPopover();
+      await openPopover();
+      await wrapper.find('[data-test="trigger"]').trigger('click');
+      expect(desktopPopover().exists()).toBe(false);
+      expect(wrapper.emitted('hide')).toHaveLength(1);
+    });
+  });
+
+  describe('content slot hide', () => {
+    it('closes when the slot invokes the provided hide function', async () => {
+      mountPopover();
+      await openPopover();
+      await wrapper.find('[data-test="panel-action"]').trigger('click');
+      expect(desktopPopover().exists()).toBe(false);
+      expect(wrapper.emitted('hide')).toHaveLength(1);
+    });
+  });
+
+  describe('exposed methods', () => {
+    it('opens via show and closes via hide', async () => {
+      mountPopover();
+      await wrapper.vm.show();
+      await flushPromises();
+      expect(desktopPopover().exists()).toBe(true);
+      wrapper.vm.hide();
+      await flushPromises();
+      expect(desktopPopover().exists()).toBe(false);
+      expect(wrapper.emitted('show')).toHaveLength(1);
+      expect(wrapper.emitted('hide')).toHaveLength(1);
+    });
+
+    it('toggles via toggle', async () => {
+      mountPopover();
+      await wrapper.vm.toggle();
+      await flushPromises();
+      expect(desktopPopover().exists()).toBe(true);
+      await wrapper.vm.toggle();
+      await flushPromises();
+      expect(desktopPopover().exists()).toBe(false);
+    });
+
+    it('does not emit hide when already closed', async () => {
+      mountPopover();
+      wrapper.vm.hide();
+      await flushPromises();
+      expect(wrapper.emitted('hide')).toBeUndefined();
+    });
+  });
+
+  describe('escape key', () => {
+    const pressEscape = target =>
+      (target || document).dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+
+    it('closes on Escape while open', async () => {
+      mountPopover();
+      await openPopover();
+      pressEscape();
+      await flushPromises();
+      expect(desktopPopover().exists()).toBe(false);
+      expect(wrapper.emitted('hide')).toHaveLength(1);
+    });
+
+    it('does nothing on Escape while closed', async () => {
+      mountPopover();
+      await flushPromises();
+      pressEscape();
+      await flushPromises();
+      expect(wrapper.emitted('hide')).toBeUndefined();
+    });
+
+    it('closes on Escape pressed inside its own content', async () => {
+      mountPopover();
+      await openPopover();
+      pressEscape(wrapper.find('[data-test="panel-action"]').element);
+      await flushPromises();
+      expect(desktopPopover().exists()).toBe(false);
+    });
+
+    it('stays open on Escape pressed inside a nested overlay', async () => {
+      mountPopover();
+      await openPopover();
+      const overlay = document.createElement('dialog');
+      overlay.className = 'ProseMirror-prompt-backdrop';
+      document.body.appendChild(overlay);
+      pressEscape(overlay);
+      await flushPromises();
+      expect(desktopPopover().exists()).toBe(true);
+      expect(wrapper.emitted('hide')).toBeUndefined();
+    });
+  });
+
+  describe('click outside', () => {
+    it('closes when clicking outside', async () => {
+      mountPopover();
+      await openPopover();
+      document.body.click();
+      await flushPromises();
+      expect(desktopPopover().exists()).toBe(false);
+      expect(wrapper.emitted('hide')).toHaveLength(1);
+    });
+
+    it('stays open when clicking inside the content', async () => {
+      mountPopover();
+      await openPopover();
+      desktopPopover().element.click();
+      await flushPromises();
+      expect(desktopPopover().exists()).toBe(true);
+      expect(wrapper.emitted('hide')).toBeUndefined();
+    });
+  });
+
+  describe('mobile view', () => {
+    it('renders a centered modal with backdrop below the md breakpoint', async () => {
+      belowMd.value = true;
+      mountPopover();
+      await openPopover();
+      expect(mobileBackdrop().exists()).toBe(true);
+      expect(mobileBackdrop().find('[data-test="panel-action"]').exists()).toBe(
+        true
+      );
+      expect(desktopPopover().exists()).toBe(false);
+    });
+
+    it('keeps the anchored popover below md when disableMobileView is set', async () => {
+      belowMd.value = true;
+      mountPopover({ disableMobileView: true });
+      await openPopover();
+      expect(mobileBackdrop().exists()).toBe(false);
+      expect(desktopPopover().exists()).toBe(true);
+    });
+  });
+
+  describe('close on scroll', () => {
+    const scrollWithTriggerMovedBy = async offset => {
+      await openPopover();
+      wrapper.find('span').element.getBoundingClientRect = () => ({
+        top: offset,
+      });
+      document.dispatchEvent(new Event('scroll'));
+      await flushPromises();
+    };
+
+    it('closes when the trigger drifts beyond the threshold', async () => {
+      mountPopover();
+      await scrollWithTriggerMovedBy(100);
+      expect(desktopPopover().exists()).toBe(false);
+      expect(wrapper.emitted('hide')).toHaveLength(1);
+    });
+
+    it('stays open for small drift within the threshold', async () => {
+      mountPopover();
+      await scrollWithTriggerMovedBy(10);
+      expect(desktopPopover().exists()).toBe(true);
+    });
+
+    it('stays open when closeOnScroll is disabled', async () => {
+      mountPopover({ closeOnScroll: false });
+      await scrollWithTriggerMovedBy(100);
+      expect(desktopPopover().exists()).toBe(true);
+    });
+  });
+});

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/InboxChannels.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/InboxChannels.vue
@@ -62,7 +62,7 @@ const items = computed(() => {
   <div class="mx-auto flex flex-col gap-6 mb-8 max-w-7xl w-full !px-6">
     <PageHeader class="block lg:hidden !mb-0" :header-title="pageTitle" />
     <div
-      class="grid grid-cols-1 lg:grid-cols-8 lg:divide-x lg:divide-n-weak rounded-xl border border-n-weak h-full min-h-[50dvh]"
+      class="grid grid-cols-1 lg:grid-cols-8 lg:divide-x lg:rtl:divide-x-reverse lg:divide-n-weak rounded-xl border border-n-weak h-full min-h-[50dvh]"
     >
       <woot-wizard
         class="hidden lg:block col-span-2 h-fit py-8 px-6"

--- a/app/javascript/dashboard/routes/dashboard/settings/teams/Create/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/teams/Create/Index.vue
@@ -25,7 +25,7 @@ export default {
 <template>
   <div class="flex flex-col gap-6 mb-8 max-w-7xl mx-auto w-full !px-6">
     <div
-      class="grid grid-cols-1 lg:grid-cols-8 lg:divide-x lg:divide-n-weak rounded-xl border border-n-weak h-full min-h-[50dvh] w-full"
+      class="grid grid-cols-1 lg:grid-cols-8 lg:divide-x lg:rtl:divide-x-reverse lg:divide-n-weak rounded-xl border border-n-weak h-full min-h-[50dvh] w-full"
     >
       <woot-wizard
         class="hidden lg:block col-span-2 h-fit py-8 px-6"

--- a/app/javascript/dashboard/routes/dashboard/settings/teams/Edit/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/teams/Edit/Index.vue
@@ -29,7 +29,7 @@ export default {
 <template>
   <div class="flex flex-col gap-6 mb-8 max-w-7xl mx-auto w-full !px-6">
     <div
-      class="grid grid-cols-1 lg:grid-cols-8 lg:divide-x lg:divide-n-weak rounded-xl border border-n-weak h-full min-h-[50dvh] w-full"
+      class="grid grid-cols-1 lg:grid-cols-8 lg:divide-x lg:rtl:divide-x-reverse lg:divide-n-weak rounded-xl border border-n-weak h-full min-h-[50dvh] w-full"
     >
       <woot-wizard
         class="hidden lg:block col-span-2 h-fit py-8 px-6"

--- a/app/javascript/dashboard/routes/dashboard/settings/teams/TeamForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/teams/TeamForm.vue
@@ -108,7 +108,7 @@ export default {
           @blur="v$.title.$touch"
         />
         <div class="absolute top-[1.75rem] start-0">
-          <Popover align="start">
+          <Popover align="start" disable-mobile-view>
             <NextButton
               type="button"
               variant="ghost"

--- a/app/javascript/dashboard/routes/dashboard/settings/teams/TeamForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/teams/TeamForm.vue
@@ -1,11 +1,11 @@
 <script>
 import validations from './helpers/validations';
 import FormInput from 'v3/components/Form/Input.vue';
-import { reactive, ref, defineAsyncComponent } from 'vue';
+import { reactive, defineAsyncComponent } from 'vue';
 import { useVuelidate } from '@vuelidate/core';
-import { OnClickOutside } from '@vueuse/components';
 
 import NextButton from 'dashboard/components-next/button/Button.vue';
+import Popover from 'dashboard/components-next/popover/Popover.vue';
 import EmojiIcon from 'dashboard/components-next/emoji-icon-picker/EmojiIcon.vue';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 
@@ -17,8 +17,8 @@ const EmojiIconPicker = defineAsyncComponent(
 export default {
   components: {
     NextButton,
+    Popover,
     FormInput,
-    OnClickOutside,
     EmojiIcon,
     Icon,
     EmojiIconPicker,
@@ -59,17 +59,14 @@ export default {
       iconColor,
     });
 
-    const isIconPickerOpen = ref(false);
-
     const rules = validations;
     const v$ = useVuelidate(rules, state);
-    return { state, v$, isIconPickerOpen };
+    return { state, v$ };
   },
   methods: {
     onSelectIcon({ type, value, color }) {
       this.state.icon = value;
       this.state.iconColor = type === 'icon' ? color : '';
-      this.isIconPickerOpen = false;
     },
     onColorChange(color) {
       this.state.iconColor = color;
@@ -77,7 +74,6 @@ export default {
     onRemoveIcon() {
       this.state.icon = '';
       this.state.iconColor = '';
-      this.isIconPickerOpen = false;
     },
     handleSubmit() {
       this.v$.$touch();
@@ -111,36 +107,45 @@ export default {
           :error-message="v$.title.$error ? v$.title.$errors[0].$message : ''"
           @blur="v$.title.$touch"
         />
-        <OnClickOutside
-          class="absolute top-[1.75rem] start-0"
-          @trigger="isIconPickerOpen = false"
-        >
-          <NextButton
-            type="button"
-            variant="ghost"
-            color="slate"
-            class="text-lg !size-[2.5rem] !p-0 ltr:!rounded-r-none rtl:!rounded-l-none"
-            @click="isIconPickerOpen = !isIconPickerOpen"
-          >
-            <EmojiIcon
-              v-if="state.icon"
-              :value="state.icon"
-              :color="state.iconColor"
-              class="size-5 text-xl !leading-5"
-            />
-            <Icon v-else icon="i-lucide-smile-plus " class="size-4" />
-          </NextButton>
-          <EmojiIconPicker
-            v-if="isIconPickerOpen"
-            class="start-0 top-10"
-            :value="state.icon"
-            :color="state.iconColor"
-            show-remove-button
-            @select="onSelectIcon"
-            @color-change="onColorChange"
-            @remove="onRemoveIcon"
-          />
-        </OnClickOutside>
+        <div class="absolute top-[1.75rem] start-0">
+          <Popover align="start">
+            <NextButton
+              type="button"
+              variant="ghost"
+              color="slate"
+              class="text-lg !size-[2.5rem] !p-0 ltr:!rounded-r-none rtl:!rounded-l-none"
+            >
+              <EmojiIcon
+                v-if="state.icon"
+                :value="state.icon"
+                :color="state.iconColor"
+                class="size-5 text-xl !leading-5"
+              />
+              <Icon v-else icon="i-lucide-smile-plus " class="size-4" />
+            </NextButton>
+            <template #content="{ hide }">
+              <EmojiIconPicker
+                class="!static !shadow-none !outline-none"
+                :value="state.icon"
+                :color="state.iconColor"
+                show-remove-button
+                @select="
+                  event => {
+                    onSelectIcon(event);
+                    hide();
+                  }
+                "
+                @color-change="onColorChange"
+                @remove="
+                  () => {
+                    onRemoveIcon();
+                    hide();
+                  }
+                "
+              />
+            </template>
+          </Popover>
+        </div>
       </div>
       <FormInput
         v-model="state.description"


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the team icon/emoji picker getting clipped at the bottom of the team create/edit form. The picker was rendered as an absolutely positioned element inside the wizard card, whose content pane is a scroll container, causing the picker to be cut off on shorter laptop-height windows.

The picker now uses the shared `Popover` component, which renders it outside the card and positions it based on the available viewport space. This also adds Escape-to-close and close-on-scroll behavior and removes the custom open-state and click-outside handling from the form.


Fixes https://linear.app/chatwoot/issue/CW-8040/ui-is-broken-in-teams-page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screencast

**Before**

https://github.com/user-attachments/assets/33a7435a-e155-4bc9-b7fc-ce8aef9b3120



**After**

https://github.com/user-attachments/assets/c2362d67-f780-496c-aff5-8916eb5c4a99




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
