### PR TITLE
feat(audio): allow audio transcription to use account-level OpenAI integration (BYOK)

### DIFF
--- a/enterprise/app/services/llm/legacy_base_open_ai_service.rb
+++ b/enterprise/app/services/llm/legacy_base_open_ai_service.rb
@@ -11,9 +11,10 @@ class Llm::LegacyBaseOpenAiService
 
   attr_reader :client, :model
 
-  def initialize
+  def initialize(api_key: nil)
+    api_key ||= InstallationConfig.find_by!(name: 'CAPTAIN_OPEN_AI_API_KEY').value
     @client = OpenAI::Client.new(
-      access_token: InstallationConfig.find_by!(name: 'CAPTAIN_OPEN_AI_API_KEY').value,
+      access_token: api_key,
       uri_base: uri_base,
       log_errors: Rails.env.development?
     )

--- a/enterprise/app/services/llm/speech_to_text_service.rb
+++ b/enterprise/app/services/llm/speech_to_text_service.rb
@@ -12,12 +12,18 @@ class Llm::SpeechToTextService < Llm::LegacyBaseOpenAiService
 
   attr_reader :blob, :account, :transcription_model
 
-  # Transcription runs on Captain's OpenAI credentials and consumes its response credits.
+  # Transcription runs on Captain's OpenAI credentials and consumes its response credits,
+  # or uses account-level OpenAI integration (BYOK).
   def self.available_for?(account)
     return false unless account.feature_enabled?('captain_integration')
     return false if account.audio_transcriptions.blank?
+    return true if account_openai_hook_configured?(account)
 
     account.usage_limits[:captain][:responses][:current_available].positive?
+  end
+
+  def self.account_openai_hook_configured?(account)
+    account&.hooks&.find_by(app_id: 'openai', status: 'enabled')&.settings&.dig('api_key').present?
   end
 
   def self.too_large?(blob)
@@ -25,10 +31,10 @@ class Llm::SpeechToTextService < Llm::LegacyBaseOpenAiService
   end
 
   def initialize(blob:, account:)
-    super()
     @blob = blob
     @account = account
     @transcription_model = Llm::FeatureRouter.resolve(feature: 'audio_transcription', account: account)[:model]
+    super(api_key: api_key)
   end
 
   def perform
@@ -51,13 +57,33 @@ class Llm::SpeechToTextService < Llm::LegacyBaseOpenAiService
       end
     end
 
-    account.increment_response_usage if transcribed_text.present?
+    account.increment_response_usage if transcribed_text.present? && !account_openai_hook_configured?
     transcribed_text
   ensure
     FileUtils.rm_f(temp_file_path) if temp_file_path.present?
   end
 
   private
+
+  def api_key
+    hook_api_key.presence || system_api_key
+  end
+
+  def hook_api_key
+    openai_hook&.settings&.dig('api_key')
+  end
+
+  def system_api_key
+    InstallationConfig.find_by(name: 'CAPTAIN_OPEN_AI_API_KEY')&.value
+  end
+
+  def openai_hook
+    @openai_hook ||= account&.hooks&.find_by(app_id: 'openai', status: 'enabled')
+  end
+
+  def account_openai_hook_configured?
+    hook_api_key.present?
+  end
 
   def fetch_audio_file
     temp_dir = Rails.root.join('tmp/uploads/audio-transcriptions')

--- a/spec/enterprise/services/llm/speech_to_text_service_spec.rb
+++ b/spec/enterprise/services/llm/speech_to_text_service_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Llm::SpeechToTextService, type: :service do
     end
 
     context 'when account has an account-level OpenAI integration hook (BYOK)' do
-      let!(:hook) { create(:integrations_hook, :openai, account: account, settings: { 'api_key' => 'account-own-key' }) }
+      let!(:_hook) { create(:integrations_hook, :openai, account: account, settings: { 'api_key' => 'account-own-key' }) }
 
       it 'initializes client with account hook API key' do
         expect(OpenAI::Client).to receive(:new).with(

--- a/spec/enterprise/services/llm/speech_to_text_service_spec.rb
+++ b/spec/enterprise/services/llm/speech_to_text_service_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe Llm::SpeechToTextService, type: :service do
 
       expect(described_class.available_for?(account)).to be(true)
     end
+
+    context 'when account has an account-level OpenAI integration hook (BYOK)' do
+      before do
+        create(:integrations_hook, :openai, account: account, settings: { 'api_key' => 'account-own-key' })
+      end
+
+      it 'is true even when captain responses are exhausted' do
+        account.enable_features!('captain_integration')
+        allow(account).to receive(:usage_limits).and_return(captain: { responses: { current_available: 0 } })
+
+        expect(described_class.available_for?(account)).to be(true)
+      end
+    end
   end
 
   describe '.too_large?' do
@@ -115,6 +128,26 @@ RSpec.describe Llm::SpeechToTextService, type: :service do
       service.perform
 
       expect(account).not_to have_received(:increment_response_usage)
+    end
+
+    context 'when account has an account-level OpenAI integration hook (BYOK)' do
+      let!(:hook) { create(:integrations_hook, :openai, account: account, settings: { 'api_key' => 'account-own-key' }) }
+
+      it 'initializes client with account hook API key' do
+        expect(OpenAI::Client).to receive(:new).with(
+          hash_including(access_token: 'account-own-key')
+        ).and_call_original
+
+        described_class.new(blob: attachment.file.blob, account: account)
+      end
+
+      it 'does not consume a captain response credit on successful transcription' do
+        allow(audio_api).to receive(:transcribe).and_return({ 'text' => 'Audio transcript' })
+
+        service.perform
+
+        expect(account).not_to have_received(:increment_response_usage)
+      end
     end
   end
 end

--- a/spec/enterprise/services/messages/audio_transcription_service_spec.rb
+++ b/spec/enterprise/services/messages/audio_transcription_service_spec.rb
@@ -110,5 +110,18 @@ RSpec.describe Messages::AudioTranscriptionService, type: :service do
         expect(service.perform).to eq({ error: 'Audio too large for transcription' })
       end
     end
+
+    context 'when account has an account-level OpenAI integration hook (BYOK)' do
+      before do
+        create(:integrations_hook, :openai, account: account, settings: { 'api_key' => 'account-own-key' })
+        allow(account).to receive(:usage_limits).and_return(captain: { responses: { current_available: 0 } })
+        allow(service).to receive(:transcribe_audio).and_return('BYOK transcription')
+      end
+
+      it 'allows transcription even when captain response limit is 0' do
+        result = service.perform
+        expect(result).to eq({ success: true, transcriptions: 'BYOK transcription' })
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #15624

### Description
Allows audio transcription (for voice messages and voice call recordings) to use account-level OpenAI integration credentials (BYOK) when configured on the account, falling back to system-level `CAPTAIN_OPEN_AI_API_KEY` if not present.

### Changes
- Check account-level OpenAI integration hook credentials before falling back to system keys in `Llm::SpeechToTextService`.
- Update `Llm::SpeechToTextService.available_for?` so accounts with BYOK configured are not blocked by exhausted system response credits.
- Skip incrementing response usage for BYOK transcriptions.
- Allow custom `api_key` injection into `Llm::LegacyBaseOpenAiService`.
- Add comprehensive RSpec test coverage for account-level BYOK audio transcription.