### PR TITLE
fix(mail,reports): support multi-delimiter email lists and prepend UTF-8 BOM to CSV downloads

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -101,8 +101,12 @@ class Messages::MessageBuilder
 
   def process_email_string(email_string)
     return [] if email_string.blank?
+    return email_string if email_string.is_a?(Array)
 
-    email_string.gsub(/\s+/, '').split(',')
+    # Handles commas, semicolons, and spaces as separators while preserving display names like 'Name <email@example.com>'
+    email_string.to_s.split(/[,;\n\r]+/).flat_map do |token|
+      token.strip.scan(/[^<>\s]+@[^<>\s]+|[^<]+<[^>]+>/).presence || token.strip
+    end.map(&:strip).reject(&:blank?).uniq
   end
 
   def message_type

--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -99,17 +99,8 @@ class Messages::MessageBuilder
     @message.content_attributes[:email] = email_attributes
   end
 
-  def process_email_string(email_string)
-    return [] if email_string.blank?
-    return email_string if email_string.is_a?(Array)
-
-    # Handles commas, semicolons, and spaces as separators while preserving display names like 'Name <email@example.com>'
-    email_string.to_s.split(/[,;\n\r]+/).flat_map do |token|
-      token.strip.scan(/[^<>\s]+@[^<>\s]+|[^<]+<[^>]+>/).presence || token.strip
-    end.map(&:strip).reject(&:blank?).uniq
-  end
-
   def message_type
+
     if @conversation.inbox.channel_type != 'Channel::Api' && @message_type == 'incoming'
       raise StandardError, 'Incoming messages are only allowed in Api inboxes'
     end

--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -100,7 +100,6 @@ class Messages::MessageBuilder
   end
 
   def message_type
-
     if @conversation.inbox.channel_type != 'Channel::Api' && @message_type == 'incoming'
       raise StandardError, 'Incoming messages are only allowed in Api inboxes'
     end

--- a/app/controllers/api/v1/accounts/csat_survey_responses_controller.rb
+++ b/app/controllers/api/v1/accounts/csat_survey_responses_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::Accounts::CsatSurveyResponsesController < Api::V1::Accounts::BaseController
   include Sift
   include DateRangeHelper
+  include CsvExportConcern
 
   RESULTS_PER_PAGE = 25
 
@@ -20,9 +21,7 @@ class Api::V1::Accounts::CsatSurveyResponsesController < Api::V1::Accounts::Base
   end
 
   def download
-    response.headers['Content-Type'] = 'text/csv'
-    response.headers['Content-Disposition'] = 'attachment; filename=csat_report.csv'
-    render layout: false, template: 'api/v1/accounts/csat_survey_responses/download', formats: [:csv]
+    render_csv_with_bom('csat_report', 'api/v1/accounts/csat_survey_responses/download', formats: [:csv])
   end
 
   private

--- a/app/controllers/api/v2/accounts/reports_controller.rb
+++ b/app/controllers/api/v2/accounts/reports_controller.rb
@@ -1,6 +1,7 @@
 class Api::V2::Accounts::ReportsController < Api::V1::Accounts::BaseController
   include Api::V2::Accounts::ReportsHelper
   include Api::V2::Accounts::HeatmapHelper
+  include CsvExportConcern
 
   before_action :check_authorization
 
@@ -97,9 +98,7 @@ class Api::V2::Accounts::ReportsController < Api::V1::Accounts::BaseController
   private
 
   def generate_csv(filename, template)
-    response.headers['Content-Type'] = 'text/csv'
-    response.headers['Content-Disposition'] = "attachment; filename=#{filename}.csv"
-    render layout: false, template: template, formats: [:csv]
+    render_csv_with_bom(filename, template, formats: [:csv])
   end
 
   def check_authorization

--- a/app/controllers/concerns/csv_export_concern.rb
+++ b/app/controllers/concerns/csv_export_concern.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module CsvExportConcern
+  extend ActiveSupport::Concern
+
+  UTF8_BOM = "\xEF\xBB\xBF"
+
+  def render_csv_with_bom(filename, template, formats: [:csv])
+    response.headers['Content-Type'] = 'text/csv; charset=utf-8'
+    response.headers['Content-Disposition'] = "attachment; filename=#{filename}.csv"
+
+    csv_string = render_to_string(layout: false, template: template, formats: formats)
+    send_data "#{UTF8_BOM}#{csv_string}", filename: "#{filename}.csv", type: 'text/csv; charset=utf-8', disposition: 'attachment'
+  end
+end

--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -17,6 +17,16 @@ module EmailHelper
     end
   end
 
+  def process_email_string(email_string)
+    return [] if email_string.blank?
+    return email_string if email_string.is_a?(Array)
+
+    email_string.to_s.split(/[,;\n\r]+/).flat_map do |token|
+      token.strip.scan(/[^<>\s]+@[^<>\s]+|[^<]+<[^>]+>/).presence || token.strip
+    end.map(&:strip).reject(&:blank?).uniq
+  end
+
+
   # ref: https://www.rfc-editor.org/rfc/rfc5233.html
   # This is not a  mandatory requirement for email addresses, but it is a common practice.
   # john+test@xyc.com is the same as john@xyc.com

--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -26,7 +26,6 @@ module EmailHelper
     end.map(&:strip).reject(&:blank?).uniq
   end
 
