### PR TITLE
fix(notifications): read FCM v1 responses when a push fails

### DIFF
--- a/app/services/notification/push_notification_service.rb
+++ b/app/services/notification/push_notification_service.rb
@@ -116,11 +116,24 @@ class Notification::PushNotificationService
   end
 
   def remove_subscription_if_error(subscription, response)
-    if JSON.parse(response[:body])['results']&.first&.keys&.include?('error')
-      subscription.destroy!
-    else
+    if response[:status_code] == 200
       Rails.logger.info("FCM push sent to #{user.email} with title #{push_message[:title]}")
+      return
     end
+
+    error_code = fcm_error_code(response[:body])
+    # Only UNREGISTERED means the token is gone for good; every other error can
+    # be transient or caused by the request itself.
+    subscription.destroy! if error_code == 'UNREGISTERED'
+    Rails.logger.warn("FCM push failed for subscription #{subscription.id}: HTTP #{response[:status_code]} (#{error_code})")
+  end
+
+  def fcm_error_code(body)
+    error = JSON.parse(body.to_s).fetch('error', {})
+    detail = error.fetch('details', []).find { |item| item['@type'] == 'type.googleapis.com/google.firebase.fcm.v1.FcmError' }
+    detail&.fetch('errorCode', nil) || error['status'] || 'UNKNOWN'
+  rescue JSON::ParserError
+    'UNKNOWN'
   end
 
   def fcm_options(subscription)

--- a/spec/services/notification/push_notification_service_spec.rb
+++ b/spec/services/notification/push_notification_service_spec.rb
@@ -13,7 +13,9 @@ describe Notification::PushNotificationService do
         allow(WebPush).to receive(:payload_send).and_return(true)
         allow(Rails.logger).to receive(:info)
         allow(Notification::FcmService).to receive(:new).and_return(fcm_service_double)
-        allow(fcm_double).to receive(:send_v1).and_return({ body: { 'results': [] }.to_json })
+        allow(fcm_double).to receive(:send_v1).and_return(
+          { status_code: 200, body: { name: 'projects/test/messages/1' }.to_json }
+        )
         allow(GlobalConfigService).to receive(:load).with('FIREBASE_PROJECT_ID', nil).and_return('test_project_id')
         allow(GlobalConfigService).to receive(:load).with('FIREBASE_CREDENTIALS', nil).and_return('test_credentials')
       end
@@ -44,6 +46,72 @@ describe Notification::PushNotificationService do
   end
 
   context 'when the push server returns error' do
+    context 'with an FCM v1 error response' do
+      let!(:subscription) { create(:notification_subscription, user: notification.user, subscription_type: 'fcm') }
+      let(:error_code) { 'UNREGISTERED' }
+      let(:response) do
+        {
+          status_code: 404,
+          body: { error: { status: 'NOT_FOUND', details: [
+            { '@type': 'type.googleapis.com/google.firebase.fcm.v1.FcmError', errorCode: error_code }
+          ] } }.to_json
+        }
+      end
+
+      before do
+        allow(Notification::FcmService).to receive(:new).and_return(fcm_service_double)
+        allow(fcm_double).to receive(:send_v1).and_return(response)
+        allow(GlobalConfigService).to receive(:load).with('FIREBASE_PROJECT_ID', nil).and_return('test_project_id')
+        allow(GlobalConfigService).to receive(:load).with('FIREBASE_CREDENTIALS', nil).and_return('test_credentials')
+        allow(Rails.logger).to receive(:info)
+        allow(Rails.logger).to receive(:warn)
+      end
+
+      it 'removes an unregistered token and reports the failure' do
+        described_class.new(notification: notification).perform
+
+        expect(NotificationSubscription.exists?(subscription.id)).to be(false)
+        expect(Rails.logger).to have_received(:warn).with("FCM push failed for subscription #{subscription.id}: HTTP 404 (UNREGISTERED)")
+        expect(Rails.logger).not_to have_received(:info).with(/FCM push sent/)
+      end
+
+      %w[INVALID_ARGUMENT SENDER_ID_MISMATCH THIRD_PARTY_AUTH_ERROR QUOTA_EXCEEDED UNAVAILABLE INTERNAL].each do |code|
+        context "with #{code}" do
+          let(:error_code) { code }
+
+          it 'keeps the subscription and reports the failure' do
+            described_class.new(notification: notification).perform
+
+            expect(NotificationSubscription.exists?(subscription.id)).to be(true)
+            expect(Rails.logger).to have_received(:warn).with(/#{code}/)
+            expect(Rails.logger).not_to have_received(:info).with(/FCM push sent/)
+          end
+        end
+      end
+
+      context 'when the error carries no FCM details' do
+        let(:response) { { status_code: 401, body: { error: { status: 'UNAUTHENTICATED' } }.to_json } }
+
+        it 'keeps the subscription and reports the API status' do
+          described_class.new(notification: notification).perform
+
+          expect(NotificationSubscription.exists?(subscription.id)).to be(true)
+          expect(Rails.logger).to have_received(:warn).with(/HTTP 401 \(UNAUTHENTICATED\)/)
+        end
+      end
+
+      context 'when the body is not JSON' do
+        let(:response) { { status_code: 503, body: '<html>Service unavailable</html>' } }
+
+        it 'keeps the subscription and reports the HTTP failure' do
+          described_class.new(notification: notification).perform
+
+          expect(NotificationSubscription.exists?(subscription.id)).to be(true)
+          expect(Rails.logger).to have_received(:warn).with(/HTTP 503 \(UNKNOWN\)/)
+        end
+      end
+    end
+
     it 'sends webpush notifications for webpush subscription' do
       with_modified_env VAPID_PUBLIC_KEY: 'test' do
         mock_response = instance_double(Net::HTTPResponse, body: 'Subscription is invalid')


### PR DESCRIPTION
## Description

Push notifications sent through the FCM HTTP v1 API report their outcome in a body shaped like `{"error": {"status": …, "details": [{"errorCode": …}]}}`, but `remove_subscription_if_error` still looked for the legacy `results` array. Since that key is absent from both success and error bodies, every failed push was logged as `FCM push sent to …`, device tokens FCM reports as `UNREGISTERED` were never deleted and were retried on every later notification, and a response body that is not JSON raised `JSON::ParserError` out of the notification job.

A 200 response is now the success signal. Anything else is logged with its HTTP status and FCM error code, and the subscription is deleted only for `UNREGISTERED`, which is the one code that means the token is gone for good.

Closes #15737

## How to reproduce

1. Set `FIREBASE_PROJECT_ID` and `FIREBASE_CREDENTIALS` so pushes go straight to FCM.
2. Register a mobile device, then uninstall the app so its token becomes unregistered.
3. Trigger a notification for that user.

Before: the log says `FCM push sent to …` and the `NotificationSubscription` row survives. After: the log says `FCM push failed for subscription <id>: HTTP 404 (UNREGISTERED)` and the row is removed.

## What changed

- `Notification::PushNotificationService#remove_subscription_if_error` reads the v1 response, plus a small `fcm_error_code` helper that tolerates a body that is not JSON.
- Regression coverage for `UNREGISTERED`, for the error codes that must keep the subscription, for an error without FCM details, and for a non-JSON body.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCAg5BTURQSx4HpTv88xWS
