### PR TITLE
fix: keep hard break markers out of linkified URLs

### DIFF
--- a/app/javascript/shared/helpers/MessageFormatter.js
+++ b/app/javascript/shared/helpers/MessageFormatter.js
@@ -1,6 +1,7 @@
 import MarkdownIt from 'markdown-it';
 import mila from 'markdown-it-link-attributes';
 import mentionPlugin from './markdownIt/link';
+import linkifyHardbreaks from './markdownIt/linkifyHardbreaks';
 
 const setImageSizing = inlineToken => {
   const imgSrc = inlineToken.attrGet('src');
@@ -52,6 +53,7 @@ const createMarkdownInstance = (linkify = true) => {
     maxNesting: 20,
   })
     .disable(['lheading'])
+    .use(linkifyHardbreaks)
     .use(mentionPlugin)
     .use(imgResizeManager)
     .use(mila, {

--- a/app/javascript/shared/helpers/markdownIt/linkifyHardbreaks.js
+++ b/app/javascript/shared/helpers/markdownIt/linkifyHardbreaks.js
@@ -1,0 +1,26 @@
+// The editor stores a hard line break as a backslash followed by a newline.
+// markdown-it runs its inline `linkify` rule before the `escape` rule, so a bare
+// URL sitting right before that marker swallows the backslash into the match and
+// renders an `href` ending in `%5C`, which usually 404s.
+//
+// Trimming the marker off the match hands it back to the `escape` rule, which
+// turns it into the hard break it was meant to be. A run of backslashes with an
+// even length is a chain of escaped backslashes, not a break marker, so it stays
+// part of the URL.
+export default function linkifyHardbreaks(md) {
+  const matchAtStart = md.linkify.matchAtStart.bind(md.linkify);
+
+  md.linkify.matchAtStart = text => {
+    const match = matchAtStart(text);
+    if (!match || text[match.lastIndex] !== '\n') return match;
+
+    const trailingBackslashes = /\\+$/.exec(match.raw)?.[0].length ?? 0;
+    if (trailingBackslashes % 2 === 0) return match;
+
+    match.raw = match.raw.slice(0, -1);
+    match.text = match.text.slice(0, -1);
+    match.url = match.url.slice(0, -1);
+    match.lastIndex -= 1;
+    return match;
+  };
+}

--- a/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
+++ b/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
@@ -241,6 +241,15 @@ After`;
       );
     });
 
+    it('keeps the hard-break marker out of a link written without a scheme', () => {
+      const { formattedMessage } = new MessageFormatter(
+        'www.example.com/trip/\\\nNext line'
+      );
+
+      expect(formattedMessage).toContain('href="http://www.example.com/trip/"');
+      expect(formattedMessage).not.toContain('%5C');
+    });
+
     it('keeps a trailing backslash that is not a hard break', () => {
       const { formattedMessage } = new MessageFormatter(
         'https://example.com/trip\\ next'

--- a/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
+++ b/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
@@ -219,4 +219,34 @@ After`;
       expect(formattedMessage).toContain('--</p>');
     });
   });
+
+  describe('bare links before a hard break', () => {
+    it('keeps the hard-break marker out of the link', () => {
+      const { formattedMessage } = new MessageFormatter(
+        'https://example.com/trip/\\\nNext line'
+      );
+
+      expect(formattedMessage).toContain('href="https://example.com/trip/"');
+      expect(formattedMessage).not.toContain('%5C');
+      expect(formattedMessage).toContain('<br />');
+    });
+
+    it('keeps an escaped backslash inside the link', () => {
+      const { formattedMessage } = new MessageFormatter(
+        'https://example.com/trip\\\\\nNext line'
+      );
+
+      expect(formattedMessage).toContain(
+        'href="https://example.com/trip%5C%5C"'
+      );
+    });
+
+    it('keeps a trailing backslash that is not a hard break', () => {
+      const { formattedMessage } = new MessageFormatter(
+        'https://example.com/trip\\ next'
+      );
+
+      expect(formattedMessage).toContain('href="https://example.com/trip%5C"');
+    });
+  });
 });


### PR DESCRIPTION
## Description

A bare URL typed right before a hard line break renders with the break marker inside the link: the `href` ends in `%5C` and the visible link text carries a stray backslash, so the link usually 404s when it is clicked from the message bubble.

markdown-it applies its inline `linkify` rule before the `escape` rule, so the backslash of the editor's `\` + newline hard break marker is absorbed into the URL match before Markdown can turn it into a `<br />`. A small markdown-it plugin now trims that marker back off the match and leaves it for the escape rule, which restores the hard break. A trailing run of backslashes with an even length is a chain of escaped backslashes and stays part of the URL, and stored message content is untouched.

Closes #15731

## How to reproduce

1. In the reply editor, type or paste a bare URL such as `https://example.com/trip/`.
2. Insert a hard line break with Shift+Enter and add another line.
3. Send the message and inspect the link in the bubble.

Before: `<a href="https://example.com/trip/%5C">https://example.com/trip/\</a>`
After: `<a href="https://example.com/trip/">https://example.com/trip/</a>` followed by a line break.

## What changed

- `app/javascript/shared/helpers/markdownIt/linkifyHardbreaks.js`: new markdown-it plugin that keeps the hard break marker out of a linkify match.
- `MessageFormatter` registers the plugin, so the dashboard, the widget and Help Center rendering all share the fix.
- Regression coverage in `MessageFormatter.spec.js` for the hard break case, for escaped backslash pairs and for a trailing backslash that is not a break marker.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCAg5BTURQSx4HpTv88xWS
