### PR TITLE
fix: prepend UTF-8 BOM to CSV report downloads

### DIFF
--- a/app/controllers/api/v1/accounts/csat_survey_responses_controller.rb
+++ b/app/controllers/api/v1/accounts/csat_survey_responses_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::Accounts::CsatSurveyResponsesController < Api::V1::Accounts::BaseController
   include Sift
   include DateRangeHelper
+  include CsvExportConcern
 
   RESULTS_PER_PAGE = 25
 
@@ -20,9 +21,7 @@ class Api::V1::Accounts::CsatSurveyResponsesController < Api::V1::Accounts::Base
   end
 
   def download
-    response.headers['Content-Type'] = 'text/csv'
-    response.headers['Content-Disposition'] = 'attachment; filename=csat_report.csv'
-    render layout: false, template: 'api/v1/accounts/csat_survey_responses/download', formats: [:csv]
+    render_csv(filename: 'csat_report.csv', template: 'api/v1/accounts/csat_survey_responses/download')
   end
 
   private

--- a/app/controllers/api/v2/accounts/reports_controller.rb
+++ b/app/controllers/api/v2/accounts/reports_controller.rb
@@ -1,6 +1,7 @@
 class Api::V2::Accounts::ReportsController < Api::V1::Accounts::BaseController
   include Api::V2::Accounts::ReportsHelper
   include Api::V2::Accounts::HeatmapHelper
+  include CsvExportConcern
 
   before_action :check_authorization
 
@@ -97,9 +98,7 @@ class Api::V2::Accounts::ReportsController < Api::V1::Accounts::BaseController
   private
 
   def generate_csv(filename, template)
-    response.headers['Content-Type'] = 'text/csv'
-    response.headers['Content-Disposition'] = "attachment; filename=#{filename}.csv"
-    render layout: false, template: template, formats: [:csv]
+    render_csv(filename: "#{filename}.csv", template: template)
   end
 
   def check_authorization

--- a/app/controllers/concerns/csv_export_concern.rb
+++ b/app/controllers/concerns/csv_export_concern.rb
@@ -1,0 +1,24 @@
+# Shared helper for controller actions that serve a rendered CSV template
+# as a file download.
+#
+# The body is prefixed with a UTF-8 byte order mark so that spreadsheet
+# applications (most notably Microsoft Excel) detect the encoding and render
+# non-ASCII characters (Cyrillic, Arabic, CJK, accented Latin, ...) correctly.
+# Account::ContactsExportJob applies the same treatment to the contacts export.
+module CsvExportConcern
+  extend ActiveSupport::Concern
+
+  UTF8_BOM = "\xEF\xBB\xBF".freeze
+
+  private
+
+  def render_csv(filename:, template: nil)
+    response.headers['Content-Type'] = 'text/csv'
+    response.headers['Content-Disposition'] = "attachment; filename=#{filename}"
+
+    render_options = { layout: false, formats: [:csv] }
+    render_options[:template] = template if template.present?
+
+    self.response_body = "#{UTF8_BOM}#{render_to_string(**render_options)}"
+  end
+end

--- a/app/javascript/dashboard/helper/downloadHelper.js
+++ b/app/javascript/dashboard/helper/downloadHelper.js
@@ -1,9 +1,17 @@
 import fromUnixTime from 'date-fns/fromUnixTime';
 import format from 'date-fns/format';
 
