### PR TITLE
feat(inboxes): group channels and browse their conversations together

### DIFF
--- a/app/controllers/api/v1/accounts/channel_groups_controller.rb
+++ b/app/controllers/api/v1/accounts/channel_groups_controller.rb
@@ -1,0 +1,45 @@
+class Api::V1::Accounts::ChannelGroupsController < Api::V1::Accounts::BaseController
+  before_action :fetch_channel_group, only: [:update, :destroy]
+  before_action :check_authorization
+
+  def index
+    @channel_groups = Current.account.channel_groups.includes(:inboxes).order(:name)
+    @accessible_inbox_ids = policy_scope(Current.account.inboxes).pluck(:id)
+  end
+
+  def create
+    @channel_group = Current.account.channel_groups.new(channel_group_params)
+    save_with_members
+  end
+
+  def update
+    @channel_group.assign_attributes(channel_group_params)
+    save_with_members
+  end
+
+  def destroy
+    @channel_group.destroy!
+    head :ok
+  end
+
+  private
+
+  def fetch_channel_group
+    @channel_group = Current.account.channel_groups.find(params[:id])
+  end
+
+  def channel_group_params
+    params.require(:channel_group).permit(:name)
+  end
+
+  # An inbox belongs to at most one group, so assigning it here moves it out of
+  # the group it was in.
+  def save_with_members
+    ActiveRecord::Base.transaction do
+      @channel_group.save!
+      next if params[:channel_group][:inbox_ids].nil?
+
+      @channel_group.inboxes = Current.account.inboxes.where(id: params[:channel_group][:inbox_ids])
+    end
+  end
+end

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -34,7 +34,6 @@ class ConversationFinder
   def initialize(current_user, params)
     @current_user = current_user
     @current_account = current_user.account
-    @is_admin = current_account.account_users.find_by(user_id: current_user.id)&.administrator?
     @params = params
   end
 
@@ -89,10 +88,10 @@ class ConversationFinder
   end
 
   def set_inboxes
-    @inbox_ids = if params[:inbox_id]
+    @inbox_ids = if params[:channel_group_id]
+                   current_account.channel_groups.find(params[:channel_group_id]).inboxes.select(:id)
+                 elsif params[:inbox_id]
                    @current_user.assigned_inboxes.where(id: params[:inbox_id])
-                 else
-                   @current_user.assigned_inboxes.pluck(:id)
                  end
   end
 
@@ -107,7 +106,7 @@ class ConversationFinder
   def find_conversation_by_inbox
     @conversations = current_account.conversations
 
-    return unless params[:inbox_id]
+    return if params[:inbox_id].blank? && params[:channel_group_id].blank?
 
     @conversations = @conversations.where(inbox_id: @inbox_ids)
   end

--- a/app/javascript/dashboard/api/channelGroups.js
+++ b/app/javascript/dashboard/api/channelGroups.js
@@ -1,0 +1,3 @@
+import ApiClient from './ApiClient';
+
+export default new ApiClient('channel_groups', { accountScoped: true });

