### PR TITLE
fix(conversations): keep activity labels aligned with list order

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -161,9 +161,16 @@ export const mutations = {
     { lastActivityAt, conversationId }
   ) {
     const [chat] = _state.allConversations.filter(c => c.id === conversationId);
-    if (chat) {
-      chat.last_activity_at = lastActivityAt;
-    }
+    if (!chat || !Number.isFinite(lastActivityAt)) return;
+
+    // The list sorts on last_activity_at while the cards label themselves with
+    // timestamp, which the API sends as the same value. Move them together, and
+    // never backwards, so a card's label always matches its place in the list.
+    chat.last_activity_at = Math.max(
+      chat.last_activity_at ?? 0,
+      lastActivityAt
+    );
+    chat.timestamp = chat.last_activity_at;
   },
   [types.ASSIGN_PRIORITY](_state, { priority, conversationId }) {
     const [chat] = _state.allConversations.filter(c => c.id === conversationId);
@@ -254,7 +261,6 @@ export const mutations = {
       chat.messages[pendingMessageIndex] = message;
     } else {
       chat.messages.push(message);
-      chat.timestamp = message.created_at;
       const { conversation: { unread_count: unreadCount = 0 } = {} } = message;
       chat.unread_count = unreadCount;
       if (selectedChatId === conversationId) {

--- a/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
@@ -57,11 +57,50 @@ describe('#mutations', () => {
       });
 
       expect(state.allConversations).toEqual([
-        { id: 1, meta: {}, last_activity_at: 1602256198 },
+        {
+          id: 1,
+          meta: {},
+          last_activity_at: 1602256198,
+          timestamp: 1602256198,
+        },
       ]);
     });
   });
   describe('#UPDATE_CONVERSATION_LAST_ACTIVITY', () => {
+    it('keeps the card label and the sort key on the same value', () => {
+      const state = {
+        allConversations: [
+          { id: 1, last_activity_at: 1602256100, timestamp: 1602256100 },
+        ],
+      };
+
+      mutations[types.UPDATE_CONVERSATION_LAST_ACTIVITY](state, {
+        lastActivityAt: 1602256198,
+        conversationId: 1,
+      });
+
+      expect(state.allConversations).toEqual([
+        { id: 1, last_activity_at: 1602256198, timestamp: 1602256198 },
+      ]);
+    });
+
+    it('ignores an older activity time', () => {
+      const state = {
+        allConversations: [
+          { id: 1, last_activity_at: 1602256198, timestamp: 1602256198 },
+        ],
+      };
+
+      mutations[types.UPDATE_CONVERSATION_LAST_ACTIVITY](state, {
+        lastActivityAt: 1602256100,
+        conversationId: 1,
+      });
+
+      expect(state.allConversations).toEqual([
+        { id: 1, last_activity_at: 1602256198, timestamp: 1602256198 },
+      ]);
+    });
+
     it('update conversation last activity', () => {
       const state = { allConversations: [{ id: 1, meta: {} }] };
       mutations[types.ASSIGN_TEAM](state, {
@@ -116,6 +155,29 @@ describe('#mutations', () => {
       expect(state.allConversations).toEqual([]);
     });
 
+    it('leaves the activity time to the conversation update', () => {
+      const state = {
+        allConversations: [
+          {
+            id: 1,
+            messages: [],
+            last_activity_at: 1602256100,
+            timestamp: 1602256100,
+          },
+        ],
+        selectedChatId: -1,
+      };
+
+      mutations[types.ADD_MESSAGE](state, {
+        conversation_id: 1,
+        content: 'Test message',
+        created_at: 1602256198,
+      });
+
+      expect(state.allConversations[0].timestamp).toEqual(1602256100);
+      expect(state.allConversations[0].last_activity_at).toEqual(1602256100);
+    });
+
     it('add message to the conversation if it does not exist in the store', () => {
       global.bus = { $emit: vi.fn() };
       const state = {
@@ -138,7 +200,6 @@ describe('#mutations', () => {
             },
           ],
           unread_count: 0,
-          timestamp: 1602256198,
         },
       ]);
       expect(emitter.emit).not.toHaveBeenCalled();
@@ -166,7 +227,6 @@ describe('#mutations', () => {
             },
           ],
           unread_count: 0,
-          timestamp: 1602256198,
         },
       ]);
       expect(emitter.emit).toHaveBeenCalledWith('SCROLL_TO_MESSAGE');


### PR DESCRIPTION
## Description

A conversation card shows an activity time that can disagree with where the conversation sits in the list. The cards label themselves with `timestamp` while the list sorts on `last_activity_at` — the API sends both as the same value — but the store updated them from different places: `ADD_MESSAGE` wrote only `timestamp`, and `UPDATE_CONVERSATION_LAST_ACTIVITY` wrote only `last_activity_at`.

The conversation update now owns both fields, so a card's label and its position always come from the same activity time, and an older value is ignored so out-of-order events cannot move a conversation backwards.

Closes #15739

## How to reproduce

1. Sort the conversation list by "Latest" and reply in a conversation that is not at the top.
2. The card reads "now" while the conversation stays in place, because only `timestamp` moved.
3. If the send fails, the card keeps that fresh label for the rest of the session.

The reverse case is an update that only advances `last_activity_at`: the list reorders while the card keeps its old label.

## What changed

- `UPDATE_CONVERSATION_LAST_ACTIVITY` sets `last_activity_at` and `timestamp` together, and only forwards in time.
- `ADD_MESSAGE` no longer writes `timestamp`; the activity time arrives with the conversation update that follows the message.
- Regression tests for both mutations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCAg5BTURQSx4HpTv88xWS
