### PR TITLE
feat: play the audio alert when a conversation is assigned to me

### DIFF
--- a/app/javascript/dashboard/helper/AudioAlerts/AudioNotificationStore.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/AudioNotificationStore.js
@@ -29,7 +29,11 @@ class AudioNotificationStore {
   };
 
   isMessageFromCurrentConversation = message => {
-    return this.store.getters.getSelectedChat?.id === message.conversation_id;
+    return this.isCurrentConversation(message.conversation_id);
+  };
+
+  isCurrentConversation = conversationId => {
+    return this.store.getters.getSelectedChat?.id === conversationId;
   };
 
   hasConversationPermission = user => {

--- a/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/DashboardAudioNotificationHelper.js
@@ -12,6 +12,7 @@ import {
 } from './AudioMessageHelper';
 import WindowVisibilityHelper from './WindowVisibilityHelper';
 import { useAlert } from 'dashboard/composables';
+import wootConstants from 'dashboard/constants/globals';
 
 const NOTIFICATION_TIME = 30000;
 const ALERT_DURATION = 10000;
@@ -206,6 +207,43 @@ export class DashboardAudioNotificationHelper {
       if (this.notificationConfig.playAlertOnlyWhenHidden) {
         return;
       }
+    }
+
+    this.playAudioAlert();
+    showBadgeOnFavicon();
+    this.playAudioEvery30Seconds();
+  };
+
+  /**
+   * Alerts the agent when a conversation is assigned to them without a new
+   * message being sent (auto-assignment, a teammate or an automation rule).
+   * Reuses the "assigned" audio preference and the hidden-window setting so
+   * no additional configuration is required.
+   *
+   * @param {Object} conversation - `assignee.changed` payload (conversation push data)
+   */
+  onConversationAssigned = conversation => {
+    if (!this.currentUser) return;
+    if (!this.store.hasConversationPermission(this.currentUser)) return;
+
+    const assigneeId = conversation?.meta?.assignee?.id;
+    if (!assigneeId || assigneeId !== this.currentUser.id) return;
+
+    if (conversation.status === wootConstants.STATUS_TYPE.PENDING) return;
+
+    const { audioAlertType } = this.notificationConfig;
+    if (audioAlertType.includes('none')) return;
+    if (
+      !audioAlertType.includes('all') &&
+      !audioAlertType.includes(EVENT_TYPES.ASSIGNED) &&
+      !audioAlertType.includes('mine')
+    ) {
+      return;
+    }
+
+    if (WindowVisibilityHelper.isWindowVisible()) {
+      if (this.store.isCurrentConversation(conversation.id)) return;
+      if (this.notificationConfig.playAlertOnlyWhenHidden) return;
     }
 
     this.playAudioAlert();

--- a/app/javascript/dashboard/helper/AudioAlerts/specs/AudioNotificationStore.spec.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/specs/AudioNotificationStore.spec.js
@@ -119,6 +119,26 @@ describe('AudioNotificationStore', () => {
     });
   });
 
