### PR TITLE
docs(campaigns): document campaign creation and scheduling APIs

### DIFF
--- a/swagger/definitions/index.yml
+++ b/swagger/definitions/index.yml
@@ -312,3 +312,12 @@ reporting_event_meta:
   $ref: ./resource/reporting_event_meta.yml
 reporting_events_list_response:
   $ref: ./resource/reporting_events_list_response.yml
+
+campaign:
+  $ref: ./resource/campaign.yml
+campaign_fields:
+  $ref: ./request/campaign/fields.yml
+campaign_create_payload:
+  $ref: ./request/campaign/create.yml
+campaign_update_payload:
+  $ref: ./request/campaign/update.yml

--- a/swagger/definitions/index.yml
+++ b/swagger/definitions/index.yml
@@ -321,3 +321,6 @@ campaign_create_payload:
   $ref: ./request/campaign/create.yml
 campaign_update_payload:
   $ref: ./request/campaign/update.yml
+
+campaign_whatsapp_template_params:
+  $ref: ./request/campaign/whatsapp_template_params.yml

--- a/swagger/definitions/request/campaign/create.yml
+++ b/swagger/definitions/request/campaign/create.yml
@@ -2,7 +2,33 @@ type: object
 required: [campaign]
 properties:
   campaign:
+    description: >-
+      Choose the variant matching the inbox referenced by inbox_id. The channel type
+      is stored on the inbox and cannot be inferred from this request by a schema validator.
+      These variants describe the inputs needed for delivery; creation can accept incomplete
+      inputs without guaranteeing that the campaign will send.
     allOf:
       - $ref: '#/components/schemas/campaign_fields'
       - type: object
         required: [title, inbox_id, message]
+      - anyOf:
+          - title: Website campaign
+            description: For a Website inbox, supply URL trigger rules. An audience is not required.
+            type: object
+            required: [trigger_rules]
+            properties:
+              trigger_rules:
+                type: object
+                required: [url]
+                properties:
+                  url:
+                    type: string
+                    format: uri
+          - title: SMS campaign
+            description: For an SMS or Twilio SMS inbox, supply at least one audience label.
+            type: object
+            required: [audience]
+          - title: WhatsApp campaign
+            description: For a WhatsApp Cloud inbox with campaigns enabled, supply audience labels and template parameters.
+            type: object
+            required: [audience, template_params]

--- a/swagger/definitions/request/campaign/create.yml
+++ b/swagger/definitions/request/campaign/create.yml
@@ -1,0 +1,8 @@
+type: object
+required: [campaign]
+properties:
+  campaign:
+    allOf:
+      - $ref: '#/components/schemas/campaign_fields'
+      - type: object
+        required: [title, inbox_id, message, trigger_rules]

--- a/swagger/definitions/request/campaign/create.yml
+++ b/swagger/definitions/request/campaign/create.yml
@@ -5,4 +5,4 @@ properties:
     allOf:
       - $ref: '#/components/schemas/campaign_fields'
       - type: object
-        required: [title, inbox_id, message, trigger_rules]
+        required: [title, inbox_id, message]

--- a/swagger/definitions/request/campaign/fields.yml
+++ b/swagger/definitions/request/campaign/fields.yml
@@ -38,7 +38,7 @@ properties:
   trigger_rules:
     type: object
     additionalProperties: true
-    description: Website campaign trigger rules. Use an empty object for a one-off campaign.
+    description: Website campaign trigger rules. Defaults to an empty object and can be omitted for a one-off campaign.
     example:
       url: https://example.com/pricing
       time_on_page: 10

--- a/swagger/definitions/request/campaign/fields.yml
+++ b/swagger/definitions/request/campaign/fields.yml
@@ -25,9 +25,11 @@ properties:
     example: '2027-01-15T10:00:00Z'
   audience:
     type: array
-    description: Audience labels for a one-off campaign. Contacts matching any selected label are included.
+    minItems: 1
+    description: Required when creating a one-off SMS or WhatsApp campaign. Provide at least one label from this account. Contacts matching any selected label are included. When updating, omit this field to retain the existing audience.
     items:
       type: object
+      required: [type, id]
       properties:
         type:
           type: string
@@ -46,6 +48,5 @@ properties:
     type: boolean
     description: Restrict an ongoing website campaign to inbox business hours.
   template_params:
-    type: [object, 'null']
-    additionalProperties: true
-    description: Channel-specific template parameters, when applicable.
+    $ref: '#/components/schemas/campaign_whatsapp_template_params'
+    description: Required when creating a WhatsApp campaign. Use a template available in the selected inbox. When updating, omit this field to retain the existing template parameters.

--- a/swagger/definitions/request/campaign/fields.yml
+++ b/swagger/definitions/request/campaign/fields.yml
@@ -1,0 +1,51 @@
+type: object
+properties:
+  title:
+    type: string
+    description: Campaign title.
+  description:
+    type: [string, 'null']
+    description: Internal description of the campaign.
+  inbox_id:
+    type: integer
+    description: ID of an inbox in this account. Supported inbox types are Website, Twilio SMS, SMS, and WhatsApp.
+  sender_id:
+    type: [integer, 'null']
+    description: ID of a user in this account to use as the campaign sender.
+  message:
+    type: string
+    description: Campaign message content.
+  enabled:
+    type: boolean
+    description: Whether an ongoing website campaign is enabled. This does not cancel a scheduled one-off campaign.
+  scheduled_at:
+    type: string
+    format: date-time
+    description: Scheduled time for a one-off campaign, as an ISO 8601 timestamp with timezone. Defaults to the current time when omitted; website campaigns ignore this field. Responses return Unix seconds instead.
+    example: '2027-01-15T10:00:00Z'
+  audience:
+    type: array
+    description: Audience labels for a one-off campaign. Contacts matching any selected label are included.
+    items:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [Label]
+        id:
+          type: integer
+          description: ID of a label in this account.
+  trigger_rules:
+    type: object
+    additionalProperties: true
+    description: Website campaign trigger rules. Use an empty object for a one-off campaign.
+    example:
+      url: https://example.com/pricing
+      time_on_page: 10
+  trigger_only_during_business_hours:
+    type: boolean
+    description: Restrict an ongoing website campaign to inbox business hours.
+  template_params:
+    type: [object, 'null']
+    additionalProperties: true
+    description: Channel-specific template parameters, when applicable.

--- a/swagger/definitions/request/campaign/update.yml
+++ b/swagger/definitions/request/campaign/update.yml
@@ -1,0 +1,6 @@
+type: object
+required: [campaign]
+properties:
+  campaign:
+    allOf:
+      - $ref: '#/components/schemas/campaign_fields'

--- a/swagger/definitions/request/campaign/whatsapp_template_params.yml
+++ b/swagger/definitions/request/campaign/whatsapp_template_params.yml
@@ -1,0 +1,46 @@
+type: object
+required: [name, language]
+properties:
+  name:
+    type: string
+    minLength: 1
+    description: Name of the approved template in the selected inbox's message_templates.
+  language:
+    type: string
+    minLength: 1
+    description: Language code matching that template in the selected inbox.
+    example: en
+  namespace:
+    type: string
+    description: Template namespace, when present in the selected template.
+  category:
+    type: string
+    description: Category of the selected template.
+  processed_params:
+    type: object
+    description: >-
+      Values for the selected template's variables, grouped by component. Supply all
+      parameters needed by that template. May be omitted for a template without variables.
+      Body keys use positional numbers or the template's named parameters. Liquid
+      expressions such as {{ contact.name }} are rendered separately for each recipient.
+    properties:
+      body:
+        type: object
+        additionalProperties:
+          type: string
+      header:
+        type: object
+        additionalProperties: true
+        description: Text parameter values or media_url, media_type, and optional media_name for a media header.
+      footer:
+        type: object
+        additionalProperties:
+          type: string
+      buttons:
+        type: array
+        items:
+          type: object
+          additionalProperties: true
+    example:
+      body:
+        '1': '{{ contact.name }}'

--- a/swagger/definitions/resource/campaign.yml
+++ b/swagger/definitions/resource/campaign.yml
@@ -1,0 +1,61 @@
+type: object
+properties:
+  id:
+    type: integer
+    description: Account-scoped campaign ID. Use this value in campaign API paths.
+  title:
+    type: string
+  description:
+    type: [string, 'null']
+  account_id:
+    type: integer
+  inbox:
+    $ref: '#/components/schemas/inbox'
+  sender:
+    type: object
+    description: Sender details, or an empty object when no sender is assigned.
+    additionalProperties: true
+  message:
+    type: string
+  template_params:
+    type: [object, 'null']
+    additionalProperties: true
+  campaign_status:
+    type: string
+    enum: [active, processing, completed]
+  campaign_type:
+    type: string
+    enum: [ongoing, one_off]
+    description: Derived from the inbox type; website campaigns are ongoing and supported messaging campaigns are one-off.
+  enabled:
+    type: boolean
+  scheduled_at:
+    type: integer
+    description: Scheduled time in Unix seconds. Only present for one-off campaigns.
+  started_at:
+    type: [integer, 'null']
+    description: Start time in Unix seconds. Only present for one-off campaigns.
+  completed_at:
+    type: [integer, 'null']
+    description: Completion time in Unix seconds. Only present for one-off campaigns.
+  audience:
+    type: [array, 'null']
+    description: Audience for a one-off campaign. Only present for one-off campaigns.
+    items:
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: integer
+  trigger_rules:
+    type: object
+    additionalProperties: true
+  trigger_only_during_business_hours:
+    type: boolean
+  created_at:
+    type: string
+    format: date-time
+  updated_at:
+    type: string
+    format: date-time

