### PR TITLE
fix: generate Captain FAQ suggestions in account locale

### DIFF
--- a/enterprise/app/services/captain/llm/conversation_faq_service.rb
+++ b/enterprise/app/services/captain/llm/conversation_faq_service.rb
@@ -8,7 +8,7 @@ class Captain::Llm::ConversationFaqService < Llm::BaseAiService
   LLM_FEATURE = 'conversation_faq_generation'.freeze
 
   def self.language_for(conversation)
-    language = conversation.language.presence || conversation.account.locale.presence || I18n.default_locale.to_s
+    language = conversation.account.locale.presence || I18n.default_locale.to_s
     normalize_language(language)
   end
 

--- a/enterprise/app/services/captain/llm/conversation_faq_service.rb
+++ b/enterprise/app/services/captain/llm/conversation_faq_service.rb
@@ -9,14 +9,8 @@ class Captain::Llm::ConversationFaqService < Llm::BaseAiService
 
   def self.language_for(conversation)
     language = conversation.account.locale.presence || I18n.default_locale.to_s
-    normalize_language(language)
-  end
-
-  def self.normalize_language(language)
     language.to_s.tr('-', '_').split('_').first.downcase
   end
-
-  private_class_method :normalize_language
 
   def initialize(assistant, conversation)
     super(feature: LLM_FEATURE, account: conversation.account, fallback_model: Llm::Models.default_model_for(LLM_FEATURE))
@@ -29,7 +23,7 @@ class Captain::Llm::ConversationFaqService < Llm::BaseAiService
   def generate_suggestions
     return [] if no_human_interaction?
 
-    generate.map { |faq| route_candidate(faq) }
+    generate.select { |faq| in_account_language?(faq) }.map { |faq| route_candidate(faq) }
   end
 
   private
@@ -38,6 +32,14 @@ class Captain::Llm::ConversationFaqService < Llm::BaseAiService
 
   def no_human_interaction?
     conversation.first_reply_created_at.nil?
+  end
+
+  def in_account_language?(faq)
+    @language_detector ||= CLD3::NNetLanguageIdentifier.new(0, 1000)
+    %w[question answer].all? do |field|
+      result = @language_detector.find_language(faq.fetch(field))
+      result&.reliable? && result.language.to_s == faq_language
+    end
   end
 
   def route_candidate(faq)

--- a/enterprise/app/services/captain/llm/conversation_faq_service.rb
+++ b/enterprise/app/services/captain/llm/conversation_faq_service.rb
@@ -9,8 +9,14 @@ class Captain::Llm::ConversationFaqService < Llm::BaseAiService
 
   def self.language_for(conversation)
     language = conversation.account.locale.presence || I18n.default_locale.to_s
+    normalize_language(language)
+  end
+
+  def self.normalize_language(language)
     language.to_s.tr('-', '_').split('_').first.downcase
   end
+
+  private_class_method :normalize_language
 
   def initialize(assistant, conversation)
     super(feature: LLM_FEATURE, account: conversation.account, fallback_model: Llm::Models.default_model_for(LLM_FEATURE))
@@ -23,7 +29,7 @@ class Captain::Llm::ConversationFaqService < Llm::BaseAiService
   def generate_suggestions
     return [] if no_human_interaction?
 
-    generate.select { |faq| in_account_language?(faq) }.map { |faq| route_candidate(faq) }
+    generate.map { |faq| route_candidate(faq) }
   end
 
   private
@@ -32,14 +38,6 @@ class Captain::Llm::ConversationFaqService < Llm::BaseAiService
 
   def no_human_interaction?
     conversation.first_reply_created_at.nil?
-  end
-
-  def in_account_language?(faq)
-    @language_detector ||= CLD3::NNetLanguageIdentifier.new(0, 1000)
-    %w[question answer].all? do |field|
-      result = @language_detector.find_language(faq.fetch(field))
-      result&.reliable? && result.language.to_s == faq_language
-    end
   end
 
   def route_candidate(faq)

--- a/spec/enterprise/jobs/captain/llm/conversation_faq_job_spec.rb
+++ b/spec/enterprise/jobs/captain/llm/conversation_faq_job_spec.rb
@@ -30,8 +30,9 @@ RSpec.describe Captain::Llm::ConversationFaqJob, type: :job do
       described_class.perform_now(conversation, assistant)
     end
 
