### PR TITLE
feat(sidebar): expand the collapsed sidebar on hover

### DIFF
--- a/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
+++ b/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { h, ref, computed, onMounted, watch } from 'vue';
 import { provideSidebarContext, useSidebarResize } from './provider';
+import { useSidebarHoverPreview } from './useSidebarHoverPreview';
 import { useAccount } from 'dashboard/composables/useAccount';
 import { useConfig } from 'dashboard/composables/useConfig';
 import { useKbd } from 'dashboard/composables/utils/useKbd';
@@ -141,11 +142,29 @@ const {
   snapToCollapsed,
   snapToExpanded,
   COLLAPSED_THRESHOLD,
+  DEFAULT_WIDTH,
 } = useSidebarResize();
+
+const sidebarRef = ref(null);
+const {
+  isHovered,
+  open: openHoverPreview,
+  close: closeHoverPreview,
+} = useSidebarHoverPreview(sidebarRef);
+
+// Hovering the collapsed rail shows the full sidebar over the page, so the
+// conversation list keeps its width until the agent pins the sidebar open.
+const isPreviewOpen = computed(
+  () => !isMobile.value && isCollapsed.value && isHovered.value
+);
 
 // On mobile, sidebar is always expanded (flyout mode)
 const isEffectivelyCollapsed = computed(
-  () => !isMobile.value && isCollapsed.value
+  () => !isMobile.value && isCollapsed.value && !isPreviewOpen.value
+);
+
+const sidebarPanelWidth = computed(() =>
+  isPreviewOpen.value ? DEFAULT_WIDTH : sidebarWidth.value
 );
 
 // Resize handle logic
@@ -168,7 +187,7 @@ const getClientX = event =>
 const onResizeStart = event => {
   isResizing.value = true;
   startX.value = getClientX(event);
-  startWidth.value = sidebarWidth.value;
+  startWidth.value = sidebarPanelWidth.value;
   Object.assign(document.body.style, {
     cursor: 'col-resize',
     userSelect: 'none',
@@ -200,9 +219,10 @@ const onResizeEnd = () => {
   }
 };
 
-const onResizeHandleDoubleClick = () => {
+const toggleCollapsed = () => {
   if (isCollapsed.value) snapToExpanded();
   else snapToCollapsed();
+  closeHoverPreview();
 };
 
 // Support both mouse and touch events
@@ -952,157 +972,189 @@ const menuItems = computed(() => {
 </script>
 
 <template>
-  <aside
-    v-on-click-outside="[
-      closeMobileSidebar,
-      {
-        ignore: [
-          '#mobile-sidebar-launcher',
-          '[data-popover-content]',
-          '[data-popover-backdrop]',
-        ],
-      },
-    ]"
-    class="bg-n-background flex flex-col text-sm pb-px fixed top-0 ltr:left-0 rtl:right-0 h-full z-40 w-[200px] md:w-auto md:relative md:flex-shrink-0 md:ltr:translate-x-0 md:rtl:translate-x-0 ltr:border-r rtl:border-l border-n-weak"
-    :class="[
-      {
-        'shadow-lg md:shadow-none': isMobileSidebarOpen,
-        'ltr:-translate-x-full rtl:translate-x-full': !isMobileSidebarOpen,
-        'transition-transform duration-200 ease-out md:transition-[width]':
-          !isResizing,
-      },
-    ]"
+  <div
+    class="md:relative md:flex-shrink-0"
+    :class="{
+      'transition-[width] duration-200 motion-reduce:transition-none':
+        !isResizing,
+    }"
     :style="isMobile ? undefined : { width: `${sidebarWidth}px` }"
   >
-    <section
-      class="grid"
-      :class="isEffectivelyCollapsed ? 'mt-3 mb-6 gap-4' : 'mt-1 mb-4 gap-2'"
+    <aside
+      ref="sidebarRef"
+      v-on-click-outside="[
+        closeMobileSidebar,
+        {
+          ignore: [
+            '#mobile-sidebar-launcher',
+            '[data-popover-content]',
+            '[data-popover-backdrop]',
+          ],
+        },
+      ]"
+      class="bg-n-background flex flex-col text-sm pb-px fixed top-0 ltr:left-0 rtl:right-0 h-full z-40 w-[200px] md:absolute md:ltr:translate-x-0 md:rtl:translate-x-0 ltr:border-r rtl:border-l border-n-weak"
+      :class="[
+        {
+          'shadow-lg': isMobileSidebarOpen || isPreviewOpen,
+          'md:shadow-none': !isPreviewOpen,
+          'ltr:-translate-x-full rtl:translate-x-full': !isMobileSidebarOpen,
+          'transition-transform duration-200 ease-out md:transition-[width] motion-reduce:transition-none':
+            !isResizing,
+        },
+      ]"
+      :style="isMobile ? undefined : { width: `${sidebarPanelWidth}px` }"
+      @pointerenter="openHoverPreview"
     >