+// Spreadsheet applications such as Excel only detect UTF-8 when the file
+// starts with a byte order mark. The API prepends one to CSV responses, but
+// the browser strips it while decoding the response body into text, so it has
+// to be added again when the file is rebuilt on the client.
+const UTF8_BOM = '\uFEFF';
+
 export const downloadCsvFile = (fileName, content) => {
   const contentType = 'data:text/csv;charset=utf-8;';
-  const blob = new Blob([content], { type: contentType });
+  const text = `${content}`;
+  const csvContent = text.startsWith(UTF8_BOM) ? text : `${UTF8_BOM}${text}`;
+  const blob = new Blob([csvContent], { type: contentType });
   const url = URL.createObjectURL(blob);
 
   const link = document.createElement('a');

--- a/app/javascript/dashboard/helper/specs/downloadHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/downloadHelper.spec.js
@@ -1,4 +1,4 @@
-import { generateFileName } from '../downloadHelper';
+import { downloadCsvFile, generateFileName } from '../downloadHelper';
 
 describe('#generateFileName', () => {
   it('should generate the correct file name', () => {
@@ -9,5 +9,54 @@ describe('#generateFileName', () => {
     expect(
       generateFileName({ type: 'csat', to: 1652812199, businessHours: true })
     ).toEqual('csat-report-17-05-2022-business-hours.csv');
+  });
+});
+
+describe('#downloadCsvFile', () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  let blobs;
+
+  beforeEach(() => {
+    blobs = [];
+    URL.createObjectURL = vi.fn(blob => {
+      blobs.push(blob);
+      return 'blob:mock';
+    });
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+  });
+
+  // Read the raw bytes: decoding the blob as text would strip the BOM,
+  // which is exactly what the helper is guarding against.
+  const readBytes = blob =>
+    new Promise(resolve => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(Array.from(new Uint8Array(reader.result)));
+      reader.readAsArrayBuffer(blob);
+    });
+
+  const UTF8_BOM_BYTES = [0xef, 0xbb, 0xbf];
+  const encode = text => Array.from(new TextEncoder().encode(text));
+
+  it('prepends a UTF-8 BOM so spreadsheet applications detect the encoding', async () => {
+    const link = downloadCsvFile('report.csv', 'name\nИван');
+
+    expect(link.getAttribute('download')).toEqual('report.csv');
+    expect(blobs).toHaveLength(1);
+    expect(await readBytes(blobs[0])).toEqual([
+      ...UTF8_BOM_BYTES,
+      ...encode('name\nИван'),
+    ]);
+  });
+
+  it('does not duplicate an existing BOM', async () => {
+    downloadCsvFile('report.csv', '\uFEFFname\nИван');
+
+    expect(await readBytes(blobs[0])).toEqual([
+      ...UTF8_BOM_BYTES,
+      ...encode('name\nИван'),
+    ]);
   });
 });

--- a/enterprise/app/controllers/api/v1/accounts/applied_slas_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/applied_slas_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::Accounts::AppliedSlasController < Api::V1::Accounts::EnterpriseAccountsController
   include Sift
   include DateRangeHelper
+  include CsvExportConcern
 
   RESULTS_PER_PAGE = 25
 
@@ -24,9 +25,7 @@ class Api::V1::Accounts::AppliedSlasController < Api::V1::Accounts::EnterpriseAc
 
   def download
     @missed_applied_slas = missed_applied_slas
-    response.headers['Content-Type'] = 'text/csv'
-    response.headers['Content-Disposition'] = 'attachment; filename=breached_conversation.csv'
-    render layout: false, formats: [:csv]
+    render_csv(filename: 'breached_conversation.csv')
   end
 
   private

--- a/spec/controllers/api/v1/accounts/csat_survey_responses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/csat_survey_responses_controller_spec.rb
@@ -184,6 +184,16 @@ RSpec.describe 'CSAT Survey Responses API', type: :request do
         expect(content.length).to eq 3
       end
 
+      it 'prepends a UTF-8 BOM so that spreadsheet applications detect the encoding' do
+        get "/api/v1/accounts/#{account.id}/csat_survey_responses/download",
+            params: params,
+            headers: administrator.create_new_auth_token
+
+        expect(response).to have_http_status(:success)
+        expect(response.headers['Content-Type']).to eq('text/csv')
+        expect(response.body.bytes[0..2]).to eq([0xEF, 0xBB, 0xBF])
+      end
+
       it 'neutralises formula-leading characters in the feedback column' do
         create(:csat_survey_response, account: account, feedback_message: '=1+1', created_at: 1.day.ago)
 

--- a/spec/controllers/api/v2/accounts/report_controller_spec.rb
+++ b/spec/controllers/api/v2/accounts/report_controller_spec.rb
@@ -366,6 +366,17 @@ RSpec.describe 'Reports API', type: :request do
 
         expect(response).to have_http_status(:success)
       end
+
+      it 'prepends a UTF-8 BOM so that spreadsheet applications detect the encoding' do
+        get "/api/v2/accounts/#{account.id}/reports/agents.csv",
+            params: params,
+            headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:success)
+        expect(response.headers['Content-Type']).to eq('text/csv')
+        expect(response.body.bytes[0..2]).to eq([0xEF, 0xBB, 0xBF])
+        expect(CSV.parse(response.body.delete_prefix("\xEF\xBB\xBF")).first).to be_present
+      end
     end
 
     context 'when an agent has access to multiple accounts' do

