### PR TITLE
feat(line): allow a Flex container to be passed through untouched

### DIFF
--- a/app/services/line/send_on_line_service.rb
+++ b/app/services/line/send_on_line_service.rb
@@ -22,7 +22,9 @@ class Line::SendOnLineService < Base::SendOnChannelService
   end
 
   def build_payload
-    if message.content_type == 'input_select' && message.content_attributes['items'].any?
+    if flex_container.present?
+      build_flex_payload
+    elsif message.content_type == 'input_select' && message.content_attributes['items'].any?
       build_input_select_payload
     else
       build_text_payload
@@ -62,6 +64,33 @@ class Line::SendOnLineService < Base::SendOnChannelService
     {
       type: 'text',
       text: message.outgoing_content
+    }
+  end
+
+  # A caller (an agent bot, an automation, an integration) may supply a complete
+  # LINE Flex container in `content_attributes['line_flex']`, which is sent
+  # through untouched. The generated input_select bubble below cannot express a
+  # hero image, a URI action, or a carousel, so anything richer than a list of
+  # reply buttons is currently unreachable from Chatwoot.
+  #
+  # Only a bubble or carousel is accepted; anything else falls back to the
+  # existing behaviour rather than sending LINE a payload it will reject.
+  # https://developers.line.biz/en/reference/messaging-api/#flex-message
+  def flex_container
+    container = message.content_attributes['line_flex']
+    return unless container.is_a?(Hash)
+    return unless %w[bubble carousel].include?(container['type'] || container[:type])
+
+    container
+  end
+
+  # altText is what LINE shows in the notification and on clients that cannot
+  # render Flex, so it must never be blank. LINE caps it at 400 characters.
+  def build_flex_payload
+    {
+      type: 'flex',
+      altText: (message.outgoing_content.presence || 'Message')[0, 400],
+      contents: flex_container
     }
   end
 

--- a/spec/services/line/send_on_line_service_spec.rb
+++ b/spec/services/line/send_on_line_service_spec.rb
@@ -212,6 +212,7 @@ describe Line::SendOnLineService do
         described_class.new(message: message).perform
       end
     end
