### PR TITLE
feat(messages): accept an idempotency key when creating a message

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -28,8 +28,7 @@ class Messages::MessageBuilder
     # When the message has no quoted content, it will just be rendered as a regular message
     # The frontend is equipped to handle this case
     process_email_content
-    @message.save!
-    @message
+    @message.save_or_replay!
   end
 
   private
@@ -152,6 +151,7 @@ class Messages::MessageBuilder
       items: @items,
       in_reply_to: @in_reply_to,
       echo_id: @params[:echo_id],
+      client_message_id: @params[:client_message_id],
       source_id: @params[:source_id]
     }.merge(external_created_at).merge(automation_rule_id).merge(campaign_id).merge(template_params)
   end

--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::Conversations::BaseController
   before_action :ensure_api_inbox, only: :update
+  before_action :ensure_client_message_id_is_a_key, only: :create
 
   def index
     @messages = message_finder.perform
@@ -9,6 +10,8 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
     user = Current.user || @resource
     mb = Messages::MessageBuilder.new(user, @conversation, params)
     @message = mb.perform
+  rescue CustomExceptions::ClientMessageIdConflict => e
+    render json: { error: e.message }, status: e.http_status
   rescue StandardError => e
     render_could_not_create_error(e.message)
   end
@@ -92,6 +95,17 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
 
   def already_translated_content_available?
     message.translations.present? && message.translations[permitted_params[:target_language]].present?
+  end
+
+  # Omitting client_message_id keeps the non-idempotent behaviour, but sending one means
+  # asking for idempotency. A blank or non-string value cannot key anything, and JSON
+  # numbers or booleans would be cast into a key that only looks deliberate, so both are
+  # refused here rather than at the model, which never sees the value the client sent.
+  def ensure_client_message_id_is_a_key
+    return unless params.key?(:client_message_id)
+    return if params[:client_message_id].is_a?(String) && params[:client_message_id].present?
+
+    render_could_not_create_error('client_message_id must be a non-empty string')
   end
 
   # API inbox check

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,8 +1,15 @@
 class ApiController < ApplicationController
+  # Advertised so clients can detect optional API behaviour without version sniffing.
+  # message_client_message_id_text: message creation accepts a client_message_id for
+  # attachment-free text replies and private notes, and replays the original message
+  # when that key is reused.
+  CAPABILITIES = %w[message_client_message_id_text].freeze
+
   skip_before_action :set_current_user, only: [:index]
 
   def index
     render json: { version: Chatwoot.config[:version],
+                   capabilities: CAPABILITIES,
                    timestamp: Time.now.utc.to_fs(:db),
                    queue_services: redis_status,
                    data_services: postgres_status }

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -17,6 +17,8 @@
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  account_id                :integer          not null
+#  client_message_digest     :string(64)
+#  client_message_id         :string(64)
 #  conversation_id           :integer          not null
 #  inbox_id                  :integer          not null
 #  sender_id                 :bigint
@@ -31,6 +33,7 @@
 #  index_messages_on_additional_attributes_campaign_id  (((additional_attributes -> 'campaign_id'::text))) USING gin
 #  index_messages_on_content                            (content) USING gin
 #  index_messages_on_conversation_account_type_created  (conversation_id,account_id,message_type,created_at)
+#  index_messages_on_conversation_id_and_client_message_id  (conversation_id,client_message_id) UNIQUE WHERE (client_message_id IS NOT NULL)
 #  index_messages_on_conversation_id                    (conversation_id)
 #  index_messages_on_created_at                         (created_at)
 #  index_messages_on_inbox_id                           (inbox_id)
@@ -44,6 +47,14 @@ class Message < ApplicationRecord
   include MessageFilterHelpers
   include Liquidable
   NUMBER_OF_PERMITTED_ATTACHMENTS = 15
