### PR TITLE
fix: preserve URLs in editor rewrites

### DIFF
--- a/lib/captain/base_task_service.rb
+++ b/lib/captain/base_task_service.rb
@@ -1,6 +1,7 @@
 class Captain::BaseTaskService
   include Integrations::LlmInstrumentation
   include Captain::ToolInstrumentation
+  include Captain::UrlPreserver
   include Llm::ExceptionTrackable
 
   # gpt-4o-mini supports 128,000 tokens

--- a/lib/captain/follow_up_service.rb
+++ b/lib/captain/follow_up_service.rb
@@ -32,11 +32,13 @@ class Captain::FollowUpService < Captain::BaseTaskService
       *history,
       { role: 'user', content: user_message }
     ]
+    messages, placeholders = protect_urls_in_messages(messages)
 
     response = make_api_call(feature: 'editor', messages: messages)
     return response if response[:error]
 
-    response.merge(follow_up_context: update_follow_up_context(user_message, response[:message]))
+    message = restored_response(response[:message], placeholders)
+    response.merge(message: message, follow_up_context: update_follow_up_context(user_message, message))
   end
 
   private
@@ -50,6 +52,13 @@ class Captain::FollowUpService < Captain::BaseTaskService
       Be concise and focused on their specific request.
       Output only the reply, no preamble, tags, or explanation.
     PROMPT
+  end
+
+  def restored_response(message, placeholders)
+    return message if placeholders.empty?
+    return follow_up_context['last_response'] unless safe_url_placeholder_output?(message, placeholders)
+
+    restore_url_placeholders(message, placeholders)
   end
 
   def describe_previous_action(event_name)

--- a/lib/captain/rewrite_service.rb
+++ b/lib/captain/rewrite_service.rb
@@ -1,7 +1,6 @@
 class Captain::RewriteService < Captain::BaseTaskService
   pattr_initialize [:account!, :content!, :operation!, { conversation_display_id: nil }]
 
