### PR TITLE
fix: handle empty priority in automation conditions

### DIFF
--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -55,8 +55,18 @@ class AutomationRules::ConditionsFilterService < FilterService
     if query_hash[:filter_operator] == 'starts_with'
       @filter_values["value_#{current_index}"] = "#{string_filter_values(query_hash)}%"
       like_filter_string(query_hash[:filter_operator], current_index)
+    elsif query_hash[:attribute_key] == 'priority' && filter_values(query_hash) == [nil]
+      query_hash[:filter_operator] == 'equal_to' ? 'IS NULL' : 'IS NOT NULL'
     else
       super
+    end
+  end
+
+  def filter_values(query_hash)
+    return super unless query_hash[:attribute_key] == 'priority'
+
+    query_hash[:values].map do |value|
+      value.nil? || value == 'nil' ? nil : Conversation.priorities.fetch(value.to_s)
     end
   end
 

--- a/spec/services/automation_rules/conditions_filter_service_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_spec.rb
@@ -38,6 +38,30 @@ RSpec.describe AutomationRules::ConditionsFilterService do
       end
     end
 
+    context 'when conditions are based on priority' do
+      it 'matches a conversation with no priority' do
+        rule.update!(conditions: [{ 'values': ['nil'], 'attribute_key': 'priority',
+                                    'query_operator': nil, 'filter_operator': 'equal_to' }])
+
+        expect(described_class.new(rule, conversation, { changed_attributes: {} }).perform).to be(true)
+      end
+
+      it 'does not match a conversation with no priority for not_equal_to' do
+        rule.update!(conditions: [{ 'values': ['nil'], 'attribute_key': 'priority',
+                                    'query_operator': nil, 'filter_operator': 'not_equal_to' }])
+
+        expect(described_class.new(rule, conversation, { changed_attributes: {} }).perform).to be(false)
+      end
+
+      it 'matches a named priority' do
+        conversation.update!(priority: :medium)
+        rule.update!(conditions: [{ 'values': ['medium'], 'attribute_key': 'priority',
+                                    'query_operator': nil, 'filter_operator': 'equal_to' }])
+
+        expect(described_class.new(rule, conversation, { changed_attributes: {} }).perform).to be(true)
+      end
+    end
+
     context 'when conditions based on filter_operator start_with' do
       before do
         contact = conversation.contact


### PR DESCRIPTION
## Summary

- Convert the automation UI value `nil` into a database null for priority conditions.
- Convert named priorities through `Conversation.priorities` before querying the integer column.
- Use `IS NULL` and `IS NOT NULL` for the Priority None condition.
- Leave labels, contacts, messages, and other filters unchanged.

## Why

The `3.x` UI stores the Priority None option as the string `nil`, while conversations store no priority as a database null. The `3.x` filter service also does not convert names such as `medium` into the integer stored in the priority column.

The earlier pull request #15083 attempted a broader fix. This replacement keeps only the reported priority case and tests the exact value saved by the UI.

Refs #12797

## Checks

- Ruby syntax checks passed for both changed files.
- RuboCop passed for both changed files.
- `git diff --check` passed.
- The focused Rails spec could not run locally because the current Cook validator expects Captain V2 models that do not exist on `3.x`. CI must complete before merge.