+
+  CLIENT_MESSAGE_ID_FORMAT = /\A[A-Za-z0-9_.:-]{1,64}\z/
+  # A client_message_id makes a repeated send resolve to the original message, so the
+  # fingerprint has to cover everything that decides what gets delivered. This first
+  # rollout therefore accepts keys only for plain text replies and private notes, whose
+  # request is fully described by CLIENT_MESSAGE_FINGERPRINT_ATTRIBUTES.
+  CLIENT_MESSAGE_ID_CONTENT_ATTRIBUTE_KEYS = %w[in_reply_to].freeze
+  CLIENT_MESSAGE_FINGERPRINT_ATTRIBUTES = %i[content private message_type content_type in_reply_to sender_type sender_id].freeze
 
   TEMPLATE_PARAMS_SCHEMA = {
     'type': 'object',
@@ -65,6 +76,7 @@ class Message < ApplicationRecord
 
   before_validation :ensure_content_type
   before_validation :prevent_message_flooding
+  before_validation :ensure_client_message_digest, on: :create
   before_save :ensure_processed_message_content
   before_save :ensure_in_reply_to
 
@@ -78,7 +90,12 @@ class Message < ApplicationRecord
 
   validates :content_type, presence: true
   validates :content, length: { maximum: 150_000 }
+  validate :client_message_id_bounded, :client_message_id_payload_supported, on: :create, unless: -> { client_message_id.nil? }
   validates :processed_message_content, length: { maximum: 150_000 }
+
+  # The durable identity a client sends to make a repeated send idempotent, and the
+  # fingerprint of the request it was accepted for. Neither is rewritten afterwards.
+  attr_readonly :client_message_id, :client_message_digest
 
   # when you have a temperory id in your frontend and want it echoed back via action cable
   attr_accessor :echo_id
@@ -145,7 +162,7 @@ class Message < ApplicationRecord
   end
 
   def push_event_data
-    data = attributes.symbolize_keys.merge(
+    data = attributes.symbolize_keys.except(:client_message_digest).merge(
       created_at: created_at.to_i,
       message_type: message_type_before_type_cast,
       conversation_id: conversation&.display_id,
@@ -154,6 +171,27 @@ class Message < ApplicationRecord
     data[:echo_id] = echo_id if echo_id.present?
     data[:attachments] = attachments.map(&:push_event_data) if attachments.present?
     merge_sender_attributes(data)
+  end
+
+  # Persists the message, or answers with the message that already holds this
+  # conversation-scoped client_message_id, because the client retried a send whose response
+  # was lost or raced itself. A retry is answered even when the same send would now be
+  # refused, since the conversation may have hit the flood limit or lost the quoted message
+  # in the meantime, but never when the key or the payload itself is unacceptable.
+  def save_or_replay!
+    # requires_new keeps a duplicate key rollback inside a savepoint, so a caller that
+    # opened its own transaction is not left holding an aborted one.
+    self.class.transaction(requires_new: true) { save! }
+    self
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+    raise if client_message_id.blank? || errors[:client_message_id].any?
+
+    # Postgres held a duplicate INSERT until the transaction that created the winning row
+    # committed, so by the time it failed that row is visible.
+    original = conversation.messages.find_by(client_message_id: client_message_id)
+    raise if original.nil?
+
+    replay_of(original)
   end
 
   def conversation_push_event_data
@@ -285,6 +323,45 @@ class Message < ApplicationRecord
   end
 
   private
+
+  def replay_of(original)
+    if original.client_message_digest != client_message_digest
+      raise CustomExceptions::ClientMessageIdConflict.new(client_message_id: client_message_id)
+    end
+
+    # Echo back the correlation id of the attempt being answered rather than the original
+    # one, so the retrying client can still resolve its in-flight optimistic message.
+    original.echo_id = echo_id
+    original
+  end
+
+  def client_message_id_bounded
+    return if CLIENT_MESSAGE_ID_FORMAT.match?(client_message_id)
+
+    errors.add(:client_message_id, 'must be 1 to 64 characters of A-Z, a-z, 0-9, and . : - _')
+  end
+
+  def client_message_id_payload_supported
+    errors.add(:client_message_id, 'is only supported for outgoing text messages') unless outgoing? && text? && content.present?
+    return unless unfingerprinted_payload?
+
+    errors.add(:client_message_id, 'is not supported alongside attachments, templates, campaigns, email fields or an external source id')
+  end
+
+  def unfingerprinted_payload?
+    attachments.any? || source_id.present? || additional_attributes.present? ||
+      content_attributes.any? { |key, value| value.present? && CLIENT_MESSAGE_ID_CONTENT_ATTRIBUTE_KEYS.exclude?(key.to_s) }
+  end
+
+  # Fingerprints the request as the client sent it. Server side enrichment such as quoted
+  # message resolution, delivery status or email rendering happens afterwards and must not
+  # change what a retry of the same send fingerprints to.
+  def ensure_client_message_digest
+    return if client_message_id.blank?
+
+    request = CLIENT_MESSAGE_FINGERPRINT_ATTRIBUTES.map { |attribute| public_send(attribute) }
+    self.client_message_digest = Digest::SHA256.hexdigest(request.to_json)
+  end
 
   def prevent_message_flooding
     # Added this to cover the validation specs in messages

--- a/app/views/api/v1/models/_message.json.jbuilder
+++ b/app/views/api/v1/models/_message.json.jbuilder
@@ -2,6 +2,7 @@ json.id message.id
 json.content message.content
 json.inbox_id message.inbox_id
 json.echo_id message.echo_id if message.echo_id
+json.client_message_id message.client_message_id if message.client_message_id
 json.conversation_id message.conversation.display_id
 json.message_type message.message_type_before_type_cast
 json.content_type message.content_type

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,8 @@ en:
       resolved: Conversation is resolved and does not accept new messages
       unread_counts:
         feature_not_enabled: Conversation unread counts feature not enabled for this account
+    message:
+      client_message_id_conflict: The client_message_id %{client_message_id} was already used for a different message in this conversation
     data_import:
       data_type:
         invalid: Invalid data type

--- a/db/migrate/20260908130000_add_client_message_id_to_messages.rb
+++ b/db/migrate/20260908130000_add_client_message_id_to_messages.rb
@@ -1,0 +1,19 @@
+class AddClientMessageIdToMessages < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    # Durable identity supplied by a client so a send that is retried after a lost
+    # response resolves to the original message instead of delivering a second one.
+    add_column :messages, :client_message_id, :string, limit: 64
+    # Fingerprint of the payload the key was accepted for, stored once at creation so
+    # later edits to the message cannot make a conflicting reuse look like a replay.
+    add_column :messages, :client_message_digest, :string, limit: 64
+
+    add_index :messages, [:conversation_id, :client_message_id],
+              unique: true,
+              where: 'client_message_id IS NOT NULL',
+              name: 'index_messages_on_conversation_id_and_client_message_id',
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_09_08_130000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -1252,6 +1252,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
     t.jsonb "additional_attributes", default: {}
     t.text "processed_message_content"
     t.jsonb "sentiment", default: {}
+    t.string "client_message_id", limit: 64
+    t.string "client_message_digest", limit: 64
     t.index "((additional_attributes -> 'campaign_id'::text))", name: "index_messages_on_additional_attributes_campaign_id", using: :gin
     t.index ["account_id", "content_type", "created_at"], name: "idx_messages_account_content_created"
     t.index ["account_id", "created_at", "message_type"], name: "index_messages_on_account_created_type"
@@ -1259,6 +1261,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_14_000000) do
     t.index ["account_id"], name: "index_messages_on_account_id"
     t.index ["content"], name: "index_messages_on_content", opclass: :gin_trgm_ops, using: :gin
     t.index ["conversation_id", "account_id", "message_type", "created_at"], name: "index_messages_on_conversation_account_type_created"
+    t.index ["conversation_id", "client_message_id"], name: "index_messages_on_conversation_id_and_client_message_id", unique: true, where: "(client_message_id IS NOT NULL)"
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["created_at"], name: "index_messages_on_created_at"
     t.index ["inbox_id"], name: "index_messages_on_inbox_id"

--- a/lib/custom_exceptions/client_message_id_conflict.rb
+++ b/lib/custom_exceptions/client_message_id_conflict.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CustomExceptions::ClientMessageIdConflict < CustomExceptions::Base
+  def message
+    I18n.t('errors.message.client_message_id_conflict', client_message_id: @data[:client_message_id])
+  end
+
+  def http_status
+    409
+  end
+end

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -22,6 +22,137 @@ describe Messages::MessageBuilder do
     end
   end
 
+  describe 'client_message_id' do
+    let(:first_attempt) do
+      ActionController::Parameters.new({ content: 'test', client_message_id: '01JD8Z9Q6F7', echo_id: 'attempt-1' })
+    end
+    let(:retried_attempt) do
+      ActionController::Parameters.new({ content: 'test', client_message_id: '01JD8Z9Q6F7', echo_id: 'attempt-2' })
+    end
+
+    it 'stores the key and its payload fingerprint on the created message' do
+      message = described_class.new(user, conversation, first_attempt).perform
+
+      expect(message.client_message_id).to eq('01JD8Z9Q6F7')
+      expect(message.client_message_digest).to be_present
+    end
+
+    it 'returns the original message when the client retries a send whose response was lost' do
+      original = described_class.new(user, conversation, first_attempt).perform
+
+      replayed = described_class.new(user, conversation, retried_attempt).perform
+
+      expect(replayed.id).to eq(original.id)
+      expect(replayed.created_at).to eq(original.reload.created_at)
+      expect(conversation.messages.count).to eq(1)
+    end
+
+    it 'echoes the correlation id of the retry rather than the original attempt' do
+      described_class.new(user, conversation, first_attempt).perform
+
+      replayed = described_class.new(user, conversation, retried_attempt).perform
+
+      expect(replayed.echo_id).to eq('attempt-2')
+    end
+
+    it 'does not queue delivery again for a replayed send' do
+      described_class.new(user, conversation, first_attempt).perform
+
+      expect { described_class.new(user, conversation, retried_attempt).perform }.not_to have_enqueued_job(SendReplyJob)
+    end
+
+    it 'rejects the key when it is reused for different content' do
+      described_class.new(user, conversation, first_attempt).perform
+      conflicting = ActionController::Parameters.new({ content: 'a different message', client_message_id: '01JD8Z9Q6F7' })
+
+      expect { described_class.new(user, conversation, conflicting).perform }
+        .to raise_error(CustomExceptions::ClientMessageIdConflict)
+    end
+
+    it 'rejects the key when it is reused to turn a reply into a private note' do
+      described_class.new(user, conversation, first_attempt).perform
+      conflicting = ActionController::Parameters.new({ content: 'test', private: true, client_message_id: '01JD8Z9Q6F7' })
+
+      expect { described_class.new(user, conversation, conflicting).perform }
+        .to raise_error(CustomExceptions::ClientMessageIdConflict)
+    end
+
+    it 'replays a retry that a fresh send would now be refused' do
+      original = described_class.new(user, conversation, first_attempt).perform
+
+      replayed = with_modified_env CONVERSATION_MESSAGE_PER_MINUTE_LIMIT: '1' do
+        described_class.new(user, conversation, retried_attempt).perform
+      end
+
+      expect(replayed.id).to eq(original.id)
+      expect(conversation.messages.count).to eq(1)
+    end
+
+    it 'replays a retry sent after the original message was deleted' do
+      original = described_class.new(user, conversation, first_attempt).perform
+      original.update!(content: 'This message was deleted', content_type: :text, content_attributes: { deleted: true })
+
+      replayed = described_class.new(user, conversation, retried_attempt).perform
+
+      expect(replayed.id).to eq(original.id)
+      expect(conversation.messages.count).to eq(1)
+    end
+
+    it 'leaves a transaction the caller opened usable' do
+      original = described_class.new(user, conversation, first_attempt).perform
+
+      replayed = nil
+      ActiveRecord::Base.transaction do
+        replayed = described_class.new(user, conversation, retried_attempt).perform
+        conversation.messages.count
+      end
+
+      expect(replayed.id).to eq(original.id)
+    end
+
+    it 'leaves clients that send no key on the existing behaviour' do
+      keyless = ActionController::Parameters.new({ content: 'test' })
+
+      described_class.new(user, conversation, keyless).perform
+      described_class.new(user, conversation, keyless).perform
+
+      expect(conversation.messages.count).to eq(2)
+    end
+  end
+
+  describe 'concurrent sends reusing a client_message_id' do
+    # Two callers have to race on separate database connections, which the transaction
+    # the rest of the suite shares between the example and the connection cannot provide.
+    self.use_transactional_tests = false
+
+    let(:params) { ActionController::Parameters.new({ content: 'test', client_message_id: '01JD8Z9Q6F7' }) }
+
+    # Rows created here are committed, so they have to be removed again. Installation config
+    # is seeded once per database and the rest of the suite reads it.
+    after do
+      tables = ActiveRecord::Base.connection.tables - %w[schema_migrations ar_internal_metadata installation_configs]
+      ActiveRecord::Base.connection.execute("TRUNCATE #{tables.join(', ')} CASCADE")
+    end
+
+    it 'creates one message and answers both callers with it' do
+      conversation
+      user
+      barrier = Concurrent::CyclicBarrier.new(2)
+
+      messages = Array.new(2) do
+        Thread.new do
+          ActiveRecord::Base.connection_pool.with_connection do
+            barrier.wait
+            described_class.new(user, conversation, params.deep_dup).perform
+          end
+        end
+      end.map(&:value)
+
+      expect(conversation.messages.count).to eq(1)
+      expect(messages.map(&:id).uniq).to eq([conversation.messages.first.id])
+    end
+  end
+
   describe '#content_attributes' do
     context 'when content_attributes is a JSON string' do
       let(:params) do

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -98,6 +98,102 @@ RSpec.describe 'Conversation Messages API', type: :request do
         expect(conversation.messages.last.attachments.first.file_type).to eq('image')
       end
 
+      context 'when the request carries a client_message_id' do
+        let(:client_message_id) { '01JD8Z9Q6FYX8N3W2ABCDEF' }
+
+        it 'returns the durable identity on the created message' do
+          post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+               params: { content: 'test-message', client_message_id: client_message_id },
+               headers: agent.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:success)
+          expect(response).to conform_schema(200)
+          expect(response.parsed_body['client_message_id']).to eq(client_message_id)
+        end
+
+        it 'answers a retry after a lost response with the original message and delivers once' do
+          post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+               params: { content: 'test-message', client_message_id: client_message_id, echo_id: 'attempt-1' },
+               headers: agent.create_new_auth_token,
+               as: :json
+          original = response.parsed_body
+
+          expect do
+            post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+                 params: { content: 'test-message', client_message_id: client_message_id, echo_id: 'attempt-2' },
+                 headers: agent.create_new_auth_token,
+                 as: :json
+          end.not_to have_enqueued_job(SendReplyJob)
+
+          expect(response).to have_http_status(:success)
+          expect(response).to conform_schema(200)
+          expect(response.parsed_body['id']).to eq(original['id'])
+          expect(response.parsed_body['created_at']).to eq(original['created_at'])
+          expect(response.parsed_body['echo_id']).to eq('attempt-2')
+          expect(conversation.messages.count).to eq(1)
+        end
+
+        it 'rejects a key reused for a different message' do
+          post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+               params: { content: 'test-message', client_message_id: client_message_id },
+               headers: agent.create_new_auth_token,
+               as: :json
+
+          post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+               params: { content: 'a different message', client_message_id: client_message_id },
+               headers: agent.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:conflict)
+          expect(response.parsed_body['error']).to include(client_message_id)
+          expect(conversation.messages.count).to eq(1)
+        end
+
+        it 'rejects a key sent as an empty string rather than treating it as omitted' do
+          post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+               params: { content: 'test-message', client_message_id: '' },
+               headers: agent.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body['error']).to eq('client_message_id must be a non-empty string')
+          expect(conversation.messages.count).to eq(0)
+        end
+
+        it 'rejects a key sent as a JSON number rather than casting it to a string' do
+          post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+               params: { content: 'test-message', client_message_id: 1234 },
+               headers: agent.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body['error']).to eq('client_message_id must be a non-empty string')
+          expect(conversation.messages.count).to eq(0)
+        end
+
+        it 'rejects a key outside the accepted bounds' do
+          post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+               params: { content: 'test-message', client_message_id: "spaces are not allowed #{client_message_id}" },
+               headers: agent.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(conversation.messages.count).to eq(0)
+        end
+
+        it 'rejects a key on a payload the capability does not cover' do
+          file = fixture_file_upload(Rails.root.join('spec/assets/avatar.png'), 'image/png')
+
+          post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+               params: { content: 'test-message', client_message_id: client_message_id, attachments: [file] },
+               headers: agent.create_new_auth_token
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(conversation.messages.count).to eq(0)
+        end
+      end
+
       context 'when api inbox' do
         let(:api_channel) { create(:channel_api, account: account) }
         let(:api_inbox) { create(:inbox, channel: api_channel, account: account) }

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -145,12 +145,95 @@ RSpec.describe Message do
         },
         sentiment: {},
         sender: message.sender.push_event_data,
