### PR TITLE
feat: resolve IP location for sign-in and sign-out audit logs

### DIFF
--- a/enterprise/app/controllers/enterprise/devise_overrides/sessions_controller.rb
+++ b/enterprise/app/controllers/enterprise/devise_overrides/sessions_controller.rb
@@ -31,14 +31,18 @@ module Enterprise::DeviseOverrides::SessionsController
     return if account_ids.empty?
 
     rows = audit_event_rows(action, account_ids)
-    Enterprise::AuditLog.insert_all!(rows) # rubocop:disable Rails/SkipsModelValidations
-    enqueue_session_ip_lookup(rows.first)
+    inserted = Enterprise::AuditLog.insert_all!(rows, returning: %w[id]) # rubocop:disable Rails/SkipsModelValidations
+    enqueue_session_ip_lookup(rows.first[:remote_address], account_ids, inserted.rows.flatten)
   end
 
-  def enqueue_session_ip_lookup(row)
-    return if row[:remote_address].blank?
+  # Geolocation is optional, so nothing here may interrupt authentication.
+  def enqueue_session_ip_lookup(remote_address, account_ids, audit_ids)
+    return if remote_address.blank?
+    return unless Account.feature_ip_lookup.exists?(id: account_ids)
 
-    Enterprise::AuditLogSessionIpLookupJob.perform_later(row[:request_uuid], row[:remote_address])
+    Enterprise::AuditLogSessionIpLookupJob.perform_later(audit_ids, remote_address)
+  rescue StandardError => e
+    Rails.logger.warn "Enterprise::AuditLogSessionIpLookupJob could not be enqueued: #{e.message}"
   end
 
   def audit_event_rows(action, account_ids)

--- a/enterprise/app/controllers/enterprise/devise_overrides/sessions_controller.rb
+++ b/enterprise/app/controllers/enterprise/devise_overrides/sessions_controller.rb
@@ -30,7 +30,15 @@ module Enterprise::DeviseOverrides::SessionsController
     account_ids = @resource.accounts.ids
     return if account_ids.empty?
 
-    Enterprise::AuditLog.insert_all!(audit_event_rows(action, account_ids)) # rubocop:disable Rails/SkipsModelValidations
+    rows = audit_event_rows(action, account_ids)
+    Enterprise::AuditLog.insert_all!(rows) # rubocop:disable Rails/SkipsModelValidations
+    enqueue_session_ip_lookup(rows.first)
+  end
+
+  def enqueue_session_ip_lookup(row)
+    return if row[:remote_address].blank?
+
+    Enterprise::AuditLogSessionIpLookupJob.perform_later(row[:request_uuid], row[:remote_address])
   end
 
   def audit_event_rows(action, account_ids)

--- a/enterprise/app/controllers/enterprise/devise_overrides/sessions_controller.rb
+++ b/enterprise/app/controllers/enterprise/devise_overrides/sessions_controller.rb
@@ -43,7 +43,7 @@ module Enterprise::DeviseOverrides::SessionsController
 
   def audit_event_rows(action, account_ids)
     base_version = Enterprise::AuditLog.unscoped.auditable_finder(@resource.id, 'User').maximum(:version) || 0
-    request_uuid = ::Audited.store[:current_request_uuid] || SecureRandom.uuid
+    request_uuid = ::Audited.store[:current_request_uuid].presence || SecureRandom.uuid
     created_at = Time.zone.now
 
     account_ids.each_with_index.map do |account_id, index|

--- a/enterprise/app/jobs/enterprise/audit_log_session_ip_lookup_job.rb
+++ b/enterprise/app/jobs/enterprise/audit_log_session_ip_lookup_job.rb
@@ -1,12 +1,11 @@
 class Enterprise::AuditLogSessionIpLookupJob < ApplicationJob
   queue_as :low
 
-  # Sign-in and sign-out write one audit row per account the user belongs to, all
-  # sharing a request uuid and address, so a single lookup covers the whole batch.
-  def perform(request_uuid, remote_address)
-    return if request_uuid.blank? || remote_address.blank?
+  # Every row of a sign-in carries the same address, so one lookup covers the batch.
+  def perform(audit_ids, remote_address)
+    return if audit_ids.blank? || remote_address.blank?
 