--- a/swagger/definitions/resource/inbox.yml
+++ b/swagger/definitions/resource/inbox.yml
@@ -7,7 +7,9 @@ properties:
     type: string
     description: The name of the inbox
   website_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: Website URL
   page_id:
     type:
@@ -56,16 +58,22 @@ properties:
     type: string
     description: The avatar image of the inbox
   widget_color:
-    type: string
+    type:
+      - string
+      - 'null'
     description: Widget Color used for customization of the widget
   website_token:
-    type: string
+    type:
+      - string
+      - 'null'
     description: Website Token
   enable_auto_assignment:
     type: boolean
     description: The flag which shows whether Auto Assignment is enabled or not
   web_widget_script:
-    type: string
+    type:
+      - string
+      - 'null'
     description: Script used to load the website widget
   welcome_title:
     type:
@@ -168,7 +176,9 @@ properties:
       - 'null'
     description: Liquid HTML layout for branded email replies. Available to administrators for Email inbox show/update responses.
   hmac_mandatory:
-    type: boolean
+    type:
+      - boolean
+      - 'null'
     description: Whether HMAC verification is mandatory
   selected_feature_flags:
     type:
@@ -178,7 +188,9 @@ properties:
     items:
       type: string
   reply_time:
-    type: string
+    type:
+      - string
+      - 'null'
     description: Expected reply time
   messaging_service_sid:
     type:

--- a/swagger/index.yml
+++ b/swagger/index.yml
@@ -47,6 +47,8 @@ tags:
     description: Account-specific Agent Bots
   - name: Agents
     description: Agent management APIs
+  - name: Campaigns
+    description: Create, schedule, and manage campaigns. Requires an account administrator and API access enabled for the account.
   - name: Canned Responses
     description: Pre-defined responses for common queries
   - name: Contacts
@@ -104,6 +106,7 @@ x-tagGroups:
       - Account
       - Agents
       - Audit Logs
+      - Campaigns
       - Canned Responses
       - Contacts
       - Contact Labels

--- a/swagger/paths/application/campaigns/create.yml
+++ b/swagger/paths/application/campaigns/create.yml
@@ -6,6 +6,7 @@ security:
   - userApiKey: []
 description: >-
   Create a campaign. For a supported messaging inbox, provide scheduled_at to schedule a one-off campaign; omitting it makes the campaign eligible for the next scheduler run. Website campaigns use trigger_rules instead. Channel-specific campaign availability and requirements still apply.
+  One-off campaigns require at least one audience label for delivery. WhatsApp campaigns also require template_params with the selected template name, language, and any variable values. A successful creation response does not confirm delivery.
   Requires an account administrator and API access enabled for the account.
 requestBody:
   required: true
@@ -13,15 +14,46 @@ requestBody:
     application/json:
       schema:
         $ref: '#/components/schemas/campaign_create_payload'
-      example:
-        campaign:
-          title: January announcement
-          inbox_id: 12
-          message: Our January offers are here!
-          scheduled_at: '2027-01-15T10:00:00Z'
-          audience:
-            - type: Label
-              id: 5
+      examples:
+        sms:
+          summary: Schedule an SMS campaign
+          value:
+            campaign:
+              title: January announcement
+              inbox_id: 12
+              message: Our January offers are here!
+              scheduled_at: '2027-01-15T10:00:00Z'
+              audience:
+                - type: Label
+                  id: 5
+        whatsapp:
+          summary: Schedule a WhatsApp campaign using a template with one body variable
+          value:
+            campaign:
+              title: Order update
+              inbox_id: 15
+              message: 'Hello {{ contact.name }}, your order has shipped.'
+              scheduled_at: '2027-01-15T10:00:00Z'
+              audience:
+                - type: Label
+                  id: 5
+              template_params:
+                name: order_shipped
+                language: en
+                processed_params:
+                  body:
+                    '1': '{{ contact.name }}'
+        website:
+          summary: Create an ongoing website campaign
+          value:
+            campaign:
+              title: Pricing help
+              inbox_id: 8
+              sender_id: 3
+              message: Can we help you choose a plan?
+              trigger_rules:
+                url: https://example.com/pricing
+                time_on_page: 10
 responses:
   '200':
     description: Success

--- a/swagger/paths/application/campaigns/create.yml
+++ b/swagger/paths/application/campaigns/create.yml
@@ -22,7 +22,6 @@ requestBody:
           audience:
             - type: Label
               id: 5
-          trigger_rules: {}
 responses:
   '200':
     description: Success
@@ -31,8 +30,8 @@ responses:
         schema:
           $ref: '#/components/schemas/campaign'
   '401':
-    description: Unauthorized
+    description: Authentication failed or the user is not an account administrator
   '403':
-    description: Administrator permissions are required, or API access is disabled for the account
+    description: API access is disabled for the account
   '422':
     description: Campaign validation failed

--- a/swagger/paths/application/campaigns/create.yml
+++ b/swagger/paths/application/campaigns/create.yml
@@ -1,0 +1,38 @@
+tags:
+  - Campaigns
+operationId: create-campaign
+summary: Create a campaign
+security:
+  - userApiKey: []
+description: >-
+  Create a campaign. For a supported messaging inbox, provide scheduled_at to schedule a one-off campaign; omitting it makes the campaign eligible for the next scheduler run. Website campaigns use trigger_rules instead. Channel-specific campaign availability and requirements still apply.
+  Requires an account administrator and API access enabled for the account.
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: '#/components/schemas/campaign_create_payload'
+      example:
+        campaign:
+          title: January announcement
+          inbox_id: 12
+          message: Our January offers are here!
+          scheduled_at: '2027-01-15T10:00:00Z'
+          audience:
+            - type: Label
+              id: 5
+          trigger_rules: {}
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/campaign'
+  '401':
+    description: Unauthorized
+  '403':
+    description: Administrator permissions are required, or API access is disabled for the account
+  '422':
+    description: Campaign validation failed

--- a/swagger/paths/application/campaigns/delete.yml
+++ b/swagger/paths/application/campaigns/delete.yml
@@ -11,6 +11,6 @@ responses:
   '200':
     description: Success
   '401':
-    description: Unauthorized
+    description: Authentication failed or the user is not an account administrator
   '403':
-    description: Administrator permissions are required, or API access is disabled for the account
+    description: API access is disabled for the account

--- a/swagger/paths/application/campaigns/delete.yml
+++ b/swagger/paths/application/campaigns/delete.yml
@@ -1,0 +1,16 @@
+tags:
+  - Campaigns
+operationId: delete-campaign
+summary: Delete a campaign
+security:
+  - userApiKey: []
+description: >-
+  Delete a campaign from the account.
+  Requires an account administrator and API access enabled for the account.
+responses:
+  '200':
+    description: Success
+  '401':
+    description: Unauthorized
+  '403':
+    description: Administrator permissions are required, or API access is disabled for the account

--- a/swagger/paths/application/campaigns/index.yml
+++ b/swagger/paths/application/campaigns/index.yml
@@ -1,0 +1,22 @@
+tags:
+  - Campaigns
+operationId: list-campaigns
+summary: List campaigns
+security:
+  - userApiKey: []
+description: >-
+  List all campaigns in the account. The response is an unpaginated array.
+  Requires an account administrator and API access enabled for the account.
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: '#/components/schemas/campaign'
+  '401':
+    description: Unauthorized
+  '403':
+    description: Administrator permissions are required, or API access is disabled for the account

--- a/swagger/paths/application/campaigns/index.yml
+++ b/swagger/paths/application/campaigns/index.yml
@@ -17,6 +17,6 @@ responses:
           items:
             $ref: '#/components/schemas/campaign'
   '401':
-    description: Unauthorized
+    description: Authentication failed or the user is not an account administrator
   '403':
-    description: Administrator permissions are required, or API access is disabled for the account
+    description: API access is disabled for the account

--- a/swagger/paths/application/campaigns/show.yml
+++ b/swagger/paths/application/campaigns/show.yml
@@ -1,0 +1,20 @@
+tags:
+  - Campaigns
+operationId: get-campaign
+summary: Get a campaign
+security:
+  - userApiKey: []
+description: >-
+  Retrieve a campaign using its account-scoped ID.
+  Requires an account administrator and API access enabled for the account.
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/campaign'
+  '401':
+    description: Unauthorized
+  '403':
+    description: Administrator permissions are required, or API access is disabled for the account

--- a/swagger/paths/application/campaigns/show.yml
+++ b/swagger/paths/application/campaigns/show.yml
@@ -15,6 +15,6 @@ responses:
         schema:
           $ref: '#/components/schemas/campaign'
   '401':
-    description: Unauthorized
+    description: Authentication failed or the user is not an account administrator
   '403':
-    description: Administrator permissions are required, or API access is disabled for the account
+    description: API access is disabled for the account

--- a/swagger/paths/application/campaigns/update.yml
+++ b/swagger/paths/application/campaigns/update.yml
@@ -21,8 +21,8 @@ responses:
         schema:
           $ref: '#/components/schemas/campaign'
   '401':
-    description: Unauthorized
+    description: Authentication failed or the user is not an account administrator
   '403':
-    description: Administrator permissions are required, or API access is disabled for the account
+    description: API access is disabled for the account
   '422':
     description: Campaign validation failed

--- a/swagger/paths/application/campaigns/update.yml
+++ b/swagger/paths/application/campaigns/update.yml
@@ -1,0 +1,28 @@
+tags:
+  - Campaigns
+operationId: update-campaign
+summary: Update a campaign
+security:
+  - userApiKey: []
+description: >-
+  Update campaign fields, including scheduled_at to reschedule an active one-off campaign. Completed campaigns cannot be updated.
+  Requires an account administrator and API access enabled for the account.
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: '#/components/schemas/campaign_update_payload'
+responses:
+  '200':
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/campaign'
+  '401':
+    description: Unauthorized
+  '403':
+    description: Administrator permissions are required, or API access is disabled for the account
+  '422':
+    description: Campaign validation failed

