### PR TITLE
fix(captain): use the current output token parameter in website analysis

### DIFF
--- a/enterprise/app/services/captain/onboarding/website_analyzer_service.rb
+++ b/enterprise/app/services/captain/onboarding/website_analyzer_service.rb
@@ -61,7 +61,7 @@ class Captain::Onboarding::WebsiteAnalyzerService < Llm::BaseAiService
   def extract_business_info
     response = instrument_llm_call(instrumentation_params) do
       chat
-        .with_params(response_format: { type: 'json_object' }, max_tokens: 1000)
+        .with_params(response_format: { type: 'json_object' }, max_completion_tokens: 1000)
         .with_temperature(0.1)
         .with_instructions(build_analysis_prompt)
         .ask(@website_content)

--- a/spec/enterprise/services/captain/onboarding/website_analyzer_service_spec.rb
+++ b/spec/enterprise/services/captain/onboarding/website_analyzer_service_spec.rb
@@ -52,6 +52,14 @@ RSpec.describe Captain::Onboarding::WebsiteAnalyzerService do
         expect(mock_chat).to receive(:with_temperature).with(0.1).and_return(mock_chat)
         service.analyze
       end
+
+      it 'limits the response with the output token parameter current models accept' do
+        expect(mock_chat).to receive(:with_params).with(
+          response_format: { type: 'json_object' }, max_completion_tokens: 1000
+        ).and_return(mock_chat)
+
+        service.analyze
+      end
     end
 
     context 'when website content fetch raises an error' do


### PR DESCRIPTION
## Description

Captain's onboarding website analysis fails on installations configured with a GPT-5 family model. `Captain::Onboarding::WebsiteAnalyzerService#extract_business_info` sends `max_tokens`, and OpenAI answers with `Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`, so the analysis returns an error instead of the business summary.

This switches the request to `max_completion_tokens`, which is the current chat completions parameter and is also accepted by the earlier models the analyzer supports, so no configuration change is needed.

Closes #15712

## How to reproduce

1. Configure a self-hosted installation with `CAPTAIN_OPEN_AI_MODEL=gpt-5-mini`.
2. Run the Captain website onboarding analysis.
3. The OpenAI request returns HTTP 400 because it contains `max_tokens`.

## What changed

- `enterprise/app/services/captain/onboarding/website_analyzer_service.rb`: `max_tokens` → `max_completion_tokens`.
- Regression coverage asserting the request parameters in the existing service spec.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCAg5BTURQSx4HpTv88xWS
