### PR TITLE
feat(billing): cancel subscriptions at period end and show the cancellation date

### DIFF
--- a/app/helpers/billing_helper.rb
+++ b/app/helpers/billing_helper.rb
@@ -34,4 +34,12 @@ module BillingHelper
 
     Time.zone.at(period_end)
   end
+
+  # Stripe schedules cancellations on cancel_at; older subscriptions only set cancel_at_period_end.
+  def subscription_cancels_on(subscription)
+    cancel_at = subscription['cancel_at']
+    return Time.zone.at(cancel_at) if cancel_at.present?
+
+    subscription_ends_on(subscription) if subscription['cancel_at_period_end']
+  end
 end

--- a/app/helpers/billing_helper.rb
+++ b/app/helpers/billing_helper.rb
@@ -24,8 +24,9 @@ module BillingHelper
   end
 
   # current_period_end moved to the subscription item in newer Stripe API versions; read both.
+  # Stripe objects don't respond to dig, so the items path is walked with [].
   def subscription_period_end(subscription)
-    subscription['current_period_end'] || subscription['items']['data'].first&.[]('current_period_end')
+    subscription['current_period_end'] || subscription['items']&.[]('data')&.first&.[]('current_period_end')
   end
 
   def subscription_ends_on(subscription)

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -585,6 +585,7 @@
       "PLAN_NOTE": "You are currently subscribed to the **{plan}** plan with **{quantity}** licenses",
       "SEAT_COUNT": "Number of seats",
       "RENEWS_ON": "Renews on",
