### PR TITLE
fix: Instagram/Facebook: a failed attachment download silently discards the entire inbound message

### DIFF
--- a/app/builders/messages/messenger/message_builder.rb
+++ b/app/builders/messages/messenger/message_builder.rb
@@ -41,6 +41,13 @@ class Messages::Messenger::MessageBuilder
     # after_create_commit broadcast bails on `file.attached?`. Re-fire here
     # for audio so the bubble updates without waiting on transcription.
     attachment.message&.reload&.send_update_event if attachment.file_type.to_sym == :audio
+  rescue Down::Error => e
+    # Meta's CDN links expire and intermittently 404. Letting this raise unwinds the
+    # ActiveRecord transaction in Messages::Instagram::BaseMessageBuilder#perform, which
+    # discards the entire inbound message - along with the conversation and contact_inbox
+    # when it is that contact's first message. The attachment already stores external_url,
+    # so keep the message and lose only the stored copy of the file.
+    Rails.logger.warn "Failed to download attachment #{file_url}: #{e.message}"
   end
 
   def attachment_params(attachment)

--- a/app/builders/messages/messenger/message_builder.rb
+++ b/app/builders/messages/messenger/message_builder.rb
@@ -47,7 +47,8 @@ class Messages::Messenger::MessageBuilder
     # discards the entire inbound message - along with the conversation and contact_inbox
     # when it is that contact's first message. The attachment already stores external_url,
     # so keep the message and lose only the stored copy of the file.
-    Rails.logger.warn "Failed to download attachment #{file_url}: #{e.message}"
+    # file_url is a signed CDN link, so log the attachment instead of the URL.
+    Rails.logger.warn "Failed to download attachment #{attachment.id}: #{e.message}"
   end
 
   def attachment_params(attachment)
@@ -83,6 +84,7 @@ class Messages::Messenger::MessageBuilder
   def update_attachment_file_type(attachment)
     return if @message.reload.attachments.blank?
     return unless attachment.file_type == 'share' || attachment.file_type == 'story_mention'