+        client_message_id: message.client_message_id,
         echo_id: 'random-echo_id'
       }
     end
 
     it 'returns push event payload' do
       expect(push_event_data).to eq(expected_data)
+    end
+  end
+
+  describe 'client_message_id' do
+    let(:conversation) { create(:conversation) }
+    let(:other_conversation) { create(:conversation, account: conversation.account, inbox: conversation.inbox) }
+
+    it 'rejects a key outside the accepted bounds' do
+      message = build(:message, conversation: conversation, message_type: 'outgoing', client_message_id: 'a' * 65)
+
+      expect(message).not_to be_valid
+      expect(message.errors[:client_message_id]).to include('must be 1 to 64 characters of A-Z, a-z, 0-9, and . : - _')
+    end
+
+    it 'rejects a key on a payload the stored fingerprint does not describe' do
+      message = build(:message, :with_attachment, conversation: conversation, message_type: 'outgoing',
+                                                  client_message_id: '01JD8Z9Q6F7')
+
+      expect(message).not_to be_valid
+      expect(message.errors[:client_message_id])
+        .to include('is not supported alongside attachments, templates, campaigns, email fields or an external source id')
+    end
+
+    it 'rejects a key on an incoming message' do
+      message = build(:message, conversation: conversation, message_type: 'incoming', client_message_id: '01JD8Z9Q6F7')
+
+      expect(message).not_to be_valid
+      expect(message.errors[:client_message_id]).to include('is only supported for outgoing text messages')
+    end
+
+    it 'refuses a second message reusing the key in the same conversation' do
+      create(:message, conversation: conversation, message_type: 'outgoing', content: 'hello', client_message_id: '01JD8Z9Q6F7')
+
+      expect do
+        create(:message, conversation: conversation, message_type: 'outgoing', content: 'hello', client_message_id: '01JD8Z9Q6F7')
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'scopes the key to a single conversation' do
+      create(:message, conversation: conversation, message_type: 'outgoing', content: 'hello', client_message_id: '01JD8Z9Q6F7')
+
+      expect do
+        create(:message, conversation: other_conversation, message_type: 'outgoing', content: 'hello', client_message_id: '01JD8Z9Q6F7')
+      end.to change(described_class, :count).by(1)
+    end
+
+    it 'keeps the fingerprint recorded at creation after the message content changes' do
+      message = create(:message, conversation: conversation, message_type: 'outgoing', content: 'hello', client_message_id: '01JD8Z9Q6F7')
+      original_digest = message.client_message_digest
+
+      message.update!(content: 'edited afterwards')
+
+      expect(original_digest).to be_present
+      expect(message.reload.client_message_digest).to eq(original_digest)
+    end
+
+    it 'fingerprints the note flag so a reply cannot replay a note' do
+      sender = create(:user, account: conversation.account)
+      reply = create(:message, conversation: conversation, message_type: 'outgoing', content: 'hello', sender: sender,
+                               client_message_id: '01JD8Z9Q6F7')
+      note = create(:message, conversation: other_conversation, message_type: 'outgoing', content: 'hello', private: true, sender: sender,
+                              client_message_id: '01JD8Z9Q6F7')
+
+      expect(note.client_message_digest).not_to eq(reply.client_message_digest)
+    end
+
+    it 'accepts the delivery status and error enrichment that follows an accepted send' do
+      message = create(:message, conversation: conversation, message_type: 'outgoing', content: 'hello', client_message_id: '01JD8Z9Q6F7')
+
+      expect do
+        message.update!(status: :failed, content_attributes: message.content_attributes.merge(external_error: 'channel rejected it'))
+      end.not_to raise_error
+    end
+
+    it 'does not let a later write rewrite the key or its fingerprint' do
+      message = create(:message, conversation: conversation, message_type: 'outgoing', content: 'hello', client_message_id: '01JD8Z9Q6F7')
+      original_digest = message.client_message_digest
+
+      message.update!(client_message_id: 'ZZZZZZZZZZZ', client_message_digest: 'f' * 64, content: 'edited')
+
+      expect(message.reload.client_message_id).to eq('01JD8Z9Q6F7')
+      expect(message.client_message_digest).to eq(original_digest)
     end
   end
 

