### PR TITLE
perf: batch load data before serialization in api/v1/:account_id/conversations

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -73,6 +73,9 @@ class Conversation < ApplicationRecord
   private_constant :CONVERSATION_UPDATED_ADDITIONAL_ATTRIBUTE_KEYS, :FILTERED_UNREAD_COUNT_ADDITIONAL_ATTRIBUTE_KEYS,
                    :FILTERED_UNREAD_COUNT_UPDATE_KEYS
 
+  # Populated only for read-only list serialization.
+  attr_accessor :list_preload_data
+
   validates :account_id, presence: true
   validates :inbox_id, presence: true
   validates :contact_id, presence: true
@@ -164,8 +167,28 @@ class Conversation < ApplicationRecord
     self[:last_activity_at] || created_at
   end
 
+  def latest_message
+    return list_preload_data[:latest_message] if list_preload_data
+
+    messages.where(account_id: account_id).includes(attachments: { file_attachment: :blob }).reorder(created_at: :desc, id: :desc).first
+  end
+
+  def last_non_activity_message
+    return list_preload_data[:last_non_activity_message] if list_preload_data
+
+    messages.where(account_id: account_id).non_activity_messages.first
+  end
+
   def last_incoming_message
+    return list_preload_data[:last_incoming_message] if list_preload_data
+
     messages.where(account_id: account_id)&.incoming&.last
+  end
+
+  def unread_incoming_messages_count
+    return list_preload_data[:unread_count] if list_preload_data
+
+    unread_incoming_messages.count
   end
 
   def toggle_status

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -159,7 +159,7 @@ class Message < ApplicationRecord
   def conversation_push_event_data
     {
       assignee_id: conversation.assignee_id,
-      unread_count: conversation.unread_incoming_messages.count,
+      unread_count: conversation.unread_incoming_messages_count,
       last_activity_at: conversation.last_activity_at.to_i,
       contact_inbox: { source_id: conversation.contact_inbox.source_id }
     }

--- a/app/services/conversations/list_preloader.rb
+++ b/app/services/conversations/list_preloader.rb
@@ -1,0 +1,74 @@
+# Request-local data for list serialization; never load entire message histories.
+class Conversations::ListPreloader
+  def initialize(conversations)
+    @conversations = conversations.to_a
+  end
+
+  def perform
+    return if @conversations.empty?
+
+    preload_associations
+    latest = latest_messages(Message.all)
+    non_activity = latest_messages(Message.non_activity_messages)
+    incoming = latest_messages(Message.incoming)
+    preload_messages(latest.values + non_activity.values)
+    counts = unread_counts
+
+    @conversations.each do |conversation|
+      conversation.list_preload_data = {
+        latest_message: latest[conversation.id],
+        last_non_activity_message: non_activity[conversation.id],
+        last_incoming_message: incoming[conversation.id],
+        unread_count: [counts.fetch(conversation.id, 0), 10].min
+      }
+    end
+  end
+
+  private
+
+  def preload_associations
+    ActiveRecord::Associations::Preloader.new(
+      records: @conversations,
+      associations: [:account, :team, :contact_inbox, { inbox: :channel },
+                     { contact: { avatar_attachment: :blob } },
+                     { assignee: [:account_users, { avatar_attachment: :blob }] },
+                     { ai_assignee: { avatar_attachment: :blob } }]
+    ).call
+    Current.user.teams.load if Current.user.is_a?(User)
+  end
+
+  def latest_messages(scope)
+    # DISTINCT ON returns at most one record per conversation, including on long threads.
+    scope.joins(:conversation)
+         .where(conversation_id: @conversations.map(&:id))
+         .where('messages.account_id = conversations.account_id')
+         .select('DISTINCT ON (messages.conversation_id) messages.*')
+         .reorder('messages.conversation_id, messages.created_at DESC, messages.id DESC')
+         .index_by(&:conversation_id)
+  end
+
+  def preload_messages(messages)
+    conversations = @conversations.index_by(&:id)
+    messages.each do |message|
+      conversation = conversations.fetch(message.conversation_id)
+      message.association(:conversation).target = conversation
+      message.association(:inbox).target = conversation.inbox
+    end
+    ActiveRecord::Associations::Preloader.new(
+      records: messages,
+      associations: [{ attachments: { file_attachment: :blob } }, { sender: { avatar_attachment: :blob } }]
+    ).call
+
+    senders = messages.filter_map(&:sender).uniq
+    ActiveRecord::Associations::Preloader.new(records: senders.grep(User), associations: :account_users).call
+    ActiveRecord::Associations::Preloader.new(records: senders.grep(Contact), associations: :account).call
+  end
+
+  def unread_counts
+    Message.incoming.joins(:conversation)
+           .where(conversation_id: @conversations.map(&:id))
+           .where('messages.account_id = conversations.account_id')
+           .where('conversations.agent_last_seen_at IS NULL OR messages.created_at > conversations.agent_last_seen_at')
+           .reorder(nil).group(:conversation_id).count
+  end
+end

