### PR TITLE
feat: auto-resolve inactive pending conversations

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -120,7 +120,8 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def permitted_settings_attributes
-    [:auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting, :audio_transcriptions, :auto_resolve_label]
+    [:auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting, :audio_transcriptions, :auto_resolve_label,
+     :auto_resolve_pending_after, :auto_resolve_pending_message]
   end
 
   def check_signup_enabled

--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -72,6 +72,26 @@
         },
         "UPDATE_BUTTON": "Save Changes"
       },
+      "AUTO_RESOLVE_PENDING": {
+        "TITLE": "Auto-resolve pending conversations",
+        "NOTE": "Automatically resolve conversations that stay in the pending status without any activity for a certain period, independently of the setting for open conversations.",
+        "DURATION": {
+          "LABEL": "Inactivity duration",
+          "HELP": "Time period of inactivity after which a pending conversation is auto-resolved",
+          "PLACEHOLDER": "30",
+          "ERROR": "Auto resolve duration should be between 10 minutes and 999 days",
+          "API": {
+            "SUCCESS": "Pending auto resolve settings updated successfully",
+            "ERROR": "Failed to update pending auto resolve settings"
+          }
+        },
+        "MESSAGE": {
+          "LABEL": "Custom auto-resolution message",
+          "PLACEHOLDER": "This conversation was marked resolved by the system due to inactivity",
+          "HELP": "Message sent to the customer after a pending conversation is auto-resolved"
+        },
+        "UPDATE_BUTTON": "Save Changes"
+      },
       "NAME": {
         "LABEL": "Account name",
         "PLACEHOLDER": "Your account name",

--- a/app/javascript/dashboard/routes/dashboard/settings/account/components/AutoResolvePending.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/components/AutoResolvePending.vue
@@ -1,0 +1,161 @@
+<script setup>
+import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useAccount } from 'dashboard/composables/useAccount';
+import { useAlert } from 'dashboard/composables';
+import WithLabel from 'v3/components/Form/WithLabel.vue';
+import Editor from 'next/Editor/Editor.vue';
+import Switch from 'next/switch/Switch.vue';
+import NextButton from 'dashboard/components-next/button/Button.vue';
+import DurationInput from 'next/input/DurationInput.vue';
+import { DURATION_UNITS } from 'dashboard/components-next/input/constants';
+
+const { t } = useI18n();
+const duration = ref(0);
+const unit = ref(DURATION_UNITS.MINUTES);
+const message = ref('');
+const isEnabled = ref(false);
+const isSubmitting = ref(false);
+
+const { currentAccount, updateAccount } = useAccount();
+
+watch(
+  currentAccount,
+  () => {
+    const { auto_resolve_pending_after, auto_resolve_pending_message } =
+      currentAccount.value?.settings || {};
+
+    duration.value = auto_resolve_pending_after;
+    message.value = auto_resolve_pending_message;
+
+    // Set unit based on duration and its divisibility
+    if (duration.value) {
+      if (duration.value % (24 * 60) === 0) {
+        unit.value = DURATION_UNITS.DAYS;
+      } else if (duration.value % 60 === 0) {
+        unit.value = DURATION_UNITS.HOURS;
+      } else {
+        unit.value = DURATION_UNITS.MINUTES;
+      }
+      isEnabled.value = true;
+    }
+  },
+  { deep: true, immediate: true }
+);
+
+const updateAccountSettings = async settings => {
+  try {
+    isSubmitting.value = true;
+    await updateAccount(settings, { silent: true });
+    useAlert(
+      t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_PENDING.DURATION.API.SUCCESS')
+    );
+  } catch (error) {
+    useAlert(
+      t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_PENDING.DURATION.API.ERROR')
+    );
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+
+const handleSubmit = async () => {
+  if (duration.value < 10) {
+    useAlert(t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_PENDING.DURATION.ERROR'));
+    return Promise.resolve();
+  }
+
+  return updateAccountSettings({
+    auto_resolve_pending_after: duration.value,
+    auto_resolve_pending_message: message.value,
+  });
+};
+
+const handleDisable = async () => {
+  duration.value = null;
+  message.value = '';
+
+  return updateAccountSettings({
+    auto_resolve_pending_after: null,
+    auto_resolve_pending_message: '',
+  });
+};
+
+const toggleAutoResolvePending = async () => {
+  if (!isEnabled.value) handleDisable();
+};
+</script>
+
+<template>
+  <div
+    class="flex flex-col w-full outline-1 outline outline-n-container rounded-xl bg-n-solid-2 divide-y divide-n-weak"
+  >
+    <div class="flex flex-col gap-2 items-start px-5 py-4">
+      <div class="flex justify-between items-center w-full">
+        <h3 class="text-heading-2 text-n-slate-12">
+          {{ t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_PENDING.TITLE') }}
+        </h3>
+        <div class="flex justify-end">
+          <Switch v-model="isEnabled" @change="toggleAutoResolvePending" />
+        </div>
+      </div>
+      <p class="mb-0 text-body-para text-n-slate-11">
+        {{ t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_PENDING.NOTE') }}
+      </p>
+    </div>
+
+    <div v-if="isEnabled" class="px-5 py-4">
+      <form class="grid gap-5" @submit.prevent="handleSubmit">
+        <WithLabel
+          :label="
+            t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_PENDING.DURATION.LABEL')
+          "
+          :help-message="
+            t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_PENDING.DURATION.HELP')
+          "
+        >
+          <div class="gap-2 w-full grid grid-cols-[3fr_1fr]">
+            <!-- allow 10 mins to 999 days -->
+            <DurationInput
+              v-model="duration"
+              v-model:unit="unit"
+              min="0"
+              max="1438560"
+              class="w-full"
+            />
+          </div>
+        </WithLabel>
+        <WithLabel
+          :label="t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_PENDING.MESSAGE.LABEL')"
+          :help-message="
+            t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_PENDING.MESSAGE.HELP')
+          "
+        >
+          <Editor
+            v-model="message"
+            class="w-full"
+            channel-type="Context::NoToolbar"
+            enable-variables
+            :enable-canned-responses="false"
+            :show-character-count="false"
+            :placeholder="
+              t(
+                'GENERAL_SETTINGS.FORM.AUTO_RESOLVE_PENDING.MESSAGE.PLACEHOLDER'
+              )
+            "
+          />
+        </WithLabel>
+        <div class="flex gap-2">
+          <NextButton
+            blue
+            type="submit"
+            :is-loading="isSubmitting"
+            :label="
+              t('GENERAL_SETTINGS.FORM.AUTO_RESOLVE_PENDING.UPDATE_BUTTON')
+            "
+          />
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/conversationWorkflow/index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/conversationWorkflow/index.vue
@@ -7,6 +7,7 @@ import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';
 import SettingsLayout from '../SettingsLayout.vue';
 import ConversationRequiredAttributes from 'dashboard/components-next/ConversationWorkflow/ConversationRequiredAttributes.vue';
 import AutoResolve from 'dashboard/routes/dashboard/settings/account/components/AutoResolve.vue';
+import AutoResolvePending from 'dashboard/routes/dashboard/settings/account/components/AutoResolvePending.vue';
 
 const { accountId } = useAccount();
 const isFeatureEnabledonAccount = useMapGetter(
@@ -41,6 +42,7 @@ const showRequiredAttributes = computed(() => {
     <template #body>
       <div class="flex flex-col gap-6 mt-4">
         <AutoResolve v-if="showAutoResolutionConfig" />
+        <AutoResolvePending v-if="showAutoResolutionConfig" />
         <ConversationRequiredAttributes :is-enabled="showRequiredAttributes" />
       </div>
     </template>

--- a/app/jobs/account/conversations_resolution_scheduler_job.rb
+++ b/app/jobs/account/conversations_resolution_scheduler_job.rb
@@ -5,6 +5,10 @@ class Account::ConversationsResolutionSchedulerJob < ApplicationJob
     Account.with_auto_resolve.find_each(batch_size: 100) do |account|
       Conversations::ResolutionJob.perform_later(account: account)
     end
+
+    Account.with_auto_resolve_pending.find_each(batch_size: 100) do |account|
+      Conversations::PendingResolutionJob.perform_later(account: account)
+    end
   end
 end
 Account::ConversationsResolutionSchedulerJob.prepend_mod_with('Account::ConversationsResolutionSchedulerJob')

--- a/app/jobs/conversations/pending_resolution_job.rb
+++ b/app/jobs/conversations/pending_resolution_job.rb
@@ -1,0 +1,25 @@
+# Resolves conversations that have been sitting in the `pending` status with no
+# activity for longer than the account's `auto_resolve_pending_after` setting.
+#
+# `Conversations::ResolutionJob` only handles `open` conversations. Pending
+# conversations (typically ones a bot could not hand off) would otherwise stay
+# pending forever and pollute the pending folder and the reports.
+class Conversations::PendingResolutionJob < ApplicationJob
+  queue_as :low
+
+  def perform(account:)
+    # limiting the number of conversations to be resolved to avoid any performance issues
+    resolvable_conversations = conversation_scope(account).limit(Limits::BULK_ACTIONS_LIMIT)
+    resolvable_conversations.each do |conversation|
+      ::MessageTemplates::Template::AutoResolvePending.new(conversation: conversation).perform if account.auto_resolve_pending_message.present?
+      conversation.resolved!
+    end
+  end
+
+  private
+
+  def conversation_scope(account)
+    # Exclude orphan conversations where contact was deleted but conversation cleanup is pending
+    account.conversations.resolvable_pending(account.auto_resolve_pending_after).where.not(contact_id: nil)
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -55,6 +55,7 @@ class Account < ApplicationRecord
   store_accessor :settings, :auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting
 
   store_accessor :settings, :audio_transcriptions, :auto_resolve_label
+  store_accessor :settings, :auto_resolve_pending_after, :auto_resolve_pending_message
   store_accessor :settings, :captain_models, :captain_features
   store_accessor :settings, :reporting_timezone
   store_accessor :settings, :keep_pending_on_bot_failure
@@ -111,6 +112,7 @@ class Account < ApplicationRecord
   enum :status, { active: 0, suspended: 1 }
 
   scope :with_auto_resolve, -> { where("(settings ->> 'auto_resolve_after')::int IS NOT NULL") }
+  scope :with_auto_resolve_pending, -> { where("(settings ->> 'auto_resolve_pending_after')::int IS NOT NULL") }
 
   before_validation :validate_limit_keys
   after_create_commit :notify_creation

--- a/app/models/concerns/account_settings_schema.rb
+++ b/app/models/concerns/account_settings_schema.rb
@@ -13,6 +13,8 @@ module AccountSettingsSchema
         'auto_resolve_ignore_waiting': { 'type': %w[boolean null] },
         'audio_transcriptions': { 'type': %w[boolean null] },
         'auto_resolve_label': { 'type': %w[string null] },
+        'auto_resolve_pending_after': { 'type': %w[integer null], 'minimum': 10, 'maximum': 1_439_856 },
+        'auto_resolve_pending_message': { 'type': %w[string null] },
         'keep_pending_on_bot_failure': { 'type': %w[boolean null] },
         'captain_auto_resolve_mode': { 'type': %w[string null], 'enum': ['evaluated', 'legacy', 'disabled', nil] },
         'captain_false_promise_harness_enabled': { 'type': %w[boolean null] },

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -103,6 +103,11 @@ class Conversation < ApplicationRecord
 
     open.where('last_activity_at < ?', Time.now.utc - auto_resolve_after.minutes)
   }
+  scope :resolvable_pending, lambda { |auto_resolve_pending_after|
+    return none if auto_resolve_pending_after.to_i.zero?
+
+    pending.where('last_activity_at < ?', Time.now.utc - auto_resolve_pending_after.minutes)
+  }
 
   scope :last_user_message_at, lambda {
     joins(

--- a/app/services/message_templates/template/auto_resolve_pending.rb
+++ b/app/services/message_templates/template/auto_resolve_pending.rb
@@ -1,0 +1,17 @@
+class MessageTemplates::Template::AutoResolvePending < MessageTemplates::Template::AutoResolve
+  def perform
+    return if conversation.account.auto_resolve_pending_message.blank?
+
+    if within_messaging_window?
+      conversation.messages.create!(auto_resolve_message_params)
+    else
+      create_auto_resolve_not_sent_activity_message
+    end
+  end
+
+  private
+
+  def auto_resolve_message_params
+    super.merge(content: account.auto_resolve_pending_message)
+  end
+end

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -298,6 +298,8 @@ RSpec.describe 'Accounts API', type: :request do
         auto_resolve_after: 40,
         auto_resolve_message: 'Auto resolved',
         auto_resolve_ignore_waiting: false,
+        auto_resolve_pending_after: 60,
+        auto_resolve_pending_message: 'Pending auto resolved',
         timezone: 'Asia/Kolkata',
         industry: 'Technology',
         company_size: '1-10'
@@ -324,7 +326,8 @@ RSpec.describe 'Accounts API', type: :request do
         expect(account.reload.domain).to eq(params[:domain])
         expect(account.reload.support_email).to eq(params[:support_email])
 
-        %w[auto_resolve_after auto_resolve_message auto_resolve_ignore_waiting].each do |attribute|
+        %w[auto_resolve_after auto_resolve_message auto_resolve_ignore_waiting auto_resolve_pending_after
+           auto_resolve_pending_message].each do |attribute|
           expect(account.reload.settings[attribute]).to eq(params[attribute.to_sym])
         end
 

--- a/spec/jobs/account/conversations_resolution_scheduler_job_spec.rb
+++ b/spec/jobs/account/conversations_resolution_scheduler_job_spec.rb
@@ -15,4 +15,15 @@ RSpec.describe Account::ConversationsResolutionSchedulerJob do
     expect(Conversations::ResolutionJob).to receive(:perform_later).with(account: account).once
     described_class.perform_now
   end
+
+  it 'enqueues Conversations::PendingResolutionJob' do
+    account.update(auto_resolve_pending_after: 10 * 60 * 24)
+    expect(Conversations::PendingResolutionJob).to receive(:perform_later).with(account: account).once
+    described_class.perform_now
+  end
+
+  it 'does not enqueue Conversations::PendingResolutionJob when pending auto resolve is not configured' do
+    expect(Conversations::PendingResolutionJob).not_to receive(:perform_later)
+    described_class.perform_now
+  end
 end

--- a/spec/jobs/conversations/pending_resolution_job_spec.rb
+++ b/spec/jobs/conversations/pending_resolution_job_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe Conversations::PendingResolutionJob do
+  subject(:job) { described_class.perform_later(account: account) }
+
+  let!(:account) { create(:account) }
+  let!(:conversation) { create(:conversation, account: account, status: :pending) }
+
+  it 'enqueues the job' do
+    expect { job }.to have_enqueued_job(described_class)
+      .with(account: account)
+      .on_queue('low')
+  end
+
+  it 'does nothing when there is no pending auto resolve duration' do
+    conversation.update(last_activity_at: 13.days.ago)
+    described_class.perform_now(account: account)
+    expect(conversation.reload.status).to eq('pending')
+  end
+
+  it 'resolves pending conversations inactive for longer than the configured duration' do
+    account.update(auto_resolve_pending_after: 14_400) # 10 days in minutes
+    conversation.update(last_activity_at: 13.days.ago)
+    described_class.perform_now(account: account)
+    expect(conversation.reload.status).to eq('resolved')
+  end
+
+  it 'does not resolve pending conversations with recent activity' do
+    account.update(auto_resolve_pending_after: 14_400)
+    conversation.update(last_activity_at: 2.days.ago)
+    described_class.perform_now(account: account)
+    expect(conversation.reload.status).to eq('pending')
+  end
+
+  it 'does not touch open conversations' do
+    account.update(auto_resolve_pending_after: 14_400)
+    open_conversation = create(:conversation, account: account, status: :open, last_activity_at: 13.days.ago)
+    described_class.perform_now(account: account)
+    expect(open_conversation.reload.status).to eq('open')
+  end
+
+  it 'sends the configured message before resolving' do
+    account.update(auto_resolve_pending_after: 14_400, auto_resolve_pending_message: 'Closing this pending conversation.')
+    conversation.update(last_activity_at: 13.days.ago)
+
+    described_class.perform_now(account: account)
+
+    expect(conversation.reload.status).to eq('resolved')
+    expect(conversation.messages.template.last.content).to eq('Closing this pending conversation.')
+  end
+
+  it 'does not send a message when none is configured' do
+    account.update(auto_resolve_pending_after: 14_400)
+    conversation.update(last_activity_at: 13.days.ago)
+
+    expect { described_class.perform_now(account: account) }.not_to(change { conversation.messages.count })
+    expect(conversation.reload.status).to eq('resolved')
+  end
+
+  it 'skips orphan conversations without a contact' do
+    account.update(auto_resolve_pending_after: 14_400)
+    orphan_conversation = create(:conversation, account: account, status: :pending, last_activity_at: 13.days.ago)
+    orphan_conversation.update_columns(contact_id: nil, contact_inbox_id: nil) # rubocop:disable Rails/SkipsModelValidations
+    conversation.update(last_activity_at: 13.days.ago)
+
+    described_class.perform_now(account: account)
+
+    expect(orphan_conversation.reload.status).to eq('pending')
+    expect(conversation.reload.status).to eq('resolved')
+  end
+
+  it 'resolves only a limited number of conversations in a single execution' do
+    stub_const('Limits::BULK_ACTIONS_LIMIT', 2)
+    account.update(auto_resolve_pending_after: 14_400)
+    create_list(:conversation, 3, account: account, status: :pending, last_activity_at: 13.days.ago)
+    described_class.perform_now(account: account)
+    expect(account.conversations.resolved.count).to eq(Limits::BULK_ACTIONS_LIMIT)
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -296,6 +296,28 @@ RSpec.describe Account do
       end
     end
 
+    context 'when auto_resolve_pending_after' do
+      it 'validates minimum value' do
+        account.settings = { auto_resolve_pending_after: 4 }
+        expect(account).to be_invalid
+        expect(account.errors.messages).to eq({ auto_resolve_pending_after: ['must be greater than or equal to 10'] })
+      end
+
+      it 'validates maximum value' do
+        account.settings = { auto_resolve_pending_after: 1_439_857 }
+        expect(account).to be_invalid
+        expect(account.errors.messages).to eq({ auto_resolve_pending_after: ['must be less than or equal to 1439856'] })
+      end
+
+      it 'allows valid and null values' do
+        account.settings = { auto_resolve_pending_after: 15 }
+        expect(account).to be_valid
+
+        account.settings = { auto_resolve_pending_after: nil }
+        expect(account).to be_valid
+      end
+    end
+
     context 'when auto_resolve_message' do
       it 'allows string values' do
         account.settings = { auto_resolve_message: 'This conversation has been resolved automatically.' }

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -1293,4 +1293,24 @@ RSpec.describe Conversation do
       expect(conversation.reload.status_changed_at).to be_within(1.second).of(original)
     end
   end
+
+  describe '.resolvable_pending' do
+    let(:account) { create(:account) }
+    let!(:stale_pending) { create(:conversation, account: account, status: :pending, last_activity_at: 3.days.ago) }
+    let!(:recent_pending) { create(:conversation, account: account, status: :pending, last_activity_at: 1.hour.ago) }
+    let!(:stale_open) { create(:conversation, account: account, status: :open, last_activity_at: 3.days.ago) }
+
+    it 'returns pending conversations inactive for longer than the given minutes' do
+      expect(account.conversations.resolvable_pending(60 * 24)).to contain_exactly(stale_pending)
+    end
+
+    it 'returns nothing when the duration is not set' do
+      expect(account.conversations.resolvable_pending(nil)).to be_empty
+    end
+
+    it 'never returns open conversations' do
+      expect(account.conversations.resolvable_pending(1)).not_to include(stale_open)
+      expect(account.conversations.resolvable_pending(1)).not_to include(recent_pending)
+    end
+  end
 end

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -1309,8 +1309,8 @@ RSpec.describe Conversation do
     end
 
     it 'never returns open conversations' do
+      expect(account.conversations.resolvable_pending(1)).to contain_exactly(stale_pending, recent_pending)
       expect(account.conversations.resolvable_pending(1)).not_to include(stale_open)
-      expect(account.conversations.resolvable_pending(1)).not_to include(recent_pending)
     end
   end
 end


### PR DESCRIPTION
## Description

Auto-resolve (`Settings → Conversation workflow → Auto-resolve conversations`) only touches **open** conversations: `Conversations::ResolutionJob` relies on the `resolvable_all` / `resolvable_not_waiting` scopes, which are built on `open.where('last_activity_at < ?', …)`. Conversations that stay in **pending** — typically ones a bot could not hand off — are never resolved, accumulate over time and pollute the Pending folder and the reports. This was confirmed in #10241 before it was closed by the stale bot.

This PR adds an independent, opt-in threshold for pending conversations:

- `auto_resolve_pending_after` (minutes, same 10 min – 999 days validation as `auto_resolve_after`) and `auto_resolve_pending_message` in `account.settings` (schema, `store_accessor`, permitted params).
- `Conversation.resolvable_pending(minutes)` scope and `Account.with_auto_resolve_pending`.
- `Conversations::PendingResolutionJob`, scheduled from `Account::ConversationsResolutionSchedulerJob` next to the existing job, limited to `Limits::BULK_ACTIONS_LIMIT` per run and skipping orphan conversations, mirroring `ResolutionJob`.
- `MessageTemplates::Template::AutoResolvePending` (subclass of `AutoResolve`) so the pending message respects the messaging window the same way.
- `AutoResolvePending.vue` settings card below the existing auto-resolve card (same layout/components), only rendered when the `auto_resolve_conversations` feature flag is on.

Existing `auto_resolve_after` behaviour is untouched; nothing happens for accounts that do not set the new value.

Fixes #15688

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- `spec/jobs/conversations/pending_resolution_job_spec.rb` (9 cases: enqueue queue, not configured, stale pending resolved, recent pending kept, open untouched, message sent / not sent, orphan skipped, bulk limit).
- Scheduler, `Account` settings validation, `Conversation.resolvable_pending` and `accounts#update` permitted params specs extended.
- rubocop clean on all changed Ruby files; eslint/prettier clean on the Vue/JSON changes.
- Ruby specs could not be run locally (no Postgres + pgvector on this machine) — verified through CI.
- An equivalent implementation has been running in our fork since April 2026; this is a port on top of `develop`, reusing the existing auto-resolve building blocks.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (verified in CI)
- [ ] Any dependent changes have been merged and published in downstream modules