+
     context 'when the message carries a LINE Flex container' do
       let(:bubble) do
         {
@@ -250,18 +251,18 @@ describe Line::SendOnLineService do
 
       it 'truncates altText to the 400 characters LINE allows' do
         flex_message.update!(content: 'a' * 500)
-        expect(line_client).to receive(:push_message) do |_to, payload|
-          expect(payload[:altText].length).to eq(400)
-        end
+        sent = nil
+        allow(line_client).to receive(:push_message) { |_to, payload| sent = payload and nil }
         described_class.new(message: flex_message).perform
+        expect(sent[:altText].length).to eq(400)
       end
 
       it 'never sends a blank altText' do
         flex_message.update!(content: '')
-        expect(line_client).to receive(:push_message) do |_to, payload|
-          expect(payload[:altText]).to be_present
-        end
+        sent = nil
+        allow(line_client).to receive(:push_message) { |_to, payload| sent = payload and nil }
         described_class.new(message: flex_message).perform
+        expect(sent[:altText]).to be_present
       end
 
       it 'accepts a carousel as well as a bubble' do
@@ -305,6 +306,5 @@ describe Line::SendOnLineService do
         described_class.new(message: message).perform
       end
     end
-
   end
 end

--- a/spec/services/line/send_on_line_service_spec.rb
+++ b/spec/services/line/send_on_line_service_spec.rb
@@ -212,5 +212,99 @@ describe Line::SendOnLineService do
         described_class.new(message: message).perform
       end
     end
+    context 'when the message carries a LINE Flex container' do
+      let(:bubble) do
+        {
+          'type' => 'bubble',
+          'hero' => { 'type' => 'image', 'url' => 'https://example.com/hero.jpg' },
+          'footer' => {
+            'type' => 'box', 'layout' => 'vertical',
+            'contents' => [
+              { 'type' => 'button', 'style' => 'primary',
+                'action' => { 'type' => 'uri', 'label' => 'Open', 'uri' => 'https://example.com/form' } }
+            ]
+          }
+        }
+      end
+      let(:flex_message) do
+        create(:message, message_type: :outgoing, content: 'Report a problem',
+                         content_attributes: { 'line_flex' => bubble },
+                         conversation: create(:conversation, inbox: line_channel.inbox))
+      end
+
+      before { allow(line_client).to receive(:push_message) }
+
+      it 'sends it through untouched' do
+        expect(line_client).to receive(:push_message).with(
+          anything, hash_including(type: 'flex', contents: bubble)
+        )
+        described_class.new(message: flex_message).perform
+      end
+
+      it 'uses the message content as altText' do
+        expect(line_client).to receive(:push_message).with(
+          anything, hash_including(altText: 'Report a problem')
+        )
+        described_class.new(message: flex_message).perform
+      end
+
+      it 'truncates altText to the 400 characters LINE allows' do
+        flex_message.update!(content: 'a' * 500)
+        expect(line_client).to receive(:push_message) do |_to, payload|
+          expect(payload[:altText].length).to eq(400)
+        end
+        described_class.new(message: flex_message).perform
+      end
+
+      it 'never sends a blank altText' do
+        flex_message.update!(content: '')
+        expect(line_client).to receive(:push_message) do |_to, payload|
+          expect(payload[:altText]).to be_present
+        end
+        described_class.new(message: flex_message).perform
+      end
+
+      it 'accepts a carousel as well as a bubble' do
+        flex_message.update!(content_attributes: { 'line_flex' => { 'type' => 'carousel', 'contents' => [bubble] } })
+        expect(line_client).to receive(:push_message).with(
+          anything, hash_including(type: 'flex')
+        )
+        described_class.new(message: flex_message).perform
+      end
+    end
+
+    context 'when line_flex is present but not a usable container' do
+      before { allow(line_client).to receive(:push_message) }
+
+      # Falling back keeps a malformed attribute from turning every reply into a
+      # LINE 400. The text the agent wrote still reaches the customer.
+      it 'falls back to text when the type is not bubble or carousel' do
+        bad = create(:message, message_type: :outgoing, content: 'plain text',
+                               content_attributes: { 'line_flex' => { 'type' => 'box' } },
+                               conversation: create(:conversation, inbox: line_channel.inbox))
+        expect(line_client).to receive(:push_message).with(anything, hash_including(type: 'text'))
+        described_class.new(message: bad).perform
+      end
+
+      it 'falls back to text when it is not a hash' do
+        bad = create(:message, message_type: :outgoing, content: 'plain text',
+                               content_attributes: { 'line_flex' => 'bubble' },
+                               conversation: create(:conversation, inbox: line_channel.inbox))
+        expect(line_client).to receive(:push_message).with(anything, hash_including(type: 'text'))
+        described_class.new(message: bad).perform
+      end
+    end
+
+    context 'when no Flex container is supplied' do
+      before { allow(line_client).to receive(:push_message) }
+
+      # Guards the existing behaviour: every message that worked before must
+      # still take the same path.
+      it 'still sends a plain text message' do
+        expect(line_client).to receive(:push_message).with(anything, hash_including(type: 'text'))
+        described_class.new(message: message).perform
+      end
+    end
+
   end
 end


### PR DESCRIPTION
## What

Lets a caller supply a complete LINE Flex container in `content_attributes['line_flex']`, which `Line::SendOnLineService` sends through as-is.

## Why

Today the LINE channel can send three things:

- text
- image/video attachments (other file types are skipped)
- for `input_select`, a bubble Chatwoot builds itself

That generated bubble is a vertical box of buttons whose action is `type: 'message'` — it can only send text back. So the useful half of Flex is unreachable from Chatwoot: a hero image, a `type: 'uri'` button that opens a link or a LIFF app, a carousel.

An integration that needs one of those has to bypass Chatwoot and call the LINE Push API directly. The message then never appears in the conversation, and the agent who picks the conversation up cannot see what the customer was already sent — which is the part that hurts.

## How

```ruby
message.content_attributes['line_flex'] = {
  'type' => 'bubble',
  'hero' => { 'type' => 'image', 'url' => 'https://…/hero.jpg' },
  'footer' => { 'type' => 'box', 'layout' => 'vertical', 'contents' => [
    { 'type' => 'button', 'style' => 'primary',
      'action' => { 'type' => 'uri', 'label' => 'Open', 'uri' => 'https://…' } }
  ] }
}
```

No migration, no new `content_type`, and no change to any existing path — text, attachments and `input_select` behave exactly as before.

Deliberately conservative:

- only a `bubble` or `carousel` is accepted; anything else falls back to existing behaviour rather than handing LINE a payload it rejects with a 400 and marking the agent's reply `failed`
- `altText` comes from the message content, truncated to LINE's 400-character limit, and is never blank — it is what LINE shows in the push notification and on clients that cannot render Flex

## Tests

`spec/services/line/send_on_line_service_spec.rb` covers the passthrough, altText from content, truncation at 400, the never-blank case, a carousel, both malformed shapes falling back to text, and a control asserting an ordinary message still sends as text.

## Note for maintainers

#14044 also touches `build_payload` in this file. The two changes are independent — that PR does not add Flex passthrough — but they will conflict textually. Happy to rebase whichever lands second.