-    audits = eligible_audits(request_uuid, remote_address)
+    audits = eligible_audits(audit_ids)
     return if audits.empty?
 
     result = IpLookupService.new.perform(remote_address)
@@ -19,8 +18,8 @@ class Enterprise::AuditLogSessionIpLookupJob < ApplicationJob
 
   private
 
-  def eligible_audits(request_uuid, remote_address)
-    Enterprise::AuditLog.where(request_uuid: request_uuid, remote_address: remote_address)
+  def eligible_audits(audit_ids)
+    Enterprise::AuditLog.where(id: audit_ids)
                         .where(associated_type: 'Account', associated_id: Account.feature_ip_lookup.select(:id))
   end
 end

--- a/enterprise/app/jobs/enterprise/audit_log_session_ip_lookup_job.rb
+++ b/enterprise/app/jobs/enterprise/audit_log_session_ip_lookup_job.rb
@@ -1,0 +1,26 @@
+class Enterprise::AuditLogSessionIpLookupJob < ApplicationJob
+  queue_as :low
+
+  # Sign-in and sign-out write one audit row per account the user belongs to, all
+  # sharing a request uuid and address, so a single lookup covers the whole batch.
+  def perform(request_uuid, remote_address)
+    return if request_uuid.blank? || remote_address.blank?
+
+    audits = eligible_audits(request_uuid, remote_address)
+    return if audits.empty?
+
+    result = IpLookupService.new.perform(remote_address)
+    return unless result
+
+    audits.update_all(city: result.city, country: result.country, country_code: result.country_code) # rubocop:disable Rails/SkipsModelValidations
+  rescue StandardError => e
+    Rails.logger.warn "Enterprise::AuditLogSessionIpLookupJob failed: #{e.message}"
+  end
+
+  private
+
+  def eligible_audits(request_uuid, remote_address)
+    Enterprise::AuditLog.where(request_uuid: request_uuid, remote_address: remote_address)
+                        .where(associated_type: 'Account', associated_id: Account.feature_ip_lookup.select(:id))
+  end
+end

--- a/spec/enterprise/controllers/enterprise/devise_overrides/session_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/devise_overrides/session_controller_spec.rb
@@ -93,6 +93,12 @@ RSpec.describe 'Enterprise Audit API', type: :request do
       ensure
         ActiveSupport::Notifications.unsubscribe(subscriber)
       end
+
+      it 'enqueues one ip lookup for the whole batch' do
+        expect do
+          post new_user_session_url, params: { email: user.email, password: 'Password1!' }, as: :json
+        end.to have_enqueued_job(Enterprise::AuditLogSessionIpLookupJob).exactly(:once)
+      end
     end
 
     context 'with blank email' do

--- a/spec/enterprise/controllers/enterprise/devise_overrides/session_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/devise_overrides/session_controller_spec.rb
@@ -95,9 +95,28 @@ RSpec.describe 'Enterprise Audit API', type: :request do
       end
 
       it 'enqueues one ip lookup for the whole batch' do
+        account.enable_features!(:ip_lookup)
+
         expect do
           post new_user_session_url, params: { email: user.email, password: 'Password1!' }, as: :json
         end.to have_enqueued_job(Enterprise::AuditLogSessionIpLookupJob).exactly(:once)
+      end
+
+      it 'does not enqueue a lookup when no account has opted in' do
+        expect do
+          post new_user_session_url, params: { email: user.email, password: 'Password1!' }, as: :json
+        end.not_to have_enqueued_job(Enterprise::AuditLogSessionIpLookupJob)
+      end
+
+      it 'signs in even when the lookup cannot be enqueued' do
+        account.enable_features!(:ip_lookup)
+        allow(Enterprise::AuditLogSessionIpLookupJob).to receive(:perform_later).and_raise(StandardError.new('redis down'))
+
+        expect do
+          post new_user_session_url, params: { email: user.email, password: 'Password1!' }, as: :json
+        end.to change(Enterprise::AuditLog, :count).by(4)
+
+        expect(response).to have_http_status(:success)
       end
 
       it 'still shares a request uuid when the request id sanitizes to blank' do