-  URL_PATTERN = %r{https?://[^\s<>\])]+}
   TONE_OPERATIONS = %i[casual professional friendly confident straightforward].freeze
   ALLOWED_OPERATIONS = (%i[fix_spelling_grammar improve] + TONE_OPERATIONS).freeze
 
@@ -36,26 +35,39 @@ class Captain::RewriteService < Captain::BaseTaskService
   end
 
   def call_llm_with_prompt(system_content, user_content = content)
+    messages, placeholders = protect_urls_in_messages([
+                                                        { role: 'system', content: system_content },
+                                                        { role: 'user', content: user_content }
+                                                      ])
     response = make_api_call(
       feature: 'editor',
-      messages: [
-        { role: 'system', content: system_content },
-        { role: 'user', content: user_content }
-      ]
+      messages: messages
     )
 
-    preserve_urls(response)
+    preserve_urls(response, placeholders)
   end
 
-  def preserve_urls(response)
-    original_urls = content.scan(URL_PATTERN)
-    return response if response[:error] || original_urls.empty?
+  def preserve_urls(response, placeholders)
+    return response if response[:error] || placeholders.empty?
 
-    rewritten_urls = response[:message].to_s.scan(URL_PATTERN)
-    return response.merge(message: content) unless rewritten_urls.size == original_urls.size
+    expected_placeholders = content.scan(URL_PATTERN).map { |url| placeholders.fetch(url) }
+    actual_placeholders = response[:message].to_s.scan(URL_PLACEHOLDER_PATTERN)
+    message = if safe_url_placeholder_output?(response[:message], placeholders) && actual_placeholders.tally == expected_placeholders.tally
+                restore_url_placeholders(response[:message], placeholders)
+              else
+                content
+              end
 
-    index = -1
-    response.merge(message: response[:message].gsub(URL_PATTERN) { original_urls[index += 1] })
+    response_with_message(response, message)
+  end
+
+  def response_with_message(response, message)
+    updated_response = response.merge(message: message)
+    return updated_response unless response[:follow_up_context]
+
+    updated_response.merge(
+      follow_up_context: response[:follow_up_context].merge(original_context: content, last_response: message)
+    )
   end
 
   def render_liquid_template(template_content, variables = {})

--- a/lib/captain/rewrite_service.rb
+++ b/lib/captain/rewrite_service.rb
@@ -1,6 +1,7 @@
 class Captain::RewriteService < Captain::BaseTaskService
   pattr_initialize [:account!, :content!, :operation!, { conversation_display_id: nil }]
 
+  URL_PATTERN = %r{https?://[^\s<>\])]+}
   TONE_OPERATIONS = %i[casual professional friendly confident straightforward].freeze
   ALLOWED_OPERATIONS = (%i[fix_spelling_grammar improve] + TONE_OPERATIONS).freeze
 
@@ -35,13 +36,26 @@ class Captain::RewriteService < Captain::BaseTaskService
   end
 
   def call_llm_with_prompt(system_content, user_content = content)
-    make_api_call(
+    response = make_api_call(
       feature: 'editor',
       messages: [
         { role: 'system', content: system_content },
         { role: 'user', content: user_content }
       ]
     )
+
+    preserve_urls(response)
+  end
+
+  def preserve_urls(response)
+    original_urls = content.scan(URL_PATTERN)
+    return response if response[:error] || original_urls.empty?
+
+    rewritten_urls = response[:message].to_s.scan(URL_PATTERN)
+    return response.merge(message: content) unless rewritten_urls.size == original_urls.size
+
+    index = -1
+    response.merge(message: response[:message].gsub(URL_PATTERN) { original_urls[index += 1] })
   end
 
   def render_liquid_template(template_content, variables = {})

--- a/lib/captain/url_preserver.rb
+++ b/lib/captain/url_preserver.rb
@@ -1,0 +1,30 @@
+module Captain::UrlPreserver
+  URL_PATTERN = %r{https?://[^\s<>\])]+}
+  URL_PLACEHOLDER_PATTERN = /__CHATWOOT_URL_\d+__/
+
+  private
+
+  def protect_urls_in_messages(messages)
+    urls = messages.flat_map { |message| message[:content].to_s.scan(URL_PATTERN) }.uniq
+    return [messages, {}] if urls.empty?
+
+    placeholders = urls.each_with_index.to_h { |url, index| [url, "__CHATWOOT_URL_#{index}__"] }
+    protected_messages = messages.map do |message|
+      protected_content = message[:content].to_s.gsub(URL_PATTERN) { |url| placeholders.fetch(url) }
+      protected_content += "\n\nKeep every __CHATWOOT_URL_n__ placeholder unchanged." if message[:role] == 'system'
+      message.merge(content: protected_content)
+    end
+
+    [protected_messages, placeholders]
+  end
+
+  def restore_url_placeholders(content, placeholders)
+    urls_by_placeholder = placeholders.invert
+    content.to_s.gsub(URL_PLACEHOLDER_PATTERN) { |placeholder| urls_by_placeholder.fetch(placeholder, placeholder) }
+  end
+
+  def safe_url_placeholder_output?(content, placeholders)
+    content.to_s.scan(URL_PATTERN).empty? &&
+      (content.to_s.scan(URL_PLACEHOLDER_PATTERN) - placeholders.values).empty?
+  end
+end

--- a/spec/lib/captain/follow_up_service_spec.rb
+++ b/spec/lib/captain/follow_up_service_spec.rb
@@ -73,6 +73,21 @@ RSpec.describe Captain::FollowUpService do
         expect(result[:follow_up_context]['conversation_history'][-2]['content']).to eq('Make it more concise')
         expect(result[:follow_up_context]['conversation_history'][-1]['content']).to eq('Refined response')
       end
+
+      it 'preserves URL identity in the response and history' do
+        follow_up_context['original_context'] = 'Use https://chatwoot.com/billing'
+        follow_up_context['last_response'] = 'Billing: https://chatwoot.com/billing Support: https://chatwoot.com/support'
+        allow(service).to receive(:make_api_call) do |args|
+          expect(args[:messages].pluck(:content).join).not_to include('https://chatwoot.com')
+          { message: 'Support: __CHATWOOT_URL_1__ Billing: __CHATWOOT_URL_0__' }
+        end
+
+        result = service.perform
+
+        expect(result[:message]).to eq('Support: https://chatwoot.com/support Billing: https://chatwoot.com/billing')
+        expect(result[:follow_up_context]['last_response']).to eq(result[:message])
+        expect(result[:follow_up_context]['conversation_history'].last['content']).to eq(result[:message])
+      end
     end
 
     context 'when follow-up context is missing' do

--- a/spec/lib/captain/rewrite_service_spec.rb
+++ b/spec/lib/captain/rewrite_service_spec.rb
@@ -140,6 +140,34 @@ RSpec.describe Captain::RewriteService do
 
       expect(result[:message]).to eq('Rewritten text')
     end
+
+    context 'when the model changes a URL' do
+      let(:content) do
+        'Read <https://chatwoot.com/articles/purchasing-a-paid-self_hosted-license-a-step_by_step-guide>'
+      end
+      let(:mock_response) do
+        instance_double(
+          RubyLLM::Message,
+          content: 'Please read <https://chatwoot.com/articles/purchasing-a-paid-self_hosted-license-a-step_by-step-guide>',
+          input_tokens: 10,
+          output_tokens: 5
+        )
+      end
+
+      it 'restores the original URL' do
+        expect(service.perform[:message]).to eq(
+          'Please read <https://chatwoot.com/articles/purchasing-a-paid-self_hosted-license-a-step_by_step-guide>'
+        )
+      end
+    end
+
+    context 'when the model removes a URL' do
+      let(:content) { 'Read https://chatwoot.com/guide for help' }
+
+      it 'returns the original content' do
+        expect(service.perform[:message]).to eq(content)
+      end
+    end
   end
 
   describe '#perform with invalid operation' do

--- a/spec/lib/captain/rewrite_service_spec.rb
+++ b/spec/lib/captain/rewrite_service_spec.rb
@@ -148,15 +148,39 @@ RSpec.describe Captain::RewriteService do
       let(:mock_response) do
         instance_double(
           RubyLLM::Message,
-          content: 'Please read <https://chatwoot.com/articles/purchasing-a-paid-self_hosted-license-a-step_by-step-guide>',
+          content: 'Please read <__CHATWOOT_URL_0__>',
           input_tokens: 10,
           output_tokens: 5
         )
       end
 
       it 'restores the original URL' do
-        expect(service.perform[:message]).to eq(
+        expect(mock_chat).to receive(:ask).with('Read <__CHATWOOT_URL_0__>').and_return(mock_response)
+
+        result = service.perform
+
+        expect(result[:message]).to eq(
           'Please read <https://chatwoot.com/articles/purchasing-a-paid-self_hosted-license-a-step_by_step-guide>'
+        )
+        expect(result[:follow_up_context][:original_context]).to eq(content)
+        expect(result[:follow_up_context][:last_response]).to eq(result[:message])
+      end
+    end
+
+    context 'when the model reorders URLs' do
+      let(:content) { 'Read [billing](https://chatwoot.com/billing) then [support](https://chatwoot.com/support)' }
+      let(:mock_response) do
+        instance_double(
+          RubyLLM::Message,
+          content: 'Read [support](__CHATWOOT_URL_1__) then [billing](__CHATWOOT_URL_0__)',
+          input_tokens: 10,
+          output_tokens: 5
+        )
+      end
+
+      it 'keeps each link with its label' do
+        expect(service.perform[:message]).to eq(
+          'Read [support](https://chatwoot.com/support) then [billing](https://chatwoot.com/billing)'
         )
       end
     end
@@ -165,7 +189,11 @@ RSpec.describe Captain::RewriteService do
       let(:content) { 'Read https://chatwoot.com/guide for help' }
 
       it 'returns the original content' do
-        expect(service.perform[:message]).to eq(content)
+        result = service.perform
+
+        expect(result[:message]).to eq(content)
+        expect(result[:follow_up_context][:original_context]).to eq(content)
+        expect(result[:follow_up_context][:last_response]).to eq(content)
       end
     end
   end


### PR DESCRIPTION
## Description

AI Improve can change characters inside a URL while rewriting the surrounding message. One observed response changed `step_by_step` to `step_by-step`, which sent the customer to a missing page.

This change replaces URLs with stable placeholders before editor rewrites and restores them afterward. Each URL keeps its identity if the model reorders links. Chatwoot also stores restored URLs in follow-up context and protects them during later refinements.

If the initial rewrite changes the placeholder set or count, Chatwoot returns the original draft instead of returning a response with uncertain links.

## Type of change

- [x] Bug fix

## How has this been tested?

- `bundle exec rspec spec/lib/captain/rewrite_service_spec.rb spec/lib/captain/follow_up_service_spec.rb`
- `bundle exec rubocop lib/captain/base_task_service.rb lib/captain/url_preserver.rb lib/captain/rewrite_service.rb lib/captain/follow_up_service.rb spec/lib/captain/rewrite_service_spec.rb spec/lib/captain/follow_up_service_spec.rb`

The regression tests cover the observed URL change, multiple reordered links, fallback when a link is removed, and restored links in follow-up history.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self review of my code
- [x] I have added tests that prove the fix is effective
- [x] New and existing focused unit tests pass locally with my changes