-      <div
-        class="flex gap-2 items-center min-w-0"
-        :class="{
-          'justify-center px-1': isEffectivelyCollapsed,
-          'px-2': !isEffectivelyCollapsed,
-        }"
-      >
-        <template v-if="isEffectivelyCollapsed">
-          <SidebarAccountSwitcher
-            is-collapsed
-            @show-create-account-modal="emit('showCreateAccountModal')"
-          />
-        </template>
-        <template v-else>
-          <div class="grid flex-shrink-0 place-content-center size-6">
-            <Logo class="size-4" />
-          </div>
-          <div class="flex-shrink-0 w-px h-3 bg-n-strong" />
-          <SidebarAccountSwitcher
-            class="flex-grow -mx-1 min-w-0"
-            @show-create-account-modal="emit('showCreateAccountModal')"
-          />
-        </template>
+      <div class="hidden md:flex px-2 pt-2">
+        <Button
+          :icon="
+            isCollapsed
+              ? 'i-lucide-panel-left-open'
+              : 'i-lucide-panel-left-close'
+          "
+          :aria-label="
+            isCollapsed ? t('SIDEBAR.PIN_OPEN') : t('SIDEBAR.COLLAPSE')
+          "
+          :title="isCollapsed ? t('SIDEBAR.PIN_OPEN') : t('SIDEBAR.COLLAPSE')"
+          :aria-pressed="!isCollapsed"
+          ghost
+          slate
+          sm
+          @click="toggleCollapsed"
+        />
       </div>
-      <div
-        class="flex gap-2"
-        :class="isEffectivelyCollapsed ? 'flex-col items-center' : 'px-2'"
+      <section
+        class="grid"
+        :class="isEffectivelyCollapsed ? 'mt-3 mb-6 gap-4' : 'mt-1 mb-4 gap-2'"
       >
-        <RouterLink
-          v-if="!isEffectivelyCollapsed"
-          :to="{ name: 'search' }"
-          class="flex gap-2 items-center px-2 py-1 w-full h-7 rounded-lg outline outline-1 outline-n-weak bg-n-button-color transition-all duration-100 ease-out"
+        <div
+          class="flex gap-2 items-center min-w-0"
+          :class="{
+            'justify-center px-1': isEffectivelyCollapsed,
+            'px-2': !isEffectivelyCollapsed,
+          }"
         >
