### PR TITLE
fix: scroll to unread/last message when opening a conversation

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -23,7 +23,10 @@ import inboxMixin, { INBOX_FEATURES } from 'shared/mixins/inboxMixin';
 // utils
 import { emitter } from 'shared/helpers/mitt';
 import { getTypingUsersText } from '../../../helper/commons';
-import { calculateScrollTop } from './helpers/scrollTopCalculationHelper';
+import {
+  calculateScrollTop,
+  getRelevantMessageElements,
+} from './helpers/scrollTopCalculationHelper';
 import { LocalStorage } from 'shared/helpers/localStorage';
 import {
   filterDuplicateSourceMessages,
@@ -364,30 +367,15 @@ export default {
     },
     scrollToBottom() {
       this.isProgrammaticScroll = true;
-      let relevantMessages = [];
-
-      // label suggestions are not part of the messages list
-      // so we need to handle them separately
-      let labelSuggestions =
-        this.conversationPanel.querySelector('.label-suggestion');
 
       // if there are unread messages, scroll to the first unread message
-      if (this.unreadMessageCount > 0) {
-        // capturing only the unread messages
-        relevantMessages =
-          this.conversationPanel.querySelectorAll('.message--unread');
-      } else if (labelSuggestions) {
-        // when scrolling to the bottom, the label suggestions is below the last message
-        // so we scroll there if there are no unread messages
-        // Unread messages always take the highest priority
-        relevantMessages = [labelSuggestions];
-      } else {
-        // if there are no unread messages or label suggestion, scroll to the last message
-        // capturing last message from the messages list
-        relevantMessages = Array.from(
-          this.conversationPanel.querySelectorAll('.message--read')
-        ).slice(-1);
-      }
+      // (unread messages always take the highest priority), then to the
+      // label suggestions, and finally to the last message
+      const relevantMessages = getRelevantMessageElements({
+        container: this.conversationPanel,
+        unreadMessages: this.unReadMessages,
+        unreadMessageCount: this.unreadMessageCount,
+      });
 
       this.conversationPanel.scrollTop = calculateScrollTop(
         this.conversationPanel.scrollHeight,

--- a/app/javascript/dashboard/components/widgets/conversation/helpers/scrollTopCalculationHelper.js
+++ b/app/javascript/dashboard/components/widgets/conversation/helpers/scrollTopCalculationHelper.js
@@ -16,3 +16,42 @@ export const calculateScrollTop = (
     conversationPanelHeight - combinedMessageScrollHeight - parentHeight / 2
   );
 };
+
+/**
+ * Finds the DOM elements the conversation panel should be scrolled to.
+ *
+ * Priority: unread messages > label suggestions > last message. Unread
+ * messages come first so that the "N unread messages" badge is brought into
+ * view, otherwise the panel is scrolled to the end of the list.
+ *
+ * @param {Object} options
+ * @param {HTMLElement} options.container - The scrollable conversation panel
+ * @param {Array<{ id: number }>} options.unreadMessages - Messages after the agent's last seen time
+ * @param {number} options.unreadMessageCount - Unread count reported for the conversation
+ * @returns {HTMLElement[]}
+ */
+export const getRelevantMessageElements = ({
+  container,
+  unreadMessages = [],
+  unreadMessageCount = 0,
+}) => {
+  if (!container) return [];
+
+  if (unreadMessageCount > 0) {
+    const unreadElements = unreadMessages
+      .map(({ id }) => container.querySelector(`#message${id}`))
+      .filter(Boolean);
+    if (unreadElements.length) return unreadElements;
+  }
+
+  // label suggestions are not part of the messages list
+  // so we need to handle them separately
+  const labelSuggestions = container.querySelector('.label-suggestion');
+  if (labelSuggestions) return [labelSuggestions];
+
+  // if there are no unread messages or label suggestions,
+  // scroll to the last rendered message bubble
+  return Array.from(
+    container.querySelectorAll('.message-bubble-container')
+  ).slice(-1);
+};

--- a/app/javascript/dashboard/components/widgets/conversation/helpers/scrollTopCalculationHelper.js
+++ b/app/javascript/dashboard/components/widgets/conversation/helpers/scrollTopCalculationHelper.js
@@ -1,5 +1,16 @@
+// `scrollHeight` does not include margins, but the space a message takes in
+// the list does (`mb-2` on `.message-bubble-container`), so they have to be
+// added back or the computed offset drifts by the margin per message.
+const getVerticalMargin = element => {
+  const view = element.ownerDocument?.defaultView;
+  if (!view?.getComputedStyle) return 0;
+
+  const { marginTop, marginBottom } = view.getComputedStyle(element);
+  return (parseFloat(marginTop) || 0) + (parseFloat(marginBottom) || 0);
+};
+
 const totalMessageHeight = (total, element) => {
-  return total + element.scrollHeight;
+  return total + element.scrollHeight + getVerticalMargin(element);
 };
 
 export const calculateScrollTop = (

--- a/app/javascript/dashboard/components/widgets/conversation/helpers/specs/scrollTopCalculationHelper.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/helpers/specs/scrollTopCalculationHelper.spec.js
@@ -87,4 +87,17 @@ describe('#calculateScrollTop', () => {
     }
     expect(calculateScrollTop(1000, 300, relevantMessages)).toEqual(550);
   });
+
+  it('includes the vertical margins of the messages', () => {
+    const relevantMessages = [1, 2, 3].map(() => {
+      const element = document.createElement('div');
+      element.style.marginBottom = '8px';
+      Object.defineProperty(element, 'scrollHeight', { value: 100 });
+      document.body.appendChild(element);
+      return element;
+    });
+
+    // 1000 - 3 * (100 + 8) - 300 / 2
+    expect(calculateScrollTop(1000, 300, relevantMessages)).toEqual(526);
+  });
 });

