### PR TITLE
docs: drop duplicated words in three comments

### DIFF
--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -71,7 +71,7 @@ class MailPresenter < SimpleDelegator
   end
 
   # check content disposition check
-  # if inline, upload to AWS and and take the URL
+  # if inline, upload to AWS and take the URL
   def attachments
     # ref : https://github.com/gorails-screencasts/action-mailbox-action-text/blob/master/app/mailboxes/posts_mailbox.rb
     mail.attachments.map do |attachment|

--- a/lib/integrations/bot_processor_service.rb
+++ b/lib/integrations/bot_processor_service.rb
@@ -33,7 +33,7 @@ class Integrations::BotProcessorService
 
   def message_content(message)
     # TODO: might needs to change this to a way that we fetch the updated value from event data instead
-    # cause the message.updated event could be that that the message was deleted
+    # cause the message.updated event could be that the message was deleted
 
     return message.content_attributes['submitted_values']&.first&.dig('value') if event_name == 'message.updated'
 

--- a/lib/integrations/dialogflow/processor_service.rb
+++ b/lib/integrations/dialogflow/processor_service.rb
@@ -52,7 +52,7 @@ class Integrations::Dialogflow::ProcessorService < Integrations::BotProcessorSer
 
   def message_content(message)
     # TODO: might needs to change this to a way that we fetch the updated value from event data instead
-    # cause the message.updated event could be that that the message was deleted
+    # cause the message.updated event could be that the message was deleted
 
     return message.content_attributes['submitted_values']&.first&.dig('value') if event_name == 'message.updated'
 


### PR DESCRIPTION
Three comments carried doubled words:

- `app/presenters/mail_presenter.rb`: "upload to AWS **and and** take the URL"
- `lib/integrations/bot_processor_service.rb` + `lib/integrations/dialogflow/processor_service.rb`: "could be **that that** the message was deleted"

Comments only.