--- a/swagger/paths/index.yml
+++ b/swagger/paths/index.yml
@@ -849,3 +849,27 @@
           application/json:
             schema:
               $ref: '#/components/schemas/conversation_messages'
+
+# Campaigns
+/api/v1/accounts/{account_id}/campaigns:
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+  get:
+    $ref: ./application/campaigns/index.yml
+  post:
+    $ref: ./application/campaigns/create.yml
+/api/v1/accounts/{account_id}/campaigns/{id}:
+  parameters:
+    - $ref: '#/components/parameters/account_id'
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Account-scoped campaign ID returned by the campaign API.
+  get:
+    $ref: ./application/campaigns/show.yml
+  patch:
+    $ref: ./application/campaigns/update.yml
+  delete:
+    $ref: ./application/campaigns/delete.yml

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -9685,10 +9685,10 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Authentication failed or the user is not an account administrator"
           },
           "403": {
-            "description": "Administrator permissions are required, or API access is disabled for the account"
+            "description": "API access is disabled for the account"
           }
         }
       },
@@ -9722,8 +9722,7 @@
                       "type": "Label",
                       "id": 5
                     }
-                  ],
-                  "trigger_rules": {}
+                  ]
                 }
               }
             }
@@ -9741,10 +9740,10 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Authentication failed or the user is not an account administrator"
           },
           "403": {
-            "description": "Administrator permissions are required, or API access is disabled for the account"
+            "description": "API access is disabled for the account"
           },
           "422": {
             "description": "Campaign validation failed"
@@ -9791,10 +9790,10 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Authentication failed or the user is not an account administrator"
           },
           "403": {
-            "description": "Administrator permissions are required, or API access is disabled for the account"
+            "description": "API access is disabled for the account"
           }
         }
       },
@@ -9832,10 +9831,10 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Authentication failed or the user is not an account administrator"
           },
           "403": {
-            "description": "Administrator permissions are required, or API access is disabled for the account"
+            "description": "API access is disabled for the account"
           },
           "422": {
             "description": "Campaign validation failed"
@@ -9859,10 +9858,10 @@
             "description": "Success"
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Authentication failed or the user is not an account administrator"
           },
           "403": {
-            "description": "Administrator permissions are required, or API access is disabled for the account"
+            "description": "API access is disabled for the account"
           }
         }
       }
@@ -16673,7 +16672,7 @@
           "trigger_rules": {
             "type": "object",
             "additionalProperties": true,
-            "description": "Website campaign trigger rules. Use an empty object for a one-off campaign.",
+            "description": "Website campaign trigger rules. Defaults to an empty object and can be omitted for a one-off campaign.",
             "example": {
               "url": "https://example.com/pricing",
               "time_on_page": 10
@@ -16709,8 +16708,7 @@
                 "required": [
                   "title",
                   "inbox_id",
-                  "message",
-                  "trigger_rules"
+                  "message"
                 ]
               }
             ]

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -9651,6 +9651,221 @@
           }
         }
       }
+    },
+    "/api/v1/accounts/{account_id}/campaigns": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        }
+      ],
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "operationId": "list-campaigns",
+        "summary": "List campaigns",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "List all campaigns in the account. The response is an unpaginated array. Requires an account administrator and API access enabled for the account.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/campaign"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Administrator permissions are required, or API access is disabled for the account"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Campaigns"
+        ],
+        "operationId": "create-campaign",
+        "summary": "Create a campaign",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Create a campaign. For a supported messaging inbox, provide scheduled_at to schedule a one-off campaign; omitting it makes the campaign eligible for the next scheduler run. Website campaigns use trigger_rules instead. Channel-specific campaign availability and requirements still apply. Requires an account administrator and API access enabled for the account.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/campaign_create_payload"
+              },
+              "example": {
+                "campaign": {
+                  "title": "January announcement",
+                  "inbox_id": 12,
+                  "message": "Our January offers are here!",
+                  "scheduled_at": "2027-01-15T10:00:00Z",
+                  "audience": [
+                    {
+                      "type": "Label",
+                      "id": 5
+                    }
+                  ],
+                  "trigger_rules": {}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/campaign"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Administrator permissions are required, or API access is disabled for the account"
+          },
+          "422": {
+            "description": "Campaign validation failed"
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/{account_id}/campaigns/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          },
+          "description": "Account-scoped campaign ID returned by the campaign API."
+        }
+      ],
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "operationId": "get-campaign",
+        "summary": "Get a campaign",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Retrieve a campaign using its account-scoped ID. Requires an account administrator and API access enabled for the account.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/campaign"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Administrator permissions are required, or API access is disabled for the account"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Campaigns"
+        ],
+        "operationId": "update-campaign",
+        "summary": "Update a campaign",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Update campaign fields, including scheduled_at to reschedule an active one-off campaign. Completed campaigns cannot be updated. Requires an account administrator and API access enabled for the account.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/campaign_update_payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/campaign"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Administrator permissions are required, or API access is disabled for the account"
+          },
+          "422": {
+            "description": "Campaign validation failed"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Campaigns"
+        ],
+        "operationId": "delete-campaign",
+        "summary": "Delete a campaign",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Delete a campaign from the account. Requires an account administrator and API access enabled for the account.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Administrator permissions are required, or API access is disabled for the account"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -16287,6 +16502,235 @@
             "description": "List of reporting events"
           }
         }
+      },
+      "campaign": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Account-scoped campaign ID. Use this value in campaign API paths."
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "account_id": {
+            "type": "integer"
+          },
+          "inbox": {
+            "$ref": "#/components/schemas/inbox"
+          },
+          "sender": {
+            "type": "object",
+            "description": "Sender details, or an empty object when no sender is assigned.",
+            "additionalProperties": true
+          },
+          "message": {
+            "type": "string"
+          },
+          "template_params": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          },
+          "campaign_status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "processing",
+              "completed"
+            ]
+          },
+          "campaign_type": {
+            "type": "string",
+            "enum": [
+              "ongoing",
+              "one_off"
+            ],
+            "description": "Derived from the inbox type; website campaigns are ongoing and supported messaging campaigns are one-off."
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "scheduled_at": {
+            "type": "integer",
+            "description": "Scheduled time in Unix seconds. Only present for one-off campaigns."
+          },
+          "started_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Start time in Unix seconds. Only present for one-off campaigns."
+          },
+          "completed_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Completion time in Unix seconds. Only present for one-off campaigns."
+          },
+          "audience": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "description": "Audience for a one-off campaign. Only present for one-off campaigns.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "trigger_rules": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "trigger_only_during_business_hours": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "campaign_fields": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Campaign title."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Internal description of the campaign."
+          },
+          "inbox_id": {
+            "type": "integer",
+            "description": "ID of an inbox in this account. Supported inbox types are Website, Twilio SMS, SMS, and WhatsApp."
+          },
+          "sender_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of a user in this account to use as the campaign sender."
+          },
+          "message": {
+            "type": "string",
+            "description": "Campaign message content."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether an ongoing website campaign is enabled. This does not cancel a scheduled one-off campaign."
+          },
+          "scheduled_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Scheduled time for a one-off campaign, as an ISO 8601 timestamp with timezone. Defaults to the current time when omitted; website campaigns ignore this field. Responses return Unix seconds instead.",
+            "example": "2027-01-15T10:00:00Z"
+          },
+          "audience": {
+            "type": "array",
+            "description": "Audience labels for a one-off campaign. Contacts matching any selected label are included.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Label"
+                  ]
+                },
+                "id": {
+                  "type": "integer",
+                  "description": "ID of a label in this account."
+                }
+              }
+            }
+          },
+          "trigger_rules": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Website campaign trigger rules. Use an empty object for a one-off campaign.",
+            "example": {
+              "url": "https://example.com/pricing",
+              "time_on_page": 10
+            }
+          },
+          "trigger_only_during_business_hours": {
+            "type": "boolean",
+            "description": "Restrict an ongoing website campaign to inbox business hours."
+          },
+          "template_params": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true,
+            "description": "Channel-specific template parameters, when applicable."
+          }
+        }
+      },
+      "campaign_create_payload": {
+        "type": "object",
+        "required": [
+          "campaign"
+        ],
+        "properties": {
+          "campaign": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/campaign_fields"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "title",
+                  "inbox_id",
+                  "message",
+                  "trigger_rules"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "campaign_update_payload": {
+        "type": "object",
+        "required": [
+          "campaign"
+        ],
+        "properties": {
+          "campaign": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/campaign_fields"
+              }
+            ]
+          }
+        }
       }
     },
     "parameters": {
@@ -16535,6 +16979,10 @@
       "description": "Agent management APIs"
     },
     {
+      "name": "Campaigns",
+      "description": "Create, schedule, and manage campaigns. Requires an account administrator and API access enabled for the account."
+    },
+    {
       "name": "Canned Responses",
       "description": "Pre-defined responses for common queries"
     },
@@ -16640,6 +17088,7 @@
         "Account",
         "Agents",
         "Audit Logs",