-
   # ref: https://www.rfc-editor.org/rfc/rfc5233.html
   # This is not a  mandatory requirement for email addresses, but it is a common practice.
   # john+test@xyc.com is the same as john@xyc.com

--- a/enterprise/app/controllers/api/v1/accounts/applied_slas_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/applied_slas_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::Accounts::AppliedSlasController < Api::V1::Accounts::EnterpriseAccountsController
   include Sift
   include DateRangeHelper
+  include CsvExportConcern
 
   RESULTS_PER_PAGE = 25
 
@@ -24,9 +25,7 @@ class Api::V1::Accounts::AppliedSlasController < Api::V1::Accounts::EnterpriseAc
 
   def download
     @missed_applied_slas = missed_applied_slas
-    response.headers['Content-Type'] = 'text/csv'
-    response.headers['Content-Disposition'] = 'attachment; filename=breached_conversation.csv'
-    render layout: false, formats: [:csv]
+    render_csv_with_bom('breached_conversation', 'enterprise/api/v1/accounts/applied_slas/download', formats: [:csv])
   end
 
   private

--- a/enterprise/app/controllers/api/v1/accounts/applied_slas_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/applied_slas_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::Accounts::AppliedSlasController < Api::V1::Accounts::EnterpriseAc
 
   def download
     @missed_applied_slas = missed_applied_slas
-    render_csv_with_bom('breached_conversation', 'enterprise/api/v1/accounts/applied_slas/download', formats: [:csv])
+    render_csv_with_bom('breached_conversation', 'api/v1/accounts/applied_slas/download', formats: [:csv])
   end
 
   private

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -313,4 +313,30 @@ describe Messages::MessageBuilder do
       end
     end
   end
+
+  describe '#process_email_string' do
+    let(:builder) { described_class.new(user, conversation, params) }
+
+    it 'handles comma separated emails' do
+      expect(builder.send(:process_email_string, 'a@example.com, b@example.com')).to eq(['a@example.com', 'b@example.com'])
+    end
+
+    it 'handles semicolon separated emails' do
+      expect(builder.send(:process_email_string, 'a@example.com;b@example.com')).to eq(['a@example.com', 'b@example.com'])
+    end
+
+    it 'handles space separated emails' do
+      expect(builder.send(:process_email_string, 'a@example.com b@example.com')).to eq(['a@example.com', 'b@example.com'])
+    end
+
+    it 'handles display names with angle brackets' do
+      result = builder.send(:process_email_string, 'Jane Doe <jane@example.com>; John <john@example.com>')
+      expect(result).to eq(['Jane Doe <jane@example.com>', 'John <john@example.com>'])
+    end
+
+    it 'returns empty array on blank input' do
+      expect(builder.send(:process_email_string, '')).to eq([])
+      expect(builder.send(:process_email_string, nil)).to eq([])
+    end
+  end
 end

--- a/spec/controllers/api/v2/accounts/reports_controller_spec.rb
+++ b/spec/controllers/api/v2/accounts/reports_controller_spec.rb
@@ -421,5 +421,16 @@ RSpec.describe Api::V2::Accounts::ReportsController, type: :request do
         expect(agent_entry['outgoing_messages_count']).to eq(3)
       end
     end
+
+    context 'when requesting CSV format' do
+      it 'prepends UTF-8 BOM in CSV report downloads' do
+        get "/api/v2/accounts/#{account.id}/reports/agents",
+            params: { since: 1.day.ago.to_i, until: Time.current.to_i },
+            headers: admin.create_new_auth_token, as: :csv
+
+        expect(response).to have_http_status(:success)
+        expect(response.body.bytes.take(3)).to eq([0xEF, 0xBB, 0xBF])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
Fixes #15609, Fixes #15684

### Summary of Changes

1. **Multi-delimiter Email Parsing (#15609)**:
   - Updated `Messages::MessageBuilder#process_email_string` to gracefully handle email recipient lists delimited by commas, semicolons (standard Outlook copy-paste separator), newlines, and spaces.
   - Preserves bracketed recipient display names (e.g. `Jane Doe <jane@example.com>`).

2. **UTF-8 BOM Prepending for CSV Downloads (#15684)**:
   - Added reusable `CsvExportConcern#render_csv_with_bom` to ensure report CSV downloads include the UTF-8 Byte Order Mark (`\xEF\xBB\xBF`).
   - Prevents Excel from rendering non-ASCII names and UTF-8 characters (e.g., Cyrillic, Chinese, accented Latin names) as garbled text / mojibake.
   - Applied to `ReportsController`, `CsatSurveyResponsesController`, and `AppliedSlasController`.

3. **Specs & Tests**:
   - Added unit tests in `spec/builders/messages/message_builder_spec.rb` covering all separator styles and display name formats.
   - Added request specs in `spec/controllers/api/v2/accounts/reports_controller_spec.rb` verifying the presence of the UTF-8 BOM in downloaded CSV payloads.

### Files Changed:
- `app/controllers/concerns/csv_export_concern.rb`
- `app/controllers/api/v1/accounts/csat_survey_responses_controller.rb`
- `app/controllers/api/v2/accounts/reports_controller.rb`
- `enterprise/app/controllers/api/v1/accounts/applied_slas_controller.rb`
- `app/builders/messages/message_builder.rb`
- `spec/builders/messages/message_builder_spec.rb`
- `spec/controllers/api/v2/accounts/reports_controller_spec.rb`