-          <span class="flex-shrink-0 i-lucide-search size-4 text-n-slate-10" />
-          <span class="flex-grow text-start text-n-slate-10">
-            {{ t('COMBOBOX.SEARCH_PLACEHOLDER') }}
-          </span>
-          <span
-            class="hidden tracking-wide pointer-events-none select-none text-n-slate-10"
-          >
-            {{ searchShortcut }}
-          </span>
-        </RouterLink>
-        <RouterLink
-          v-else
-          :to="{ name: 'search' }"
-          class="flex items-center justify-center size-8 rounded-lg outline outline-1 outline-n-weak bg-n-button-color transition-all duration-100 ease-out hover:bg-n-alpha-2 dark:hover:bg-n-slate-9/30"
-          :title="t('COMBOBOX.SEARCH_PLACEHOLDER')"
-        >
-          <span class="i-lucide-search size-4 text-n-slate-11" />
-        </RouterLink>
-        <ComposeConversation align="start">
-          <template #trigger="{ isOpen }">
-            <Button
-              icon="i-lucide-pen-line"
-              color="slate"
-              size="sm"
-              class="dark:hover:!bg-n-slate-9/30"
-              :class="[
-                isEffectivelyCollapsed
-                  ? '!size-8 !outline-n-weak !text-n-slate-11'
-                  : '!h-7 !outline-n-weak !text-n-slate-11',
-                { '!bg-n-alpha-2 dark:!bg-n-slate-9/30': isOpen },
-              ]"
+          <template v-if="isEffectivelyCollapsed">
+            <SidebarAccountSwitcher
+              is-collapsed
+              @show-create-account-modal="emit('showCreateAccountModal')"
             />
           </template>
-        </ComposeConversation>
-      </div>
-    </section>
-    <nav
-      class="grid overflow-y-scroll flex-grow gap-2 pb-5 no-scrollbar min-w-0"
-      :class="isEffectivelyCollapsed ? 'px-1' : 'px-2'"
-    >
-      <ul
-        class="flex flex-col gap-1 m-0 list-none min-w-0"
-        :class="{ 'items-center': isEffectivelyCollapsed }"
+          <template v-else>
+            <div class="grid flex-shrink-0 place-content-center size-6">
+              <Logo class="size-4" />
+            </div>
+            <div class="flex-shrink-0 w-px h-3 bg-n-strong" />
+            <SidebarAccountSwitcher
+              class="flex-grow -mx-1 min-w-0"
+              @show-create-account-modal="emit('showCreateAccountModal')"
+            />
+          </template>
+        </div>
+        <div
+          class="flex gap-2"
+          :class="isEffectivelyCollapsed ? 'flex-col items-center' : 'px-2'"
+        >
+          <RouterLink
+            v-if="!isEffectivelyCollapsed"
+            :to="{ name: 'search' }"
+            class="flex gap-2 items-center px-2 py-1 w-full h-7 rounded-lg outline outline-1 outline-n-weak bg-n-button-color transition-all duration-100 ease-out"
+          >
+            <span
+              class="flex-shrink-0 i-lucide-search size-4 text-n-slate-10"
+            />
+            <span class="flex-grow text-start text-n-slate-10">
+              {{ t('COMBOBOX.SEARCH_PLACEHOLDER') }}
+            </span>
+            <span
+              class="hidden tracking-wide pointer-events-none select-none text-n-slate-10"
+            >
+              {{ searchShortcut }}
+            </span>
+          </RouterLink>
+          <RouterLink
+            v-else
+            :to="{ name: 'search' }"
+            class="flex items-center justify-center size-8 rounded-lg outline outline-1 outline-n-weak bg-n-button-color transition-all duration-100 ease-out hover:bg-n-alpha-2 dark:hover:bg-n-slate-9/30"
+            :title="t('COMBOBOX.SEARCH_PLACEHOLDER')"
+          >
+            <span class="i-lucide-search size-4 text-n-slate-11" />
+          </RouterLink>
+          <ComposeConversation align="start">
+            <template #trigger="{ isOpen }">
+              <Button
+                icon="i-lucide-pen-line"
+                color="slate"
+                size="sm"
+                class="dark:hover:!bg-n-slate-9/30"
+                :class="[
+                  isEffectivelyCollapsed
+                    ? '!size-8 !outline-n-weak !text-n-slate-11'
+                    : '!h-7 !outline-n-weak !text-n-slate-11',
+                  { '!bg-n-alpha-2 dark:!bg-n-slate-9/30': isOpen },
+                ]"
+              />
+            </template>
+          </ComposeConversation>
+        </div>
+      </section>
+      <nav
+        class="grid overflow-y-scroll flex-grow gap-2 pb-5 no-scrollbar min-w-0"
+        :class="isEffectivelyCollapsed ? 'px-1' : 'px-2'"
       >