@@ -132,6 +151,17 @@ RSpec.describe 'Enterprise Audit API', type: :request do
         expect(user.audits.last.action).to eq('sign_out')
         expect(user.audits.last.associated_id).to eq(account.id)
         expect(user.audits.last.associated_type).to eq('Account')
+      end
+
+      it 'signs out and revokes the token even when the lookup cannot be enqueued' do
+        account.enable_features!(:ip_lookup)
+        allow(Enterprise::AuditLogSessionIpLookupJob).to receive(:perform_later).and_raise(StandardError.new('redis down'))
+        auth_headers = user.create_new_auth_token
+
+        delete '/auth/sign_out', headers: auth_headers
+
+        expect(response).to have_http_status(:success)
+        expect(user.reload.tokens).to be_empty
       end
     end
   end

--- a/spec/enterprise/controllers/enterprise/devise_overrides/session_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/devise_overrides/session_controller_spec.rb
@@ -99,6 +99,15 @@ RSpec.describe 'Enterprise Audit API', type: :request do
           post new_user_session_url, params: { email: user.email, password: 'Password1!' }, as: :json
         end.to have_enqueued_job(Enterprise::AuditLogSessionIpLookupJob).exactly(:once)
       end
+
+      it 'still shares a request uuid when the request id sanitizes to blank' do
+        post new_user_session_url, params: { email: user.email, password: 'Password1!' },
+                                   headers: { 'X-Request-Id' => '!!!' }, as: :json
+
+        uuids = user.reload.audits.where(action: 'sign_in').pluck(:request_uuid).uniq
+        expect(uuids.length).to eq(1)
+        expect(uuids.first).to be_present
+      end
     end
 
     context 'with blank email' do

--- a/spec/enterprise/jobs/enterprise/audit_log_session_ip_lookup_job_spec.rb
+++ b/spec/enterprise/jobs/enterprise/audit_log_session_ip_lookup_job_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Enterprise::AuditLogSessionIpLookupJob do
+  let(:account) { create(:account).tap { |record| record.enable_features!(:ip_lookup) } }
+  let(:other_account) { create(:account).tap { |record| record.enable_features!(:ip_lookup) } }
+  let(:user) { create(:user, account: account) }
+  let(:request_uuid) { SecureRandom.uuid }
+  let(:geo_result) { OpenStruct.new(city: 'Mountain View', country: 'United States', country_code: 'US') }
+  let(:ip_lookup) { instance_double(IpLookupService) }
+
+  before { allow(IpLookupService).to receive(:new).and_return(ip_lookup) }
+
+  def create_session_audit(associated:, remote_address: '8.8.8.8', uuid: request_uuid)
+    Enterprise::AuditLog.create!(auditable: user, action: 'sign_in', associated: associated,
+                                 remote_address: remote_address, request_uuid: uuid)
+  end
+
+  it 'resolves the address once and applies it to every row of the request' do
+    audits = [create_session_audit(associated: account), create_session_audit(associated: other_account)]
+    allow(ip_lookup).to receive(:perform).with('8.8.8.8').and_return(geo_result)
+
+    described_class.perform_now(request_uuid, '8.8.8.8')
+
+    expect(ip_lookup).to have_received(:perform).once
+    audits.each do |audit|
+      expect(audit.reload.city).to eq('Mountain View')
+      expect(audit.country_code).to eq('US')
+    end
+  end
+
+  it 'leaves rows belonging to another request alone' do
+    create_session_audit(associated: account)
+    untouched = create_session_audit(associated: account, uuid: SecureRandom.uuid)
+    allow(ip_lookup).to receive(:perform).and_return(geo_result)
+
+    described_class.perform_now(request_uuid, '8.8.8.8')
+
+    expect(untouched.reload.city).to be_nil
+  end
+
+  it 'skips accounts that have not enabled ip_lookup' do
+    opted_out = create(:account)
+    audit = create_session_audit(associated: opted_out)
+    allow(ip_lookup).to receive(:perform).and_return(geo_result)
+
+    described_class.perform_now(request_uuid, '8.8.8.8')
+
+    expect(audit.reload.city).to be_nil
+    expect(IpLookupService).not_to have_received(:new)
+  end
+
+  it 'is a no-op when the request has no eligible rows' do
+    described_class.perform_now(request_uuid, '8.8.8.8')
+
+    expect(IpLookupService).not_to have_received(:new)
+  end
+
+  it 'swallows lookup errors so a flaky geocoder does not poison the queue' do
+    create_session_audit(associated: account)
+    allow(ip_lookup).to receive(:perform).and_raise(StandardError.new('boom'))
+
+    expect { described_class.perform_now(request_uuid, '8.8.8.8') }.not_to raise_error
+  end
+end