--- a/swagger/definitions/request/conversation/create_message_payload.yml
+++ b/swagger/definitions/request/conversation/create_message_payload.yml
@@ -24,6 +24,19 @@ properties:
     type: object
     description: Attributes based on the content type
     example: {}
+  client_message_id:
+    type: string
+    maxLength: 64
+    pattern: '^[A-Za-z0-9_.:-]{1,64}$'
+    description: |
+      Optional durable identity for this send, unique within the conversation. Repeating a
+      create with the same value returns the message the first accepted request created, in
+      its current stored state, instead of sending another one, so a client can safely retry
+      a send whose response was lost. Reusing the value for a different payload is rejected
+      with 409. Supported for attachment-free text replies and private notes only; advertised
+      as `message_client_message_id_text` by `GET /api`. Send it as a JSON string; an empty or
+      non-string value is rejected with 422 rather than treated as absent.
+    example: '01JD8Z9Q6FYX8N3W2ABCDEF'
   campaign_id:
     type: integer
     description: The campaign id to which the message belongs

--- a/swagger/definitions/resource/message.yml
+++ b/swagger/definitions/resource/message.yml
@@ -41,6 +41,13 @@ properties:
       - string
       - 'null'
     description: The source ID of the message
+  client_message_id:
+    type:
+      - string
+      - 'null'
+    description: |
+      The durable identity supplied by the client on creation. Present only when the
+      client sent one. Unique within the conversation.
   content_type:
     type:
       - string