-        <SidebarGroup
-          v-for="item in menuItems"
-          :key="item.name"
-          v-bind="item"
-        />
-      </ul>
-    </nav>
-    <section
-      class="flex relative flex-col flex-shrink-0 gap-1 justify-between items-center"
-    >
-      <div
-        class="pointer-events-none absolute inset-x-0 -top-[1.938rem] h-8 bg-gradient-to-t from-n-background to-transparent"
-      />
-      <SidebarChangelogCard
-        v-if="
-          isOnChatwootCloud &&
-          !isACustomBrandedInstance &&
-          !isEffectivelyCollapsed
-        "
-      />
-      <SidebarChangelogButton
-        v-if="
-          isOnChatwootCloud &&
-          !isACustomBrandedInstance &&
-          isEffectivelyCollapsed
-        "
-      />
-      <div
-        class="px-1 py-1.5 flex-shrink-0 flex w-full z-50 gap-2 items-center border-t border-n-weak shadow-[0px_-2px_4px_0px_rgba(27,28,29,0.02)]"
-        :class="isEffectivelyCollapsed ? 'justify-center' : 'justify-between'"
+        <ul
+          class="flex flex-col gap-1 m-0 list-none min-w-0"
+          :class="{ 'items-center': isEffectivelyCollapsed }"
+        >
+          <SidebarGroup
+            v-for="item in menuItems"
+            :key="item.name"
+            v-bind="item"
+          />
+        </ul>
+      </nav>
+      <section
+        class="flex relative flex-col flex-shrink-0 gap-1 justify-between items-center"
       >
-        <SidebarProfileMenu
-          :is-collapsed="isEffectivelyCollapsed"
-          @open-key-shortcut-modal="emit('openKeyShortcutModal')"
+        <div
+          class="pointer-events-none absolute inset-x-0 -top-[1.938rem] h-8 bg-gradient-to-t from-n-background to-transparent"
+        />
+        <SidebarChangelogCard
+          v-if="
+            isOnChatwootCloud &&
+            !isACustomBrandedInstance &&
+            !isEffectivelyCollapsed
+          "
+        />
+        <SidebarChangelogButton
+          v-if="
+            isOnChatwootCloud &&
+            !isACustomBrandedInstance &&
+            isEffectivelyCollapsed
+          "
+        />
+        <div
+          class="px-1 py-1.5 flex-shrink-0 flex w-full z-50 gap-2 items-center border-t border-n-weak shadow-[0px_-2px_4px_0px_rgba(27,28,29,0.02)]"
+          :class="isEffectivelyCollapsed ? 'justify-center' : 'justify-between'"
+        >
+          <SidebarProfileMenu
+            :is-collapsed="isEffectivelyCollapsed"
+            @open-key-shortcut-modal="emit('openKeyShortcutModal')"
+          />
+        </div>
+      </section>
+      <!-- Resize Handle (desktop only) -->
+      <div
+        class="hidden md:block absolute top-0 h-full w-1 cursor-col-resize z-40 ltr:right-0 rtl:left-0 group"
+        @mousedown="onResizeStart"
+        @touchstart="onResizeStart"
+        @dblclick="toggleCollapsed"
+      >
+        <div
+          class="absolute top-0 h-full w-px ltr:right-0 rtl:left-0 bg-transparent group-hover:bg-n-brand transition-colors"
+          :class="{ 'bg-n-brand': isResizing }"
         />
       </div>
-    </section>
-    <!-- Resize Handle (desktop only) -->
-    <div
-      class="hidden md:block absolute top-0 h-full w-1 cursor-col-resize z-40 ltr:right-0 rtl:left-0 group"
-      @mousedown="onResizeStart"
-      @touchstart="onResizeStart"
-      @dblclick="onResizeHandleDoubleClick"
-    >
-      <div
-        class="absolute top-0 h-full w-px ltr:right-0 rtl:left-0 bg-transparent group-hover:bg-n-brand transition-colors"
-        :class="{ 'bg-n-brand': isResizing }"
-      />
-    </div>
-  </aside>
+    </aside>
+  </div>
 </template>

