### PR TITLE
fix: preserve spacing between automation conditions

### DIFF
--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -150,7 +150,7 @@ class AutomationRules::ConditionsFilterService < FilterService
       return assignee_presence_filter(table_name, query_hash)
     end
 
-    return tag_filter_query(query_hash, current_index) if attribute_key == 'labels'
+    return " #{tag_filter_query(query_hash, current_index)} " if attribute_key == 'labels'
 
     filter_operator_value = filter_operation(query_hash, current_index)
 


### PR DESCRIPTION
Automation rules containing consecutive label conditions, or an assignee condition followed by a label condition, can now execute regardless of condition order.

### What caused the failure

The automation condition filter builds a SQL expression by concatenating the fragment generated for each condition. Label conditions recently began using the shared `tag_filter_query` helper, whose fragments do not include surrounding whitespace.

When a label condition followed an assignee condition or another label condition, the concatenated SQL contained tokens such as `andEXISTS` or `andNOT EXISTS`. PostgreSQL rejected the query with a syntax error. The condition service rescued that error and returned `false`, so the automation silently appeared not to match. Some condition orders happened to produce valid SQL, which made reordering look like a workaround.

This change pads label fragments at the automation filter boundary so adjacent SQL tokens remain separated for every condition order.

### Closes

- [Support conversation 93445](https://app.chatwoot.com/app/accounts/1/conversations/93445)
- [Support conversation 93437](https://app.chatwoot.com/app/accounts/1/conversations/93437)

### How to reproduce

Create a message-created automation combining assignee presence and label conditions, then trigger it with the label condition in different positions. The automation should execute for every logically equivalent ordering.