### PR TITLE
docs: fix two stale JSDoc @param blocks

### DIFF
--- a/app/javascript/dashboard/composables/useAutomation.js
+++ b/app/javascript/dashboard/composables/useAutomation.js
@@ -100,7 +100,6 @@ export function useAutomation(startValue = null) {
 
   /**
    * Resets a filter in the automation.value.
-   * @param {Object} automationTypes - The automation types object.
    * @param {number} index - The index of the filter to reset.
    * @param {Object} currentCondition - The current condition object.
    */

--- a/app/javascript/shared/helpers/ReportsDataHelper.js
+++ b/app/javascript/shared/helpers/ReportsDataHelper.js
@@ -68,7 +68,7 @@ export const generateEmptyHeatmapData = () => {
  * Reconciles new data with existing heatmap data based on timestamps
  *
  * @param {Array} data - An array of objects containing timestamp and value
- * @param {Array} heatmapData - An array of objects containing timestamp, value and other properties
+ * @param {Array} dataFromStore - An array of objects containing timestamp, value and other properties
  * @returns {Array} - An array of objects with updated values
  */
 export const reconcileHeatmapData = (data, dataFromStore) => {
@@ -89,7 +89,7 @@ export const reconcileHeatmapData = (data, dataFromStore) => {
 /**
  * Groups heatmap data by day
  *
- * @param {Array} heatmapData - An array of objects containing timestamp, value and other properties
+ * @param {Array} dataFromStore - An array of objects containing timestamp, value and other properties
  * @returns {Map} - A Map object with dates as keys and corresponding data objects as values
  */
 export const groupHeatmapByDay = heatmapData => {


### PR DESCRIPTION
Two JSDoc blocks documented parameters that don't match the signatures:

- `dashboard/composables/useAutomation.js` `resetFilter(index, currentCondition)`: the block listed a closure variable (`automationTypes`) as a parameter — dropped
- `shared/helpers/ReportsDataHelper.js` `reconcileHeatmapData(data, dataFromStore)`: documented `heatmapData` (a locally derived variable) → renamed to `dataFromStore`

Docs-only.