### PR TITLE
fix(widget): preserve spacing after message lists

### DIFF
--- a/app/javascript/widget/components/AgentMessageBubble.vue
+++ b/app/javascript/widget/components/AgentMessageBubble.vue
@@ -99,7 +99,7 @@ export default {
     >
       <div
         v-dompurify-html="formatMessage(message, false)"
-        class="message-content text-n-slate-12"
+        class="message-content text-n-slate-12 [&>ul:not(:last-child)]:mb-4 [&>ol:not(:last-child)]:mb-4"
       />
       <EmailInput
         v-if="isTemplateEmail"


### PR DESCRIPTION
Agent messages in the chat widget now keep a visible gap between a list and the paragraph that follows it. Previously, section titles such as “Office hours?” appeared directly against the final bullet of the preceding section, even when the Markdown included a blank line.

The change gives top-level bullet and numbered lists the same spacing as paragraphs when another block follows. Nested lists and lists at the end of a message retain their existing spacing.

### Screenshots

| Before | After |
| :---: | :---: |
| <img width="320" alt="Before: office hours touches the preceding list" src="https://github.com/user-attachments/assets/6ae307f6-b4ee-4491-be39-dd02b0ee3c2e" /> | <img width="320" alt="After: spacing separates office hours from the preceding list" src="https://github.com/user-attachments/assets/17099541-27b7-4a40-aba3-e7448b319073" /> |

### How to test

1. Send an agent reply to a website-widget conversation containing a bullet list followed by a bold paragraph, separated by a blank line.
2. Open the reply in the widget. Confirm there is a 16px gap between the list and the next paragraph.
3. Repeat with a numbered list. Confirm nested lists and a list at the end of the message do not gain extra bottom spacing.


