### PR TITLE
feat(whatsapp): grant embedded signup access after use case submission

### DIFF
--- a/app/javascript/dashboard/api/channel/whatsappChannel.js
+++ b/app/javascript/dashboard/api/channel/whatsappChannel.js
@@ -10,6 +10,12 @@ class WhatsappChannel extends ApiClient {
     return axios.post(`${this.baseUrl()}/whatsapp/authorization`, params);
   }
 
+  requestEmbeddedSignupAccess(useCase) {
+    return axios.post(`${this.baseUrl()}/whatsapp/access_request`, {
+      use_case: useCase,
+    });
+  }
+
   reauthorizeWhatsApp({ inboxId, ...params }) {
     return axios.post(`${this.baseUrl()}/whatsapp/authorization`, {
       ...params,

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -426,9 +426,13 @@
           "MANUAL_LINK_TEXT": "manual setup flow",
           "ACCESS_REQUEST": {
             "TITLE": "Quick setup with Meta",
-            "DESCRIPTION": "Connect a new number or an existing number from the WhatsApp Business app without manual configuration. To request this option, tell our team what your business does, how you’ll use WhatsApp, and which Chatwoot account needs access.",
-            "FOOTNOTE": "We’ll review your request and let you know if this option can be enabled. You can also continue with manual setup below.",
-            "BUTTON": "Request access"
+            "DESCRIPTION": "Connect a new number or an existing number from the WhatsApp Business app without manual configuration. Tell us what your business does and how you’ll use WhatsApp to enable this option.",
+            "BUTTON": "Request access",
+            "FORM_DESCRIPTION": "Tell us about your business and how you plan to use WhatsApp. Submit your use case to enable quick setup for your account.",
+            "USE_CASE_LABEL": "Business use case",
+            "USE_CASE_PLACEHOLDER": "For example, we sell home furnishings and use WhatsApp to answer product questions and help customers with their orders.",
+            "SUBMIT": "Submit",
+            "ERROR": "We couldn’t enable access. Please try again."
           },
           "RESTRICTED_WARNING": "WhatsApp Embedded Signup is temporarily unavailable due to an API-level issue on Meta’s side, not a problem with Chatwoot. You can use manual setup for eligible Cloud API numbers. We’re working closely with Meta to resolve it as quickly as possible.",
           "STATUS_LINK": "View status updates",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useI18n, I18nT } from 'vue-i18n';
 import Twilio from './Twilio.vue';
@@ -7,6 +7,7 @@ import ThreeSixtyDialogWhatsapp from './360DialogWhatsapp.vue';
 import CloudWhatsapp from './CloudWhatsapp.vue';
 import WhatsappManualSetup from './WhatsappManualSetup.vue';
 import WhatsappEmbeddedSignup from './WhatsappEmbeddedSignup.vue';
+import WhatsappAccessRequestDialog from '../components/WhatsappAccessRequestDialog.vue';
 import ChannelSelector from 'dashboard/components/ChannelSelector.vue';
 import Banner from 'dashboard/components-next/banner/Banner.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
@@ -18,6 +19,7 @@ import { META_RESTRICTION_STATUS_URL } from 'dashboard/constants/globals';
 const route = useRoute();
 const router = useRouter();
 const { t } = useI18n();
+const accessRequestDialogRef = ref(null);
 const {
   isCloudFeatureEnabled,
   isOnChatwootCloud,
@@ -128,12 +130,13 @@ const handleManualLinkClick = () => {
 };
 
 const requestEmbeddedSignupAccess = () => {
-  window.$chatwoot?.toggle();
+  accessRequestDialogRef.value.open();
 };
 </script>
 
 <template>
   <div class="col-span-6 w-full h-full min-h-0 overflow-y-auto p-6">
+    <WhatsappAccessRequestDialog ref="accessRequestDialogRef" />
     <div v-if="isManualSetup">
       <div
         v-if="shouldShowEmbeddedSignupAccessRequest"
@@ -168,13 +171,6 @@ const requestEmbeddedSignupAccess = () => {
           {{
             $t(
               'INBOX_MGMT.ADD.WHATSAPP.EMBEDDED_SIGNUP.ACCESS_REQUEST.DESCRIPTION'
-            )
-          }}
-        </p>
-        <p class="mt-2 ms-10 max-w-3xl text-label-small text-n-slate-10">
-          {{
-            $t(
-              'INBOX_MGMT.ADD.WHATSAPP.EMBEDDED_SIGNUP.ACCESS_REQUEST.FOOTNOTE'
             )
           }}
         </p>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappAccessRequestDialog.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappAccessRequestDialog.vue
@@ -74,7 +74,7 @@ defineExpose({ open });
       :max-length="MAX_USE_CASE_LENGTH"
       :disabled="isSubmitting"
       :message="errorMessage"
-      message-type="error"
+      :message-type="errorMessage ? 'error' : 'info'"
       show-character-count
       autofocus
     />

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappAccessRequestDialog.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappAccessRequestDialog.vue
@@ -1,0 +1,82 @@
+<script setup>
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useStore } from 'dashboard/composables/store';
+import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
+import TextArea from 'dashboard/components-next/textarea/TextArea.vue';
+
+const MAX_USE_CASE_LENGTH = 2000;
+
+const { t } = useI18n();
+const store = useStore();
+const dialogRef = ref(null);
+const useCase = ref('');
+const isSubmitting = ref(false);
+const errorMessage = ref('');
+
+const submit = async () => {
+  if (isSubmitting.value || !useCase.value.trim()) return;
+
+  isSubmitting.value = true;
+  errorMessage.value = '';
+  try {
+    await store.dispatch(
+      'accounts/requestWhatsappEmbeddedSignupAccess',
+      useCase.value.trim()
+    );
+    dialogRef.value.close();
+  } catch {
+    errorMessage.value = t(
+      'INBOX_MGMT.ADD.WHATSAPP.EMBEDDED_SIGNUP.ACCESS_REQUEST.ERROR'
+    );
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+
+const open = () => {
+  errorMessage.value = '';
+  dialogRef.value.open();
+};
+
+defineExpose({ open });
+</script>
+
+<template>
+  <Dialog
+    ref="dialogRef"
+    :title="t('INBOX_MGMT.ADD.WHATSAPP.EMBEDDED_SIGNUP.ACCESS_REQUEST.BUTTON')"
+    :description="
+      t(
+        'INBOX_MGMT.ADD.WHATSAPP.EMBEDDED_SIGNUP.ACCESS_REQUEST.FORM_DESCRIPTION'
+      )
+    "
+    :confirm-button-label="
+      t('INBOX_MGMT.ADD.WHATSAPP.EMBEDDED_SIGNUP.ACCESS_REQUEST.SUBMIT')
+    "
+    :disable-confirm-button="!useCase.trim()"
+    :is-loading="isSubmitting"
+    @confirm="submit"
+  >
+    <TextArea
+      id="whatsapp-use-case"
+      v-model="useCase"
+      :label="
+        t(
+          'INBOX_MGMT.ADD.WHATSAPP.EMBEDDED_SIGNUP.ACCESS_REQUEST.USE_CASE_LABEL'
+        )
+      "
+      :placeholder="
+        t(
+          'INBOX_MGMT.ADD.WHATSAPP.EMBEDDED_SIGNUP.ACCESS_REQUEST.USE_CASE_PLACEHOLDER'
+        )
+      "
+      :max-length="MAX_USE_CASE_LENGTH"
+      :disabled="isSubmitting"
+      :message="errorMessage"
+      message-type="error"
+      show-character-count
+      autofocus
+    />
+  </Dialog>
+</template>

--- a/app/javascript/dashboard/store/modules/accounts.js
+++ b/app/javascript/dashboard/store/modules/accounts.js
@@ -4,6 +4,7 @@ import AccountAPI from '../../api/account';
 import OnboardingAPI from '../../api/onboarding';
 import { differenceInDays } from 'date-fns';
 import EnterpriseAccountAPI from '../../api/enterprise/account';
+import WhatsappChannel from '../../api/channel/whatsappChannel';
 import { throwErrorMessage } from '../utils/api';
 import { getLanguageDirection } from 'dashboard/components/widgets/conversation/advancedFilterItems/languages';
 
@@ -55,6 +56,17 @@ export const getters = {
 };
 
 export const actions = {
+  requestWhatsappEmbeddedSignupAccess: async (
+    { commit, state: accountState, rootState },
+    useCase
+  ) => {
+    const accountId = rootState.route.params.accountId;
+    const { data } = await WhatsappChannel.requestEmbeddedSignupAccess(useCase);
+    commit(types.default.EDIT_ACCOUNT, {
+      ...findRecordById(accountState, accountId),
+      features: data.features,
+    });
+  },
   get: async ({ commit }, { silent } = {}) => {
     if (!silent) {
       commit(types.default.SET_ACCOUNT_UI_FLAG, { isFetchingItem: true });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -384,6 +384,7 @@ Rails.application.routes.draw do
 
           namespace :whatsapp do
             resource :authorization, only: [:create]
+            resource :access_request, only: [:create] if ChatwootApp.enterprise?
             post 'manual/preview', to: 'manual_setup#preview'
             post 'manual/connect', to: 'manual_setup#connect'
             get 'manual/:inbox_id/webhook_status', to: 'manual_setup#webhook_status'

--- a/enterprise/app/controllers/api/v1/accounts/whatsapp/access_requests_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/whatsapp/access_requests_controller.rb
@@ -1,0 +1,24 @@
+class Api::V1::Accounts::Whatsapp::AccessRequestsController < Api::V1::Accounts::BaseController
+  FEATURE_NAME = 'whatsapp_embedded_signup_inbox_creation'.freeze
+
+  before_action :check_admin_authorization?
+
+  def create
+    raise Pundit::NotAuthorizedError unless ChatwootApp.chatwoot_cloud?
+
+    use_case = params.permit(:use_case).require(:use_case).to_s.strip
+    raise ActionController::ParameterMissing, :use_case if use_case.blank?
+
+    account = Current.account
+    account.with_lock do
+      managed_features = Internal::Accounts::InternalAttributesService.new(account).manually_managed_features
+      account.enable_features(FEATURE_NAME)
+      account.update!(internal_attributes: account.internal_attributes.merge(
+        'whatsapp_use_case' => use_case,
+        'manually_managed_features' => managed_features | [FEATURE_NAME]
+      ))
+    end
+
+    render json: { features: account.enabled_features }
+  end
+end


### PR DESCRIPTION
Customers can request WhatsApp Embedded Signup access by submitting their business use case in the dashboard. Access is enabled immediately and preserved across billing changes.

#### How to test
On a Cloud account without Embedded Signup access, open WhatsApp inbox setup, click **Request access**, and submit a use case. The signup form should appear immediately, and access should remain enabled after refreshing.

<img width="1596" height="1456" alt="CleanShot 2026-09-09 at 12 14 55@2x" src="https://github.com/user-attachments/assets/a4ea5824-a4ec-48fc-9bab-b7858386fb78" />