--- a/swagger/definitions/resource/message_detailed.yml
+++ b/swagger/definitions/resource/message_detailed.yml
@@ -38,6 +38,14 @@ properties:
       - string
       - 'null'
     description: The echo ID of the message, used for deduplication
+  client_message_id:
+    type:
+      - string
+      - 'null'
+    description: |
+      The durable identity supplied by the client on creation, unique within the
+      conversation. Unlike `echo_id` it is persisted, and a repeated create with the same
+      value returns this message in its current stored state instead of sending another one.
   created_at:
     type: integer
     description: The timestamp when message was created

--- a/swagger/paths/application/conversation/messages/create.yml
+++ b/swagger/paths/application/conversation/messages/create.yml
@@ -145,6 +145,12 @@ responses:
           allOf:
             - $ref: '#/components/schemas/generic_id'
             - $ref: '#/components/schemas/message'
+  '409':
+    description: The client_message_id was already used for a different message in this conversation
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/bad_request_error'
   '404':
     description: Conversation not found
     content:

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -7207,6 +7207,16 @@
               }
             }
           },
+          "409": {
+            "description": "The client_message_id was already used for a different message in this conversation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Conversation not found",
             "content": {
@@ -10452,6 +10462,13 @@
             ],
             "description": "The source ID of the message"
           },
