### PR TITLE
fix: improve Google OAuth signup error feedback

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/login.json
+++ b/app/javascript/dashboard/i18n/locale/en/login.json
@@ -17,7 +17,7 @@
     },
     "OAUTH": {
       "GOOGLE_LOGIN": "Login with Google",
-      "BUSINESS_ACCOUNTS_ONLY": "Please use your company email address to login",
+      "BUSINESS_ACCOUNTS_ONLY": "You can't create a new account with a personal email address. Please sign up using your work email.",
       "NO_ACCOUNT_FOUND": "We couldn't find an account for your email address."
     },
     "FORGOT_PASSWORD": "Forgot your password?",

--- a/app/javascript/v3/components/SnackBar/Container.vue
+++ b/app/javascript/v3/components/SnackBar/Container.vue
@@ -26,6 +26,8 @@ export default {
   },
   methods: {
     onNewToastMessage({ message, action }) {
+      const duration = action?.duration || this.duration;
+
       this.snackbarAlertMessages.push({
         key: new Date().getTime(),
         message,
@@ -33,7 +35,7 @@ export default {
       });
       window.setTimeout(() => {
         this.snackbarAlertMessages.splice(0, 1);
-      }, this.duration);
+      }, duration);
     },
   },
 };

--- a/app/javascript/v3/components/SnackBar/Container.vue
+++ b/app/javascript/v3/components/SnackBar/Container.vue
@@ -27,14 +27,19 @@ export default {
   methods: {
     onNewToastMessage({ message, action }) {
       const duration = action?.duration || this.duration;
-
-      this.snackbarAlertMessages.push({
+      const snackbarAlertMessage = {
         key: new Date().getTime(),
         message,
         action,
-      });
+      };
+
+      this.snackbarAlertMessages.push(snackbarAlertMessage);
       window.setTimeout(() => {
-        this.snackbarAlertMessages.splice(0, 1);
+        const messageIndex =
+          this.snackbarAlertMessages.indexOf(snackbarAlertMessage);
+        if (messageIndex !== -1) {
+          this.snackbarAlertMessages.splice(messageIndex, 1);
+        }
       }, duration);
     },
   },

--- a/app/javascript/v3/views/login/Index.vue
+++ b/app/javascript/v3/views/login/Index.vue
@@ -30,6 +30,7 @@ const ERROR_MESSAGES = {
 
 const IMPERSONATION_URL_SEARCH_KEY = 'impersonation';
 const USER_NOT_CONFIRMED_ERROR_CODE = 'user_not_confirmed';
+const AUTH_ERROR_TOAST_DURATION = 6000;
 
 export default {
   components: {
@@ -115,7 +116,7 @@ export default {
       const messageKey = ERROR_MESSAGES[this.authError] ?? 'LOGIN.API.UNAUTH';
       // Use a method to get the translated text to avoid dynamic key warning
       const translatedMessage = this.getTranslatedMessage(messageKey);
-      useAlert(translatedMessage);
+      useAlert(translatedMessage, { duration: AUTH_ERROR_TOAST_DURATION });
       // wait for idle state
       this.requestIdleCallbackPolyfill(() => {
         // Remove the error query param from the url


### PR DESCRIPTION
Improves the Google OAuth signup error shown when someone uses a personal email address. The message now explains that a work email is required and stays visible for six seconds.