### PR TITLE
feat(contacts): show whatsapp usernames in social links

### DIFF
--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
@@ -48,6 +48,7 @@ const SOCIAL_CONFIG = {
   LINKEDIN: 'i-ri-linkedin-box-fill',
   FACEBOOK: 'i-ri-facebook-circle-fill',
   INSTAGRAM: 'i-ri-instagram-line',
+  WHATSAPP: 'i-ri-whatsapp-line',
   TELEGRAM: 'i-ri-telegram-fill',
   TIKTOK: 'i-ri-tiktok-fill',
   TWITTER: 'i-ri-twitter-x-fill',
@@ -76,6 +77,7 @@ const defaultState = {
       tiktok: '',
       linkedin: '',
       twitter: '',
+      whatsapp: '',
     },
   },
 };
@@ -90,6 +92,7 @@ const validationRules = {
 const v$ = useVuelidate(validationRules, state);
 
 const isFormInvalid = computed(() => v$.value.$invalid);
+const normalizeWhatsAppUsername = value => value?.toString().replace(/^@+/, '');
 const hasCompaniesFeature = computed(
   () =>
     currentAccount.value?.id && isCloudFeatureEnabled(FEATURE_FLAGS.COMPANIES)
@@ -129,11 +132,15 @@ const prepareStateBasedOnProps = () => {
     country = '',
     city = '',
     socialTelegramUserName = '',
+    socialWhatsappUserName = '',
     socialProfiles = {},
   } = additionalAttributes || {};
 
   const telegramUsername =
     socialProfiles?.telegram || socialTelegramUserName || '';
+  const whatsappUsername = normalizeWhatsAppUsername(
+    socialProfiles?.whatsapp || socialWhatsappUserName || ''
+  );
 
   Object.assign(state, {
     id,
@@ -152,6 +159,7 @@ const prepareStateBasedOnProps = () => {
       socialProfiles: {
         ...socialProfiles,
         telegram: telegramUsername,
+        whatsapp: whatsappUsername,
       },
     },
   });
@@ -245,6 +253,16 @@ const handleCompanySelection = async ({ id, name }) => {
   state.companyId = id || '';
   state.additionalAttributes.companyName = name || '';
   await emitContactUpdate();
+};
+
+const handleSocialProfileInput = item => {
+  const key = item.key.toLowerCase();
+  if (key === 'whatsapp') {
+    state.additionalAttributes.socialProfiles[key] = normalizeWhatsAppUsername(
+      state.additionalAttributes.socialProfiles[key]
+    );
+  }
+  emit('update', state);
 };
 
 const resetValidation = () => {
@@ -354,7 +372,7 @@ defineExpose({
             class="w-auto min-w-[100px] text-sm bg-transparent outline-none reset-base text-n-slate-12 dark:text-n-slate-12 placeholder:text-n-slate-10 dark:placeholder:text-n-slate-10"
             :placeholder="item.placeholder"
             :size="item.placeholder.length"
-            @input="emit('update', state)"
+            @input="handleSocialProfileInput(item)"
           />
         </div>
       </div>

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -3,6 +3,7 @@
     "NOT_AVAILABLE": "Not Available",
     "EMAIL_ADDRESS": "Email Address",
     "PHONE_NUMBER": "Phone number",
+    "WHATSAPP_USERNAME": "WhatsApp username",
     "IDENTIFIER": "Identifier",
     "COPY_SUCCESSFUL": "Copied to clipboard successfully",
     "COMPANY": "Company",
@@ -461,6 +462,9 @@
           },
           "INSTAGRAM": {
             "PLACEHOLDER": "Add Instagram"
+          },
+          "WHATSAPP": {
+            "PLACEHOLDER": "Add WhatsApp"
           },
           "TELEGRAM": {
             "PLACEHOLDER": "Add Telegram"

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactForm.vue
@@ -66,6 +66,7 @@ export default {
         { key: 'linkedin', prefixURL: 'https://linkedin.com/' },
         { key: 'github', prefixURL: 'https://github.com/' },
         { key: 'telegram', prefixURL: 'https://t.me/' },
+        { key: 'whatsapp', prefixURL: '@' },
         { key: 'tiktok', prefixURL: 'https://tiktok.com/@' },
       ],
     };
@@ -126,6 +127,9 @@ export default {
     this.setDialCode();
   },
   methods: {
+    normalizeWhatsAppUsername(value) {
+      return value?.toString().replace(/^@+/, '') || '';
+    },
     onCancel() {
       this.$emit('cancel');
     },
@@ -178,8 +182,10 @@ export default {
         social_profiles: socialProfiles = {},
         screen_name: twitterScreenName,
         social_telegram_user_name: telegramUserName,
+        social_whatsapp_user_name: whatsappUserName,
       } = additionalAttributes;
       this.socialProfileUserNames = {
+        ...socialProfiles,
         twitter: socialProfiles.twitter || twitterScreenName || '',
         facebook: socialProfiles.facebook || '',
         linkedin: socialProfiles.linkedin || '',
@@ -187,6 +193,9 @@ export default {
         telegram: socialProfiles.telegram || telegramUserName || '',
         instagram: socialProfiles.instagram || '',
         tiktok: socialProfiles.tiktok || '',
+        whatsapp: this.normalizeWhatsAppUsername(
+          socialProfiles.whatsapp || whatsappUserName || ''
+        ),
       };
     },
     getContactObject() {
@@ -196,6 +205,12 @@ export default {
           name: '',
         };
       }
+      const socialProfileUserNames = {
+        ...this.socialProfileUserNames,
+        whatsapp: this.normalizeWhatsAppUsername(
+          this.socialProfileUserNames.whatsapp
+        ),
+      };
       const contactObject = {
         id: this.contact.id,
         name: this.name,
@@ -212,7 +227,7 @@ export default {
               ? ''
               : this.country.name,
           city: this.city,
-          social_profiles: this.socialProfileUserNames,
+          social_profiles: socialProfileUserNames,
         },
       };
       if (this.avatarFile) {

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -96,6 +96,17 @@ export default {
         telegram,
       };
     },
+    whatsappUsername() {
+      const username =
+        this.socialProfiles.whatsapp ||
+        this.additionalAttributes.social_whatsapp_user_name ||
+        '';
+
+      return username.toString().replace(/^@+/, '');
+    },
+    formattedWhatsappUsername() {
+      return this.whatsappUsername ? `@${this.whatsappUsername}` : '';
+    },
   },
   watch: {
     'contact.id': {
@@ -271,6 +282,14 @@ export default {
             show-copy
             editable
             @update="value => onFieldUpdate('phone_number', value)"
+          />
+          <ContactInfoRow
+            v-if="formattedWhatsappUsername"
+            :value="formattedWhatsappUsername"
+            icon="brand-whatsapp"
+            emoji="💬"
+            :title="$t('CONTACT_PANEL.WHATSAPP_USERNAME')"
+            show-copy
           />
           <ContactInfoRow
             v-if="contact.identifier"

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfoRow.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfoRow.vue
@@ -156,6 +156,15 @@ export default {
         {{ $t('CONTACT_PANEL.NOT_AVAILABLE') }}
       </span>
       <NextButton
+        v-if="showCopy"
+        ghost
+        xs
+        slate
+        class="ltr:-ml-1 rtl:-mr-1"
+        icon="i-lucide-clipboard"
+        @click="onCopy"
+      />
+      <NextButton
         v-if="editable"
         ghost
         xs


### PR DESCRIPTION
WhatsApp username is already captured from BSUID-aware webhook payloads, but agents could not see or preserve it consistently while editing contacts. This change exposes the stored WhatsApp username in the contact social links UI and keeps it intact when contact details are saved.

The conversation contact panel also shows the username as read-only identity metadata because that compact panel does not expose the social-links editor. Routing and outbound addressing remain unchanged; username remains display metadata in this PR.

### Related

Related: https://linear.app/chatwoot/issue/CW-7804/add-bsuid-and-whatsapp-username-search-and-contact-identity-ui

Fixes https://github.com/chatwoot/chatwoot/issues/15281

### Things to know

- WhatsApp username is shown and stored under `social_profiles.whatsapp`.
- Existing `social_whatsapp_user_name` values are preserved by both contact edit forms.
- This does not add BSUID or WhatsApp username search yet.

### How to test

1. Open a WhatsApp contact that has `additional_attributes.social_profiles.whatsapp` or `additional_attributes.social_whatsapp_user_name`.
2. Confirm the conversation contact panel shows the WhatsApp username and allows copying it.
3. Open the contact details page and confirm WhatsApp appears under Edit social links.
4. Update another contact field and save.
5. Reload the contact and confirm the WhatsApp username is still present.
