### PR TITLE
Log unmatched failed WhatsApp status events instead of silently dropping them

### DIFF
--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -49,12 +49,30 @@ class Whatsapp::IncomingMessageBaseService
 
   def process_statuses
     status = @processed_params[:statuses].first
-    return unless find_message_by_source_id(status[:id])
+    return log_unmatched_failed_status(status) unless find_message_by_source_id(status[:id])
 
     update_whatsapp_identifiers_from_status(status)
     update_message_with_status(@message, status)
   rescue ArgumentError => e
     Rails.logger.error "Error while processing whatsapp status update #{e.message}"
+  end
+
+  # WhatsApp Cloud API reports failures downloading INBOUND media (e.g. error
+  # code 131052 "Media download error") through this same "statuses" webhook,
+  # but since the download failure happens before the message can be
+  # persisted, `find_message_by_source_id` never matches and the event was
+  # silently dropped with no trace anywhere -- not in the database, not in
+  # the logs. Self-hosted instances have no way to detect that a contact's
+  # media never arrived, or to let the agent/contact know something needs
+  # to be resent. Log it at warn level so it's at least observable.
+  def log_unmatched_failed_status(status)
+    return unless status[:status] == 'failed'
+
+    error = status[:errors]&.first || {}
+    Rails.logger.warn(
+      "WhatsApp status=failed for unknown message (source_id=#{status[:id]}, " \
+      "recipient=#{status[:recipient_id]}, error=#{error[:code]}: #{error[:title]})"
+    )
   end
 
   def update_message_with_status(message, status)

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -60,6 +60,48 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
       end
     end
 
+    context 'when a failed status arrives for a message that was never persisted' do
+      # This mirrors what WhatsApp Cloud API sends when it fails to download
+      # inbound media (e.g. error 131052 "Media download error") before the
+      # message could be created -- `find_message_by_source_id` never
+      # matches, so the event previously vanished with no trace anywhere.
+      let(:unmatched_failed_status_params) do
+        {
+          phone_number: whatsapp_channel.phone_number,
+          object: 'whatsapp_business_account',
+          entry: [{
+            changes: [{
+              value: {
+                statuses: [{
+                  id: 'wamid.unmatched-media-download-failure',
+                  status: 'failed',
+                  timestamp: '1664799904',
+                  recipient_id: sender_number,
+                  errors: [{ code: 131_052, title: 'Media download error' }]
+                }]
+              }
+            }]
+          }]
+        }.with_indifferent_access
+      end
+
+      it 'logs a warning with the source id and error details' do
+        expect(Rails.logger).to receive(:warn).with(
+          a_string_matching(/wamid\.unmatched-media-download-failure/).and(a_string_matching(/131052/))
+        )
+
+        described_class.new(inbox: whatsapp_channel.inbox, params: unmatched_failed_status_params).perform
+      end
+
+      it 'does not create a conversation' do
+        allow(Rails.logger).to receive(:warn)
+
+        expect do
+          described_class.new(inbox: whatsapp_channel.inbox, params: unmatched_failed_status_params).perform
+        end.not_to change(Conversation, :count)
+      end
+    end
+
     context 'when document attachment includes an accented filename' do
       let(:document_params) do
         {


### PR DESCRIPTION
## Summary

WhatsApp Cloud API reports failures downloading inbound media (e.g. error `131052` "Media download error") through the same `statuses` webhook used for outbound delivery receipts. Because the download failure happens *before* the message can be persisted, `process_statuses`' call to `find_message_by_source_id` never matches anything, and the event is silently discarded — not stored in the database, not logged anywhere.

In practice this means a contact can genuinely send a photo from their WhatsApp app (it shows as sent on their end), WhatsApp's own backend can fail to relay it to us, and the self-hosted instance has zero record that anything happened — no message, no error, nothing an agent or admin can act on.

We hit this in production today with a real customer: she sent a bill photo, it never showed up in the conversation, and the only way to figure out what happened was to grep raw `docker logs` output on the Rails container and manually decode the ActiveJob params. The exact payload we saw:

```ruby
{"statuses" => [{"id" => "wamid...", "status" => "failed", "timestamp" => "...",
  "recipient_id" => "...", "errors" => [{"code" => 131052, "title" => "Media download error",
  "message" => "Media download error",
  "error_data" => {"details" => "Failed to download incoming media due to internal error."}}]}]}
```

## What this changes

Adds a `warn`-level log line for exactly this case (`status: failed` with no matching message), including the source id and error code/title, so self-hosted instances can at least detect and alert on it (e.g. via log-based monitoring) instead of the event vanishing without a trace.

No behavior change to the happy path — statuses that *do* match an existing message still go through `update_message_with_status` exactly as before.

## Test plan

- Added a spec covering this exact scenario (failed status for an unknown/unmatched source id): asserts the warning is logged with the source id and error code, and that no conversation is created as a side effect.
- `ruby -c` syntax-checked both changed files locally.
- I wasn't able to run the full Rails test suite in the environment I had available for this change (no bundler/test gems in the production image we run), so I'd appreciate CI/a maintainer double-checking the spec runs cleanly — happy to adjust if the expectations don't match your conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)