### PR TITLE
fix: enable reply suggestion search for self-hosted Premium

### DIFF
--- a/enterprise/lib/enterprise/captain/reply_suggestion_service.rb
+++ b/enterprise/lib/enterprise/captain/reply_suggestion_service.rb
@@ -8,7 +8,7 @@ module Enterprise::Captain::ReplySuggestionService
   private
 
   def use_search_tool?
-    ChatwootApp.chatwoot_cloud? || ChatwootApp.self_hosted_enterprise?
+    ChatwootApp.chatwoot_cloud? || ChatwootApp.self_hosted_enterprise? || ChatwootHub.pricing_plan == 'premium'
   end
 
   def prompt_variables

--- a/spec/enterprise/lib/captain/reply_suggestion_service_spec.rb
+++ b/spec/enterprise/lib/captain/reply_suggestion_service_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Captain::ReplySuggestionService do
+  describe '#use_search_tool?' do
+    subject(:use_search_tool?) { described_class.allocate.send(:use_search_tool?) }
+
+    before do
+      allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(false)
+      allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(false)
+      allow(ChatwootHub).to receive(:pricing_plan).and_return('premium')
+    end
+
+    it { is_expected.to be(true) }
+  end
+end

--- a/spec/lib/captain/reply_suggestion_service_spec.rb
+++ b/spec/lib/captain/reply_suggestion_service_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Captain::ReplySuggestionService do
   let(:inbox) { create(:inbox, account: account) }
   let(:conversation) { create(:conversation, account: account, inbox: inbox) }
   let(:captured_messages) { [] }
-  let(:mock_chat) { instance_double(RubyLLM::Chat) }
 
   before do
     create(:installation_config, name: 'CAPTAIN_OPEN_AI_API_KEY', value: 'test-key')
@@ -17,6 +16,7 @@ RSpec.describe Captain::ReplySuggestionService do
     allow(account).to receive(:feature_enabled?).with('captain_tasks').and_return(true)
 
     mock_response = instance_double(RubyLLM::Message, content: 'Sure, I can help!', input_tokens: 50, output_tokens: 20)
+    mock_chat = instance_double(RubyLLM::Chat)
     mock_context = instance_double(RubyLLM::Context, chat: mock_chat)
 
     allow(Llm::Config).to receive(:with_api_key).and_yield(mock_context)
@@ -49,23 +49,6 @@ RSpec.describe Captain::ReplySuggestionService do
       user_message = captured_messages.find { |m| m[:role] == 'user' }
       expect(user_message[:content]).to include('Message History:')
       expect(user_message[:content]).to include('User: I need help')
-    end
-
-    context 'when self-hosted Premium' do
-      before do
-        agent
-        allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(false)
-        allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(false)
-        allow(ChatwootHub).to receive(:pricing_plan).and_return('premium')
-      end
-
-      it 'adds the documentation search tool' do
-        expect(mock_chat).to receive(:with_tool)
-          .with(instance_of(Captain::Tools::SearchReplyDocumentationService))
-          .and_return(mock_chat)
-
-        service.perform
-      end
     end
 
     context 'with chat channel' do

--- a/spec/lib/captain/reply_suggestion_service_spec.rb
+++ b/spec/lib/captain/reply_suggestion_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Captain::ReplySuggestionService do
   let(:inbox) { create(:inbox, account: account) }
   let(:conversation) { create(:conversation, account: account, inbox: inbox) }
   let(:captured_messages) { [] }
+  let(:mock_chat) { instance_double(RubyLLM::Chat) }
 
   before do
     create(:installation_config, name: 'CAPTAIN_OPEN_AI_API_KEY', value: 'test-key')
@@ -16,7 +17,6 @@ RSpec.describe Captain::ReplySuggestionService do
     allow(account).to receive(:feature_enabled?).with('captain_tasks').and_return(true)
 
     mock_response = instance_double(RubyLLM::Message, content: 'Sure, I can help!', input_tokens: 50, output_tokens: 20)
-    mock_chat = instance_double(RubyLLM::Chat)
     mock_context = instance_double(RubyLLM::Context, chat: mock_chat)
 
     allow(Llm::Config).to receive(:with_api_key).and_yield(mock_context)
@@ -49,6 +49,23 @@ RSpec.describe Captain::ReplySuggestionService do
       user_message = captured_messages.find { |m| m[:role] == 'user' }
       expect(user_message[:content]).to include('Message History:')
       expect(user_message[:content]).to include('User: I need help')
+    end
+
+    context 'when self-hosted Premium' do
+      before do
+        agent
+        allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(false)
+        allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(false)
+        allow(ChatwootHub).to receive(:pricing_plan).and_return('premium')
+      end
+
+      it 'adds the documentation search tool' do
+        expect(mock_chat).to receive(:with_tool)
+          .with(instance_of(Captain::Tools::SearchReplyDocumentationService))
+          .and_return(mock_chat)
+
+        service.perform
+      end
     end
 
     context 'with chat channel' do


### PR DESCRIPTION
## Summary

- Enable documentation search for reply suggestions on self-hosted Premium installations.
- Keep the existing Cloud and self-hosted Enterprise behavior.
- Add a focused regression test for the Premium path.

## Why

Self-hosted Premium includes Captain and embeddings, but the reply suggestion search gate only allowed Cloud and self-hosted Enterprise. Agents on Premium received suggestions without FAQ search.

## Tests

- `bundle exec rspec spec/lib/captain/reply_suggestion_service_spec.rb`
- `bundle exec rubocop enterprise/lib/enterprise/captain/reply_suggestion_service.rb spec/lib/captain/reply_suggestion_service_spec.rb`
- `git diff --check`

Linear: https://linear.app/chatwoot/issue/AI-211/enable-search-documents-in-reply-suggestions-for-self-hosted-premium