--- a/app/javascript/dashboard/components-next/sidebar/specs/useSidebarHoverPreview.spec.js
+++ b/app/javascript/dashboard/components-next/sidebar/specs/useSidebarHoverPreview.spec.js
@@ -1,0 +1,103 @@
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import { useSidebarHoverPreview } from '../useSidebarHoverPreview';
+
+const mountPreview = () => {
+  const sidebar = document.createElement('aside');
+  const insideSidebar = document.createElement('button');
+  sidebar.appendChild(insideSidebar);
+  document.body.appendChild(sidebar);
+
+  const menu = document.createElement('div');
+  menu.setAttribute('data-popover-content', '');
+  const insideMenu = document.createElement('button');
+  menu.appendChild(insideMenu);
+  document.body.appendChild(menu);
+
+  let preview;
+  const wrapper = mount({
+    setup() {
+      preview = useSidebarHoverPreview(ref(sidebar));
+      return () => null;
+    },
+  });
+
+  return { wrapper, preview, insideSidebar, insideMenu };
+};
+
+const pointerOver = target =>
+  target.dispatchEvent(new Event('pointerover', { bubbles: true }));
+
+describe('useSidebarHoverPreview', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('opens on a mouse pointer and ignores touch', () => {
+    const { preview } = mountPreview();
+
+    preview.open({ pointerType: 'touch' });
+    expect(preview.isHovered.value).toBe(false);
+
+    preview.open({ pointerType: 'mouse' });
+    expect(preview.isHovered.value).toBe(true);
+  });
+
+  it('closes once the pointer rests outside the sidebar', () => {
+    const { preview } = mountPreview();
+    preview.open();
+
+    pointerOver(document.body);
+    expect(preview.isHovered.value).toBe(true);
+
+    vi.runAllTimers();
+    expect(preview.isHovered.value).toBe(false);
+  });
+
+  it('stays open while the pointer is over the sidebar or a menu opened from it', () => {
+    const { preview, insideSidebar, insideMenu } = mountPreview();
+    preview.open();
+
+    pointerOver(insideSidebar);
+    vi.runAllTimers();
+    expect(preview.isHovered.value).toBe(true);
+
+    pointerOver(insideMenu);
+    vi.runAllTimers();
+    expect(preview.isHovered.value).toBe(true);
+  });
+
+  it('cancels a pending close when the pointer comes back', () => {
+    const { preview, insideSidebar } = mountPreview();
+    preview.open();
+
+    pointerOver(document.body);
+    pointerOver(insideSidebar);
+    vi.runAllTimers();
+
+    expect(preview.isHovered.value).toBe(true);
+  });
+
+  it('closes on Escape', () => {
+    const { preview } = mountPreview();
+    preview.open();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(preview.isHovered.value).toBe(false);
+  });
+
+  it('closes immediately when asked to', () => {
+    const { preview } = mountPreview();
+    preview.open();
+
+    preview.close();
+
+    expect(preview.isHovered.value).toBe(false);
+  });
+});

