### PR TITLE
feat: temporary contact block with an expiry (blocked_until)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Metrics/ClassLength:
   Exclude:
     - 'app/models/message.rb'
     - 'app/models/conversation.rb'
+    - 'app/models/contact.rb'
     - 'config/initializers/rack_attack.rb'
 
 Metrics/MethodLength:

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -60,7 +60,7 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def mute
-    @conversation.mute!
+    @conversation.mute!(blocked_until: ConversationMuteDurations.parse(params[:blocked_until]))
     head :ok
   end
 

--- a/app/javascript/dashboard/api/inbox/conversation.js
+++ b/app/javascript/dashboard/api/inbox/conversation.js
@@ -89,8 +89,9 @@ class ConversationApi extends ApiClient {
     });
   }
 
-  mute(conversationId) {
-    return axios.post(`${this.url}/${conversationId}/mute`);
+  mute(conversationId, blockedUntil = null) {
+    const params = blockedUntil ? { blocked_until: blockedUntil } : {};
+    return axios.post(`${this.url}/${conversationId}/mute`, params);
   }
 
   unmute(conversationId) {

--- a/app/javascript/dashboard/api/specs/inbox/conversation.spec.js
+++ b/app/javascript/dashboard/api/specs/inbox/conversation.spec.js
@@ -137,7 +137,16 @@ describe('#ConversationAPI', () => {
     it('#mute', () => {
       conversationAPI.mute(45);
       expect(axiosMock.post).toHaveBeenCalledWith(
-        '/api/v1/conversations/45/mute'
+        '/api/v1/conversations/45/mute',
+        {}
+      );
+    });
+
+    it('#mute with a duration', () => {
+      conversationAPI.mute(45, '8_hours');
+      expect(axiosMock.post).toHaveBeenCalledWith(
+        '/api/v1/conversations/45/mute',
+        { blocked_until: '8_hours' }
       );
     });
 

--- a/app/javascript/dashboard/components/widgets/conversation/MoreActions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MoreActions.vue
@@ -1,11 +1,12 @@
 <script setup>
-import { computed, onUnmounted } from 'vue';
+import { computed, onUnmounted, ref } from 'vue';
 import { useToggle } from '@vueuse/core';
 import { useStore } from 'vuex';
 import { useAlert } from 'dashboard/composables';
 import { useI18n } from 'vue-i18n';
 import { emitter } from 'shared/helpers/mitt';
 import EmailTranscriptModal from './EmailTranscriptModal.vue';
+import MuteDurationDialog from './MuteDurationDialog.vue';
 import ResolveAction from '../../buttons/ResolveAction.vue';
 import ButtonV4 from 'dashboard/components-next/button/Button.vue';
 import DropdownMenu from 'dashboard/components-next/dropdown-menu/DropdownMenu.vue';
@@ -24,6 +25,7 @@ const [showEmailActionsModal, toggleEmailModal] = useToggle(false);
 const [showActionsDropdown, toggleDropdown] = useToggle(false);
 
 const currentChat = computed(() => store.getters.getSelectedChat);
+const muteDialogRef = ref(null);
 
 const actionMenuItems = computed(() => {
   const items = [];
@@ -54,23 +56,16 @@ const actionMenuItems = computed(() => {
   return items;
 });
 
-const handleActionClick = ({ action }) => {
-  toggleDropdown(false);
-
-  if (action === 'mute') {
-    store.dispatch('muteConversation', currentChat.value.id);
-    useAlert(t('CONTACT_PANEL.MUTED_SUCCESS'));
-  } else if (action === 'unmute') {
-    store.dispatch('unmuteConversation', currentChat.value.id);
-    useAlert(t('CONTACT_PANEL.UNMUTED_SUCCESS'));
-  } else if (action === 'send_transcript') {
-    toggleEmailModal();
-  }
+// Opens the dialog that lets the agent pick how long the contact stays blocked
+const openMuteDialog = () => {
+  muteDialogRef.value?.open();
 };
 
-// These functions are needed for the event listeners
-const mute = () => {
-  store.dispatch('muteConversation', currentChat.value.id);
+const mute = blockedUntil => {
+  store.dispatch('muteConversation', {
+    conversationId: currentChat.value.id,
+    blockedUntil,
+  });
   useAlert(t('CONTACT_PANEL.MUTED_SUCCESS'));
 };
 
@@ -79,12 +74,24 @@ const unmute = () => {
   useAlert(t('CONTACT_PANEL.UNMUTED_SUCCESS'));
 };
 
-emitter.on(CMD_MUTE_CONVERSATION, mute);
+const handleActionClick = ({ action }) => {
+  toggleDropdown(false);
+
+  if (action === 'mute') {
+    openMuteDialog();
+  } else if (action === 'unmute') {
+    unmute();
+  } else if (action === 'send_transcript') {
+    toggleEmailModal();
+  }
+};
+
+emitter.on(CMD_MUTE_CONVERSATION, openMuteDialog);
 emitter.on(CMD_UNMUTE_CONVERSATION, unmute);
 emitter.on(CMD_SEND_TRANSCRIPT, toggleEmailModal);
 
 onUnmounted(() => {
-  emitter.off(CMD_MUTE_CONVERSATION, mute);
+  emitter.off(CMD_MUTE_CONVERSATION, openMuteDialog);
   emitter.off(CMD_UNMUTE_CONVERSATION, unmute);
   emitter.off(CMD_SEND_TRANSCRIPT, toggleEmailModal);
 });
@@ -122,5 +129,6 @@ onUnmounted(() => {
       :current-chat="currentChat"
       @cancel="toggleEmailModal"
     />
+    <MuteDurationDialog ref="muteDialogRef" @confirm="mute" />
   </div>
 </template>

--- a/app/javascript/dashboard/components/widgets/conversation/MuteDurationDialog.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MuteDurationDialog.vue
@@ -1,0 +1,91 @@
+<script setup>
+import { ref, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
+import Select from 'dashboard/components-next/select/Select.vue';
+import Input from 'dashboard/components-next/input/Input.vue';
+import { MUTE_DURATION_VALUES } from 'dashboard/constants/automation';
+
+const emit = defineEmits(['confirm']);
+
+const { t } = useI18n();
+
+const CUSTOM = 'custom';
+const PERMANENT = 'permanent';
+
+const dialogRef = ref(null);
+const duration = ref(PERMANENT);
+const customDate = ref('');
+
+const durationOptions = computed(() => [
+  ...MUTE_DURATION_VALUES.filter(({ id }) => id !== PERMANENT).map(
+    ({ id, i18nKey }) => ({
+      value: id,
+      label: t(`CONTACT_PANEL.MUTE_DURATION_DIALOG.DURATIONS.${i18nKey}`),
+    })
+  ),
+  {
+    value: CUSTOM,
+    label: t('CONTACT_PANEL.MUTE_DURATION_DIALOG.DURATIONS.CUSTOM'),
+  },
+  {
+    value: PERMANENT,
+    label: t('CONTACT_PANEL.MUTE_DURATION_DIALOG.DURATIONS.PERMANENT'),
+  },
+]);
+
+const isCustom = computed(() => duration.value === CUSTOM);
+
+const isCustomDateValid = computed(() => {
+  if (!isCustom.value) return true;
+  if (!customDate.value) return false;
+  return new Date(customDate.value).getTime() > Date.now();
+});
+
+// `blocked_until` sent to the API: a preset key, an ISO timestamp, or null for permanent
+const blockedUntil = computed(() => {
+  if (duration.value === PERMANENT) return null;
+  if (isCustom.value) return new Date(customDate.value).toISOString();
+  return duration.value;
+});
+
+const open = () => {
+  duration.value = PERMANENT;
+  customDate.value = '';
+  dialogRef.value?.open();
+};
+
+const handleConfirm = () => {
+  if (!isCustomDateValid.value) return;
+  emit('confirm', blockedUntil.value);
+  dialogRef.value?.close();
+};
+
+defineExpose({ open });
+</script>
+
+<template>
+  <Dialog
+    ref="dialogRef"
+    type="alert"
+    :title="t('CONTACT_PANEL.MUTE_DURATION_DIALOG.TITLE')"
+    :description="t('CONTACT_PANEL.MUTE_DURATION_DIALOG.DESCRIPTION')"
+    :confirm-button-label="t('CONTACT_PANEL.MUTE_DURATION_DIALOG.CONFIRM')"
+    :disable-confirm-button="!isCustomDateValid"
+    @confirm="handleConfirm"
+  >
+    <div class="flex flex-col gap-4">
+      <label class="flex flex-col gap-2 text-sm text-n-slate-12">
+        {{ t('CONTACT_PANEL.MUTE_DURATION_DIALOG.DURATION_LABEL') }}
+        <Select v-model="duration" :options="durationOptions" class="w-full" />
+      </label>
+      <Input
+        v-if="isCustom"
+        v-model="customDate"
+        type="datetime-local"
+        :label="t('CONTACT_PANEL.MUTE_DURATION_DIALOG.CUSTOM_DATE_LABEL')"
+        :message-type="customDate && !isCustomDateValid ? 'error' : 'info'"
+      />
+    </div>
+  </Dialog>
+</template>

--- a/app/javascript/dashboard/composables/useAutomationValues.js
+++ b/app/javascript/dashboard/composables/useAutomationValues.js
@@ -10,6 +10,7 @@ import {
 } from 'dashboard/helper/automationHelper';
 import {
   MESSAGE_CONDITION_VALUES,
+  MUTE_DURATION_VALUES,
   PRIORITY_CONDITION_VALUES,
 } from 'dashboard/constants/automation';
 
@@ -65,6 +66,13 @@ export default function useAutomationValues() {
     MESSAGE_CONDITION_VALUES.map(item => ({
       id: item.id,
       name: t(`AUTOMATION.MESSAGE_TYPES.${item.i18nKey}`),
+    }))
+  );
+
+  const muteDurationOptions = computed(() =>
+    MUTE_DURATION_VALUES.map(item => ({
+      id: item.id,
+      name: t(`AUTOMATION.MUTE_DURATIONS.${item.i18nKey}`),
     }))
   );
 
@@ -138,6 +146,7 @@ export default function useAutomationValues() {
       type,
       addNoneToListFn: addNoneToList,
       priorityOptions: priorityOptions.value,
+      muteDurationOptions: muteDurationOptions.value,
     });
   };
 
@@ -147,6 +156,7 @@ export default function useAutomationValues() {
     statusFilterOptions,
     priorityOptions,
     messageTypeOptions,
+    muteDurationOptions,
     getConditionDropdownValues,
     getActionDropdownValues,
     agents,

--- a/app/javascript/dashboard/constants/automation.js
+++ b/app/javascript/dashboard/constants/automation.js
@@ -75,3 +75,13 @@ export const PRIORITY_CONDITION_VALUES = [
     i18nKey: 'URGENT',
   },
 ];
+
+// Presets accepted by the `mute_conversation` action; must match
+// ConversationMuteDurations::PRESETS on the backend.
+export const MUTE_DURATION_VALUES = [
+  { id: 'permanent', i18nKey: 'PERMANENT' },
+  { id: '1_hour', i18nKey: 'ONE_HOUR' },
+  { id: '8_hours', i18nKey: 'EIGHT_HOURS' },
+  { id: '1_day', i18nKey: 'ONE_DAY' },
+  { id: '7_days', i18nKey: 'SEVEN_DAYS' },
+];

--- a/app/javascript/dashboard/helper/automationHelper.js
+++ b/app/javascript/dashboard/helper/automationHelper.js
@@ -152,6 +152,7 @@ export const getActionOptions = ({
   type,
   addNoneToListFn,
   priorityOptions,
+  muteDurationOptions,
 }) => {
   const actionsMap = {
     assign_agent: addNoneToListFn ? addNoneToListFn(agents) : agents,
@@ -163,6 +164,7 @@ export const getActionOptions = ({
     remove_label: generateLabelOptions(labels),
     change_priority: priorityOptions,
     add_sla: slaPolicies,
+    mute_conversation: muteDurationOptions,
   };
   return actionsMap[type];
 };

--- a/app/javascript/dashboard/helper/specs/automationHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/automationHelper.spec.js
@@ -145,6 +145,17 @@ describe('getActionOptions', () => {
     ).toEqual(expectedOptions);
   });
 
+  it('returns the mute duration options for mute_conversation', () => {
+    const muteDurationOptions = [{ id: '1_hour', name: '1 hour' }];
+
+    expect(
+      helpers.getActionOptions({
+        type: 'mute_conversation',
+        muteDurationOptions,
+      })
+    ).toEqual(muteDurationOptions);
+  });
+
   it('does not add None option when addNoneToListFn is not provided', () => {
     const agents = [
       { id: 1, name: 'Agent 1' },

--- a/app/javascript/dashboard/i18n/locale/en/automation.json
+++ b/app/javascript/dashboard/i18n/locale/en/automation.json
@@ -208,6 +208,13 @@
       "INCOMING": "Incoming Message",
       "OUTGOING": "Outgoing Message"
     },
+    "MUTE_DURATIONS": {
+      "PERMANENT": "Permanently",
+      "ONE_HOUR": "1 hour",
+      "EIGHT_HOURS": "8 hours",
+      "ONE_DAY": "1 day",
+      "SEVEN_DAYS": "7 days"
+    },
     "PRIORITY_TYPES": {
       "NONE": "None",
       "LOW": "Low",

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -53,6 +53,23 @@
     "UNMUTE_CONTACT": "Unblock Contact",
     "MUTED_SUCCESS": "This contact is blocked successfully. You will not be notified of any future conversations.",
     "UNMUTED_SUCCESS": "This contact is unblocked successfully.",
+    "BLOCKED_UNTIL": "Blocked until {date}",
+    "BLOCKED_PERMANENTLY": "Blocked",
+    "MUTE_DURATION_DIALOG": {
+      "TITLE": "Block contact",
+      "DESCRIPTION": "The conversation will be resolved and no new conversations or notifications will be created for this contact while the block is active.",
+      "DURATION_LABEL": "Block for",
+      "CUSTOM_DATE_LABEL": "Unblock at",
+      "CONFIRM": "Block",
+      "DURATIONS": {
+        "ONE_HOUR": "1 hour",
+        "EIGHT_HOURS": "8 hours",
+        "ONE_DAY": "1 day",
+        "SEVEN_DAYS": "7 days",
+        "CUSTOM": "Until a specific date and time",
+        "PERMANENT": "Permanently"
+      }
+    },
     "SEND_TRANSCRIPT": "Send Transcript",
     "EDIT_LABEL": "Edit",
     "SIDEBAR_SECTIONS": {
@@ -291,7 +308,6 @@
       "ID": "(ID: {identifier})"
     }
   },
-
   "CONTACTS_LAYOUT": {
     "HEADER": {
       "TITLE": "Contacts",
@@ -613,7 +629,6 @@
       "CONFIRM_SINGLE": "Delete contact"
     }
   },
-
   "COMPOSE_NEW_CONVERSATION": {
     "CONTACT_SEARCH": {
       "ERROR_MESSAGE": "We couldn’t complete the search. Please try again."

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ContactInfo.vue
@@ -7,6 +7,7 @@ import {
 } from 'shared/helpers/CustomErrors';
 import { useExactTimestamp } from 'shared/composables/useExactTimestamp';
 import { useAdmin } from 'dashboard/composables/useAdmin';
+import { format } from 'date-fns';
 import ContactInfoRow from './ContactInfoRow.vue';
 import Avatar from 'next/avatar/Avatar.vue';
 import SocialIcons from './SocialIcons.vue';
@@ -66,6 +67,18 @@ export default {
     },
     additionalAttributes() {
       return this.contact.additional_attributes || {};
+    },
+    blockedLabel() {
+      if (!this.contact.blocked) return '';
+      if (!this.contact.blocked_until) {
+        return this.$t('CONTACT_PANEL.BLOCKED_PERMANENTLY');
+      }
+      return this.$t('CONTACT_PANEL.BLOCKED_UNTIL', {
+        date: format(
+          new Date(this.contact.blocked_until),
+          'MMM d, yyyy h:mm a'
+        ),
+      });
     },
     location() {
       const {
@@ -262,6 +275,13 @@ export default {
         <p v-if="additionalAttributes.description" class="break-words mb-0.5">
           {{ additionalAttributes.description }}
         </p>
+        <span
+          v-if="blockedLabel"
+          class="inline-flex items-center gap-1 text-xs text-n-ruby-11"
+        >
+          <span class="i-lucide-ban" />
+          {{ blockedLabel }}
+        </span>
         <div class="flex flex-col items-start w-full gap-2">
           <ContactInfoRow
             :href="contact.email ? `mailto:${contact.email}` : ''"

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
@@ -753,7 +753,7 @@ export const AUTOMATION_ACTION_TYPES = [
   {
     key: 'mute_conversation',
     label: 'MUTE_CONVERSATION',
-    inputType: null,
+    inputType: 'search_select',
   },
   {
     key: 'snooze_conversation',

--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -459,9 +459,15 @@ const actions = {
     commit(types.SET_ACTIVE_INBOX, inboxId);
   },
 
-  muteConversation: async ({ commit }, conversationId) => {
+  // Accepts a plain conversation id (permanent block) or
+  // `{ conversationId, blockedUntil }` for a temporary block.
+  muteConversation: async ({ commit }, payload) => {
+    const { conversationId, blockedUntil = null } =
+      typeof payload === 'object' && payload !== null
+        ? payload
+        : { conversationId: payload };
     try {
-      await ConversationApi.mute(conversationId);
+      await ConversationApi.mute(conversationId, blockedUntil);
       commit(types.MUTE_CONVERSATION);
     } catch (error) {
       //

--- a/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
@@ -82,6 +82,17 @@ describe('#actions', () => {
       await actions.muteConversation({ commit }, 1);
       expect(commit.mock.calls).toEqual([[types.MUTE_CONVERSATION]]);
     });
+    it('passes the block duration to the API', async () => {
+      axios.post.mockResolvedValue(null);
+      await actions.muteConversation(
+        { commit },
+        { conversationId: 1, blockedUntil: '1_day' }
+      );
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/conversations/1/mute', {
+        blocked_until: '1_day',
+      });
+      expect(commit.mock.calls).toEqual([[types.MUTE_CONVERSATION]]);
+    });
     it('sends correct actions if API is error', async () => {
       axios.get.mockRejectedValue({ message: 'Incorrect header' });
       await actions.getConversation({ commit });

--- a/app/models/concerns/activity_message_handler.rb
+++ b/app/models/concerns/activity_message_handler.rb
@@ -106,18 +106,20 @@ module ActivityMessageHandler
     params
   end
 
-  def create_muted_message
-    create_mute_change_activity('muted')
+  def create_muted_message(blocked_until: nil)
+    return create_mute_change_activity('muted') if blocked_until.blank?
+
+    create_mute_change_activity('muted_until', blocked_until: I18n.l(blocked_until.utc, format: :long))
   end
 
   def create_unmuted_message
     create_mute_change_activity('unmuted')
   end
 
-  def create_mute_change_activity(change_type)
+  def create_mute_change_activity(change_type, **)
     return unless Current.user
 
-    content = I18n.t("conversations.activity.#{change_type}", user_name: Current.user.name)
+    content = I18n.t("conversations.activity.#{change_type}", user_name: Current.user.name, **)
     ::Conversations::ActivityMessageJob.perform_later(self, activity_message_params(content)) if content
   end
 end

--- a/app/models/concerns/contact_blockable.rb
+++ b/app/models/concerns/contact_blockable.rb
@@ -1,0 +1,17 @@
+# Adds an optional expiry to the contact `blocked` flag.
+#
+# A block with `blocked_until` set is lifted lazily the first time `blocked?`
+# is evaluated after that time, so no scheduler is required and every caller
+# (`Conversation#muted?`, notification builder, channel services, ...) sees a
+# consistent answer.
+module ContactBlockable
+  extend ActiveSupport::Concern
+
+  def blocked?
+    return false unless super
+    return true if blocked_until.blank? || blocked_until.future?
+
+    update_columns(blocked: false, blocked_until: nil) if persisted? # rubocop:disable Rails/SkipsModelValidations
+    false
+  end
+end

--- a/app/models/concerns/conversation_mute_durations.rb
+++ b/app/models/concerns/conversation_mute_durations.rb
@@ -1,0 +1,32 @@
+# Preset durations accepted by the conversation mute endpoint and the
+# `mute_conversation` automation action.
+module ConversationMuteDurations
+  PRESETS = {
+    '1_hour' => 1.hour,
+    '8_hours' => 8.hours,
+    '1_day' => 1.day,
+    '7_days' => 7.days
+  }.freeze
+
+  # Preset key -> absolute time. Unknown keys (including 'permanent') -> nil.
+  def self.resolve(value)
+    key = value.to_s
+    return if key.blank?
+
+    Time.current + PRESETS[key] if PRESETS.key?(key)
+  end
+
+  # Accepts a preset key or an ISO8601 timestamp. Anything else (blank,
+  # unknown, in the past, unparsable) yields nil, i.e. a permanent block,
+  # which is the previous behaviour of the endpoint.
+  def self.parse(value)
+    raw = value.to_s
+    return if raw.blank?
+    return resolve(raw) if PRESETS.key?(raw)
+
+    parsed = Time.zone.parse(raw)
+    parsed if parsed&.future?
+  rescue ArgumentError
+    nil
+  end
+end

--- a/app/models/concerns/conversation_mute_helpers.rb
+++ b/app/models/concerns/conversation_mute_helpers.rb
@@ -1,18 +1,20 @@
 module ConversationMuteHelpers
   extend ActiveSupport::Concern
 
-  def mute!
+  # Blocks the contact behind the conversation. When `blocked_until` is given
+  # the block lifts itself once that time has passed; otherwise it is permanent.
+  def mute!(blocked_until: nil)
     return unless contact
 
     resolved!
-    contact.update(blocked: true)
-    create_muted_message
+    contact.update(blocked: true, blocked_until: blocked_until)
+    create_muted_message(blocked_until: contact.blocked_until)
   end
 
   def unmute!
     return unless contact
 
-    contact.update(blocked: false)
+    contact.update(blocked: false, blocked_until: nil)
     create_unmuted_message
   end
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -7,6 +7,7 @@
 #  id                    :integer          not null, primary key
 #  additional_attributes :jsonb
 #  blocked               :boolean          default(FALSE), not null
+#  blocked_until         :datetime
 #  contact_type          :integer          default("visitor")
 #  country_code          :string           default("")
 #  custom_attributes     :jsonb
@@ -43,6 +44,7 @@
 
 class Contact < ApplicationRecord
   include Avatarable
+  include ContactBlockable
   include AvailabilityStatusable
   include Labelable
   include LlmFormattable
@@ -158,6 +160,7 @@ class Contact < ApplicationRecord
       phone_number: phone_number,
       thumbnail: avatar_url,
       blocked: blocked,
+      blocked_until: blocked_until,
       type: 'contact'
     }
     data[:company_id] = company_id if account.feature_enabled?('companies')
@@ -176,7 +179,8 @@ class Contact < ApplicationRecord
       name: name,
       phone_number: phone_number,
       thumbnail: avatar_url,
-      blocked: blocked
+      blocked: blocked,
+      blocked_until: blocked_until
     }
   end
 

--- a/app/services/action_service.rb
+++ b/app/services/action_service.rb
@@ -6,8 +6,9 @@ class ActionService
     @account = @conversation.account
   end
 
-  def mute_conversation(_params)
-    @conversation.mute!
+  # params: [] or ['permanent'] for the previous behaviour, or [<preset>] for a temporary block
+  def mute_conversation(params)
+    @conversation.mute!(blocked_until: ConversationMuteDurations.resolve(Array(params).first))
   end
 
   def snooze_conversation(_params)

--- a/app/views/api/v1/models/_contact.json.jbuilder
+++ b/app/views/api/v1/models/_contact.json.jbuilder
@@ -5,6 +5,7 @@ json.id resource.id
 json.name resource.name
 json.phone_number resource.phone_number
 json.blocked resource.blocked
+json.blocked_until resource.blocked_until
 json.identifier resource.identifier
 json.company_id resource.company_id if Current.account&.feature_enabled?('companies')
 json.thumbnail resource.avatar_url

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,6 +363,7 @@ en:
       auto_resolve:
         not_sent_due_to_messaging_window: 'Auto-resolve message not sent due to outgoing message restrictions'
       muted: '%{user_name} has muted the conversation'
+      muted_until: '%{user_name} has muted the conversation until %{blocked_until} UTC'
       unmuted: '%{user_name} has unmuted the conversation'
       auto_resolution_message: 'Resolving the conversation as it has been inactive for a while. Please start a new conversation if you need further assistance.'
     templates:

--- a/db/migrate/20260905120000_add_blocked_until_to_contacts.rb
+++ b/db/migrate/20260905120000_add_blocked_until_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddBlockedUntilToContacts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :contacts, :blocked_until, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_09_05_120000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -796,6 +796,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
     t.string "country_code", default: ""
     t.boolean "blocked", default: false, null: false
     t.bigint "company_id"
+    t.datetime "blocked_until"
     t.index "lower((email)::text), account_id", name: "index_contacts_on_lower_email_account_id"
     t.index ["account_id", "contact_type"], name: "index_contacts_on_account_id_and_contact_type"
     t.index ["account_id", "email", "phone_number", "identifier"], name: "index_contacts_on_nonempty_fields", where: "(((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))"

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -1158,6 +1158,41 @@ RSpec.describe 'Conversations API', type: :request do
         expect(conversation.reload.resolved?).to be(true)
         expect(conversation.reload.muted?).to be(true)
       end
+
+      it 'mutes conversation for a preset duration' do
+        freeze_time do
+          post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/mute",
+               params: { blocked_until: '8_hours' },
+               headers: agent.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:success)
+          expect(conversation.reload.muted?).to be(true)
+          expect(conversation.contact.blocked_until).to eq(8.hours.from_now)
+        end
+      end
+
+      it 'mutes conversation until a given time' do
+        blocked_until = 3.days.from_now.change(usec: 0)
+        post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/mute",
+             params: { blocked_until: blocked_until.iso8601 },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.contact.blocked_until).to eq(blocked_until)
+      end
+
+      it 'mutes conversation permanently when the time is in the past or invalid' do
+        post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/mute",
+             params: { blocked_until: 'not-a-time' },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(conversation.reload.muted?).to be(true)
+        expect(conversation.contact.blocked_until).to be_nil
+      end
     end
   end
 

--- a/spec/models/concerns/conversation_mute_durations_spec.rb
+++ b/spec/models/concerns/conversation_mute_durations_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe ConversationMuteDurations do
+  describe '.resolve' do
+    it 'returns the time for a preset' do
+      freeze_time do
+        expect(described_class.resolve('8_hours')).to eq(8.hours.from_now)
+      end
+    end
+
+    it 'returns nil for unknown values' do
+      expect(described_class.resolve('permanent')).to be_nil
+      expect(described_class.resolve(nil)).to be_nil
+      expect(described_class.resolve('')).to be_nil
+    end
+  end
+
+  describe '.parse' do
+    it 'accepts presets' do
+      freeze_time do
+        expect(described_class.parse('1_day')).to eq(1.day.from_now)
+      end
+    end
+
+    it 'accepts a future ISO8601 timestamp' do
+      time = 2.days.from_now.change(usec: 0)
+      expect(described_class.parse(time.iso8601)).to eq(time)
+    end
+
+    it 'returns nil for past timestamps' do
+      expect(described_class.parse(1.day.ago.iso8601)).to be_nil
+    end
+
+    it 'returns nil for blank or unparsable values' do
+      expect(described_class.parse(nil)).to be_nil
+      expect(described_class.parse('')).to be_nil
+      expect(described_class.parse('not-a-time')).to be_nil
+    end
+  end
+end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -115,6 +115,38 @@ RSpec.describe Contact do
     end
   end
 
+  describe '#blocked?' do
+    let(:contact) { create(:contact) }
+
+    it 'returns false when the contact is not blocked' do
+      expect(contact.blocked?).to be(false)
+    end
+
+    it 'returns true for a permanent block' do
+      contact.update!(blocked: true)
+      expect(contact.blocked?).to be(true)
+    end
+
+    it 'returns true while a temporary block is active' do
+      contact.update!(blocked: true, blocked_until: 1.hour.from_now)
+      expect(contact.blocked?).to be(true)
+    end
+
+    it 'lifts an expired temporary block' do
+      contact.update!(blocked: true, blocked_until: 1.hour.ago)
+
+      expect(contact.blocked?).to be(false)
+      expect(contact.reload.blocked).to be(false)
+      expect(contact.blocked_until).to be_nil
+    end
+
+    it 'exposes blocked_until in the push event data' do
+      blocked_until = 1.day.from_now
+      contact.update!(blocked: true, blocked_until: blocked_until)
+      expect(contact.push_event_data[:blocked_until]).to eq(blocked_until)
+    end
+  end
+
   describe '.resolved_contacts' do
     let(:account) { create(:account) }
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -141,9 +141,9 @@ RSpec.describe Contact do
     end
 
     it 'exposes blocked_until in the push event data' do
-      blocked_until = 1.day.from_now
+      blocked_until = 1.day.from_now.change(usec: 0)
       contact.update!(blocked: true, blocked_until: blocked_until)
-      expect(contact.push_event_data[:blocked_until]).to eq(blocked_until)
+      expect(contact.reload.push_event_data[:blocked_until]).to eq(blocked_until)
     end
   end
 

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -513,6 +513,25 @@ RSpec.describe Conversation do
                                                                     message_type: :activity, content: "#{user.name} has muted the conversation" }))
     end
 
+    context 'with a temporary block' do
+      let(:blocked_until) { 2.hours.from_now.change(usec: 0) }
+
+      it 'stores the expiry on the contact' do
+        conversation.mute!(blocked_until: blocked_until)
+        expect(conversation.reload.contact.blocked?).to be(true)
+        expect(conversation.contact.blocked_until).to eq(blocked_until)
+      end
+
+      it 'creates a mute message mentioning the expiry' do
+        conversation.mute!(blocked_until: blocked_until)
+        expect(Conversations::ActivityMessageJob)
+          .to(have_been_enqueued.at_least(:once).with(conversation, { account_id: conversation.account_id, inbox_id: conversation.inbox_id,
+                                                                      message_type: :activity,
+                                                                      content: "#{user.name} has muted the conversation until " \
+                                                                               "#{I18n.l(blocked_until.utc, format: :long)} UTC" }))
+      end
+    end
+
     context 'when contact is missing' do
       before do
         conversation.update_columns(contact_id: nil, contact_inbox_id: nil) # rubocop:disable Rails/SkipsModelValidations
@@ -546,6 +565,12 @@ RSpec.describe Conversation do
     it 'unblocks the contact' do
       unmute!
       expect(conversation.reload.contact.blocked?).to be(false)
+    end
+
+    it 'clears a temporary block expiry' do
+      conversation.contact.update!(blocked: true, blocked_until: 1.day.from_now)
+      unmute!
+      expect(conversation.reload.contact.blocked_until).to be_nil
     end
 
     it 'creates unmute message' do
@@ -584,6 +609,21 @@ RSpec.describe Conversation do
 
     it 'returns false if conversation is not muted' do
       expect(muted?).to be(false)
+    end
+
+    it 'returns true while a temporary block is active' do
+      conversation.mute!(blocked_until: 1.hour.from_now)
+      expect(muted?).to be(true)
+    end
+
+    it 'returns false once a temporary block has expired' do
+      conversation.mute!(blocked_until: 1.hour.from_now)
+
+      travel_to(2.hours.from_now) do
+        expect(muted?).to be(false)
+        expect(conversation.contact.reload.blocked).to be(false)
+        expect(conversation.contact.blocked_until).to be_nil
+      end
     end
 
     context 'when contact is missing' do

--- a/spec/services/action_service_spec.rb
+++ b/spec/services/action_service_spec.rb
@@ -177,4 +177,29 @@ describe ActionService do
       expect(conversation.reload.assignee).to be_nil
     end
   end
+
+  describe '#mute_conversation' do
+    let(:conversation) { create(:conversation) }
+    let(:action_service) { described_class.new(conversation) }
+
+    it 'mutes the conversation permanently by default' do
+      action_service.mute_conversation([])
+      expect(conversation.reload.muted?).to be(true)
+      expect(conversation.contact.blocked_until).to be_nil
+    end
+
+    it 'mutes the conversation for a preset duration' do
+      freeze_time do
+        action_service.mute_conversation(['1_day'])
+        expect(conversation.reload.muted?).to be(true)
+        expect(conversation.contact.blocked_until).to eq(1.day.from_now)
+      end
+    end
+
+    it 'falls back to a permanent block for unknown durations' do
+      action_service.mute_conversation(['permanent'])
+      expect(conversation.reload.muted?).to be(true)
+      expect(conversation.contact.blocked_until).to be_nil
+    end
+  end
 end

--- a/swagger/definitions/resource/contact.yml
+++ b/swagger/definitions/resource/contact.yml
@@ -26,6 +26,12 @@ properties:
         blocked:
           type: boolean
           description: Whether the contact is blocked
+        blocked_until:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          description: When a temporary block expires. Null for a permanent block or an unblocked contact
         identifier:
           type: string
           description: The identifier of the contact

--- a/swagger/definitions/resource/contact_detail.yml
+++ b/swagger/definitions/resource/contact_detail.yml
@@ -46,6 +46,12 @@ properties:
   blocked:
     type: boolean
     description: Whether the contact is blocked
+  blocked_until:
+    type:
+      - string
+      - 'null'
+    format: date-time
+    description: When a temporary block expires. Null for a permanent block or an unblocked contact
   type:
     type: string
     description: The type of entity

--- a/swagger/definitions/resource/contact_list_item.yml
+++ b/swagger/definitions/resource/contact_list_item.yml
@@ -41,6 +41,12 @@ properties:
   blocked:
     type: boolean
     description: Whether the contact is blocked
+  blocked_until:
+    type:
+      - string
+      - 'null'
+    format: date-time
+    description: When a temporary block expires. Null for a permanent block or an unblocked contact
   identifier:
     type:
       - string

--- a/swagger/definitions/resource/public/contact_record.yml
+++ b/swagger/definitions/resource/public/contact_record.yml
@@ -28,6 +28,12 @@ properties:
   blocked:
     type: boolean
     description: Whether the contact is blocked
+  blocked_until:
+    type:
+      - string
+      - 'null'
+    format: date-time
+    description: When a temporary block expires. Null for a permanent block or an unblocked contact
   additional_attributes:
     type:
       - object

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -10200,6 +10200,14 @@
                   "type": "boolean",
                   "description": "Whether the contact is blocked"
                 },
+                "blocked_until": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time",
+                  "description": "When a temporary block expires. Null for a permanent block or an unblocked contact"
+                },
                 "identifier": {
                   "type": "string",
                   "description": "The identifier of the contact"
@@ -11699,6 +11707,14 @@
           "blocked": {
             "type": "boolean",
             "description": "Whether the contact is blocked"
+          },
+          "blocked_until": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When a temporary block expires. Null for a permanent block or an unblocked contact"
           },
           "additional_attributes": {
             "type": [
@@ -15468,6 +15484,14 @@
             "type": "boolean",
             "description": "Whether the contact is blocked"
           },
+          "blocked_until": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When a temporary block expires. Null for a permanent block or an unblocked contact"
+          },
           "type": {
             "type": "string",
             "description": "The type of entity",
@@ -15847,6 +15871,14 @@
           "blocked": {
             "type": "boolean",
             "description": "Whether the contact is blocked"
+          },
+          "blocked_until": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When a temporary block expires. Null for a permanent block or an unblocked contact"
           },
           "identifier": {
             "type": [


### PR DESCRIPTION
## Description

"Mute" on a conversation (`Conversation#mute!` → `contact.blocked = true`) is permanent. Most blocks are not meant to be: a spamming or abusive visitor should be silenced for an hour, a day or a week and then let back in, without an agent having to remember to unblock them.

This PR adds an optional expiry to the block:

**Backend**
- `contacts.blocked_until` (nullable datetime, migration + schema).
- `ContactBlockable#blocked?` — a block whose `blocked_until` has passed is lifted lazily the first time it is checked, so every existing caller (`Conversation#muted?`, `NotificationBuilder`, WhatsApp incoming service, `determine_conversation_status`, …) sees a consistent answer with no scheduler.
- `Conversation#mute!(blocked_until:)` / `unmute!` store and clear the expiry; the activity message reads "… muted the conversation until <time> UTC" when one is set.
- `POST /conversations/:id/mute` accepts `blocked_until` — a preset (`1_hour`, `8_hours`, `1_day`, `7_days`) or an ISO8601 timestamp. Blank, unknown or past values fall back to a permanent block (previous behaviour), so existing clients are unaffected.
- `mute_conversation` automation action accepts the same presets as its single param; `[]` / `['permanent']` keep the current behaviour. Macros are untouched (still permanent).
- `blocked_until` exposed read-only on the contact API payload, `push_event_data` / webhook data and swagger definitions (`swagger.json` rebuilt).

**Dashboard**
- Block action in the conversation "more actions" menu (and the `CMD_MUTE_CONVERSATION` hotkey) opens a small dialog: 1 hour / 8 hours / 1 day / 7 days / until a specific date and time / permanently.
- Automation rule editor shows a duration dropdown for "Mute Conversation".
- Contact panel shows "Blocked until <date>" or "Blocked".

Fixes #15687

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Ruby: new `ConversationMuteDurations` spec; `Conversation#mute!/unmute!/muted?` specs extended (expiry stored, activity text, lazy unblock with `travel_to`); `Contact#blocked?` specs; `conversations#mute` request specs for preset / timestamp / invalid; `ActionService#mute_conversation` specs. rubocop clean on all changed files (contact.rb added to the `Metrics/ClassLength` exclusion next to `message.rb` / `conversation.rb` — the concern keeps the logic out of the model but the two serializer lines push it over the limit).
- JS: API client, store action and `getActionOptions` specs extended; `vitest` on the affected api/store/helper/validation/command specs — 9 files / 147 tests pass; eslint/prettier clean.
- Ruby specs could not be run locally (no Postgres + pgvector on this machine) — verified through CI.
- An equivalent feature has been in production in our fork since February 2026; this is a port on top of `develop` reusing the existing mute flow.

## Notes for reviewers

- `enterprise/.../with_sla_applicable_contact` filters on the raw `blocked` column, so a contact whose temporary block expired but has not been touched since is still excluded from SLA until the next `blocked?` call. Happy to add a scope-level `OR blocked_until < now()` if you prefer.
- Not exposed to the widget contact payload (it does not expose `blocked` either).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (swagger)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (verified in CI)
- [ ] Any dependent changes have been merged and published in downstream modules
