### PR TITLE
fix: automation rules cannot be edited after closing the panel

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleForm.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleForm.spec.js
@@ -1,4 +1,4 @@
-import { nextTick } from 'vue';
+import { nextTick, reactive } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import AutomationRuleForm from './AutomationRuleForm.vue';
@@ -88,6 +88,8 @@ const buildAutomation = ({ delayed = false } = {}) => ({
   files: [],
 });
 
+const panelOpen = vi.fn();
+
 const mountComponent = ({ mode, automation }) =>
   shallowMount(AutomationRuleForm, {
     props: {
@@ -108,7 +110,7 @@ const mountComponent = ({ mode, automation }) =>
         SidePanel: {
           template: '<div><slot /><slot name="footer" /></div>',
           methods: {
-            open: vi.fn(),
+            open: panelOpen,
             close: vi.fn(),
           },
         },
@@ -129,6 +131,19 @@ const selectRunType = async (wrapper, isDelayed) => {
 describe('AutomationRuleForm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('opens a rule whose conditions hold reactive dropdown options', async () => {
+    const automation = buildAutomation();
+    // Conditions hydrated from store-backed dropdowns (inboxes, agents, contacts) hold
+    // reactive option objects rather than plain ones.
+    automation.conditions[0].values = [reactive({ id: 1, name: 'Sales' })];
+    const wrapper = mountComponent({ mode: 'edit', automation });
+
+    wrapper.vm.open();
+    await nextTick();
+
+    expect(panelOpen).toHaveBeenCalled();
   });
 
   it('restores unsaved wait conditions after switching a new rule to instant and back', async () => {

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleForm.vue
@@ -1,13 +1,5 @@
 <script setup>
-import {
-  ref,
-  computed,
-  h,
-  shallowRef,
-  toRaw,
-  useTemplateRef,
-  watch,
-} from 'vue';
+import { ref, computed, h, shallowRef, useTemplateRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useAccount } from 'dashboard/composables/useAccount';
 import { useOperators } from 'dashboard/components-next/filter/operators';
@@ -131,12 +123,14 @@ const inboxOptions = computed(
   () => props.getConditionDropdownValues('inbox_id') || []
 );
 
+const cloneConditions = conditions => JSON.parse(JSON.stringify(conditions));
+
 const captureTriggerDraft = () => {
   if (!automation.value) return null;
 
   return {
     eventName: automation.value.event_name,
-    conditions: structuredClone(toRaw(automation.value.conditions)),
+    conditions: cloneConditions(automation.value.conditions),
   };
 };
 
@@ -144,7 +138,7 @@ const restoreTriggerDraft = draft => {
   if (!automation.value || !draft) return;
 
   automation.value.event_name = draft.eventName;
-  automation.value.conditions = structuredClone(draft.conditions);
+  automation.value.conditions = cloneConditions(draft.conditions);
 };
 
 // Show the wait in the largest whole unit (240 min → 4 hours). The delay is passed in by open()
@@ -161,9 +155,10 @@ const syncDelayState = executionDelay => {
   delayMinutes.value = minutes;
   waitSectionKey.value += 1;
 
-  const triggerDraft = captureTriggerDraft();
-  instantTriggerDraft.value = executionDelay ? null : triggerDraft;
-  waitTriggerDraft.value = executionDelay ? triggerDraft : null;
+  // Drafts are captured when the run type actually changes, so they start empty: seeding them
+  // here would read `automation` before its model prop settles and keep the previous rule.
+  instantTriggerDraft.value = null;
+  waitTriggerDraft.value = null;
 };
 
 watch(


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes automation rules becoming uneditable after closing the edit panel.
When editing a rule with an Inbox, Assignee, or Contact condition and closing the panel, the Automation settings page could no longer open another rule until the browser was refreshed. This was caused by a `DataCloneError` when cloning automation rule data.

This also fixes the form state getting corrupted when switching a rule between "Run instantly" and "Run after a wait", where the trigger event and conditions could be restored with unrelated values.


Fixes https://linear.app/chatwoot/issue/CW-8075/closing-the-automation-edit-dialog-with-x-blocks-opening-any-other

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### How to reproduce

1. Go to Settings → Automation.
2. Edit a rule that has an Inbox, Assignee, or Contact condition, then close the panel.
3. Click edit on any other rule. Nothing opens, and the console shows `DataCloneError: #<Object> could not be cloned.`

With delayed automations enabled, there is a second path:

1. Open a rule.
2. Switch to "Run after a wait".
3. Switch back to "Run instantly".
4. The event and conditions are restored with incorrect values.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
