### PR TITLE
fix: preserve HTML-like outbound message content

### DIFF
--- a/app/services/messages/markdown_renderers/base_markdown_renderer.rb
+++ b/app/services/messages/markdown_renderers/base_markdown_renderer.rb
@@ -26,6 +26,14 @@ class Messages::MarkdownRenderers::BaseMarkdownRenderer < CommonMarker::Renderer
     out('</del>')
   end
 
+  def html(node)
+    out(node.string_content)
+  end
+
+  def inline_html(node)
+    out(node.string_content)
+  end
+
   def method_missing(method_name, node = nil, *args, **kwargs, &)
     return super unless node.is_a?(CommonMarker::Node)
 

--- a/app/services/messages/markdown_renderers/telegram_renderer.rb
+++ b/app/services/messages/markdown_renderers/telegram_renderer.rb
@@ -32,6 +32,14 @@ class Messages::MarkdownRenderers::TelegramRenderer < Messages::MarkdownRenderer
     out('<pre>', node.string_content, '</pre>')
   end
 
+  def html(node)
+    out(CGI.escapeHTML(node.string_content))
+  end
+
+  def inline_html(node)
+    out(CGI.escapeHTML(node.string_content))
+  end
+
   def list(node)
     @list_type = node.list_type
     @list_item_number = @list_type == :ordered_list ? node.list_start : 0

--- a/spec/models/channel/telegram_spec.rb
+++ b/spec/models/channel/telegram_spec.rb
@@ -92,6 +92,25 @@ RSpec.describe Channel::Telegram do
       expect(telegram_channel.send_message_on_telegram(message)).to eq('telegram_123')
     end
 
+    it 'sends raw HTML as escaped text' do
+      conversation = create(:conversation, inbox: telegram_channel.inbox, additional_attributes: { 'chat_id' => '123' })
+      message = create(:message, message_type: :outgoing, content: "<a>\n<b></b></a>asdf", conversation: conversation)
+
+      stub_request(:post, "https://api.telegram.org/bot#{telegram_channel.bot_token}/sendMessage")
+        .with(
+          body: "chat_id=123&text=#{
+            ERB::Util.url_encode("&lt;a&gt;\n&lt;b&gt;&lt;/b&gt;&lt;/a&gt;asdf")
+          }&reply_markup=&parse_mode=HTML&reply_to_message_id="
+        )
+        .to_return(
+          status: 200,
+          body: { result: { message_id: 'telegram_123' } }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect(telegram_channel.send_message_on_telegram(message)).to eq('telegram_123')
+    end
+
     it 'send message with reply_markup' do
       message = create(
         :message, message_type: :outgoing, content: 'test', content_type: 'input_select',

--- a/spec/services/messages/markdown_renderer_service_spec.rb
+++ b/spec/services/messages/markdown_renderer_service_spec.rb
@@ -536,6 +536,74 @@ RSpec.describe Messages::MarkdownRendererService, type: :service do
       end
     end
 
+    context 'when content contains raw HTML' do
+      let(:html_block) { "<a>\n<b></b></a>asdf" }
+
+      %w[
+        Channel::Whatsapp
+        Channel::Instagram
+        Channel::FacebookPage
+        Channel::Line
+        Channel::Sms
+        Channel::TwitterProfile
+        Channel::TwilioSms
+      ].each do |channel_type|
+        it "preserves HTML block content for #{channel_type}" do
+          result = described_class.new(html_block, channel_type).render
+
+          expect(result).to eq(html_block)
+        end
+      end
+
+      it 'preserves an HTML block containing only tags' do
+        content = "<a>\n<b></b></a>"
+        result = described_class.new(content, 'Channel::Whatsapp').render
+
+        expect(result).to eq(content)
+      end
+
+      it 'preserves content following an HTML block' do
+        content = "#{html_block}\n\nfollowing"
+        result = described_class.new(content, 'Channel::Whatsapp').render
+
+        expect(result).to eq(content)
+      end
+
+      it 'preserves inline HTML' do
+        content = 'hello <strong>world</strong>'
+        result = described_class.new(content, 'Channel::Whatsapp').render
+
+        expect(result).to eq(content)
+      end
+
+      it 'escapes raw HTML for Telegram HTML parse mode' do
+        result = described_class.new(html_block, 'Channel::Telegram').render
+
+        expect(result).to eq("&lt;a&gt;\n&lt;b&gt;&lt;/b&gt;&lt;/a&gt;asdf")
+      end
+
+      it 'escapes inline HTML for Telegram HTML parse mode' do
+        content = 'hello <strong>world</strong>'
+        result = described_class.new(content, 'Channel::Telegram').render
+
+        expect(result).to eq('hello &lt;strong&gt;world&lt;/strong&gt;')
+      end
+
+      it 'escapes HTML attributes for Telegram HTML parse mode' do
+        content = '<a title="1 > 0">text</a>'
+        result = described_class.new(content, 'Channel::Telegram').render
+
+        expect(result).to eq('&lt;a title=&quot;1 &gt; 0&quot;&gt;text&lt;/a&gt;')
+      end
+
+      it 'preserves HTML block content for Twilio WhatsApp channels' do
+        channel = instance_double(Channel::TwilioSms, whatsapp?: true)
+        result = described_class.new(html_block, 'Channel::TwilioSms', channel).render
+
+        expect(result).to eq(html_block)
+      end
+    end
+
     # Shared test for all text-based channels that preserve multiple newlines
     # This tests the real-world scenario where frontend sends newlines with whitespace between them
     context 'when content has multiple newlines with whitespace between them' do


### PR DESCRIPTION
Preserves messages containing raw HTML-like text instead of silently dropping their contents before channel delivery. Telegram escapes the literal tags because its provider payload uses HTML parse mode, while the other text-based channels retain the original content.

## Closes

Closes #13493

## How to reproduce

1. Send `<a>\n<b></b></a>asdf` through a WhatsApp or another text-based inbox.
2. Without this change, the outbound markdown renderer returns an empty string and the message cannot be delivered.
3. With this change, the original content is retained. Telegram displays the same literal text through an HTML-safe payload.

## What changed

- Render CommonMark HTML block and inline HTML nodes from their stored string content.
- Escape those nodes specifically in the Telegram renderer to preserve literal text without treating it as provider markup.
- Add exact regression coverage for all affected channel mappings, tags-only content, trailing content, inline HTML, Twilio WhatsApp routing, and the final Telegram request payload.