-    it 'locks FAQ grouping for the assistant and normalized language' do
-      conversation.update!(additional_attributes: { conversation_language: 'pt-BR' })
+    it 'locks FAQ grouping using the normalized account locale despite the conversation language' do
+      account.update!(locale: 'pt_BR')
+      conversation.update!(additional_attributes: { conversation_language: 'fr' })
       expected_key = "CAPTAIN_CONVERSATION_FAQ_LOCK::#{assistant.id}::pt"
 
       expect(lock_manager).to receive(:lock).with(expected_key, described_class::LOCK_TIMEOUT).and_return(true)

--- a/spec/enterprise/services/captain/llm/conversation_faq_service_spec.rb
+++ b/spec/enterprise/services/captain/llm/conversation_faq_service_spec.rb
@@ -367,11 +367,11 @@ RSpec.describe Captain::Llm::ConversationFaqService do
       end
 
       before do
-        conversation.update!(additional_attributes: { conversation_language: 'pt-BR' })
+        conversation.account.update!(locale: 'pt_BR')
         allow(embedding_service).to receive(:get_embedding).and_return(embedding_one)
       end
 
-      it 'creates a separate suggestion in the conversation language' do
+      it 'creates a separate suggestion in the account language' do
         expect do
           service.generate_suggestions
         end.to change(captain_assistant.faq_suggestions, :count).by(1)
@@ -424,7 +424,7 @@ RSpec.describe Captain::Llm::ConversationFaqService do
         create(:captain_assistant_response, assistant: captain_assistant, account: captain_assistant.account,
                                             question: 'How do I enable the feature?', answer: 'Turn it on in settings.',
                                             embedding: embedding_one)
-        conversation.update!(additional_attributes: { conversation_language: 'pt-BR' })
+        conversation.account.update!(locale: 'pt_BR')
         allow(embedding_service).to receive(:get_embedding).and_return(embedding_one)
         allow(mock_chat).to receive(:ask) do |input|
           input.start_with?('{') ? match_response : mock_response
@@ -512,7 +512,7 @@ RSpec.describe Captain::Llm::ConversationFaqService do
   end
 
   describe 'language handling' do
-    context 'when conversation has different language' do
+    context 'when conversation has no detected language' do
       let(:account) { create(:account, locale: 'fr') }
       let(:captain_assistant) { create(:captain_assistant, account: account) }
       let(:conversation) do
@@ -545,13 +545,16 @@ RSpec.describe Captain::Llm::ConversationFaqService do
         allow(embedding_service).to receive(:get_embedding).and_return(embedding_one, embedding_two)
       end
 
-      it 'uses the conversation language for the system prompt' do
+      it 'uses account language for the prompt and stored suggestions and observations' do
         expect(Captain::Llm::ConversationFaqPromptsService).to receive(:generator)
-          .with('portuguese')
+          .with('english')
           .at_least(:once)
           .and_call_original
 
         service.generate_suggestions
+
+        expect(captain_assistant.faq_suggestions.pluck(:language)).to eq(%w[en en])
+        expect(Captain::FaqObservation.where(conversation: conversation).pluck(:language)).to eq(%w[en en])
       end
     end
   end

--- a/spec/enterprise/services/captain/llm/conversation_faq_service_spec.rb
+++ b/spec/enterprise/services/captain/llm/conversation_faq_service_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Captain::Llm::ConversationFaqService do
   let(:service) { described_class.new(captain_assistant, conversation) }
   let(:embedding_service) { instance_double(Captain::Llm::EmbeddingService) }
   let(:mock_chat) { instance_double(RubyLLM::Chat) }
