### PR TITLE
fix(formatter): prevent backslash in URL when bare URL is followed by hard break (#15731)

### DIFF
--- a/app/javascript/shared/helpers/MessageFormatter.js
+++ b/app/javascript/shared/helpers/MessageFormatter.js
@@ -73,6 +73,8 @@ const createMarkdownInstance = (linkify = true) => {
 const COLWIDTHS_MARKER_REGEX =
   /^[ \t>]*<!--cw-colwidths:[\d,]+-->[ \t]*\r?\n?/gm;
 
+const BARE_URL_HARD_BREAK_REGEX = /(https?:\/\/[^\s\\]+)\\\r?(\n|$)/g;
+
 const TWITTER_USERNAME_REGEX = /(^|[^@\w])@(\w{1,15})\b/g;
 const TWITTER_USERNAME_REPLACEMENT = '$1[@$2](http://twitter.com/$2)';
 const TWITTER_HASH_REGEX = /(^|\s)#(\w+)/g;
@@ -85,7 +87,9 @@ class MessageFormatter {
     isAPrivateNote = false,
     linkify = true
   ) {
-    this.message = (message || '').replace(COLWIDTHS_MARKER_REGEX, '');
+    this.message = (message || '')
+      .replace(COLWIDTHS_MARKER_REGEX, '')
+      .replace(BARE_URL_HARD_BREAK_REGEX, '$1 \\$2');
     this.isAPrivateNote = isAPrivateNote;
     this.isATweet = isATweet;
     this.linkify = linkify;

--- a/app/javascript/shared/helpers/MessageFormatter.js
+++ b/app/javascript/shared/helpers/MessageFormatter.js
@@ -73,7 +73,33 @@ const createMarkdownInstance = (linkify = true) => {
 const COLWIDTHS_MARKER_REGEX =
   /^[ \t>]*<!--cw-colwidths:[\d,]+-->[ \t]*\r?\n?/gm;
 
-const BARE_URL_HARD_BREAK_REGEX = /(https?:\/\/[^\s\\]+)\\\r?(\n|$)/g;
+const BARE_URL_HARD_BREAK_LINE_REGEX = /(https?:\/\/[^\s\\]+)\\(\r?)$/;
+const FENCE_LINE_REGEX = /^\s{0,3}(`{3,}|~{3,})/;
+
+// markdown-it does not linkify code tokens, so the bare-URL hard-break
+// workaround must skip fenced code blocks; rewriting them would alter the
+// user's verbatim code (an extra space before the backslash).
+const escapeBareUrlHardBreaks = message => {
+  const lines = message.split('\n');
+  let inFence = false;
+  let fenceChar = '';
+  for (let i = 0; i < lines.length; i += 1) {
+    const fence = lines[i].match(FENCE_LINE_REGEX);
+    if (fence) {
+      if (!inFence) {
+        inFence = true;
+        fenceChar = fence[1][0];
+      } else if (fence[1][0] === fenceChar) {
+        inFence = false;
+      }
+      continue;
+    }
+    if (!inFence) {
+      lines[i] = lines[i].replace(BARE_URL_HARD_BREAK_LINE_REGEX, '$1 \\$2');
+    }
+  }
+  return lines.join('\n');
+};
 
 const TWITTER_USERNAME_REGEX = /(^|[^@\w])@(\w{1,15})\b/g;
 const TWITTER_USERNAME_REPLACEMENT = '$1[@$2](http://twitter.com/$2)';
@@ -87,9 +113,9 @@ class MessageFormatter {
     isAPrivateNote = false,
     linkify = true
   ) {
-    this.message = (message || '')
-      .replace(COLWIDTHS_MARKER_REGEX, '')
-      .replace(BARE_URL_HARD_BREAK_REGEX, '$1 \\$2');
+    this.message = escapeBareUrlHardBreaks(
+      (message || '').replace(COLWIDTHS_MARKER_REGEX, '')
+    );
     this.isAPrivateNote = isAPrivateNote;
     this.isATweet = isATweet;
     this.linkify = linkify;

--- a/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
+++ b/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
@@ -29,6 +29,12 @@ describe('#MessageFormatter', () => {
         '<p><a href="https://example.com/trip/" class="link" rel="noreferrer noopener nofollow" target="_blank">https://example.com/trip/</a> <br />\nNext line</p>'
       );
     });
+    it('should not alter URL lines inside a fenced code block', () => {
+      const message = '```sh\nhttps://example.com/api\\\nnext\n```';
+      const result = new MessageFormatter(message).formattedMessage;
+      expect(result).not.toMatch('api \\');
+      expect(result).toContain('https://example.com/api\\');
+    });
   });
 
   describe('parses heading to strong', () => {

--- a/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
+++ b/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
@@ -23,6 +23,12 @@ describe('#MessageFormatter', () => {
         '<p>Hey {{customer.name}}, check https://chatwoot.com</p>'
       );
     });
+    it('should format bare URL followed by hard break correctly without adding backslash to URL (#15731)', () => {
+      const message = 'https://example.com/trip/\\\nNext line';
+      expect(new MessageFormatter(message).formattedMessage).toMatch(
+        '<p><a href="https://example.com/trip/" class="link" rel="noreferrer noopener nofollow" target="_blank">https://example.com/trip/</a> <br />\nNext line</p>'
+      );
+    });
   });
 
   describe('parses heading to strong', () => {


### PR DESCRIPTION
### Summary
Fixes #15731 where a bare URL followed immediately by a CommonMark markdown hard break (\\\\\\ followed by line break) causes the backslash to be captured into the autolink regex and URL-encoded as \%5C\ in the output \href\ attribute.

### Changes
- Added \BARE_URL_HARD_BREAK_REGEX\ in \pp/javascript/shared/helpers/MessageFormatter.js\ to strip trailing backslashes from autolink matches when immediately preceding a hard break.
- Added unit test in \pp/javascript/shared/helpers/specs/MessageFormatter.spec.js\ verifying \https://example.com\\\\\n\.

### Verification
- Ran \pnpm vitest run app/javascript/shared/helpers/specs/MessageFormatter.spec.js\ — 34/34 tests passed.