+    return unless attachment.file.attached?
 
     attachment.file_type = file_type(attachment.file&.content_type)
     attachment.save!

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -342,6 +342,10 @@ const componentToRender = computed(() => {
     const fileType = props.attachments[0].fileType;
 
     if (fileType === ATTACHMENT_TYPES.FALLBACK) return FallbackBubble;
+    // `share` attachments have no dedicated chip (see AttachmentChips.vue) or bubble, so a
+    // failed-download share - kept as a message with only `external_url` - would otherwise
+    // render as a fully blank bubble. Fall back to the generic link card for it.
+    if (fileType === ATTACHMENT_TYPES.SHARE) return FallbackBubble;
 
     if (!props.content) {
       if (fileType === ATTACHMENT_TYPES.IMAGE) return ImageBubble;

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -58,6 +58,15 @@ class Attachment < ApplicationRecord
     file.attached? ? url_for(file) : ''
   end
 
+  # Falls back to the source CDN link when the blob failed to download and was never attached.
+  def link_url
+    file.attached? ? file_url : external_url
+  end
+
+  def link_title
+    file.attached? ? file.filename.to_s : external_url
+  end
+
   # NOTE: for External services use this methods since redirect doesn't work effectively in a lot of cases
   def download_url
     ActiveStorage::Current.url_options = Rails.application.routes.default_url_options if ActiveStorage::Current.url_options.blank?

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -105,6 +105,8 @@ class Attachment < ApplicationRecord
   end
 
   def audio_metadata
+    return { data_url: external_url, thumb_url: '' } unless file.attached?
+
     audio_file_data = base_data.merge(file_metadata)
     audio_file_data.merge(
       {

--- a/app/views/mailers/conversation_reply_mailer/conversation_transcript.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/conversation_transcript.html.erb
@@ -35,7 +35,7 @@
       <% if message.attachments.present? %>
         <p>Attachments:</p>
         <% message.attachments.each do |attachment| %>
-          <p><a href="<%= attachment.file_url %>" target="_blank"><%= attachment.file.filename.to_s %></a></p>
+          <p><a href="<%= attachment.link_url %>" target="_blank"><%= attachment.link_title %></a></p>
         <% end %>
       <% end %>
       <p style="font-size: 90%; font-size: 90%;color: #899096;margin-top: -8px; margin-bottom: 0px;">

--- a/app/views/mailers/conversation_reply_mailer/reply_with_summary.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/reply_with_summary.html.erb
@@ -23,7 +23,7 @@
           Attachments:
           <% message.attachments.each_with_index do |attachment, index| %>
             <% if index > 0 %><br /><% end %>
-            <a href="<%= attachment.file_url %>" target="_blank"><%= attachment.file.filename.to_s %></a>
+            <a href="<%= attachment.link_url %>" target="_blank"><%= attachment.link_title %></a>
           <% end %>
         </p>
       <% end %>

--- a/app/views/mailers/conversation_reply_mailer/reply_without_summary.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/reply_without_summary.html.erb
@@ -6,7 +6,7 @@
     <% if message.attachments.present? %>
       <p>Attachments:</p>
       <% message.attachments.each do |attachment| %>
-        <p><a href="<%= attachment.file_url %>" target="_blank"><%= attachment.file.filename.to_s %></a></p>
+        <p><a href="<%= attachment.link_url %>" target="_blank"><%= attachment.link_title %></a></p>
       <% end %>
     <% end %>
   </p>

--- a/enterprise/app/services/messages/audio_transcription_service.rb
+++ b/enterprise/app/services/messages/audio_transcription_service.rb
@@ -10,8 +10,9 @@ class Messages::AudioTranscriptionService
   def perform
     return { error: 'Message not found' } if message.blank?
     return { error: 'Transcription disabled for this inbox' } if call_recording_transcription_disabled?
+    return { error: 'Audio file not available' } unless attachment.file.attached?
     return { error: 'Transcription limit exceeded' } unless Llm::SpeechToTextService.available_for?(account)
-    return { error: 'Audio too large for transcription' } if Llm::SpeechToTextService.too_large?(attachment.file&.blob)
+    return { error: 'Audio too large for transcription' } if Llm::SpeechToTextService.too_large?(attachment.file.blob)
 
     transcriptions = transcribe_audio
     Rails.logger.info "Audio transcription successful: #{transcriptions}"

--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -68,12 +68,18 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
     [text, unattached_attachment_note].select(&:present?).join("\n")
   end
 
+  # file_type values that never carry a downloaded file by design - their data lives entirely
+  # in external_url/meta, so an attachment of one of these types is not a failed download.
+  NEVER_DOWNLOADED_FILE_TYPES = %w[location fallback contact embed].freeze
+
   # build_files_array skips attachments whose blob failed to download, so without this
   # note an attachment-only message (no text) ends up with blank message_content and is
   # never posted to Slack at all - the customer's message becomes invisible there.
+  # Deliberately broader than with_attached_file?: a share/story_mention/ig_* attachment can
+  # also fail its download and end up unattached, and still needs this fallback.
   def unattached_attachment_note
-    unattached = message.attachments.select do |attachment|
-      attachment.with_attached_file? && !attachment.file.attached? && attachment.external_url.present?
+    unattached = message.attachments.reject do |attachment|
+      attachment.file.attached? || attachment.external_url.blank? || NEVER_DOWNLOADED_FILE_TYPES.include?(attachment.file_type)
     end
     return if unattached.blank?
 

--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -63,12 +63,21 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
 
   def message_text
     content = message.processed_message_content || message.content
+    text = content.present? ? content.gsub(MENTION_REGEX, '\1') : content
 
-    if content.present?
-      content.gsub(MENTION_REGEX, '\1')
-    else
-      content
+    [text, unattached_attachment_note].select(&:present?).join("\n")
+  end
+
+  # build_files_array skips attachments whose blob failed to download, so without this
+  # note an attachment-only message (no text) ends up with blank message_content and is
+  # never posted to Slack at all - the customer's message becomes invisible there.
+  def unattached_attachment_note
+    unattached = message.attachments.select do |attachment|
+      attachment.with_attached_file? && !attachment.file.attached? && attachment.external_url.present?
     end
+    return if unattached.blank?
+
+    unattached.map { |attachment| "Attachment (could not be uploaded): #{attachment.external_url}" }.join("\n")
   end
 
   def formatted_inbox_name

--- a/lib/integrations/slack/send_on_slack_service.rb
+++ b/lib/integrations/slack/send_on_slack_service.rb
@@ -143,6 +143,7 @@ class Integrations::Slack::SendOnSlackService < Base::SendOnChannelService
   def build_files_array
     message.attachments.filter_map do |attachment|
       next unless attachment.with_attached_file?
+      next unless attachment.file.attached?
 
       build_file_payload(attachment)
     end

--- a/spec/builders/messages/instagram/message_builder_spec.rb
+++ b/spec/builders/messages/instagram/message_builder_spec.rb
@@ -155,6 +155,25 @@ describe Messages::Instagram::MessageBuilder do
       expect(message.attachments.count).to eq(0)
     end
 
+    it 'creates the message when the attachment download fails' do
+      messaging = dm_params[:entry][0]['messaging'][0]
+      messaging['message']['attachments'] = [{ 'type' => 'image', 'payload' => { 'url' => 'https://www.example.com/test.jpeg' } }]
+      create_instagram_contact_for_sender(messaging['sender']['id'], instagram_inbox)
+
+      stub_request(:get, 'https://www.example.com/test.jpeg').to_return(status: 404, body: '', headers: {})
+
+      described_class.new(messaging, instagram_inbox).perform
+
+      instagram_inbox.reload
+
+      expect(instagram_inbox.conversations.count).to be 1
+      expect(instagram_inbox.messages.count).to be 1
+
+      message = instagram_inbox.messages.first
+      expect(message.content).to eq('This is the first message from the customer')
+      expect(message.attachments.first.external_url).to eq('https://www.example.com/test.jpeg')
+    end
+
     it 'does not create message for unsupported file type' do
       messaging = story_mention_params[:entry][0][:messaging][0]
       contact = create_instagram_contact_for_sender(messaging['sender']['id'], instagram_inbox)

--- a/spec/enterprise/services/messages/audio_transcription_service_spec.rb
+++ b/spec/enterprise/services/messages/audio_transcription_service_spec.rb
@@ -4,7 +4,15 @@ RSpec.describe Messages::AudioTranscriptionService, type: :service do
   let(:account) { create(:account, audio_transcriptions: true) }
   let(:conversation) { create(:conversation, account: account) }
   let(:message) { create(:message, account: account, conversation: conversation) }
-  let(:attachment) { message.attachments.create!(account: account, file_type: :audio) }
+  let(:attachment) do
+    message.attachments.create!(account: account, file_type: :audio).tap do |a|
+      a.file.attach(
+        io: File.open(Rails.public_path.join('audio/widget/ding.mp3')),
+        filename: 'ding.mp3',
+        content_type: 'audio/mpeg'
+      )
+    end
+  end
 
   before do
     # Create required installation configs
@@ -91,6 +99,15 @@ RSpec.describe Messages::AudioTranscriptionService, type: :service do
       it 'returns existing transcription without calling API' do
         result = service.perform
         expect(result).to eq({ success: true, transcriptions: 'Existing transcription' })
+      end
+    end
+
+    context 'when the attachment has no blob because the download failed' do
+      let(:attachment) { message.attachments.create!(account: account, file_type: :audio, external_url: 'https://lookaside.fbsbx.com/example.mp3') }
+
+      it 'returns an error without transcribing' do
+        expect(service).not_to receive(:transcribe_audio)
+        expect(service.perform).to eq({ error: 'Audio file not available' })
       end
     end
 

--- a/spec/lib/integrations/slack/send_on_slack_service_spec.rb
+++ b/spec/lib/integrations/slack/send_on_slack_service_spec.rb
@@ -254,6 +254,26 @@ describe Integrations::Slack::SendOnSlackService do
         expect(message.external_source_id_slack).to eq 'cw-origin-6789.12345'
       end
 
+      it 'posts a link to the source file when an attachment-only message failed to download' do
+        message.update!(content: nil)
+        message.attachments.new(account_id: message.account_id, file_type: :image, external_url: 'https://lookaside.fbsbx.com/example.jpeg')
+
+        expect(slack_client).to receive(:chat_postMessage).with(
+          channel: hook.reference_id,
+          text: 'Attachment (could not be uploaded): https://lookaside.fbsbx.com/example.jpeg',
+          username: "#{message.sender.name} (Contact)",
+          thread_ts: conversation.identifier,
+          icon_url: anything,
+          unfurl_links: true
+        ).and_return(slack_message)
+
+        expect(slack_client).not_to receive(:files_upload_v2)
+
+        message.save!
+
+        builder.perform
+      end
+
       it 'will not call file_upload if attachment does not have a file (e.g facebook - fallback type)' do
         expect(slack_client).to receive(:chat_postMessage).with(
           channel: hook.reference_id,

--- a/spec/lib/integrations/slack/send_on_slack_service_spec.rb
+++ b/spec/lib/integrations/slack/send_on_slack_service_spec.rb
@@ -274,6 +274,24 @@ describe Integrations::Slack::SendOnSlackService do
         builder.perform
       end
 
+      it 'posts a link to the source file when a failed-download share attachment has no text' do
+        message.update!(content: nil)
+        message.attachments.new(account_id: message.account_id, file_type: :share, external_url: 'https://lookaside.fbsbx.com/share.jpeg')
+
+        expect(slack_client).to receive(:chat_postMessage).with(
+          channel: hook.reference_id,
+          text: 'Attachment (could not be uploaded): https://lookaside.fbsbx.com/share.jpeg',
+          username: "#{message.sender.name} (Contact)",
+          thread_ts: conversation.identifier,
+          icon_url: anything,
+          unfurl_links: true
+        ).and_return(slack_message)
+
+        message.save!
+
+        builder.perform
+      end
+
       it 'will not call file_upload if attachment does not have a file (e.g facebook - fallback type)' do
         expect(slack_client).to receive(:chat_postMessage).with(
           channel: hook.reference_id,

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -79,6 +79,13 @@ RSpec.describe ConversationReplyMailer do
         expect(cc_mail.cc.first).to eq(cc_message.content_attributes[:cc_emails])
         expect(cc_mail.bcc.first).to eq(cc_message.content_attributes[:bcc_emails])
       end
+
+      it 'links to the external url instead of raising when an attachment has no blob' do
+        message.attachments.create!(account: account, file_type: :image, external_url: 'https://lookaside.fbsbx.com/example.jpeg')
+
+        expect { mail }.not_to raise_error
+        expect(mail.body.decoded).to include('https://lookaside.fbsbx.com/example.jpeg')
+      end
     end
 
     context 'without assignee' do
@@ -890,6 +897,14 @@ RSpec.describe ConversationReplyMailer do
 
         expect(transcript.decoded).to include('Transcript Brand')
         expect(transcript.decoded).to include(message.content)
+      end
+
+      it 'links to the external url instead of raising when a transcript attachment has no blob' do
+        message.attachments.create!(account: new_account, file_type: :image, external_url: 'https://lookaside.fbsbx.com/example.jpeg')
+
+        transcript = nil
+        expect { transcript = described_class.conversation_transcript(conversation, 'customer@example.com').deliver_now }.not_to raise_error
+        expect(transcript.decoded).to include('https://lookaside.fbsbx.com/example.jpeg')
       end
     end
   end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -251,6 +251,20 @@ RSpec.describe Attachment do
     end
   end
 
+  describe 'push_event_data for audio attachments' do
+    it 'returns external_url as data_url when no file is attached' do
+      attachment = message.attachments.create!(
+        account_id: message.account_id,
+        file_type: :audio,
+        external_url: 'https://lookaside.fbsbx.com/ig_messaging_cdn/?asset_id=123'
+      )
+
+      event_data = attachment.push_event_data
+      expect(event_data[:data_url]).to eq('https://lookaside.fbsbx.com/ig_messaging_cdn/?asset_id=123')
+      expect(event_data[:thumb_url]).to eq('')
+    end
+  end
+
   describe 'push_event_data for embed attachments' do
     it 'returns external url as data_url' do
       attachment = message.attachments.create!(account_id: message.account_id, file_type: :embed, external_url: 'https://example.com/embed')

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe Attachment do
     end
 
     it 'falls back to the external url when no file is attached' do
-      attachment = message.attachments.new(account_id: message.account_id, file_type: :image,
-                                            external_url: 'https://lookaside.fbsbx.com/example.jpeg')
+      url = 'https://lookaside.fbsbx.com/example.jpeg'
+      attachment = message.attachments.new(account_id: message.account_id, file_type: :image, external_url: url)
 
-      expect(attachment.link_url).to eq('https://lookaside.fbsbx.com/example.jpeg')
-      expect(attachment.link_title).to eq('https://lookaside.fbsbx.com/example.jpeg')
+      expect(attachment.link_url).to eq(url)
+      expect(attachment.link_title).to eq(url)
     end
   end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -32,6 +32,24 @@ RSpec.describe Attachment do
     end
   end
 
+  describe 'link_url and link_title' do
+    it 'returns the file url and filename when a file is attached' do
+      attachment = message.attachments.create!(account_id: message.account_id, file_type: :image)
+      attachment.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
+
+      expect(attachment.link_url).to eq(attachment.file_url)
+      expect(attachment.link_title).to eq('avatar.png')
+    end
+
+    it 'falls back to the external url when no file is attached' do
+      attachment = message.attachments.new(account_id: message.account_id, file_type: :image,
+                                            external_url: 'https://lookaside.fbsbx.com/example.jpeg')
+
+      expect(attachment.link_url).to eq('https://lookaside.fbsbx.com/example.jpeg')
+      expect(attachment.link_title).to eq('https://lookaside.fbsbx.com/example.jpeg')
+    end
+  end
+
   describe 'with_attached_file?' do
     it 'returns true if its an attachment with file' do
       attachment = message.attachments.new(account_id: message.account_id, file_type: :image)


### PR DESCRIPTION
Inbound Instagram messages containing attachments are no longer lost when Meta's CDN fails to serve
the file. Previously a single failed image download discarded the whole message, and on a contact's
first message it discarded the conversation and contact too — leaving no trace in the inbox that the
customer had written at all.

## Closes

Closes #15664

## How to reproduce

1. Connect an Instagram channel and have a customer send a DM with one or more photos.
2. Make one of the `lookaside.fbsbx.com` attachment URLs return 404 (in production these signed URLs
   expire and intermittently 404 on their own).
3. Before this change: the webhook returns 200, `Webhooks::InstagramEventsJob` logs `ERROR ... 404
   Not Found` and then logs as performed, and nothing appears in the inbox.
4. After this change: the message appears with its text and the attachment's `external_url`, and the
   failed download is logged as a warning.

## What changed

`Messages::Messenger::MessageBuilder#attach_file` now rescues `Down::Error`, matching the guard that
`create_story_reply_attachment` already applies to the same call in the Instagram builder.

The download previously raised into the `ActiveRecord::Base.transaction` in
`Messages::Instagram::BaseMessageBuilder#perform`, whose `rescue StandardError` then swallowed it —
so the rollback took the message, its attachments and (via `build_conversation`) the conversation and
`contact_inbox`, with no retry and no dead letter.

Fixing it in the shared builder also covers `Channel::FacebookPage`, which inherits `attach_file` and
wraps `build_contact_inbox` in the same transaction.

Related to #15449 (same trigger, opposite symptom), which reports the same `Down::Error` trigger on Telegram/Twilio/Line where the
absence of a transaction leaves ghost conversations instead. Those channels each have their own
`attach_files`/`Down.download` and are not touched here.

The attachment keeps its `external_url`, so the media is still referenced from the message; only the
stored copy of the file is lost.
