### PR TITLE
fix(whatsapp): preserve retries after incoming media failures

### DIFF
--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -15,6 +15,10 @@ class Whatsapp::IncomingMessageBaseService
 
     process_identity_change_messages
     return process_messages if messages_data.present?
+  rescue StandardError
+    # A rolled-back message must remain eligible for the webhook job's next attempt.
+    @message_source_lock&.release!
+    raise
   end
 
   # Returns messages array for both regular messages and echo events

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -105,6 +105,7 @@ module Whatsapp::IncomingMessageServiceHelpers
   def lock_message_source_id!
     return false if messages_data.blank?
 
-    Whatsapp::MessageDedupLock.new(messages_data.first[:id]).acquire!
+    @message_source_lock = Whatsapp::MessageDedupLock.new(messages_data.first[:id])
+    @message_source_lock.acquire!
   end
 end

--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -2,6 +2,14 @@
 # https://developers.facebook.com/docs/whatsapp/api/media/
 
 class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageBaseService
+  def perform
+    super
+  rescue CustomExceptions::WhatsappMediaDownloadError => e
+    # Record authorization failures after the message transaction has rolled back.
+    inbox.channel.authorization_error! if e.http_status == 401
+    raise
+  end
+
   private
 
   def processed_params
@@ -14,12 +22,9 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
       headers: inbox.channel.api_headers
     )
 
-    # This url response will be failure if the access token has expired.
-    inbox.channel.authorization_error! if url_response.unauthorized?
+    raise CustomExceptions::WhatsappMediaDownloadError.new(attachment_payload[:id], url_response.code) unless url_response.success?
 
-    return unless url_response.success?
-
-    downloaded_file = Down.download(url_response.parsed_response['url'], headers: inbox.channel.api_headers)
+    downloaded_file = Down.download(url_response.parsed_response.fetch('url'), headers: inbox.channel.api_headers)
     # WhatsApp Cloud sends the original filename in the payload; preserve it so accented
     # names keep their correct extension instead of relying on the mangled remote metadata.
     filename = attachment_payload[:filename]

--- a/app/services/whatsapp/message_dedup_lock.rb
+++ b/app/services/whatsapp/message_dedup_lock.rb
@@ -9,11 +9,16 @@ class Whatsapp::MessageDedupLock
   def initialize(source_id, ttl: DEFAULT_TTL)
     @key = format(KEY_PREFIX, id: source_id)
     @ttl = ttl
+    @token = SecureRandom.uuid
   end
 
   # Returns true when the lock is acquired (caller should proceed).
   # Returns false when another worker already holds the lock.
   def acquire!
-    ::Redis::Alfred.set(@key, true, nx: true, ex: @ttl)
+    ::Redis::Alfred.set(@key, @token, nx: true, ex: @ttl)
+  end
+
+  def release!
+    ::Redis::Alfred.delete_if_equals(@key, @token)
   end
 end

