### PR TITLE
fix(core): add guard clause for missing account/user in Agents::Destr…

### DIFF
--- a/app/jobs/agents/destroy_job.rb
+++ b/app/jobs/agents/destroy_job.rb
@@ -2,6 +2,8 @@ class Agents::DestroyJob < ApplicationJob
   queue_as :low
 
   def perform(account, user)
+    return if account.nil? || user.nil?
+
     ActiveRecord::Base.transaction do
       destroy_notification_setting(account, user)
       remove_user_from_teams(account, user)


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes a NoMethodError in Agents::DestroyJob where the job crashes when attempting to call .id on a nil object during account deletion executed via the Super Admin UI.

When an account deletion process is initiated from the Super Admin console, dependent records or user/account instances might already be destroyed or cleaned up by preceding jobs/hooks. This causes account or user to return nil, triggering a NoMethodError (undefined method 'id' for nil) in Sidekiq and leaving the account deletion state hanging indefinitely in the UI ("in progress").

This PR adds a guard clause at the entry point of Agents::DestroyJob#perform to return early if either account or user is nil.

Fixes #

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

1. Triggered an account deletion process via the Super Admin UI /super_admin/accounts.
2. Simulated a missing/orphaned account or user record during the execution of Agents::DestroyJob.
3. Verified via Sidekiq logs that Agents::DestroyJob now exits gracefully without throwing a NoMethodError exception or retrying continuously.
4. Confirmed that the deletion process completes cleanly in the Super Admin interface.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