+        "Campaigns",
         "Canned Responses",
         "Contacts",
         "Contact Labels",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -10965,7 +10965,10 @@
             "description": "The name of the inbox"
           },
           "website_url": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Website URL"
           },
           "page_id": {
@@ -11033,11 +11036,17 @@
             "description": "The avatar image of the inbox"
           },
           "widget_color": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Widget Color used for customization of the widget"
           },
           "website_token": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Website Token"
           },
           "enable_auto_assignment": {
@@ -11045,7 +11054,10 @@
             "description": "The flag which shows whether Auto Assignment is enabled or not"
           },
           "web_widget_script": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Script used to load the website widget"
           },
           "welcome_title": {
@@ -11187,7 +11199,10 @@
             "description": "Liquid HTML layout for branded email replies. Available to administrators for Email inbox show/update responses."
           },
           "hmac_mandatory": {
-            "type": "boolean",
+            "type": [
+              "boolean",
+              "null"
+            ],
             "description": "Whether HMAC verification is mandatory"
           },
           "selected_feature_flags": {
@@ -11201,7 +11216,10 @@
             }
           },
           "reply_time": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Expected reply time"
           },
           "messaging_service_sid": {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -9703,7 +9703,7 @@
             "userApiKey": []
           }
         ],
-        "description": "Create a campaign. For a supported messaging inbox, provide scheduled_at to schedule a one-off campaign; omitting it makes the campaign eligible for the next scheduler run. Website campaigns use trigger_rules instead. Channel-specific campaign availability and requirements still apply. Requires an account administrator and API access enabled for the account.",
+        "description": "Create a campaign. For a supported messaging inbox, provide scheduled_at to schedule a one-off campaign; omitting it makes the campaign eligible for the next scheduler run. Website campaigns use trigger_rules instead. Channel-specific campaign availability and requirements still apply. One-off campaigns require at least one audience label for delivery. WhatsApp campaigns also require template_params with the selected template name, language, and any variable values. A successful creation response does not confirm delivery. Requires an account administrator and API access enabled for the account.",
         "requestBody": {
           "required": true,
           "content": {
@@ -9711,18 +9711,64 @@
               "schema": {
                 "$ref": "#/components/schemas/campaign_create_payload"
               },
-              "example": {
-                "campaign": {
-                  "title": "January announcement",
-                  "inbox_id": 12,
-                  "message": "Our January offers are here!",
-                  "scheduled_at": "2027-01-15T10:00:00Z",
-                  "audience": [
-                    {
-                      "type": "Label",
-                      "id": 5
+              "examples": {
+                "sms": {
+                  "summary": "Schedule an SMS campaign",
+                  "value": {
+                    "campaign": {
+                      "title": "January announcement",
+                      "inbox_id": 12,
+                      "message": "Our January offers are here!",
+                      "scheduled_at": "2027-01-15T10:00:00Z",
+                      "audience": [
+                        {
+                          "type": "Label",
+                          "id": 5
+                        }
+                      ]
                     }
-                  ]
+                  }
+                },
+                "whatsapp": {
+                  "summary": "Schedule a WhatsApp campaign using a template with one body variable",
+                  "value": {
+                    "campaign": {
+                      "title": "Order update",
+                      "inbox_id": 15,
+                      "message": "Hello {{ contact.name }}, your order has shipped.",
+                      "scheduled_at": "2027-01-15T10:00:00Z",
+                      "audience": [
+                        {
+                          "type": "Label",
+                          "id": 5
+                        }
+                      ],
+                      "template_params": {
+                        "name": "order_shipped",
+                        "language": "en",
+                        "processed_params": {
+                          "body": {
+                            "1": "{{ contact.name }}"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "website": {
+                  "summary": "Create an ongoing website campaign",
+                  "value": {
+                    "campaign": {
+                      "title": "Pricing help",
+                      "inbox_id": 8,
+                      "sender_id": 3,
+                      "message": "Can we help you choose a plan?",
+                      "trigger_rules": {
+                        "url": "https://example.com/pricing",
+                        "time_on_page": 10
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -16670,9 +16716,14 @@
           },
           "audience": {
             "type": "array",
-            "description": "Audience labels for a one-off campaign. Contacts matching any selected label are included.",
+            "minItems": 1,
+            "description": "Required when creating a one-off SMS or WhatsApp campaign. Provide at least one label from this account. Contacts matching any selected label are included. When updating, omit this field to retain the existing audience.",
             "items": {
               "type": "object",
+              "required": [
+                "type",
+                "id"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
@@ -16701,12 +16752,7 @@
             "description": "Restrict an ongoing website campaign to inbox business hours."
           },
           "template_params": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "additionalProperties": true,
-            "description": "Channel-specific template parameters, when applicable."
+            "$ref": "#/components/schemas/campaign_whatsapp_template_params"
           }
         }
       },
@@ -16717,6 +16763,7 @@
         ],
         "properties": {
           "campaign": {
+            "description": "Choose the variant matching the inbox referenced by inbox_id. The channel type is stored on the inbox and cannot be inferred from this request by a schema validator. These variants describe the inputs needed for delivery; creation can accept incomplete inputs without guaranteeing that the campaign will send.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/campaign_fields"
@@ -16727,6 +16774,49 @@
                   "title",
                   "inbox_id",
                   "message"
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "title": "Website campaign",
+                    "description": "For a Website inbox, supply URL trigger rules. An audience is not required.",
+                    "type": "object",
+                    "required": [
+                      "trigger_rules"
+                    ],
+                    "properties": {
+                      "trigger_rules": {
+                        "type": "object",
+                        "required": [
+                          "url"
+                        ],
+                        "properties": {
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "SMS campaign",
+                    "description": "For an SMS or Twilio SMS inbox, supply at least one audience label.",
+                    "type": "object",
+                    "required": [
+                      "audience"
+                    ]
+                  },
+                  {
+                    "title": "WhatsApp campaign",
+                    "description": "For a WhatsApp Cloud inbox with campaigns enabled, supply audience labels and template parameters.",
+                    "type": "object",
+                    "required": [
+                      "audience",
+                      "template_params"
+                    ]
+                  }
                 ]
               }
             ]
@@ -16745,6 +16835,69 @@
                 "$ref": "#/components/schemas/campaign_fields"
               }
             ]
+          }
+        }
+      },
+      "campaign_whatsapp_template_params": {
+        "type": "object",
+        "required": [
+          "name",
+          "language"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the approved template in the selected inbox's message_templates."
+          },
+          "language": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Language code matching that template in the selected inbox.",
+            "example": "en"
+          },
+          "namespace": {
+            "type": "string",
+            "description": "Template namespace, when present in the selected template."
+          },
+          "category": {
+            "type": "string",
+            "description": "Category of the selected template."
+          },
+          "processed_params": {
+            "type": "object",
+            "description": "Values for the selected template's variables, grouped by component. Supply all parameters needed by that template. May be omitted for a template without variables. Body keys use positional numbers or the template's named parameters. Liquid expressions such as {{ contact.name }} are rendered separately for each recipient.",
+            "properties": {
+              "body": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "header": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Text parameter values or media_url, media_type, and optional media_name for a media header."
+              },
+              "footer": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "example": {
+              "body": {
+                "1": "{{ contact.name }}"
+              }
+            }
           }
         }
       }

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -8192,10 +8192,10 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Authentication failed or the user is not an account administrator"
           },
           "403": {
-            "description": "Administrator permissions are required, or API access is disabled for the account"
+            "description": "API access is disabled for the account"
           }
         }
       },
@@ -8229,8 +8229,7 @@
                       "type": "Label",
                       "id": 5
                     }
-                  ],
-                  "trigger_rules": {}
+                  ]
                 }
               }
             }
@@ -8248,10 +8247,10 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Authentication failed or the user is not an account administrator"
           },
           "403": {
-            "description": "Administrator permissions are required, or API access is disabled for the account"
+            "description": "API access is disabled for the account"
           },
           "422": {
             "description": "Campaign validation failed"
@@ -8298,10 +8297,10 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Authentication failed or the user is not an account administrator"
           },
           "403": {
-            "description": "Administrator permissions are required, or API access is disabled for the account"
+            "description": "API access is disabled for the account"
           }
         }
       },
@@ -8339,10 +8338,10 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Authentication failed or the user is not an account administrator"
           },
           "403": {
-            "description": "Administrator permissions are required, or API access is disabled for the account"
+            "description": "API access is disabled for the account"
           },
           "422": {
             "description": "Campaign validation failed"
@@ -8366,10 +8365,10 @@
             "description": "Success"
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Authentication failed or the user is not an account administrator"
           },
           "403": {
-            "description": "Administrator permissions are required, or API access is disabled for the account"
+            "description": "API access is disabled for the account"
           }
         }
       }
@@ -15170,7 +15169,7 @@
           "trigger_rules": {
             "type": "object",
             "additionalProperties": true,
-            "description": "Website campaign trigger rules. Use an empty object for a one-off campaign.",
+            "description": "Website campaign trigger rules. Defaults to an empty object and can be omitted for a one-off campaign.",
             "example": {
               "url": "https://example.com/pricing",
               "time_on_page": 10
@@ -15206,8 +15205,7 @@
                 "required": [
                   "title",
                   "inbox_id",
-                  "message",
-                  "trigger_rules"
+                  "message"
                 ]
               }
             ]

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -8158,6 +8158,221 @@
           }
         }
       }