+          "client_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The durable identity supplied by the client on creation. Present only when the\nclient sent one. Unique within the conversation.\n"
+          },
           "content_type": {
             "type": [
               "string",
@@ -12792,6 +12809,13 @@
             "type": "object",
             "description": "Attributes based on the content type",
             "example": {}
+          },
+          "client_message_id": {
+            "type": "string",
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9_.:-]{1,64}$",
+            "description": "Optional durable identity for this send, unique within the conversation. Repeating a\ncreate with the same value returns the message the first accepted request created, in\nits current stored state, instead of sending another one, so a client can safely retry\na send whose response was lost. Reusing the value for a different payload is rejected\nwith 409. Supported for attachment-free text replies and private notes only; advertised\nas `message_client_message_id_text` by `GET /api`. Send it as a JSON string; an empty or\nnon-string value is rejected with 422 rather than treated as absent.\n",
+            "example": "01JD8Z9Q6FYX8N3W2ABCDEF"
           },
           "campaign_id": {
             "type": "integer",
@@ -15554,6 +15578,13 @@
               "null"
             ],
             "description": "The echo ID of the message, used for deduplication"
+          },
+          "client_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The durable identity supplied by the client on creation, unique within the\nconversation. Unlike `echo_id` it is persisted, and a repeated create with the same\nvalue returns this message in its current stored state instead of sending another one.\n"
           },
           "created_at": {
             "type": "integer",

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -5750,6 +5750,16 @@
               }
             }
           },
