### PR TITLE
fix(whatsapp): classify BSUID contacts as leads

### DIFF
--- a/app/services/whatsapp/identifier_sync_service.rb
+++ b/app/services/whatsapp/identifier_sync_service.rb
@@ -3,7 +3,7 @@ class Whatsapp::IdentifierSyncService
 
   def perform(source_ids: [], username: nil, phone_number: nil)
     create_contact_inboxes(source_ids)
-    update_contact(username, phone_number)
+    update_contact(source_ids, username, phone_number)
   end
 
   private
@@ -21,11 +21,12 @@ class Whatsapp::IdentifierSyncService
     end
   end
 
-  def update_contact(username, phone_number)
+  def update_contact(source_ids, username, phone_number)
     return if synced_contact.blank?
 
     update_contact_phone_number(phone_number)
     update_contact_username(username)
+    update_contact_type_for_bsuid_identity(source_ids)
   end
 
   def update_contact_phone_number(phone_number)
@@ -41,6 +42,17 @@ class Whatsapp::IdentifierSyncService
     return if username.blank?
 
     synced_contact.update!(additional_attributes: additional_attributes_with_username(username))
+  end
+
+  def update_contact_type_for_bsuid_identity(source_ids)
+    return unless synced_contact.visitor?
+    return unless source_ids.any? { |source_id| whatsapp_bsuid_source_id?(source_id) }
+
+    synced_contact.update!(contact_type: :lead)
+  end
+
+  def whatsapp_bsuid_source_id?(source_id)
+    source_id.to_s.delete_prefix('whatsapp:').match?(RegexHelper::WHATSAPP_BSUID_REGEX)
   end
 
   def synced_contact

--- a/spec/services/whatsapp/identifier_sync_service_spec.rb
+++ b/spec/services/whatsapp/identifier_sync_service_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::IdentifierSyncService do
+  let(:account) { create(:account) }
+
+  describe '#perform' do
+    it 'marks a WhatsApp Cloud BSUID-only visitor as a lead for CRM v2 contact visibility' do
+      channel = create(:channel_whatsapp, provider: 'whatsapp_cloud', account: account,
+                                          validate_provider_config: false, sync_templates: false)
+      contact = create(:contact, account: account, name: 'BSUID customer', email: nil, phone_number: nil, identifier: nil)
+      contact_inbox = create(:contact_inbox, contact: contact, inbox: channel.inbox, source_id: 'IN.2081978709342942')
+
+      described_class.new(contact_inbox: contact_inbox, contact: contact).perform(
+        source_ids: ['IN.2081978709342942', 'IN.ENT.9081726354']
+      )
+
+      expect(contact.reload).to be_lead
+      expect(account.contacts.resolved_contacts(use_crm_v2: true)).to include(contact)
+    end
+
+    it 'marks a Twilio WhatsApp BSUID-only visitor as a lead' do
+      channel = create(:channel_twilio_sms, :whatsapp, account: account)
+      contact = create(:contact, account: account, name: 'Twilio BSUID customer', email: nil, phone_number: nil, identifier: nil)
+      contact_inbox = create(:contact_inbox, contact: contact, inbox: channel.inbox, source_id: 'whatsapp:IN.2081978709342942')
+
+      described_class.new(contact_inbox: contact_inbox, contact: contact).perform(
+        source_ids: ['whatsapp:IN.2081978709342942']
+      )
+
+      expect(contact.reload).to be_lead
+    end
+
+    it 'does not mark a visitor as a lead for non-BSUID WhatsApp source ids' do
+      channel = create(:channel_whatsapp, provider: 'whatsapp_cloud', account: account,
+                                          validate_provider_config: false, sync_templates: false)
+      contact = create(:contact, account: account, name: 'Phone customer', email: nil, phone_number: nil, identifier: nil)
+      contact_inbox = create(:contact_inbox, contact: contact, inbox: channel.inbox, source_id: '919745786257')
+
+      described_class.new(contact_inbox: contact_inbox, contact: contact).perform(
+        source_ids: ['919745786257']
+      )
+
+      expect(contact.reload).to be_visitor
+    end
+  end
+end


### PR DESCRIPTION
WhatsApp customers who only expose a business-scoped user ID are reachable in the inbox, but they should also be classified as CRM leads once CRM v2 is enabled. This change promotes visitor contacts to leads when WhatsApp identity sync sees a BSUID, so future CRM v2 contact lists treat them like real reachable channel contacts.

The change keeps BSUIDs in ContactInbox aliases and does not write them into contacts.identifier.

### Things to know

- This is scoped to WhatsApp BSUID identities, including Meta Cloud IDs and Twilio's whatsapp:<BSUID> shape.
- This does not change the legacy resolved_contacts predicate when crm_v2 is disabled.
- Existing BSUID-only contacts may still need a backfill before enabling CRM v2 broadly.
- Plain phone source IDs and anonymous widget visitors are unaffected.

### How to test

1. Receive a WhatsApp message where the contact identity is a BSUID and no phone number is available.
2. Confirm the contact remains attached to the WhatsApp ContactInbox identity.
3. Confirm the contact is classified as a lead.
4. Enable CRM v2 for the account and confirm the contact appears in the Contacts list.
5. Repeat with a Twilio WhatsApp BSUID payload and confirm the same lead classification.
6. Confirm a phone-only WhatsApp source ID does not get promoted by this BSUID-specific rule.

### What changed

- Promotes visitor contacts to leads when WhatsApp identifier sync sees a BSUID source ID.
- Supports both native Cloud BSUIDs and Twilio-prefixed WhatsApp BSUIDs.
- Adds focused service coverage for CRM v2 visibility and non-BSUID behavior.

Related: https://linear.app/chatwoot/issue/CW-7982/whatsapp-contacts-identified-only-by-a-business-scoped-user-id-are
Related: https://github.com/chatwoot/chatwoot/issues/15530