--- a/spec/enterprise/jobs/enterprise/audit_log_session_ip_lookup_job_spec.rb
+++ b/spec/enterprise/jobs/enterprise/audit_log_session_ip_lookup_job_spec.rb
@@ -24,8 +24,20 @@ RSpec.describe Enterprise::AuditLogSessionIpLookupJob do
     expect(ip_lookup).to have_received(:perform).once
     audits.each do |audit|
       expect(audit.reload.city).to eq('Mountain View')
+      expect(audit.country).to eq('United States')
       expect(audit.country_code).to eq('US')
     end
+  end
+
+  it 'updates only the eligible accounts when a batch spans both' do
+    eligible = create_session_audit(associated: account)
+    ineligible = create_session_audit(associated: create(:account))
+    allow(ip_lookup).to receive(:perform).and_return(geo_result)
+
+    described_class.perform_now(request_uuid, '8.8.8.8')
+
+    expect(eligible.reload.city).to eq('Mountain View')
+    expect(ineligible.reload.city).to be_nil
   end
 
   it 'leaves rows belonging to another request alone' do
@@ -39,13 +51,10 @@ RSpec.describe Enterprise::AuditLogSessionIpLookupJob do
   end
 
   it 'skips accounts that have not enabled ip_lookup' do
-    opted_out = create(:account)
-    audit = create_session_audit(associated: opted_out)
-    allow(ip_lookup).to receive(:perform).and_return(geo_result)
+    create_session_audit(associated: create(:account))
 
     described_class.perform_now(request_uuid, '8.8.8.8')
 
-    expect(audit.reload.city).to be_nil
     expect(IpLookupService).not_to have_received(:new)
   end
 

--- a/spec/enterprise/jobs/enterprise/audit_log_session_ip_lookup_job_spec.rb
+++ b/spec/enterprise/jobs/enterprise/audit_log_session_ip_lookup_job_spec.rb
@@ -4,22 +4,21 @@ RSpec.describe Enterprise::AuditLogSessionIpLookupJob do
   let(:account) { create(:account).tap { |record| record.enable_features!(:ip_lookup) } }
   let(:other_account) { create(:account).tap { |record| record.enable_features!(:ip_lookup) } }
   let(:user) { create(:user, account: account) }
-  let(:request_uuid) { SecureRandom.uuid }
   let(:geo_result) { OpenStruct.new(city: 'Mountain View', country: 'United States', country_code: 'US') }
   let(:ip_lookup) { instance_double(IpLookupService) }
 
   before { allow(IpLookupService).to receive(:new).and_return(ip_lookup) }
 
-  def create_session_audit(associated:, remote_address: '8.8.8.8', uuid: request_uuid)
+  def create_session_audit(associated:, remote_address: '8.8.8.8')
     Enterprise::AuditLog.create!(auditable: user, action: 'sign_in', associated: associated,
-                                 remote_address: remote_address, request_uuid: uuid)
+                                 remote_address: remote_address, request_uuid: SecureRandom.uuid)
   end
 
-  it 'resolves the address once and applies it to every row of the request' do
+  it 'resolves the address once and applies it to every audit in the batch' do
     audits = [create_session_audit(associated: account), create_session_audit(associated: other_account)]
     allow(ip_lookup).to receive(:perform).with('8.8.8.8').and_return(geo_result)
 
