### PR TITLE
fix: prevent stale messages when switching conversations

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -19,6 +19,8 @@ import {
   syncConversationCallVisibility,
 } from 'dashboard/helper/voice';
 
+const pendingHistoryRequests = new Map();
+
 export const hasMessageFailedWithExternalError = pendingMessage => {
   // This helper is used to check if the message has failed with an external error.
   // We have two cases
@@ -85,25 +87,35 @@ const actions = {
     commit(types.CLEAR_CURRENT_CHAT_WINDOW);
   },
 
-  fetchPreviousMessages: async ({ commit }, data) => {
-    try {
-      const {
-        data: { meta, payload },
-      } = await MessageApi.getPreviousMessages(data);
-      commit(`conversationMetadata/${types.SET_CONVERSATION_METADATA}`, {
-        id: data.conversationId,
-        data: meta,
-      });
-      commit(types.SET_PREVIOUS_CONVERSATIONS, {
-        id: data.conversationId,
-        data: payload,
-      });
-      if (!payload.length) {
-        commit(types.SET_ALL_MESSAGES_LOADED, data.conversationId);
-      }
-    } catch (error) {
-      // Handle error
+  fetchPreviousMessages: ({ commit }, data) => {
+    const requestKey = JSON.stringify([
+      MessageApi.url,
+      data.conversationId,
+      data.before,
+      data.after,
+    ]);
+    if (pendingHistoryRequests.has(requestKey)) {
+      return pendingHistoryRequests.get(requestKey);
     }
+
+    const request = MessageApi.getPreviousMessages(data)
+      .then(({ data: { meta, payload } }) => {
+        commit(`conversationMetadata/${types.SET_CONVERSATION_METADATA}`, {
+          id: data.conversationId,
+          data: meta,
+        });
+        commit(types.SET_PREVIOUS_CONVERSATIONS, {
+          id: data.conversationId,
+          data: payload,
+        });
+        if (!payload.length) {
+          commit(types.SET_ALL_MESSAGES_LOADED, data.conversationId);
+        }
+      })
+      .finally(() => pendingHistoryRequests.delete(requestKey));
+
+    pendingHistoryRequests.set(requestKey, request);
+    return request;
   },
 
   fetchAllAttachments: async ({ commit }, conversationId) => {

--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -83,7 +83,13 @@ export const mutations = {
   [types.SET_PREVIOUS_CONVERSATIONS](_state, { id, data }) {
     if (data.length) {
       const [chat] = _state.allConversations.filter(c => c.id === id);
-      chat.messages.unshift(...data);
+      const messageIds = new Set(chat.messages.map(message => message.id));
+      const newMessages = data.filter(message => {
+        if (messageIds.has(message.id)) return false;
+        messageIds.add(message.id);
+        return true;
+      });
+      chat.messages.unshift(...newMessages);
     }
   },
   [types.SET_ALL_ATTACHMENTS](_state, { id, data }) {

--- a/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
@@ -1,4 +1,7 @@
 import axios from 'axios';
+import { createStore } from 'vuex';
+import { mutations } from '../../conversations';
+import conversationMetadata from '../../conversationMetadata';
 import actions, {
   hasMessageFailedWithExternalError,
 } from '../../conversations/actions';
@@ -56,6 +59,109 @@ describe('#hasMessageFailedWithExternalError', () => {
 });
 
 describe('#actions', () => {
+  describe('conversation history loading', () => {
+    let store;
+    let conversationA;
+    let conversationB;
+
+    beforeEach(() => {
+      conversationA = { id: 42, messages: [{ id: 100 }] };
+      conversationB = { id: 43, messages: [{ id: 200 }] };
+      store = createStore({
+        state: {
+          allConversations: [conversationA, conversationB],
+          selectedChatId: null,
+        },
+        actions,
+        mutations,
+        modules: {
+          conversationMetadata: {
+            ...conversationMetadata,
+            state: { records: {} },
+          },
+        },
+      });
+    });
+
+    it('shares pending history when switching A to B to A and keeps responses in their own conversations', async () => {
+      let resolveA;
+      let resolveB;
+      axios.get
+        .mockImplementationOnce(
+          () =>
+            new Promise(resolve => {
+              resolveA = resolve;
+            })
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise(resolve => {
+              resolveB = resolve;
+            })
+        );
+
+      const firstA = store.dispatch('setActiveChat', { data: conversationA });
+      const firstB = store.dispatch('setActiveChat', { data: conversationB });
+      const secondA = store.dispatch('setActiveChat', { data: conversationA });
+
+      expect(axios.get).toHaveBeenCalledTimes(2);
+      expect(conversationA.dataFetched).toBeUndefined();
+
+      resolveB({ data: { meta: {}, payload: [{ id: 199 }] } });
+      await firstB;
+      expect(store.state.selectedChatId).toBe(42);
+      expect(conversationA.messages).toEqual([{ id: 100 }]);
+      expect(conversationB.messages).toEqual([{ id: 199 }, { id: 200 }]);
+
+      resolveA({ data: { meta: {}, payload: [{ id: 99 }] } });
+      await Promise.all([firstA, secondA]);
+      expect(conversationA.messages).toEqual([{ id: 99 }, { id: 100 }]);
+      expect(conversationA.dataFetched).toBe(true);
+      expect(conversationB.dataFetched).toBe(true);
+    });
+
+    it('leaves failed history unfetched and retries when the conversation is reopened', async () => {
+      axios.get.mockRejectedValueOnce(new Error('Network error'));
+
+      await store.dispatch('setActiveChat', { data: conversationA });
+
+      expect(conversationA.dataFetched).toBeUndefined();
+      expect(conversationA.messages).toEqual([{ id: 100 }]);
+      expect(conversationA.allMessagesLoaded).toBe(false);
+
+      axios.get.mockResolvedValueOnce({
+        data: { meta: {}, payload: [{ id: 99 }] },
+      });
+      await store.dispatch('setActiveChat', { data: conversationA });
+
+      expect(axios.get).toHaveBeenCalledTimes(2);
+      expect(conversationA.messages).toEqual([{ id: 99 }, { id: 100 }]);
+      expect(conversationA.dataFetched).toBe(true);
+    });
+
+    it.each(['before', 'after'])(
+      'loads distinct %s cursors independently and allows a completed request again',
+      async cursor => {
+        let resolveHistory;
+        const response = new Promise(resolve => {
+          resolveHistory = resolve;
+        });
+        axios.get.mockReturnValue(response);
+        const firstParams = { conversationId: 42, [cursor]: 90 };
+        const secondParams = { conversationId: 42, [cursor]: 80 };
+
+        const first = store.dispatch('fetchPreviousMessages', firstParams);
+        const second = store.dispatch('fetchPreviousMessages', secondParams);
+        expect(axios.get).toHaveBeenCalledTimes(2);
+
+        resolveHistory({ data: { meta: {}, payload: [] } });
+        await Promise.all([first, second]);
+        await store.dispatch('fetchPreviousMessages', firstParams);
+        expect(axios.get).toHaveBeenCalledTimes(3);
+      }
+    );
+  });
+
   describe('#getConversation', () => {
     it('sends correct actions if API is success', async () => {
       axios.get.mockResolvedValue({

--- a/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
@@ -652,6 +652,34 @@ describe('#mutations', () => {
   });
 
   describe('#SET_PREVIOUS_CONVERSATIONS', () => {
+    it('merges overlapping history once while preserving newer realtime message data', () => {
+      const realtimeMessage = {
+        id: 2,
+        content: 'Updated content',
+        status: 'read',
+      };
+      const state = {
+        allConversations: [{ id: 1, messages: [realtimeMessage, { id: 3 }] }],
+      };
+      const payload = {
+        id: 1,
+        data: [
+          { id: 1 },
+          { id: 1 },
+          { id: 2, content: 'Old content', status: 'sent' },
+        ],
+      };
+
+      mutations[types.SET_PREVIOUS_CONVERSATIONS](state, payload);
+      mutations[types.SET_PREVIOUS_CONVERSATIONS](state, payload);
+
+      expect(state.allConversations[0].messages).toEqual([
+        { id: 1 },
+        realtimeMessage,
+        { id: 3 },
+      ]);
+    });
+
     it('should prepend messages to conversation messages array', () => {
       const state = {
         allConversations: [{ id: 1, messages: [{ id: 'msg2' }] }],


### PR DESCRIPTION
Fixes a frontend race that can leave messages from a previously opened conversation visible in the current conversation until the page is refreshed.

Switching A → B → A before A’s history finishes loading can request the same page twice. Both responses prepend the same messages. If reconnect sync later sorts those duplicates, Vue can leave stale bubbles behind while reconciling duplicate message keys.

History loads now share pending requests for the same account, conversation, and pagination cursors. History merges skip existing message IDs, preserving newer realtime updates, and failed loads remain eligible for retry. Regression specs cover rapid switching, response isolation, failure and retry, pagination, and overlapping history.

## How to reproduce

1. Choose two conversations, A and B, with distinct messages and enough history to scroll.
2. Open browser DevTools and set Network throttling to **Slow 3G**.
3. Reload the page to clear the frontend conversation cache.
4. Open A, switch to B, then return to A **before A’s message history finishes loading**.
5. Wait for the requests to finish. Repeat from step 3 if needed, since this depends on timing.
6. Briefly disconnect and reconnect your network to trigger reconnect sync, then switch between A and B.

**Before the fix:** Duplicate messages may appear, and reconnect sync can leave stale message bubbles from another conversation visible until a refresh.

**Expected after the fix:** Each conversation shows only its own messages, without duplicates. Scrolling up continues to load older messages correctly.