+    },
+    "/api/v1/accounts/{account_id}/campaigns": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        }
+      ],
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "operationId": "list-campaigns",
+        "summary": "List campaigns",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "List all campaigns in the account. The response is an unpaginated array. Requires an account administrator and API access enabled for the account.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/campaign"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Administrator permissions are required, or API access is disabled for the account"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Campaigns"
+        ],
+        "operationId": "create-campaign",
+        "summary": "Create a campaign",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Create a campaign. For a supported messaging inbox, provide scheduled_at to schedule a one-off campaign; omitting it makes the campaign eligible for the next scheduler run. Website campaigns use trigger_rules instead. Channel-specific campaign availability and requirements still apply. Requires an account administrator and API access enabled for the account.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/campaign_create_payload"
+              },
+              "example": {
+                "campaign": {
+                  "title": "January announcement",
+                  "inbox_id": 12,
+                  "message": "Our January offers are here!",
+                  "scheduled_at": "2027-01-15T10:00:00Z",
+                  "audience": [
+                    {
+                      "type": "Label",
+                      "id": 5
+                    }
+                  ],
+                  "trigger_rules": {}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/campaign"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Administrator permissions are required, or API access is disabled for the account"
+          },
+          "422": {
+            "description": "Campaign validation failed"
+          }
+        }
+      }
+    },
+    "/api/v1/accounts/{account_id}/campaigns/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/account_id"
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          },
+          "description": "Account-scoped campaign ID returned by the campaign API."
+        }
+      ],
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "operationId": "get-campaign",
+        "summary": "Get a campaign",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Retrieve a campaign using its account-scoped ID. Requires an account administrator and API access enabled for the account.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/campaign"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Administrator permissions are required, or API access is disabled for the account"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Campaigns"
+        ],
+        "operationId": "update-campaign",
+        "summary": "Update a campaign",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Update campaign fields, including scheduled_at to reschedule an active one-off campaign. Completed campaigns cannot be updated. Requires an account administrator and API access enabled for the account.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/campaign_update_payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/campaign"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Administrator permissions are required, or API access is disabled for the account"
+          },
+          "422": {
+            "description": "Campaign validation failed"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Campaigns"
+        ],
+        "operationId": "delete-campaign",
+        "summary": "Delete a campaign",
+        "security": [
+          {
+            "userApiKey": []
+          }
+        ],
+        "description": "Delete a campaign from the account. Requires an account administrator and API access enabled for the account.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Administrator permissions are required, or API access is disabled for the account"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -14784,6 +14999,235 @@
             "description": "List of reporting events"
           }
         }
+      },
+      "campaign": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Account-scoped campaign ID. Use this value in campaign API paths."
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "account_id": {
+            "type": "integer"
+          },
+          "inbox": {
+            "$ref": "#/components/schemas/inbox"
+          },
+          "sender": {
+            "type": "object",
+            "description": "Sender details, or an empty object when no sender is assigned.",
+            "additionalProperties": true
+          },
+          "message": {
+            "type": "string"
+          },
+          "template_params": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          },
+          "campaign_status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "processing",
+              "completed"
+            ]
+          },
+          "campaign_type": {
+            "type": "string",
+            "enum": [
+              "ongoing",
+              "one_off"
+            ],
+            "description": "Derived from the inbox type; website campaigns are ongoing and supported messaging campaigns are one-off."
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "scheduled_at": {
+            "type": "integer",
+            "description": "Scheduled time in Unix seconds. Only present for one-off campaigns."
+          },
+          "started_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Start time in Unix seconds. Only present for one-off campaigns."
+          },
+          "completed_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Completion time in Unix seconds. Only present for one-off campaigns."
+          },
+          "audience": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "description": "Audience for a one-off campaign. Only present for one-off campaigns.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "trigger_rules": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "trigger_only_during_business_hours": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "campaign_fields": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Campaign title."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Internal description of the campaign."
+          },
+          "inbox_id": {
+            "type": "integer",
+            "description": "ID of an inbox in this account. Supported inbox types are Website, Twilio SMS, SMS, and WhatsApp."
+          },
+          "sender_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of a user in this account to use as the campaign sender."
+          },
+          "message": {
+            "type": "string",
+            "description": "Campaign message content."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether an ongoing website campaign is enabled. This does not cancel a scheduled one-off campaign."
+          },
+          "scheduled_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Scheduled time for a one-off campaign, as an ISO 8601 timestamp with timezone. Defaults to the current time when omitted; website campaigns ignore this field. Responses return Unix seconds instead.",
+            "example": "2027-01-15T10:00:00Z"
+          },
+          "audience": {
+            "type": "array",
+            "description": "Audience labels for a one-off campaign. Contacts matching any selected label are included.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Label"
+                  ]
+                },
+                "id": {
+                  "type": "integer",
+                  "description": "ID of a label in this account."
+                }
+              }
+            }
+          },
+          "trigger_rules": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Website campaign trigger rules. Use an empty object for a one-off campaign.",
+            "example": {
+              "url": "https://example.com/pricing",
+              "time_on_page": 10
+            }
+          },
+          "trigger_only_during_business_hours": {
+            "type": "boolean",
+            "description": "Restrict an ongoing website campaign to inbox business hours."
+          },
+          "template_params": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true,
+            "description": "Channel-specific template parameters, when applicable."
+          }
+        }
+      },
+      "campaign_create_payload": {
+        "type": "object",
+        "required": [
+          "campaign"
+        ],
+        "properties": {
+          "campaign": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/campaign_fields"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "title",
+                  "inbox_id",
+                  "message",
+                  "trigger_rules"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "campaign_update_payload": {
+        "type": "object",
+        "required": [
+          "campaign"
+        ],
+        "properties": {
+          "campaign": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/campaign_fields"
+              }
+            ]
+          }
+        }
       }
     },
     "parameters": {
@@ -15016,6 +15460,10 @@
       "description": "Agent management APIs"
     },
     {
+      "name": "Campaigns",
+      "description": "Create, schedule, and manage campaigns. Requires an account administrator and API access enabled for the account."
+    },
+    {
       "name": "Canned Responses",
       "description": "Pre-defined responses for common queries"
     },
@@ -15105,6 +15553,7 @@
         "Account",
         "Agents",
         "Audit Logs",
+        "Campaigns",
         "Canned Responses",
         "Contacts",
         "Contact Labels",

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -9472,7 +9472,10 @@
             "description": "The name of the inbox"
           },
           "website_url": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Website URL"
           },
           "page_id": {
@@ -9540,11 +9543,17 @@
             "description": "The avatar image of the inbox"
           },
           "widget_color": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Widget Color used for customization of the widget"
           },
           "website_token": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Website Token"
           },
           "enable_auto_assignment": {
@@ -9552,7 +9561,10 @@
             "description": "The flag which shows whether Auto Assignment is enabled or not"
           },
           "web_widget_script": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Script used to load the website widget"
           },
           "welcome_title": {
@@ -9694,7 +9706,10 @@
             "description": "Liquid HTML layout for branded email replies. Available to administrators for Email inbox show/update responses."
           },
           "hmac_mandatory": {
-            "type": "boolean",
+            "type": [
+              "boolean",
+              "null"
+            ],
             "description": "Whether HMAC verification is mandatory"
           },
           "selected_feature_flags": {
@@ -9708,7 +9723,10 @@
             }
           },
           "reply_time": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Expected reply time"
           },
           "messaging_service_sid": {

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -8210,7 +8210,7 @@
             "userApiKey": []
           }
         ],