+      "CANCELS_ON": "Cancels on",
       "CURRENCY": "Currency"
     },
     "CURRENCY": {

--- a/app/javascript/dashboard/routes/dashboard/settings/billing/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/billing/Index.vue
@@ -82,6 +82,13 @@ const subscriptionRenewsOn = computed(() => {
   return format(endDate, 'dd MMM, yyyy');
 });
 
+// Set only while a cancellation is scheduled; the plan stays active until this date.
+const subscriptionCancelsOn = computed(() => {
+  if (!customAttributes.value.subscription_cancels_on) return '';
+  const cancelDate = new Date(customAttributes.value.subscription_cancels_on);
+  return format(cancelDate, 'dd MMM, yyyy');
+});
+
 /**
  * Computed property indicating if user has a billing plan
  * @returns {boolean}
@@ -235,7 +242,12 @@ onMounted(handleBillingPageLogic);
               :value="subscribedQuantity"
             />
             <DetailItem
-              v-if="subscriptionRenewsOn"
+              v-if="subscriptionCancelsOn"
+              :label="$t('BILLING_SETTINGS.CURRENT_PLAN.CANCELS_ON')"
+              :value="subscriptionCancelsOn"
+            />
+            <DetailItem
+              v-else-if="subscriptionRenewsOn"
               :label="$t('BILLING_SETTINGS.CURRENT_PLAN.RENEWS_ON')"
               :value="subscriptionRenewsOn"
             />

--- a/app/views/api/v1/models/_account.json.jbuilder
+++ b/app/views/api/v1/models/_account.json.jbuilder
@@ -6,6 +6,7 @@ if resource.custom_attributes.present?
     json.subscribed_quantity resource.custom_attributes['subscribed_quantity']
     json.subscription_status resource.custom_attributes['subscription_status']
     json.subscription_ends_on resource.custom_attributes['subscription_ends_on']
+    json.subscription_cancels_on resource.custom_attributes['subscription_cancels_on']
     json.billing_currency resource.billing_currency if resource.respond_to?(:billing_currency) && Enterprise::Billing::Currencies.enabled?
     json.website resource.custom_attributes['website'] if resource.custom_attributes['website'].present?
     json.industry resource.custom_attributes['industry'] if resource.custom_attributes['industry'].present?

--- a/enterprise/app/controllers/enterprise/api/v1/accounts_controller.rb
+++ b/enterprise/app/controllers/enterprise/api/v1/accounts_controller.rb
@@ -146,7 +146,7 @@ class Enterprise::Api::V1::AccountsController < Api::BaseController
     reason = 'manual_deletion'
 
     if @account.mark_for_deletion(reason)
-      cancel_cloud_subscriptions_for_deletion
+      Enterprise::CancelCloudSubscriptionsJob.perform_later(@account)
 
       render json: { message: 'Account marked for deletion' }, status: :ok
     else
@@ -169,12 +169,6 @@ class Enterprise::Api::V1::AccountsController < Api::BaseController
   def create_stripe_billing_session(customer_id)
     session = Enterprise::Billing::CreateSessionService.new.create_session(customer_id)
     render_redirect_url(session.url)
-  end
-
-  def cancel_cloud_subscriptions_for_deletion
-    Enterprise::Billing::CancelCloudSubscriptionsService.new(account: @account).perform
-  rescue Stripe::StripeError => e
-    Rails.logger.warn("Failed to cancel cloud subscriptions for account #{@account.id}: #{e.class} - #{e.message}")
   end
 
   def render_redirect_url(redirect_url)

--- a/enterprise/app/jobs/enterprise/cancel_cloud_subscriptions_job.rb
+++ b/enterprise/app/jobs/enterprise/cancel_cloud_subscriptions_job.rb
@@ -6,6 +6,9 @@ class Enterprise::CancelCloudSubscriptionsJob < ApplicationJob
   retry_on Stripe::StripeError, wait: :polynomially_longer, attempts: 10
 
   def perform(account)
+    # A retry can land after the admin cancelled the deletion; don't cancel a retained account's plan.
+    return if account.custom_attributes['marked_for_deletion_at'].blank?
+
     Enterprise::Billing::CancelCloudSubscriptionsService.new(account: account).perform
   end
 end

--- a/enterprise/app/jobs/enterprise/cancel_cloud_subscriptions_job.rb
+++ b/enterprise/app/jobs/enterprise/cancel_cloud_subscriptions_job.rb
@@ -1,0 +1,11 @@
+class Enterprise::CancelCloudSubscriptionsJob < ApplicationJob
+  queue_as :default
+
+  # The account is deleted 7 days after it is marked, so a Stripe outage has time to recover.
+  # Retries are safe: the service skips subscriptions that already have a cancellation scheduled.
+  retry_on Stripe::StripeError, wait: :polynomially_longer, attempts: 10
+
+  def perform(account)
+    Enterprise::Billing::CancelCloudSubscriptionsService.new(account: account).perform
+  end
+end

--- a/enterprise/app/services/enterprise/billing/cancel_cloud_subscriptions_service.rb
+++ b/enterprise/app/services/enterprise/billing/cancel_cloud_subscriptions_service.rb
@@ -1,4 +1,6 @@
 class Enterprise::Billing::CancelCloudSubscriptionsService
+  include BillingHelper
+
   pattr_initialize [:account!]
 
   def perform
@@ -6,9 +8,10 @@ class Enterprise::Billing::CancelCloudSubscriptionsService
     return unless ChatwootApp.chatwoot_cloud?
 
     subscriptions.each do |subscription|
-      next if subscription.cancel_at_period_end
+      next if subscription_cancels_on(subscription).present?
 
-      Stripe::Subscription.update(subscription.id, cancel_at_period_end: true)
+      # cancel_at_period_end is deprecated; an explicit timestamp works on every billing mode.
+      Stripe::Subscription.update(subscription.id, cancel_at: subscription_period_end(subscription))
     end
   end
 

--- a/enterprise/app/services/enterprise/billing/create_stripe_customer_service.rb
+++ b/enterprise/app/services/enterprise/billing/create_stripe_customer_service.rb
@@ -81,6 +81,7 @@ class Enterprise::Billing::CreateStripeCustomerService
       'subscribed_quantity' => subscription['quantity'],
       'subscription_status' => subscription['status'],
       'subscription_ends_on' => subscription_ends_on(subscription),
+      'subscription_cancels_on' => subscription_cancels_on(subscription),
       'billing_currency' => billing_currency_for(subscription)
     )
   end

--- a/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
+++ b/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
@@ -68,6 +68,7 @@ class Enterprise::Billing::HandleStripeEventService
         'subscribed_quantity' => subscription['quantity'],
         'subscription_status' => subscription['status'],
         'subscription_ends_on' => subscription_ends_on(subscription),
+        'subscription_cancels_on' => subscription_cancels_on(subscription),
         'billing_currency' => billing_currency_for(subscription, plan)
       )
     )

--- a/spec/enterprise/controllers/enterprise/api/v1/accounts_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/api/v1/accounts_controller_spec.rb
@@ -393,11 +393,7 @@ RSpec.describe 'Enterprise Billing APIs', type: :request do
           InstallationConfig.where(name: 'DEPLOYMENT_ENV').first_or_initialize.update!(value: 'cloud')
         end
 
-        it 'marks the account for deletion when action is delete' do
-          cancellation_service = instance_double(Enterprise::Billing::CancelCloudSubscriptionsService, perform: true)
-          allow(Enterprise::Billing::CancelCloudSubscriptionsService).to receive(:new).with(account: account)
-                                                                                      .and_return(cancellation_service)
-
+        it 'marks the account for deletion and queues the subscription cancellation' do
           post "/enterprise/api/v1/accounts/#{account.id}/toggle_deletion",
                headers: admin.create_new_auth_token,
                params: { action_type: 'delete' },
@@ -406,24 +402,7 @@ RSpec.describe 'Enterprise Billing APIs', type: :request do
           expect(response).to have_http_status(:ok)
           expect(account.reload.custom_attributes['marked_for_deletion_at']).to be_present
           expect(account.custom_attributes['marked_for_deletion_reason']).to eq('manual_deletion')
-          expect(Enterprise::Billing::CancelCloudSubscriptionsService).to have_received(:new).with(account: account)
-          expect(cancellation_service).to have_received(:perform)
-        end
-
-        it 'returns success even if stripe cancellation fails' do
-          cancellation_service = instance_double(Enterprise::Billing::CancelCloudSubscriptionsService)
-          allow(Enterprise::Billing::CancelCloudSubscriptionsService).to receive(:new).with(account: account)
-                                                                                      .and_return(cancellation_service)
-          allow(cancellation_service).to receive(:perform).and_raise(Stripe::APIError.new('stripe unavailable'))
-
-          post "/enterprise/api/v1/accounts/#{account.id}/toggle_deletion",
-               headers: admin.create_new_auth_token,
-               params: { action_type: 'delete' },
-               as: :json
-
-          expect(response).to have_http_status(:ok)
-          expect(account.reload.custom_attributes['marked_for_deletion_at']).to be_present
-          expect(account.custom_attributes['marked_for_deletion_reason']).to eq('manual_deletion')
+          expect(Enterprise::CancelCloudSubscriptionsJob).to have_been_enqueued.with(account)
         end
 
         it 'unmarks the account for deletion when action is undelete' do

--- a/spec/enterprise/jobs/enterprise/cancel_cloud_subscriptions_job_spec.rb
+++ b/spec/enterprise/jobs/enterprise/cancel_cloud_subscriptions_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Enterprise::CancelCloudSubscriptionsJob, type: :job do
   subject(:job) { described_class.perform_later(account) }
 
-  let(:account) { create(:account) }
+  let(:account) { create(:account, custom_attributes: { 'marked_for_deletion_at' => 7.days.from_now.iso8601 }) }
 
   it 'queues the job' do
     expect { job }.to have_enqueued_job(described_class).with(account).on_queue('default')
@@ -16,6 +16,15 @@ RSpec.describe Enterprise::CancelCloudSubscriptionsJob, type: :job do
     perform_enqueued_jobs { job }
 
     expect(cancellation_service).to have_received(:perform)
+  end
+
+  it 'does nothing when the deletion was cancelled before the job ran' do
+    account.update!(custom_attributes: {})
+    allow(Enterprise::Billing::CancelCloudSubscriptionsService).to receive(:new)
+
+    perform_enqueued_jobs { job }
+
+    expect(Enterprise::Billing::CancelCloudSubscriptionsService).not_to have_received(:new)
   end
 
   it 'retries when Stripe is unavailable so the cancellation is not lost' do

--- a/spec/enterprise/jobs/enterprise/cancel_cloud_subscriptions_job_spec.rb
+++ b/spec/enterprise/jobs/enterprise/cancel_cloud_subscriptions_job_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Enterprise::CancelCloudSubscriptionsJob, type: :job do
+  subject(:job) { described_class.perform_later(account) }
+
+  let(:account) { create(:account) }
+
+  it 'queues the job' do
+    expect { job }.to have_enqueued_job(described_class).with(account).on_queue('default')
+  end
+
+  it 'executes perform' do
+    cancellation_service = instance_double(Enterprise::Billing::CancelCloudSubscriptionsService, perform: true)
+    allow(Enterprise::Billing::CancelCloudSubscriptionsService).to receive(:new).with(account: account).and_return(cancellation_service)
+
+    perform_enqueued_jobs { job }
+
+    expect(cancellation_service).to have_received(:perform)
+  end
+
+  it 'retries when Stripe is unavailable so the cancellation is not lost' do
+    allow(Enterprise::Billing::CancelCloudSubscriptionsService).to receive(:new).and_raise(Stripe::APIError.new('stripe unavailable'))
+    account
+
+    expect { described_class.perform_now(account) }.to change(enqueued_jobs, :size).by(1)
+  end
+end

--- a/spec/enterprise/services/enterprise/billing/cancel_cloud_subscriptions_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/cancel_cloud_subscriptions_service_spec.rb
@@ -32,11 +32,15 @@ RSpec.describe Enterprise::Billing::CancelCloudSubscriptionsService do
     end
 
     context 'when account is cloud with active subscriptions' do
-      let(:subscription_response) { Struct.new(:data).new([sub_1, sub_2]) }
-      let(:sub_1) { instance_double(Stripe::Subscription, id: 'sub_1', cancel_at_period_end: false) }
-      let(:sub_2) { instance_double(Stripe::Subscription, id: 'sub_2', cancel_at_period_end: true) }
+      let(:period_end) { 1_790_845_600 }
+      let(:base) { { cancel_at: nil, cancel_at_period_end: false, items: { data: [{ current_period_end: period_end }] } } }
+      let(:subscription_response) { Struct.new(:data).new([sub_1, sub_2, sub_3]) }
+      let(:sub_1) { Stripe::Subscription.construct_from(base.merge(id: 'sub_1')) }
+      # Flexible billing schedules the cancellation on cancel_at, classic billing on cancel_at_period_end.
+      let(:sub_2) { Stripe::Subscription.construct_from(base.merge(id: 'sub_2', cancel_at: period_end)) }
+      let(:sub_3) { Stripe::Subscription.construct_from(base.merge(id: 'sub_3', cancel_at_period_end: true)) }
 
-      it 'marks only active subscriptions that are not yet set to cancel at period end' do
+      it 'schedules cancellation at the period end, skipping the ones already cancelling' do
         allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
         allow(Stripe::Subscription).to receive(:list).and_return(subscription_response)
         allow(Stripe::Subscription).to receive(:update)
@@ -44,7 +48,8 @@ RSpec.describe Enterprise::Billing::CancelCloudSubscriptionsService do
         service.perform
 
         expect(Stripe::Subscription).to have_received(:list).with(customer: 'cus_123', status: 'active', limit: 100)
-        expect(Stripe::Subscription).to have_received(:update).with('sub_1', cancel_at_period_end: true).once
+        expect(Stripe::Subscription).to have_received(:update).with('sub_1', cancel_at: period_end).once
+        expect(Stripe::Subscription).to have_received(:update).once
       end
     end
   end

--- a/spec/enterprise/services/enterprise/billing/create_stripe_customer_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/create_stripe_customer_service_spec.rb
@@ -83,6 +83,7 @@ describe Enterprise::Billing::CreateStripeCustomerService do
           plan_name: 'A Plan Name',
           subscription_status: 'active',
           subscription_ends_on: subscription_ends_on,
+          subscription_cancels_on: nil,
           billing_currency: 'usd'
         }.with_indifferent_access
       )
@@ -112,6 +113,7 @@ describe Enterprise::Billing::CreateStripeCustomerService do
           plan_name: 'A Plan Name',
           subscription_status: 'active',
           subscription_ends_on: subscription_ends_on,
+          subscription_cancels_on: nil,
           billing_currency: 'usd'
         }.with_indifferent_access
       )

--- a/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_cancellation_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_cancellation_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+describe Enterprise::Billing::HandleStripeEventService do
+  let(:period_end) { 1_790_845_600 }
+  let(:cancels_on) { Time.zone.at(period_end).as_json }
+  # Shape Stripe sends for a portal cancellation: the schedule lands on cancel_at, cancel_at_period_end stays false.
+  let(:cancelling_subscription) do
+    {
+      customer: 'cus_123',
+      status: 'active',
+      quantity: 4,
+      current_period_end: period_end,
+      cancel_at: period_end,
+      cancel_at_period_end: false,
+      plan: { id: 'price_enterprise', product: 'prod_enterprise' }
+    }
+  end
+  let!(:account) do
+    create(:account,
+           custom_attributes: { 'stripe_customer_id' => 'cus_123', 'plan_name' => 'Enterprise' },
+           limits: { 'captain_responses' => 800 })
+  end
+
+  def handle(overrides = {}, previous: {}, type: 'customer.subscription.updated')
+    event = Stripe::Event.construct_from(
+      type: type,
+      data: { object: cancelling_subscription.merge(overrides), previous_attributes: previous }
+    )
+    described_class.new.perform(event: event)
+    account.reload
+  end
+
+  before do
+    allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
+    create(:installation_config, name: 'CHATWOOT_CLOUD_PLANS', value: [
+             { 'name' => 'Hacker', 'product_id' => ['prod_hacker'], 'price_ids' => ['price_hacker'] },
+             { 'name' => 'Enterprise', 'product_id' => ['prod_enterprise'], 'price_ids' => ['price_enterprise'] }
+           ])
+    create(:installation_config, name: 'CAPTAIN_CLOUD_PLAN_LIMITS',
+                                 value: { 'hacker' => { 'responses' => 0 }, 'enterprise' => { 'responses' => 800 } })
+  end
+
+  it 'stores the cancellation date and keeps the plan active until then' do
+    handle
+
+    expect(account.custom_attributes).to include(
+      'subscription_cancels_on' => cancels_on,
+      'subscription_ends_on' => cancels_on,
+      'subscription_status' => 'active',
+      'plan_name' => 'Enterprise'
+    )
+    expect(account.limits['captain_responses']).to eq(800)
+  end
+
+  it 'falls back to the period end for classic billing, which only sets cancel_at_period_end' do
+    handle({ cancel_at: nil, cancel_at_period_end: true })
+
+    expect(account.custom_attributes['subscription_cancels_on']).to eq(cancels_on)
+  end
+
+  it 'clears the cancellation date when the customer resumes the subscription' do
+    handle
+    handle({ cancel_at: nil }, previous: { cancel_at: period_end })
+
+    expect(account.custom_attributes['subscription_cancels_on']).to be_nil
+  end
+
+  it 'clears the cancellation date when a seat change resumes the subscription' do
+    handle
+    handle({ cancel_at: nil, quantity: 5 }, previous: { cancel_at: period_end, quantity: 4 })
+
+    expect(account.custom_attributes).to include('subscription_cancels_on' => nil, 'subscribed_quantity' => 5)
+    expect(account.limits['captain_responses']).to eq(800)
+  end
+
+  it 'clears the cancellation date when the subscription is finally deleted' do
+    handle
+    free_plan = { plan: { id: 'price_hacker', product: 'prod_hacker' }, quantity: 2, status: 'active',
+                  current_period_end: period_end }.with_indifferent_access
+    allow(Stripe::Subscription).to receive_messages(list: Struct.new(:data).new([]), create: free_plan)
+
+    handle({ status: 'canceled' }, type: 'customer.subscription.deleted')
+
+    expect(account.custom_attributes).to include('plan_name' => 'Hacker', 'subscription_cancels_on' => nil)
+  end
+end

--- a/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
@@ -37,6 +37,8 @@ describe Enterprise::Billing::HandleStripeEventService do
     allow(subscription).to receive(:[]).with('quantity').and_return('10')
     allow(subscription).to receive(:[]).with('status').and_return('active')
     allow(subscription).to receive(:[]).with('current_period_end').and_return(1_686_567_520)
+    allow(subscription).to receive(:[]).with('cancel_at').and_return(nil)
+    allow(subscription).to receive(:[]).with('cancel_at_period_end').and_return(false)
     allow(subscription).to receive(:customer).and_return('cus_123')
     allow(event).to receive(:created).and_return(account.created_at.to_i + 1.day.to_i)
     allow(event).to receive(:type).and_return('customer.subscription.updated')

--- a/spec/helpers/billing_helper_spec.rb
+++ b/spec/helpers/billing_helper_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe BillingHelper do
       expect(helper.send(:non_web_inboxes, account)).to eq(1)
     end
 
+    it 'reads the period end from the subscription or its items, and tolerates neither being set' do
+      expect(helper.send(:subscription_period_end, { 'current_period_end' => 1_790_845_600 })).to eq(1_790_845_600)
+      expect(helper.send(:subscription_period_end, { 'items' => { 'data' => [{ 'current_period_end' => 1_790_845_600 }] } })).to eq(1_790_845_600)
+      expect(helper.send(:subscription_period_end, { 'cancel_at_period_end' => true })).to be_nil
+    end
+
     it 'returns true for the default plan name' do
       expect(helper.send(:default_plan?, account)).to be(true)
       account.custom_attributes['plan_name'] = 'Startups'


### PR DESCRIPTION
The billing page now shows when a subscription is set to end. After a customer cancels from the Stripe portal, the plan card shows "Cancels on <date>" instead of "Renews on", and goes back to "Renews on" if they resume.

## Closes

- [CW-8034](https://linear.app/chatwoot/issue/CW-8034/mark-the-subscription-as-cancelled-at-the-end-of-the-period)

## How to test

1. On a cloud account with a paid plan, cancel the subscription from the billing portal.
2. Settings → Billing shows "Cancels on <date>", and the plan stays active until that date.
3. Resume the subscription, or change the seat count, in the portal — the card goes back to "Renews on".

## What changed

- `subscription_cancels_on` is read from Stripe's `cancel_at` (falling back to the period end for older subscriptions that only set `cancel_at_period_end`), stored on the account and exposed in the account payload.
- Account deletion now schedules the cancellation with an explicit `cancel_at` timestamp. `cancel_at_period_end` is deprecated and is not used by Stripe's flexible billing mode, where it stays `false` even while a cancellation is scheduled.