+  describe('isCurrentConversation', () => {
+    it('should return true when the conversation is the selected chat', () => {
+      store.getters.getSelectedChat = { id: 1 };
+
+      expect(audioNotificationStore.isCurrentConversation(1)).toBe(true);
+    });
+
+    it('should return false when the conversation is not the selected chat', () => {
+      store.getters.getSelectedChat = { id: 2 };
+
+      expect(audioNotificationStore.isCurrentConversation(1)).toBe(false);
+    });
+
+    it('should return false when no chat is selected', () => {
+      store.getters.getSelectedChat = null;
+
+      expect(audioNotificationStore.isCurrentConversation(1)).toBe(false);
+    });
+  });
+
   describe('isMessageFromCurrentConversation', () => {
     it('should return true when message is from selected chat', () => {
       store.getters.getSelectedChat = { id: 6179 };

--- a/app/javascript/dashboard/helper/AudioAlerts/specs/DashboardAudioNotificationHelper.spec.js
+++ b/app/javascript/dashboard/helper/AudioAlerts/specs/DashboardAudioNotificationHelper.spec.js
@@ -1,0 +1,195 @@
+import { DashboardAudioNotificationHelper } from '../DashboardAudioNotificationHelper';
+import WindowVisibilityHelper from '../WindowVisibilityHelper';
+import { showBadgeOnFavicon } from '../faviconHelper';
+
+vi.mock('../faviconHelper', () => ({
+  showBadgeOnFavicon: vi.fn(),
+  initFaviconSwitcher: vi.fn(),
+}));
+
+vi.mock('dashboard/composables', () => ({
+  useAlert: vi.fn(),
+}));
+
+vi.mock('dashboard/store', () => ({ default: {} }));
+
+vi.mock('dashboard/helper/permissionsHelper', () => ({
+  getUserPermissions: vi.fn(() => ['administrator']),
+}));
+
+describe('DashboardAudioNotificationHelper', () => {
+  const currentUser = { id: 7 };
+  let helper;
+  let store;
+
+  const buildHelper = ({ audioAlertType, alwaysPlayAudioAlert }) => {
+    const instance = new DashboardAudioNotificationHelper(store);
+    instance.intializeAudio = vi.fn();
+    instance.set({
+      currentUser,
+      alwaysPlayAudioAlert,
+      alertIfUnreadConversationExist: false,
+      audioAlertType,
+      audioAlertTone: 'ding',
+    });
+    instance.playAudioAlert = vi.fn();
+    instance.playAudioEvery30Seconds = vi.fn();
+    return instance;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = {
+      getters: {
+        getMineChats: vi.fn(() => []),
+        getSelectedChat: null,
+        getCurrentAccountId: 1,
+        getConversationById: vi.fn(),
+      },
+    };
+    vi.spyOn(WindowVisibilityHelper, 'isWindowVisible').mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('onConversationAssigned', () => {
+    const assignedToMe = {
+      id: 42,
+      status: 'open',
+      meta: { assignee: { id: currentUser.id } },
+    };
+
+    it('plays the alert when a conversation is assigned to the current user', () => {
+      helper = buildHelper({
+        audioAlertType: 'assigned',
+        alwaysPlayAudioAlert: false,
+      });
+
+      helper.onConversationAssigned(assignedToMe);
+
+      expect(helper.playAudioAlert).toHaveBeenCalledTimes(1);
+      expect(showBadgeOnFavicon).toHaveBeenCalledTimes(1);
+      expect(helper.playAudioEvery30Seconds).toHaveBeenCalledTimes(1);
+    });
+
+    it('plays the alert when all alerts are enabled', () => {
+      helper = buildHelper({
+        audioAlertType: 'all',
+        alwaysPlayAudioAlert: false,
+      });
+
+      helper.onConversationAssigned(assignedToMe);
+
+      expect(helper.playAudioAlert).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not play when the conversation is assigned to someone else', () => {
+      helper = buildHelper({
+        audioAlertType: 'assigned',
+        alwaysPlayAudioAlert: false,
+      });
+
+      helper.onConversationAssigned({
+        ...assignedToMe,
+        meta: { assignee: { id: 99 } },
+      });
+
+      expect(helper.playAudioAlert).not.toHaveBeenCalled();
+    });
+
+    it('does not play when the conversation is unassigned', () => {
+      helper = buildHelper({
+        audioAlertType: 'assigned',
+        alwaysPlayAudioAlert: false,
+      });
+
+      helper.onConversationAssigned({
+        ...assignedToMe,
+        meta: { assignee: null },
+      });
+
+      expect(helper.playAudioAlert).not.toHaveBeenCalled();
+    });
+
+    it('does not play when alerts are disabled', () => {
+      helper = buildHelper({
+        audioAlertType: 'none',
+        alwaysPlayAudioAlert: false,
+      });
+
+      helper.onConversationAssigned(assignedToMe);
+
+      expect(helper.playAudioAlert).not.toHaveBeenCalled();
+    });
+
+    it('does not play when the user only listens for unassigned conversations', () => {
+      helper = buildHelper({
+        audioAlertType: 'unassigned',
+        alwaysPlayAudioAlert: false,
+      });
+
+      helper.onConversationAssigned(assignedToMe);
+
+      expect(helper.playAudioAlert).not.toHaveBeenCalled();
+    });
+
+    it('does not play for pending conversations', () => {
+      helper = buildHelper({
+        audioAlertType: 'assigned',
+        alwaysPlayAudioAlert: false,
+      });
+
+      helper.onConversationAssigned({ ...assignedToMe, status: 'pending' });
+
+      expect(helper.playAudioAlert).not.toHaveBeenCalled();
+    });
+
+    it('does not play when the window is visible and alerts are limited to hidden windows', () => {
+      WindowVisibilityHelper.isWindowVisible.mockReturnValue(true);
+      helper = buildHelper({
+        audioAlertType: 'assigned',
+        alwaysPlayAudioAlert: false,
+      });
+
+      helper.onConversationAssigned(assignedToMe);
+
+      expect(helper.playAudioAlert).not.toHaveBeenCalled();
+    });
+
+    it('plays when the window is visible and alerts are always enabled', () => {
+      WindowVisibilityHelper.isWindowVisible.mockReturnValue(true);
+      helper = buildHelper({
+        audioAlertType: 'assigned',
+        alwaysPlayAudioAlert: true,
+      });
+
+      helper.onConversationAssigned(assignedToMe);
+
+      expect(helper.playAudioAlert).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not play when the user is already viewing the conversation', () => {
+      WindowVisibilityHelper.isWindowVisible.mockReturnValue(true);
+      store.getters.getSelectedChat = { id: assignedToMe.id };
+      helper = buildHelper({
+        audioAlertType: 'assigned',
+        alwaysPlayAudioAlert: true,
+      });
+
+      helper.onConversationAssigned(assignedToMe);
+
+      expect(helper.playAudioAlert).not.toHaveBeenCalled();
+    });
+
+    it('does nothing before the helper is configured', () => {
+      helper = new DashboardAudioNotificationHelper(store);
+      helper.playAudioAlert = vi.fn();
+
+      helper.onConversationAssigned(assignedToMe);
+
+      expect(helper.playAudioAlert).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -109,6 +109,7 @@ class ActionCableConnector extends BaseActionCableConnector {
     const { id } = payload;
     if (id) {
       this.app.$store.dispatch('updateConversation', payload);
+      DashboardAudioNotificationHelper.onConversationAssigned(payload);
     }
     this.fetchConversationStats();
   };

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -133,7 +133,8 @@ class ActionCableListener < BaseListener
 
   def assignee_changed(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members)
+    # the assignee may not be an inbox member (assigned by an admin or an automation) but must be notified
+    tokens = (user_tokens(account, conversation.inbox.members) + [conversation.assignee&.pubsub_token]).compact.uniq
 
     broadcast(account, tokens, ASSIGNEE_CHANGED, conversation.push_event_data)
   end

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -225,6 +225,37 @@ describe ActionCableListener do
     end
   end
 
+  describe '#assignee_changed' do
+    let(:event_name) { :'assignee.changed' }
+    let!(:event) { Events::Base.new(event_name, Time.zone.now, conversation: conversation, user: agent) }
+
+    it 'sends the event to inbox members and admins' do
+      expect(conversation.inbox.reload.inbox_members.count).to eq(1)
+
+      expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+        a_collection_containing_exactly(agent.pubsub_token, admin.pubsub_token),
+        'assignee.changed',
+        conversation.push_event_data.merge(account_id: account.id)
+      )
+      listener.assignee_changed(event)
+    end
+
+    context 'when the assignee is not a member of the inbox' do
+      let(:other_agent) { create(:user, account: account, role: :agent) }
+
+      before { conversation.update!(assignee: other_agent) }
+
+      it 'also sends the event to the assignee' do
+        expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+          a_collection_containing_exactly(agent.pubsub_token, admin.pubsub_token, other_agent.pubsub_token),
+          'assignee.changed',
+          conversation.push_event_data.merge(account_id: account.id)
+        )
+        listener.assignee_changed(event)
+      end
+    end
+  end
+
   describe '#conversation_updated' do
     let(:event_name) { :'conversation.updated' }
     let!(:event) { Events::Base.new(event_name, Time.zone.now, conversation: conversation, user: agent, is_private: false) }


### PR DESCRIPTION
## Description

`Settings → Profile → Audio notifications` lets an agent be alerted for conversations "assigned to me", but the preference is only evaluated in `DashboardAudioNotificationHelper#onNewMessage`, i.e. on `message.created`. When a conversation that already contains the customer's message is assigned to an agent — by auto-assignment, a teammate or an automation rule — nothing plays and no favicon badge is shown until the customer writes again.

This PR:

- adds `DashboardAudioNotificationHelper#onConversationAssigned`, called from `ActionCableConnector#onAssigneeChanged`. It reuses the existing preferences (`audioAlertType` with `assigned` / `mine` / `all`, `playAlertOnlyWhenHidden`) and the same skip rules as new messages (pending conversations, the conversation currently open, missing permissions). No new setting is introduced.
- includes the assignee's own `pubsub_token` in the `assignee.changed` broadcast (`ActionCableListener#assignee_changed`), so an agent who is not an inbox member but was assigned by an admin or an automation still receives the event.
- extracts `AudioNotificationStore#isCurrentConversation` so both handlers share the "am I looking at it" check.

Fixes #15689

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- New `DashboardAudioNotificationHelper.spec.js` (11 cases: assigned to me / someone else / unassigned, `none` / `all` / `unassigned`-only preferences, pending status, visible window with and without "always play", conversation currently open, helper not configured).
- `AudioNotificationStore.spec.js` extended for `isCurrentConversation`.
- `action_cable_listener_spec.rb`: new `#assignee_changed` block covering inbox members + admins and an assignee outside the inbox.
- `vitest` on `helper/AudioAlerts` + `helper/specs/actionCable.spec.js`: 5 files / 65 tests pass; eslint/prettier clean; rubocop clean.
- The same behaviour has been running in our fork since May 2026; this is a re-implementation on top of `develop` with the existing preference model.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (JS); Ruby specs verified in CI
- [ ] Any dependent changes have been merged and published in downstream modules