--- a/app/services/conversations/message_window_service.rb
+++ b/app/services/conversations/message_window_service.rb
@@ -65,6 +65,6 @@ class Conversations::MessageWindowService
   end
 
   def last_incoming_message
-    @last_incoming_message ||= @conversation.messages.where(account_id: @conversation.account_id).incoming&.last
+    @last_incoming_message ||= @conversation.last_incoming_message
   end
 end

--- a/app/views/api/v1/accounts/conversations/filter.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/filter.json.jbuilder
@@ -1,3 +1,4 @@
+Conversations::ListPreloader.new(@conversations).perform
 contact_info_requests = Whatsapp::ContactInfoRequestEligibilityService.availability_by_conversation(@conversations)
 
 json.meta do

--- a/app/views/api/v1/accounts/conversations/index.json.jbuilder
+++ b/app/views/api/v1/accounts/conversations/index.json.jbuilder
@@ -1,3 +1,4 @@
+Conversations::ListPreloader.new(@conversations).perform
 contact_info_requests = Whatsapp::ContactInfoRequestEligibilityService.availability_by_conversation(@conversations)
 
 json.data do

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -33,9 +33,7 @@ json.id conversation.display_id
 # but add an id tiebreaker: without it, same-second siblings (e.g. the input_csat survey
 # created alongside activity messages during an auto-resolve burst) could resolve to a
 # lower-id activity, and backward pagination would then never load the higher-id survey.
-last_message = conversation.messages.where(account_id: conversation.account_id)
-                           .includes([{ attachments: [{ file_attachment: [:blob] }] }])
-                           .reorder(created_at: :desc, id: :desc).first
+last_message = conversation.latest_message
 if last_message.blank?
   json.messages []
 else
@@ -67,8 +65,8 @@ json.created_at conversation.created_at.to_i
 json.updated_at conversation.updated_at.to_f
 json.timestamp conversation.last_activity_at.to_i
 json.first_reply_created_at conversation.first_reply_created_at.to_i
-json.unread_count conversation.unread_incoming_messages.count
-json.last_non_activity_message conversation.messages.where(account_id: conversation.account_id).non_activity_messages.first.try(:push_event_data)
+json.unread_count conversation.unread_incoming_messages_count
+json.last_non_activity_message conversation.last_non_activity_message.try(:push_event_data)
 json.last_activity_at conversation.last_activity_at.to_i
 json.priority conversation.priority
 json.waiting_since conversation.waiting_since.to_i.to_i

