### PR TITLE
fix: survive cleanup callbacks that run after the account is gone

### DIFF
--- a/app/models/account_user.rb
+++ b/app/models/account_user.rb
@@ -52,6 +52,10 @@ class AccountUser < ApplicationRecord
   end
 
   def remove_user_from_account
+    # The account may already be gone when this runs as part of deleting it, and
+    # the job has nothing left to clean up in that case.
+    return unless account && user
+
     ::Agents::DestroyJob.perform_later(account, user)
   end
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -160,7 +160,7 @@ class Contact < ApplicationRecord
       blocked: blocked,
       type: 'contact'
     }
-    data[:company_id] = company_id if account.feature_enabled?('companies')
+    data[:company_id] = company_id if account&.feature_enabled?('companies')
     data
   end
 

--- a/spec/models/account_user_spec.rb
+++ b/spec/models/account_user_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe AccountUser do
     end
   end
 
+  describe '#remove_user_from_account' do
+    it 'does not enqueue the cleanup job when the account is already gone' do
+      allow(account_user).to receive(:account).and_return(nil)
+
+      expect { account_user.remove_user_from_account }.not_to have_enqueued_job(Agents::DestroyJob)
+    end
+  end
+
   describe 'filtered unread count invalidation' do
     let(:account) { create(:account) }
     let(:user) { create(:user) }

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -115,6 +115,15 @@ RSpec.describe Contact do
     end
   end
 
+  describe '#push_event_data' do
+    it 'omits company data when the account is already gone' do
+      contact = create(:contact)
+      allow(contact).to receive(:account).and_return(nil)
+
+      expect(contact.push_event_data).not_to have_key(:company_id)
+    end
+  end
+
   describe '.resolved_contacts' do
     let(:account) { create(:account) }
 


### PR DESCRIPTION
## Description

Deleting an account leaves failing background jobs behind. Its children are destroyed with `dependent: :destroy_async`, so their callbacks run after the account row is already gone:

- `Contact#push_event_data` calls `account.feature_enabled?('companies')`, and it is reached from `after_destroy_commit`, so the job destroying the account's contacts raises `NoMethodError: undefined method 'feature_enabled?' for nil`, retries, and the contacts survive.
- `AccountUser#remove_user_from_account` enqueues `Agents::DestroyJob.perform_later(nil, user)`, which then fails in the worker with `NoMethodError: undefined method 'id' for nil`.

Both callbacks now skip the work that needed the account: the payload omits the company id, and no cleanup job is enqueued when there is nothing left to clean up.

Closes #15741

## How to reproduce

```ruby
account = Account.create!(name: 'Deletion probe')
user = User.create!(name: 'Probe', email: 'probe@example.com', password: 'Password1!')
account_user = AccountUser.create!(account: account, user: user, role: :agent)
contact = account.contacts.create!(name: 'Probe contact')

Account.where(id: account.id).delete_all       # the state the async destroy job sees

Contact.find(contact.id).destroy!              # NoMethodError before this change
Agents::DestroyJob.perform_now(nil, user)      # NoMethodError before this change
```

## What changed

- `Contact#push_event_data` reads the feature flag through `account&.`.
- `AccountUser#remove_user_from_account` returns early when the account or user is gone.
- A spec for each.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCAg5BTURQSx4HpTv88xWS