--- a/app/javascript/dashboard/components-next/sidebar/useSidebarHoverPreview.js
+++ b/app/javascript/dashboard/components-next/sidebar/useSidebarHoverPreview.js
@@ -1,0 +1,57 @@
+import { ref, onBeforeUnmount } from 'vue';
+import { useEventListener } from '@vueuse/core';
+
+// Menus opened from the sidebar are teleported out of it, so the pointer leaves
+// the sidebar on its way to them. Keep the preview open across that gap and for
+// as long as the pointer stays inside one of those layers.
+const PREVIEW_LAYER_SELECTOR = '[data-popover-content], [data-dropdown-menu]';
+const CLOSE_DELAY = 180;
+
+/**
+ * Reveals the full sidebar while the pointer rests on the collapsed rail. The
+ * preview is transient: it never writes to the stored sidebar width.
+ *
+ * @param {import('vue').Ref<HTMLElement>} sidebarRef Sidebar root element.
+ */
+export function useSidebarHoverPreview(sidebarRef) {
+  const isHovered = ref(false);
+  let closeTimer = null;
+
+  const cancelClose = () => clearTimeout(closeTimer);
+
+  const close = () => {
+    cancelClose();
+    isHovered.value = false;
+  };
+
+  const open = event => {
+    // Touch devices use the drawer, and a tap would leave the preview stuck open.
+    if (event?.pointerType === 'touch') return;
+    cancelClose();
+    isHovered.value = true;
+  };
+
+  const closeWhenPointerLeaves = event => {
+    if (!isHovered.value) return;
+
+    cancelClose();
+    const staysWithinPreview =
+      sidebarRef.value?.contains(event.target) ||
+      event.target?.closest?.(PREVIEW_LAYER_SELECTOR);
+    if (staysWithinPreview) return;
+
+    closeTimer = setTimeout(close, CLOSE_DELAY);
+  };
+
+  const closeOnEscape = event => {
+    if (event.key === 'Escape') close();
+  };
+
+  useEventListener(document, 'pointerover', closeWhenPointerLeaves);
+  useEventListener(document, 'keydown', closeOnEscape);
+  useEventListener(document, 'pointerleave', close);
+  useEventListener(window, 'blur', close);
+  onBeforeUnmount(cancelClose);
+
+  return { isHovered, open, close };
+}

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -309,6 +309,8 @@
     }
   },
   "SIDEBAR": {
+    "PIN_OPEN": "Pin sidebar open",
+    "COLLAPSE": "Collapse sidebar",
     "NO_ITEMS": "No items",
     "CURRENTLY_VIEWING_ACCOUNT": "Currently viewing:",
     "SWITCH": "Switch",


### PR DESCRIPTION
## Description

A collapsed sidebar keeps only the icon rail, so reaching a section behind it means expanding the sidebar again and giving conversation width back to navigation. Hovering the collapsed rail now shows the full sidebar over the page: the conversation list keeps its width because the preview does not reserve layout space, and the sidebar returns to the rail shortly after the pointer moves away.

A pin control at the top of the sidebar expands or collapses it for good, so the behaviour is reachable from the keyboard and not only by hovering, and Escape dismisses a preview. The preview never writes to the stored sidebar width, so an agent's saved preference is untouched. The resize handle, its double click shortcut and the mobile drawer behave as before.

Closes #15710

## How to test

1. Collapse the sidebar (the new pin control at the top, the resize handle, or a double click on it).
2. Move the pointer onto the icon rail: the full sidebar appears over the page and the conversation list does not move.
3. Open a menu from the sidebar, such as the account switcher or a section's sort menu: the preview stays open while the pointer travels to it.
4. Move the pointer back to the page, or press Escape: the sidebar returns to the rail.
5. Use the pin control to keep the sidebar open; the preview no longer applies and the layout reserves the width again.

## What changed

- `useSidebarHoverPreview.js`: new composable holding the preview state, the close delay, the teleported menu layers that keep it open, and Escape handling.
- `Sidebar.vue`: the sidebar panel is positioned inside a wrapper that reserves the stored width, so the preview overlays the page instead of pushing it. Most of the template diff is that one level of indentation.
- A pin/collapse control at the top of the sidebar on desktop, which also serves as the keyboard-accessible way to expand it.
- Unit coverage for the composable in `specs/useSidebarHoverPreview.spec.js`.

## Open question

The issue asked whether the compact rail should become the default for agents without a saved preference. This PR keeps the current default, so nothing changes until an agent collapses the sidebar. Flipping the default is a one-line change in `provider.js` (`uiSettings.value.sidebar_width ?? MIN_WIDTH`) and I am happy to add it if you prefer that.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCAg5BTURQSx4HpTv88xWS