-  let(:language_detector) { instance_double(CLD3::NNetLanguageIdentifier) }
   let(:sample_faqs) do
     [
       { 'question' => 'What is the purpose?', 'answer' => 'To help users.' },
@@ -23,11 +22,6 @@ RSpec.describe Captain::Llm::ConversationFaqService do
     create(:installation_config, name: 'CAPTAIN_OPEN_AI_API_KEY', value: 'test-key')
     allow(Captain::Llm::EmbeddingService).to receive(:new).and_return(embedding_service)
     allow(RubyLLM).to receive(:chat).and_return(mock_chat)
-    allow(CLD3::NNetLanguageIdentifier).to receive(:new).and_return(language_detector)
-    allow(language_detector).to receive(:find_language) do
-      instance_double(CLD3::NNetLanguageIdentifier::Result, reliable?: true,
-                                                            language: described_class.language_for(conversation).to_sym)
-    end
     allow(mock_chat).to receive(:with_temperature).and_return(mock_chat)
     allow(mock_chat).to receive(:with_params).and_return(mock_chat)
     allow(mock_chat).to receive(:with_instructions).and_return(mock_chat)
@@ -514,78 +508,6 @@ RSpec.describe Captain::Llm::ConversationFaqService do
       it 'returns empty array' do
         expect(service.generate_suggestions).to eq([])
       end
-    end
-  end
-
-  describe 'language validation' do
-    before do
-      allow(embedding_service).to receive(:get_embedding).and_return(embedding_one, embedding_two)
-    end
-
-    shared_examples 'rejecting the generated FAQs' do
-      it 'creates neither suggestions nor observations and skips embeddings' do
-        expect(embedding_service).not_to receive(:get_embedding)
-        expect { expect(service.generate_suggestions).to eq([]) }
-          .to not_change(Captain::FaqSuggestion, :count).and not_change(Captain::FaqObservation, :count)
-      end
-    end
-
-    context 'with the local language detector' do
-      let(:sample_faqs) do
-        [
-          { 'question' => 'How can I change the language used in my account?',
-            'answer' => 'Open the account settings and select the language you want to use.' },
-          { 'question' => 'Comment puis-je changer la langue de mon compte ?',
-            'answer' => 'Ouvrez les paramètres du compte et sélectionnez la langue que vous souhaitez utiliser.' }
-        ]
-      end
-
-      before { allow(CLD3::NNetLanguageIdentifier).to receive(:new).and_call_original }
-
-      it 'persists only the English candidate for an English account' do
-        expect { service.generate_suggestions }
-          .to change(Captain::FaqSuggestion, :count).by(1).and change(Captain::FaqObservation, :count).by(1)
-
-        expect(captain_assistant.faq_suggestions.sole.question).to eq(sample_faqs.first.fetch('question'))
-        expect(Captain::FaqObservation.where(conversation: conversation).sole.language).to eq('en')
-        expect(embedding_service).to have_received(:get_embedding).once
-      end
-    end
-
-    context 'when the generated text is in another language' do
-      before do
-        allow(language_detector).to receive(:find_language)
-          .and_return(instance_double(CLD3::NNetLanguageIdentifier::Result, reliable?: true, language: :fr))
-      end
-
-      it_behaves_like 'rejecting the generated FAQs'
-    end
-
-    context 'when language detection is uncertain' do
-      before do
-        allow(language_detector).to receive(:find_language)
-          .and_return(instance_double(CLD3::NNetLanguageIdentifier::Result, reliable?: false, language: :en))
-      end
-
-      it_behaves_like 'rejecting the generated FAQs'
-    end
-
-    context 'when no language is detected' do
-      before { allow(language_detector).to receive(:find_language).and_return(nil) }
-
-      it_behaves_like 'rejecting the generated FAQs'
-    end
-
-    context 'when only the answer is in another language' do
-      let(:sample_faqs) { [{ 'question' => 'How does it work?', 'answer' => 'La réponse est en français.' }] }
-
-      before do
-        allow(language_detector).to receive(:find_language).with(sample_faqs.first.fetch('answer'))
-                                                           .and_return(instance_double(CLD3::NNetLanguageIdentifier::Result, reliable?: true,
-                                                                                                                             language: :fr))
-      end
-
-      it_behaves_like 'rejecting the generated FAQs'
     end
   end
 

--- a/spec/enterprise/services/captain/llm/conversation_faq_service_spec.rb
+++ b/spec/enterprise/services/captain/llm/conversation_faq_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Captain::Llm::ConversationFaqService do
   let(:service) { described_class.new(captain_assistant, conversation) }
   let(:embedding_service) { instance_double(Captain::Llm::EmbeddingService) }
   let(:mock_chat) { instance_double(RubyLLM::Chat) }
+  let(:language_detector) { instance_double(CLD3::NNetLanguageIdentifier) }
   let(:sample_faqs) do
     [
       { 'question' => 'What is the purpose?', 'answer' => 'To help users.' },
@@ -22,6 +23,11 @@ RSpec.describe Captain::Llm::ConversationFaqService do
     create(:installation_config, name: 'CAPTAIN_OPEN_AI_API_KEY', value: 'test-key')
     allow(Captain::Llm::EmbeddingService).to receive(:new).and_return(embedding_service)
     allow(RubyLLM).to receive(:chat).and_return(mock_chat)
+    allow(CLD3::NNetLanguageIdentifier).to receive(:new).and_return(language_detector)
+    allow(language_detector).to receive(:find_language) do
+      instance_double(CLD3::NNetLanguageIdentifier::Result, reliable?: true,
+                                                            language: described_class.language_for(conversation).to_sym)
+    end
     allow(mock_chat).to receive(:with_temperature).and_return(mock_chat)
     allow(mock_chat).to receive(:with_params).and_return(mock_chat)
     allow(mock_chat).to receive(:with_instructions).and_return(mock_chat)
@@ -508,6 +514,78 @@ RSpec.describe Captain::Llm::ConversationFaqService do
       it 'returns empty array' do
         expect(service.generate_suggestions).to eq([])
       end
+    end
+  end
+
+  describe 'language validation' do
+    before do
+      allow(embedding_service).to receive(:get_embedding).and_return(embedding_one, embedding_two)
+    end
+
+    shared_examples 'rejecting the generated FAQs' do
+      it 'creates neither suggestions nor observations and skips embeddings' do
+        expect(embedding_service).not_to receive(:get_embedding)
+        expect { expect(service.generate_suggestions).to eq([]) }
+          .to not_change(Captain::FaqSuggestion, :count).and not_change(Captain::FaqObservation, :count)
+      end
+    end
+
+    context 'with the local language detector' do
+      let(:sample_faqs) do
+        [
+          { 'question' => 'How can I change the language used in my account?',
+            'answer' => 'Open the account settings and select the language you want to use.' },
+          { 'question' => 'Comment puis-je changer la langue de mon compte ?',
+            'answer' => 'Ouvrez les paramètres du compte et sélectionnez la langue que vous souhaitez utiliser.' }
+        ]
+      end
+
+      before { allow(CLD3::NNetLanguageIdentifier).to receive(:new).and_call_original }
+
+      it 'persists only the English candidate for an English account' do
+        expect { service.generate_suggestions }
+          .to change(Captain::FaqSuggestion, :count).by(1).and change(Captain::FaqObservation, :count).by(1)
+
+        expect(captain_assistant.faq_suggestions.sole.question).to eq(sample_faqs.first.fetch('question'))
+        expect(Captain::FaqObservation.where(conversation: conversation).sole.language).to eq('en')
+        expect(embedding_service).to have_received(:get_embedding).once
+      end
+    end
+
+    context 'when the generated text is in another language' do
+      before do
+        allow(language_detector).to receive(:find_language)
+          .and_return(instance_double(CLD3::NNetLanguageIdentifier::Result, reliable?: true, language: :fr))
+      end
+
+      it_behaves_like 'rejecting the generated FAQs'
+    end
+
+    context 'when language detection is uncertain' do
+      before do
+        allow(language_detector).to receive(:find_language)
+          .and_return(instance_double(CLD3::NNetLanguageIdentifier::Result, reliable?: false, language: :en))
+      end
+
+      it_behaves_like 'rejecting the generated FAQs'
+    end
+
+    context 'when no language is detected' do
+      before { allow(language_detector).to receive(:find_language).and_return(nil) }
+
+      it_behaves_like 'rejecting the generated FAQs'
+    end
+
+    context 'when only the answer is in another language' do
+      let(:sample_faqs) { [{ 'question' => 'How does it work?', 'answer' => 'La réponse est en français.' }] }
+
+      before do
+        allow(language_detector).to receive(:find_language).with(sample_faqs.first.fetch('answer'))
+                                                           .and_return(instance_double(CLD3::NNetLanguageIdentifier::Result, reliable?: true,
+                                                                                                                             language: :fr))
+      end
+
+      it_behaves_like 'rejecting the generated FAQs'
     end
   end
 


### PR DESCRIPTION
## Description

FAQ suggestions currently use the conversation language, so an English account can receive Arabic suggestions. Generate FAQ questions and answers in the account language regardless of the source conversation language.

Use the account locale for the generation prompt, saved suggestion and observation language, matching scopes, and job lock. Keep the language columns and existing base-language normalization. If the account locale changes, new FAQs use the new language and existing records retain their original language.

Language selection reads the account locale directly. No language classifier or extra LLM call is added.

Fixes [CW-7568](https://linear.app/chatwoot/issue/CW-7568/suggestions-to-be-made-in-account-locale).

## Type of change

- [x] Bug fix

## How has this been tested?

- FAQ service and job specs: 34 examples, 0 failures in an isolated Cook test database, with mocked LLM responses.
- RuboCop passed for all three changed files.
- The final tree exactly matches the previously tested account-locale change after reverting the CLD3 follow-up.
- `git diff --check` passed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing focused unit tests pass locally