--- a/lib/custom_exceptions/whatsapp_media_download_error.rb
+++ b/lib/custom_exceptions/whatsapp_media_download_error.rb
@@ -1,0 +1,8 @@
+class CustomExceptions::WhatsappMediaDownloadError < StandardError
+  attr_reader :http_status
+
+  def initialize(media_id, http_status)
+    @http_status = http_status
+    super("WhatsApp media lookup failed for #{media_id} (HTTP #{http_status})")
+  end
+end

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -17,6 +17,7 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
             value: {
               contacts: [{ profile: { name: 'Sojan Jose' }, wa_id: sender_number }],
               messages: [{
+                id: 'wamid.incoming-media-retry',
                 from: sender_number,
                 image: {
                   id: 'b1c68f38-8734-4ad3-b4a1-ef0c10d683',
@@ -51,12 +52,48 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
           status: 401
         )
 
+        expect { described_class.new(inbox: whatsapp_channel.inbox, params: params).perform }
+          .to raise_error(CustomExceptions::WhatsappMediaDownloadError)
+        expect(whatsapp_channel.inbox.messages).to be_empty
+        expect(whatsapp_channel.reload.authorization_error_count).to eq(1)
+
+        stub_media_url_request
+        stub_sample_png_request
         described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
-        expect(whatsapp_channel.inbox.conversations.count).not_to eq(0)
-        expect_contact_name
-        expect(whatsapp_channel.inbox.messages.first.content).to eq('Check out my product!')
-        expect(whatsapp_channel.inbox.messages.first.attachments.present?).to be false
-        expect(whatsapp_channel.authorization_error_count).to eq(1)
+        expect(whatsapp_channel.inbox.messages.count).to eq(1)
+        expect_message_has_attachment
+      end
+    end
+
+    context 'when media retrieval fails temporarily' do
+      it 'retries a failed lookup immediately and deduplicates the successfully saved message' do
+        stub_request(:get, whatsapp_channel.media_url('b1c68f38-8734-4ad3-b4a1-ef0c10d683')).to_return(status: 503)
+
+        expect { described_class.new(inbox: whatsapp_channel.inbox, params: params).perform }
+          .to raise_error(CustomExceptions::WhatsappMediaDownloadError)
+        expect(whatsapp_channel.inbox.messages).to be_empty
+        expect(whatsapp_channel.reload.authorization_error_count).to eq(0)
+
+        stub_media_url_request
+        stub_sample_png_request
+        2.times { described_class.new(inbox: whatsapp_channel.inbox, params: params).perform }
+
+        expect(whatsapp_channel.inbox.messages.count).to eq(1)
+        expect_message_has_attachment
+      end
+
+      it 'releases the lock when downloading the media file fails' do
+        stub_media_url_request
+        stub_request(:get, 'https://chatwoot-assets.local/sample.png').to_return(status: 503)
+
+        expect { described_class.new(inbox: whatsapp_channel.inbox, params: params).perform }.to raise_error(Down::ServerError)
+        expect(whatsapp_channel.inbox.messages).to be_empty
+
+        stub_sample_png_request
+        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+
+        expect(whatsapp_channel.inbox.messages.count).to eq(1)
+        expect_message_has_attachment
       end
     end
 

--- a/spec/services/whatsapp/message_dedup_lock_spec.rb
+++ b/spec/services/whatsapp/message_dedup_lock_spec.rb
@@ -7,6 +7,32 @@ describe Whatsapp::MessageDedupLock do
 
   after { Redis::Alfred.delete(redis_key) }
 
+  describe '#release!' do
+    it 'allows another attempt after the owner releases the lock' do
+      lock.acquire!
+      lock.release!
+
+      expect(described_class.new(source_id).acquire!).to be_truthy
+    end
+
+    it 'does not release a lock held by another worker' do
+      lock.acquire!
+      described_class.new(source_id).release!
+
+      expect(described_class.new(source_id).acquire!).to be_falsy
+    end
+
+    it 'does not release a replacement lock after the original lock expires' do
+      lock.acquire!
+      Redis::Alfred.delete(redis_key)
+      replacement = described_class.new(source_id)
+      replacement.acquire!
+      lock.release!
+
+      expect(described_class.new(source_id).acquire!).to be_falsy
+    end
+  end
+
   describe '#acquire!' do
     it 'returns truthy on first acquire' do
       expect(lock.acquire!).to be_truthy


### PR DESCRIPTION
Incoming WhatsApp Cloud images can be saved without attachments after a failed media lookup, while a failed file download can leave its message-source lock behind and suppress retries. This change raises lookup failures, releases only the failing worker's lock, and allows a successful retry to save the complete message exactly once.

## Closes

Closes #15754.

## How to reproduce

1. Process an incoming WhatsApp Cloud image payload with a stable message ID while its media lookup returns HTTP 503. Before this change, an attachment-less message can be saved and the next delivery is considered a duplicate.
2. Alternatively, allow lookup to succeed and make the media-file download return HTTP 503. The transaction rolls back, but the message lock suppresses an immediate retry.
3. Restore successful lookup/download responses and replay the same payload. With this change, the attachment is saved; another replay does not create a second message.

## What changed

- Raise `WhatsappMediaDownloadError` for unsuccessful media lookups instead of silently omitting the attachment.
- Record HTTP 401 authorization failures after the message transaction rolls back.
- Retain the lock instance and use an ownership token with the existing atomic `delete_if_equals` operation when processing raises. A failed worker cannot release another worker's replacement lock.
- Extend existing regression coverage for lookup/download recovery, persisted authorization accounting, duplicate suppression and lock ownership. The 120 relevant local examples pass, and RuboCop reports no offenses in the seven changed files. Provider failures are simulated locally; no live-provider delivery claim is made.

This draft is submitted for maintainer feedback on the proposed approach. It is independent of #15702, which already covers outgoing media uploads. No outbound upload, image conversion, deployment, subscription or registry changes are included.