-        "description": "Create a campaign. For a supported messaging inbox, provide scheduled_at to schedule a one-off campaign; omitting it makes the campaign eligible for the next scheduler run. Website campaigns use trigger_rules instead. Channel-specific campaign availability and requirements still apply. Requires an account administrator and API access enabled for the account.",
+        "description": "Create a campaign. For a supported messaging inbox, provide scheduled_at to schedule a one-off campaign; omitting it makes the campaign eligible for the next scheduler run. Website campaigns use trigger_rules instead. Channel-specific campaign availability and requirements still apply. One-off campaigns require at least one audience label for delivery. WhatsApp campaigns also require template_params with the selected template name, language, and any variable values. A successful creation response does not confirm delivery. Requires an account administrator and API access enabled for the account.",
         "requestBody": {
           "required": true,
           "content": {
@@ -8218,18 +8218,64 @@
               "schema": {
                 "$ref": "#/components/schemas/campaign_create_payload"
               },
-              "example": {
-                "campaign": {
-                  "title": "January announcement",
-                  "inbox_id": 12,
-                  "message": "Our January offers are here!",
-                  "scheduled_at": "2027-01-15T10:00:00Z",
-                  "audience": [
-                    {
-                      "type": "Label",
-                      "id": 5
+              "examples": {
+                "sms": {
+                  "summary": "Schedule an SMS campaign",
+                  "value": {
+                    "campaign": {
+                      "title": "January announcement",
+                      "inbox_id": 12,
+                      "message": "Our January offers are here!",
+                      "scheduled_at": "2027-01-15T10:00:00Z",
+                      "audience": [
+                        {
+                          "type": "Label",
+                          "id": 5
+                        }
+                      ]
                     }
-                  ]
+                  }
+                },
+                "whatsapp": {
+                  "summary": "Schedule a WhatsApp campaign using a template with one body variable",
+                  "value": {
+                    "campaign": {
+                      "title": "Order update",
+                      "inbox_id": 15,
+                      "message": "Hello {{ contact.name }}, your order has shipped.",
+                      "scheduled_at": "2027-01-15T10:00:00Z",
+                      "audience": [
+                        {
+                          "type": "Label",
+                          "id": 5
+                        }
+                      ],
+                      "template_params": {
+                        "name": "order_shipped",
+                        "language": "en",
+                        "processed_params": {
+                          "body": {
+                            "1": "{{ contact.name }}"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "website": {
+                  "summary": "Create an ongoing website campaign",
+                  "value": {
+                    "campaign": {
+                      "title": "Pricing help",
+                      "inbox_id": 8,
+                      "sender_id": 3,
+                      "message": "Can we help you choose a plan?",
+                      "trigger_rules": {
+                        "url": "https://example.com/pricing",
+                        "time_on_page": 10
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -15167,9 +15213,14 @@
           },
           "audience": {
             "type": "array",
-            "description": "Audience labels for a one-off campaign. Contacts matching any selected label are included.",
+            "minItems": 1,
+            "description": "Required when creating a one-off SMS or WhatsApp campaign. Provide at least one label from this account. Contacts matching any selected label are included. When updating, omit this field to retain the existing audience.",
             "items": {
               "type": "object",
+              "required": [
+                "type",
+                "id"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
@@ -15198,12 +15249,7 @@
             "description": "Restrict an ongoing website campaign to inbox business hours."
           },
           "template_params": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "additionalProperties": true,
-            "description": "Channel-specific template parameters, when applicable."
+            "$ref": "#/components/schemas/campaign_whatsapp_template_params"
           }
         }
       },
@@ -15214,6 +15260,7 @@
         ],
         "properties": {
           "campaign": {
+            "description": "Choose the variant matching the inbox referenced by inbox_id. The channel type is stored on the inbox and cannot be inferred from this request by a schema validator. These variants describe the inputs needed for delivery; creation can accept incomplete inputs without guaranteeing that the campaign will send.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/campaign_fields"
@@ -15224,6 +15271,49 @@
                   "title",
                   "inbox_id",
                   "message"
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "title": "Website campaign",
+                    "description": "For a Website inbox, supply URL trigger rules. An audience is not required.",
+                    "type": "object",
+                    "required": [
+                      "trigger_rules"
+                    ],
+                    "properties": {
+                      "trigger_rules": {
+                        "type": "object",
+                        "required": [
+                          "url"
+                        ],
+                        "properties": {
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "SMS campaign",
+                    "description": "For an SMS or Twilio SMS inbox, supply at least one audience label.",
+                    "type": "object",
+                    "required": [
+                      "audience"
+                    ]
+                  },
+                  {
+                    "title": "WhatsApp campaign",
+                    "description": "For a WhatsApp Cloud inbox with campaigns enabled, supply audience labels and template parameters.",
+                    "type": "object",
+                    "required": [
+                      "audience",
+                      "template_params"
+                    ]
+                  }
                 ]
               }
             ]
@@ -15242,6 +15332,69 @@
                 "$ref": "#/components/schemas/campaign_fields"
               }
             ]
+          }
+        }
+      },
+      "campaign_whatsapp_template_params": {
+        "type": "object",
+        "required": [
+          "name",
+          "language"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the approved template in the selected inbox's message_templates."
+          },
+          "language": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Language code matching that template in the selected inbox.",
+            "example": "en"
+          },
+          "namespace": {
+            "type": "string",
+            "description": "Template namespace, when present in the selected template."
+          },
+          "category": {
+            "type": "string",
+            "description": "Category of the selected template."
+          },
+          "processed_params": {
+            "type": "object",
+            "description": "Values for the selected template's variables, grouped by component. Supply all parameters needed by that template. May be omitted for a template without variables. Body keys use positional numbers or the template's named parameters. Liquid expressions such as {{ contact.name }} are rendered separately for each recipient.",
+            "properties": {
+              "body": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "header": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Text parameter values or media_url, media_type, and optional media_name for a media header."
+              },
+              "footer": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "example": {
+              "body": {
+                "1": "{{ contact.name }}"
+              }
+            }
           }
         }
       }

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -1724,7 +1724,10 @@
             "description": "The name of the inbox"
           },
           "website_url": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Website URL"
           },
           "page_id": {
@@ -1792,11 +1795,17 @@
             "description": "The avatar image of the inbox"
           },
           "widget_color": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Widget Color used for customization of the widget"
           },
           "website_token": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Website Token"
           },
           "enable_auto_assignment": {
@@ -1804,7 +1813,10 @@
             "description": "The flag which shows whether Auto Assignment is enabled or not"
           },
           "web_widget_script": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Script used to load the website widget"
           },
           "welcome_title": {
@@ -1946,7 +1958,10 @@
             "description": "Liquid HTML layout for branded email replies. Available to administrators for Email inbox show/update responses."
           },
           "hmac_mandatory": {
-            "type": "boolean",
+            "type": [
+              "boolean",
+              "null"
+            ],
             "description": "Whether HMAC verification is mandatory"
           },
           "selected_feature_flags": {
@@ -1960,7 +1975,10 @@
             }
           },
           "reply_time": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Expected reply time"
           },
           "messaging_service_sid": {

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -7421,7 +7421,7 @@
           "trigger_rules": {
             "type": "object",
             "additionalProperties": true,
-            "description": "Website campaign trigger rules. Use an empty object for a one-off campaign.",
+            "description": "Website campaign trigger rules. Defaults to an empty object and can be omitted for a one-off campaign.",
             "example": {
               "url": "https://example.com/pricing",
               "time_on_page": 10
@@ -7457,8 +7457,7 @@
                 "required": [
                   "title",
                   "inbox_id",
-                  "message",
-                  "trigger_rules"
+                  "message"
                 ]
               }
             ]

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -7250,6 +7250,235 @@
             "description": "List of reporting events"
           }
         }
+      },
+      "campaign": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Account-scoped campaign ID. Use this value in campaign API paths."
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "account_id": {
+            "type": "integer"
+          },
+          "inbox": {
+            "$ref": "#/components/schemas/inbox"
+          },
+          "sender": {
+            "type": "object",
+            "description": "Sender details, or an empty object when no sender is assigned.",
+            "additionalProperties": true
+          },
+          "message": {
+            "type": "string"
+          },
+          "template_params": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          },
+          "campaign_status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "processing",
+              "completed"
+            ]
+          },
+          "campaign_type": {
+            "type": "string",
+            "enum": [
+              "ongoing",
+              "one_off"
+            ],
+            "description": "Derived from the inbox type; website campaigns are ongoing and supported messaging campaigns are one-off."
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "scheduled_at": {
+            "type": "integer",
+            "description": "Scheduled time in Unix seconds. Only present for one-off campaigns."
+          },
+          "started_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Start time in Unix seconds. Only present for one-off campaigns."
+          },
+          "completed_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Completion time in Unix seconds. Only present for one-off campaigns."
+          },
+          "audience": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "description": "Audience for a one-off campaign. Only present for one-off campaigns.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "trigger_rules": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "trigger_only_during_business_hours": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "campaign_fields": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Campaign title."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Internal description of the campaign."
+          },
+          "inbox_id": {
+            "type": "integer",
+            "description": "ID of an inbox in this account. Supported inbox types are Website, Twilio SMS, SMS, and WhatsApp."
+          },
+          "sender_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of a user in this account to use as the campaign sender."
+          },
+          "message": {
+            "type": "string",
+            "description": "Campaign message content."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether an ongoing website campaign is enabled. This does not cancel a scheduled one-off campaign."
+          },
+          "scheduled_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Scheduled time for a one-off campaign, as an ISO 8601 timestamp with timezone. Defaults to the current time when omitted; website campaigns ignore this field. Responses return Unix seconds instead.",
+            "example": "2027-01-15T10:00:00Z"
+          },
+          "audience": {
+            "type": "array",
+            "description": "Audience labels for a one-off campaign. Contacts matching any selected label are included.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Label"
+                  ]
+                },
+                "id": {
+                  "type": "integer",
+                  "description": "ID of a label in this account."
+                }
+              }
+            }
+          },
+          "trigger_rules": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Website campaign trigger rules. Use an empty object for a one-off campaign.",
+            "example": {
+              "url": "https://example.com/pricing",
+              "time_on_page": 10
+            }
+          },
+          "trigger_only_during_business_hours": {
+            "type": "boolean",
+            "description": "Restrict an ongoing website campaign to inbox business hours."
+          },
+          "template_params": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true,
+            "description": "Channel-specific template parameters, when applicable."
+          }
+        }
+      },
+      "campaign_create_payload": {
+        "type": "object",
+        "required": [
+          "campaign"
+        ],
+        "properties": {
+          "campaign": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/campaign_fields"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "title",
+                  "inbox_id",
+                  "message",
+                  "trigger_rules"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "campaign_update_payload": {
+        "type": "object",
+        "required": [
+          "campaign"
+        ],
+        "properties": {
+          "campaign": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/campaign_fields"
+              }
+            ]
+          }
+        }
       }
     },
     "parameters": {
@@ -7503,6 +7732,7 @@
         "Account",
         "Agents",
         "Audit Logs",
+        "Campaigns",
         "Canned Responses",
         "Contacts",
         "Contact Labels",

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -7419,9 +7419,14 @@
           },
           "audience": {
             "type": "array",
-            "description": "Audience labels for a one-off campaign. Contacts matching any selected label are included.",
+            "minItems": 1,
+            "description": "Required when creating a one-off SMS or WhatsApp campaign. Provide at least one label from this account. Contacts matching any selected label are included. When updating, omit this field to retain the existing audience.",
             "items": {
               "type": "object",
+              "required": [
+                "type",
+                "id"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
@@ -7450,12 +7455,7 @@
             "description": "Restrict an ongoing website campaign to inbox business hours."
           },
           "template_params": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "additionalProperties": true,
-            "description": "Channel-specific template parameters, when applicable."
+            "$ref": "#/components/schemas/campaign_whatsapp_template_params"
           }
         }
       },
@@ -7466,6 +7466,7 @@
         ],
         "properties": {
           "campaign": {
+            "description": "Choose the variant matching the inbox referenced by inbox_id. The channel type is stored on the inbox and cannot be inferred from this request by a schema validator. These variants describe the inputs needed for delivery; creation can accept incomplete inputs without guaranteeing that the campaign will send.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/campaign_fields"
@@ -7476,6 +7477,49 @@
                   "title",
                   "inbox_id",
                   "message"
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "title": "Website campaign",
+                    "description": "For a Website inbox, supply URL trigger rules. An audience is not required.",
+                    "type": "object",
+                    "required": [
+                      "trigger_rules"
+                    ],
+                    "properties": {
+                      "trigger_rules": {
+                        "type": "object",
+                        "required": [
+                          "url"
+                        ],
+                        "properties": {
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "SMS campaign",
+                    "description": "For an SMS or Twilio SMS inbox, supply at least one audience label.",
+                    "type": "object",
+                    "required": [
+                      "audience"
+                    ]
+                  },
+                  {
+                    "title": "WhatsApp campaign",
+                    "description": "For a WhatsApp Cloud inbox with campaigns enabled, supply audience labels and template parameters.",
+                    "type": "object",
+                    "required": [
+                      "audience",
+                      "template_params"
+                    ]
+                  }
                 ]
               }
             ]
@@ -7494,6 +7538,69 @@
                 "$ref": "#/components/schemas/campaign_fields"
               }
             ]