+          "409": {
+            "description": "The client_message_id was already used for a different message in this conversation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bad_request_error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Conversation not found",
             "content": {
@@ -8959,6 +8969,13 @@
             ],
             "description": "The source ID of the message"
           },
+          "client_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The durable identity supplied by the client on creation. Present only when the\nclient sent one. Unique within the conversation.\n"
+          },
           "content_type": {
             "type": [
               "string",
@@ -11299,6 +11316,13 @@
             "type": "object",
             "description": "Attributes based on the content type",
             "example": {}
+          },
+          "client_message_id": {
+            "type": "string",
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9_.:-]{1,64}$",
+            "description": "Optional durable identity for this send, unique within the conversation. Repeating a\ncreate with the same value returns the message the first accepted request created, in\nits current stored state, instead of sending another one, so a client can safely retry\na send whose response was lost. Reusing the value for a different payload is rejected\nwith 409. Supported for attachment-free text replies and private notes only; advertised\nas `message_client_message_id_text` by `GET /api`. Send it as a JSON string; an empty or\nnon-string value is rejected with 422 rather than treated as absent.\n",
+            "example": "01JD8Z9Q6FYX8N3W2ABCDEF"
           },
           "campaign_id": {
             "type": "integer",
@@ -14061,6 +14085,13 @@
               "null"
             ],
             "description": "The echo ID of the message, used for deduplication"
+          },
+          "client_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The durable identity supplied by the client on creation, unique within the\nconversation. Unlike `echo_id` it is persisted, and a repeated create with the same\nvalue returns this message in its current stored state instead of sending another one.\n"
           },
           "created_at": {
             "type": "integer",

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -1425,6 +1425,13 @@
             ],
             "description": "The source ID of the message"
           },
+          "client_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The durable identity supplied by the client on creation. Present only when the\nclient sent one. Unique within the conversation.\n"
+          },
           "content_type": {
             "type": [
               "string",
@@ -3765,6 +3772,13 @@
             "type": "object",
             "description": "Attributes based on the content type",
             "example": {}
+          },
+          "client_message_id": {
+            "type": "string",
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9_.:-]{1,64}$",
+            "description": "Optional durable identity for this send, unique within the conversation. Repeating a\ncreate with the same value returns the message the first accepted request created, in\nits current stored state, instead of sending another one, so a client can safely retry\na send whose response was lost. Reusing the value for a different payload is rejected\nwith 409. Supported for attachment-free text replies and private notes only; advertised\nas `message_client_message_id_text` by `GET /api`. Send it as a JSON string; an empty or\nnon-string value is rejected with 422 rather than treated as absent.\n",
+            "example": "01JD8Z9Q6FYX8N3W2ABCDEF"
           },
           "campaign_id": {
             "type": "integer",
@@ -6527,6 +6541,13 @@
               "null"
             ],
             "description": "The echo ID of the message, used for deduplication"
+          },
+          "client_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The durable identity supplied by the client on creation, unique within the\nconversation. Unlike `echo_id` it is persisted, and a repeated create with the same\nvalue returns this message in its current stored state instead of sending another one.\n"
           },
           "created_at": {
             "type": "integer",

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -840,6 +840,13 @@
             ],
             "description": "The source ID of the message"
           },
+          "client_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The durable identity supplied by the client on creation. Present only when the\nclient sent one. Unique within the conversation.\n"
+          },
           "content_type": {
             "type": [
               "string",
@@ -3180,6 +3187,13 @@
             "type": "object",
             "description": "Attributes based on the content type",
             "example": {}
+          },
+          "client_message_id": {
+            "type": "string",
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9_.:-]{1,64}$",
+            "description": "Optional durable identity for this send, unique within the conversation. Repeating a\ncreate with the same value returns the message the first accepted request created, in\nits current stored state, instead of sending another one, so a client can safely retry\na send whose response was lost. Reusing the value for a different payload is rejected\nwith 409. Supported for attachment-free text replies and private notes only; advertised\nas `message_client_message_id_text` by `GET /api`. Send it as a JSON string; an empty or\nnon-string value is rejected with 422 rather than treated as absent.\n",
+            "example": "01JD8Z9Q6FYX8N3W2ABCDEF"
           },
           "campaign_id": {
             "type": "integer",
@@ -5942,6 +5956,13 @@
               "null"
             ],
             "description": "The echo ID of the message, used for deduplication"