--- a/app/javascript/dashboard/api/inbox/conversation.js
+++ b/app/javascript/dashboard/api/inbox/conversation.js
@@ -14,6 +14,7 @@ class ConversationApi extends ApiClient {
       page,
       labels,
       teamId,
+      channelGroupId,
       conversationType,
       sortBy,
       updatedWithin,
@@ -25,6 +26,7 @@ class ConversationApi extends ApiClient {
       params: {
         inbox_id: inboxId,
         team_id: teamId,
+        channel_group_id: channelGroupId,
         status,
         assignee_type: assigneeType,
         page,
@@ -102,7 +104,15 @@ class ConversationApi extends ApiClient {
     return axios.post(`${this.url}/${conversationId}/unmute`);
   }
 
-  meta({ inboxId, status, assigneeType, labels, teamId, conversationType }) {
+  meta({
+    inboxId,
+    status,
+    assigneeType,
+    labels,
+    teamId,
+    channelGroupId,
+    conversationType,
+  }) {
     return axios.get(`${this.url}/meta`, {
       params: {
         inbox_id: inboxId,
@@ -110,6 +120,7 @@ class ConversationApi extends ApiClient {
         assignee_type: assigneeType,
         labels,
         team_id: teamId,
+        channel_group_id: channelGroupId,
         conversation_type: conversationType,
       },
     });

--- a/app/javascript/dashboard/components-next/copilot/CopilotLauncher.vue
+++ b/app/javascript/dashboard/components-next/copilot/CopilotLauncher.vue
@@ -16,6 +16,7 @@ const isConversationRoute = computed(() => {
     'conversation_through_inbox',
     'conversations_through_label',
     'team_conversations_through_label',
+    'conversations_through_channel_group',
     'conversations_through_folders',
     'conversation_through_mentions',
     'conversation_through_unattended',

--- a/app/javascript/dashboard/components-next/sidebar/MobileSidebarLauncher.vue
+++ b/app/javascript/dashboard/components-next/sidebar/MobileSidebarLauncher.vue
@@ -22,6 +22,7 @@ const isConversationRoute = computed(() => {
     'conversations_through_label',
     'team_conversations_through_label',
     'conversations_through_folders',
+    'conversations_through_channel_group',
     'conversation_through_mentions',
     'conversation_through_unattended',
     'conversation_through_participating',

--- a/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
+++ b/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
@@ -355,46 +355,71 @@ const buildChannelItem = inbox => ({
     }),
 });
 
-// Grouped channels appear under their group, ungrouped channels stay on their
-// own, and both are sorted together by the section's sort option.
-const channelItems = computed(() => {
+const buildChannelGroupItem = ({ group, memberInboxes }) => ({
+  name: `channel-group-${group.id}`,
+  label: group.name,
+  icon: 'i-lucide-folder',
+  to: accountScopedRoute('channel_group_conversations', {
+    channelGroupId: group.id,
+  }),
+  activeOn: ['conversations_through_channel_group'],
+  children: memberInboxes.map(buildChannelItem),
+  badgeCount: memberInboxes.reduce(
+    (count, inbox) => count + getInboxUnreadCount.value(inbox.id),
+    0
+  ),
+});
+
+// Groups and ungrouped channels share the Channels section, so they are sorted
+// together on the channel the sort options already know about: a group takes the
+// place of its oldest channel and carries the unread count of all of them.
+const sortedChannelEntities = computed(() => {
   const groupedInboxIds = new Set(
     channelGroups.value.flatMap(group => group.inbox_ids)
   );
 
   const groups = channelGroups.value
-    .map(group => {
-      const children = sortedInboxes.value
-        .filter(inbox => group.inbox_ids.includes(inbox.id))
-        .map(buildChannelItem);
-
-      return {
-        name: `channel-group-${group.id}`,
-        label: group.name,
-        icon: 'i-lucide-folder',
-        to: accountScopedRoute('channel_group_conversations', {
-          channelGroupId: group.id,
-        }),
-        activeOn: ['conversations_through_channel_group'],
-        children,
-        badgeCount: children.reduce(
-          (count, child) => count + child.badgeCount,
-          0
-        ),
-      };
-    })
-    .filter(group => group.children.length);
+    .map(group => ({
+      group,
+      memberInboxes: sortedInboxes.value.filter(inbox =>
+        group.inbox_ids.includes(inbox.id)
+      ),
+    }))
+    .filter(({ memberInboxes }) => memberInboxes.length)
+    .map(entity => ({
+      ...entity,
+      id: Math.min(...entity.memberInboxes.map(inbox => inbox.id)),
+      label: entity.group.name,
+      unreadCount: entity.memberInboxes.reduce(
+        (count, inbox) => count + getInboxUnreadCount.value(inbox.id),
+        0
+      ),
+    }));
 
   const ungrouped = sortedInboxes.value
     .filter(inbox => !groupedInboxIds.has(inbox.id))
-    .map(buildChannelItem);
+    .map(inbox => ({
+      inbox,
+      id: inbox.id,
+      created_at: inbox.created_at,
+      label: inbox.name,
+      unreadCount: getInboxUnreadCount.value(inbox.id),
+    }));
 
   return sortSidebarItems([...groups, ...ungrouped], {
     sortBy: getSortForSection(SIDEBAR_SORT_SECTIONS.CHANNELS),
-    labelKey: item => item.label,
-    unreadCountKey: item => item.badgeCount,
+    labelKey: entity => entity.label,
+    unreadCountKey: entity => entity.unreadCount,
   });
 });
+
+const channelItems = computed(() =>
+  sortedChannelEntities.value.map(entity =>
+    entity.group
+      ? buildChannelGroupItem(entity)
+      : buildChannelItem(entity.inbox)
+  )
+);
 
 const sortedLabels = computed(() =>
   sortSidebarItems(labels.value, {

--- a/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
+++ b/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
@@ -133,6 +133,24 @@ const setExpandedItem = name => {
   expandedItem.value = expandedItem.value === name ? null : name;
 };
 
+// Channel groups start collapsed, and expanding one only reveals its channels:
+// the conversation view stays on whatever the agent opened.
+const expandedChannelGroups = ref([]);
+const toggleChannelGroup = name => {
+  expandedChannelGroups.value = expandedChannelGroups.value.includes(name)
+    ? expandedChannelGroups.value.filter(item => item !== name)
+    : [...expandedChannelGroups.value, name];
+};
+
+watch(
+  accountId,
+  () => {
+    expandedChannelGroups.value = [];
+    store.dispatch('channelGroups/get');
+  },
+  { immediate: true }
+);
+
 const {
   sidebarWidth,
   isCollapsed,
@@ -156,6 +174,8 @@ const startWidth = ref(0);
 provideSidebarContext({
   expandedItem,
   setExpandedItem,
+  expandedChannelGroups,
+  toggleChannelGroup,
   isCollapsed: isEffectivelyCollapsed,
   sidebarWidth,
   isResizing,
@@ -212,6 +232,7 @@ useEventListener(document, 'touchmove', onResizeMove, { passive: false });
 useEventListener(document, 'touchend', onResizeEnd);
 
 const inboxes = useMapGetter('inboxes/getInboxes');
+const channelGroups = useMapGetter('channelGroups/getGroups');
 const labels = useMapGetter('labels/getLabelsOnSidebar');
 const allUnreadCount = useMapGetter(
   'conversationUnreadCounts/getAllUnreadCount'
@@ -318,6 +339,62 @@ const sortedInboxes = computed(() =>
     unreadCountKey: inbox => getInboxUnreadCount.value(inbox.id),
   })
 );
+
+const buildChannelItem = inbox => ({
+  name: `${inbox.name}-${inbox.id}`,
+  label: inbox.name,
+  badgeCount: getInboxUnreadCount.value(inbox.id),
+  icon: h(ChannelIcon, { inbox, class: 'size-[16px]' }),
+  to: accountScopedRoute('inbox_dashboard', { inbox_id: inbox.id }),
+  component: leafProps =>
+    h(ChannelLeaf, {
+      label: leafProps.label,
+      active: leafProps.active,
+      inbox,
+      badgeCount: leafProps.badgeCount,
+    }),
+});
+
+// Grouped channels appear under their group, ungrouped channels stay on their
+// own, and both are sorted together by the section's sort option.
+const channelItems = computed(() => {
+  const groupedInboxIds = new Set(
+    channelGroups.value.flatMap(group => group.inbox_ids)
+  );
+
+  const groups = channelGroups.value
+    .map(group => {
+      const children = sortedInboxes.value
+        .filter(inbox => group.inbox_ids.includes(inbox.id))
+        .map(buildChannelItem);
+
+      return {
+        name: `channel-group-${group.id}`,
+        label: group.name,
+        icon: 'i-lucide-folder',
+        to: accountScopedRoute('channel_group_conversations', {
+          channelGroupId: group.id,
+        }),
+        activeOn: ['conversations_through_channel_group'],
+        children,
+        badgeCount: children.reduce(
+          (count, child) => count + child.badgeCount,
+          0
+        ),
+      };
+    })
+    .filter(group => group.children.length);
+
+  const ungrouped = sortedInboxes.value
+    .filter(inbox => !groupedInboxIds.has(inbox.id))
+    .map(buildChannelItem);
+
+  return sortSidebarItems([...groups, ...ungrouped], {
+    sortBy: getSortForSection(SIDEBAR_SORT_SECTIONS.CHANNELS),
+    labelKey: item => item.label,
+    unreadCountKey: item => item.badgeCount,
+  });
+});
 
 const sortedLabels = computed(() =>
   sortSidebarItems(labels.value, {
@@ -462,20 +539,7 @@ const menuItems = computed(() => {
           ...buildSortConfig(SIDEBAR_SORT_SECTIONS.CHANNELS),
           collapsible: true,
           showTreeLine: true,
-          children: sortedInboxes.value.map(inbox => ({
-            name: `${inbox.name}-${inbox.id}`,
-            label: inbox.name,
-            badgeCount: getInboxUnreadCount.value(inbox.id),
-            icon: h(ChannelIcon, { inbox, class: 'size-[16px]' }),
-            to: accountScopedRoute('inbox_dashboard', { inbox_id: inbox.id }),
-            component: leafProps =>
-              h(ChannelLeaf, {
-                label: leafProps.label,
-                active: leafProps.active,
-                inbox,
-                badgeCount: leafProps.badgeCount,
-              }),
-          })),
+          children: channelItems.value,
         },
         {
           name: 'Labels',
@@ -843,6 +907,7 @@ const menuItems = computed(() => {
           icon: 'i-lucide-inbox',
           activeOn: [
             'settings_inbox_list',
+            'settings_channel_groups',
             'settings_inbox_show',
             'settings_inbox_new',
             'settings_inbox_finish',

--- a/app/javascript/dashboard/components-next/sidebar/SidebarChannelGroup.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarChannelGroup.vue
@@ -1,0 +1,82 @@
+<script setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useSidebarContext } from './provider';
+import SidebarGroupLeaf from './SidebarGroupLeaf.vue';
+import SidebarUnreadBadge from './SidebarUnreadBadge.vue';
+
+const props = defineProps({
+  name: { type: String, required: true },
+  label: { type: String, required: true },
+  to: { type: Object, required: true },
+  children: { type: Array, default: () => [] },
+  badgeCount: { type: Number, default: 0 },
+  activeChild: { type: Object, default: undefined },
+});
+
+const { t } = useI18n();
+const { expandedChannelGroups, toggleChannelGroup, isAllowed } =
+  useSidebarContext();
+
+const isExpanded = computed(() =>
+  expandedChannelGroups.value.includes(props.name)
+);
+const accessibleChildren = computed(() =>
+  props.children.filter(child => isAllowed(child.to))
+);
+const isActive = computed(
+  () =>
+    props.activeChild?.name === props.name ||
+    accessibleChildren.value.some(
+      child => child.name === props.activeChild?.name
+    )
+);
+</script>
+
+<template>
+  <li class="list-none min-w-0 py-0.5">
+    <div
+      class="flex items-center min-w-0 rounded-lg text-n-slate-11 hover:bg-n-alpha-2"
+      :class="{ 'bg-n-alpha-2 text-n-slate-12': isActive }"
+    >
+      <RouterLink
+        :to="to"
+        :title="label"
+        class="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5"
+      >
+        <span class="i-lucide-folder size-4 flex-shrink-0" />
+        <span class="truncate flex-1 text-sm">{{ label }}</span>
+        <SidebarUnreadBadge :count="badgeCount" />
+      </RouterLink>
+      <button
+        type="button"
+        class="flex items-center justify-center size-7 me-1 rounded-md hover:bg-n-alpha-2 focus-visible:outline focus-visible:outline-n-brand"
+        :aria-label="
+          isExpanded
+            ? t('SIDEBAR.CHANNEL_GROUP.COLLAPSE', { name: label })
+            : t('SIDEBAR.CHANNEL_GROUP.EXPAND', { name: label })
+        "
+        :aria-expanded="isExpanded"
+        @click="toggleChannelGroup(name)"
+      >
+        <span
+          class="size-3"
+          :class="
+            isExpanded
+              ? 'i-lucide-chevron-down'
+              : 'i-lucide-chevron-right rtl:rotate-180'
+          "
+        />
+      </button>
+    </div>
+    <ul v-if="isExpanded" class="m-0 p-0 list-none">
+      <SidebarGroupLeaf
+        v-for="child in accessibleChildren"
+        :key="child.name"
+        v-bind="child"
+        :active="activeChild?.name === child.name"
+        thin-tree-line
+      />
+    </ul>
+  </li>
+</template>

--- a/app/javascript/dashboard/components-next/sidebar/SidebarChannelGroup.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarChannelGroup.vue
@@ -14,6 +14,10 @@ const props = defineProps({
   activeChild: { type: Object, default: undefined },
 });
 
+// The collapsed sidebar renders this inside a popover that has to close once the
+// agent navigates; the expanded sidebar simply ignores the event.
+const emit = defineEmits(['navigate']);
+
 const { t } = useI18n();
 const { expandedChannelGroups, toggleChannelGroup, isAllowed } =
   useSidebarContext();
@@ -43,6 +47,7 @@ const isActive = computed(
         :to="to"
         :title="label"
         class="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5"
+        @click="emit('navigate')"
       >
         <span class="i-lucide-folder size-4 flex-shrink-0" />
         <span class="truncate flex-1 text-sm">{{ label }}</span>
@@ -76,6 +81,7 @@ const isActive = computed(
         v-bind="child"
         :active="activeChild?.name === child.name"
         thin-tree-line
+        @click="emit('navigate')"
       />
     </ul>
   </li>

--- a/app/javascript/dashboard/components-next/sidebar/SidebarCollapsedPopover.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarCollapsedPopover.vue
@@ -8,6 +8,7 @@ import Icon from 'next/icon/Icon.vue';
 import TeleportWithDirection from 'dashboard/components-next/TeleportWithDirection.vue';
 import SidebarUnreadBadge from './SidebarUnreadBadge.vue';
 import SidebarSortMenu from './SidebarSortMenu.vue';
+import SidebarChannelGroup from './SidebarChannelGroup.vue';
 
 const props = defineProps({
   label: { type: String, required: true },
@@ -180,44 +181,50 @@ onMounted(async () => {
                   v-if="expandedSubGroup === child.name"
                   class="m-0 p-0 list-none ltr:pl-4 rtl:pr-4 mt-1 overflow-hidden"
                 >
-                  <li
+                  <template
                     v-for="subChild in getAccessibleSubChildren(child.children)"
                     :key="subChild.name"
-                    class="py-0.5"
                   >
-                    <button
-                      class="flex items-center gap-2 px-2 py-1.5 w-full rounded-lg text-sm text-left rtl:text-right transition-colors duration-150 ease-out"
-                      :class="{
-                        'text-n-slate-12 bg-n-alpha-2': isActive(subChild),
-                        'text-n-slate-11 hover:bg-n-alpha-2':
-                          !isActive(subChild),
-                      }"
-                      @click="navigateAndClose(subChild.to)"
-                    >
-                      <component
-                        :is="subChild.component"
-                        v-if="shouldRenderComponent(subChild)"
-                        v-bind="{
-                          label: subChild.label,
-                          icon: subChild.icon,
-                          active: isActive(subChild),
-                          badgeCount: subChild.badgeCount,
+                    <SidebarChannelGroup
+                      v-if="subChild.children"
+                      v-bind="subChild"
+                      :active-child="activeChild"
+                    />
+                    <li v-else class="py-0.5">
+                      <button
+                        class="flex items-center gap-2 px-2 py-1.5 w-full rounded-lg text-sm text-left rtl:text-right transition-colors duration-150 ease-out"
+                        :class="{
+                          'text-n-slate-12 bg-n-alpha-2': isActive(subChild),
+                          'text-n-slate-11 hover:bg-n-alpha-2':
+                            !isActive(subChild),
                         }"
-                      />
-                      <template v-else>
+                        @click="navigateAndClose(subChild.to)"
+                      >
                         <component
-                          :is="renderIcon(subChild.icon).component"
-                          v-if="subChild.icon"
-                          v-bind="renderIcon(subChild.icon).props"
-                          class="size-4 flex-shrink-0"
+                          :is="subChild.component"
+                          v-if="shouldRenderComponent(subChild)"
+                          v-bind="{
+                            label: subChild.label,
+                            icon: subChild.icon,
+                            active: isActive(subChild),
+                            badgeCount: subChild.badgeCount,
+                          }"
                         />
-                        <span class="flex-1 truncate">
-                          {{ subChild.label }}
-                        </span>
-                        <SidebarUnreadBadge :count="subChild.badgeCount" />
-                      </template>
-                    </button>
-                  </li>
+                        <template v-else>
+                          <component
+                            :is="renderIcon(subChild.icon).component"
+                            v-if="subChild.icon"
+                            v-bind="renderIcon(subChild.icon).props"
+                            class="size-4 flex-shrink-0"
+                          />
+                          <span class="flex-1 truncate">
+                            {{ subChild.label }}
+                          </span>
+                          <SidebarUnreadBadge :count="subChild.badgeCount" />
+                        </template>
+                      </button>
+                    </li>
+                  </template>
                 </ul>
               </Transition>
             </li>

--- a/app/javascript/dashboard/components-next/sidebar/SidebarCollapsedPopover.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarCollapsedPopover.vue
@@ -189,6 +189,7 @@ onMounted(async () => {
                       v-if="subChild.children"
                       v-bind="subChild"
                       :active-child="activeChild"
+                      @navigate="emit('close')"
                     />
                     <li v-else class="py-0.5">
                       <button

--- a/app/javascript/dashboard/components-next/sidebar/SidebarGroup.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarGroup.vue
@@ -39,9 +39,14 @@ const {
   cancelClose,
 } = usePopoverState();
 
-const navigableChildren = computed(() => {
-  return props.children?.flatMap(child => child.children || child) || [];
-});
+// Sections nest at most one level deep today, except channels, where a group of
+// channels adds another level below its section.
+const flattenItems = items =>
+  items.flatMap(item => [item, ...flattenItems(item.children || [])]);
+
+const navigableChildren = computed(() =>
+  flattenItems(props.children || []).filter(child => child.to)
+);
 
 const route = useRoute();
 const router = useRouter();
@@ -109,7 +114,7 @@ const handleWindowBlur = () => {
 };
 
 const hasAccessibleSubChildren = child => {
-  return child.children?.some(
+  return flattenItems(child.children || []).some(
     subChild => subChild.to && isAllowed(subChild.to)
   );
 };
@@ -127,9 +132,9 @@ const visibleChildren = computed(() => {
 const accessibleItems = computed(() => {
   if (!hasChildren.value) return [];
 
-  return visibleChildren.value
-    .flatMap(child => child.children || child)
-    .filter(child => child.to && isAllowed(child.to));
+  return flattenItems(visibleChildren.value).filter(
+    child => child.to && isAllowed(child.to)
+  );
 });
 
 const hasAccessibleChildren = computed(() => {

--- a/app/javascript/dashboard/components-next/sidebar/SidebarSubGroup.vue
+++ b/app/javascript/dashboard/components-next/sidebar/SidebarSubGroup.vue
@@ -6,6 +6,7 @@ import { LOCAL_STORAGE_KEYS } from 'dashboard/constants/localStorage';
 import { LocalStorage } from 'shared/helpers/localStorage';
 import Icon from 'next/icon/Icon.vue';
 import SidebarGroupLeaf from './SidebarGroupLeaf.vue';
+import SidebarChannelGroup from './SidebarChannelGroup.vue';
 import SidebarGroupSeparator from './SidebarGroupSeparator.vue';
 
 import { useSidebarContext } from './provider';
@@ -48,9 +49,11 @@ const storageKey = computed(() =>
 const isSubGroupExpanded = computed(
   () => !props.collapsible || !minimizedSections.value[storageKey.value]
 );
-const hasActiveChild = computed(() =>
-  props.children.some(child => child.name === props.activeChild?.name)
-);
+const isActiveItem = child =>
+  child.name === props.activeChild?.name ||
+  child.children?.some(item => item.name === props.activeChild?.name);
+
+const hasActiveChild = computed(() => props.children.some(isActiveItem));
 
 const accessibleItems = computed(() =>
   props.children.filter(child => {
@@ -101,10 +104,7 @@ const expandSubGroupOnActiveChild = () => {
 };
 
 const shouldShowItem = child => {
-  return (
-    isSubGroupExpanded.value &&
-    (props.isExpanded || props.activeChild?.name === child.name)
-  );
+  return isSubGroupExpanded.value && (props.isExpanded || isActiveItem(child));
 };
 
 // set scrollEnd to true when the scroll reaches the end
@@ -156,15 +156,22 @@ watch([hasActiveChild, storageKey], expandSubGroupOnActiveChild, {
             'max-h-60 overflow-y-scroll no-scrollbar': isScrollable,
           }"
         >
-          <SidebarGroupLeaf
-            v-for="child in children"
-            v-show="shouldShowItem(child)"
-            v-bind="child"
-            :key="child.name"
-            :active="activeChild?.name === child.name"
-            :hide-tree-line="hideLeafTreeLine"
-            thin-tree-line
-          />
+          <template v-for="child in accessibleItems" :key="child.name">
+            <SidebarChannelGroup
+              v-if="child.children"
+              v-show="shouldShowItem(child)"
+              v-bind="child"
+              :active-child="activeChild"
+            />
+            <SidebarGroupLeaf
+              v-else
+              v-show="shouldShowItem(child)"
+              v-bind="child"
+              :active="activeChild?.name === child.name"
+              :hide-tree-line="hideLeafTreeLine"
+              thin-tree-line
+            />
+          </template>
         </div>
         <div
           v-if="isScrollable && isExpanded"

--- a/app/javascript/dashboard/components-next/sidebar/specs/SidebarChannelGroup.spec.js
+++ b/app/javascript/dashboard/components-next/sidebar/specs/SidebarChannelGroup.spec.js
@@ -96,6 +96,19 @@ describe('SidebarChannelGroup', () => {
     expect(toggleChannelGroup).toHaveBeenCalledWith('channel-group-1');
   });
 
+  it('reports navigation so a collapsed sidebar popover can close', async () => {
+    const { wrapper } = mountChannelGroup({
+      expandedChannelGroups: ['channel-group-1'],
+    });
+
+    await wrapper.get('a').trigger('click');
+    await wrapper.get('.sidebar-leaf').trigger('click');
+
+    expect(
+      wrapper.findComponent({ name: 'SidebarChannelGroup' }).emitted('navigate')
+    ).toHaveLength(2);
+  });
+
   it('shows the unread count of the group', () => {
     const { wrapper } = mountChannelGroup();
 

--- a/app/javascript/dashboard/components-next/sidebar/specs/SidebarChannelGroup.spec.js
+++ b/app/javascript/dashboard/components-next/sidebar/specs/SidebarChannelGroup.spec.js
@@ -1,0 +1,112 @@
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import SidebarChannelGroup from '../SidebarChannelGroup.vue';
+import { provideSidebarContext } from '../provider';
+
+vi.mock('dashboard/composables/store', () => ({
+  useMapGetter: () => ref(1),
+}));
+
+vi.mock('dashboard/composables/usePolicy', () => ({
+  usePolicy: () => ({ shouldShow: () => true }),
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    resolve: () => ({ path: '/' }),
+    getRoutes: () => [],
+  }),
+}));
+
+const children = [
+  {
+    name: 'WhatsApp Sales-1',
+    label: 'WhatsApp Sales',
+    to: { name: 'inbox_dashboard', params: { inbox_id: 1 } },
+  },
+  {
+    name: 'Email-2',
+    label: 'Email',
+    to: { name: 'inbox_dashboard', params: { inbox_id: 2 } },
+  },
+];
+
+const mountChannelGroup = ({ expandedChannelGroups = [], ...props } = {}) => {
+  const toggleChannelGroup = vi.fn();
+
+  const wrapper = mount(
+    {
+      components: { SidebarChannelGroup },
+      setup() {
+        provideSidebarContext({
+          expandedChannelGroups: ref(expandedChannelGroups),
+          toggleChannelGroup,
+        });
+      },
+      template: '<SidebarChannelGroup v-bind="$attrs" />',
+    },
+    {
+      attrs: {
+        name: 'channel-group-1',
+        label: 'Northstar',
+        to: { name: 'channel_group_conversations' },
+        children,
+        badgeCount: 3,
+        ...props,
+      },
+      global: {
+        stubs: {
+          RouterLink: { props: ['to'], template: '<a><slot /></a>' },
+          SidebarGroupLeaf: {
+            props: { label: { type: String, required: true } },
+            template: '<li class="sidebar-leaf">{{ label }}</li>',
+          },
+        },
+      },
+    }
+  );
+
+  return { wrapper, toggleChannelGroup };
+};
+
+describe('SidebarChannelGroup', () => {
+  it('hides its channels until the group is expanded', () => {
+    const { wrapper } = mountChannelGroup();
+
+    expect(wrapper.findAll('.sidebar-leaf')).toHaveLength(0);
+    expect(wrapper.get('button').attributes('aria-expanded')).toBe('false');
+  });
+
+  it('lists its channels when expanded', () => {
+    const { wrapper } = mountChannelGroup({
+      expandedChannelGroups: ['channel-group-1'],
+    });
+
+    expect(wrapper.findAll('.sidebar-leaf').map(leaf => leaf.text())).toEqual([
+      'WhatsApp Sales',
+      'Email',
+    ]);
+  });
+
+  it('toggles only the group it belongs to', async () => {
+    const { wrapper, toggleChannelGroup } = mountChannelGroup();
+
+    await wrapper.get('button').trigger('click');
+
+    expect(toggleChannelGroup).toHaveBeenCalledWith('channel-group-1');
+  });
+
+  it('shows the unread count of the group', () => {
+    const { wrapper } = mountChannelGroup();
+
+    expect(wrapper.get('[data-test-id="sidebar-unread-badge"]').text()).toBe(
+      '3'
+    );
+  });
+
+  it('marks the group active while one of its channels is open', () => {
+    const { wrapper } = mountChannelGroup({ activeChild: children[1] });
+
+    expect(wrapper.get('li > div').classes()).toContain('bg-n-alpha-2');
+  });
+});

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -56,6 +56,7 @@ import { ASSIGNEE_TYPE_TAB_PERMISSIONS } from 'dashboard/constants/permissions.j
 const props = defineProps({
   conversationInbox: { type: [String, Number], default: 0 },
   teamId: { type: [String, Number], default: 0 },
+  channelGroupId: { type: [String, Number], default: 0 },
   label: { type: String, default: '' },
   conversationType: { type: String, default: '' },
   foldersId: { type: [String, Number], default: 0 },
@@ -246,6 +247,16 @@ const conversationListPagination = computed(() => {
   return currentPage.value + 1;
 });
 
+const channelGroups = useMapGetter('channelGroups/getGroups');
+const activeChannelGroup = computed(() =>
+  channelGroups.value.find(group => group.id === Number(props.channelGroupId))
+);
+// Live updates arrive per conversation, so the list needs the member inboxes to
+// decide whether an incoming conversation belongs to the open group.
+const channelGroupInboxIds = computed(() =>
+  props.channelGroupId ? activeChannelGroup.value?.inbox_ids || [] : undefined
+);
+
 const conversationFilters = computed(() => {
   return {
     inboxId: props.conversationInbox ? props.conversationInbox : undefined,
@@ -255,6 +266,8 @@ const conversationFilters = computed(() => {
     page: conversationListPagination.value,
     labels: props.label ? [props.label] : undefined,
     teamId: props.teamId || undefined,
+    channelGroupId: props.channelGroupId || undefined,
+    channelGroupInboxIds: channelGroupInboxIds.value,
     conversationType: props.conversationType || undefined,
   };
 });
@@ -275,6 +288,9 @@ const pageTitle = computed(() => {
   }
   if (activeTeam.value.name) {
     return activeTeam.value.name;
+  }
+  if (props.channelGroupId) {
+    return activeChannelGroup.value?.name || t('CHANNEL_GROUPS.TITLE');
   }
   if (props.label) {
     return `#${props.label}`;
@@ -513,6 +529,20 @@ function initializeExistingFilterToModal() {
     props.label
   ).map(useCamelCase);
 
+  if (channelGroupInboxIds.value) {
+    otherFilters.push({
+      attributeKey: 'inbox_id',
+      attributeModel: 'standard',
+      customAttributeType: '',
+      filterOperator: 'equal_to',
+      queryOperator: 'and',
+      values: channelGroupInboxIds.value.map(id => ({
+        id,
+        name: store.getters['inboxes/getInbox'](id)?.name,
+      })),
+    });
+  }
+
   appliedFilter.value = [...appliedFilter.value, ...otherFilters];
 }
 
@@ -650,7 +680,7 @@ function openLastItemAfterDeleteInFolder() {
 
 function redirectToConversationList() {
   const {
-    params: { accountId, inbox_id: inboxId, label, teamId },
+    params: { accountId, inbox_id: inboxId, label, teamId, channelGroupId },
     name,
   } = route;
 
@@ -670,6 +700,7 @@ function redirectToConversationList() {
       inboxId,
       label,
       teamId,
+      channelGroupId,
     })
   );
 }
@@ -857,6 +888,7 @@ provide('isConversationSelected', isConversationSelected);
 provide('deleteConversation', handleDelete);
 
 watch(activeTeam, () => resetAndFetchData());
+watch(channelGroupInboxIds, () => resetAndFetchData());
 
 watch(
   computed(() => props.conversationInbox),
@@ -958,6 +990,7 @@ watch(chatLists, () => {
       :show-end-of-list-message="showEndOfListMessage"
       :label="label"
       :team-id="teamId"
+      :channel-group-id="channelGroupId"
       :folders-id="foldersId"
       :conversation-type="conversationType"
       :show-assignee="showAssigneeInConversationCard"

--- a/app/javascript/dashboard/components/ConversationItem.vue
+++ b/app/javascript/dashboard/components/ConversationItem.vue
@@ -11,6 +11,7 @@ import ConversationContextMenu from './widgets/conversation/contextMenu/Index.vu
 const props = defineProps({
   source: { type: Object, required: true },
   teamId: { type: [String, Number], default: 0 },
+  channelGroupId: { type: [String, Number], default: 0 },
   label: { type: String, default: '' },
   conversationType: { type: String, default: '' },
   foldersId: { type: [String, Number], default: 0 },
@@ -87,6 +88,7 @@ const conversationPath = computed(() =>
       id: props.source.id,
       label: props.label,
       teamId: props.teamId,
+      channelGroupId: props.channelGroupId,
       conversationType: props.conversationType,
       foldersId: props.foldersId,
     })

--- a/app/javascript/dashboard/components/ConversationList.vue
+++ b/app/javascript/dashboard/components/ConversationList.vue
@@ -15,6 +15,7 @@ const props = defineProps({
   showEndOfListMessage: { type: Boolean, default: false },
   label: { type: String, default: '' },
   teamId: { type: [String, Number], default: 0 },
+  channelGroupId: { type: [String, Number], default: 0 },
   foldersId: { type: [String, Number], default: 0 },
   conversationType: { type: String, default: '' },
   showAssignee: { type: Boolean, default: false },
@@ -73,6 +74,7 @@ defineExpose({ conversationListRef });
         :source="item"
         :label="label"
         :team-id="teamId"
+        :channel-group-id="channelGroupId"
         :folders-id="foldersId"
         :conversation-type="conversationType"
         :show-assignee="showAssignee"

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
@@ -42,7 +42,13 @@ const chatMetadata = computed(() => props.chat.meta);
 
 const backButtonUrl = computed(() => {
   const {
-    params: { inbox_id: inboxId, label, teamId, id: customViewId },
+    params: {
+      inbox_id: inboxId,
+      label,
+      teamId,
+      channelGroupId,
+      id: customViewId,
+    },
     name,
   } = route;
 
@@ -56,6 +62,7 @@ const backButtonUrl = computed(() => {
     inboxId,
     label,
     teamId,
+    channelGroupId,
     conversationType: conversationTypeMap[name],
     customViewId,
   });

--- a/app/javascript/dashboard/helper/URLHelper.js
+++ b/app/javascript/dashboard/helper/URLHelper.js
@@ -9,6 +9,7 @@ export const conversationUrl = ({
   id,
   label,
   teamId,
+  channelGroupId,
   conversationType = '',
   foldersId,
 }) => {
@@ -19,6 +20,8 @@ export const conversationUrl = ({
     url = `accounts/${accountId}/label/${label}/conversations/${id}`;
   } else if (teamId) {
     url = `accounts/${accountId}/team/${teamId}/conversations/${id}`;
+  } else if (channelGroupId) {
+    url = `accounts/${accountId}/channel-groups/${channelGroupId}/conversations/${id}`;
   } else if (foldersId && foldersId !== 0) {
     url = `accounts/${accountId}/custom_view/${foldersId}/conversations/${id}`;
   } else if (conversationType === 'mention') {
@@ -37,6 +40,7 @@ export const conversationListPageURL = ({
   inboxId,
   label,
   teamId,
+  channelGroupId,
   customViewId,
 }) => {
   let url = `accounts/${accountId}/dashboard`;
@@ -46,6 +50,8 @@ export const conversationListPageURL = ({
     url = `accounts/${accountId}/team/${teamId}`;
   } else if (inboxId) {
     url = `accounts/${accountId}/inbox/${inboxId}`;
+  } else if (channelGroupId) {
+    url = `accounts/${accountId}/channel-groups/${channelGroupId}`;
   } else if (customViewId) {
     url = `accounts/${accountId}/custom_view/${customViewId}`;
   } else if (conversationType) {

--- a/app/javascript/dashboard/helper/routeHelpers.js
+++ b/app/javascript/dashboard/helper/routeHelpers.js
@@ -94,6 +94,7 @@ export const isAConversationRoute = (
     'inbox_dashboard',
     'label_conversations',
     'team_conversations',
+    'channel_group_conversations',
     'folder_conversations',
     'conversation_participating',
   ];
@@ -104,6 +105,7 @@ export const isAConversationRoute = (
     'conversation_through_inbox',
     'conversations_through_label',
     'conversations_through_team',
+    'conversations_through_channel_group',
     'conversations_through_folders',
     'conversation_through_participating',
   ];
@@ -128,6 +130,8 @@ export const getConversationDashboardRoute = routeName => {
       return 'label_conversations';
     case 'conversations_through_team':
       return 'team_conversations';
+    case 'conversations_through_channel_group':
+      return 'channel_group_conversations';
     case 'conversations_through_folders':
       return 'folder_conversations';
     case 'conversation_through_participating':

--- a/app/javascript/dashboard/helper/specs/routeHelpers.spec.js
+++ b/app/javascript/dashboard/helper/specs/routeHelpers.spec.js
@@ -148,6 +148,9 @@ describe('isAConversationRoute', () => {
     expect(isAConversationRoute('conversation_through_inbox')).toBe(true);
     expect(isAConversationRoute('conversations_through_label')).toBe(true);
     expect(isAConversationRoute('conversations_through_team')).toBe(true);
+    expect(isAConversationRoute('conversations_through_channel_group')).toBe(
+      true
+    );
     expect(isAConversationRoute('dashboard')).toBe(false);
   });
 
@@ -158,6 +161,9 @@ describe('isAConversationRoute', () => {
     expect(isAConversationRoute('inbox_dashboard', true)).toBe(true);
     expect(isAConversationRoute('label_conversations', true)).toBe(true);
     expect(isAConversationRoute('team_conversations', true)).toBe(true);
+    expect(isAConversationRoute('channel_group_conversations', true)).toBe(
+      true
+    );
     expect(isAConversationRoute('folder_conversations', true)).toBe(true);
     expect(isAConversationRoute('conversation_participating', true)).toBe(true);
   });
@@ -212,6 +218,9 @@ describe('getConversationDashboardRoute', () => {
     expect(getConversationDashboardRoute('conversations_through_team')).toEqual(
       'team_conversations'
     );
+    expect(
+      getConversationDashboardRoute('conversations_through_channel_group')
+    ).toEqual('channel_group_conversations');
     expect(
       getConversationDashboardRoute('conversations_through_folders')
     ).toEqual('folder_conversations');

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -1,4 +1,29 @@
 {
+  "CHANNEL_GROUPS": {
+    "TITLE": "Channel groups",
+    "DESCRIPTION": "Organize related channels into shared groups. Open a group to see its conversations, or expand it in the sidebar to browse individual channels.",
+    "CREATE": "Create group",
+    "EDIT": "Edit group",
+    "BACK": "Back to inboxes",
+    "NAME": "Group name",
+    "NAME_HINT": "Up to {count} characters.",
+    "NAME_PLACEHOLDER": "e.g. Northstar",
+    "SAVE": "Save group",
+    "DELETE": "Delete group",
+    "DELETE_NAMED": "Delete {name}",
+    "DELETE_DESCRIPTION": "The channels and their conversations are kept. The channels will appear individually in the sidebar.",
+    "CHANNEL_COUNT": "{count} channels",
+    "MEMBERS_HINT": "Select the channels for this group. A channel belongs to one group, so selecting a channel moves it out of the group it is in.",
+    "SEARCH": "Search channels",
+    "EMPTY": "Create a group to organize related channels in the sidebar.",
+    "NO_CHANNELS": "No channels found.",
+    "SAVED": "Channel group saved.",
+    "DELETED": "Channel group deleted.",
+    "LOAD_ERROR": "Could not load channel groups.",
+    "RETRY": "Retry",
+    "SAVE_ERROR": "Could not save the group. Use a unique name of up to 100 characters.",
+    "DELETE_ERROR": "Could not delete the group."
+  },
   "PROFILE_SETTINGS": {
     "LINK": "Profile Settings",
     "TITLE": "Profile Settings",
@@ -309,6 +334,10 @@
     }
   },
   "SIDEBAR": {
+    "CHANNEL_GROUP": {
+      "EXPAND": "Show channels in {name}",
+      "COLLAPSE": "Hide channels in {name}"
+    },
     "NO_ITEMS": "No items",
     "CURRENTLY_VIEWING_ACCOUNT": "Currently viewing:",
     "SWITCH": "Switch",

--- a/app/javascript/dashboard/routes/dashboard/conversation/ContactConversations.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ContactConversations.vue
@@ -51,7 +51,7 @@ const contextMenu = ref({ x: null, y: null });
 
 const buildConversationUrl = conversationId => {
   const {
-    params: { accountId, inbox_id: inboxId, label, teamId },
+    params: { accountId, inbox_id: inboxId, label, teamId, channelGroupId },
     name,
   } = route;
 
@@ -69,6 +69,7 @@ const buildConversationUrl = conversationId => {
       id: conversationId,
       label,
       teamId,
+      channelGroupId,
       foldersId: isOnFoldersView({ route: { name } }) ? route.params.id : 0,
       conversationType,
     })

--- a/app/javascript/dashboard/routes/dashboard/conversation/ConversationView.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ConversationView.vue
@@ -44,6 +44,10 @@ export default {
       type: String,
       default: '',
     },
+    channelGroupId: {
+      type: [String, Number],
+      default: 0,
+    },
     conversationType: {
       type: String,
       default: '',
@@ -201,6 +205,7 @@ export default {
       :conversation-inbox="inboxId"
       :label="label"
       :team-id="teamId"
+      :channel-group-id="channelGroupId"
       :conversation-type="conversationType"
       :folders-id="foldersId"
       :is-on-expanded-layout="isOnExpandedLayout"

--- a/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/conversation/conversation.routes.js
@@ -42,8 +42,46 @@ const redirectFolderConversationIfUnavailable = async (to, _from, next) => {
   });
 };
 
+const isChannelGroupAvailable = async channelGroupId => {
+  let groups = store.getters['channelGroups/getGroups'];
+  if (!groups.some(group => group.id === Number(channelGroupId))) {
+    await store.dispatch('channelGroups/get');
+    groups = store.getters['channelGroups/getGroups'];
+  }
+  return groups.some(group => group.id === Number(channelGroupId));
+};
+
+const redirectIfChannelGroupUnavailable = async (to, _from, next) => {
+  if (await isChannelGroupAvailable(to.params.channelGroupId)) {
+    next();
+    return;
+  }
+  next({ name: 'home', params: { accountId: to.params.accountId } });
+};
+
 export default {
   routes: [
+    {
+      path: frontendURL('accounts/:accountId/channel-groups/:channelGroupId'),
+      name: 'channel_group_conversations',
+      meta: { permissions: CONVERSATION_PERMISSIONS },
+      beforeEnter: redirectIfChannelGroupUnavailable,
+      component: ConversationView,
+      props: route => ({ channelGroupId: route.params.channelGroupId }),
+    },
+    {
+      path: frontendURL(
+        'accounts/:accountId/channel-groups/:channelGroupId/conversations/:conversation_id'
+      ),
+      name: 'conversations_through_channel_group',
+      meta: { permissions: CONVERSATION_PERMISSIONS },
+      beforeEnter: redirectIfChannelGroupUnavailable,
+      component: ConversationView,
+      props: route => ({
+        channelGroupId: route.params.channelGroupId,
+        conversationId: route.params.conversation_id,
+      }),
+    },
     {
       path: frontendURL('accounts/:accountId/dashboard'),
       name: 'home',

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/ChannelGroups.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/ChannelGroups.vue
@@ -1,0 +1,270 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useStore, useMapGetter } from 'dashboard/composables/store';
+import { useAlert } from 'dashboard/composables';
+import SettingsLayout from '../SettingsLayout.vue';
+import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';
+import Button from 'dashboard/components-next/button/Button.vue';
+import Input from 'dashboard/components-next/input/Input.vue';
+import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
+import ChannelIcon from 'next/icon/ChannelIcon.vue';
+
+const MAX_NAME_LENGTH = 100;
+
+const { t } = useI18n();
+const store = useStore();
+const groups = useMapGetter('channelGroups/getGroups');
+const inboxes = useMapGetter('inboxes/getInboxes');
+
+const isLoading = ref(false);
+const isSaving = ref(false);
+const hasLoadError = ref(false);
+const editorDialog = ref(null);
+const deleteDialog = ref(null);
+const editingGroupId = ref(null);
+const deletingGroup = ref(null);
+const name = ref('');
+const inboxIds = ref([]);
+const searchQuery = ref('');
+const errorMessage = ref('');
+
+const groupByInboxId = computed(() =>
+  Object.fromEntries(
+    groups.value.flatMap(group => group.inbox_ids.map(id => [id, group]))
+  )
+);
+
+const filteredInboxes = computed(() =>
+  [...inboxes.value]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .filter(inbox =>
+      inbox.name
+        .toLocaleLowerCase()
+        .includes(searchQuery.value.toLocaleLowerCase())
+    )
+);
+
+const currentGroupOf = inbox => {
+  const group = groupByInboxId.value[inbox.id];
+  return group?.id === editingGroupId.value ? null : group;
+};
+
+const canSave = computed(() => {
+  const trimmedName = name.value.trim();
+  return (
+    trimmedName.length > 0 &&
+    trimmedName.length <= MAX_NAME_LENGTH &&
+    !isSaving.value
+  );
+});
+
+const load = async () => {
+  isLoading.value = true;
+  hasLoadError.value = false;
+  try {
+    await Promise.all([
+      store.dispatch('channelGroups/get'),
+      store.dispatch('inboxes/get'),
+    ]);
+  } catch {
+    hasLoadError.value = true;
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+onMounted(load);
+
+const openEditor = (group = null) => {
+  editingGroupId.value = group?.id ?? null;
+  name.value = group?.name ?? '';
+  inboxIds.value = [...(group?.inbox_ids ?? [])];
+  searchQuery.value = '';
+  errorMessage.value = '';
+  editorDialog.value.open();
+};
+
+const save = async () => {
+  if (!canSave.value) return;
+
+  isSaving.value = true;
+  errorMessage.value = '';
+  try {
+    const payload = { name: name.value.trim(), inbox_ids: inboxIds.value };
+    if (editingGroupId.value) {
+      await store.dispatch('channelGroups/update', {
+        id: editingGroupId.value,
+        ...payload,
+      });
+    } else {
+      await store.dispatch('channelGroups/create', payload);
+    }
+    editorDialog.value.close();
+    useAlert(t('CHANNEL_GROUPS.SAVED'));
+  } catch (error) {
+    errorMessage.value =
+      error.response?.data?.message || t('CHANNEL_GROUPS.SAVE_ERROR');
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+const confirmDelete = group => {
+  deletingGroup.value = group;
+  deleteDialog.value.open();
+};
+
+const remove = async () => {
+  if (isSaving.value) return;
+
+  isSaving.value = true;
+  try {
+    await store.dispatch('channelGroups/delete', deletingGroup.value.id);
+    deleteDialog.value.close();
+    useAlert(t('CHANNEL_GROUPS.DELETED'));
+  } catch {
+    useAlert(t('CHANNEL_GROUPS.DELETE_ERROR'));
+  } finally {
+    isSaving.value = false;
+  }
+};
+</script>
+
+<template>
+  <SettingsLayout
+    :is-loading="isLoading"
+    :no-records-found="!groups.length && !hasLoadError"
+    :no-records-message="t('CHANNEL_GROUPS.EMPTY')"
+  >
+    <template #header>
+      <BaseSettingsHeader
+        :title="t('CHANNEL_GROUPS.TITLE')"
+        :description="t('CHANNEL_GROUPS.DESCRIPTION')"
+      >
+        <template #actions>
+          <RouterLink :to="{ name: 'settings_inbox_list' }">
+            <Button slate size="sm" :label="t('CHANNEL_GROUPS.BACK')" />
+          </RouterLink>
+          <Button
+            size="sm"
+            :label="t('CHANNEL_GROUPS.CREATE')"
+            :disabled="isLoading || hasLoadError"
+            @click="openEditor()"
+          />
+        </template>
+      </BaseSettingsHeader>
+    </template>
+    <template #body>
+      <div
+        v-if="hasLoadError"
+        role="alert"
+        class="flex items-center gap-3 text-n-ruby-11"
+      >
+        {{ t('CHANNEL_GROUPS.LOAD_ERROR') }}
+        <Button
+          slate
+          size="sm"
+          :label="t('CHANNEL_GROUPS.RETRY')"
+          @click="load"
+        />
+      </div>
+      <div
+        v-for="group in groups"
+        :key="group.id"
+        class="flex items-center justify-between gap-4 py-4 border-b border-n-weak"
+      >
+        <div class="min-w-0">
+          <h3 class="truncate text-heading-3 text-n-slate-12">
+            {{ group.name }}
+          </h3>
+          <p class="text-body-main text-n-slate-11">
+            {{
+              t('CHANNEL_GROUPS.CHANNEL_COUNT', {
+                count: group.inbox_ids.length,
+              })
+            }}
+          </p>
+        </div>
+        <div class="flex gap-2">
+          <Button
+            slate
+            size="sm"
+            :label="t('CHANNEL_GROUPS.EDIT')"
+            @click="openEditor(group)"
+          />
+          <Button
+            slate
+            size="sm"
+            icon="i-lucide-trash-2"
+            :aria-label="t('CHANNEL_GROUPS.DELETE_NAMED', { name: group.name })"
+            @click="confirmDelete(group)"
+          />
+        </div>
+      </div>
+    </template>
+    <Dialog
+      ref="editorDialog"
+      :title="
+        editingGroupId ? t('CHANNEL_GROUPS.EDIT') : t('CHANNEL_GROUPS.CREATE')
+      "
+      :confirm-button-label="t('CHANNEL_GROUPS.SAVE')"
+      :disable-confirm-button="!canSave"
+      :is-loading="isSaving"
+      @confirm="save"
+    >
+      <div class="flex flex-col gap-4">
+        <Input
+          v-model="name"
+          autofocus
+          :label="t('CHANNEL_GROUPS.NAME')"
+          :placeholder="t('CHANNEL_GROUPS.NAME_PLACEHOLDER')"
+          :message="t('CHANNEL_GROUPS.NAME_HINT', { count: MAX_NAME_LENGTH })"
+          :disabled="isSaving"
+        />
+        <p class="text-sm text-n-slate-11">
+          {{ t('CHANNEL_GROUPS.MEMBERS_HINT') }}
+        </p>
+        <Input v-model="searchQuery" :label="t('CHANNEL_GROUPS.SEARCH')" />
+        <div class="flex flex-col gap-1 overflow-y-auto max-h-64">
+          <label
+            v-for="inbox in filteredInboxes"
+            :key="inbox.id"
+            class="flex items-center gap-2 px-2 py-2 text-sm rounded-lg text-n-slate-12 hover:bg-n-alpha-2"
+          >
+            <input
+              v-model="inboxIds"
+              type="checkbox"
+              :value="inbox.id"
+              :disabled="isSaving"
+              class="border rounded border-n-weak"
+            />
+            <ChannelIcon :inbox="inbox" class="flex-shrink-0 size-4" />
+            <span class="truncate">{{ inbox.name }}</span>
+            <span
+              v-if="currentGroupOf(inbox)"
+              class="text-xs ms-auto text-n-slate-10"
+            >
+              {{ currentGroupOf(inbox).name }}
+            </span>
+          </label>
+          <p v-if="!filteredInboxes.length" class="text-sm text-n-slate-11">
+            {{ t('CHANNEL_GROUPS.NO_CHANNELS') }}
+          </p>
+        </div>
+        <p v-if="errorMessage" role="alert" class="text-sm text-n-ruby-11">
+          {{ errorMessage }}
+        </p>
+      </div>
+    </Dialog>
+    <Dialog
+      ref="deleteDialog"
+      type="alert"
+      :title="t('CHANNEL_GROUPS.DELETE_NAMED', { name: deletingGroup?.name })"
+      :description="t('CHANNEL_GROUPS.DELETE_DESCRIPTION')"
+      :confirm-button-label="t('CHANNEL_GROUPS.DELETE')"
+      :is-loading="isSaving"
+      @confirm="remove"
+    />
+  </SettingsLayout>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Index.vue
@@ -112,6 +112,9 @@ const openDelete = inbox => {
           </span>
         </template>
         <template #actions>
+          <router-link v-if="isAdmin" :to="{ name: 'settings_channel_groups' }">
+            <Button slate :label="$t('CHANNEL_GROUPS.TITLE')" size="sm" />
+          </router-link>
           <router-link v-if="isAdmin" :to="{ name: 'settings_inbox_new' }">
             <Button :label="$t('SETTINGS.INBOXES.NEW_INBOX')" size="sm" />
           </router-link>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/inbox.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/inbox.routes.js
@@ -5,6 +5,7 @@ import ChannelFactory from './ChannelFactory.vue';
 import SettingsContent from '../Wrapper.vue';
 import SettingsWrapper from '../SettingsWrapper.vue';
 import InboxHome from './Index.vue';
+import ChannelGroups from './ChannelGroups.vue';
 import Settings from './Settings.vue';
 import InboxChannel from './InboxChannels.vue';
 import ChannelList from './ChannelList.vue';
@@ -27,6 +28,15 @@ export default {
           path: 'list',
           name: 'settings_inbox_list',
           component: InboxHome,
+          meta: {
+            featureFlag: FEATURE_FLAGS.INBOX_MANAGEMENT,
+            permissions: ['administrator'],
+          },
+        },
+        {
+          path: 'groups',
+          name: 'settings_channel_groups',
+          component: ChannelGroups,
           meta: {
             featureFlag: FEATURE_FLAGS.INBOX_MANAGEMENT,
             permissions: ['administrator'],

--- a/app/javascript/dashboard/store/index.js
+++ b/app/javascript/dashboard/store/index.js
@@ -14,6 +14,7 @@ import bulkActions from './modules/bulkActions';
 import campaigns from './modules/campaigns';
 import cannedResponse from './modules/cannedResponse';
 import categories from './modules/helpCenterCategories';
+import channelGroups from './modules/channelGroups';
 import contactConversations from './modules/contactConversations';
 import contactLabels from './modules/contactLabels';
 import contactNotes from './modules/contactNotes';
@@ -81,6 +82,7 @@ export default createStore({
     campaigns,
     cannedResponse,
     categories,
+    channelGroups,
     contactConversations,
     contactLabels,
     contactNotes,

--- a/app/javascript/dashboard/store/modules/channelGroups.js
+++ b/app/javascript/dashboard/store/modules/channelGroups.js
@@ -1,0 +1,47 @@
+import ChannelGroupsAPI from 'dashboard/api/channelGroups';
+
+export const state = { records: [], accountId: null };
+
+export const getters = {
+  // Groups belong to one account, so a stale list must not leak into the next
+  // account the agent switches to.
+  getGroups: ($state, _getters, _rootState, rootGetters) =>
+    $state.accountId === rootGetters.getCurrentAccountId ? $state.records : [],
+};
+
+export const mutations = {
+  setGroups($state, { records, accountId }) {
+    $state.records = records;
+    $state.accountId = accountId;
+  },
+};
+
+export const actions = {
+  async get({ commit, rootGetters }) {
+    const accountId = rootGetters.getCurrentAccountId;
+    const { data } = await ChannelGroupsAPI.get();
+    if (accountId !== rootGetters.getCurrentAccountId) return;
+
+    commit('setGroups', { records: data, accountId });
+  },
+  async create({ dispatch }, group) {
+    await ChannelGroupsAPI.create({ channel_group: group });
+    await dispatch('get');
+  },
+  async update({ dispatch }, { id, ...group }) {
+    await ChannelGroupsAPI.update(id, { channel_group: group });
+    await dispatch('get');
+  },
+  async delete({ dispatch }, id) {
+    await ChannelGroupsAPI.delete(id);
+    await dispatch('get');
+  },
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions,
+};

--- a/app/javascript/dashboard/store/modules/conversations/helpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers.js
@@ -36,7 +36,14 @@ export const filterByUnattended = (
 };
 
 export const applyPageFilters = (conversation, filters) => {
-  const { inboxId, status, labels = [], teamId, conversationType } = filters;
+  const {
+    inboxId,
+    status,
+    labels = [],
+    teamId,
+    channelGroupInboxIds,
+    conversationType,
+  } = filters;
   const {
     status: chatStatus,
     inbox_id: chatInboxId,
@@ -51,6 +58,9 @@ export const applyPageFilters = (conversation, filters) => {
   let shouldFilter = filterByStatus(chatStatus, status);
   shouldFilter = filterByInbox(shouldFilter, inboxId, chatInboxId);
   shouldFilter = filterByTeam(shouldFilter, teamId, chatTeamId);
+  if (channelGroupInboxIds) {
+    shouldFilter = shouldFilter && channelGroupInboxIds.includes(chatInboxId);
+  }
   shouldFilter = filterByLabel(shouldFilter, labels, chatLabels);
   shouldFilter = filterByUnattended(
     shouldFilter,

--- a/app/javascript/dashboard/store/modules/specs/channelGroups/channelGroups.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/channelGroups/channelGroups.spec.js
@@ -1,0 +1,77 @@
+import ChannelGroupsAPI from 'dashboard/api/channelGroups';
+import { actions, getters, mutations } from '../../channelGroups';
+
+vi.mock('dashboard/api/channelGroups');
+
+const groups = [{ id: 1, name: 'Northstar', inbox_ids: [3, 4] }];
+
+describe('#getters', () => {
+  it('returns the groups of the account they were fetched for', () => {
+    const state = { records: groups, accountId: 1 };
+
+    expect(getters.getGroups(state, {}, {}, { getCurrentAccountId: 1 })).toEqual(
+      groups
+    );
+  });
+
+  it('returns nothing after switching to another account', () => {
+    const state = { records: groups, accountId: 1 };
+
+    expect(
+      getters.getGroups(state, {}, {}, { getCurrentAccountId: 2 })
+    ).toEqual([]);
+  });
+});
+
+describe('#mutations', () => {
+  it('stores the groups with the account they belong to', () => {
+    const state = { records: [], accountId: null };
+
+    mutations.setGroups(state, { records: groups, accountId: 1 });
+
+    expect(state).toEqual({ records: groups, accountId: 1 });
+  });
+});
+
+describe('#actions', () => {
+  const commit = vi.fn();
+
+  beforeEach(() => {
+    commit.mockClear();
+  });
+
+  it('stores the fetched groups', async () => {
+    ChannelGroupsAPI.get.mockResolvedValue({ data: groups });
+
+    await actions.get({ commit, rootGetters: { getCurrentAccountId: 1 } });
+
+    expect(commit).toHaveBeenCalledWith('setGroups', {
+      records: groups,
+      accountId: 1,
+    });
+  });
+
+  it('discards a response that arrives after an account switch', async () => {
+    const rootGetters = { getCurrentAccountId: 1 };
+    ChannelGroupsAPI.get.mockImplementation(() => {
+      rootGetters.getCurrentAccountId = 2;
+      return Promise.resolve({ data: groups });
+    });
+
+    await actions.get({ commit, rootGetters });
+
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the list after a group changes', async () => {
+    const dispatch = vi.fn();
+    ChannelGroupsAPI.create.mockResolvedValue({});
+
+    await actions.create({ dispatch }, { name: 'Harbor', inbox_ids: [] });
+
+    expect(ChannelGroupsAPI.create).toHaveBeenCalledWith({
+      channel_group: { name: 'Harbor', inbox_ids: [] },
+    });
+    expect(dispatch).toHaveBeenCalledWith('get');
+  });
+});

--- a/app/javascript/dashboard/store/modules/specs/channelGroups/channelGroups.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/channelGroups/channelGroups.spec.js
@@ -9,9 +9,9 @@ describe('#getters', () => {
   it('returns the groups of the account they were fetched for', () => {
     const state = { records: groups, accountId: 1 };
 
-    expect(getters.getGroups(state, {}, {}, { getCurrentAccountId: 1 })).toEqual(
-      groups
-    );
+    expect(
+      getters.getGroups(state, {}, {}, { getCurrentAccountId: 1 })
+    ).toEqual(groups);
   });
 
   it('returns nothing after switching to another account', () => {

--- a/app/javascript/dashboard/store/modules/specs/conversations/helpers.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/helpers.spec.js
@@ -57,6 +57,20 @@ describe('#findPendingMessageIndex', () => {
 });
 
 describe('#applyPageFilters', () => {
+  describe('#filter-channel-group', () => {
+    it('returns true if the conversation belongs to a channel of the group', () => {
+      const filters = { status: 'open', channelGroupInboxIds: [2, 3] };
+
+      expect(applyPageFilters(conversationList[0], filters)).toEqual(true);
+    });
+
+    it('returns false if the conversation belongs to a channel outside the group', () => {
+      const filters = { status: 'pending', channelGroupInboxIds: [2, 3] };
+
+      expect(applyPageFilters(conversationList[3], filters)).toEqual(false);
+    });
+  });
+
   describe('#filter-team', () => {
     it('returns true if conversation has team and team filter is active', () => {
       const filters = {

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -96,6 +96,7 @@ class Account < ApplicationRecord
   has_many :portals, dependent: :destroy_async, class_name: '::Portal'
   has_many :sms_channels, dependent: :destroy_async, class_name: '::Channel::Sms'
   has_many :teams, dependent: :destroy_async
+  has_many :channel_groups, dependent: :destroy_async
   has_many :telegram_channels, dependent: :destroy_async, class_name: '::Channel::Telegram'
   has_many :twilio_sms, dependent: :destroy_async, class_name: '::Channel::TwilioSms'
   has_many :twitter_profiles, dependent: :destroy_async, class_name: '::Channel::TwitterProfile'

--- a/app/models/channel_group.rb
+++ b/app/models/channel_group.rb
@@ -1,0 +1,34 @@
+# == Schema Information
+#
+# Table name: channel_groups
+#
+#  id         :bigint           not null, primary key
+#  name       :string(100)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  account_id :bigint           not null
+#
+# Indexes
+#
+#  index_channel_groups_on_account_id           (account_id)
+#  index_channel_groups_on_account_id_and_name  (account_id, lower((name)::text)) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (account_id => accounts.id) ON DELETE => cascade
+#
+class ChannelGroup < ApplicationRecord
+  belongs_to :account
+  has_many :inboxes, dependent: :nullify
+
+  before_validation :strip_name
+
+  validates :name, presence: true, length: { maximum: 100 },
+                   uniqueness: { scope: :account_id, case_sensitive: false }
+
+  private
+
+  def strip_name
+    self.name = name&.strip
+  end
+end

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -57,6 +57,7 @@ class Inbox < ApplicationRecord
   validate :ensure_valid_max_assignment_limit
 
   belongs_to :account
+  belongs_to :channel_group, optional: true
   belongs_to :portal, optional: true
 
   belongs_to :channel, polymorphic: true, dependent: :destroy

--- a/app/policies/channel_group_policy.rb
+++ b/app/policies/channel_group_policy.rb
@@ -1,0 +1,17 @@
+class ChannelGroupPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def create?
+    @account_user.administrator?
+  end
+
+  def update?
+    @account_user.administrator?
+  end
+
+  def destroy?
+    @account_user.administrator?
+  end
+end

--- a/app/views/api/v1/accounts/channel_groups/create.json.jbuilder
+++ b/app/views/api/v1/accounts/channel_groups/create.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/v1/models/channel_group', formats: [:json], resource: @channel_group, inbox_ids: @channel_group.inbox_ids

--- a/app/views/api/v1/accounts/channel_groups/index.json.jbuilder
+++ b/app/views/api/v1/accounts/channel_groups/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @channel_groups do |channel_group|
+  json.partial! 'api/v1/models/channel_group', formats: [:json], resource: channel_group,
+                inbox_ids: channel_group.inboxes.map(&:id) & @accessible_inbox_ids
+end

--- a/app/views/api/v1/accounts/channel_groups/index.json.jbuilder
+++ b/app/views/api/v1/accounts/channel_groups/index.json.jbuilder
@@ -1,4 +1,6 @@
 json.array! @channel_groups do |channel_group|
-  json.partial! 'api/v1/models/channel_group', formats: [:json], resource: channel_group,
+  json.partial! 'api/v1/models/channel_group',
+                formats: [:json],
+                resource: channel_group,
                 inbox_ids: channel_group.inboxes.map(&:id) & @accessible_inbox_ids
 end

--- a/app/views/api/v1/accounts/channel_groups/update.json.jbuilder
+++ b/app/views/api/v1/accounts/channel_groups/update.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/v1/models/channel_group', formats: [:json], resource: @channel_group, inbox_ids: @channel_group.inbox_ids

--- a/app/views/api/v1/models/_channel_group.json.jbuilder
+++ b/app/views/api/v1/models/_channel_group.json.jbuilder
@@ -1,0 +1,4 @@
+json.id resource.id
+json.name resource.name
+json.account_id resource.account_id
+json.inbox_ids inbox_ids

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -340,6 +340,8 @@ Rails.application.routes.draw do
           end
           resource :notification_settings, only: [:show, :update]
 
+          resources :channel_groups, only: [:index, :create, :update, :destroy]
+
           resources :teams do
             resources :team_members, only: [:index, :create] do
               collection do

--- a/db/migrate/20260908120000_create_channel_groups.rb
+++ b/db/migrate/20260908120000_create_channel_groups.rb
@@ -1,0 +1,12 @@
+class CreateChannelGroups < ActiveRecord::Migration[7.1]
+  def change
+    create_table :channel_groups do |t|
+      t.references :account, null: false, foreign_key: { on_delete: :cascade }
+      t.string :name, null: false, limit: 100
+
+      t.timestamps
+    end
+    add_index :channel_groups, 'account_id, lower(name)', unique: true, name: 'index_channel_groups_on_account_id_and_name'
+    add_reference :inboxes, :channel_group, foreign_key: { on_delete: :nullify }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_09_08_120000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -626,6 +626,15 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
     t.index ["page_id"], name: "index_channel_facebook_pages_on_page_id"
   end
 
+  create_table "channel_groups", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.string "name", limit: 100, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index "account_id, lower((name)::text)", name: "index_channel_groups_on_account_id_and_name", unique: true
+    t.index ["account_id"], name: "index_channel_groups_on_account_id"
+  end
+
   create_table "channel_instagram", force: :cascade do |t|
     t.string "access_token", null: false
     t.datetime "expires_at", null: false
@@ -1150,7 +1159,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
     t.integer "sender_name_type", default: 0, null: false
     t.string "business_name"
     t.jsonb "csat_config", default: {}, null: false
+    t.bigint "channel_group_id"
     t.index ["account_id"], name: "index_inboxes_on_account_id"
+    t.index ["channel_group_id"], name: "index_inboxes_on_channel_group_id"
     t.index ["channel_id", "channel_type"], name: "index_inboxes_on_channel_id_and_channel_type"
     t.index ["portal_id"], name: "index_inboxes_on_portal_id"
   end
@@ -1596,6 +1607,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
   add_foreign_key "campaign_recipients", "campaigns", on_delete: :cascade
   add_foreign_key "campaign_recipients", "contacts", on_delete: :cascade
   add_foreign_key "campaign_recipients", "inboxes", on_delete: :cascade
+  add_foreign_key "channel_groups", "accounts", on_delete: :cascade
+  add_foreign_key "inboxes", "channel_groups", on_delete: :nullify
   add_foreign_key "inboxes", "portals"
   add_foreign_key "user_sessions", "users"
   create_trigger("accounts_after_insert_row_tr", :generated => true, :compatibility => 1).

--- a/spec/controllers/api/v1/accounts/channel_groups_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/channel_groups_controller_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+
+RSpec.describe 'Channel Groups API', type: :request do
+  let(:account) { create(:account) }
+  let(:administrator) { create(:user, account: account, role: :administrator) }
+  let(:agent) { create(:user, account: account, role: :agent) }
+  let!(:channel_group) { create(:channel_group, account: account, name: 'Northstar') }
+  let!(:inbox) { create(:inbox, account: account, channel_group: channel_group) }
+
+  describe 'GET /api/v1/accounts/{account.id}/channel_groups' do
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized' do
+        get "/api/v1/accounts/#{account.id}/channel_groups"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an authenticated agent' do
+      it 'lists only the members the agent can access' do
+        accessible_inbox = create(:inbox, account: account, channel_group: channel_group)
+        create(:inbox_member, user: agent, inbox: accessible_inbox)
+
+        get "/api/v1/accounts/#{account.id}/channel_groups",
+            headers: agent.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response).to conform_schema(200)
+        expect(response.parsed_body.first['name']).to eq('Northstar')
+        expect(response.parsed_body.first['inbox_ids']).to eq([accessible_inbox.id])
+      end
+    end
+
+    context 'when it is an authenticated administrator' do
+      it 'lists every member of the group' do
+        get "/api/v1/accounts/#{account.id}/channel_groups",
+            headers: administrator.create_new_auth_token, as: :json
+
+        expect(response.parsed_body.first['inbox_ids']).to eq([inbox.id])
+      end
+    end
+  end
+
+  describe 'POST /api/v1/accounts/{account.id}/channel_groups' do
+    let(:other_account_inbox) { create(:inbox, account: create(:account)) }
+
+    it 'returns unauthorized for an agent' do
+      post "/api/v1/accounts/#{account.id}/channel_groups",
+           params: { channel_group: { name: 'Harbor' } },
+           headers: agent.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'creates the group with its members' do
+      new_inbox = create(:inbox, account: account)
+
+      post "/api/v1/accounts/#{account.id}/channel_groups",
+           params: { channel_group: { name: 'Harbor', inbox_ids: [new_inbox.id] } },
+           headers: administrator.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body['name']).to eq('Harbor')
+      expect(new_inbox.reload.channel_group_id).to eq(response.parsed_body['id'])
+    end
+
+    it 'ignores inboxes from another account' do
+      post "/api/v1/accounts/#{account.id}/channel_groups",
+           params: { channel_group: { name: 'Harbor', inbox_ids: [other_account_inbox.id] } },
+           headers: administrator.create_new_auth_token, as: :json
+
+      expect(response.parsed_body['inbox_ids']).to be_empty
+      expect(other_account_inbox.reload.channel_group_id).to be_nil
+    end
+
+    it 'rejects a duplicate name' do
+      post "/api/v1/accounts/#{account.id}/channel_groups",
+           params: { channel_group: { name: 'northstar' } },
+           headers: administrator.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe 'PATCH /api/v1/accounts/{account.id}/channel_groups/{id}' do
+    it 'returns unauthorized for an agent' do
+      patch "/api/v1/accounts/#{account.id}/channel_groups/#{channel_group.id}",
+            params: { channel_group: { name: 'Renamed' } },
+            headers: agent.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'renames the group and keeps its members' do
+      patch "/api/v1/accounts/#{account.id}/channel_groups/#{channel_group.id}",
+            params: { channel_group: { name: 'Renamed' } },
+            headers: administrator.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(channel_group.reload.name).to eq('Renamed')
+      expect(response.parsed_body['inbox_ids']).to eq([inbox.id])
+    end
+
+    it 'replaces the members when inbox ids are sent' do
+      new_inbox = create(:inbox, account: account)
+
+      patch "/api/v1/accounts/#{account.id}/channel_groups/#{channel_group.id}",
+            params: { channel_group: { name: 'Northstar', inbox_ids: [new_inbox.id] } },
+            headers: administrator.create_new_auth_token, as: :json
+
+      expect(response.parsed_body['inbox_ids']).to eq([new_inbox.id])
+      expect(inbox.reload.channel_group_id).to be_nil
+    end
+
+    it 'moves an inbox out of the group it belonged to' do
+      other_group = create(:channel_group, account: account, name: 'Harbor')
+
+      patch "/api/v1/accounts/#{account.id}/channel_groups/#{other_group.id}",
+            params: { channel_group: { name: 'Harbor', inbox_ids: [inbox.id] } },
+            headers: administrator.create_new_auth_token, as: :json
+
+      expect(inbox.reload.channel_group_id).to eq(other_group.id)
+      expect(channel_group.reload.inboxes).to be_empty
+    end
+  end
+
+  describe 'DELETE /api/v1/accounts/{account.id}/channel_groups/{id}' do
+    it 'returns unauthorized for an agent' do
+      delete "/api/v1/accounts/#{account.id}/channel_groups/#{channel_group.id}",
+             headers: agent.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'deletes the group and keeps its inboxes' do
+      delete "/api/v1/accounts/#{account.id}/channel_groups/#{channel_group.id}",
+             headers: administrator.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(account.channel_groups).to be_empty
+      expect(inbox.reload.channel_group_id).to be_nil
+    end
+  end
+end

--- a/spec/factories/channel_groups.rb
+++ b/spec/factories/channel_groups.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :channel_group do
+    sequence(:name) { |n| "Channel group #{n}" }
+    account
+  end
+end

--- a/spec/finders/conversation_finder_spec.rb
+++ b/spec/finders/conversation_finder_spec.rb
@@ -195,6 +195,27 @@ describe ConversationFinder do
       end
     end
 
+    context 'with channel group' do
+      let!(:grouped_inbox) { create(:inbox, account: account) }
+      let!(:channel_group) { create(:channel_group, account: account, inboxes: [grouped_inbox]) }
+      let!(:grouped_conversation) { create(:conversation, account: account, inbox: grouped_inbox) }
+      let(:params) { { channel_group_id: channel_group.id } }
+
+      it 'returns conversations from every inbox of the group' do
+        create(:inbox_member, user: user_1, inbox: grouped_inbox)
+
+        result = conversation_finder.perform
+
+        expect(result[:conversations].map(&:id)).to contain_exactly(grouped_conversation.id)
+      end
+
+      it 'does not return conversations from inboxes the agent cannot access' do
+        result = conversation_finder.perform
+
+        expect(result[:conversations]).to be_empty
+      end
+    end
+
     context 'with labels' do
       let(:params) { { labels: ['resolved'] } }
 

--- a/spec/models/channel_group_spec.rb
+++ b/spec/models/channel_group_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe ChannelGroup do
+  let(:account) { create(:account) }
+
+  describe 'validations' do
+    it 'requires a name' do
+      expect(build(:channel_group, account: account, name: ' ')).not_to be_valid
+    end
+
+    it 'rejects a name already used in the account, ignoring case' do
+      create(:channel_group, account: account, name: 'Northstar')
+
+      expect(build(:channel_group, account: account, name: 'northstar')).not_to be_valid
+    end
+
+    it 'allows the same name in another account' do
+      create(:channel_group, account: account, name: 'Northstar')
+
+      expect(build(:channel_group, account: create(:account), name: 'Northstar')).to be_valid
+    end
+  end
+
+  describe 'members' do
+    it 'keeps its inboxes when the group is deleted' do
+      channel_group = create(:channel_group, account: account)
+      inbox = create(:inbox, account: account, channel_group: channel_group)
+
+      channel_group.destroy!
+
+      expect(inbox.reload).to be_persisted
+      expect(inbox.channel_group_id).to be_nil
+    end
+  end
+end

--- a/swagger/definitions/index.yml
+++ b/swagger/definitions/index.yml
@@ -12,6 +12,8 @@ generic_id:
   $ref: ./resource/extension/generic.yml
 canned_response:
   $ref: ./resource/canned_response.yml
+channel_group:
+  $ref: ./resource/channel_group.yml
 custom_attribute:
   $ref: ./resource/custom_attribute.yml
 automation_rule:
@@ -181,6 +183,10 @@ inbox_update_sms_channel_payload:
 # Team
 team_create_update_payload:
   $ref: ./request/team/create_update_payload.yml
+
+# Channel Group
+channel_group_create_update_payload:
+  $ref: ./request/channel_group/create_update_payload.yml
 
 # Label
 label_create_update_payload:

--- a/swagger/definitions/request/channel_group/create_update_payload.yml
+++ b/swagger/definitions/request/channel_group/create_update_payload.yml
@@ -1,0 +1,12 @@
+type: object
+properties:
+  name:
+    type: string
+    description: The name of the channel group, unique within the account
+    example: Northstar
+  inbox_ids:
+    type: array
+    description: The IDs of the inboxes in the group. An inbox belongs to one group, so listing it here moves it out of the group it was in. Omit the attribute to keep the current members.
+    items:
+      type: number
+    example: [1, 2]

--- a/swagger/definitions/resource/channel_group.yml
+++ b/swagger/definitions/resource/channel_group.yml
@@ -1,0 +1,16 @@
+type: object
+properties:
+  id:
+    type: number
+    description: The ID of the channel group
+  name:
+    type: string
+    description: The name of the channel group
+  account_id:
+    type: number
+    description: The ID of the account the channel group belongs to
+  inbox_ids:
+    type: array
+    description: The IDs of the inboxes in the group that the current user can access
+    items:
+      type: number

--- a/swagger/index.yml
+++ b/swagger/index.yml
@@ -49,6 +49,8 @@ tags:
     description: Agent management APIs
   - name: Canned Responses
     description: Pre-defined responses for common queries
+  - name: Channel Groups
+    description: Group related inboxes for navigation and filtering
   - name: Contacts
     description: Contact management APIs
   - name: Contact Labels
@@ -105,6 +107,7 @@ x-tagGroups:
       - Agents
       - Audit Logs
       - Canned Responses
+      - Channel Groups
       - Contacts
       - Contact Labels
       - Conversation Assignments

--- a/swagger/parameters/channel_group_id.yml
+++ b/swagger/parameters/channel_group_id.yml
@@ -1,0 +1,6 @@
+in: path
+name: channel_group_id
+schema:
+  type: integer
+required: true
+description: The ID of the channel group

--- a/swagger/parameters/index.yml
+++ b/swagger/parameters/index.yml
@@ -7,6 +7,9 @@ agent_bot_id:
 team_id:
   $ref: ./team_id.yml
 
+channel_group_id:
+  $ref: ./channel_group_id.yml
+
 inbox_id:
   $ref: ./inbox_id.yml
 

--- a/swagger/paths/application/channel_groups/create.yml
+++ b/swagger/paths/application/channel_groups/create.yml
@@ -1,0 +1,28 @@
+tags:
+  - Channel Groups
+operationId: create-a-channel-group
+summary: Create a channel group
+security:
+  - userApiKey: []
+description: Create a channel group in the account. Administrator access is required.
+parameters:
+  - $ref: '#/components/parameters/account_id'
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: '#/components/schemas/channel_group_create_update_payload'
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/channel_group'
+  '401':
+    description: Unauthorized
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/application/channel_groups/delete.yml
+++ b/swagger/paths/application/channel_groups/delete.yml
@@ -1,0 +1,22 @@
+tags:
+  - Channel Groups
+operationId: delete-a-channel-group
+summary: Delete a channel group
+security:
+  - userApiKey: []
+description: Delete a channel group. Its inboxes and their conversations are kept. Administrator access is required.
+responses:
+  '200':
+    description: Success
+  '401':
+    description: Unauthorized
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'
+  '404':
+    description: The channel group does not exist in the account
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/application/channel_groups/index.yml
+++ b/swagger/paths/application/channel_groups/index.yml
@@ -1,0 +1,23 @@
+tags:
+  - Channel Groups
+operationId: list-all-channel-groups
+summary: List all channel groups
+security:
+  - userApiKey: []
+description: List the channel groups of the account, with the group members the current user can access
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          type: array
+          description: 'Array of channel groups'
+          items:
+            $ref: '#/components/schemas/channel_group'
+  '401':
+    description: Unauthorized
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/application/channel_groups/update.yml
+++ b/swagger/paths/application/channel_groups/update.yml
@@ -1,0 +1,26 @@
+tags:
+  - Channel Groups
+operationId: update-a-channel-group
+summary: Update a channel group
+security:
+  - userApiKey: []
+description: Rename a channel group or replace its members. Administrator access is required.
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: '#/components/schemas/channel_group_create_update_payload'
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/channel_group'
+  '401':
+    description: Unauthorized
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'

--- a/swagger/paths/index.yml
+++ b/swagger/paths/index.yml
@@ -511,6 +511,23 @@
 /api/v1/profile:
   $ref: ./profile/index.yml
 
+# Channel Groups
+/api/v1/accounts/{account_id}/channel_groups:
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+  get:
+    $ref: ./application/channel_groups/index.yml
+  post:
+    $ref: ./application/channel_groups/create.yml
+/api/v1/accounts/{account_id}/channel_groups/{channel_group_id}:
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+    - $ref: '#/components/parameters/channel_group_id'
+  patch:
+    $ref: ./application/channel_groups/update.yml
+  delete:
+    $ref: ./application/channel_groups/delete.yml
+
 # Teams
 /api/v1/accounts/{account_id}/teams:
   parameters:

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -7744,6 +7744,195 @@
         }
       }
     },
+    "/api/v1/accounts/{account_id}/channel_groups": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        }
+      ],
+      "get": {
+        "tags": [
+          "Channel Groups"
+        ],
+        "operationId": "list-all-channel-groups",
+        "summary": "List all channel groups",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "List the channel groups of the account, with the group members the current user can access",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Array of channel groups",
+                  "items": {
+                    "$ref": "#/components/schemas/channel_group"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Channel Groups"
+        ],
+        "operationId": "create-a-channel-group",
+        "summary": "Create a channel group",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Create a channel group in the account. Administrator access is required.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/account_id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/channel_group_create_update_payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/channel_group"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/{account_id}/channel_groups/{channel_group_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "$ref": "#/components/parameters/channel_group_id"
+        }
+      ],
+      "patch": {
+        "tags": [
+          "Channel Groups"
+        ],
+        "operationId": "update-a-channel-group",
+        "summary": "Update a channel group",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Rename a channel group or replace its members. Administrator access is required.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/channel_group_create_update_payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/channel_group"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Channel Groups"
+        ],
+        "operationId": "delete-a-channel-group",
+        "summary": "Delete a channel group",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Delete a channel group. Its inboxes and their conversations are kept. Administrator access is required.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The channel group does not exist in the account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/accounts/{account_id}/teams": {
       "parameters": [
         {
@@ -9718,6 +9907,30 @@
           "updated_at": {
             "type": "string",
             "description": "The date and time when the canned response was updated"
+          }
+        }
+      },
+      "channel_group": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "description": "The ID of the channel group"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the channel group"
+          },
+          "account_id": {
+            "type": "number",
+            "description": "The ID of the account the channel group belongs to"
+          },
+          "inbox_ids": {
+            "type": "array",
+            "description": "The IDs of the inboxes in the group that the current user can access",
+            "items": {
+              "type": "number"
+            }
           }
         }
       },
@@ -14052,6 +14265,27 @@
           }
         }
       },
+      "channel_group_create_update_payload": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the channel group, unique within the account",
+            "example": "Northstar"
+          },
+          "inbox_ids": {
+            "type": "array",
+            "description": "The IDs of the inboxes in the group. An inbox belongs to one group, so listing it here moves it out of the group it was in. Omit the attribute to keep the current members.",
+            "items": {
+              "type": "number"
+            },
+            "example": [
+              1,
+              2
+            ]
+          }
+        }
+      },
       "label_create_update_payload": {
         "type": "object",
         "properties": {
@@ -16307,6 +16541,15 @@
         "required": true,
         "description": "The ID of the team to be updated"
       },
+      "channel_group_id": {
+        "in": "path",
+        "name": "channel_group_id",
+        "schema": {
+          "type": "integer"
+        },
+        "required": true,
+        "description": "The ID of the channel group"
+      },
       "inbox_id": {
         "in": "path",
         "name": "inbox_id",
@@ -16529,6 +16772,10 @@
       "description": "Pre-defined responses for common queries"
     },
     {
+      "name": "Channel Groups",
+      "description": "Group related inboxes for navigation and filtering"
+    },
+    {
       "name": "Contacts",
       "description": "Contact management APIs"
     },
@@ -16631,6 +16878,7 @@
         "Agents",
         "Audit Logs",
         "Canned Responses",
+        "Channel Groups",
         "Contacts",
         "Contact Labels",
         "Conversation Assignments",

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -6287,6 +6287,195 @@
         }
       }
     },
+    "/api/v1/accounts/{account_id}/channel_groups": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        }
+      ],
+      "get": {
+        "tags": [
+          "Channel Groups"
+        ],
+        "operationId": "list-all-channel-groups",
+        "summary": "List all channel groups",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "List the channel groups of the account, with the group members the current user can access",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Array of channel groups",
+                  "items": {
+                    "$ref": "#/components/schemas/channel_group"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Channel Groups"
+        ],
+        "operationId": "create-a-channel-group",
+        "summary": "Create a channel group",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Create a channel group in the account. Administrator access is required.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/account_id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/channel_group_create_update_payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/channel_group"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/{account_id}/channel_groups/{channel_group_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "$ref": "#/components/parameters/channel_group_id"
+        }
+      ],
+      "patch": {
+        "tags": [
+          "Channel Groups"
+        ],
+        "operationId": "update-a-channel-group",
+        "summary": "Update a channel group",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Rename a channel group or replace its members. Administrator access is required.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/channel_group_create_update_payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/channel_group"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Channel Groups"
+        ],
+        "operationId": "delete-a-channel-group",
+        "summary": "Delete a channel group",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Delete a channel group. Its inboxes and their conversations are kept. Administrator access is required.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The channel group does not exist in the account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/accounts/{account_id}/teams": {
       "parameters": [
         {
@@ -8225,6 +8414,30 @@
           "updated_at": {
             "type": "string",
             "description": "The date and time when the canned response was updated"
+          }
+        }
+      },
+      "channel_group": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "description": "The ID of the channel group"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the channel group"
+          },
+          "account_id": {
+            "type": "number",
+            "description": "The ID of the account the channel group belongs to"
+          },
+          "inbox_ids": {
+            "type": "array",
+            "description": "The IDs of the inboxes in the group that the current user can access",
+            "items": {
+              "type": "number"
+            }
           }
         }
       },
@@ -12559,6 +12772,27 @@
           }
         }
       },
+      "channel_group_create_update_payload": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the channel group, unique within the account",
+            "example": "Northstar"
+          },
+          "inbox_ids": {
+            "type": "array",
+            "description": "The IDs of the inboxes in the group. An inbox belongs to one group, so listing it here moves it out of the group it was in. Omit the attribute to keep the current members.",
+            "items": {
+              "type": "number"
+            },
+            "example": [
+              1,
+              2
+            ]
+          }
+        }
+      },
       "label_create_update_payload": {
         "type": "object",
         "properties": {
@@ -14814,6 +15048,15 @@
         "required": true,
         "description": "The ID of the team to be updated"
       },
+      "channel_group_id": {
+        "in": "path",
+        "name": "channel_group_id",
+        "schema": {
+          "type": "integer"
+        },
+        "required": true,
+        "description": "The ID of the channel group"
+      },
       "inbox_id": {
         "in": "path",
         "name": "inbox_id",
@@ -15020,6 +15263,10 @@
       "description": "Pre-defined responses for common queries"
     },
     {
+      "name": "Channel Groups",
+      "description": "Group related inboxes for navigation and filtering"
+    },
+    {
       "name": "Contacts",
       "description": "Contact management APIs"
     },
@@ -15106,6 +15353,7 @@
         "Agents",
         "Audit Logs",
         "Canned Responses",
+        "Channel Groups",
         "Contacts",
         "Contact Labels",
         "Conversation Assignments",

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -694,6 +694,30 @@
           }
         }
       },
+      "channel_group": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "description": "The ID of the channel group"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the channel group"
+          },
+          "account_id": {
+            "type": "number",
+            "description": "The ID of the account the channel group belongs to"
+          },
+          "inbox_ids": {
+            "type": "array",
+            "description": "The IDs of the inboxes in the group that the current user can access",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
       "custom_attribute": {
         "type": "object",
         "properties": {
@@ -5025,6 +5049,27 @@
           }
         }
       },
+      "channel_group_create_update_payload": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the channel group, unique within the account",
+            "example": "Northstar"
+          },
+          "inbox_ids": {
+            "type": "array",
+            "description": "The IDs of the inboxes in the group. An inbox belongs to one group, so listing it here moves it out of the group it was in. Omit the attribute to keep the current members.",
+            "items": {
+              "type": "number"
+            },
+            "example": [
+              1,
+              2
+            ]
+          }
+        }
+      },
       "label_create_update_payload": {
         "type": "object",
         "properties": {
@@ -7280,6 +7325,15 @@
         "required": true,
         "description": "The ID of the team to be updated"
       },
+      "channel_group_id": {
+        "in": "path",
+        "name": "channel_group_id",
+        "schema": {
+          "type": "integer"
+        },
+        "required": true,
+        "description": "The ID of the channel group"
+      },
       "inbox_id": {
         "in": "path",
         "name": "inbox_id",
@@ -7504,6 +7558,7 @@
         "Agents",
         "Audit Logs",
         "Canned Responses",
+        "Channel Groups",
         "Contacts",
         "Contact Labels",
         "Conversation Assignments",

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -109,6 +109,30 @@
           }
         }
       },
+      "channel_group": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "description": "The ID of the channel group"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the channel group"
+          },
+          "account_id": {
+            "type": "number",
+            "description": "The ID of the account the channel group belongs to"
+          },
+          "inbox_ids": {
+            "type": "array",
+            "description": "The IDs of the inboxes in the group that the current user can access",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
       "custom_attribute": {
         "type": "object",
         "properties": {
@@ -4440,6 +4464,27 @@
           }
         }
       },
+      "channel_group_create_update_payload": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the channel group, unique within the account",
+            "example": "Northstar"
+          },
+          "inbox_ids": {
+            "type": "array",
+            "description": "The IDs of the inboxes in the group. An inbox belongs to one group, so listing it here moves it out of the group it was in. Omit the attribute to keep the current members.",
+            "items": {
+              "type": "number"
+            },
+            "example": [
+              1,
+              2
+            ]
+          }
+        }
+      },
       "label_create_update_payload": {
         "type": "object",
         "properties": {
@@ -6695,6 +6740,15 @@
         "required": true,
         "description": "The ID of the team to be updated"
       },
+      "channel_group_id": {
+        "in": "path",
+        "name": "channel_group_id",
+        "schema": {
+          "type": "integer"
+        },
+        "required": true,
+        "description": "The ID of the channel group"
+      },
       "inbox_id": {
         "in": "path",
         "name": "inbox_id",
@@ -6911,6 +6965,7 @@
         "Agents",
         "Audit Logs",
         "Canned Responses",
+        "Channel Groups",
         "Contacts",
         "Contact Labels",
         "Conversation Assignments",

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -870,6 +870,30 @@
           }
         }
       },
+      "channel_group": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "description": "The ID of the channel group"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the channel group"
+          },
+          "account_id": {
+            "type": "number",
+            "description": "The ID of the account the channel group belongs to"
+          },
+          "inbox_ids": {
+            "type": "array",
+            "description": "The IDs of the inboxes in the group that the current user can access",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
       "custom_attribute": {
         "type": "object",
         "properties": {
@@ -5201,6 +5225,27 @@
           }
         }
       },
+      "channel_group_create_update_payload": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the channel group, unique within the account",
+            "example": "Northstar"
+          },
+          "inbox_ids": {
+            "type": "array",
+            "description": "The IDs of the inboxes in the group. An inbox belongs to one group, so listing it here moves it out of the group it was in. Omit the attribute to keep the current members.",
+            "items": {
+              "type": "number"
+            },
+            "example": [
+              1,
+              2
+            ]
+          }
+        }
+      },
       "label_create_update_payload": {
         "type": "object",
         "properties": {
@@ -7456,6 +7501,15 @@
         "required": true,
         "description": "The ID of the team to be updated"
       },
+      "channel_group_id": {
+        "in": "path",
+        "name": "channel_group_id",
+        "schema": {
+          "type": "integer"
+        },
+        "required": true,
+        "description": "The ID of the channel group"
+      },
       "inbox_id": {
         "in": "path",
         "name": "inbox_id",
@@ -7684,6 +7738,7 @@
         "Agents",
         "Audit Logs",
         "Canned Responses",
+        "Channel Groups",
         "Contacts",
         "Contact Labels",
         "Conversation Assignments",


### PR DESCRIPTION
## Description

An account that serves several brands or business units ends up with a long, flat channel list, and working through one brand means visiting its inboxes one by one.

Administrators can now group channels under **Settings → Inboxes → Channel groups**. A group appears in the sidebar next to the ungrouped channels and starts collapsed. Selecting it opens the conversations of every member channel the agent can access; the chevron next to it reveals the channels themselves without changing the conversation view that is open. Channels that are not in a group keep their place in the list.

Grouping only organizes navigation and filtering. Inbox permissions still decide which channels and conversations an agent sees, adding an inbox to a group grants nobody access to it, a channel belongs to at most one group, and deleting a group keeps its channels and their conversations.

Closes #15711

## How to test

1. As an administrator, open Settings → Inboxes → Channel groups and create a group with two or three inboxes.
2. In the sidebar, under Channels, the group appears collapsed. Click its name: the conversation list shows the conversations of all its member inboxes, each still labelled with the inbox it came from, and the status/assignment tabs and counts apply to the group.
3. Click the chevron next to the group: its channels appear below it and the open conversation view stays where it was. Selecting a channel opens the usual single-inbox view.
4. As an agent who is a member of only one inbox of the group, the group lists only that inbox and the combined view shows only its conversations.
5. Delete the group: its inboxes reappear individually in the sidebar and their conversations are untouched.

## What changed

- `channel_groups` table, `ChannelGroup` model and a nullable `channel_group_id` on inboxes, so removing a group never touches inboxes or conversations.
- `Api::V1::Accounts::ChannelGroupsController` with `index`, `create`, `update` and `destroy`. Reading is open to the account; writing is administrator-only through `ChannelGroupPolicy`. `index` returns only the members the current user can access, and membership is always resolved through the account's own inboxes.
- `ConversationFinder` accepts `channel_group_id` and scopes conversations to the group's inboxes before the existing permission filter runs, so a group can never widen what an agent sees.
- Dashboard: a channel group settings page, the sidebar group entry with its own expand control, the combined conversation routes, and the store module behind them.
- The API is documented under the new **Channel Groups** tag in the OpenAPI spec.

The finder change also drops two pieces of dead code in that class (`@is_admin`, and the `set_inboxes` branch whose result was never read), because the class sits on RuboCop's `Metrics/ClassLength` limit.

## Questions for maintainers

The issue left a few product decisions open, and the implementation takes the simplest reading of each. Happy to change any of them:

- Terminology: "channel groups", matching the sidebar section, rather than "inbox groups".
- One level of grouping, and at most one group per channel.
- Selecting a channel that already belongs to another group moves it, rather than rejecting the change; the settings dialog shows the group a channel currently belongs to.
- The combined conversation view is part of this PR, since a group that cannot be opened offers little over renaming inboxes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCAg5BTURQSx4HpTv88xWS