+          }
+        }
+      },
+      "campaign_whatsapp_template_params": {
+        "type": "object",
+        "required": [
+          "name",
+          "language"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the approved template in the selected inbox's message_templates."
+          },
+          "language": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Language code matching that template in the selected inbox.",
+            "example": "en"
+          },
+          "namespace": {
+            "type": "string",
+            "description": "Template namespace, when present in the selected template."
+          },
+          "category": {
+            "type": "string",
+            "description": "Category of the selected template."
+          },
+          "processed_params": {
+            "type": "object",
+            "description": "Values for the selected template's variables, grouped by component. Supply all parameters needed by that template. May be omitted for a template without variables. Body keys use positional numbers or the template's named parameters. Liquid expressions such as {{ contact.name }} are rendered separately for each recipient.",
+            "properties": {
+              "body": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "header": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Text parameter values or media_url, media_type, and optional media_name for a media header."
+              },
+              "footer": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "example": {
+              "body": {
+                "1": "{{ contact.name }}"
+              }
+            }
           }
         }
       }

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -6665,6 +6665,235 @@
             "description": "List of reporting events"
           }
         }
+      },
+      "campaign": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Account-scoped campaign ID. Use this value in campaign API paths."
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "account_id": {
+            "type": "integer"
+          },
+          "inbox": {
+            "$ref": "#/components/schemas/inbox"
+          },
+          "sender": {
+            "type": "object",
+            "description": "Sender details, or an empty object when no sender is assigned.",
+            "additionalProperties": true
+          },
+          "message": {
+            "type": "string"
+          },
+          "template_params": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          },
+          "campaign_status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "processing",
+              "completed"
+            ]
+          },
+          "campaign_type": {
+            "type": "string",
+            "enum": [
+              "ongoing",
+              "one_off"
+            ],
+            "description": "Derived from the inbox type; website campaigns are ongoing and supported messaging campaigns are one-off."
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "scheduled_at": {
+            "type": "integer",
+            "description": "Scheduled time in Unix seconds. Only present for one-off campaigns."
+          },
+          "started_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Start time in Unix seconds. Only present for one-off campaigns."
+          },
+          "completed_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Completion time in Unix seconds. Only present for one-off campaigns."
+          },
+          "audience": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "description": "Audience for a one-off campaign. Only present for one-off campaigns.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "trigger_rules": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "trigger_only_during_business_hours": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "campaign_fields": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Campaign title."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Internal description of the campaign."
+          },
+          "inbox_id": {
+            "type": "integer",
+            "description": "ID of an inbox in this account. Supported inbox types are Website, Twilio SMS, SMS, and WhatsApp."
+          },
+          "sender_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of a user in this account to use as the campaign sender."
+          },
+          "message": {
+            "type": "string",
+            "description": "Campaign message content."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether an ongoing website campaign is enabled. This does not cancel a scheduled one-off campaign."
+          },
+          "scheduled_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Scheduled time for a one-off campaign, as an ISO 8601 timestamp with timezone. Defaults to the current time when omitted; website campaigns ignore this field. Responses return Unix seconds instead.",
+            "example": "2027-01-15T10:00:00Z"
+          },
+          "audience": {
+            "type": "array",
+            "description": "Audience labels for a one-off campaign. Contacts matching any selected label are included.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Label"
+                  ]
+                },
+                "id": {
+                  "type": "integer",
+                  "description": "ID of a label in this account."
+                }
+              }
+            }
+          },
+          "trigger_rules": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Website campaign trigger rules. Use an empty object for a one-off campaign.",
+            "example": {
+              "url": "https://example.com/pricing",
+              "time_on_page": 10
+            }
+          },
+          "trigger_only_during_business_hours": {
+            "type": "boolean",
+            "description": "Restrict an ongoing website campaign to inbox business hours."
+          },
+          "template_params": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true,
+            "description": "Channel-specific template parameters, when applicable."
+          }
+        }
+      },
+      "campaign_create_payload": {
+        "type": "object",
+        "required": [
+          "campaign"
+        ],
+        "properties": {
+          "campaign": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/campaign_fields"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "title",
+                  "inbox_id",
+                  "message",
+                  "trigger_rules"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "campaign_update_payload": {
+        "type": "object",
+        "required": [
+          "campaign"
+        ],
+        "properties": {
+          "campaign": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/campaign_fields"
+              }
+            ]
+          }
+        }
       }
     },
     "parameters": {
@@ -6910,6 +7139,7 @@
         "Account",
         "Agents",
         "Audit Logs",
+        "Campaigns",
         "Canned Responses",
         "Contacts",
         "Contact Labels",

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -6834,9 +6834,14 @@
           },
           "audience": {
             "type": "array",
-            "description": "Audience labels for a one-off campaign. Contacts matching any selected label are included.",
+            "minItems": 1,
+            "description": "Required when creating a one-off SMS or WhatsApp campaign. Provide at least one label from this account. Contacts matching any selected label are included. When updating, omit this field to retain the existing audience.",
             "items": {
               "type": "object",
+              "required": [
+                "type",
+                "id"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
@@ -6865,12 +6870,7 @@
             "description": "Restrict an ongoing website campaign to inbox business hours."
           },
           "template_params": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "additionalProperties": true,
-            "description": "Channel-specific template parameters, when applicable."
+            "$ref": "#/components/schemas/campaign_whatsapp_template_params"
           }
         }
       },
@@ -6881,6 +6881,7 @@
         ],
         "properties": {
           "campaign": {
+            "description": "Choose the variant matching the inbox referenced by inbox_id. The channel type is stored on the inbox and cannot be inferred from this request by a schema validator. These variants describe the inputs needed for delivery; creation can accept incomplete inputs without guaranteeing that the campaign will send.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/campaign_fields"
@@ -6891,6 +6892,49 @@
                   "title",
                   "inbox_id",
                   "message"
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "title": "Website campaign",
+                    "description": "For a Website inbox, supply URL trigger rules. An audience is not required.",
+                    "type": "object",
+                    "required": [
+                      "trigger_rules"
+                    ],
+                    "properties": {
+                      "trigger_rules": {
+                        "type": "object",
+                        "required": [
+                          "url"
+                        ],
+                        "properties": {
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "SMS campaign",
+                    "description": "For an SMS or Twilio SMS inbox, supply at least one audience label.",
+                    "type": "object",
+                    "required": [
+                      "audience"
+                    ]
+                  },
+                  {
+                    "title": "WhatsApp campaign",
+                    "description": "For a WhatsApp Cloud inbox with campaigns enabled, supply audience labels and template parameters.",
+                    "type": "object",
+                    "required": [
+                      "audience",
+                      "template_params"
+                    ]
+                  }
                 ]
               }
             ]
@@ -6909,6 +6953,69 @@
                 "$ref": "#/components/schemas/campaign_fields"
               }
             ]
