### PR TITLE
fix: send Captain resolution message from resolve tool

### DIFF
--- a/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
+++ b/enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb
@@ -71,13 +71,13 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
     false
   end
 
-  def resolve_time_based_conversation(conversation, inbox)
+  def resolve_time_based_conversation(conversation, _inbox)
     resolved = false
     conversation.with_lock do
       conversation.reload
       next unless conversation.pending? && inactive_for_initial_action?(conversation)
 
-      create_resolution_message(conversation, inbox)
+      create_resolution_message(conversation)
       conversation.resolved!
       resolved = true
     end
@@ -93,12 +93,12 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
     nil
   end
 
-  def resolve_conversation(conversation, inbox, reason)
+  def resolve_conversation(conversation, _inbox, reason)
     resolved = with_inference_activity_context(conversation, CAPTAIN_INFERENCE_RESOLVE_ACTIVITY_REASON) do
       perform_locked_transition(conversation) do
         conversation.resolved!
         create_private_note(conversation, "Auto-resolved: #{reason}")
-        create_resolution_message(conversation, inbox)
+        create_resolution_message(conversation)
       end
     end
     record_inference_resolution(conversation) if resolved
@@ -167,19 +167,11 @@ class Captain::InboxPendingConversationsResolutionJob < ApplicationJob
     )
   end
 
-  def create_resolution_message(conversation, inbox)
-    return unless captain_assistant.send_inactivity_resolution_message?
-
-    I18n.with_locale(inbox.account.locale) do
-      resolution_message = captain_assistant.config['resolution_message']
-      conversation.messages.create!(
-        message_type: :outgoing,
-        account_id: conversation.account_id,
-        inbox_id: conversation.inbox_id,
-        content: resolution_message.presence || I18n.t('conversations.activity.auto_resolution_message'),
-        sender: captain_assistant
-      )
-    end
+  def create_resolution_message(conversation)
+    Captain::Conversation::ResolutionMessageService.new(
+      conversation: conversation,
+      assistant: captain_assistant
+    ).perform(use_default_message: true)
   end
 
   def create_handoff_message(conversation)

--- a/enterprise/app/services/captain/conversation/resolution_message_service.rb
+++ b/enterprise/app/services/captain/conversation/resolution_message_service.rb
@@ -1,0 +1,21 @@
+class Captain::Conversation::ResolutionMessageService
+  pattr_initialize [:conversation!, :assistant!]
+
+  def perform(use_default_message: false)
+    return unless assistant.send_inactivity_resolution_message?
+
+    I18n.with_locale(conversation.account.locale) do
+      resolution_message = assistant.config['resolution_message'].presence
+      resolution_message ||= I18n.t('conversations.activity.auto_resolution_message') if use_default_message
+      return if resolution_message.blank?
+
+      conversation.messages.create!(
+        message_type: :outgoing,
+        account_id: conversation.account_id,
+        inbox_id: conversation.inbox_id,
+        content: resolution_message,
+        sender: assistant
+      )
+    end
+  end
+end

--- a/enterprise/lib/captain/tools/resolve_conversation_tool.rb
+++ b/enterprise/lib/captain/tools/resolve_conversation_tool.rb
@@ -10,6 +10,7 @@ class Captain::Tools::ResolveConversationTool < Captain::Tools::BasePublicTool
 
     log_tool_usage('resolve_conversation', { conversation_id: conversation.id, reason: reason })
 
+    Captain::Conversation::ResolutionMessageService.new(conversation: conversation, assistant: @assistant).perform
     conversation.with_captain_activity_context(reason: reason, reason_type: :tool) { conversation.resolved! }
     Captain::ConversationEvents.resolved(conversation: conversation, assistant: @assistant,
                                          source: Captain::ConversationEvents::Sources::TOOL, at: Time.current)

--- a/enterprise/lib/captain/tools/resolve_conversation_tool.rb
+++ b/enterprise/lib/captain/tools/resolve_conversation_tool.rb
@@ -10,8 +10,12 @@ class Captain::Tools::ResolveConversationTool < Captain::Tools::BasePublicTool
 
     log_tool_usage('resolve_conversation', { conversation_id: conversation.id, reason: reason })
 
-    Captain::Conversation::ResolutionMessageService.new(conversation: conversation, assistant: @assistant).perform
-    conversation.with_captain_activity_context(reason: reason, reason_type: :tool) { conversation.resolved! }
+    conversation.with_captain_activity_context(reason: reason, reason_type: :tool) do
+      Conversation.transaction do
+        Captain::Conversation::ResolutionMessageService.new(conversation: conversation, assistant: @assistant).perform
+        conversation.resolved!
+      end
+    end
     Captain::ConversationEvents.resolved(conversation: conversation, assistant: @assistant,
                                          source: Captain::ConversationEvents::Sources::TOOL, at: Time.current)
 

--- a/spec/enterprise/lib/captain/tools/resolve_conversation_tool_spec.rb
+++ b/spec/enterprise/lib/captain/tools/resolve_conversation_tool_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Captain::Tools::ResolveConversationTool do
   end
 
   describe 'resolving a conversation' do
+    before { account.enable_features('captain_integration_v2') }
+
     it 'marks resolved and enqueues an activity message with the reason' do
       tool.perform(tool_context, reason: 'Possible spam')
 