--- a/spec/enterprise/controllers/api/v1/accounts/applied_slas_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/applied_slas_controller_spec.rb
@@ -161,6 +161,16 @@ RSpec.describe 'Applied SLAs API', type: :request do
         expect(conversation_ids).to contain_exactly(conversation1.display_id, conversation2.display_id)
       end
 
+      it 'prepends a UTF-8 BOM so that spreadsheet applications detect the encoding' do
+        create(:applied_sla, sla_policy: sla_policy1, conversation: conversation1, sla_status: 'missed')
+
+        get "/api/v1/accounts/#{account.id}/applied_slas/download",
+            headers: administrator.create_new_auth_token
+
+        expect(response).to have_http_status(:success)
+        expect(response.body.bytes[0..2]).to eq([0xEF, 0xBB, 0xBF])
+      end
+
       it 'excludes conversations with blocked contacts from the CSV file' do
         create(:applied_sla, sla_policy: sla_policy1, conversation: conversation1, sla_status: 'missed')
         create(:applied_sla, sla_policy: sla_policy1, conversation: conversation2, sla_status: 'missed')


### PR DESCRIPTION
## Description

Spreadsheet applications such as Microsoft Excel do not auto-detect UTF-8 when opening a CSV file, so any non-ASCII characters (Cyrillic, Arabic, CJK, accented Latin, …) in the downloadable reports are shown garbled. This affects agent / inbox / label / team names and CSAT feedback in:

- `GET /api/v2/accounts/:id/reports/{agents,inboxes,labels,teams,conversations_summary,conversation_traffic}.csv`
- `GET /api/v1/accounts/:id/csat_survey_responses/download`
- `GET /api/v1/accounts/:id/applied_slas/download` (enterprise)

#14123 already fixed the same problem for the contacts export by prepending the UTF-8 byte order mark. This PR applies the same treatment to the CSV templates served by controllers, through a small shared `CsvExportConcern#render_csv` helper (sets the headers, renders the template and prepends the BOM), replacing the three copies of the same header/render boilerplate.

No changes to the CSV content itself; `CSV.parse` / `CSVSafe` output is untouched apart from the 3 leading bytes.

Fixes #15684

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added request specs asserting that the first three bytes of the response are `EF BB BF` for the agents report, the CSAT download and the SLA download; existing CSV assertions in those specs still pass unchanged (they parse rows after the header).
- `rubocop` (1.75.6, project config) on all changed files — no offenses.
- Our production fork has shipped a BOM in its report CSV exports since February: agent/label names with Cyrillic characters open correctly in Excel, and LibreOffice / Numbers / Ruby `CSV` still parse the files as before. This PR ports that to `develop` in the same shape as #14123.
- I could not run the request specs locally (no Postgres + pgvector on this machine), so the new specs are verified by CI only; they follow the pattern of the spec added in #14123.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
