### PR TITLE
fix: mirror directional widget icons in RTL locales

### DIFF
--- a/app/javascript/shared/components/CustomerSatisfaction.vue
+++ b/app/javascript/shared/components/CustomerSatisfaction.vue
@@ -176,7 +176,7 @@ export default {
         }"
       >
         <Spinner v-if="isUpdating && feedback" />
-        <FluentIcon v-else icon="chevron-right" />
+        <FluentIcon v-else icon="chevron-right" class="rtl:rotate-180" />
       </button>
     </form>
   </div>

--- a/app/javascript/widget/components/ChatHeader.vue
+++ b/app/javascript/widget/components/ChatHeader.vue
@@ -32,7 +32,11 @@ const onBackButtonClick = () => {
         class="px-2 ltr:-ml-3 rtl:-mr-3"
         @click="onBackButtonClick"
       >
-        <FluentIcon icon="chevron-left" size="24" class="text-n-slate-12" />
+        <FluentIcon
+          icon="chevron-left"
+          size="24"
+          class="text-n-slate-12 rtl:rotate-180"
+        />
       </button>
       <img
         v-if="avatarUrl"

--- a/app/javascript/widget/components/ChatSendButton.vue
+++ b/app/javascript/widget/components/ChatSendButton.vue
@@ -28,9 +28,14 @@ export default {
   <button
     type="submit"
     :disabled="disabled"
-    class="min-h-8 min-w-8 flex items-center justify-center ml-1"
+    class="min-h-8 min-w-8 flex items-center justify-center ms-1"
   >
-    <FluentIcon v-if="!loading" icon="send" :style="`color: ${color}`" />
+    <FluentIcon
+      v-if="!loading"
+      icon="send"
+      class="rtl:-scale-x-100"
+      :style="`color: ${color}`"
+    />
     <Spinner v-else size="small" />
   </button>
 </template>

--- a/app/javascript/widget/components/pageComponents/Home/Article/ArticleListItem.vue
+++ b/app/javascript/widget/components/pageComponents/Home/Article/ArticleListItem.vue
@@ -26,6 +26,6 @@ const onClick = () => {
     >
       {{ title }}
     </button>
-    <span class="i-lucide-chevron-right text-base shrink-0" />
+    <span class="i-lucide-chevron-right text-base shrink-0 rtl:rotate-180" />
   </div>
 </template>

--- a/app/javascript/widget/components/specs/RtlDirectionalIcons.spec.js
+++ b/app/javascript/widget/components/specs/RtlDirectionalIcons.spec.js
@@ -1,0 +1,80 @@
+import { mount, shallowMount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import FluentIcon from 'shared/components/FluentIcon/Index.vue';
+import CustomerSatisfaction from 'shared/components/CustomerSatisfaction.vue';
+import ChatHeader from '../ChatHeader.vue';
+import ChatSendButton from '../ChatSendButton.vue';
+import EmailInput from '../template/EmailInput.vue';
+import ArticleListItem from '../pageComponents/Home/Article/ArticleListItem.vue';
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+}));
+
+const store = createStore({
+  modules: {
+    appConfig: {
+      namespaced: true,
+      getters: { getWidgetColor: () => '#1f93ff' },
+    },
+  },
+});
+
+describe('widget directional icons in RTL', () => {
+  it('mirrors the header back chevron', () => {
+    const wrapper = shallowMount(ChatHeader, {
+      props: { showBackButton: true },
+    });
+
+    expect(wrapper.findComponent(FluentIcon).classes()).toContain(
+      'rtl:rotate-180'
+    );
+  });
+
+  it('mirrors the composer send icon', () => {
+    const wrapper = shallowMount(ChatSendButton);
+
+    expect(wrapper.findComponent(FluentIcon).classes()).toContain(
+      'rtl:-scale-x-100'
+    );
+  });
+
+  it('mirrors the CSAT submit chevron', () => {
+    const wrapper = shallowMount(CustomerSatisfaction, {
+      props: { messageId: 1 },
+      global: {
+        plugins: [store],
+        directives: {
+          dompurifyHtml: (element, binding) => {
+            element.textContent = binding.value;
+          },
+        },
+      },
+    });
+
+    expect(wrapper.findComponent(FluentIcon).classes()).toContain(
+      'rtl:rotate-180'
+    );
+  });
+
+  it('mirrors the email input submit chevron', () => {
+    const wrapper = shallowMount(EmailInput, {
+      props: { messageId: 1 },
+      global: { plugins: [store] },
+    });
+
+    expect(wrapper.findComponent(FluentIcon).classes()).toContain(
+      'rtl:rotate-180'
+    );
+  });
+
+  it('mirrors the article list item chevron', () => {
+    const wrapper = mount(ArticleListItem, {
+      props: { title: 'Article', link: '/article' },
+    });
+
+    expect(wrapper.find('.i-lucide-chevron-right').classes()).toContain(
+      'rtl:rotate-180'
+    );
+  });
+});

--- a/app/javascript/widget/components/template/EmailInput.vue
+++ b/app/javascript/widget/components/template/EmailInput.vue
@@ -96,7 +96,11 @@ export default {
           color: textColor,
         }"
       >
-        <FluentIcon v-if="!isUpdating" icon="chevron-right" />
+        <FluentIcon
+          v-if="!isUpdating"
+          icon="chevron-right"
+          class="rtl:rotate-180"
+        />
         <Spinner v-else class="mx-2" />
       </button>
     </form>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes directional widget icons not mirroring correctly in RTL locales. The relevant chevrons and send icon now use the correct direction when the widget is rendered in RTL, while LTR rendering remains unchanged.

Fixes [CW-8120](https://linear.app/chatwoot/issue/CW-8120/website-widget-directional-icons-back-chevron-send-button-csat-arrow), https://github.com/chatwoot/chatwoot/issues/15696

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Screencast

**Before**

https://github.com/user-attachments/assets/1c95b438-136d-46e0-a346-d3cd4ce0ce5c



**After**

https://github.com/user-attachments/assets/85c2870e-34ef-49d5-8fab-95b728736b6c




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
