### PR TITLE
fix(sdk): guard bubble visibility before DOM mount

### DIFF
--- a/app/javascript/entrypoints/sdk.js
+++ b/app/javascript/entrypoints/sdk.js
@@ -88,12 +88,20 @@ const runSDK = ({ baseUrl, websiteToken }) => {
       let widgetElm = document.querySelector('.woot--bubble-holder');
       let widgetHolder = document.querySelector('.woot-widget-holder');
       if (visibility === 'hide') {
-        addClasses(widgetHolder, 'woot-widget--without-bubble');
-        addClasses(widgetElm, 'woot-hidden');
+        if (widgetHolder) {
+          addClasses(widgetHolder, 'woot-widget--without-bubble');
+        }
+        if (widgetElm) {
+          addClasses(widgetElm, 'woot-hidden');
+        }
         window.$chatwoot.hideMessageBubble = true;
       } else if (visibility === 'show') {
-        removeClasses(widgetElm, 'woot-hidden');
-        removeClasses(widgetHolder, 'woot-widget--without-bubble');
+        if (widgetElm) {
+          removeClasses(widgetElm, 'woot-hidden');
+        }
+        if (widgetHolder) {
+          removeClasses(widgetHolder, 'woot-widget--without-bubble');
+        }
         window.$chatwoot.hideMessageBubble = false;
       }
       IFrameHelper.sendMessage(SDK_SET_BUBBLE_VISIBILITY, {

--- a/app/javascript/entrypoints/sdk.spec.js
+++ b/app/javascript/entrypoints/sdk.spec.js
@@ -1,5 +1,6 @@
 import Cookies from 'js-cookie';
 import { IFrameHelper } from '../sdk/IFrameHelper';
+import { SDK_SET_BUBBLE_VISIBILITY } from 'shared/constants/sharedFrameEvents';
 import './sdk';
 
 vi.mock('../sdk/IFrameHelper', () => ({
@@ -55,5 +56,46 @@ describe('$chatwoot.setUser', () => {
       identifier: 'second-user',
       user: secondUser,
     });
+  });
+});
+
+describe('$chatwoot.toggleBubbleVisibility', () => {
+  beforeEach(() => {
+    delete window.$chatwoot;
+    window.chatwootSettings = {};
+    document
+      .querySelectorAll('.woot--bubble-holder, .woot-widget-holder')
+      .forEach(element => element.remove());
+    IFrameHelper.sendMessage.mockClear();
+
+    window.chatwootSDK.run({
+      baseUrl: 'https://app.chatwoot.com',
+      websiteToken: 'website-token',
+    });
+  });
+
+  afterEach(() => {
+    delete window.$chatwoot;
+    delete window.chatwootSettings;
+    vi.clearAllMocks();
+  });
+
+  it('handles visibility changes before the widget DOM is mounted', () => {
+    expect(document.querySelector('.woot--bubble-holder')).toBeNull();
+    expect(document.querySelector('.woot-widget-holder')).toBeNull();
+
+    expect(() => window.$chatwoot.toggleBubbleVisibility('hide')).not.toThrow();
+    expect(window.$chatwoot.hideMessageBubble).toBe(true);
+    expect(IFrameHelper.sendMessage).toHaveBeenLastCalledWith(
+      SDK_SET_BUBBLE_VISIBILITY,
+      { hideMessageBubble: true }
+    );
+
+    expect(() => window.$chatwoot.toggleBubbleVisibility('show')).not.toThrow();
+    expect(window.$chatwoot.hideMessageBubble).toBe(false);
+    expect(IFrameHelper.sendMessage).toHaveBeenLastCalledWith(
+      SDK_SET_BUBBLE_VISIBILITY,
+      { hideMessageBubble: false }
+    );
   });
 });


### PR DESCRIPTION
## Summary
- guard bubble and widget-holder class mutations when SDK calls arrive before the widget DOM mounts
- preserve the requested `hideMessageBubble` state and visibility message
- add focused regression coverage for both hide and show calls before DOM mount

Fixes #15545

## Testing
- `Frontend Lint & Test` — passed
- `Run Chatwoot CE spec` — passed
- `Test Docker Build` — passed
- `Run MFA Tests` — passed
- `Run Size Limit Check` — passed
- `Log Lines Percentage Check` — passed

The separate `Auto-assign PR to Author` workflow failed, but it is repository automation and does not exercise this change.