+          },
+          "client_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The durable identity supplied by the client on creation, unique within the\nconversation. Unlike `echo_id` it is persisted, and a repeated create with the same\nvalue returns this message in its current stored state instead of sending another one.\n"
           },
           "created_at": {
             "type": "integer",

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -1601,6 +1601,13 @@
             ],
             "description": "The source ID of the message"
           },
+          "client_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The durable identity supplied by the client on creation. Present only when the\nclient sent one. Unique within the conversation.\n"
+          },
           "content_type": {
             "type": [
               "string",
@@ -3941,6 +3948,13 @@
             "type": "object",
             "description": "Attributes based on the content type",
             "example": {}
+          },
+          "client_message_id": {
+            "type": "string",
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9_.:-]{1,64}$",
+            "description": "Optional durable identity for this send, unique within the conversation. Repeating a\ncreate with the same value returns the message the first accepted request created, in\nits current stored state, instead of sending another one, so a client can safely retry\na send whose response was lost. Reusing the value for a different payload is rejected\nwith 409. Supported for attachment-free text replies and private notes only; advertised\nas `message_client_message_id_text` by `GET /api`. Send it as a JSON string; an empty or\nnon-string value is rejected with 422 rather than treated as absent.\n",
+            "example": "01JD8Z9Q6FYX8N3W2ABCDEF"
           },
           "campaign_id": {
             "type": "integer",
@@ -6703,6 +6717,13 @@
               "null"
             ],
             "description": "The echo ID of the message, used for deduplication"
+          },
+          "client_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The durable identity supplied by the client on creation, unique within the\nconversation. Unlike `echo_id` it is persisted, and a repeated create with the same\nvalue returns this message in its current stored state instead of sending another one.\n"
           },
           "created_at": {
             "type": "integer",


### PR DESCRIPTION
## Description

A client that loses the response to `POST …/conversations/{id}/messages` cannot tell whether the message was created, so it has to choose between delivering it twice and losing it. `echo_id` does not help: it correlates an optimistic bubble with a response, but a second request carrying the same value still creates a second message.

Message creation now accepts an optional `client_message_id`. The key is unique per conversation, enforced by a partial unique index rather than a read-then-write check, so two concurrent retries cannot both insert. Reusing the key replays the message that was already created — the response is the original message, carrying the retry's own `echo_id` so the client can still resolve its in-flight bubble. Reusing the key for a different payload answers `409` instead of quietly resolving to an unrelated message.

Requests that omit the parameter behave exactly as they do today.

Closes #15743

## How to test

```bash
# first send
curl -X POST "$HOST/api/v1/accounts/1/conversations/1/messages" \
  -H "api_access_token: $TOKEN" -H 'Content-Type: application/json' \
  -d '{"content":"hello","client_message_id":"01J8Z2K9"}'

# same key, same payload: replays the original, nothing new is delivered
curl -X POST … -d '{"content":"hello","client_message_id":"01J8Z2K9"}'      # => 200, same message id

# same key, different payload
curl -X POST … -d '{"content":"different","client_message_id":"01J8Z2K9"}'  # => 409
```

`GET /api` lists `message_client_message_id_text` under `capabilities`, so a client can check for support before relying on it — a server that ignored the parameter would deliver duplicates.

## What changed

- Migration adding `client_message_id` and `client_message_digest` to messages, with a partial unique index on `(conversation_id, client_message_id)` created concurrently.
- `Message#save_or_replay!`, used by `Messages::MessageBuilder`, which persists the message or answers with the one that already holds the key. The digest fingerprints the request the key was accepted for, taken before server-side enrichment, so later edits cannot turn a conflict into a false replay.
- Validation limiting the first version to attachment-free outgoing text replies and private notes, where the fingerprinted attributes describe the whole request. Attachments, templates, campaigns, email fields and external source ids are refused with a clear error instead of being silently non-idempotent.
- A controller guard rejecting a key that is not a non-empty string, `CustomExceptions::ClientMessageIdConflict` mapped to `409`, the field in the message payload, the capability list on `GET /api`, and the OpenAPI documentation.
- Model, builder and request specs covering replay, conflict, concurrent retries, unsupported payloads and key validation.

## Notes

- A retry is answered even when the same send would now be refused (the conversation has since hit the flood limit, or the quoted message is gone), because the client is asking about a message that already exists.
- The first version is deliberately narrow. Widening it to attachments means fingerprinting uploaded files, which is worth doing separately.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCAg5BTURQSx4HpTv88xWS
