### PR TITLE
fix(auth): show OAuth error toast after snackbar mounts

### DIFF
--- a/app/javascript/v3/views/login/Index.vue
+++ b/app/javascript/v3/views/login/Index.vue
@@ -112,16 +112,21 @@ export default {
     if (this.ssoAuthToken) {
       this.submitLogin();
     }
+  },
+  mounted() {
     if (this.authError) {
-      const messageKey = ERROR_MESSAGES[this.authError] ?? 'LOGIN.API.UNAUTH';
-      // Use a method to get the translated text to avoid dynamic key warning
-      const translatedMessage = this.getTranslatedMessage(messageKey);
-      useAlert(translatedMessage, { duration: AUTH_ERROR_TOAST_DURATION });
-      // wait for idle state
-      this.requestIdleCallbackPolyfill(() => {
-        // Remove the error query param from the url
-        const { query } = this.$route;
-        this.$router.replace({ query: { ...query, error: undefined } });
+      // Wait for the sibling snackbar to mount and subscribe to toast events.
+      this.$nextTick(() => {
+        const messageKey = ERROR_MESSAGES[this.authError] ?? 'LOGIN.API.UNAUTH';
+        // Use a method to get the translated text to avoid dynamic key warning
+        const translatedMessage = this.getTranslatedMessage(messageKey);
+        useAlert(translatedMessage, { duration: AUTH_ERROR_TOAST_DURATION });
+        // wait for idle state
+        this.requestIdleCallbackPolyfill(() => {
+          // Remove the error query param from the url
+          const { query } = this.$route;
+          this.$router.replace({ query: { ...query, error: undefined } });
+        });
       });
     }
   },


### PR DESCRIPTION
Personal email signups through Google now show the existing error toast when redirected back to login. The message remains visible for six seconds.

The login page previously emitted the toast before the snackbar subscribed to events. Emit it after mounting and the next Vue tick so the snackbar receives it.

## How to reproduce

1. Open `/app/login?error=business-account-only` while signed out, or attempt Google signup with a new personal email on an installation that requires work emails.
2. Confirm the work-email error toast appears for six seconds.
3. Confirm the `error` query parameter is removed after the toast is triggered.