--- a/spec/services/conversations/list_preloader_spec.rb
+++ b/spec/services/conversations/list_preloader_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.describe Conversations::ListPreloader do
+  let(:account) { create(:account) }
+  let(:agent) { create(:user, :with_avatar, account: account, role: :agent) }
+  let(:inbox) { create(:inbox, account: account, channel: create(:channel_api, account: account)) }
+  let(:team) { create(:team, account: account) }
+  let(:contact) { create(:contact, :with_avatar, account: account) }
+  let(:conversation) do
+    create(
+      :conversation,
+      account: account,
+      inbox: inbox,
+      contact: contact,
+      assignee: agent,
+      team: team,
+      agent_last_seen_at: 2.hours.ago
+    )
+  end
+
+  before do
+    Current.account = account
+    Current.user = agent
+  end
+
+  after do
+    Current.reset
+  end
+
+  describe '#perform' do
+    context 'with messages to serialize' do
+      let(:same_time) { 10.minutes.ago }
+      let!(:unread_messages) do
+        create_list(
+          :message,
+          11,
+          account: account,
+          inbox: inbox,
+          conversation: conversation,
+          message_type: :incoming,
+          created_at: 1.hour.ago
+        )
+      end
+      let!(:first_same_time_message) do
+        create(
+          :message,
+          :with_attachment,
+          account: account,
+          inbox: inbox,
+          conversation: conversation,
+          sender: agent,
+          message_type: :outgoing,
+          created_at: same_time
+        )
+      end
+      let!(:last_non_activity_message) do
+        create(
+          :message,
+          :with_attachment,
+          account: account,
+          inbox: inbox,
+          conversation: conversation,
+          sender: agent,
+          message_type: :outgoing,
+          created_at: first_same_time_message.created_at
+        )
+      end
+      let!(:latest_message) do
+        create(
+          :message,
+          :with_attachment,
+          account: account,
+          inbox: inbox,
+          conversation: conversation,
+          sender: agent,
+          message_type: :activity,
+          created_at: 5.minutes.ago
+        )
+      end
+
+      before do
+        create(
+          :message,
+          account: account,
+          inbox: inbox,
+          conversation: conversation,
+          message_type: :incoming,
+          created_at: 3.hours.ago
+        )
+        described_class.new([conversation]).perform
+      end
+
+      it 'preloads the messages and capped unread count used by list serialization' do
+        expect(conversation.latest_message).to eq(latest_message)
+        expect(conversation.last_non_activity_message).to eq(last_non_activity_message)
+        expect(conversation.last_incoming_message).to eq(unread_messages.last)
+        expect(conversation.unread_incoming_messages_count).to eq(10)
+      end
+
+      it 'preloads message attachments, blobs, senders and account users' do
+        preloaded_latest_message = conversation.latest_message
+        preloaded_non_activity_message = conversation.last_non_activity_message
+
+        expect(preloaded_latest_message.association(:attachments)).to be_loaded
+        expect(preloaded_latest_message.attachments.first.file_attachment.association(:blob)).to be_loaded
+        expect(preloaded_non_activity_message.association(:attachments)).to be_loaded
+        expect(preloaded_non_activity_message.association(:sender)).to be_loaded
+        expect(preloaded_non_activity_message.sender.association(:account_users)).to be_loaded
+      end
+    end
+
+    it 'uses a fixed number of message queries for the conversation page' do
+      conversations = create_list(:conversation, 2, account: account, inbox: inbox, agent_last_seen_at: 1.hour.ago)
+      conversations.each do |item|
+        create_list(:message, 2, account: account, inbox: inbox, conversation: item, message_type: :incoming)
+      end
+      message_queries = []
+      subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+        next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+        message_queries << payload[:sql] if payload[:sql].include?('FROM "messages"')
+      end
+
+      ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record') do
+        described_class.new(conversations).perform
+      end
+
+      expect(message_queries.size).to eq(4)
+    end
+
+    it 'does not query when there are no conversations' do
+      expect(ActiveRecord::Associations::Preloader).not_to receive(:new)
+      expect(Message).not_to receive(:all)
+
+      described_class.new([]).perform
+    end
+  end
+end


### PR DESCRIPTION
## Description
Fixes an N+1 issue identified in `GET /api/v1/accounts/:account_id/conversations`. 
During my test, For a 25-conversation page, serialization repeatedly queried each conversation for, 
 - Latest message
 - Latest non-activity message
 - Latest incoming message used by can_reply?
 - Unread incoming-message count
 - Message attachments and ActiveStorage blobs
 - Message senders and account-user records 
 - Contact/assignee avatars
 - Team membership 

I observed the cost grows approximately linearly with the number of conversations because this work happened inside the per-conversation.

With this PR, conversation lists now batch-load preview messages, unread counts, attachments, senders, and related records before serialization. This removes per-conversation queries, significantly improving list performance. See the benchmark below for more details.

## How to reproduce
1. Open an account containing at least 25 conversations with message history.
2. Request `GET /api/v1/accounts/:account_id/conversations?status=open&page=1`.
3. Observe repeated message, attachment, sender, account-user, and team-membership queries for each conversation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Added service specs covering message selection, unread-count behavior, association preloading, fixed query count, and empty lists.
- Profiled authenticated conversation-list requests with 25 conversations.

## Performance
| Metric | Before mean | After mean | Mean change | Before median | After median |
|---|---:|---:|---:|---:|---:|
| Request duration (ms) | 343.57 | 159.82 | -53.5% | 339.58 | 159.81 |
| SQL duration (ms) | 68.97 | 21.08 | -69.4% | 68.89 | 21.39 |
| Allocated objects | 143732.20 | 51245.60 | -64.3% | 143729.00 | 51241.00 |
| SQL queries (uncached) | 170 | 27 | -84.1% | 170 | 27 |
| Cached SQL events | 202 | 4 | -98.0% | 202 | 4 |
| Duplicate fingerprints | 146 | 3 | -97.9% | 146 | 3 |
| Message queries | 76 | 5 | -93.4% | 76 | 5 |


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
