### PR TITLE
feat: improve quoted content experience in email replies

### DIFF
--- a/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/Editor.vue
@@ -1021,7 +1021,7 @@ useEmitter(BUS_EVENTS.INSERT_INTO_RICH_EDITOR, content => {
       hidden
       @change="onFileChange"
     />
-    <div ref="editor" />
+    <div ref="editor" class="editor-mount" />
     <slot name="footer" />
   </div>
 </template>

--- a/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
@@ -119,14 +119,6 @@ export default {
       type: String,
       default: '',
     },
-    showQuotedReplyToggle: {
-      type: Boolean,
-      default: false,
-    },
-    quotedReplyEnabled: {
-      type: Boolean,
-      default: false,
-    },
     isEditorDisabled: {
       type: Boolean,
       default: false,
@@ -136,7 +128,6 @@ export default {
     'toggleInsertArticle',
     'selectWhatsappTemplate',
     'selectContentTemplate',
-    'toggleQuotedReply',
     'requestContactInfoTemplate',
   ],
   setup(props) {
@@ -262,11 +253,6 @@ export default {
     isFetchingAppIntegrations() {
       return this.uiFlags.isFetching;
     },
-    quotedReplyToggleTooltip() {
-      return this.quotedReplyEnabled
-        ? this.$t('CONVERSATION.REPLYBOX.QUOTED_REPLY.DISABLE_TOOLTIP')
-        : this.$t('CONVERSATION.REPLYBOX.QUOTED_REPLY.ENABLE_TOOLTIP');
-    },
   },
   mounted() {
     ActiveStorage.start();
@@ -345,16 +331,6 @@ export default {
         faded
         sm
         @click="toggleMessageSignature"
-      />
-      <NextButton
-        v-if="showQuotedReplyToggle"
-        v-tooltip.top-end="quotedReplyToggleTooltip"
-        icon="i-ph-quotes"
-        :variant="quotedReplyEnabled ? 'solid' : 'faded'"
-        color="slate"
-        sm
-        :aria-pressed="quotedReplyEnabled"
-        @click="$emit('toggleQuotedReply')"
       />
       <NextButton
         v-if="enableWhatsAppTemplates"

--- a/app/javascript/dashboard/components/widgets/conversation/QuotedEmailPreview.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/QuotedEmailPreview.vue
@@ -9,6 +9,8 @@ import {
 } from 'vue';
 import { useMessageFormatter } from 'shared/composables/useMessageFormatter';
 import { useI18n } from 'vue-i18n';
+import { useEmitter } from 'dashboard/composables/emitter';
+import { BUS_EVENTS } from 'shared/constants/busEvents';
 import NextButton from 'dashboard/components-next/button/Button.vue';
 
 const props = defineProps({
@@ -64,6 +66,11 @@ const toggleExpand = async () => {
   requestEditorHeight(bodyHeight + quoteHeight);
 };
 
+// The resizable wrapper resets its height on the same event.
+useEmitter(BUS_EVENTS.MESSAGE_SENT, () => {
+  isExpanded.value = false;
+});
+
 onBeforeUnmount(() => requestEditorHeight(0));
 </script>
 
@@ -92,16 +99,25 @@ onBeforeUnmount(() => requestEditorHeight(0));
         @click="emit('remove')"
       />
     </div>
-    <div
-      v-if="isExpanded"
-      ref="contentRef"
-      class="mt-2 overflow-y-auto text-sm max-h-60 min-h-0 text-n-slate-11"
+    <Transition
+      enter-active-class="transition-opacity duration-200 ease-out"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-200 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
     >
-      <p v-if="header" class="mb-1">{{ header }}</p>
       <div
-        v-dompurify-html="formattedQuotedEmailText"
-        class="w-full max-w-none break-words border-s-2 border-n-slate-6 ps-3 prose prose-sm dark:prose-invert"
-      />
-    </div>
+        v-if="isExpanded"
+        ref="contentRef"
+        class="mt-2 overflow-y-auto text-sm max-h-60 min-h-0 text-n-slate-11"
+      >
+        <p v-if="header" class="mb-1">{{ header }}</p>
+        <div
+          v-dompurify-html="formattedQuotedEmailText"
+          class="w-full max-w-none break-words border-s-2 border-n-slate-6 ps-3 prose prose-sm dark:prose-invert"
+        />
+      </div>
+    </Transition>
   </div>
 </template>

--- a/app/javascript/dashboard/components/widgets/conversation/QuotedEmailPreview.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/QuotedEmailPreview.vue
@@ -9,25 +9,28 @@ const props = defineProps({
     type: String,
     required: true,
   },
-  previewText: {
+  header: {
     type: String,
-    required: true,
+    default: '',
   },
 });
 
-const emit = defineEmits(['toggle']);
+const emit = defineEmits(['remove']);
 
 const { t } = useI18n();
 const { formatMessage } = useMessageFormatter();
 
 const isExpanded = ref(false);
 
-const formattedQuotedEmailText = computed(() => {
-  if (!props.quotedEmailText) {
-    return '';
-  }
-  return formatMessage(props.quotedEmailText, false, false, true);
-});
+const formattedQuotedEmailText = computed(() =>
+  formatMessage(props.quotedEmailText, false, false, true)
+);
+
+const toggleTooltip = computed(() =>
+  isExpanded.value
+    ? t('CONVERSATION.REPLYBOX.QUOTED_REPLY.HIDE_TOOLTIP')
+    : t('CONVERSATION.REPLYBOX.QUOTED_REPLY.SHOW_TOOLTIP')
+);
 
 const toggleExpand = () => {
   isExpanded.value = !isExpanded.value;
@@ -35,41 +38,36 @@ const toggleExpand = () => {
 </script>
 
 <template>
-  <div class="mt-2">
+  <div class="mt-1">
+    <div class="flex items-center gap-1">
+      <button
+        v-tooltip="toggleTooltip"
+        type="button"
+        class="inline-flex items-center justify-center h-4 rounded-md w-7 bg-n-alpha-2 text-n-slate-11 hover:bg-n-alpha-3 hover:text-n-slate-12"
+        :aria-label="toggleTooltip"
+        :aria-expanded="isExpanded"
+        @click="toggleExpand"
+      >
+        <span class="i-lucide-ellipsis size-3.5" />
+      </button>
+      <NextButton
+        v-if="isExpanded"
+        v-tooltip="t('CONVERSATION.REPLYBOX.QUOTED_REPLY.REMOVE')"
+        ghost
+        slate
+        xs
+        icon="i-lucide-x"
+        @click="emit('remove')"
+      />
+    </div>
     <div
-      class="relative rounded-md px-3 py-2 text-xs text-n-slate-12 bg-n-slate-3 dark:bg-n-solid-3"
+      v-if="isExpanded"
+      class="mt-2 overflow-y-auto text-sm max-h-60 text-n-slate-11"
     >
-      <div class="absolute top-2 right-2 z-10 flex items-center gap-1">
-        <NextButton
-          v-tooltip="
-            isExpanded
-              ? t('CONVERSATION.REPLYBOX.QUOTED_REPLY.COLLAPSE')
-              : t('CONVERSATION.REPLYBOX.QUOTED_REPLY.EXPAND')
-          "
-          ghost
-          slate
-          xs
-          :icon="isExpanded ? 'i-lucide-minimize' : 'i-lucide-maximize'"
-          @click="toggleExpand"
-        />
-        <NextButton
-          v-tooltip="t('CONVERSATION.REPLYBOX.QUOTED_REPLY.REMOVE_PREVIEW')"
-          ghost
-          slate
-          xs
-          icon="i-lucide-x"
-          @click="emit('toggle')"
-        />
-      </div>
+      <p v-if="header" class="mb-1">{{ header }}</p>
       <div
         v-dompurify-html="formattedQuotedEmailText"
-        class="w-full max-w-none break-words prose prose-sm dark:prose-invert cursor-pointer ltr:pr-8 rtl:pl-8"
-        :class="{
-          'line-clamp-1': !isExpanded,
-          'max-h-60 overflow-y-auto': isExpanded,
-        }"
-        :title="previewText"
-        @click="toggleExpand"
+        class="w-full max-w-none break-words border-s-2 border-n-slate-6 ps-3 prose prose-sm dark:prose-invert"
       />
     </div>
   </div>

--- a/app/javascript/dashboard/components/widgets/conversation/QuotedEmailPreview.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/QuotedEmailPreview.vue
@@ -1,5 +1,12 @@
 <script setup>
-import { computed, ref } from 'vue';
+import {
+  computed,
+  inject,
+  nextTick,
+  onBeforeUnmount,
+  ref,
+  useTemplateRef,
+} from 'vue';
 import { useMessageFormatter } from 'shared/composables/useMessageFormatter';
 import { useI18n } from 'vue-i18n';
 import NextButton from 'dashboard/components-next/button/Button.vue';
@@ -20,6 +27,13 @@ const emit = defineEmits(['remove']);
 const { t } = useI18n();
 const { formatMessage } = useMessageFormatter();
 
+// Matches max-h-60 on the expanded content below
+const MAX_EXPANDED_CONTENT_HEIGHT = 240;
+
+const rootRef = useTemplateRef('rootRef');
+const contentRef = useTemplateRef('contentRef');
+const requestEditorHeight = inject('requestEditorHeight', () => {});
+
 const isExpanded = ref(false);
 
 const formattedQuotedEmailText = computed(() =>
@@ -32,24 +46,42 @@ const toggleTooltip = computed(() =>
     : t('CONVERSATION.REPLYBOX.QUOTED_REPLY.SHOW_TOOLTIP')
 );
 
-const toggleExpand = () => {
+const toggleExpand = async () => {
   isExpanded.value = !isExpanded.value;
+  if (!isExpanded.value) {
+    requestEditorHeight(0);
+    return;
+  }
+
+  // Measure after nextTick — v-dompurify-html fills the pane a tick later.
+  await nextTick();
+  if (!rootRef.value || !contentRef.value) return;
+  const bodyHeight = rootRef.value.parentElement.offsetHeight;
+  const quoteHeight = Math.min(
+    contentRef.value.scrollHeight,
+    MAX_EXPANDED_CONTENT_HEIGHT
+  );
+  requestEditorHeight(bodyHeight + quoteHeight);
 };
+
+onBeforeUnmount(() => requestEditorHeight(0));
 </script>
 
 <template>
-  <div class="mt-1">
-    <div class="flex items-center gap-1">
-      <button
+  <div ref="rootRef" class="flex flex-col mt-1 min-h-0">
+    <div class="flex items-center gap-1 shrink-0">
+      <NextButton
         v-tooltip="toggleTooltip"
         type="button"
-        class="inline-flex items-center justify-center h-4 rounded-md w-7 bg-n-alpha-2 text-n-slate-11 hover:bg-n-alpha-3 hover:text-n-slate-12"
+        class="!h-4 !w-7"
+        slate
+        faded
+        xs
+        icon="i-lucide-ellipsis"
         :aria-label="toggleTooltip"
         :aria-expanded="isExpanded"
         @click="toggleExpand"
-      >
-        <span class="i-lucide-ellipsis size-3.5" />
-      </button>
+      />
       <NextButton
         v-if="isExpanded"
         v-tooltip="t('CONVERSATION.REPLYBOX.QUOTED_REPLY.REMOVE')"
@@ -62,7 +94,8 @@ const toggleExpand = () => {
     </div>
     <div
       v-if="isExpanded"
-      class="mt-2 overflow-y-auto text-sm max-h-60 text-n-slate-11"
+      ref="contentRef"
+      class="mt-2 overflow-y-auto text-sm max-h-60 min-h-0 text-n-slate-11"
     >
       <p v-if="header" class="mb-1">{{ header }}</p>
       <div

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -36,7 +36,6 @@ import wootConstants from 'dashboard/constants/globals';
 import {
   extractQuotedEmailText,
   buildQuotedEmailHeader,
-  truncatePreviewText,
   appendQuotedTextToMessage,
 } from 'dashboard/helper/quotedEmailHelper';
 import {
@@ -93,8 +92,6 @@ export default {
       uiSettings,
       isEditorHotKeyEnabled,
       fetchSignatureFlagFromUISettings,
-      setQuotedReplyFlagForInbox,
-      fetchQuotedReplyFlagFromUISettings,
     } = useUISettings();
 
     const messageEditor = useTemplateRef('messageEditor');
@@ -142,8 +139,6 @@ export default {
       uiSettings,
       isEditorHotKeyEnabled,
       fetchSignatureFlagFromUISettings,
-      setQuotedReplyFlagForInbox,
-      fetchQuotedReplyFlagFromUISettings,
       messageEditor,
       copilot,
       shortcutKey,
@@ -181,6 +176,7 @@ export default {
       showArticleSearchPopover: false,
       hasRecordedAudio: false,
       copilotAcceptedMessages: {},
+      isQuoteRemoved: false,
     };
   },
   computed: {
@@ -484,13 +480,6 @@ export default {
       const { slug = '' } = portal;
       return slug;
     },
-    quotedReplyPreference() {
-      if (!this.isAnEmailChannel) {
-        return false;
-      }
-
-      return !!this.fetchQuotedReplyFlagFromUISettings(this.channelType);
-    },
     lastEmailWithQuotedContent() {
       if (!this.isAnEmailChannel) {
         return null;
@@ -506,16 +495,18 @@ export default {
     quotedEmailText() {
       return extractQuotedEmailText(this.lastEmailWithQuotedContent);
     },
-    quotedEmailPreviewText() {
-      return truncatePreviewText(this.quotedEmailText, 80);
+    quotedEmailHeader() {
+      return buildQuotedEmailHeader(
+        this.lastEmailWithQuotedContent,
+        this.currentContact,
+        this.inbox
+      );
     },
-    shouldShowQuotedReplyToggle() {
-      return this.isAnEmailChannel && !this.isOnPrivateNote;
-    },
-    shouldShowQuotedPreview() {
+    shouldIncludeQuotedEmail() {
       return (
-        this.shouldShowQuotedReplyToggle &&
-        this.quotedReplyPreference &&
+        this.isAnEmailChannel &&
+        !this.isOnPrivateNote &&
+        !this.isQuoteRemoved &&
         !!this.quotedEmailText
       );
     },
@@ -572,6 +563,7 @@ export default {
       if (conversationId !== oldConversationId) {
         this.switchDraftContext(conversationId, this.effectiveReplyMode);
         this.resetRecorderAndClearAttachments();
+        this.isQuoteRemoved = false;
       }
     },
     message() {
@@ -676,34 +668,19 @@ export default {
 
       useTrack(CONVERSATION_EVENTS.INSERT_ARTICLE_LINK);
     },
-    toggleQuotedReply() {
-      if (!this.isAnEmailChannel) {
-        return;
-      }
-
-      const nextValue = !this.quotedReplyPreference;
-      this.setQuotedReplyFlagForInbox(this.channelType, nextValue);
-    },
-    shouldIncludeQuotedEmail() {
-      return (
-        this.quotedReplyPreference &&
-        this.shouldShowQuotedReplyToggle &&
-        !!this.quotedEmailText
-      );
+    removeQuotedEmail() {
+      this.isQuoteRemoved = true;
     },
     getMessageWithQuotedEmailText(message) {
-      if (!this.shouldIncludeQuotedEmail()) {
+      if (!this.shouldIncludeQuotedEmail) {
         return message;
       }
 
-      const quotedText = this.quotedEmailText || '';
-      const header = buildQuotedEmailHeader(
-        this.lastEmailWithQuotedContent,
-        this.currentContact,
-        this.inbox
+      return appendQuotedTextToMessage(
+        message,
+        this.quotedEmailText,
+        this.quotedEmailHeader
       );
-
-      return appendQuotedTextToMessage(message, quotedText, header);
     },
     resetRecorderAndClearAttachments() {
       // Reset audio recorder UI state
@@ -891,6 +868,7 @@ export default {
 
         if (!this.isPrivate) {
           this.clearEmailField();
+          this.isQuoteRemoved = false;
         }
 
         this.clearMessage();
@@ -1448,11 +1426,11 @@ export default {
         />
 
         <QuotedEmailPreview
-          v-if="shouldShowQuotedPreview && isDefaultEditorMode"
+          v-if="shouldIncludeQuotedEmail && isDefaultEditorMode"
           :quoted-email-text="quotedEmailText"
-          :preview-text="quotedEmailPreviewText"
+          :header="quotedEmailHeader"
           class="mb-2"
-          @toggle="toggleQuotedReply"
+          @remove="removeQuotedEmail"
         />
 
         <div
@@ -1515,8 +1493,6 @@ export default {
         :show-audio-recorder="showAudioRecorder"
         :show-emoji-picker="showEmojiPicker"
         :show-file-upload="showFileUpload"
-        :show-quoted-reply-toggle="shouldShowQuotedReplyToggle"
-        :quoted-reply-enabled="quotedReplyPreference"
         :toggle-audio-recorder-play-pause="toggleAudioRecorderPlayPause"
         :toggle-audio-recorder="toggleAudioRecorder"
         :toggle-emoji-picker="toggleEmojiPicker"
@@ -1526,7 +1502,6 @@ export default {
         @select-whatsapp-template="openWhatsappTemplateModal"
         @select-content-template="openContentTemplateModal"
         @toggle-insert-article="toggleInsertArticle"
-        @toggle-quoted-reply="toggleQuotedReply"
         @request-contact-info-template="openContactInfoTemplateModal"
       />
     </Transition>

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -133,6 +133,16 @@ export default {
         },
         allowOnFocusedInput: true,
       },
+      '$mod+KeyZ': {
+        action: e => {
+          // The editor prevents default only when its own history undid a
+          // step; inputs keep their native undo. Shift means redo.
+          if (e.defaultPrevented || e.shiftKey) return;
+          if (['INPUT', 'TEXTAREA'].includes(e.target?.tagName)) return;
+          if (proxy.restoreQuotedEmail()) e.preventDefault();
+        },
+        allowOnFocusedInput: true,
+      },
     });
 
     return {
@@ -670,6 +680,13 @@ export default {
     },
     removeQuotedEmail() {
       this.isQuoteRemoved = true;
+    },
+    restoreQuotedEmail() {
+      if (!this.isQuoteRemoved) {
+        return false;
+      }
+      this.isQuoteRemoved = false;
+      return true;
     },
     getMessageWithQuotedEmailText(message) {
       if (!this.shouldIncludeQuotedEmail) {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -1398,7 +1398,7 @@ export default {
           v-model="message"
           :conversation-id="conversationId"
           :editor-id="editorStateId"
-          class="input popover-prosemirror-menu"
+          class="input popover-prosemirror-menu resizable-editor-split"
           :is-private="isOnPrivateNote"
           :placeholder="messagePlaceHolder"
           :update-selection-with="updateEditorSelectionWith"
@@ -1423,15 +1423,17 @@ export default {
           @execute-macro="onExecuteMacro"
           @clear-selection="clearEditorSelection"
           @execute-copilot-action="executeCopilotAction"
-        />
-
-        <QuotedEmailPreview
-          v-if="shouldIncludeQuotedEmail && isDefaultEditorMode"
-          :quoted-email-text="quotedEmailText"
-          :header="quotedEmailHeader"
-          class="mb-2"
-          @remove="removeQuotedEmail"
-        />
+        >
+          <template #footer>
+            <QuotedEmailPreview
+              v-if="shouldIncludeQuotedEmail"
+              :key="conversationId"
+              :quoted-email-text="quotedEmailText"
+              :header="quotedEmailHeader"
+              @remove="removeQuotedEmail"
+            />
+          </template>
+        </WootMessageEditor>
 
         <div
           v-if="hasAttachments && isDefaultEditorMode"

--- a/app/javascript/dashboard/components/widgets/conversation/ResizableEditorWrapper.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ResizableEditorWrapper.vue
@@ -193,5 +193,33 @@ defineExpose({ toggleEditorExpand, resetEditorHeight });
       height var(--editor-height-transition),
       opacity var(--editor-height-transition);
   }
+
+  // Shares the resizable height between the editor and its footer-slot
+  // content (e.g. the quoted email preview); the 3rem floor keeps the
+  // editor usable at the minimum allowed height.
+  .resizable-editor-split {
+    @apply flex min-h-0 flex-col;
+
+    height: clamp(
+      var(--editor-min-allowed, 5rem),
+      var(--editor-height, 5rem),
+      var(--editor-max-allowed, 7.5rem)
+    );
+    transition: height var(--editor-height-transition);
+
+    .editor-mount {
+      @apply flex min-h-[3rem] flex-1 flex-col;
+    }
+
+    .ProseMirror-menubar-wrapper {
+      @apply flex min-h-0 flex-1 flex-col;
+    }
+
+    .resizable-editor-body {
+      @apply min-h-0 flex-1;
+
+      height: auto;
+    }
+  }
 }
 </style>

--- a/app/javascript/dashboard/composables/spec/useUISettings.spec.js
+++ b/app/javascript/dashboard/composables/spec/useUISettings.spec.js
@@ -13,7 +13,6 @@ const getUISettingsMock = ref({
   conversation_sidebar_items_order: DEFAULT_CONVERSATION_SIDEBAR_ITEMS_ORDER,
   contact_sidebar_items_order: DEFAULT_CONTACT_SIDEBAR_ITEMS_ORDER,
   editor_message_key: 'enter',
-  channel_email_quoted_reply_enabled: true,
 });
 
 vi.mock('dashboard/composables/store', () => ({
@@ -38,7 +37,6 @@ describe('useUISettings', () => {
         DEFAULT_CONVERSATION_SIDEBAR_ITEMS_ORDER,
       contact_sidebar_items_order: DEFAULT_CONTACT_SIDEBAR_ITEMS_ORDER,
       editor_message_key: 'enter',
-      channel_email_quoted_reply_enabled: true,
     });
   });
 
@@ -53,7 +51,6 @@ describe('useUISettings', () => {
           DEFAULT_CONVERSATION_SIDEBAR_ITEMS_ORDER,
         contact_sidebar_items_order: DEFAULT_CONTACT_SIDEBAR_ITEMS_ORDER,
         editor_message_key: 'enter',
-        channel_email_quoted_reply_enabled: true,
       },
     });
   });
@@ -68,7 +65,6 @@ describe('useUISettings', () => {
           DEFAULT_CONVERSATION_SIDEBAR_ITEMS_ORDER,
         contact_sidebar_items_order: DEFAULT_CONTACT_SIDEBAR_ITEMS_ORDER,
         editor_message_key: 'enter',
-        channel_email_quoted_reply_enabled: true,
       },
     });
   });
@@ -104,7 +100,6 @@ describe('useUISettings', () => {
         contact_sidebar_items_order: DEFAULT_CONTACT_SIDEBAR_ITEMS_ORDER,
         email_signature_enabled: true,
         editor_message_key: 'enter',
-        channel_email_quoted_reply_enabled: true,
       },
     });
   });
@@ -112,26 +107,6 @@ describe('useUISettings', () => {
   it('fetches signature flag from UI settings correctly', () => {
     const { fetchSignatureFlagFromUISettings } = useUISettings();
     expect(fetchSignatureFlagFromUISettings('email')).toBe(undefined);
-  });
-
-  it('sets quoted reply flag for inbox correctly', () => {
-    const { setQuotedReplyFlagForInbox } = useUISettings();
-    setQuotedReplyFlagForInbox('Channel::Email', false);
-    expect(mockDispatch).toHaveBeenCalledWith('updateUISettings', {
-      uiSettings: {
-        is_ct_labels_open: true,
-        conversation_sidebar_items_order:
-          DEFAULT_CONVERSATION_SIDEBAR_ITEMS_ORDER,
-        contact_sidebar_items_order: DEFAULT_CONTACT_SIDEBAR_ITEMS_ORDER,
-        editor_message_key: 'enter',
-        channel_email_quoted_reply_enabled: false,
-      },
-    });
-  });
-
-  it('fetches quoted reply flag from UI settings correctly', () => {
-    const { fetchQuotedReplyFlagFromUISettings } = useUISettings();
-    expect(fetchQuotedReplyFlagFromUISettings('Channel::Email')).toBe(true);
   });
 
   it('returns correct value for isEditorHotKeyEnabled when editor_message_key is configured', () => {

--- a/app/javascript/dashboard/composables/useUISettings.js
+++ b/app/javascript/dashboard/composables/useUISettings.js
@@ -88,13 +88,6 @@ const setSignatureFlagForInbox = (channelType, value, updateUISettings) => {
   updateUISettings({ [`${slugifiedChannel}_signature_enabled`]: value });
 };
 
-const setQuotedReplyFlagForInbox = (channelType, value, updateUISettings) => {
-  if (!channelType) return;
-
-  const slugifiedChannel = slugifyChannel(channelType);
-  updateUISettings({ [`${slugifiedChannel}_quoted_reply_enabled`]: value });
-};
-
 /**
  * Fetches the signature flag for a specific channel type from UI settings.
  * @param {string} channelType - The type of the channel.
@@ -106,13 +99,6 @@ const fetchSignatureFlagFromUISettings = (channelType, uiSettings) => {
 
   const slugifiedChannel = slugifyChannel(channelType);
   return uiSettings.value[`${slugifiedChannel}_signature_enabled`];
-};
-
-const fetchQuotedReplyFlagFromUISettings = (channelType, uiSettings) => {
-  if (!channelType) return false;
-
-  const slugifiedChannel = slugifyChannel(channelType);
-  return uiSettings.value[`${slugifiedChannel}_quoted_reply_enabled`];
 };
 
 /**
@@ -162,10 +148,6 @@ export function useUISettings() {
       setSignatureFlagForInbox(channelType, value, updateUISettings),
     fetchSignatureFlagFromUISettings: channelType =>
       fetchSignatureFlagFromUISettings(channelType, uiSettings),
-    setQuotedReplyFlagForInbox: (channelType, value) =>
-      setQuotedReplyFlagForInbox(channelType, value, updateUISettings),
-    fetchQuotedReplyFlagFromUISettings: channelType =>
-      fetchQuotedReplyFlagFromUISettings(channelType, uiSettings),
     isEditorHotKeyEnabled: key => isEditorHotKeyEnabled(key, uiSettings),
   };
 }

--- a/app/javascript/dashboard/helper/quotedEmailHelper.js
+++ b/app/javascript/dashboard/helper/quotedEmailHelper.js
@@ -1,8 +1,68 @@
 import { format, parseISO, isValid as isValidDate } from 'date-fns';
 import DOMPurify from 'dompurify';
 
+const NON_CONTENT_TAGS = new Set(['STYLE', 'SCRIPT', 'HEAD', 'TITLE']);
+const BLOCK_TAGS = new Set([
+  'ADDRESS',
+  'ARTICLE',
+  'ASIDE',
+  'BLOCKQUOTE',
+  'DD',
+  'DIV',
+  'DL',
+  'DT',
+  'FIELDSET',
+  'FIGCAPTION',
+  'FIGURE',
+  'FOOTER',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'HEADER',
+  'HR',
+  'LI',
+  'MAIN',
+  'NAV',
+  'OL',
+  'P',
+  'PRE',
+  'SECTION',
+  'TABLE',
+  'TR',
+  'UL',
+]);
+const TABLE_CELL_TAGS = new Set(['TD', 'TH']);
+
+const textFromNode = node => {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent;
+  }
+  if (
+    node.nodeType !== Node.ELEMENT_NODE ||
+    NON_CONTENT_TAGS.has(node.nodeName)
+  ) {
+    return '';
+  }
+  if (node.nodeName === 'BR') {
+    return '\n';
+  }
+
+  const childText = [...node.childNodes].map(textFromNode).join('');
+  if (BLOCK_TAGS.has(node.nodeName)) {
+    return `${childText}\n`;
+  }
+  if (TABLE_CELL_TAGS.has(node.nodeName)) {
+    return `${childText} `;
+  }
+  return childText;
+};
+
 /**
- * Extracts plain text from HTML content
+ * Extracts plain text from HTML content, keeping line breaks at block
+ * boundaries so adjacent blocks don't run together in the quoted text.
  * @param {string} html - HTML content to convert
  * @returns {string} Plain text content
  */
@@ -15,7 +75,9 @@ export const extractPlainTextFromHtml = html => {
   }
   const tempDiv = document.createElement('div');
   tempDiv.innerHTML = DOMPurify.sanitize(html);
-  return tempDiv.textContent || tempDiv.innerText || '';
+  return textFromNode(tempDiv)
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
 };
 
 /**
@@ -287,8 +349,37 @@ export const extractQuotedEmailText = lastEmail => {
   return fallbackContent;
 };
 
+// Keep in sync with the content length validation on Message (app/models/message.rb).
+const MAX_MESSAGE_CONTENT_LENGTH = 150000;
+
+// Outgoing content is rendered through Liquid on the server
+// (app/models/concerns/liquidable.rb); emit quoted {{ and {% tokens as
+// literals so customer-supplied expressions are never evaluated.
+const escapeLiquidTokens = text => text.replace(/\{[{%]/g, "{{ '$&' }}");
+
+const fitQuotedBlockWithinLimit = (quotedBlock, available) => {
+  if (quotedBlock.length <= available) {
+    return quotedBlock;
+  }
+
+  // Keep whole lines from the top — the oldest history sits at the bottom.
+  const kept = [];
+  let length = 0;
+  quotedBlock.split('\n').every(line => {
+    const nextLength = length + line.length + (kept.length ? 1 : 0);
+    if (nextLength > available) {
+      return false;
+    }
+    kept.push(line);
+    length = nextLength;
+    return true;
+  });
+  return kept.join('\n');
+};
+
 /**
- * Appends quoted text to message
+ * Appends quoted text to message, truncating the quote so the combined
+ * content stays within the server-side message length limit.
  * @param {string} message - Original message
  * @param {string} quotedText - Text to quote
  * @param {string} header - Quote header
@@ -296,21 +387,26 @@ export const extractQuotedEmailText = lastEmail => {
  */
 export const appendQuotedTextToMessage = (message, quotedText, header) => {
   const baseMessage = message ? String(message) : '';
-  const quotedBlock = formatQuotedTextAsBlockquote(quotedText, header);
+  let quotedBlock = formatQuotedTextAsBlockquote(quotedText, header);
 
   if (!quotedBlock) {
     return baseMessage;
   }
-
-  if (!baseMessage) {
-    return quotedBlock;
-  }
+  quotedBlock = escapeLiquidTokens(quotedBlock);
 
   let separator = '\n\n';
-  if (baseMessage.endsWith('\n\n')) {
+  if (!baseMessage || baseMessage.endsWith('\n\n')) {
     separator = '';
   } else if (baseMessage.endsWith('\n')) {
     separator = '\n';
+  }
+
+  quotedBlock = fitQuotedBlockWithinLimit(
+    quotedBlock,
+    MAX_MESSAGE_CONTENT_LENGTH - baseMessage.length - separator.length
+  );
+  if (!quotedBlock) {
+    return baseMessage;
   }
 
   return `${baseMessage}${separator}${quotedBlock}`;

--- a/app/javascript/dashboard/helper/quotedEmailHelper.js
+++ b/app/javascript/dashboard/helper/quotedEmailHelper.js
@@ -250,7 +250,9 @@ export const formatQuotedTextAsBlockquote = (text, header = '') => {
 };
 
 /**
- * Extracts quoted email text from last email message
+ * Extracts quoted email text from last email message.
+ * Prefers the full content over the trimmed reply so the quoted thread
+ * carries the entire history, matching regular email client behavior.
  * @param {Object} lastEmail - Last email message object
  * @returns {string} Quoted email text
  */
@@ -264,43 +266,25 @@ export const extractQuotedEmailText = lastEmail => {
   const emailContent = contentAttributes.email || {};
   const textContent = emailContent.textContent || emailContent.text_content;
 
-  if (textContent?.reply) {
-    return textContent.reply;
-  }
   if (textContent?.full) {
     return textContent.full;
   }
+  if (textContent?.reply) {
+    return textContent.reply;
+  }
 
   const htmlContent = emailContent.htmlContent || emailContent.html_content;
-  if (htmlContent?.reply) {
-    return extractPlainTextFromHtml(htmlContent.reply);
-  }
   if (htmlContent?.full) {
     return extractPlainTextFromHtml(htmlContent.full);
+  }
+  if (htmlContent?.reply) {
+    return extractPlainTextFromHtml(htmlContent.reply);
   }
 
   const fallbackContent =
     lastEmail.content || lastEmail.processed_message_content || '';
 
   return fallbackContent;
-};
-
-/**
- * Truncates text for preview display
- * @param {string} text - Text to truncate
- * @param {number} maxLength - Maximum length (default: 80)
- * @returns {string} Truncated text
- */
-export const truncatePreviewText = (text, maxLength = 80) => {
-  const preview = text.trim().replace(/\s+/g, ' ');
-  if (!preview) {
-    return '';
-  }
-
-  if (preview.length <= maxLength) {
-    return preview;
-  }
-  return `${preview.slice(0, maxLength - 3)}...`;
 };
 
 /**

--- a/app/javascript/dashboard/helper/quotedEmailHelper.js
+++ b/app/javascript/dashboard/helper/quotedEmailHelper.js
@@ -1,4 +1,4 @@
-import { format, parseISO, isValid as isValidDate } from 'date-fns';
+import { format, isValid as isValidDate, parseISO } from 'date-fns';
 import DOMPurify from 'dompurify';
 
 const NON_CONTENT_TAGS = new Set(['STYLE', 'SCRIPT', 'HEAD', 'TITLE']);
@@ -363,11 +363,18 @@ const fitQuotedBlockWithinLimit = (quotedBlock, available) => {
   }
 
   // Keep whole lines from the top — the oldest history sits at the bottom.
+  // The boundary line is cut to the remaining space so a single long line
+  // can't drop the entire quoted body.
   const kept = [];
   let length = 0;
   quotedBlock.split('\n').every(line => {
-    const nextLength = length + line.length + (kept.length ? 1 : 0);
+    const joiner = kept.length ? 1 : 0;
+    const nextLength = length + line.length + joiner;
     if (nextLength > available) {
+      const remaining = available - length - joiner;
+      if (remaining > 0) {
+        kept.push(line.slice(0, remaining));
+      }
       return false;
     }
     kept.push(line);

--- a/app/javascript/dashboard/helper/specs/quotedEmailHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/quotedEmailHelper.spec.js
@@ -10,7 +10,6 @@ import {
   buildQuotedEmailHeaderFromInbox,
   formatQuotedTextAsBlockquote,
   extractQuotedEmailText,
-  truncatePreviewText,
   appendQuotedTextToMessage,
 } from '../quotedEmailHelper';
 
@@ -335,7 +334,22 @@ describe('quotedEmailHelper', () => {
   });
 
   describe('extractQuotedEmailText', () => {
-    it('extracts text from textContent.reply', () => {
+    it('prefers textContent.full over reply to preserve the thread history', () => {
+      const lastEmail = {
+        contentAttributes: {
+          email: {
+            textContent: {
+              full: 'Full text with history',
+              reply: 'Reply text',
+            },
+          },
+        },
+      };
+      const result = extractQuotedEmailText(lastEmail);
+      expect(result).toBe('Full text with history');
+    });
+
+    it('falls back to textContent.reply', () => {
       const lastEmail = {
         contentAttributes: {
           email: { textContent: { reply: 'Reply text' } },
@@ -345,24 +359,19 @@ describe('quotedEmailHelper', () => {
       expect(result).toBe('Reply text');
     });
 
-    it('falls back to textContent.full', () => {
-      const lastEmail = {
-        contentAttributes: {
-          email: { textContent: { full: 'Full text' } },
-        },
-      };
-      const result = extractQuotedEmailText(lastEmail);
-      expect(result).toBe('Full text');
-    });
-
     it('extracts from htmlContent and converts to plain text', () => {
       const lastEmail = {
         contentAttributes: {
-          email: { htmlContent: { reply: '<p>HTML reply</p>' } },
+          email: {
+            htmlContent: {
+              full: '<p>HTML full with history</p>',
+              reply: '<p>HTML reply</p>',
+            },
+          },
         },
       };
       const result = extractQuotedEmailText(lastEmail);
-      expect(result).toBe('HTML reply');
+      expect(result).toBe('HTML full with history');
     });
 
     it('uses fallback content if structured content not available', () => {
@@ -374,44 +383,6 @@ describe('quotedEmailHelper', () => {
     it('returns empty string for null or missing email', () => {
       expect(extractQuotedEmailText(null)).toBe('');
       expect(extractQuotedEmailText({})).toBe('');
-    });
-  });
-
-  describe('truncatePreviewText', () => {
-    it('returns full text if under max length', () => {
-      const text = 'Short text';
-      const result = truncatePreviewText(text, 80);
-      expect(result).toBe('Short text');
-    });
-
-    it('truncates text exceeding max length', () => {
-      const text = 'A'.repeat(100);
-      const result = truncatePreviewText(text, 80);
-      expect(result).toHaveLength(80);
-      expect(result).toContain('...');
-    });
-
-    it('collapses multiple spaces', () => {
-      const text = 'Text   with    spaces';
-      const result = truncatePreviewText(text);
-      expect(result).toBe('Text with spaces');
-    });
-
-    it('trims whitespace', () => {
-      const text = '  Text with spaces  ';
-      const result = truncatePreviewText(text);
-      expect(result).toBe('Text with spaces');
-    });
-
-    it('returns empty string for empty input', () => {
-      expect(truncatePreviewText('')).toBe('');
-      expect(truncatePreviewText('   ')).toBe('');
-    });
-
-    it('uses default max length of 80', () => {
-      const text = 'A'.repeat(100);
-      const result = truncatePreviewText(text);
-      expect(result).toHaveLength(80);
     });
   });
 

--- a/app/javascript/dashboard/helper/specs/quotedEmailHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/quotedEmailHelper.spec.js
@@ -33,6 +33,21 @@ describe('quotedEmailHelper', () => {
       expect(result).toContain('Line 2');
     });
 
+    it('separates adjacent block elements with line breaks', () => {
+      const html = '<p>Latest</p><p>Previous</p>';
+      expect(extractPlainTextFromHtml(html)).toBe('Latest\nPrevious');
+    });
+
+    it('converts br tags to line breaks', () => {
+      const html = '<p>Line 1<br>Line 2</p>';
+      expect(extractPlainTextFromHtml(html)).toBe('Line 1\nLine 2');
+    });
+
+    it('ignores style tag content', () => {
+      const html = '<style>.a { color: red; }</style><p>Hello</p>';
+      expect(extractPlainTextFromHtml(html)).toBe('Hello');
+    });
+
     it('sanitizes onerror handlers from img tags', () => {
       const html = '<p>Hello</p><img src="x" onerror="alert(1)">';
       const result = extractPlainTextFromHtml(html);
@@ -427,6 +442,38 @@ describe('quotedEmailHelper', () => {
     it('adds single newline if message ends with one newline', () => {
       const result = appendQuotedTextToMessage('Message\n', 'Quoted', 'Header');
       expect(result).toContain('Message\n\n>');
+    });
+
+    it('escapes Liquid tokens in the quoted text and header', () => {
+      const result = appendQuotedTextToMessage(
+        'My reply with {{contact.name}}',
+        'Give me {{conversation.custom_attribute.secret}} and {% if true %}this{% endif %}',
+        'On date {{agent.email}} wrote:'
+      );
+
+      expect(result).toContain('My reply with {{contact.name}}');
+      expect(result).toContain(
+        "Give me {{ '{{' }}conversation.custom_attribute.secret}}"
+      );
+      expect(result).toContain("{{ '{%' }} if true %}this{{ '{%' }} endif %}");
+      expect(result).toContain("On date {{ '{{' }}agent.email}} wrote:");
+    });
+
+    it('drops oldest quoted lines to stay within the message length limit', () => {
+      const quotedLines = Array.from(
+        { length: 2000 },
+        (_, i) => `Line ${i}: ${'a'.repeat(90)}`
+      );
+      const result = appendQuotedTextToMessage(
+        'My reply',
+        quotedLines.join('\n'),
+        'Header'
+      );
+
+      expect(result.length).toBeLessThanOrEqual(150000);
+      expect(result.startsWith('My reply')).toBe(true);
+      expect(result).toContain('> Line 0:');
+      expect(result).not.toContain('> Line 1999:');
     });
   });
 });

--- a/app/javascript/dashboard/helper/specs/quotedEmailHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/quotedEmailHelper.spec.js
@@ -475,5 +475,17 @@ describe('quotedEmailHelper', () => {
       expect(result).toContain('> Line 0:');
       expect(result).not.toContain('> Line 1999:');
     });
+
+    it('cuts a single over-limit line instead of dropping the quoted body', () => {
+      const result = appendQuotedTextToMessage(
+        'My reply',
+        'a'.repeat(200000),
+        'Header'
+      );
+
+      expect(result.length).toBeLessThanOrEqual(150000);
+      expect(result).toContain('> Header');
+      expect(result).toContain('> aaaa');
+    });
   });
 });

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -327,11 +327,9 @@
         }
       },
       "QUOTED_REPLY": {
-        "ENABLE_TOOLTIP": "Include quoted email thread",
-        "DISABLE_TOOLTIP": "Don't include quoted email thread",
-        "REMOVE_PREVIEW": "Remove quoted email thread",
-        "COLLAPSE": "Collapse preview",
-        "EXPAND": "Expand preview"
+        "SHOW_TOOLTIP": "Show trimmed content",
+        "HIDE_TOOLTIP": "Hide trimmed content",
+        "REMOVE": "Remove quoted text"
       }
     },
     "VISIBLE_TO_AGENTS": "Private Note: Only visible to you and your team",


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds a Gmail-style experience for quoted email history in the reply editor. The quoted thread is now always included in email replies, with the toolbar toggle and preview bar replaced by a small "…" trimmed-content chip below the composer. Clicking the chip expands or collapses the quoted thread inline, while the remove button excludes it from the current message only. The next reply includes the quoted thread again automatically.

The quoted content now includes the full email thread history instead of only the last message.



### What changed

* Added Gmail-style quoted thread UI below the composer.
* Quoted email history is included automatically in replies.
* Added expand/collapse behavior for the quoted thread.
* Added the ability to remove quoted content for the current message only.
* Changed quoted content to include the full thread history.
* Removed the quote toggle from the toolbar and the previous quote preview bar.


Fixes https://linear.app/chatwoot/issue/CW-8029/include-quoted-text-in-emails-without-the-setting , https://linear.app/chatwoot/issue/CW-8032/missing-full-history-in-quoted-text

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### How to test

1. Open an email conversation that has at least one prior email.
2. The reply editor shows a "…" chip below the text area. Click it to expand the quoted thread ("On … wrote:" + quoted block), then click again to collapse it.
3. Send a reply. The outgoing email should contain your message followed by the quoted thread with the full history.
4. Expand the chip and click the × (Remove quoted text). The chip disappears, and sending now delivers only your message.
5. Switch to another conversation and back. The chip should return, since removal applies to the current message only.
6. Verify that private notes and non-email channels are unaffected, and the quote toggle button no longer appears in the toolbar.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