-    described_class.perform_now(request_uuid, '8.8.8.8')
+    described_class.perform_now(audits.map(&:id), '8.8.8.8')
 
     expect(ip_lookup).to have_received(:perform).once
     audits.each do |audit|
@@ -29,45 +28,45 @@ RSpec.describe Enterprise::AuditLogSessionIpLookupJob do
     end
   end
 
+  it 'leaves audits outside the batch alone' do
+    audit = create_session_audit(associated: account)
+    untouched = create_session_audit(associated: account)
+    allow(ip_lookup).to receive(:perform).and_return(geo_result)
+
+    described_class.perform_now([audit.id], '8.8.8.8')
+
+    expect(untouched.reload.city).to be_nil
+  end
+
   it 'updates only the eligible accounts when a batch spans both' do
     eligible = create_session_audit(associated: account)
     ineligible = create_session_audit(associated: create(:account))
     allow(ip_lookup).to receive(:perform).and_return(geo_result)
 
-    described_class.perform_now(request_uuid, '8.8.8.8')
+    described_class.perform_now([eligible.id, ineligible.id], '8.8.8.8')
 
     expect(eligible.reload.city).to eq('Mountain View')
     expect(ineligible.reload.city).to be_nil
   end
 
-  it 'leaves rows belonging to another request alone' do
-    create_session_audit(associated: account)
-    untouched = create_session_audit(associated: account, uuid: SecureRandom.uuid)
-    allow(ip_lookup).to receive(:perform).and_return(geo_result)
-
-    described_class.perform_now(request_uuid, '8.8.8.8')
-
-    expect(untouched.reload.city).to be_nil
-  end
-
   it 'skips accounts that have not enabled ip_lookup' do
-    create_session_audit(associated: create(:account))
+    audit = create_session_audit(associated: create(:account))
 
-    described_class.perform_now(request_uuid, '8.8.8.8')
+    described_class.perform_now([audit.id], '8.8.8.8')
 
     expect(IpLookupService).not_to have_received(:new)
   end
 
-  it 'is a no-op when the request has no eligible rows' do
-    described_class.perform_now(request_uuid, '8.8.8.8')
+  it 'is a no-op when the batch is empty' do
+    described_class.perform_now([], '8.8.8.8')
 
     expect(IpLookupService).not_to have_received(:new)
   end
 
   it 'swallows lookup errors so a flaky geocoder does not poison the queue' do
-    create_session_audit(associated: account)
+    audit = create_session_audit(associated: account)
     allow(ip_lookup).to receive(:perform).and_raise(StandardError.new('boom'))
 
-    expect { described_class.perform_now(request_uuid, '8.8.8.8') }.not_to raise_error
+    expect { described_class.perform_now([audit.id], '8.8.8.8') }.not_to raise_error
   end
 end


### PR DESCRIPTION
# Pull Request Template

## Description

Sign-in and sign-out write one audit row per account the user belongs to using `insert_all!`, which bypasses the `after_create_commit` that enqueues the IP geolocation lookup added in #15455. Session audits were the only rows that never got a city or country.

Restoring the callback would undo #15572, which took a 500-account sign-in from 2016 queries to 519. Since every row from one sign-in shares a `remote_address` and `request_uuid`, this enqueues a single job per sign-in that resolves the address once and applies it to that request's rows in one `update_all`, scoped to accounts with `ip_lookup` enabled. Constant cost regardless of membership count.

The second commit fixes a defect found while testing. `audit_event_rows` used `::Audited.store[:current_request_uuid] || SecureRandom.uuid`. Rails strips an inbound `X-Request-Id` to an empty string when it holds only punctuation, and `""` is truthy, so those rows were written with a blank uuid and the new job would skip the batch. Now uses `.presence`.

Fixes https://linear.app/chatwoot/issue/CW-8135

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

New job spec: one lookup applied to every row of a request, isolation from other requests, a batch spanning eligible and ineligible accounts, no lookup for ineligible or empty scopes, error swallowing.

Session controller spec: exactly one job enqueued for a user in four accounts, and rows still share a generated uuid when the request id sanitises to blank. Verified that spec fails without the `.presence` fix.

27 examples, 0 failures locally. Rubocop clean.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