--- a/app/javascript/dashboard/components/widgets/conversation/helpers/specs/scrollTopCalculationHelper.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/helpers/specs/scrollTopCalculationHelper.spec.js
@@ -1,4 +1,76 @@
-import { calculateScrollTop } from '../scrollTopCalculationHelper';
+import {
+  calculateScrollTop,
+  getRelevantMessageElements,
+} from '../scrollTopCalculationHelper';
+
+describe('#getRelevantMessageElements', () => {
+  const buildContainer = html => {
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    return container;
+  };
+
+  const messagesMarkup = `
+    <div id="message1" class="message-bubble-container"></div>
+    <div id="message2" class="message-bubble-container"></div>
+    <div id="message3" class="message-bubble-container"></div>
+  `;
+
+  it('returns the unread message elements when there are unread messages', () => {
+    const container = buildContainer(messagesMarkup);
+
+    const result = getRelevantMessageElements({
+      container,
+      unreadMessages: [{ id: 2 }, { id: 3 }],
+      unreadMessageCount: 2,
+    });
+
+    expect(result.map(element => element.id)).toEqual(['message2', 'message3']);
+  });
+
+  it('returns the label suggestions when there are no unread messages', () => {
+    const container = buildContainer(
+      `${messagesMarkup}<div class="label-suggestion"></div>`
+    );
+
+    const result = getRelevantMessageElements({
+      container,
+      unreadMessages: [],
+      unreadMessageCount: 0,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].className).toEqual('label-suggestion');
+  });
+
+  it('returns the last message when there are no unread messages or label suggestions', () => {
+    const container = buildContainer(messagesMarkup);
+
+    const result = getRelevantMessageElements({
+      container,
+      unreadMessages: [],
+      unreadMessageCount: 0,
+    });
+
+    expect(result.map(element => element.id)).toEqual(['message3']);
+  });
+
+  it('falls back to the last message when the unread messages are not rendered', () => {
+    const container = buildContainer(messagesMarkup);
+
+    const result = getRelevantMessageElements({
+      container,
+      unreadMessages: [{ id: 99 }],
+      unreadMessageCount: 1,
+    });
+
+    expect(result.map(element => element.id)).toEqual(['message3']);
+  });
+
+  it('returns an empty list when the container is not available', () => {
+    expect(getRelevantMessageElements({ container: null })).toEqual([]);
+  });
+});
 
 describe('#calculateScrollTop', () => {
   it('returns calculated value of the scrollTop property', () => {


### PR DESCRIPTION
## Description

When a conversation is opened, the message panel lands at an arbitrary offset above the last message instead of at the end of the list, and the "N unread messages" badge is never scrolled into view.

`MessagesView#scrollToBottom` still queries `.message--unread` / `.message--read` elements, but those classes were removed together with the old message bubbles in #11720 (the new `MessageList` renders `.message-bubble-container` with `id="message<id>"`). The selectors now match nothing, so `calculateScrollTop()` is always called with an empty list and only subtracts `parentHeight / 2` from the panel height.

This PR resolves the target elements from the data instead of dead CSS classes:

- unread messages are looked up by their `#message<id>` ids (from the existing `unReadMessages` computed),
- otherwise the label suggestion block,
- otherwise the last `.message-bubble-container`.

The lookup lives in `scrollTopCalculationHelper.js` next to `calculateScrollTop` so it can be unit tested; `MessagesView.vue` only wires it up. Priority order (unread → label suggestions → last message) is unchanged.

Fixes #15683 (same symptom as #10138, which was closed by the stale bot while still reproducible)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added unit tests for `getRelevantMessageElements` covering: unread messages present, label suggestions, last message fallback, unread ids not rendered, missing container.
- `pnpm exec vitest run app/javascript/dashboard/components/widgets/conversation app/javascript/dashboard/store/modules/specs/conversations` — 16 files / 331 tests pass.
- `pnpm exec eslint` / `prettier --check` on the changed files — clean (the two `no-dynamic-keys` warnings in `MessagesView.vue` are pre-existing).
- An equivalent fix (same root cause, same element lookup) has been running in our production fork since August: opening a conversation with no unread messages lands at the very bottom; opening one with unread messages brings the unread badge into view; switching back and forth between conversations behaves the same each time. This PR is a re-implementation of that fix against `develop`, reduced to the minimal change.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