@@ -27,6 +29,25 @@ RSpec.describe Captain::Tools::ResolveConversationTool do
           content: I18n.t('conversations.activity.captain.resolved_by_tool', user_name: assistant.name, reason: 'Possible spam')
         )
       )
+    end
+
+    it 'creates the configured resolution message' do
+      assistant.update!(config: assistant.config.merge('resolution_message' => 'Thanks for contacting us.'))
+
+      tool.perform(tool_context, reason: 'Issue resolved')
+
+      resolution_message = conversation.messages.outgoing.where(private: false).last
+      expect(resolution_message).to have_attributes(content: 'Thanks for contacting us.', sender: assistant)
+    end
+
+    it 'resolves without a message when resolution messages are disabled' do
+      assistant.update!(send_inactivity_resolution_message: false)
+
+      expect do
+        tool.perform(tool_context, reason: 'Issue resolved')
+      end.not_to(change { conversation.messages.outgoing.where(private: false).count })
+
+      expect(conversation.reload).to be_resolved
     end
 
     it 'emits a captain resolution event with the tool source' do

--- a/spec/enterprise/lib/captain/tools/resolve_conversation_tool_spec.rb
+++ b/spec/enterprise/lib/captain/tools/resolve_conversation_tool_spec.rb
@@ -40,6 +40,19 @@ RSpec.describe Captain::Tools::ResolveConversationTool do
       expect(resolution_message).to have_attributes(content: 'Thanks for contacting us.', sender: assistant)
     end
 
+    it 'rolls back the resolution message when resolving fails' do
+      assistant.update!(config: assistant.config.merge('resolution_message' => 'Thanks for contacting us.'))
+      allow(tool).to receive(:find_conversation).and_return(conversation)
+      allow(conversation).to receive(:resolved!).and_raise(ActiveRecord::RecordInvalid.new(conversation))
+
+      expect do
+        tool.perform(tool_context, reason: 'Issue resolved')
+      end.to raise_error(ActiveRecord::RecordInvalid)
+        .and(not_change { conversation.messages.outgoing.where(private: false).count })
+
+      expect(conversation.reload).to be_open
+    end
+
     it 'resolves without a message when resolution messages are disabled' do
       assistant.update!(send_inactivity_resolution_message: false)
 

--- a/spec/enterprise/services/captain/conversation/resolution_message_service_spec.rb
+++ b/spec/enterprise/services/captain/conversation/resolution_message_service_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Captain::Conversation::ResolutionMessageService do
+  let(:account) { create(:account) }
+  let(:assistant) { create(:captain_assistant, account: account, config: assistant_config) }
+  let(:inbox) { create(:inbox, account: account) }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox) }
+  let(:assistant_config) { { 'resolution_message' => 'Thanks for contacting us.' } }
+
+  before { account.enable_features('captain_integration_v2') }
+
+  it 'creates the configured public resolution message' do
+    message = described_class.new(conversation: conversation, assistant: assistant).perform
+
+    expect(message).to have_attributes(
+      content: 'Thanks for contacting us.',
+      message_type: 'outgoing',
+      private: false,
+      sender: assistant
+    )
+  end
+
+  it 'uses the default resolution message when no custom message is configured' do
+    assistant.update!(config: assistant.config.except('resolution_message'))
+
+    message = described_class.new(conversation: conversation, assistant: assistant).perform(use_default_message: true)
+
+    expect(message.content).to eq(I18n.t('conversations.activity.auto_resolution_message'))
+  end
+
+  it 'does not use the inactivity message outside an inactivity resolution' do
+    assistant.update!(config: assistant.config.except('resolution_message'))
+
+    expect do
+      described_class.new(conversation: conversation, assistant: assistant).perform
+    end.not_to change(conversation.messages, :count)
+  end
+
+  it 'does not create a message when resolution messages are disabled' do
+    assistant.update!(send_inactivity_resolution_message: false)
+
+    expect do
+      described_class.new(conversation: conversation, assistant: assistant).perform
+    end.not_to change(conversation.messages, :count)
+  end
+end


### PR DESCRIPTION
## Description

When Captain used the resolve conversation tool, it resolved the conversation without sending the Assistant's configured resolution message.

This change moves resolution message creation into a shared service and calls it from both Captain resolution paths. The tool sends the configured message before resolving the conversation. The inactivity job keeps its existing translated fallback when no custom message is configured.

Human initiated resolution is unchanged.

Fixes [AI-206](https://linear.app/chatwoot/issue/AI-206/resolution-tool-doesnt-not-trigger-the-resolution-message)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `bundle exec rspec spec/enterprise/services/captain/conversation/resolution_message_service_spec.rb spec/enterprise/lib/captain/tools/resolve_conversation_tool_spec.rb spec/enterprise/jobs/captain/inbox_pending_conversations_resolution_job_spec.rb`
- 51 examples, 0 failures
- `bundle exec rubocop enterprise/app/services/captain/conversation/resolution_message_service.rb enterprise/app/jobs/captain/inbox_pending_conversations_resolution_job.rb enterprise/lib/captain/tools/resolve_conversation_tool.rb spec/enterprise/services/captain/conversation/resolution_message_service_spec.rb spec/enterprise/lib/captain/tools/resolve_conversation_tool_spec.rb`
- 5 files inspected, no offenses detected

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing relevant unit tests pass locally with my changes