+          }
+        }
+      },
+      "campaign_whatsapp_template_params": {
+        "type": "object",
+        "required": [
+          "name",
+          "language"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the approved template in the selected inbox's message_templates."
+          },
+          "language": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Language code matching that template in the selected inbox.",
+            "example": "en"
+          },
+          "namespace": {
+            "type": "string",
+            "description": "Template namespace, when present in the selected template."
+          },
+          "category": {
+            "type": "string",
+            "description": "Category of the selected template."
+          },
+          "processed_params": {
+            "type": "object",
+            "description": "Values for the selected template's variables, grouped by component. Supply all parameters needed by that template. May be omitted for a template without variables. Body keys use positional numbers or the template's named parameters. Liquid expressions such as {{ contact.name }} are rendered separately for each recipient.",
+            "properties": {
+              "body": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "header": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Text parameter values or media_url, media_type, and optional media_name for a media header."
+              },
+              "footer": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "example": {
+              "body": {
+                "1": "{{ contact.name }}"
+              }
+            }
           }
         }
       }

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -1139,7 +1139,10 @@
             "description": "The name of the inbox"
           },
           "website_url": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Website URL"
           },
           "page_id": {
@@ -1207,11 +1210,17 @@
             "description": "The avatar image of the inbox"
           },
           "widget_color": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Widget Color used for customization of the widget"
           },
           "website_token": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Website Token"
           },
           "enable_auto_assignment": {
@@ -1219,7 +1228,10 @@
             "description": "The flag which shows whether Auto Assignment is enabled or not"
           },
           "web_widget_script": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Script used to load the website widget"
           },
           "welcome_title": {
@@ -1361,7 +1373,10 @@
             "description": "Liquid HTML layout for branded email replies. Available to administrators for Email inbox show/update responses."
           },
           "hmac_mandatory": {
-            "type": "boolean",
+            "type": [
+              "boolean",
+              "null"
+            ],
             "description": "Whether HMAC verification is mandatory"
           },
           "selected_feature_flags": {
@@ -1375,7 +1390,10 @@
             }
           },
           "reply_time": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Expected reply time"
           },
           "messaging_service_sid": {

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -6836,7 +6836,7 @@
           "trigger_rules": {
             "type": "object",
             "additionalProperties": true,
-            "description": "Website campaign trigger rules. Use an empty object for a one-off campaign.",
+            "description": "Website campaign trigger rules. Defaults to an empty object and can be omitted for a one-off campaign.",
             "example": {
               "url": "https://example.com/pricing",
               "time_on_page": 10
@@ -6872,8 +6872,7 @@
                 "required": [
                   "title",
                   "inbox_id",
-                  "message",
-                  "trigger_rules"
+                  "message"
                 ]
               }
             ]

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -7597,7 +7597,7 @@
           "trigger_rules": {
             "type": "object",
             "additionalProperties": true,
-            "description": "Website campaign trigger rules. Use an empty object for a one-off campaign.",
+            "description": "Website campaign trigger rules. Defaults to an empty object and can be omitted for a one-off campaign.",
             "example": {
               "url": "https://example.com/pricing",
               "time_on_page": 10
@@ -7633,8 +7633,7 @@
                 "required": [
                   "title",
                   "inbox_id",
-                  "message",
-                  "trigger_rules"
+                  "message"
                 ]
               }
             ]

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -1900,7 +1900,10 @@
             "description": "The name of the inbox"
           },
           "website_url": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Website URL"
           },
           "page_id": {
@@ -1968,11 +1971,17 @@
             "description": "The avatar image of the inbox"
           },
           "widget_color": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Widget Color used for customization of the widget"
           },
           "website_token": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Website Token"
           },
           "enable_auto_assignment": {
@@ -1980,7 +1989,10 @@
             "description": "The flag which shows whether Auto Assignment is enabled or not"
           },
           "web_widget_script": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Script used to load the website widget"
           },
           "welcome_title": {
@@ -2122,7 +2134,10 @@
             "description": "Liquid HTML layout for branded email replies. Available to administrators for Email inbox show/update responses."
           },
           "hmac_mandatory": {
-            "type": "boolean",
+            "type": [
+              "boolean",
+              "null"
+            ],
             "description": "Whether HMAC verification is mandatory"
           },
           "selected_feature_flags": {
@@ -2136,7 +2151,10 @@
             }
           },
           "reply_time": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Expected reply time"
           },
           "messaging_service_sid": {

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -7426,6 +7426,235 @@
             "description": "List of reporting events"
           }
         }
+      },
+      "campaign": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Account-scoped campaign ID. Use this value in campaign API paths."
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "account_id": {
+            "type": "integer"
+          },
+          "inbox": {
+            "$ref": "#/components/schemas/inbox"
+          },
+          "sender": {
+            "type": "object",
+            "description": "Sender details, or an empty object when no sender is assigned.",
+            "additionalProperties": true
+          },
+          "message": {
+            "type": "string"
+          },
+          "template_params": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          },
+          "campaign_status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "processing",
+              "completed"
+            ]
+          },
+          "campaign_type": {
+            "type": "string",
+            "enum": [
+              "ongoing",
+              "one_off"
+            ],
+            "description": "Derived from the inbox type; website campaigns are ongoing and supported messaging campaigns are one-off."
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "scheduled_at": {
+            "type": "integer",
+            "description": "Scheduled time in Unix seconds. Only present for one-off campaigns."
+          },
+          "started_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Start time in Unix seconds. Only present for one-off campaigns."
+          },
+          "completed_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Completion time in Unix seconds. Only present for one-off campaigns."
+          },
+          "audience": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "description": "Audience for a one-off campaign. Only present for one-off campaigns.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "trigger_rules": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "trigger_only_during_business_hours": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "campaign_fields": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Campaign title."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Internal description of the campaign."
+          },
+          "inbox_id": {
+            "type": "integer",
+            "description": "ID of an inbox in this account. Supported inbox types are Website, Twilio SMS, SMS, and WhatsApp."
+          },
+          "sender_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "ID of a user in this account to use as the campaign sender."
+          },
+          "message": {
+            "type": "string",
+            "description": "Campaign message content."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether an ongoing website campaign is enabled. This does not cancel a scheduled one-off campaign."
+          },
+          "scheduled_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Scheduled time for a one-off campaign, as an ISO 8601 timestamp with timezone. Defaults to the current time when omitted; website campaigns ignore this field. Responses return Unix seconds instead.",
+            "example": "2027-01-15T10:00:00Z"
+          },
+          "audience": {
+            "type": "array",
+            "description": "Audience labels for a one-off campaign. Contacts matching any selected label are included.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Label"
+                  ]
+                },
+                "id": {
+                  "type": "integer",
+                  "description": "ID of a label in this account."
+                }
+              }
+            }
+          },
+          "trigger_rules": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Website campaign trigger rules. Use an empty object for a one-off campaign.",
+            "example": {
+              "url": "https://example.com/pricing",
+              "time_on_page": 10
+            }
+          },
+          "trigger_only_during_business_hours": {
+            "type": "boolean",
+            "description": "Restrict an ongoing website campaign to inbox business hours."
+          },
+          "template_params": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true,
+            "description": "Channel-specific template parameters, when applicable."
+          }
+        }
+      },
+      "campaign_create_payload": {
+        "type": "object",
+        "required": [
+          "campaign"
+        ],
+        "properties": {
+          "campaign": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/campaign_fields"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "title",
+                  "inbox_id",
+                  "message",
+                  "trigger_rules"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "campaign_update_payload": {
+        "type": "object",
+        "required": [
+          "campaign"
+        ],
+        "properties": {
+          "campaign": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/campaign_fields"
+              }
+            ]
+          }
+        }
       }
     },
     "parameters": {
@@ -7683,6 +7912,7 @@
         "Account",
         "Agents",
         "Audit Logs",
+        "Campaigns",
         "Canned Responses",
         "Contacts",
         "Contact Labels",

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -7595,9 +7595,14 @@
           },
           "audience": {
             "type": "array",
-            "description": "Audience labels for a one-off campaign. Contacts matching any selected label are included.",
+            "minItems": 1,
+            "description": "Required when creating a one-off SMS or WhatsApp campaign. Provide at least one label from this account. Contacts matching any selected label are included. When updating, omit this field to retain the existing audience.",
             "items": {
               "type": "object",
+              "required": [
+                "type",
+                "id"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
@@ -7626,12 +7631,7 @@
             "description": "Restrict an ongoing website campaign to inbox business hours."
           },
           "template_params": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "additionalProperties": true,
-            "description": "Channel-specific template parameters, when applicable."
+            "$ref": "#/components/schemas/campaign_whatsapp_template_params"
           }
         }
       },
@@ -7642,6 +7642,7 @@
         ],
         "properties": {
           "campaign": {
+            "description": "Choose the variant matching the inbox referenced by inbox_id. The channel type is stored on the inbox and cannot be inferred from this request by a schema validator. These variants describe the inputs needed for delivery; creation can accept incomplete inputs without guaranteeing that the campaign will send.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/campaign_fields"
@@ -7652,6 +7653,49 @@
                   "title",
                   "inbox_id",
                   "message"
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "title": "Website campaign",
+                    "description": "For a Website inbox, supply URL trigger rules. An audience is not required.",
+                    "type": "object",
+                    "required": [
+                      "trigger_rules"
+                    ],
+                    "properties": {
+                      "trigger_rules": {
+                        "type": "object",
+                        "required": [
+                          "url"
+                        ],
+                        "properties": {
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "SMS campaign",
+                    "description": "For an SMS or Twilio SMS inbox, supply at least one audience label.",
+                    "type": "object",
+                    "required": [
+                      "audience"
+                    ]
+                  },
+                  {
+                    "title": "WhatsApp campaign",
+                    "description": "For a WhatsApp Cloud inbox with campaigns enabled, supply audience labels and template parameters.",
+                    "type": "object",
+                    "required": [
+                      "audience",
+                      "template_params"
+                    ]
+                  }
                 ]
               }
             ]
@@ -7670,6 +7714,69 @@
                 "$ref": "#/components/schemas/campaign_fields"
               }
             ]
+          }
+        }
+      },
+      "campaign_whatsapp_template_params": {
+        "type": "object",
+        "required": [
+          "name",
+          "language"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the approved template in the selected inbox's message_templates."
+          },
+          "language": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Language code matching that template in the selected inbox.",
+            "example": "en"
+          },
+          "namespace": {
+            "type": "string",
+            "description": "Template namespace, when present in the selected template."
+          },
+          "category": {
+            "type": "string",
+            "description": "Category of the selected template."
+          },
+          "processed_params": {
+            "type": "object",
+            "description": "Values for the selected template's variables, grouped by component. Supply all parameters needed by that template. May be omitted for a template without variables. Body keys use positional numbers or the template's named parameters. Liquid expressions such as {{ contact.name }} are rendered separately for each recipient.",
+            "properties": {
+              "body": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "header": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Text parameter values or media_url, media_type, and optional media_name for a media header."
+              },
+              "footer": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "example": {
+              "body": {
+                "1": "{{ contact.name }}"
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Customers can already create and schedule campaigns through the API, but these endpoints are missing from the public API reference. This adds campaign documentation to the Application API so integrators can discover the existing functionality and use it without relying on dashboard requests.

Documents listing, creating, retrieving, updating, and deleting campaigns, with request and response schemas and a scheduled campaign example. Includes administrator permissions, account API access requirements, account-scoped campaign IDs, and the distinction between website triggers and scheduled one-off campaigns.

### Things to know

- Documentation only; runtime behavior is unchanged.
- Requests accept an ISO 8601 scheduling timestamp; responses return Unix seconds.
- Existing channel-specific availability and campaign requirements still apply.
- Regenerated the combined and grouped OpenAPI files. All five documents pass OpenAPI validation, and campaign references resolve.
