### PR TITLE
feat(shopify): add gated billing infrastructure

### DIFF
--- a/app/controllers/api/v1/accounts/integrations/apps_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/apps_controller.rb
@@ -15,5 +15,9 @@ class Api::V1::Accounts::Integrations::AppsController < Api::V1::Accounts::BaseC
 
   def fetch_app
     @app = Integrations::App.find(id: params[:id])
+    return unless @app&.id == 'shopify'
+
+    # Keep direct Shopify lookups subject to the same availability checks as the integrations list.
+    raise ActiveRecord::RecordNotFound unless @app.active?(Current.account)
   end
 end

--- a/app/controllers/api/v1/accounts/integrations/base_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/base_controller.rb
@@ -7,3 +7,5 @@ class Api::V1::Accounts::Integrations::BaseController < Api::V1::Accounts::BaseC
     authorize(:hook)
   end
 end
+
+Api::V1::Accounts::Integrations::BaseController.prepend_mod_with('Api::V1::Accounts::Integrations::BaseController')

--- a/app/controllers/api/v1/accounts/integrations/hooks_controller.rb
+++ b/app/controllers/api/v1/accounts/integrations/hooks_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::Accounts::Integrations::HooksController < Api::V1::Accounts::Integrations::BaseController
   before_action :fetch_hook, except: [:create]
   before_action :check_authorization
+  before_action :ensure_shopify_enabled, if: :shopify_hook?
 
   def create
     @hook = Current.account.hooks.create!(permitted_params)
@@ -37,5 +38,13 @@ class Api::V1::Accounts::Integrations::HooksController < Api::V1::Accounts::Inte
 
   def permitted_params
     params.require(:hook).permit(:app_id, :inbox_id, :status, settings: {})
+  end
+
+  def shopify_hook?
+    action_name == 'create' ? permitted_params[:app_id] == 'shopify' : @hook.app_id == 'shopify'
+  end
+
+  def ensure_shopify_enabled
+    head :not_found unless Shopify::FeatureGate.enabled?(account: Current.account)
   end
 end

--- a/app/controllers/shopify/callbacks_controller.rb
+++ b/app/controllers/shopify/callbacks_controller.rb
@@ -23,15 +23,18 @@ class Shopify::CallbacksController < ApplicationController
   end
 
   def handle_response
-    account.hooks.create!(
-      app_id: 'shopify',
-      access_token: parsed_body['access_token'],
-      status: 'enabled',
-      reference_id: params[:shop],
-      settings: {
-        scope: parsed_body['scope']
-      }
-    )
+    account.with_lock do
+      hook = account.hooks.find_or_initialize_by(app_id: 'shopify', reference_id: Shopify::ShopDomain.normalize(params[:shop]))
+      hook.update!(
+        access_token: parsed_body['access_token'],
+        status: 'enabled',
+        settings: {
+          scope: parsed_body['scope'],
+          connected_at: Time.current.utc.iso8601(6),
+          installation_id: SecureRandom.uuid
+        }
+      )
+    end
 
     redirect_to shopify_integration_url
   end

--- a/app/controllers/super_admin/app_configs_controller.rb
+++ b/app/controllers/super_admin/app_configs_controller.rb
@@ -2,6 +2,16 @@ class SuperAdmin::AppConfigsController < SuperAdmin::ApplicationController
   GENERAL_CONFIGS = %w[ENABLE_ACCOUNT_SIGNUP FIREBASE_PROJECT_ID FIREBASE_CREDENTIALS WEBHOOK_TIMEOUT MAXIMUM_FILE_UPLOAD_SIZE
                        WIDGET_TOKEN_EXPIRY].freeze
   META_INCIDENT_CONFIGS = %w[DISABLE_META_INBOX_CREATION DISABLE_META_MESSAGE_SENDING].freeze
+  SHOPIFY_CONFIGS = %w[
+    ENABLE_SHOPIFY_INTEGRATION
+    SHOPIFY_CLIENT_ID
+    SHOPIFY_CLIENT_SECRET
+    SHOPIFY_APP_STORE_URL
+    SHOPIFY_PARTNER_ORGANIZATION_ID
+    SHOPIFY_PARTNER_APP_ID
+    SHOPIFY_PARTNER_ACCESS_TOKEN
+    SHOPIFY_PARTNER_API_VERSION
+  ].freeze
 
   before_action :set_config
   before_action :allowed_configs
@@ -19,8 +29,9 @@ class SuperAdmin::AppConfigsController < SuperAdmin::ApplicationController
   end
 
   def create
-    errors = []
+    errors = shopify_partner_config_errors
     params['app_config'].each do |key, value|
+      break if errors.any?
       next unless @allowed_configs.include?(key)
 
       i = InstallationConfig.where(name: key).first_or_create(value: value, locked: false)
@@ -46,7 +57,7 @@ class SuperAdmin::AppConfigsController < SuperAdmin::ApplicationController
 
     mapping = {
       'facebook' => %w[FB_APP_ID FB_VERIFY_TOKEN FB_APP_SECRET IG_VERIFY_TOKEN FACEBOOK_API_VERSION ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT],
-      'shopify' => %w[SHOPIFY_CLIENT_ID SHOPIFY_CLIENT_SECRET],
+      'shopify' => SHOPIFY_CONFIGS,
       'microsoft' => %w[AZURE_APP_ID AZURE_APP_SECRET],
       'email' => %w[MAILER_INBOUND_EMAIL_DOMAIN ACCOUNT_EMAILS_LIMIT ACCOUNT_EMAILS_PLAN_LIMITS],
       'linear' => %w[LINEAR_CLIENT_ID LINEAR_CLIENT_SECRET],
@@ -60,6 +71,19 @@ class SuperAdmin::AppConfigsController < SuperAdmin::ApplicationController
     }
 
     @allowed_configs = mapping.fetch(@config, general_configs)
+  end
+
+  def shopify_partner_config_errors
+    return [] unless @config == 'shopify'
+
+    saved_values = InstallationConfig.where(name: Shopify::PartnerConfiguration::KEYS).each_with_object({}) do |config, values|
+      values[config.name] = config.value
+    end
+    submitted_values = params.fetch('app_config', {}).permit(*SHOPIFY_CONFIGS).to_h
+    Shopify::PartnerConfiguration.validate_for_save!(saved_values.merge(submitted_values))
+    []
+  rescue Shopify::PartnerClient::ConfigurationError => e
+    [e.message]
   end
 
   def success_notice

--- a/app/controllers/webhooks/shopify_controller.rb
+++ b/app/controllers/webhooks/shopify_controller.rb
@@ -1,8 +1,15 @@
 class Webhooks::ShopifyController < ActionController::API
+  COMPLIANCE_TOPICS = %w[customers/data_request customers/redact shop/redact].freeze
+  MANDATORY_CLEANUP_TOPICS = (COMPLIANCE_TOPICS + %w[app/uninstalled]).freeze
+  class CleanupIncomplete < StandardError; end
+
+  before_action :ensure_shopify_enabled, unless: :mandatory_cleanup_event?
   before_action :verify_hmac!
 
   def events
     case request.headers['X-Shopify-Topic']
+    when 'app/uninstalled'
+      handle_app_uninstalled
     when 'shop/redact'
       handle_shop_redact
     end
@@ -11,6 +18,14 @@ class Webhooks::ShopifyController < ActionController::API
   end
 
   private
+
+  def ensure_shopify_enabled
+    head :not_found unless Shopify::FeatureGate.enabled?
+  end
+
+  def mandatory_cleanup_event?
+    MANDATORY_CLEANUP_TOPICS.include?(request.headers['X-Shopify-Topic'])
+  end
 
   def verify_hmac!
     secret = GlobalConfigService.load('SHOPIFY_CLIENT_SECRET', nil)
@@ -27,9 +42,34 @@ class Webhooks::ShopifyController < ActionController::API
   end
 
   def handle_shop_redact
-    shop_domain = params[:shop_domain]
-    return if shop_domain.blank?
+    Shopify::PendingInstallation.invalidate_shop!(shop: params[:shop_domain])
+    hooks = shopify_hooks(params[:shop_domain])
+    hooks.find_each do |hook|
+      Shopify::UninstallationService.new(hook: hook, occurred_at: webhook_triggered_at, delete_hook: true).perform
+    end
+    raise CleanupIncomplete, 'Shopify shop redaction is incomplete' if hooks.any? { |hook| redaction_required?(hook) }
+  end
 
-    Integrations::Hook.where(app_id: 'shopify', reference_id: shop_domain).destroy_all
+  def handle_app_uninstalled
+    Shopify::PendingInstallation.invalidate_shop!(shop: params[:myshopify_domain])
+    shopify_hooks(params[:myshopify_domain]).find_each do |hook|
+      Shopify::UninstallationService.new(hook: hook, occurred_at: webhook_triggered_at).perform
+    end
+  end
+
+  def webhook_triggered_at
+    @webhook_triggered_at ||= Time.iso8601(request.headers.fetch('X-Shopify-Triggered-At'))
+  end
+
+  def redaction_required?(hook)
+    connected_at = hook.settings['connected_at']
+    connected_at.blank? || Time.iso8601(connected_at) <= webhook_triggered_at
+  end
+
+  def shopify_hooks(shop_domain)
+    normalized_domain = Shopify::ShopDomain.normalize(shop_domain)
+    return Integrations::Hook.none unless Shopify::ShopDomain.valid?(normalized_domain)
+
+    Integrations::Hook.where(app_id: 'shopify').where('LOWER(reference_id) = ?', normalized_domain)
   end
 end

--- a/app/javascript/dashboard/api/account.js
+++ b/app/javascript/dashboard/api/account.js
@@ -6,6 +6,12 @@ class AccountAPI extends ApiClient {
     super('', { accountScoped: true });
   }
 
+  get(accountId) {
+    return accountId
+      ? axios.get(`${this.apiVersion}/accounts/${accountId}`)
+      : super.get();
+  }
+
   createAccount(data) {
     return axios.post(`${this.apiVersion}/accounts`, data);
   }

--- a/app/javascript/dashboard/api/enterprise/account.js
+++ b/app/javascript/dashboard/api/enterprise/account.js
@@ -14,6 +14,12 @@ class EnterpriseAccountAPI extends ApiClient {
     return axios.post(`${this.url}subscription`);
   }
 
+  billingSummary({ refresh = false } = {}) {
+    return axios.get(`${this.url}billing_summary`, {
+      params: { refresh },
+    });
+  }
+
   selectBillingCurrency(currency) {
     return axios.post(`${this.url}select_billing_currency`, { currency });
   }

--- a/app/javascript/dashboard/api/enterprise/specs/account.spec.js
+++ b/app/javascript/dashboard/api/enterprise/specs/account.spec.js
@@ -10,6 +10,7 @@ describe('#enterpriseAccountAPI', () => {
     expect(accountAPI).toHaveProperty('update');
     expect(accountAPI).toHaveProperty('delete');
     expect(accountAPI).toHaveProperty('checkout');
+    expect(accountAPI).toHaveProperty('billingSummary');
     expect(accountAPI).toHaveProperty('toggleDeletion');
     expect(accountAPI).toHaveProperty('createTopupCheckout');
     expect(accountAPI).toHaveProperty('getLimits');
@@ -43,6 +44,14 @@ describe('#enterpriseAccountAPI', () => {
       accountAPI.subscription();
       expect(axiosMock.post).toHaveBeenCalledWith(
         '/enterprise/api/v1/subscription'
+      );
+    });
+
+    it('#billingSummary', () => {
+      accountAPI.billingSummary({ refresh: true });
+      expect(axiosMock.get).toHaveBeenCalledWith(
+        '/enterprise/api/v1/billing_summary',
+        { params: { refresh: true } }
       );
     });
 

--- a/app/javascript/dashboard/featureFlags.js
+++ b/app/javascript/dashboard/featureFlags.js
@@ -37,6 +37,7 @@ export const FEATURE_FLAGS = {
   INBOUND_EMAILS: 'inbound_emails',
   IP_LOOKUP: 'ip_lookup',
   LINEAR: 'linear_integration',
+  SHOPIFY: 'shopify_integration',
   CAPTAIN: 'captain_integration',
   CUSTOM_ROLES: 'custom_roles',
   CHATWOOT_V4: 'chatwoot_v4',

--- a/app/javascript/dashboard/helper/featureHelper.js
+++ b/app/javascript/dashboard/helper/featureHelper.js
@@ -23,6 +23,7 @@ const FEATURE_HELP_URLS = {
   saml: 'https://chwt.app/hc/saml',
   captain: 'https://chwt.app/captain-docs',
   captain_billing: 'https://chwt.app/hc/captain_billing',
+  shopify: 'https://chwt.app/hc/shopify',
 };
 
 export function getHelpUrlForFeature(featureName) {

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -11,8 +11,13 @@
         "LABEL": "Store URL",
         "PLACEHOLDER": "your-store.myshopify.com",
         "HELP": "Enter your Shopify store's myshopify.com URL",
+        "INVALID_URL": "Please enter a valid Shopify store URL (e.g., your-store.myshopify.com)",
         "CANCEL": "Cancel",
         "SUBMIT": "Connect Store"
+      },
+      "HELP_TEXT": {
+        "TITLE": "How to use the Shopify Integration?",
+        "BODY": "With this integration, your Shopify store ***{storeDomain}*** is connected to your Chatwoot workspace. Here's what you can do:\n\n**Track orders in conversations:** When you open a conversation, the Shopify sidebar will automatically display recent orders for the customer based on their email address. This gives your support team instant context without switching tabs.\n\n**Access order details:** View order status, fulfillment status, and total amount directly within the conversation panel."
       },
       "ERROR": "There was an error connecting to Shopify. Please try again or contact support if the issue persists."
     },

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -620,6 +620,38 @@
       "BUTTON_TXT": "Chat with us"
     },
     "NO_BILLING_USER": "Your billing account is being configured. Please refresh the page and try again.",
+    "SHOPIFY": {
+      "TITLE": "Billing through Shopify",
+      "DESCRIPTION": "Your Chatwoot subscription is billed and managed securely through Shopify.",
+      "UNAVAILABLE": "Shopify billing is unavailable right now. Please contact support if this continues.",
+      "LOADING": "Checking your Shopify subscription...",
+      "PLAN_TITLE": "Shopify subscription",
+      "PLAN_DESCRIPTION": "Choose or manage your Chatwoot plan securely in Shopify.",
+      "CURRENT_PLAN": "Current plan",
+      "SUBSCRIPTION_STATUS": "Status",
+      "PRICE": "Price",
+      "PER_MONTH": "{price} / month",
+      "PER_YEAR": "{price} / year",
+      "TRIAL_ENDS_ON": "Trial ends on",
+      "RENEWS_ON": "Renews on",
+      "ACCESS_UNTIL": "Access until",
+      "LAST_VERIFIED": "Last verified",
+      "VIEW_PLANS": "View plans in Shopify",
+      "MANAGE_PLAN": "Manage in Shopify",
+      "RETRY": "Try again",
+      "ERROR_TITLE": "We could not verify your Shopify subscription",
+      "ERROR_DESCRIPTION": "Try again in a moment. Your last verified access has not been changed.",
+      "STALE_TITLE": "Showing your last verified subscription",
+      "STALE_DESCRIPTION": "Shopify could not be reached. Your access has not been changed.",
+      "STATUS": {
+        "PENDING": "Pending",
+        "ACTIVE": "Active",
+        "TRIALING": "Trial",
+        "CANCELLED": "Cancellation scheduled",
+        "EXPIRED": "Expired",
+        "MISSING": "No active plan"
+      }
+    },
     "TOPUP": {
       "BUY_CREDITS": "Buy more credits",
       "MODAL_TITLE": "Buy AI Credits",

--- a/app/javascript/dashboard/routes/dashboard/settings/billing/ProviderIndex.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/billing/ProviderIndex.vue
@@ -1,0 +1,46 @@
+<script setup>
+import { computed } from 'vue';
+import { useAccount } from 'dashboard/composables/useAccount';
+import { FEATURE_FLAGS } from 'dashboard/featureFlags';
+import { useBranding } from 'shared/composables/useBranding';
+
+import ShopifyBilling from './ShopifyBilling.vue';
+import StripeBilling from './Index.vue';
+import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';
+import SettingsLayout from '../SettingsLayout.vue';
+
+const { currentAccount, isCloudFeatureEnabled } = useAccount();
+const { replaceInstallationName } = useBranding();
+
+const isAccountLoaded = computed(() => Boolean(currentAccount.value?.id));
+const isShopifyBilling = computed(
+  () => currentAccount.value?.billing_provider === 'shopify'
+);
+const isShopifyEnabled = computed(
+  () => isAccountLoaded.value && isCloudFeatureEnabled(FEATURE_FLAGS.SHOPIFY)
+);
+</script>
+
+<template>
+  <SettingsLayout
+    v-if="!isAccountLoaded"
+    is-loading
+    :loading-message="$t('ATTRIBUTES_MGMT.LOADING')"
+  />
+  <ShopifyBilling v-else-if="isShopifyBilling && isShopifyEnabled" />
+  <SettingsLayout
+    v-else-if="isShopifyBilling"
+    no-records-found
+    :no-records-message="$t('BILLING_SETTINGS.SHOPIFY.UNAVAILABLE')"
+  >
+    <template #header>
+      <BaseSettingsHeader
+        :title="$t('BILLING_SETTINGS.SHOPIFY.TITLE')"
+        :description="
+          replaceInstallationName($t('BILLING_SETTINGS.SHOPIFY.DESCRIPTION'))
+        "
+      />
+    </template>
+  </SettingsLayout>
+  <StripeBilling v-else />
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/billing/ShopifyBilling.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/billing/ShopifyBilling.vue
@@ -1,0 +1,259 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import { format } from 'date-fns';
+import { useStore } from 'dashboard/composables/store';
+import EnterpriseAccountAPI from 'dashboard/api/enterprise/account';
+import { useBranding } from 'shared/composables/useBranding';
+
+import BillingCard from './components/BillingCard.vue';
+import DetailItem from './components/DetailItem.vue';
+import BaseSettingsHeader from '../components/BaseSettingsHeader.vue';
+import SettingsLayout from '../SettingsLayout.vue';
+import ButtonV4 from 'next/button/Button.vue';
+
+const route = useRoute();
+const router = useRouter();
+const store = useStore();
+const { t } = useI18n();
+const { replaceInstallationName } = useBranding();
+
+const summary = ref(null);
+const isLoading = ref(true);
+const isRefreshing = ref(false);
+const hasError = ref(false);
+const isStale = ref(false);
+
+const formatDate = (value, pattern = 'dd MMM, yyyy') => {
+  return format(new Date(value), pattern);
+};
+
+const isShopifyReturn = computed(
+  () => Boolean(route.query.plan_handle) || Boolean(route.query.shop)
+);
+
+const statusLabel = computed(() => {
+  const state = summary.value?.state?.toUpperCase() || 'PENDING';
+  switch (state) {
+    case 'ACTIVE':
+      return t('BILLING_SETTINGS.SHOPIFY.STATUS.ACTIVE');
+    case 'TRIALING':
+      return t('BILLING_SETTINGS.SHOPIFY.STATUS.TRIALING');
+    case 'CANCELLED':
+      return t('BILLING_SETTINGS.SHOPIFY.STATUS.CANCELLED');
+    case 'EXPIRED':
+      return t('BILLING_SETTINGS.SHOPIFY.STATUS.EXPIRED');
+    case 'MISSING':
+      return t('BILLING_SETTINGS.SHOPIFY.STATUS.MISSING');
+    default:
+      return t('BILLING_SETTINGS.SHOPIFY.STATUS.PENDING');
+  }
+});
+
+const actionLabel = computed(() => {
+  return ['active', 'trialing', 'cancelled'].includes(summary.value?.state)
+    ? t('BILLING_SETTINGS.SHOPIFY.MANAGE_PLAN')
+    : t('BILLING_SETTINGS.SHOPIFY.VIEW_PLANS');
+});
+
+const formattedPrice = computed(() => {
+  if (summary.value?.amount == null || !summary.value?.currency) return '';
+
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: summary.value.currency,
+  }).format(Number(summary.value.amount));
+});
+
+const formattedRecurringPrice = computed(() => {
+  if (!formattedPrice.value) return '';
+
+  if (summary.value?.billing_period?.toUpperCase() === 'ANNUAL') {
+    return t('BILLING_SETTINGS.SHOPIFY.PER_YEAR', {
+      price: formattedPrice.value,
+    });
+  }
+  if (summary.value?.billing_period?.toUpperCase() === 'EVERY_30_DAYS') {
+    return t('BILLING_SETTINGS.SHOPIFY.PER_MONTH', {
+      price: formattedPrice.value,
+    });
+  }
+
+  return formattedPrice.value;
+});
+
+const billingDate = computed(() => {
+  if (summary.value?.state === 'trialing' && summary.value?.trial_ends_at) {
+    return {
+      label: t('BILLING_SETTINGS.SHOPIFY.TRIAL_ENDS_ON'),
+      value: formatDate(summary.value.trial_ends_at),
+    };
+  }
+  if (!summary.value?.current_period_end) return null;
+
+  return {
+    label:
+      summary.value.state === 'cancelled'
+        ? t('BILLING_SETTINGS.SHOPIFY.ACCESS_UNTIL')
+        : t('BILLING_SETTINGS.SHOPIFY.RENEWS_ON'),
+    value: formatDate(summary.value.current_period_end),
+  };
+});
+
+const lastVerifiedAt = computed(() => {
+  if (!summary.value?.last_verified_at) return '';
+  return formatDate(summary.value.last_verified_at, 'dd MMM, yyyy, h:mm a');
+});
+
+const canManageSubscription = computed(
+  () => summary.value?.allowed_actions?.manage_subscription
+);
+
+const fetchSummary = async ({ refresh = false } = {}) => {
+  const response = await EnterpriseAccountAPI.billingSummary({ refresh });
+  return response.data;
+};
+
+const clearShopifyReturnParams = async () => {
+  const { plan_handle: _planHandle, shop: _shop, ...query } = route.query;
+  await router.replace({ query });
+};
+
+const loadSummary = async () => {
+  isLoading.value = true;
+  hasError.value = false;
+  isStale.value = false;
+
+  try {
+    summary.value = await fetchSummary();
+  } catch {
+    hasError.value = true;
+    isLoading.value = false;
+    return;
+  }
+
+  isRefreshing.value = true;
+  try {
+    summary.value = await fetchSummary({ refresh: true });
+    await store.dispatch('setUser');
+    await store.dispatch('accounts/get', {
+      accountId: route.params.accountId,
+    });
+    if (isShopifyReturn.value) {
+      await clearShopifyReturnParams();
+    }
+  } catch {
+    hasError.value = true;
+    isStale.value = true;
+  } finally {
+    isRefreshing.value = false;
+  }
+
+  isLoading.value = false;
+};
+
+const manageSubscription = () => {
+  store.dispatch('accounts/checkout');
+};
+
+onMounted(loadSummary);
+</script>
+
+<template>
+  <SettingsLayout
+    :is-loading="isLoading"
+    :loading-message="$t('BILLING_SETTINGS.SHOPIFY.LOADING')"
+  >
+    <template #header>
+      <BaseSettingsHeader
+        :title="$t('BILLING_SETTINGS.SHOPIFY.TITLE')"
+        :description="
+          replaceInstallationName($t('BILLING_SETTINGS.SHOPIFY.DESCRIPTION'))
+        "
+      />
+    </template>
+    <template #body>
+      <section class="grid gap-4">
+        <div
+          v-if="isStale"
+          class="rounded-xl border border-n-amber-5 bg-n-amber-2 px-5 py-4"
+        >
+          <p class="text-sm font-medium text-n-amber-12">
+            {{ $t('BILLING_SETTINGS.SHOPIFY.STALE_TITLE') }}
+          </p>
+          <p class="mt-1 text-sm text-n-amber-11">
+            {{ $t('BILLING_SETTINGS.SHOPIFY.STALE_DESCRIPTION') }}
+          </p>
+        </div>
+
+        <div
+          v-if="hasError && !summary"
+          class="rounded-xl border border-n-weak bg-n-solid-2 px-5 py-8 text-center"
+        >
+          <p class="text-base font-medium text-n-slate-12">
+            {{ $t('BILLING_SETTINGS.SHOPIFY.ERROR_TITLE') }}
+          </p>
+          <p class="mt-1 text-sm text-n-slate-11">
+            {{ $t('BILLING_SETTINGS.SHOPIFY.ERROR_DESCRIPTION') }}
+          </p>
+          <ButtonV4 class="mt-4" sm solid blue @click="loadSummary">
+            {{ $t('BILLING_SETTINGS.SHOPIFY.RETRY') }}
+          </ButtonV4>
+        </div>
+
+        <BillingCard
+          v-else-if="summary"
+          :title="$t('BILLING_SETTINGS.SHOPIFY.PLAN_TITLE')"
+          :description="
+            replaceInstallationName(
+              $t('BILLING_SETTINGS.SHOPIFY.PLAN_DESCRIPTION')
+            )
+          "
+        >
+          <template #action>
+            <ButtonV4
+              v-if="canManageSubscription"
+              sm
+              solid
+              blue
+              :is-loading="isRefreshing"
+              :disabled="isRefreshing"
+              @click="manageSubscription"
+            >
+              {{ actionLabel }}
+            </ButtonV4>
+          </template>
+
+          <div
+            class="grid grid-cols-1 gap-2 divide-x divide-n-weak sm:grid-cols-2 lg:grid-cols-4"
+          >
+            <DetailItem
+              :label="$t('BILLING_SETTINGS.SHOPIFY.CURRENT_PLAN')"
+              :value="summary.plan?.name || statusLabel"
+            />
+            <DetailItem
+              :label="$t('BILLING_SETTINGS.SHOPIFY.SUBSCRIPTION_STATUS')"
+              :value="statusLabel"
+            />
+            <DetailItem
+              v-if="formattedRecurringPrice"
+              :label="$t('BILLING_SETTINGS.SHOPIFY.PRICE')"
+              :value="formattedRecurringPrice"
+            />
+            <DetailItem
+              v-if="billingDate"
+              :label="billingDate.label"
+              :value="billingDate.value"
+            />
+            <DetailItem
+              v-if="lastVerifiedAt"
+              :label="$t('BILLING_SETTINGS.SHOPIFY.LAST_VERIFIED')"
+              :value="lastVerifiedAt"
+            />
+          </div>
+        </BillingCard>
+      </section>
+    </template>
+  </SettingsLayout>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/billing/billing.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/billing/billing.routes.js
@@ -1,7 +1,7 @@
 import { frontendURL } from '../../../../helper/URLHelper';
 import { INSTALLATION_TYPES } from 'dashboard/constants/installationTypes';
 import SettingsWrapper from '../SettingsWrapper.vue';
-import Index from './Index.vue';
+import ProviderIndex from './ProviderIndex.vue';
 
 export default {
   routes: [
@@ -21,7 +21,7 @@ export default {
         {
           path: '',
           name: 'billing_settings_index',
-          component: Index,
+          component: ProviderIndex,
           meta: {
             installationTypes: [INSTALLATION_TYPES.CLOUD],
             permissions: ['administrator'],

--- a/app/javascript/dashboard/routes/dashboard/settings/billing/specs/Index.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/billing/specs/Index.spec.js
@@ -1,0 +1,113 @@
+import { shallowMount } from '@vue/test-utils';
+import { nextTick, ref } from 'vue';
+
+import ProviderIndex from '../ProviderIndex.vue';
+import ShopifyBilling from '../ShopifyBilling.vue';
+import StripeBilling from '../Index.vue';
+import BaseSettingsHeader from '../../components/BaseSettingsHeader.vue';
+
+const currentAccount = ref({});
+const isCloudFeatureEnabled = vi.fn();
+
+vi.mock('dashboard/composables/useAccount', () => ({
+  useAccount: () => ({
+    currentAccount,
+    isCloudFeatureEnabled,
+  }),
+}));
+
+vi.mock('shared/composables/useBranding', () => ({
+  useBranding: () => ({
+    replaceInstallationName: text => text.replace(/chatwoot/gi, 'Acme'),
+  }),
+}));
+
+const mountComponent = () =>
+  shallowMount(ProviderIndex, {
+    global: {
+      mocks: {
+        $t: key =>
+          key === 'BILLING_SETTINGS.SHOPIFY.DESCRIPTION'
+            ? 'Your Chatwoot subscription is billed through Shopify.'
+            : key,
+      },
+      stubs: {
+        SettingsLayout: {
+          name: 'SettingsLayout',
+          props: {
+            isLoading: Boolean,
+            loadingMessage: String,
+            noRecordsFound: Boolean,
+            noRecordsMessage: String,
+          },
+          template: '<main><slot name="header" /><slot /></main>',
+        },
+        BaseSettingsHeader: {
+          name: 'BaseSettingsHeader',
+          props: ['title', 'description'],
+          template: '<header>{{ title }} {{ description }}</header>',
+        },
+      },
+    },
+  });
+
+describe('Billing settings provider dispatcher', () => {
+  beforeEach(() => {
+    currentAccount.value = {};
+    isCloudFeatureEnabled.mockReset();
+  });
+
+  it('waits for the account before mounting a billing provider', () => {
+    const wrapper = mountComponent();
+
+    expect(wrapper.findComponent(StripeBilling).exists()).toBe(false);
+    expect(wrapper.findComponent(ShopifyBilling).exists()).toBe(false);
+  });
+
+  it('preserves Stripe billing for regular accounts', async () => {
+    const wrapper = mountComponent();
+    currentAccount.value = {
+      id: 1,
+      billing_provider: 'stripe',
+    };
+    await nextTick();
+
+    expect(wrapper.findComponent(StripeBilling).exists()).toBe(true);
+    expect(wrapper.findComponent(ShopifyBilling).exists()).toBe(false);
+  });
+
+  it('shows Shopify billing when both provider and feature gate match', async () => {
+    isCloudFeatureEnabled.mockReturnValue(true);
+    const wrapper = mountComponent();
+    currentAccount.value = {
+      id: 1,
+      billing_provider: 'shopify',
+    };
+    await nextTick();
+
+    expect(wrapper.findComponent(ShopifyBilling).exists()).toBe(true);
+    expect(wrapper.findComponent(StripeBilling).exists()).toBe(false);
+  });
+
+  it('never falls back to Stripe when Shopify billing is disabled', async () => {
+    isCloudFeatureEnabled.mockReturnValue(false);
+    const wrapper = mountComponent();
+    currentAccount.value = {
+      id: 1,
+      billing_provider: 'shopify',
+    };
+    await nextTick();
+
+    expect(wrapper.findComponent(ShopifyBilling).exists()).toBe(false);
+    expect(wrapper.findComponent(StripeBilling).exists()).toBe(false);
+    expect(wrapper.findComponent(BaseSettingsHeader).props('description')).toBe(
+      'Your Acme subscription is billed through Shopify.'
+    );
+    expect(wrapper.findComponent({ name: 'SettingsLayout' }).props()).toEqual(
+      expect.objectContaining({
+        noRecordsFound: true,
+        noRecordsMessage: 'BILLING_SETTINGS.SHOPIFY.UNAVAILABLE',
+      })
+    );
+  });
+});

--- a/app/javascript/dashboard/routes/dashboard/settings/billing/specs/ShopifyBilling.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/billing/specs/ShopifyBilling.spec.js
@@ -1,0 +1,259 @@
+import { mount, flushPromises } from '@vue/test-utils';
+
+import ShopifyBilling from '../ShopifyBilling.vue';
+import EnterpriseAccountAPI from 'dashboard/api/enterprise/account';
+
+const mocks = vi.hoisted(() => ({
+  route: { query: {}, params: { accountId: 1 } },
+  replace: vi.fn(),
+  dispatch: vi.fn(),
+  translate: (key, params) => {
+    const translations = {
+      'BILLING_SETTINGS.SHOPIFY.DESCRIPTION':
+        'Your Chatwoot subscription is billed through Shopify.',
+      'BILLING_SETTINGS.SHOPIFY.PLAN_DESCRIPTION':
+        'Manage your Chatwoot plan in Shopify.',
+    };
+    if (params?.price) return `${key}: ${params.price}`;
+    return translations[key] || key;
+  },
+}));
+
+vi.mock('vue-router', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useRoute: () => mocks.route,
+    useRouter: () => ({ replace: mocks.replace }),
+  };
+});
+
+vi.mock('dashboard/composables/store', () => ({
+  useStore: () => ({ dispatch: mocks.dispatch }),
+}));
+
+vi.mock('vue-i18n', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useI18n: () => ({ t: mocks.translate }),
+  };
+});
+
+vi.mock('dashboard/api/enterprise/account', () => ({
+  default: {
+    billingSummary: vi.fn(),
+  },
+}));
+
+vi.mock('shared/composables/useBranding', () => ({
+  useBranding: () => ({
+    replaceInstallationName: text => text.replace(/chatwoot/gi, 'Acme'),
+  }),
+}));
+
+const summary = {
+  provider: 'shopify',
+  state: 'active',
+  plan: { name: 'Shopify Growth', handle: 'growth' },
+  amount: '49.00',
+  currency: 'USD',
+  billing_period: 'EVERY_30_DAYS',
+  trial_ends_at: null,
+  current_period_end: '2026-08-29T00:00:00Z',
+  allowed_actions: {
+    manage_subscription: true,
+  },
+  last_verified_at: '2026-07-29T08:30:00Z',
+};
+
+const SettingsLayoutStub = {
+  name: 'SettingsLayout',
+  props: ['isLoading', 'loadingMessage'],
+  template: '<main><slot name="header" /><slot name="body" /></main>',
+};
+
+const BillingCardStub = {
+  name: 'BillingCard',
+  props: ['title', 'description'],
+  template: '<section><slot name="action" /><slot /></section>',
+};
+
+const ButtonStub = {
+  name: 'ButtonV4',
+  props: ['isLoading', 'disabled'],
+  emits: ['click'],
+  template: '<button @click="$emit(\'click\')"><slot /></button>',
+};
+
+const mountComponent = () =>
+  mount(ShopifyBilling, {
+    global: {
+      mocks: {
+        $t: mocks.translate,
+      },
+      stubs: {
+        SettingsLayout: SettingsLayoutStub,
+        BillingCard: BillingCardStub,
+        BaseSettingsHeader: true,
+        DetailItem: {
+          name: 'DetailItem',
+          props: ['label', 'value'],
+          template: '<div>{{ label }}: {{ value }}</div>',
+        },
+        ButtonV4: ButtonStub,
+      },
+    },
+  });
+
+describe('ShopifyBilling', () => {
+  beforeEach(() => {
+    mocks.route.query = {};
+    mocks.replace.mockReset();
+    mocks.dispatch.mockReset();
+    EnterpriseAccountAPI.billingSummary.mockReset();
+  });
+
+  it('renders the normalized Shopify subscription summary', async () => {
+    EnterpriseAccountAPI.billingSummary.mockResolvedValue({ data: summary });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(EnterpriseAccountAPI.billingSummary).toHaveBeenCalledWith({
+      refresh: false,
+    });
+    expect(EnterpriseAccountAPI.billingSummary).toHaveBeenCalledWith({
+      refresh: true,
+    });
+    expect(mocks.dispatch).toHaveBeenCalledWith('setUser');
+    expect(wrapper.text()).toContain('Shopify Growth');
+    expect(wrapper.text()).toContain('BILLING_SETTINGS.SHOPIFY.STATUS.ACTIVE');
+    expect(wrapper.text()).toContain('$49.00');
+    expect(wrapper.text()).toContain(
+      'BILLING_SETTINGS.SHOPIFY.PER_MONTH: $49.00'
+    );
+    expect(wrapper.findComponent(BillingCardStub).props('description')).toBe(
+      'Manage your Acme plan in Shopify.'
+    );
+    expect(wrapper.text()).toContain('BILLING_SETTINGS.SHOPIFY.RENEWS_ON');
+  });
+
+  it('labels annual prices with their actual billing period', async () => {
+    EnterpriseAccountAPI.billingSummary.mockResolvedValue({
+      data: { ...summary, billing_period: 'ANNUAL' },
+    });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      'BILLING_SETTINGS.SHOPIFY.PER_YEAR: $49.00'
+    );
+    expect(wrapper.text()).not.toContain(
+      'BILLING_SETTINGS.SHOPIFY.PER_MONTH: $49.00'
+    );
+  });
+
+  it('opens Shopify-hosted App Pricing through the provider-aware checkout', async () => {
+    EnterpriseAccountAPI.billingSummary.mockResolvedValue({ data: summary });
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    await wrapper.find('button').trigger('click');
+
+    expect(mocks.dispatch).toHaveBeenCalledWith('accounts/checkout');
+  });
+
+  it('refreshes and clears Shopify return parameters after App Pricing', async () => {
+    mocks.route.query = {
+      shop: 'store.myshopify.com',
+      plan_handle: 'growth',
+      source: 'billing',
+    };
+    EnterpriseAccountAPI.billingSummary
+      .mockResolvedValueOnce({ data: { ...summary, state: 'pending' } })
+      .mockResolvedValueOnce({ data: summary });
+
+    mountComponent();
+    await flushPromises();
+
+    expect(EnterpriseAccountAPI.billingSummary).toHaveBeenNthCalledWith(1, {
+      refresh: false,
+    });
+    expect(EnterpriseAccountAPI.billingSummary).toHaveBeenNthCalledWith(2, {
+      refresh: true,
+    });
+    expect(mocks.dispatch).toHaveBeenCalledWith('setUser');
+    expect(mocks.dispatch).toHaveBeenCalledWith('accounts/get', {
+      accountId: 1,
+    });
+    expect(mocks.replace).toHaveBeenCalledWith({
+      query: { source: 'billing' },
+    });
+  });
+
+  it('preserves the last verified summary when a return refresh fails', async () => {
+    mocks.route.query = { plan_handle: 'growth' };
+    EnterpriseAccountAPI.billingSummary
+      .mockResolvedValueOnce({ data: summary })
+      .mockRejectedValueOnce(new Error('Shopify unavailable'));
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Shopify Growth');
+    expect(wrapper.text()).toContain('BILLING_SETTINGS.SHOPIFY.STALE_TITLE');
+    expect(mocks.replace).not.toHaveBeenCalled();
+  });
+
+  it('shows an initial error and retries without losing the page', async () => {
+    EnterpriseAccountAPI.billingSummary
+      .mockRejectedValueOnce(new Error('Shopify unavailable'))
+      .mockResolvedValueOnce({ data: summary })
+      .mockResolvedValueOnce({ data: summary });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('BILLING_SETTINGS.SHOPIFY.ERROR_TITLE');
+
+    await wrapper.find('button').trigger('click');
+    await flushPromises();
+
+    expect(EnterpriseAccountAPI.billingSummary).toHaveBeenCalledTimes(3);
+    expect(wrapper.text()).toContain('Shopify Growth');
+  });
+
+  it('shows the scheduled access end for a cancelled subscription', async () => {
+    EnterpriseAccountAPI.billingSummary.mockResolvedValue({
+      data: { ...summary, state: 'cancelled' },
+    });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(
+      'BILLING_SETTINGS.SHOPIFY.STATUS.CANCELLED'
+    );
+    expect(wrapper.text()).toContain('BILLING_SETTINGS.SHOPIFY.ACCESS_UNTIL');
+  });
+
+  it('ignores a historical trial date after the trial ends', async () => {
+    EnterpriseAccountAPI.billingSummary.mockResolvedValue({
+      data: {
+        ...summary,
+        state: 'active',
+        trial_ends_at: '2026-07-01T00:00:00Z',
+      },
+    });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('BILLING_SETTINGS.SHOPIFY.RENEWS_ON');
+    expect(wrapper.text()).not.toContain(
+      'BILLING_SETTINGS.SHOPIFY.TRIAL_ENDS_ON'
+    );
+  });
+});

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Shopify.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Shopify.vue
@@ -46,7 +46,8 @@ const hideStoreUrlModal = () => {
 };
 
 const validateStoreUrl = url => {
-  const pattern = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.com$/;
+  const pattern =
+    /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.myshopify\.(?:com|io)$/i;
   return pattern.test(url);
 };
 

--- a/app/javascript/dashboard/store/modules/accounts.js
+++ b/app/javascript/dashboard/store/modules/accounts.js
@@ -55,12 +55,12 @@ export const getters = {
 };
 
 export const actions = {
-  get: async ({ commit }, { silent } = {}) => {
+  get: async ({ commit }, { silent, accountId } = {}) => {
     if (!silent) {
       commit(types.default.SET_ACCOUNT_UI_FLAG, { isFetchingItem: true });
     }
     try {
-      const response = await AccountAPI.get();
+      const response = await AccountAPI.get(accountId);
       commit(types.default.ADD_ACCOUNT, response.data);
     } catch {
       // silent failure

--- a/app/javascript/dashboard/store/modules/specs/account/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/account/actions.spec.js
@@ -35,6 +35,18 @@ describe('#actions', () => {
         [types.default.SET_ACCOUNT_UI_FLAG, { isFetchingItem: false }],
       ]);
     });
+
+    it('fetches an explicitly selected account outside an account route', async () => {
+      axios.get.mockResolvedValue({ data: accountData });
+
+      await actions.get({ commit }, { accountId: 1, silent: true });
+
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/accounts/1');
+      expect(commit).toHaveBeenCalledWith(
+        types.default.ADD_ACCOUNT,
+        accountData
+      );
+    });
   });
 
   describe('#update', () => {

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -238,5 +238,6 @@ end
 
 Account.prepend_mod_with('Account')
 Account.prepend_mod_with('Account::PlanUsageAndLimits')
+Account.include_mod_with('AccountBillingIdentity')
 Account.include_mod_with('Concerns::Account')
 Account.include_mod_with('Audit::Account')

--- a/app/models/integrations/app.rb
+++ b/app/models/integrations/app.rb
@@ -47,6 +47,10 @@ class Integrations::App
       "#{params[:action]}&client_id=#{client_id}&redirect_uri=#{self.class.slack_integration_url}"
     when 'linear'
       build_linear_action
+    when 'shopify'
+      return unless Shopify::FeatureGate.enabled?(account: Current.account)
+
+      GlobalConfigService.load('SHOPIFY_APP_STORE_URL', nil)
     else
       params[:action]
     end
@@ -88,6 +92,8 @@ class Integrations::App
       account.webhooks.exists?
     when 'dashboard_apps'
       account.dashboard_apps.exists?
+    when 'shopify'
+      account.hooks.exists?(app_id: id, status: :enabled)
     else
       account.hooks.exists?(app_id: id)
     end
@@ -124,7 +130,8 @@ class Integrations::App
   private
 
   def shopify_enabled?(account)
-    account.feature_enabled?('shopify_integration') && GlobalConfigService.load('SHOPIFY_CLIENT_ID', nil).present?
+    Shopify::FeatureGate.enabled?(account: account) &&
+      GlobalConfigService.load('SHOPIFY_CLIENT_ID', nil).present?
   end
 
   def notion_enabled?(account)

--- a/app/models/integrations/hook.rb
+++ b/app/models/integrations/hook.rb
@@ -19,6 +19,7 @@ class Integrations::Hook < ApplicationRecord
 
   attr_readonly :app_id, :account_id, :inbox_id, :hook_type
   before_validation :ensure_hook_type, on: :create
+  before_validation :normalize_shopify_reference_id, if: :shopify?
   after_create :trigger_setup_if_crm
 
   # TODO: Remove guard once encryption keys become mandatory (target 3-4 releases out).
@@ -27,6 +28,10 @@ class Integrations::Hook < ApplicationRecord
   validates :account_id, presence: true
   validates :app_id, presence: true
   validates :inbox_id, presence: true, if: -> { hook_type == 'inbox' }
+  validates :reference_id, presence: true, format: { with: Shopify::ShopDomain::FORMAT }, if: :shopify?
+  validates :reference_id,
+            uniqueness: { case_sensitive: false, conditions: -> { where(app_id: 'shopify') } },
+            if: :shopify?
   validate :validate_settings_json_schema
   validate :ensure_feature_enabled
   validate :validate_openai_api_key, if: :validate_openai_api_key?
@@ -76,6 +81,10 @@ class Integrations::Hook < ApplicationRecord
     app_id == 'notion'
   end
 
+  def shopify?
+    app_id == 'shopify'
+  end
+
   def disable
     update(status: 'disabled')
   end
@@ -98,6 +107,8 @@ class Integrations::Hook < ApplicationRecord
   private
 
   def ensure_feature_enabled
+    return if shopify? && disabled?
+
     errors.add(:feature_flag, 'Feature not enabled') unless feature_allowed?
   end
 
@@ -105,6 +116,10 @@ class Integrations::Hook < ApplicationRecord
     return if app.blank?
 
     self.hook_type = app.params[:hook_type]
+  end
+
+  def normalize_shopify_reference_id
+    self.reference_id = Shopify::ShopDomain.normalize(reference_id)
   end
 
   def validate_settings_json_schema

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -43,3 +43,5 @@ class AccountPolicy < ApplicationPolicy
     @account_user.administrator?
   end
 end
+
+AccountPolicy.prepend_mod_with('AccountPolicy')

--- a/app/services/shopify/api_context.rb
+++ b/app/services/shopify/api_context.rb
@@ -1,0 +1,19 @@
+class Shopify::ApiContext
+  API_VERSION = ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION
+  class ConfigurationError < StandardError; end
+
+  def self.setup!
+    api_key = GlobalConfigService.load('SHOPIFY_CLIENT_ID', nil).to_s
+    api_secret_key = GlobalConfigService.load('SHOPIFY_CLIENT_SECRET', nil).to_s
+    raise ConfigurationError, 'Shopify API credentials are unavailable' if api_key.blank? || api_secret_key.blank?
+
+    ShopifyAPI::Context.setup(
+      api_key: api_key,
+      api_secret_key: api_secret_key,
+      api_version: API_VERSION,
+      scope: Shopify::IntegrationHelper::REQUIRED_SCOPES.join(','),
+      is_embedded: true,
+      is_private: false
+    )
+  end
+end

--- a/app/services/shopify/feature_gate.rb
+++ b/app/services/shopify/feature_gate.rb
@@ -1,0 +1,15 @@
+class Shopify::FeatureGate
+  ACCOUNT_FEATURE = 'shopify_integration'.freeze
+  GLOBAL_CONFIG = 'ENABLE_SHOPIFY_INTEGRATION'.freeze
+
+  def self.enabled?(account: nil)
+    return false unless globally_enabled?
+
+    account.nil? || account.feature_enabled?(ACCOUNT_FEATURE)
+  end
+
+  def self.globally_enabled?
+    configured_value = GlobalConfigService.load(GLOBAL_CONFIG, 'false')
+    ActiveModel::Type::Boolean.new.cast(configured_value)
+  end
+end

--- a/app/services/shopify/installation_generation.rb
+++ b/app/services/shopify/installation_generation.rb
@@ -1,0 +1,30 @@
+class Shopify::InstallationGeneration
+  KEY = 'shopify_installation_generation'.freeze
+
+  class Changed < StandardError; end
+
+  class << self
+    def current(account)
+      account.internal_attributes[KEY].to_i
+    end
+
+    def with_current!(account, expected_generation)
+      changed = false
+      result = nil
+      account.with_lock do
+        if current(account) == expected_generation
+          result = yield
+        else
+          changed = true
+        end
+      end
+      raise Changed, 'Shopify installation changed during authorization' if changed
+
+      result
+    end
+
+    def advance!(account)
+      account.update!(internal_attributes: account.internal_attributes.merge(KEY => current(account) + 1))
+    end
+  end
+end

--- a/app/services/shopify/partner_client.rb
+++ b/app/services/shopify/partner_client.rb
@@ -1,0 +1,133 @@
+class Shopify::PartnerClient
+  DEFAULT_API_VERSION = Shopify::PartnerConfiguration::DEFAULT_API_VERSION
+  REQUEST_TIMEOUT = 5
+  SUBSCRIPTION_EVENT_TYPES = %w[
+    SUBSCRIPTION_CANCELED
+    SUBSCRIPTION_CANCELLATION_SCHEDULED
+    SUBSCRIPTION_CREATED
+    SUBSCRIPTION_FROZEN
+    SUBSCRIPTION_UNFROZEN
+    SUBSCRIPTION_UPDATED
+  ].freeze
+  QUERY = <<~GRAPHQL.freeze
+    query Subscription($appId: ID!, $shopId: ID!, $occurredAtMin: DateTime!) {
+      activeSubscription(appId: $appId, shopId: $shopId) {
+        shop {
+          id
+          myshopifyDomain
+        }
+        billingPeriod
+        cancelAtEndOfCycle
+        trialEndsAt
+        currentBillingCycle {
+          startTime
+          endTime
+        }
+        items {
+          handle
+          description
+          price {
+            __typename
+            currency
+            ... on FlatRatePrice {
+              amount
+            }
+          }
+        }
+      }
+      events(
+        first: 1
+        orderBy: OCCURRED_AT_DESC
+        filter: {
+          eventTypes: [#{SUBSCRIPTION_EVENT_TYPES.join(', ')}]
+          occurredAtMin: $occurredAtMin
+          shopId: $shopId
+          subjectId: $appId
+        }
+      ) {
+        edges {
+          node {
+            ... on SubscriptionStatus {
+              state
+              cancelEffectiveOn
+              occurredAt
+            }
+          }
+        }
+      }
+    }
+  GRAPHQL
+
+  class ConfigurationError < StandardError; end
+  class ProviderError < StandardError; end
+
+  def subscription_snapshot(shop_id:, verified_at: nil)
+    response = request(shop_id)
+    validate_response!(response)
+    Shopify::SubscriptionSnapshot.from_partner_response(response.parsed_response.fetch('data'), verified_at: verified_at || Time.current)
+  rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET, Errno::ECONNREFUSED => e
+    raise ProviderError, "Shopify Partner API request failed (#{e.class.name})"
+  rescue JSON::ParserError, KeyError, NoMethodError, TypeError
+    raise ProviderError, 'Shopify Partner API returned an invalid response'
+  end
+
+  private
+
+  def request(shop_id)
+    HTTParty.post(
+      endpoint,
+      headers: {
+        'Content-Type' => 'application/json',
+        'X-Shopify-Access-Token' => access_token
+      },
+      body: {
+        query: QUERY,
+        variables: {
+          appId: app_id,
+          shopId: shop_id,
+          occurredAtMin: 364.days.ago.iso8601
+        }
+      }.to_json,
+      timeout: REQUEST_TIMEOUT
+    )
+  end
+
+  def endpoint
+    "https://partners.shopify.com/#{organization_id}/api/#{api_version}/graphql.json"
+  end
+
+  def organization_id
+    configuration.organization_id
+  end
+
+  def app_id
+    configuration.app_id
+  end
+
+  def access_token
+    configuration.access_token
+  end
+
+  def api_version
+    configuration.api_version
+  end
+
+  def configuration
+    @configuration ||= Shopify::PartnerConfiguration.current
+  end
+
+  def validate_response!(response)
+    raise ProviderError, "Shopify Partner API returned HTTP #{response.code}" unless response.success?
+
+    body = response.parsed_response
+    raise ProviderError, 'Shopify Partner API returned GraphQL errors' if body.is_a?(Hash) && body['errors'].present?
+    raise ProviderError, 'Shopify Partner API returned an invalid response' unless valid_response_data?(body)
+  end
+
+  def valid_response_data?(body)
+    data = body['data'] if body.is_a?(Hash)
+    data.is_a?(Hash) &&
+      data.key?('activeSubscription') &&
+      data.dig('events', 'edges').is_a?(Array)
+  end
+end

--- a/app/services/shopify/partner_configuration.rb
+++ b/app/services/shopify/partner_configuration.rb
@@ -1,0 +1,63 @@
+class Shopify::PartnerConfiguration
+  DEFAULT_API_VERSION = '2026-07'.freeze
+  CORE_KEYS = %w[
+    SHOPIFY_PARTNER_ORGANIZATION_ID
+    SHOPIFY_PARTNER_APP_ID
+    SHOPIFY_PARTNER_ACCESS_TOKEN
+  ].freeze
+  KEYS = (CORE_KEYS + ['SHOPIFY_PARTNER_API_VERSION']).freeze
+
+  class << self
+    def current
+      values = {
+        'SHOPIFY_PARTNER_ORGANIZATION_ID' => GlobalConfigService.load('SHOPIFY_PARTNER_ORGANIZATION_ID', nil),
+        'SHOPIFY_PARTNER_APP_ID' => GlobalConfigService.load('SHOPIFY_PARTNER_APP_ID', nil),
+        'SHOPIFY_PARTNER_ACCESS_TOKEN' => GlobalConfigService.load('SHOPIFY_PARTNER_ACCESS_TOKEN', nil),
+        'SHOPIFY_PARTNER_API_VERSION' => GlobalConfigService.load('SHOPIFY_PARTNER_API_VERSION', DEFAULT_API_VERSION)
+      }
+      new(values).validate_complete!
+    end
+
+    def validate_for_save!(values)
+      new(values).validate_for_save!
+    end
+  end
+
+  attr_reader :organization_id, :app_id, :access_token, :api_version
+
+  def initialize(values)
+    string_values = values.to_h.stringify_keys
+    @organization_id = string_values['SHOPIFY_PARTNER_ORGANIZATION_ID'].to_s
+    @app_id = string_values['SHOPIFY_PARTNER_APP_ID'].to_s
+    @access_token = string_values['SHOPIFY_PARTNER_ACCESS_TOKEN'].to_s
+    @api_version = string_values['SHOPIFY_PARTNER_API_VERSION'].presence || DEFAULT_API_VERSION
+  end
+
+  def validate_for_save!
+    validate_api_version!
+    return self if [organization_id, app_id, access_token].all?(&:blank?)
+
+    validate_complete!
+  end
+
+  def validate_complete!
+    raise Shopify::PartnerClient::ConfigurationError, 'SHOPIFY_PARTNER_ORGANIZATION_ID is required' if organization_id.blank?
+    raise Shopify::PartnerClient::ConfigurationError, 'SHOPIFY_PARTNER_APP_ID is required' if app_id.blank?
+    raise Shopify::PartnerClient::ConfigurationError, 'SHOPIFY_PARTNER_ACCESS_TOKEN is required' if access_token.blank?
+    raise Shopify::PartnerClient::ConfigurationError, 'SHOPIFY_PARTNER_ORGANIZATION_ID must be numeric' unless organization_id.match?(/\A\d+\z/)
+    unless app_id.match?(%r{\Agid://shopify/App/\d+\z})
+      raise Shopify::PartnerClient::ConfigurationError, 'SHOPIFY_PARTNER_APP_ID must be a Shopify App GID'
+    end
+
+    validate_api_version!
+    self
+  end
+
+  private
+
+  def validate_api_version!
+    return if api_version.match?(/\A\d{4}-(0[1-9]|1[0-2])\z/)
+
+    raise Shopify::PartnerClient::ConfigurationError, 'SHOPIFY_PARTNER_API_VERSION must use YYYY-MM format'
+  end
+end

--- a/app/services/shopify/pending_installation.rb
+++ b/app/services/shopify/pending_installation.rb
@@ -1,0 +1,202 @@
+class Shopify::PendingInstallation
+  class Error < StandardError; end
+  class InvalidToken < Error; end
+  class AlreadyClaimed < Error; end
+  class CommitOutcomeUnknown < Error; end
+  class FeatureDisabled < Error; end
+  class DuplicateShop < Error; end
+
+  PAYLOAD_TTL = 10.minutes
+  CLAIM_TTL = 1.minute
+  TOKEN_FORMAT = /\A[0-9a-f]{32}\z/
+  PAYLOAD_KEY = 'shopify_pending_install:%<token>s'.freeze
+  CLAIM_KEY = 'shopify_pending_install_claim:%<token>s'.freeze
+  GENERATION_KEY = 'shopify_pending_install_generation:%<shop>s'.freeze
+
+  attr_reader :data
+
+  def self.create(access_token:, shop:, scope:, shop_generation: nil)
+    token = SecureRandom.hex(16)
+    normalized_shop = Shopify::ShopDomain.normalize(shop)
+    raise InvalidToken, 'Invalid shop domain' unless Shopify::ShopDomain.valid?(normalized_shop)
+
+    current_generation = generation(shop: normalized_shop)
+    raise InvalidToken, 'Shopify installation is no longer active' if shop_generation.present? && shop_generation.to_i != current_generation
+
+    payload = { access_token: access_token, shop: normalized_shop, scope: scope, generation: current_generation }
+    Redis::SecureStorage.set(payload_key(token), payload, PAYLOAD_TTL)
+    token
+  end
+
+  def self.generation(shop:)
+    normalized_shop = Shopify::ShopDomain.normalize(shop)
+    return 0 unless Shopify::ShopDomain.valid?(normalized_shop)
+
+    key = generation_key(normalized_shop)
+    value = ::Redis::Alfred.get(key)
+    ::Redis::Alfred.expire(key, PAYLOAD_TTL.to_i) if value.present?
+    value.to_i
+  end
+
+  def self.invalidate_shop!(shop:)
+    normalized_shop = Shopify::ShopDomain.normalize(shop)
+    return unless Shopify::ShopDomain.valid?(normalized_shop)
+
+    key = generation_key(normalized_shop)
+    ::Redis::Alfred.with do |connection|
+      connection.multi do |transaction|
+        transaction.incr(key)
+        transaction.expire(key, PAYLOAD_TTL.to_i)
+      end
+    end
+  end
+
+  def self.claim(token:, account_id: nil)
+    raise InvalidToken, 'Invalid or expired install token' unless token.is_a?(String) && token.match?(TOKEN_FORMAT)
+
+    claim_token = SecureRandom.uuid
+    claim_key = claim_key(token)
+    claimed = ::Redis::Alfred.set(claim_key, claim_token, nx: true, ex: CLAIM_TTL.to_i)
+    raise AlreadyClaimed, 'Install token is already being used' unless claimed
+
+    new(token: token, claim_key: claim_key, claim_token: claim_token, account_id: account_id)
+  rescue StandardError
+    ::Redis::Alfred.delete_if_equals(claim_key, claim_token) if claim_key && claim_token
+    raise
+  end
+
+  def self.pending?(token:)
+    return false unless token.is_a?(String) && token.match?(TOKEN_FORMAT)
+
+    data = JSON.parse(Redis::SecureStorage.get(payload_key(token)).to_s)
+    shop = Shopify::ShopDomain.normalize(data['shop'])
+    Shopify::ShopDomain.valid?(shop) && data['generation'].to_i == generation(shop: shop)
+  rescue JSON::ParserError, TypeError
+    false
+  end
+
+  def initialize(token:, claim_key:, claim_token:, account_id:)
+    @token = token
+    @claim_key = claim_key
+    @claim_token = claim_token
+    @data = load_data
+    if account_id
+      bind_to_account!(account_id)
+    elsif data['account_id'].present?
+      raise InvalidToken, 'Install token is already bound to an account'
+    end
+  end
+
+  def consume!
+    consumed = false
+
+    ::Redis::Alfred.with do |connection|
+      connection.watch(@claim_key) do
+        next unless connection.get(@claim_key) == @claim_token
+
+        consumed = connection.multi do |transaction|
+          transaction.del(payload_key)
+          transaction.del(@claim_key)
+        end.present?
+      end
+    end
+
+    raise AlreadyClaimed, 'Install token claim has expired' unless consumed
+  rescue AlreadyClaimed
+    raise
+  rescue StandardError => e
+    state = consume_state
+    return if state == :consumed
+    raise e if state == :not_consumed
+
+    raise CommitOutcomeUnknown, 'Install token consumption outcome is unknown', cause: e
+  end
+
+  def bind_to_account!(account_id)
+    bound_account_id = data['account_id']
+    raise InvalidToken, 'Install token cannot be used by this account' if bound_account_id.present? && bound_account_id != account_id
+    return if bound_account_id == account_id
+
+    persist_data(data.merge('account_id' => account_id))
+    @data['account_id'] = account_id
+    @bound_by_claim = true
+  end
+
+  def release!(unbind: false)
+    unbind_from_account! if unbind && @bound_by_claim
+    ::Redis::Alfred.delete_if_equals(@claim_key, @claim_token)
+  end
+
+  class << self
+    private
+
+    def payload_key(token)
+      format(PAYLOAD_KEY, token: token)
+    end
+
+    def claim_key(token)
+      format(CLAIM_KEY, token: token)
+    end
+
+    def generation_key(shop)
+      format(GENERATION_KEY, shop: shop)
+    end
+  end
+
+  private
+
+  def persist_data(updated_data)
+    ttl = ::Redis::Alfred.ttl(payload_key)
+    raise InvalidToken, 'Invalid or expired install token' unless ttl.positive?
+
+    Redis::SecureStorage.set(payload_key, updated_data, ttl)
+  end
+
+  def unbind_from_account!
+    persist_data(data.except('account_id'))
+  rescue InvalidToken
+    nil
+  end
+
+  def consume_state
+    payload, claim = ::Redis::Alfred.with do |connection|
+      connection.mget(payload_key, @claim_key)
+    end
+    return :consumed if payload.nil? && claim.nil?
+    return :not_consumed if payload.present?
+
+    :unknown
+  rescue StandardError
+    :unknown
+  end
+
+  def load_data
+    json_data = Redis::SecureStorage.get(payload_key)
+    raise InvalidToken, 'Invalid or expired install token' if json_data.blank?
+
+    data = JSON.parse(json_data)
+    raise InvalidToken, 'Invalid or expired install token' unless data.is_a?(Hash)
+
+    required_values = data.values_at('access_token', 'shop', 'scope')
+    raise InvalidToken, 'Invalid or expired install token' unless required_values.all?(&:present?)
+
+    data['shop'] = Shopify::ShopDomain.normalize(data['shop'])
+    raise InvalidToken, 'Invalid or expired install token' unless Shopify::ShopDomain.valid?(data['shop'])
+
+    verify_shop_generation!(data)
+
+    data
+  rescue JSON::ParserError, TypeError
+    raise InvalidToken, 'Invalid or expired install token'
+  end
+
+  def verify_shop_generation!(data)
+    return if data['generation'].to_i == self.class.generation(shop: data['shop'])
+
+    raise InvalidToken, 'Invalid or expired install token'
+  end
+
+  def payload_key
+    format(PAYLOAD_KEY, token: @token)
+  end
+end

--- a/app/services/shopify/shop_domain.rb
+++ b/app/services/shopify/shop_domain.rb
@@ -1,0 +1,11 @@
+class Shopify::ShopDomain
+  FORMAT = /\A[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.myshopify\.(?:com|io)\z/
+
+  def self.normalize(value)
+    value.to_s.strip.downcase
+  end
+
+  def self.valid?(value)
+    normalize(value).match?(FORMAT)
+  end
+end

--- a/app/services/shopify/shop_identity.rb
+++ b/app/services/shopify/shop_identity.rb
@@ -1,0 +1,54 @@
+class Shopify::ShopIdentity
+  QUERY = <<~GRAPHQL.freeze
+    query ShopIdentity {
+      shop {
+        id
+        myshopifyDomain
+      }
+    }
+  GRAPHQL
+
+  class ProviderError < StandardError; end
+
+  def initialize(hook:)
+    @hook = hook
+  end
+
+  def shop_id
+    shop = fetch_shop
+    raise ProviderError, 'Shopify Admin API returned a different shop' unless matching_shop?(shop)
+
+    shop.fetch('id')
+  rescue ProviderError
+    raise
+  rescue Shopify::ApiContext::ConfigurationError,
+         ShopifyAPI::Errors::HttpResponseError, ShopifyAPI::Errors::MaxHttpRetriesExceededError,
+         Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET, Errno::ECONNREFUSED,
+         JSON::ParserError, KeyError, NoMethodError, TypeError => e
+    raise ProviderError, "Shopify Admin API shop lookup failed (#{e.class.name})"
+  end
+
+  private
+
+  attr_reader :hook
+
+  def fetch_shop
+    response = client.query(query: QUERY)
+    body = response.body
+    raise ProviderError, 'Shopify Admin API returned GraphQL errors' if body['errors'].present?
+
+    body.dig('data', 'shop')
+  end
+
+  def client
+    Shopify::ApiContext.setup!
+    session = ShopifyAPI::Auth::Session.new(shop: hook.reference_id, access_token: hook.access_token)
+    ShopifyAPI::Clients::Graphql::Admin.new(session: session, api_version: Shopify::ApiContext::API_VERSION)
+  end
+
+  def matching_shop?(shop)
+    stored_domain = Shopify::ShopDomain.normalize(hook.reference_id)
+    returned_domain = Shopify::ShopDomain.normalize(shop.fetch('myshopifyDomain'))
+    stored_domain == returned_domain && shop.fetch('id').match?(%r{\Agid://shopify/Shop/\d+\z})
+  end
+end

--- a/app/services/shopify/subscription_fetcher.rb
+++ b/app/services/shopify/subscription_fetcher.rb
@@ -1,0 +1,57 @@
+class Shopify::SubscriptionFetcher
+  CACHE_TTL = 2.minutes
+
+  class NotEligible < StandardError; end
+
+  def initialize(account:)
+    @account = account
+  end
+
+  def perform(force: false)
+    ensure_eligible!
+    cached_snapshot = Rails.cache.read(cache_key) unless force
+    return Shopify::SubscriptionSnapshot.from_h(cached_snapshot) if cached_snapshot.present?
+
+    fetch_current_snapshot
+  end
+
+  private
+
+  attr_reader :account
+
+  def ensure_eligible!
+    raise NotEligible, 'Shopify subscription lookup is disabled' unless Shopify::FeatureGate.enabled?(account: account)
+
+    billing_identity = account.internal_attributes.stringify_keys
+    return if billing_identity['billing_provider'] == 'shopify' && billing_identity['signup_source'] == 'shopify'
+
+    raise NotEligible, 'Account is not billed through Shopify'
+  end
+
+  def hook
+    @hook ||= account.hooks.find_by!(app_id: 'shopify', status: 'enabled')
+  end
+
+  def fetch_current_snapshot
+    hook.with_lock do
+      ensure_hook_enabled!
+      verified_at = Time.current
+      snapshot = Shopify::PartnerClient.new.subscription_snapshot(
+        shop_id: Shopify::ShopIdentity.new(hook: hook).shop_id,
+        verified_at: verified_at
+      )
+      Rails.cache.write(cache_key, snapshot.to_h, expires_in: CACHE_TTL)
+      snapshot
+    end
+  end
+
+  def ensure_hook_enabled!
+    return if hook.enabled? && hook.access_token.present?
+
+    raise ActiveRecord::RecordNotFound, 'Shopify integration credentials are unavailable'
+  end
+
+  def cache_key
+    "shopify:subscription_snapshot:account:#{account.id}"
+  end
+end

--- a/app/services/shopify/subscription_snapshot.rb
+++ b/app/services/shopify/subscription_snapshot.rb
@@ -1,0 +1,86 @@
+class Shopify::SubscriptionSnapshot
+  ENTITLED_STATES = %w[active trialing cancelled].freeze
+  STATES = (ENTITLED_STATES + %w[expired missing]).freeze
+
+  attr_reader :attributes
+
+  def self.from_partner_response(data, verified_at: Time.current)
+    active_subscription = data['activeSubscription']
+    latest_event = data.dig('events', 'edges', 0, 'node')
+
+    new(build_attributes(active_subscription, latest_event, verified_at))
+  end
+
+  def self.from_h(attributes)
+    new(attributes)
+  end
+
+  def initialize(attributes)
+    @attributes = attributes.deep_stringify_keys
+    raise ArgumentError, "Unknown Shopify subscription state: #{state}" unless STATES.include?(state)
+  end
+
+  def state
+    attributes.fetch('state')
+  end
+
+  def plan_handles
+    attributes.fetch('plan_handles')
+  end
+
+  def entitled?
+    ENTITLED_STATES.include?(state)
+  end
+
+  def to_h
+    attributes.deep_dup
+  end
+
+  class << self
+    private
+
+    def build_attributes(active_subscription, latest_event, verified_at)
+      subscription_items = Array(active_subscription&.fetch('items', nil))
+      primary_item = subscription_items.one? ? subscription_items.first : nil
+
+      {
+        'state' => subscription_state(active_subscription, latest_event, verified_at),
+        'plan_handles' => subscription_items.pluck('handle').compact,
+        'plan_name' => primary_item&.fetch('description', nil),
+        'amount' => primary_item&.dig('price', 'amount'),
+        'currency' => primary_item&.dig('price', 'currency'),
+        'billing_period' => active_subscription&.fetch('billingPeriod', nil),
+        'trial_ends_at' => active_subscription&.fetch('trialEndsAt', nil),
+        'current_period_start' => active_subscription&.dig('currentBillingCycle', 'startTime'),
+        'current_period_end' => active_subscription&.dig('currentBillingCycle', 'endTime'),
+        'cancel_at_period_end' => active_subscription&.fetch('cancelAtEndOfCycle', false) || false,
+        'shop_id' => active_subscription&.dig('shop', 'id'),
+        'shop_domain' => active_subscription&.dig('shop', 'myshopifyDomain'),
+        'latest_event' => normalize_event(latest_event),
+        'verified_at' => verified_at.utc.iso8601(6)
+      }
+    end
+
+    def subscription_state(active_subscription, latest_event, verified_at)
+      if active_subscription.present?
+        return 'cancelled' if active_subscription['cancelAtEndOfCycle'] == true
+        return 'trialing' if active_trial?(active_subscription, verified_at)
+
+        return 'active'
+      end
+
+      %w[CANCELED FROZEN].include?(latest_event&.fetch('state', nil)) ? 'expired' : 'missing'
+    end
+
+    def active_trial?(active_subscription, verified_at)
+      trial_ends_at = active_subscription['trialEndsAt']
+      trial_ends_at.present? && Time.iso8601(trial_ends_at) > verified_at
+    end
+
+    def normalize_event(latest_event)
+      return if latest_event.blank?
+
+      latest_event.slice('state', 'cancelEffectiveOn', 'occurredAt').transform_keys(&:underscore)
+    end
+  end
+end

--- a/app/services/shopify/uninstallation_service.rb
+++ b/app/services/shopify/uninstallation_service.rb
@@ -1,0 +1,47 @@
+class Shopify::UninstallationService
+  def initialize(hook:, occurred_at: nil, delete_hook: false)
+    @hook = hook
+    @account = hook.account
+    @occurred_at = occurred_at
+    @delete_hook = delete_hook
+  end
+
+  def perform
+    failure = nil
+    outcome = :stale
+    account.with_lock do
+      hook.with_lock do
+        next if stale_event?
+
+        begin
+          Shopify::InstallationGeneration.advance!(account)
+          uninstall
+          hook.destroy! if delete_hook && hook.persisted?
+          outcome = :uninstalled
+        rescue StandardError => e
+          failure = e
+        end
+      end
+    end
+    raise failure if failure
+
+    outcome
+  end
+
+  private
+
+  attr_reader :account, :hook, :occurred_at, :delete_hook
+
+  def stale_event?
+    connected_at = hook.settings['connected_at']
+    return false if occurred_at.blank? || connected_at.blank?
+
+    occurred_at < Time.iso8601(connected_at)
+  end
+
+  def uninstall
+    hook.destroy!
+  end
+end
+
+Shopify::UninstallationService.prepend_mod_with('Shopify::UninstallationService')

--- a/app/views/api/v1/models/_account.json.jbuilder
+++ b/app/views/api/v1/models/_account.json.jbuilder
@@ -26,7 +26,9 @@ if resource.custom_attributes.present?
   end
 end
 json.domain @account.domain
-json.features @account.enabled_features
+features = @account.enabled_features
+features.delete(Shopify::FeatureGate::ACCOUNT_FEATURE) unless Shopify::FeatureGate.enabled?(account: @account)
+json.features features
 json.id @account.id
 json.locale @account.locale
 json.name @account.name

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -271,6 +271,12 @@
   display_title: 'Cloud Plans'
   value:
   description: 'Config to store stripe plans for cloud'
+- name: CHATWOOT_SHOPIFY_PLANS
+  display_title: 'Shopify Plans'
+  value: []
+  locked: true
+  description: 'Locked Shopify App Pricing plan catalog with plan handles, features, and fixed limits'
+  type: code
 - name: CAPTAIN_TOPUP_OPTIONS
   display_title: 'Captain Topup Options'
   value: {}
@@ -443,6 +449,12 @@
 ## ------ End of Configs added for Slack ------ ##
 
 # ------- Shopify Integration Config ------- #
+- name: ENABLE_SHOPIFY_INTEGRATION
+  display_title: 'Enable Shopify Integration'
+  value: false
+  description: 'Enable Shopify OAuth, account integration APIs, webhooks, and dashboard surfaces'
+  locked: false
+  type: boolean
 - name: SHOPIFY_CLIENT_ID
   display_title: 'Shopify Client ID'
   description: 'The Client ID (API Key) from your Shopify Partner account'
@@ -453,6 +465,28 @@
   description: 'The Client Secret (API Secret Key) from your Shopify Partner account'
   locked: false
   type: secret
+- name: SHOPIFY_APP_STORE_URL
+  display_title: 'Shopify App Store URL'
+  description: 'The Shopify App Store listing URL (e.g., https://apps.shopify.com/your-app)'
+  locked: false
+- name: SHOPIFY_PARTNER_ORGANIZATION_ID
+  display_title: 'Shopify Partner Organization ID'
+  description: 'The numeric organization ID used to access the Shopify Partner API'
+  locked: false
+- name: SHOPIFY_PARTNER_APP_ID
+  display_title: 'Shopify Partner App ID'
+  description: 'The Shopify App GID used to query managed pricing subscriptions'
+  locked: false
+- name: SHOPIFY_PARTNER_ACCESS_TOKEN
+  display_title: 'Shopify Partner Access Token'
+  description: 'The Partner API token with Manage apps permission'
+  locked: false
+  type: secret
+- name: SHOPIFY_PARTNER_API_VERSION
+  display_title: 'Shopify Partner API Version'
+  description: 'The pinned Partner API version used for managed pricing'
+  value: '2026-07'
+  locked: false
 # ------- End of Shopify Related Config ------- #
 
 # ------- Instagram Channel Related Config ------- #

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,6 +216,9 @@ en:
     billing:
       invalid_currency: Invalid billing currency
       currency_locked: Billing currency cannot be changed after billing has been set up
+      provider_action_unavailable: This billing action is not available for Shopify-billed accounts
+      shopify_pricing_unavailable: Shopify App Pricing is not available right now
+      shopify_verification_failed: Shopify billing could not be verified right now
     topup:
       credits_required: Credits amount is required
       invalid_credits: Invalid credits amount

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -573,6 +573,7 @@ Rails.application.routes.draw do
         namespace :v1 do
           resources :accounts do
             member do
+              get :billing_summary
               post :checkout
               post :subscription
               post :select_billing_currency

--- a/enterprise/app/controllers/enterprise/api/v1/accounts/integrations/base_controller.rb
+++ b/enterprise/app/controllers/enterprise/api/v1/accounts/integrations/base_controller.rb
@@ -1,0 +1,17 @@
+module Enterprise::Api::V1::Accounts::Integrations::BaseController
+  private
+
+  def check_authorization
+    super
+    return unless shopify_billing_hook_mutation?
+
+    render json: { error: 'Shopify-billed integrations must be managed in Shopify' }, status: :unprocessable_entity
+  end
+
+  def shopify_billing_hook_mutation?
+    %w[update destroy].include?(action_name) &&
+      @hook&.app_id == 'shopify' &&
+      Current.account.billing_provider == 'shopify' &&
+      Current.account.signup_source == 'shopify'
+  end
+end

--- a/enterprise/app/controllers/enterprise/api/v1/accounts_controller.rb
+++ b/enterprise/app/controllers/enterprise/api/v1/accounts_controller.rb
@@ -1,9 +1,20 @@
 class Enterprise::Api::V1::AccountsController < Api::BaseController
   include BillingHelper
+  SHOPIFY_BILLING_ACTIONS = %i[billing_summary checkout subscription select_billing_currency topup_checkout topup_options].freeze
+  STRIPE_ONLY_BILLING_ACTIONS = %i[subscription select_billing_currency topup_checkout topup_options].freeze
+
   before_action :fetch_account
   before_action :validate_token_api_access, if: :authenticate_by_access_token?
   before_action :check_authorization
   before_action :check_cloud_env, only: [:limits, :toggle_deletion, :topup_options]
+  before_action :ensure_shopify_billing_available, only: SHOPIFY_BILLING_ACTIONS
+  before_action :ensure_stripe_billing_action, only: STRIPE_ONLY_BILLING_ACTIONS
+
+  def billing_summary
+    render json: Enterprise::Billing::SummaryService.new(account: @account).perform(refresh: ActiveModel::Type::Boolean.new.cast(params[:refresh]))
+  rescue Enterprise::Billing::SummaryService::RefreshError
+    render json: { error: I18n.t('errors.billing.shopify_verification_failed') }, status: :service_unavailable
+  end
 
   def subscription
     return render json: currency_selection_payload if @account.billing_currency_selection_required?
@@ -25,7 +36,7 @@ class Enterprise::Api::V1::AccountsController < Api::BaseController
   end
 
   def limits
-    limits = if default_plan?(@account)
+    limits = if @account.billing_provider == Account::DEFAULT_BILLING_PROVIDER && default_plan?(@account)
                {
                  'conversation' => {
                    'allowed' => 500,
@@ -49,6 +60,7 @@ class Enterprise::Api::V1::AccountsController < Api::BaseController
   end
 
   def checkout
+    return create_shopify_billing_session if shopify_billing?
     return create_stripe_billing_session(stripe_customer_id) if stripe_customer_id.present?
 
     render_invalid_billing_details
@@ -90,6 +102,12 @@ class Enterprise::Api::V1::AccountsController < Api::BaseController
 
   private
 
+  def ensure_stripe_billing_action
+    return if @account.billing_provider == Account::DEFAULT_BILLING_PROVIDER
+
+    render_could_not_create_error(I18n.t('errors.billing.provider_action_unavailable'))
+  end
+
   def validate_token_api_access
     return if @account.api_and_webhooks_enabled?
 
@@ -105,6 +123,12 @@ class Enterprise::Api::V1::AccountsController < Api::BaseController
 
     @account.update!(custom_attributes: @account.custom_attributes.merge('is_creating_customer' => true))
     Enterprise::CreateStripeCustomerJob.perform_later(@account)
+  end
+
+  def ensure_shopify_billing_available
+    return unless shopify_billing?
+
+    render_not_found_error('Not found') unless @account.signup_source == 'shopify' && Shopify::FeatureGate.enabled?(account: @account)
   end
 
   def currency_selection_payload
@@ -170,6 +194,14 @@ class Enterprise::Api::V1::AccountsController < Api::BaseController
     session = Enterprise::Billing::CreateSessionService.new.create_session(customer_id)
     render_redirect_url(session.url)
   end
+
+  def create_shopify_billing_session
+    render_redirect_url(Enterprise::Billing::ShopifyAppPricingUrl.new(account: @account).perform)
+  rescue Enterprise::Billing::ShopifyAppPricingUrl::Error, ActiveRecord::RecordNotFound
+    render_could_not_create_error(I18n.t('errors.billing.shopify_pricing_unavailable'))
+  end
+
+  def shopify_billing? = @account.billing_provider == 'shopify'
 
   def render_redirect_url(redirect_url)
     render json: { redirect_url: redirect_url }

--- a/enterprise/app/controllers/enterprise/super_admin/app_configs_controller.rb
+++ b/enterprise/app/controllers/enterprise/super_admin/app_configs_controller.rb
@@ -1,4 +1,15 @@
 module Enterprise::SuperAdmin::AppConfigsController
+  SHOPIFY_APP_HANDLE_CONFIG = {
+    'display_title' => 'Shopify App Handle',
+    'description' => 'The app handle used in Shopify Admin App Pricing URLs',
+    'locked' => false
+  }.freeze
+
+  def show
+    super
+    @installation_configs['SHOPIFY_APP_HANDLE'] = SHOPIFY_APP_HANDLE_CONFIG
+  end
+
   private
 
   def allowed_configs
@@ -13,9 +24,20 @@ module Enterprise::SuperAdmin::AppConfigsController
       @allowed_configs = captain_config_options
     when 'saml'
       @allowed_configs = saml_config_options
+    when 'shopify'
+      @allowed_configs = super + %w[SHOPIFY_APP_HANDLE]
     else
       super
     end
+  end
+
+  def shopify_partner_config_errors
+    errors = super
+    app_handle = params.dig('app_config', 'SHOPIFY_APP_HANDLE')
+    return errors if @config != 'shopify' || app_handle.nil?
+    return errors if app_handle.match?(Enterprise::Billing::ShopifyAppPricingUrl::APP_HANDLE_FORMAT)
+
+    errors + ['SHOPIFY_APP_HANDLE must contain only lowercase letters, numbers, and hyphens']
   end
 
   def custom_branding_options

--- a/enterprise/app/controllers/enterprise/super_admin/app_configs_controller.rb
+++ b/enterprise/app/controllers/enterprise/super_admin/app_configs_controller.rb
@@ -34,7 +34,7 @@ module Enterprise::SuperAdmin::AppConfigsController
   def shopify_partner_config_errors
     errors = super
     app_handle = params.dig('app_config', 'SHOPIFY_APP_HANDLE')
-    return errors if @config != 'shopify' || app_handle.nil?
+    return errors if @config != 'shopify' || app_handle.blank?
     return errors if app_handle.match?(Enterprise::Billing::ShopifyAppPricingUrl::APP_HANDLE_FORMAT)
 
     errors + ['SHOPIFY_APP_HANDLE must contain only lowercase letters, numbers, and hyphens']

--- a/enterprise/app/jobs/enterprise/billing/shopify_subscription_reconciliation_job.rb
+++ b/enterprise/app/jobs/enterprise/billing/shopify_subscription_reconciliation_job.rb
@@ -1,0 +1,21 @@
+class Enterprise::Billing::ShopifySubscriptionReconciliationJob < ApplicationJob
+  queue_as :scheduled_jobs
+
+  def perform
+    return unless Shopify::FeatureGate.globally_enabled?
+
+    Integrations::Hook.includes(:account).where(app_id: 'shopify', status: :enabled).find_each do |hook|
+      account = hook.account
+      next unless shopify_billed_account?(account)
+      next unless Shopify::FeatureGate.enabled?(account: account)
+
+      Enterprise::Billing::ShopifySubscriptionSyncJob.perform_later(account.id)
+    end
+  end
+
+  private
+
+  def shopify_billed_account?(account)
+    account.billing_provider == 'shopify' && account.signup_source == 'shopify'
+  end
+end

--- a/enterprise/app/jobs/enterprise/billing/shopify_subscription_sync_job.rb
+++ b/enterprise/app/jobs/enterprise/billing/shopify_subscription_sync_job.rb
@@ -1,0 +1,12 @@
+class Enterprise::Billing::ShopifySubscriptionSyncJob < ApplicationJob
+  queue_as :scheduled_jobs
+
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(account_id)
+    account = Account.find(account_id)
+    return unless Shopify::FeatureGate.enabled?(account: account)
+
+    Enterprise::Billing::ShopifySubscriptionSyncService.new(account: account).perform
+  end
+end

--- a/enterprise/app/jobs/enterprise/internal/trigger_hourly_scheduled_items_job.rb
+++ b/enterprise/app/jobs/enterprise/internal/trigger_hourly_scheduled_items_job.rb
@@ -1,0 +1,9 @@
+module Enterprise::Internal::TriggerHourlyScheduledItemsJob
+  def perform
+    super
+
+    return unless Shopify::FeatureGate.globally_enabled?
+
+    Enterprise::Billing::ShopifySubscriptionReconciliationJob.perform_later
+  end
+end

--- a/enterprise/app/models/enterprise/account.rb
+++ b/enterprise/app/models/enterprise/account.rb
@@ -116,6 +116,10 @@ module Enterprise::Account
   end
 
   def business_or_enterprise_plan?
+    if billing_provider == 'shopify'
+      return Enterprise::Billing::PlanConfiguration.current_plan(self)&.fetch('features', [])&.include?('advanced_assignment')
+    end
+
     plan_name = custom_attributes['plan_name']
     %w[Business Enterprise].include?(plan_name)
   end

--- a/enterprise/app/models/enterprise/account/plan_usage_and_limits.rb
+++ b/enterprise/app/models/enterprise/account/plan_usage_and_limits.rb
@@ -30,6 +30,8 @@ module Enterprise::Account::PlanUsageAndLimits # rubocop:disable Metrics/ModuleL
   end
 
   def email_transcript_enabled?
+    return current_billing_plan.present? if shopify_billing?
+
     default_plan = InstallationConfig.find_by(name: 'CHATWOOT_CLOUD_PLANS')&.value&.first
     return true if default_plan.blank?
 
@@ -41,6 +43,8 @@ module Enterprise::Account::PlanUsageAndLimits # rubocop:disable Metrics/ModuleL
   end
 
   def subscribed_features
+    return current_billing_plan&.fetch('features', []) || [] if shopify_billing?
+
     plan_features = InstallationConfig.find_by(name: 'CHATWOOT_CLOUD_PLAN_FEATURES')&.value
     return [] if plan_features.blank?
 
@@ -77,6 +81,8 @@ module Enterprise::Account::PlanUsageAndLimits # rubocop:disable Metrics/ModuleL
   end
 
   def plan_email_limit
+    return shopify_plan_limits.fetch('emails', 0) if shopify_billing?
+
     base_limit = plan_base_email_limit
     return nil if base_limit.nil?
     return base_limit if free_plan?
@@ -95,11 +101,17 @@ module Enterprise::Account::PlanUsageAndLimits # rubocop:disable Metrics/ModuleL
   end
 
   def free_plan?
+    return false if shopify_billing?
+
     default_plan = InstallationConfig.find_by(name: 'CHATWOOT_CLOUD_PLANS')&.value&.first
     default_plan.present? && plan_name&.downcase == default_plan['name']&.downcase
   end
 
   def default_captain_limits
+    shopify_billing? ? shopify_captain_limits : stripe_captain_limits
+  end
+
+  def stripe_captain_limits
     max_limits = { documents: ChatwootApp.max_limit, responses: ChatwootApp.max_limit }.with_indifferent_access
     zero_limits = { documents: 0, responses: 0 }.with_indifferent_access
     plan_quota = InstallationConfig.find_by(name: 'CAPTAIN_CLOUD_PLAN_LIMITS')&.value
@@ -122,22 +134,42 @@ module Enterprise::Account::PlanUsageAndLimits # rubocop:disable Metrics/ModuleL
     end
   end
 
+  def shopify_captain_limits
+    {
+      documents: shopify_plan_limits.fetch('captain_documents', 0),
+      responses: shopify_plan_limits.fetch('captain_responses', 0)
+    }.with_indifferent_access
+  end
+
   def plan_name
     custom_attributes['plan_name']
   end
 
   def agent_limits
-    subscribed_quantity = custom_attributes['subscribed_quantity']
+    subscribed_quantity = custom_attributes['subscribed_quantity'] unless shopify_billing?
     subscribed_quantity || get_limits(:agents)
   end
 
   def get_limits(limit_name)
     config_name = "ACCOUNT_#{limit_name.to_s.upcase}_LIMIT"
     return self[:limits][limit_name.to_s] if self[:limits][limit_name.to_s].present?
+    return shopify_plan_limits.fetch(limit_name.to_s, 0) if shopify_billing?
 
     return GlobalConfig.get(config_name)[config_name] if GlobalConfig.get(config_name)[config_name].present?
 
     ChatwootApp.max_limit
+  end
+
+  def shopify_billing?
+    billing_provider == 'shopify'
+  end
+
+  def current_billing_plan
+    Enterprise::Billing::PlanConfiguration.current_plan(self)
+  end
+
+  def shopify_plan_limits
+    current_billing_plan&.fetch('limits', {}) || {}
   end
 
   # Atomic jsonb_set to avoid clobbering concurrent writes to other custom_attributes keys.
@@ -159,6 +191,7 @@ module Enterprise::Account::PlanUsageAndLimits # rubocop:disable Metrics/ModuleL
                                      ])
     custom_attributes[key] = custom_attributes[key].to_i + 1
   end
+
   # rubocop:enable Rails/SkipsModelValidations
 
   def validate_limit_keys

--- a/enterprise/app/models/enterprise/account_billing_identity.rb
+++ b/enterprise/app/models/enterprise/account_billing_identity.rb
@@ -1,0 +1,49 @@
+module Enterprise::AccountBillingIdentity
+  extend ActiveSupport::Concern
+
+  BILLING_PROVIDERS = %w[stripe shopify].freeze
+  SIGNUP_SOURCES = %w[chatwoot shopify].freeze
+  DEFAULT_BILLING_PROVIDER = 'stripe'.freeze
+  DEFAULT_SIGNUP_SOURCE = 'chatwoot'.freeze
+
+  included do
+    validates :billing_provider, inclusion: { in: BILLING_PROVIDERS }
+    validates :signup_source, inclusion: { in: SIGNUP_SOURCES }
+    validate :validate_billing_identity_immutability, on: :update
+  end
+
+  def billing_provider
+    normalized_internal_attributes['billing_provider'].presence || DEFAULT_BILLING_PROVIDER
+  end
+
+  def billing_provider=(provider)
+    self.internal_attributes = normalized_internal_attributes.merge('billing_provider' => provider.to_s)
+  end
+
+  def signup_source
+    normalized_internal_attributes['signup_source'].presence || DEFAULT_SIGNUP_SOURCE
+  end
+
+  def signup_source=(source)
+    self.internal_attributes = normalized_internal_attributes.merge('signup_source' => source.to_s)
+  end
+
+  private
+
+  def normalized_internal_attributes
+    (internal_attributes || {}).stringify_keys
+  end
+
+  def validate_billing_identity_immutability
+    return unless will_save_change_to_internal_attributes?
+
+    validate_immutable_identity(:billing_provider, DEFAULT_BILLING_PROVIDER)
+    validate_immutable_identity(:signup_source, DEFAULT_SIGNUP_SOURCE)
+  end
+
+  def validate_immutable_identity(attribute, default)
+    stored_attributes = (attribute_in_database('internal_attributes') || {}).stringify_keys
+    stored_value = stored_attributes[attribute.to_s].presence || default
+    errors.add(attribute, 'cannot be changed after account creation') if public_send(attribute) != stored_value
+  end
+end

--- a/enterprise/app/policies/enterprise/account_policy.rb
+++ b/enterprise/app/policies/enterprise/account_policy.rb
@@ -1,0 +1,5 @@
+module Enterprise::AccountPolicy
+  def billing_summary?
+    @account_user.administrator?
+  end
+end

--- a/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
+++ b/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
@@ -27,7 +27,7 @@ class Enterprise::Billing::HandleStripeEventService
     plan = find_plan(subscription['plan']['product']) if subscription['plan'].present?
 
     # skipping self hosted plan events
-    return if plan.blank? || account.blank?
+    return if plan.blank? || !stripe_billed_account?
 
     previous_usage = capture_previous_usage
     update_account_attributes(subscription, plan)
@@ -100,7 +100,7 @@ class Enterprise::Billing::HandleStripeEventService
 
   def process_subscription_deleted
     # skipping self hosted plan events
-    return if account.blank?
+    return unless stripe_billed_account?
 
     previous_monthly_credits = current_plan_credits[:responses]
     return unless Enterprise::Billing::CreateStripeCustomerService.new(account: account).perform
@@ -170,6 +170,10 @@ class Enterprise::Billing::HandleStripeEventService
 
   def account
     @account ||= Account.where("custom_attributes->>'stripe_customer_id' = ?", subscription.customer).first
+  end
+
+  def stripe_billed_account?
+    account&.billing_provider == Account::DEFAULT_BILLING_PROVIDER
   end
 
   def find_plan(product_id)

--- a/enterprise/app/services/enterprise/billing/plan_configuration.rb
+++ b/enterprise/app/services/enterprise/billing/plan_configuration.rb
@@ -1,18 +1,57 @@
-# Resolves Stripe price ids from CHATWOOT_CLOUD_PLANS per currency.
-# A plan's `price_ids` may be a currency-keyed Hash, or a legacy Array (treated as usd).
+# Resolves billing plans from the provider-specific installation configuration.
 module Enterprise::Billing::PlanConfiguration
   CLOUD_PLANS_CONFIG = 'CHATWOOT_CLOUD_PLANS'.freeze
+  SHOPIFY_PLANS_CONFIG = Enterprise::Billing::ShopifyPlanConfiguration::CONFIG_NAME
+  PROVIDER_CONFIGS = {
+    'stripe' => CLOUD_PLANS_CONFIG,
+    'shopify' => SHOPIFY_PLANS_CONFIG
+  }.freeze
+  class InvalidConfiguration < StandardError; end
+  class UnknownPlan < StandardError; end
 
   module_function
 
-  def plans
-    InstallationConfig.find_by(name: CLOUD_PLANS_CONFIG)&.value || []
+  def plans(provider: Account::DEFAULT_BILLING_PROVIDER)
+    config_name = PROVIDER_CONFIGS.fetch(provider.to_s) do
+      raise ArgumentError, "Unsupported billing provider: #{provider}"
+    end
+    configured_plans = if provider.to_s == 'shopify'
+                         InstallationConfig.find_by!(name: config_name).value
+                       else
+                         InstallationConfig.find_by(name: config_name)&.value || []
+                       end
+
+    provider.to_s == 'shopify' ? Enterprise::Billing::ShopifyPlanConfiguration.normalize(configured_plans) : configured_plans
   end
 
-  def default_plan
-    plans.first
+  def plans_for(account)
+    plans(provider: account.billing_provider)
   end
 
+  def default_plan(account = nil)
+    provider = account&.billing_provider || Account::DEFAULT_BILLING_PROVIDER
+    plans(provider: provider).first
+  end
+
+  def current_plan(account)
+    plan_name = account.custom_attributes['plan_name']
+    return if plan_name.blank?
+
+    plans_for(account).find { |plan| plan['name'].casecmp?(plan_name.to_s) }
+  end
+
+  def current_plan!(account)
+    current_plan(account) || raise(UnknownPlan, "Unknown #{account.billing_provider} plan for account #{account.id}")
+  end
+
+  def find_shopify_plan_by_handle(handle)
+    return if handle.blank?
+
+    plans(provider: 'shopify').find { |plan| plan['handle'] == handle }
+  end
+
+  # Stripe-specific helpers. A plan's `price_ids` may be a currency-keyed Hash,
+  # or a legacy Array (treated as usd).
   # Handles both shapes during migration; once all configs are currency-keyed Hashes, drop the Array branch.
   def price_ids_by_currency(plan)
     raw = plan && plan['price_ids']

--- a/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
+++ b/enterprise/app/services/enterprise/billing/reconcile_plan_features_service.rb
@@ -1,5 +1,6 @@
 class Enterprise::Billing::ReconcilePlanFeaturesService
   CLOUD_PLANS_CONFIG = 'CHATWOOT_CLOUD_PLANS'.freeze
+  SHOPIFY_MANAGED_FEATURES = 'shopify_managed_features'.freeze
 
   # Plan hierarchy: Hacker (default) -> Startups -> Business -> Enterprise
   # Each higher tier includes all features from the lower tiers
@@ -33,15 +34,19 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
   ].freeze
   ENTERPRISE_PLAN_FEATURES = %w[audit_logs disable_branding saml].freeze
   PREMIUM_PLAN_FEATURES = (STARTUP_PLAN_FEATURES + BUSINESS_PLAN_FEATURES + ENTERPRISE_PLAN_FEATURES).freeze
+  SHOPIFY_BASE_MANAGED_FEATURES = (PREMIUM_PLAN_FEATURES + %w[channel_tiktok captain_integration_v2]).freeze
 
-  pattr_initialize [:account!]
+  pattr_initialize [:account!, { shopify_lifecycle_cleanup: false }]
 
   def perform
-    account.disable_features(*PREMIUM_PLAN_FEATURES)
-    account.disable_features('captain_integration_v2')
+    return if shopify_billing? && !shopify_lifecycle_cleanup && !Shopify::FeatureGate.enabled?(account: account)
+
+    account.disable_features(*managed_plan_features)
+    account.disable_features('captain_integration_v2') if default_plan?
     account.enable_features(*current_plan_features)
-    account.enable_features('captain_integration_v2') unless default_plan?
+    account.enable_features('captain_integration_v2') if captain_v2_enabled_by_default?
     account.enable_features(*manually_managed_features)
+    update_shopify_managed_features
     account.save!
   end
 
@@ -49,6 +54,7 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
 
   def current_plan_features
     return [] if default_plan?
+    return Enterprise::Billing::PlanConfiguration.current_plan!(account).fetch('features') if shopify_billing?
 
     case account.custom_attributes['plan_name']
     when 'Startups' then STARTUP_PLAN_FEATURES
@@ -59,6 +65,8 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
   end
 
   def default_plan?
+    return account.custom_attributes['plan_name'].blank? if shopify_billing?
+
     default_plan_name = cloud_plans.first&.dig('name')
     return false if default_plan_name.blank?
 
@@ -70,7 +78,38 @@ class Enterprise::Billing::ReconcilePlanFeaturesService
     @cloud_plans ||= InstallationConfig.find_by(name: CLOUD_PLANS_CONFIG)&.value || []
   end
 
+  def managed_plan_features
+    return PREMIUM_PLAN_FEATURES unless shopify_billing?
+
+    (SHOPIFY_BASE_MANAGED_FEATURES + previously_managed_shopify_features + current_shopify_catalog_features).uniq
+  end
+
+  def previously_managed_shopify_features
+    Array(account.internal_attributes[SHOPIFY_MANAGED_FEATURES])
+  end
+
+  def current_shopify_catalog_features
+    return @current_shopify_catalog_features if defined?(@current_shopify_catalog_features)
+
+    plans = Enterprise::Billing::PlanConfiguration.plans_for(account)
+    @current_shopify_catalog_features = plans.flat_map { |plan| plan.fetch('features') }.uniq
+  end
+
+  def update_shopify_managed_features
+    return unless shopify_billing?
+
+    account.internal_attributes[SHOPIFY_MANAGED_FEATURES] = current_shopify_catalog_features
+  end
+
+  def shopify_billing?
+    account.billing_provider == 'shopify'
+  end
+
   def manually_managed_features
     @manually_managed_features ||= Internal::Accounts::InternalAttributesService.new(account).manually_managed_features
+  end
+
+  def captain_v2_enabled_by_default?
+    !shopify_billing? && !default_plan?
   end
 end

--- a/enterprise/app/services/enterprise/billing/shopify_app_pricing_url.rb
+++ b/enterprise/app/services/enterprise/billing/shopify_app_pricing_url.rb
@@ -1,0 +1,46 @@
+class Enterprise::Billing::ShopifyAppPricingUrl
+  APP_HANDLE_FORMAT = /\A[a-z0-9][a-z0-9-]*\z/
+
+  class Error < StandardError; end
+  class ConfigurationError < Error; end
+  class NotEligible < Error; end
+
+  def initialize(account:)
+    @account = account
+  end
+
+  def perform
+    ensure_eligible!
+
+    "https://admin.shopify.com/store/#{store_handle}/charges/#{app_handle}/pricing_plans"
+  end
+
+  private
+
+  attr_reader :account
+
+  def ensure_eligible!
+    raise NotEligible, 'Shopify App Pricing is disabled' unless Shopify::FeatureGate.enabled?(account: account)
+    return if account.billing_provider == 'shopify' && account.signup_source == 'shopify'
+
+    raise NotEligible, 'Account is not billed through Shopify'
+  end
+
+  def store_handle
+    domain = Shopify::ShopDomain.normalize(shopify_hook.reference_id)
+    raise ConfigurationError, 'Shopify integration has an invalid shop domain' unless Shopify::ShopDomain.valid?(domain)
+
+    domain.sub(/\.myshopify\.(?:com|io)\z/, '')
+  end
+
+  def app_handle
+    handle = GlobalConfigService.load('SHOPIFY_APP_HANDLE', nil).to_s
+    raise ConfigurationError, 'SHOPIFY_APP_HANDLE is invalid' unless handle.match?(APP_HANDLE_FORMAT)
+
+    handle
+  end
+
+  def shopify_hook
+    @shopify_hook ||= account.hooks.find_by!(app_id: 'shopify')
+  end
+end

--- a/enterprise/app/services/enterprise/billing/shopify_plan_configuration.rb
+++ b/enterprise/app/services/enterprise/billing/shopify_plan_configuration.rb
@@ -1,0 +1,66 @@
+module Enterprise::Billing::ShopifyPlanConfiguration
+  CONFIG_NAME = 'CHATWOOT_SHOPIFY_PLANS'.freeze
+  REQUIRED_LIMITS = %w[agents inboxes].freeze
+  LIMITS = %w[agents inboxes emails captain_documents captain_responses].freeze
+
+  module_function
+
+  def normalize(configured_plans)
+    raise_invalid!("#{CONFIG_NAME} must be an array") unless configured_plans.is_a?(Array)
+
+    normalized_plans = configured_plans.map.with_index do |plan, index|
+      raise_invalid!("#{CONFIG_NAME}[#{index}] must be an object") unless plan.is_a?(Hash)
+
+      plan.deep_stringify_keys
+    end
+
+    validate!(normalized_plans)
+    normalized_plans
+  end
+
+  def validate!(plans)
+    raise_invalid!("#{CONFIG_NAME} must contain at least one plan") if plans.empty?
+
+    plans.each.with_index { |plan, index| validate_plan!(plan, index) }
+    validate_unique_field!(plans, 'name')
+    validate_unique_field!(plans, 'handle')
+  end
+
+  def validate_plan!(plan, index)
+    prefix = "#{CONFIG_NAME}[#{index}]"
+    raise_invalid!("#{prefix}.name is required") unless plan['name'].is_a?(String) && plan['name'].present?
+    raise_invalid!("#{prefix}.handle is required") unless plan['handle'].is_a?(String) && plan['handle'].present?
+    raise_invalid!("#{prefix}.features must be an array") unless plan['features'].is_a?(Array)
+    raise_invalid!("#{prefix}.limits must be an object") unless plan['limits'].is_a?(Hash)
+
+    validate_features!(plan['features'], prefix)
+    validate_limits!(plan['limits'], prefix)
+  end
+
+  def validate_features!(features, prefix)
+    known_features = Featurable::FEATURE_LIST.pluck('name')
+    invalid_features = features.reject { |feature| feature.is_a?(String) && known_features.include?(feature) }
+    raise_invalid!("#{prefix}.features contains unknown features") if invalid_features.present?
+
+    return unless features.include?(Shopify::FeatureGate::ACCOUNT_FEATURE)
+
+    raise_invalid!("#{prefix}.features cannot manage #{Shopify::FeatureGate::ACCOUNT_FEATURE}")
+  end
+
+  def validate_limits!(limits, prefix)
+    raise_invalid!("#{prefix}.limits contains unknown limits") if (limits.keys - LIMITS).present?
+    raise_invalid!("#{prefix}.limits is missing required limits") if (REQUIRED_LIMITS - limits.keys).present?
+    return if limits.values.all? { |value| value.is_a?(Integer) && value >= 0 }
+
+    raise_invalid!("#{prefix}.limits must contain non-negative integers")
+  end
+
+  def validate_unique_field!(plans, field)
+    values = plans.pluck(field).map(&:downcase)
+    raise_invalid!("#{CONFIG_NAME} contains duplicate #{field} values") unless values.uniq.length == values.length
+  end
+
+  def raise_invalid!(message)
+    raise Enterprise::Billing::PlanConfiguration::InvalidConfiguration, message
+  end
+end

--- a/enterprise/app/services/enterprise/billing/shopify_subscription_sync_service.rb
+++ b/enterprise/app/services/enterprise/billing/shopify_subscription_sync_service.rb
@@ -1,0 +1,174 @@
+class Enterprise::Billing::ShopifySubscriptionSyncService
+  SNAPSHOT_KEY = 'shopify_subscription_snapshot'.freeze
+  VERIFIED_AT_KEY = 'shopify_subscription_verified_at'.freeze
+  SUSPENSION_MARKER = 'shopify_billing_suspended'.freeze
+  SUSPENSION_REASON = 'Shopify App Pricing subscription is inactive'.freeze
+
+  class InvalidSubscription < StandardError; end
+
+  def initialize(account:)
+    @account = account
+  end
+
+  def perform(snapshot: nil)
+    return unless eligible?(snapshot)
+
+    snapshot = resolved_snapshot(snapshot)
+    reconciled = reconcile_snapshot(snapshot)
+    return persisted_snapshot if reconciled == :stale
+    return unless reconciled == :applied
+
+    log_sync(snapshot)
+    snapshot
+  rescue InvalidSubscription, Enterprise::Billing::PlanConfiguration::InvalidConfiguration,
+         Shopify::PartnerClient::ConfigurationError, Shopify::PartnerClient::ProviderError,
+         Shopify::ShopIdentity::ProviderError, ActiveRecord::RecordNotFound => e
+    log_failure(e)
+    raise
+  end
+
+  private
+
+  attr_reader :account
+
+  def resolved_snapshot(snapshot)
+    snapshot || Shopify::SubscriptionFetcher.new(account: account).perform(force: true)
+  end
+
+  def resolved_plan(snapshot)
+    configured_plan(snapshot) if snapshot.entitled?
+  end
+
+  def eligible?(snapshot = nil)
+    account.billing_provider == 'shopify' &&
+      account.signup_source == 'shopify' &&
+      (Shopify::FeatureGate.enabled?(account: account) || non_entitled_snapshot?(snapshot))
+  end
+
+  def non_entitled_snapshot?(snapshot)
+    snapshot.present? && !snapshot.entitled?
+  end
+
+  def configured_plan(snapshot)
+    handles = snapshot.plan_handles
+    raise InvalidSubscription, 'Shopify subscription must have exactly one active plan handle' unless handles.one?
+
+    Enterprise::Billing::PlanConfiguration.find_shopify_plan_by_handle(handles.first) ||
+      raise(InvalidSubscription, 'Shopify subscription has an unknown plan handle')
+  end
+
+  def reconcile_snapshot(snapshot)
+    account.with_lock do
+      next false unless eligible?(snapshot)
+      next :stale if stale_snapshot?(snapshot)
+
+      plan = configured_plan(snapshot) if snapshot.entitled?
+      snapshot.entitled? ? apply_entitlements(snapshot, plan) : remove_entitlements(snapshot)
+      Enterprise::Billing::ReconcilePlanFeaturesService.new(
+        account: account,
+        shopify_lifecycle_cleanup: non_entitled_snapshot?(snapshot)
+      ).perform
+      :applied
+    end
+  end
+
+  def stale_snapshot?(snapshot)
+    persisted_verified_at = account.custom_attributes[VERIFIED_AT_KEY]
+    return false if persisted_verified_at.blank?
+
+    Time.iso8601(snapshot.to_h.fetch('verified_at')) <= Time.iso8601(persisted_verified_at)
+  rescue ArgumentError
+    raise InvalidSubscription, 'Shopify subscription has an invalid verification timestamp'
+  end
+
+  def persisted_snapshot
+    Shopify::SubscriptionSnapshot.from_h(account.custom_attributes.fetch(SNAPSHOT_KEY))
+  end
+
+  def apply_entitlements(snapshot, plan)
+    custom_attributes = subscription_attributes(snapshot).merge(
+      'plan_name' => plan.fetch('name'),
+      'subscription_status' => snapshot.state,
+      'billing_currency' => snapshot.to_h['currency']
+    )
+    account.assign_attributes(custom_attributes: account.custom_attributes.merge(custom_attributes))
+    restore_account_if_billing_suspended
+    account.save!
+  end
+
+  def remove_entitlements(snapshot)
+    custom_attributes = account.custom_attributes.merge(
+      subscription_attributes(snapshot).merge(
+        'plan_name' => nil,
+        'subscription_status' => snapshot.state,
+        'billing_currency' => nil
+      )
+    )
+    account.assign_attributes(custom_attributes: custom_attributes)
+    suspend_account_for_billing
+    account.save!
+  end
+
+  def subscription_attributes(snapshot)
+    {
+      SNAPSHOT_KEY => snapshot.to_h,
+      VERIFIED_AT_KEY => snapshot.to_h.fetch('verified_at')
+    }
+  end
+
+  def suspend_account_for_billing
+    return unless account.active?
+
+    suspended_at = Time.current.iso8601
+    suspension = {
+      'category' => 'non_payment',
+      'reason' => SUSPENSION_REASON,
+      'suspended_at' => suspended_at
+    }
+    account.status = :suspended
+    account.internal_attributes = account.internal_attributes.merge(
+      SUSPENSION_MARKER => suspended_at,
+      'suspensions' => account.suspension_history.map(&:dup) << suspension
+    )
+  end
+
+  def restore_account_if_billing_suspended
+    suspension_marker = account.internal_attributes[SUSPENSION_MARKER]
+    return if suspension_marker.blank?
+
+    internal_attributes = account.internal_attributes.deep_dup
+    internal_attributes.delete(SUSPENSION_MARKER)
+    account.internal_attributes = internal_attributes
+    account.status = :active if shopify_owned_suspension?(suspension_marker)
+  end
+
+  def shopify_owned_suspension?(suspension_marker)
+    account.suspended? &&
+      account.suspension_history.last&.slice('category', 'reason', 'suspended_at') == {
+        'category' => 'non_payment',
+        'reason' => SUSPENSION_REASON,
+        'suspended_at' => suspension_marker
+      }
+  end
+
+  def log_sync(snapshot)
+    Rails.logger.info(
+      {
+        event: 'shopify.subscription_sync.completed',
+        account_id: account.id,
+        state: snapshot.state,
+        plan_handle: snapshot.plan_handles.one? ? snapshot.plan_handles.first : nil
+      }.to_json
+    )
+  end
+
+  def log_failure(error)
+    Rails.logger.error(
+      {
+        event: 'shopify.subscription_sync.failed',
+        account_id: account.id,
+        error_class: error.class.name
+      }.to_json
+    )
+  end
+end

--- a/enterprise/app/services/enterprise/billing/summary_service.rb
+++ b/enterprise/app/services/enterprise/billing/summary_service.rb
@@ -1,0 +1,113 @@
+class Enterprise::Billing::SummaryService
+  SHOPIFY_SNAPSHOT_KEY = 'shopify_subscription_snapshot'.freeze
+  SHOPIFY_REFRESH_ERRORS = [
+    Enterprise::Billing::ShopifySubscriptionSyncService::InvalidSubscription,
+    Enterprise::Billing::PlanConfiguration::InvalidConfiguration,
+    Shopify::SubscriptionFetcher::NotEligible,
+    Shopify::PartnerClient::ConfigurationError,
+    Shopify::PartnerClient::ProviderError,
+    Shopify::ShopIdentity::ProviderError,
+    ActiveRecord::RecordNotFound
+  ].freeze
+
+  class RefreshError < StandardError; end
+
+  def initialize(account:)
+    @account = account
+  end
+
+  def perform(refresh: false)
+    account.billing_provider == 'shopify' ? shopify_summary(refresh: refresh) : stripe_summary
+  end
+
+  private
+
+  attr_reader :account
+
+  def stripe_summary
+    attributes = account.custom_attributes
+
+    {
+      provider: account.billing_provider,
+      state: attributes['subscription_status'].presence || 'pending',
+      plan: plan_payload(name: attributes['plan_name']),
+      amount: nil,
+      currency: normalized_currency(account.billing_currency),
+      billing_period: nil,
+      trial_ends_at: nil,
+      current_period_end: attributes['subscription_ends_on'],
+      allowed_actions: stripe_allowed_actions,
+      last_verified_at: nil
+    }
+  end
+
+  def shopify_summary(refresh:)
+    snapshot = shopify_snapshot(refresh: refresh)
+    attributes = account.custom_attributes
+    handle = snapshot['plan_handles']&.one? ? snapshot['plan_handles'].first : nil
+
+    {
+      provider: account.billing_provider,
+      state: snapshot['state'].presence || attributes['subscription_status'].presence || 'pending',
+      plan: plan_payload(name: attributes['plan_name'] || snapshot['plan_name'], handle: handle),
+      amount: snapshot['amount'],
+      currency: normalized_currency(snapshot['currency'] || attributes['billing_currency']),
+      billing_period: snapshot['billing_period'],
+      trial_ends_at: snapshot['trial_ends_at'],
+      current_period_end: snapshot['current_period_end'],
+      allowed_actions: shopify_allowed_actions,
+      last_verified_at: snapshot['verified_at']
+    }
+  end
+
+  def shopify_snapshot(refresh:)
+    return account.custom_attributes.fetch(SHOPIFY_SNAPSHOT_KEY, {}) unless refresh
+
+    refreshed_snapshot = Enterprise::Billing::ShopifySubscriptionSyncService.new(account: account).perform
+    raise RefreshError, 'Shopify billing refresh is unavailable' if refreshed_snapshot.blank?
+
+    account.reload
+    account.custom_attributes.fetch(SHOPIFY_SNAPSHOT_KEY, {})
+  rescue *SHOPIFY_REFRESH_ERRORS => e
+    raise RefreshError, 'Shopify billing refresh failed', cause: e
+  end
+
+  def plan_payload(name:, handle: nil)
+    return if name.blank? && handle.blank?
+
+    { name: name, handle: handle }.compact
+  end
+
+  def normalized_currency(currency)
+    currency.to_s.upcase.presence
+  end
+
+  def stripe_allowed_actions
+    currency_selection_required = account.billing_currency_selection_required?
+    stripe_customer_present = account.custom_attributes['stripe_customer_id'].present?
+
+    {
+      start_subscription: !currency_selection_required && !stripe_customer_present,
+      manage_subscription: stripe_customer_present,
+      select_billing_currency: currency_selection_required,
+      purchase_credits: stripe_topup_available?
+    }
+  end
+
+  def shopify_allowed_actions
+    {
+      start_subscription: false,
+      manage_subscription: true,
+      select_billing_currency: false,
+      purchase_credits: false
+    }
+  end
+
+  def stripe_topup_available?
+    attributes = account.custom_attributes
+    return false if attributes['stripe_customer_id'].blank? || attributes['plan_name'].blank?
+
+    default_plan_name = Enterprise::Billing::PlanConfiguration.default_plan&.dig('name')
+    default_plan_name.blank? || !attributes['plan_name'].casecmp?(default_plan_name)
+  end
+end

--- a/enterprise/app/services/enterprise/shopify/uninstallation_service.rb
+++ b/enterprise/app/services/enterprise/shopify/uninstallation_service.rb
@@ -1,0 +1,36 @@
+module Enterprise::Shopify::UninstallationService
+  private
+
+  def uninstall
+    return super unless shopify_billed_account?
+
+    revoke_credentials
+    Enterprise::Billing::ShopifySubscriptionSyncService.new(account: account).perform(snapshot: uninstall_snapshot)
+  end
+
+  def shopify_billed_account?
+    account.billing_provider == 'shopify' && account.signup_source == 'shopify'
+  end
+
+  def uninstall_snapshot
+    verified_at = Time.current.utc.iso8601(6)
+    previous_snapshot = account.custom_attributes.fetch('shopify_subscription_snapshot', {})
+    identity = delete_hook ? {} : previous_snapshot.slice('shop_id', 'shop_domain').merge('shop_domain' => hook.reference_id)
+
+    Shopify::SubscriptionSnapshot.from_h(
+      identity.merge(
+        'state' => 'expired',
+        'plan_handles' => [],
+        'latest_event' => {
+          'state' => 'RELATIONSHIP_UNINSTALLED',
+          'occurred_at' => occurred_at&.utc&.iso8601(6) || verified_at
+        },
+        'verified_at' => verified_at
+      )
+    )
+  end
+
+  def revoke_credentials
+    hook.update!(status: :disabled, access_token: nil, settings: {})
+  end
+end

--- a/enterprise/app/views/enterprise/api/v1/accounts/partials/_account.json.jbuilder
+++ b/enterprise/app/views/enterprise/api/v1/accounts/partials/_account.json.jbuilder
@@ -1,1 +1,2 @@
-json.subscribed_features @account.subscribed_features
+json.billing_provider account.billing_provider
+json.subscribed_features account.subscribed_features

--- a/enterprise/app/views/enterprise/api/v1/models/_account_billing.json.jbuilder
+++ b/enterprise/app/views/enterprise/api/v1/models/_account_billing.json.jbuilder
@@ -1,0 +1,7 @@
+json.billing_provider account.billing_provider
+json.subscription_status account.custom_attributes['subscription_status']
+shopify_integration = Shopify::FeatureGate.enabled?(account: account)
+json.shopify_integration shopify_integration
+if shopify_integration && account.billing_provider == 'shopify'
+  json.shopify_shop_domain account.hooks.find_by(app_id: 'shopify', status: 'enabled')&.reference_id
+end

--- a/lib/redis/secure_storage.rb
+++ b/lib/redis/secure_storage.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Redis::SecureStorage provides encrypted storage for sensitive temporary data in Redis.
+# Uses ActiveSupport::MessageEncryptor with AES-256-GCM for authenticated encryption.
+#
+# Example:
+#   Redis::SecureStorage.set('session:token', { access_token: 'secret' }, 10.minutes)
+#   data = Redis::SecureStorage.get('session:token')
+#
+module Redis::SecureStorage
+  class EncryptionNotConfigured < StandardError; end
+
+  class << self
+    # Store data in Redis with encryption
+    # @param key [String] Redis key
+    # @param data [Hash, String] Data to store (will be converted to JSON)
+    # @param expiry [Integer, ActiveSupport::Duration] TTL in seconds
+    def set(key, data, expiry)
+      ensure_encryption_configured!
+      encrypted = encrypt(data)
+      Redis::Alfred.setex(key, encrypted, expiry)
+    end
+
+    # Retrieve and decrypt data from Redis
+    # @param key [String] Redis key
+    # @return [String, nil] Decrypted JSON data or nil if not found/invalid
+    def get(key)
+      ensure_encryption_configured!
+      encrypted = Redis::Alfred.get(key)
+      return nil if encrypted.blank?
+
+      decrypt(encrypted)
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage, JSON::ParserError
+      nil
+    end
+
+    # Delete data from Redis
+    # @param key [String] Redis key
+    def delete(key)
+      Redis::Alfred.delete(key)
+    end
+
+    private
+
+    def ensure_encryption_configured!
+      return if Chatwoot.encryption_configured?
+
+      raise EncryptionNotConfigured, 'Encryption must be configured to use sensitive Redis storage'
+    end
+
+    def encryptor
+      @encryptor ||= begin
+        # Derive a proper 32-byte key from secret_key_base
+        key_generator = ActiveSupport::KeyGenerator.new(Rails.application.secret_key_base)
+        key = key_generator.generate_key('redis_secure_storage', 32)
+        ActiveSupport::MessageEncryptor.new(key, cipher: 'aes-256-gcm')
+      end
+    end
+
+    def encrypt(data)
+      json_data = data.is_a?(String) ? data : data.to_json
+      encryptor.encrypt_and_sign(json_data)
+    end
+
+    def decrypt(encrypted_data)
+      encryptor.decrypt_and_verify(encrypted_data)
+    end
+  end
+end

--- a/spec/controllers/api/v1/accounts/integrations/apps_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/apps_controller_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Integration Apps API', type: :request do
   let(:account) { create(:account) }
 
-  before { allow(Integrations::Openai::KeyValidator).to receive(:valid?).and_return(true) }
+  before do
+    allow(Integrations::Openai::KeyValidator).to receive(:valid?).and_return(true)
+    allow(GlobalConfigService).to receive(:load).and_call_original
+  end
 
   describe 'GET /api/v1/integrations/apps' do
     context 'when it is an unauthenticated user' do
@@ -70,6 +73,20 @@ RSpec.describe 'Integration Apps API', type: :request do
         expect(slack_app['action']).to include('client_id=client_id')
       end
 
+      it 'omits Shopify when the installation switch is disabled' do
+        account.enable_features('shopify_integration')
+        allow(GlobalConfigService).to receive(:load)
+          .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+          .and_return(false)
+
+        get api_v1_account_integrations_apps_url(account),
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        shopify_app = response.parsed_body['payload'].find { |app| app['id'] == 'shopify' }
+        expect(shopify_app).to be_nil
+      end
+
       it 'returns visible hook settings for openai app for admins' do
         openai = create(:integrations_hook, :openai, account: account)
         get api_v1_account_integrations_apps_url(account),
@@ -133,6 +150,22 @@ RSpec.describe 'Integration Apps API', type: :request do
         app = response.parsed_body
         expect(app['id']).to eql('slack')
         expect(app['name']).to eql('Slack')
+      end
+
+      it 'returns not found for Shopify when the client ID is missing' do
+        account.enable_features('shopify_integration')
+        allow(GlobalConfigService).to receive(:load)
+          .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+          .and_return(true)
+        allow(GlobalConfigService).to receive(:load)
+          .with('SHOPIFY_CLIENT_ID', nil)
+          .and_return(nil)
+
+        get api_v1_account_integrations_app_url(account_id: account.id, id: 'shopify'),
+            headers: agent.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:not_found)
       end
 
       it 'will not return sensitive information for openai app for agents' do
@@ -204,6 +237,19 @@ RSpec.describe 'Integration Apps API', type: :request do
           'endpoint_url' => 'https://api.leadsquared.com/',
           'enable_conversation_activity' => true
         )
+      end
+
+      it 'returns not found for Shopify when either feature gate is disabled' do
+        account.enable_features('shopify_integration')
+        allow(GlobalConfigService).to receive(:load)
+          .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+          .and_return(false)
+
+        get api_v1_account_integrations_app_url(account_id: account.id, id: 'shopify'),
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/controllers/api/v1/accounts/integrations/hooks_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/integrations/hooks_controller_spec.rb
@@ -51,6 +51,21 @@ RSpec.describe 'Integration Hooks API', type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body['message']).to include(I18n.t('errors.cloudflare.realtimekit.invalid_api_token'))
       end
+
+      it 'does not create Shopify hooks when the installation switch is disabled' do
+        allow(GlobalConfigService).to receive(:load)
+          .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+          .and_return(false)
+
+        expect do
+          post api_v1_account_integrations_hooks_url(account_id: account.id),
+               params: { hook: { app_id: 'shopify' } },
+               headers: admin.create_new_auth_token,
+               as: :json
+        end.not_to change(Integrations::Hook, :count)
+
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
 
@@ -86,6 +101,21 @@ RSpec.describe 'Integration Hooks API', type: :request do
         expect(response).to have_http_status(:success)
         data = response.parsed_body
         expect(data['app_id']).to eq 'slack'
+      end
+
+      it 'does not update Shopify hooks when the account feature is disabled' do
+        shopify_hook = create(:integrations_hook, :shopify, account: account)
+        allow(GlobalConfigService).to receive(:load)
+          .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+          .and_return(true)
+
+        patch api_v1_account_integrations_hook_url(account_id: account.id, id: shopify_hook.id),
+              params: { hook: { status: 'disabled' } },
+              headers: admin.create_new_auth_token,
+              as: :json
+
+        expect(response).to have_http_status(:not_found)
+        expect(shopify_hook.reload).to be_enabled
       end
     end
   end
@@ -144,6 +174,20 @@ RSpec.describe 'Integration Hooks API', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(Integrations::Hook.exists?(hook.id)).to be false
+      end
+
+      it 'does not delete Shopify hooks when the account feature is disabled' do
+        shopify_hook = create(:integrations_hook, :shopify, account: account)
+        allow(GlobalConfigService).to receive(:load)
+          .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+          .and_return(true)
+
+        delete api_v1_account_integrations_hook_url(account_id: account.id, id: shopify_hook.id),
+               headers: admin.create_new_auth_token,
+               as: :json
+
+        expect(response).to have_http_status(:not_found)
+        expect(Integrations::Hook.exists?(shopify_hook.id)).to be true
       end
     end
   end

--- a/spec/controllers/shopify/callbacks_controller_spec.rb
+++ b/spec/controllers/shopify/callbacks_controller_spec.rb
@@ -66,10 +66,24 @@ RSpec.describe Shopify::CallbacksController, type: :request do
         expect(hook.app_id).to eq('shopify')
         expect(hook.status).to eq('enabled')
         expect(hook.reference_id).to eq(shop)
-        expect(hook.settings).to eq(
-          'scope' => 'read_products,write_products'
+        expect(hook.settings).to include(
+          'scope' => 'read_products,write_products',
+          'connected_at' => be_present,
+          'installation_id' => be_present
         )
         expect(response).to redirect_to(shopify_redirect_uri)
+      end
+
+      it 'reconnects a retained hook and ignores an older uninstall' do
+        hook = create(:integrations_hook, app_id: 'shopify', account: account, reference_id: shop)
+        hook.update!(status: :disabled, access_token: nil, settings: {})
+        expect do
+          get shopify_callback_path, params: { code: code, state: state, shop: shop }
+        end.not_to change(Integrations::Hook, :count)
+        expect(hook.reload).to be_enabled
+        expect(hook.access_token).to eq(access_token)
+        expect(Shopify::UninstallationService.new(hook: hook, occurred_at: 2.days.ago).perform).to eq(:stale)
+        expect(hook.reload).to be_enabled
       end
     end
 

--- a/spec/controllers/super_admin/app_config_controller_spec.rb
+++ b/spec/controllers/super_admin/app_config_controller_spec.rb
@@ -56,6 +56,45 @@ RSpec.describe 'Super Admin Application Config API', type: :request do
         expect(flash[:alert]).to be_blank
         expect(flash[:notice]).to be_blank
       end
+
+      it 'rejects invalid Shopify Partner configuration before persisting any submitted value' do
+        create(:installation_config, name: 'SHOPIFY_PARTNER_ORGANIZATION_ID', value: '123', locked: false)
+        sign_in(super_admin, scope: :super_admin)
+
+        post '/super_admin/app_config?config=shopify',
+             params: {
+               app_config: {
+                 SHOPIFY_PARTNER_ORGANIZATION_ID: 'not-numeric',
+                 SHOPIFY_PARTNER_APP_ID: 'gid://shopify/App/456',
+                 SHOPIFY_PARTNER_ACCESS_TOKEN: 'partner-token',
+                 SHOPIFY_PARTNER_API_VERSION: '2026-07'
+               }
+             }
+
+        expect(response).to redirect_to(super_admin_app_config_path(config: 'shopify'))
+        expect(flash[:alert]).to eq('SHOPIFY_PARTNER_ORGANIZATION_ID must be numeric')
+        expect(GlobalConfig.get('SHOPIFY_PARTNER_ORGANIZATION_ID')['SHOPIFY_PARTNER_ORGANIZATION_ID']).to eq('123')
+        expect(GlobalConfig.get('SHOPIFY_PARTNER_APP_ID')['SHOPIFY_PARTNER_APP_ID']).to be_nil
+      end
+
+      it 'validates a partial Shopify Partner update against the saved configuration' do
+        {
+          'SHOPIFY_PARTNER_ORGANIZATION_ID' => '123',
+          'SHOPIFY_PARTNER_APP_ID' => 'gid://shopify/App/456',
+          'SHOPIFY_PARTNER_ACCESS_TOKEN' => 'partner-token',
+          'SHOPIFY_PARTNER_API_VERSION' => '2026-07'
+        }.each do |name, value|
+          create(:installation_config, name: name, value: value, locked: false)
+        end
+        sign_in(super_admin, scope: :super_admin)
+
+        post '/super_admin/app_config?config=shopify',
+             params: { app_config: { SHOPIFY_PARTNER_API_VERSION: '2026-10' } }
+
+        expect(response).to redirect_to(super_admin_settings_path)
+        expect(flash[:alert]).to be_blank
+        expect(GlobalConfig.get('SHOPIFY_PARTNER_API_VERSION')['SHOPIFY_PARTNER_API_VERSION']).to eq('2026-10')
+      end
     end
   end
 end

--- a/spec/controllers/twitter/callbacks_controller_spec.rb
+++ b/spec/controllers/twitter/callbacks_controller_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe 'Twitter::CallbacksController', type: :request do
     allow(twitter_response).to receive(:raw_response).and_return(raw_response)
     allow(raw_response).to receive(:body).and_return('oauth_token=1&oauth_token_secret=1&user_id=100&screen_name=chatwoot')
     allow(twitter_client).to receive(:user_show).and_return(user_object_rsponse)
-    allow(JSON).to receive(:parse).and_return(user_object_rsponse)
     allow(Twitter::WebhookSubscribeService).to receive(:new).and_return(webhook_service)
   end
 

--- a/spec/controllers/webhooks/shopify_controller_spec.rb
+++ b/spec/controllers/webhooks/shopify_controller_spec.rb
@@ -1,0 +1,222 @@
+require 'rails_helper'
+
+RSpec.describe Webhooks::ShopifyController, type: :request do
+  let(:account) { create(:account) }
+  let(:hook) { create(:integrations_hook, :shopify, account: account, reference_id: shop_domain) }
+  let(:shop_domain) { 'feature-gated-shop.myshopify.com' }
+  let(:client_secret) { 'shopify-client-secret' }
+  let(:payload) { { shop_domain: shop_domain } }
+  let(:topic) { 'shop/redact' }
+  let(:triggered_at) { '2026-07-29T10:01:00.123456789Z' }
+  let(:body) { payload.to_json }
+  let(:headers) do
+    {
+      'CONTENT_TYPE' => 'application/json',
+      'X-Shopify-Topic' => topic,
+      'X-Shopify-Triggered-At' => triggered_at,
+      'X-Shopify-Hmac-SHA256' => Base64.strict_encode64(OpenSSL::HMAC.digest('SHA256', client_secret, body))
+    }
+  end
+
+  before do
+    account.enable_features!('shopify_integration')
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(true)
+    allow(GlobalConfigService).to receive(:load)
+      .with('SHOPIFY_CLIENT_SECRET', nil)
+      .and_return(client_secret)
+  end
+
+  it 'processes the webhook when both feature gates are enabled' do
+    hook
+
+    expect do
+      post '/webhooks/shopify', params: body, headers: headers
+    end.to change(Integrations::Hook, :count).by(-1)
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'processes redaction when the installation switch is disabled' do
+    hook
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(false)
+
+    expect do
+      post '/webhooks/shopify', params: body, headers: headers
+    end.to change(Integrations::Hook, :count).by(-1)
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'invalidates pending installations during shop redaction even when no hook exists' do
+    expect(Shopify::PendingInstallation).to receive(:invalidate_shop!).with(shop: shop_domain)
+
+    post '/webhooks/shopify', params: body, headers: headers
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'authenticates and acknowledges every compliance topic when the installation switch is disabled' do
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(false)
+
+    Webhooks::ShopifyController::COMPLIANCE_TOPICS.each do |topic|
+      headers['X-Shopify-Topic'] = topic
+
+      post '/webhooks/shopify', params: body, headers: headers
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  it 'processes redaction when the account feature is disabled' do
+    hook
+    account.disable_features!('shopify_integration')
+
+    expect do
+      post '/webhooks/shopify', params: body, headers: headers
+    end.to change(Integrations::Hook, :count).by(-1)
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'raises a retryable failure when a matching hook appears during cleanup' do
+    hook
+    inserted_hook = nil
+    app_hooks = Integrations::Hook.where(app_id: 'shopify')
+    hooks = app_hooks.where('LOWER(reference_id) = ?', shop_domain)
+
+    allow(Integrations::Hook).to receive(:where)
+      .with(app_id: 'shopify')
+      .and_return(app_hooks)
+    allow(app_hooks).to receive(:where)
+      .with('LOWER(reference_id) = ?', shop_domain)
+      .and_return(hooks)
+    allow(hooks).to receive(:find_each) do |&block|
+      block.call(hook)
+      inserted_hook ||= create(:integrations_hook, :shopify, account: create(:account), reference_id: shop_domain)
+    end
+
+    post '/webhooks/shopify', params: body, headers: headers
+
+    expect(response).to have_http_status(:internal_server_error)
+    expect(inserted_hook).to be_persisted
+  end
+
+  it 'ignores a delayed redaction from before the current installation' do
+    hook.update!(
+      settings: hook.settings.merge(
+        'connected_at' => (Time.iso8601(triggered_at) + 1.minute).iso8601(6)
+      )
+    )
+
+    expect do
+      post '/webhooks/shopify', params: body, headers: headers
+    end.not_to change(Integrations::Hook, :count)
+
+    expect(hook.reload).to be_enabled
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'delegates redaction deletion to the locked lifecycle' do
+    hook
+    uninstallation_service = instance_double(Shopify::UninstallationService)
+    allow(uninstallation_service).to receive(:perform) do
+      hook.destroy!
+      :uninstalled
+    end
+    allow(Shopify::UninstallationService).to receive(:new)
+      .with(hook: hook, occurred_at: Time.iso8601(triggered_at), delete_hook: true)
+      .and_return(uninstallation_service)
+
+    expect do
+      post '/webhooks/shopify', params: body, headers: headers
+    end.to change(Integrations::Hook, :count).by(-1)
+
+    expect(uninstallation_service).to have_received(:perform)
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'does not process normal events when the installation switch is disabled' do
+    headers['X-Shopify-Topic'] = 'orders/create'
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(false)
+
+    post '/webhooks/shopify', params: body, headers: headers
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'rejects an invalid HMAC without changing account data' do
+    hook
+    headers['X-Shopify-Hmac-SHA256'] = 'invalid'
+
+    expect do
+      post '/webhooks/shopify', params: body, headers: headers
+    end.not_to change(Integrations::Hook, :count)
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  context 'with an app/uninstalled webhook' do
+    let(:topic) { 'app/uninstalled' }
+    let(:payload) { { myshopify_domain: shop_domain.upcase } }
+    let(:uninstallation_service) { instance_double(Shopify::UninstallationService, perform: nil) }
+
+    it 'delegates the matching hook to the uninstallation lifecycle' do
+      hook
+      allow(Shopify::UninstallationService).to receive(:new)
+        .with(hook: hook, occurred_at: Time.iso8601(triggered_at))
+        .and_return(uninstallation_service)
+
+      post '/webhooks/shopify', params: body, headers: headers
+
+      expect(uninstallation_service).to have_received(:perform)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'invalidates pending installations even when no hook exists' do
+      expect(Shopify::PendingInstallation).to receive(:invalidate_shop!).with(shop: shop_domain.upcase)
+
+      post '/webhooks/shopify', params: body, headers: headers
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'delegates uninstall cleanup when the installation switch is disabled' do
+      hook
+      allow(GlobalConfigService).to receive(:load)
+        .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+        .and_return(false)
+      allow(Shopify::UninstallationService).to receive(:new)
+        .with(hook: hook, occurred_at: Time.iso8601(triggered_at))
+        .and_return(uninstallation_service)
+
+      post '/webhooks/shopify', params: body, headers: headers
+
+      expect(uninstallation_service).to have_received(:perform)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'ignores an invalid shop domain' do
+      allow(Shopify::UninstallationService).to receive(:new)
+      invalid_payload = { myshopify_domain: 'not-a-shop.example.com' }.to_json
+      invalid_headers = headers.merge(
+        'X-Shopify-Hmac-SHA256' => Base64.strict_encode64(
+          OpenSSL::HMAC.digest('SHA256', client_secret, invalid_payload)
+        )
+      )
+
+      post '/webhooks/shopify', params: invalid_payload, headers: invalid_headers
+
+      expect(Shopify::UninstallationService).not_to have_received(:new)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/enterprise/controllers/api/v1/accounts/integrations/shopify_billing_hook_protection_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/integrations/shopify_billing_hook_protection_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'Shopify billing hook protection', type: :request do
+  let(:account) do
+    create(
+      :account,
+      internal_attributes: {
+        'billing_provider' => 'shopify',
+        'signup_source' => 'shopify'
+      }
+    )
+  end
+  let(:admin) { create(:user, account: account, role: :administrator) }
+  let!(:hook) { create(:integrations_hook, :shopify, account: account, status: :enabled) }
+
+  before do
+    account.enable_features!('shopify_integration')
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(true)
+  end
+
+  it 'does not disable the billing-owned hook through the generic hooks API' do
+    patch api_v1_account_integrations_hook_url(account_id: account.id, id: hook.id),
+          params: { hook: { status: 'disabled' } },
+          headers: admin.create_new_auth_token,
+          as: :json
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response.parsed_body['error']).to eq('Shopify-billed integrations must be managed in Shopify')
+    expect(hook.reload).to be_enabled
+  end
+
+  it 'does not delete the billing-owned hook through the generic hooks API' do
+    delete api_v1_account_integrations_hook_url(account_id: account.id, id: hook.id),
+           headers: admin.create_new_auth_token,
+           as: :json
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response.parsed_body['error']).to eq('Shopify-billed integrations must be managed in Shopify')
+    expect(Integrations::Hook.exists?(hook.id)).to be(true)
+  end
+
+  it 'does not delete the billing-owned hook through the Shopify API' do
+    delete "/api/v1/accounts/#{account.id}/integrations/shopify",
+           headers: admin.create_new_auth_token,
+           as: :json
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response.parsed_body['error']).to eq('Shopify-billed integrations must be managed in Shopify')
+    expect(Integrations::Hook.exists?(hook.id)).to be(true)
+  end
+end

--- a/spec/enterprise/controllers/enterprise/api/v1/accounts_billing_providers_spec.rb
+++ b/spec/enterprise/controllers/enterprise/api/v1/accounts_billing_providers_spec.rb
@@ -1,0 +1,324 @@
+require 'rails_helper'
+
+RSpec.describe 'Enterprise Billing Provider APIs', type: :request do
+  let(:stripe_account) do
+    create(
+      :account,
+      custom_attributes: {
+        'plan_name' => 'Business',
+        'stripe_customer_id' => 'cus_test',
+        'subscription_status' => 'active',
+        'subscription_ends_on' => '2026-08-29T10:00:00Z',
+        'billing_currency' => 'usd'
+      }
+    )
+  end
+  let!(:stripe_admin) { create(:user, account: stripe_account, role: :administrator) }
+
+  let(:shopify_snapshot) do
+    {
+      'state' => 'trialing',
+      'plan_handles' => ['shopify-basic'],
+      'plan_name' => 'Shopify Basic',
+      'amount' => '29.00',
+      'currency' => 'USD',
+      'billing_period' => 'ANNUAL',
+      'trial_ends_at' => '2026-08-05T10:00:00Z',
+      'current_period_end' => '2026-08-29T10:00:00Z',
+      'verified_at' => '2026-07-29T10:00:00Z'
+    }
+  end
+  let(:shopify_account) do
+    create(
+      :account,
+      internal_attributes: {
+        'billing_provider' => 'shopify',
+        'signup_source' => 'shopify'
+      },
+      custom_attributes: {
+        'plan_name' => 'Shopify Basic',
+        'subscription_status' => 'trialing',
+        'billing_currency' => 'USD',
+        'shopify_subscription_snapshot' => shopify_snapshot,
+        'shopify_subscription_verified_at' => shopify_snapshot['verified_at']
+      }
+    ).tap { |account| account.enable_features(Shopify::FeatureGate::ACCOUNT_FEATURE) }
+  end
+  let!(:shopify_admin) { create(:user, account: shopify_account, role: :administrator) }
+  let!(:shopify_agent) { create(:user, account: shopify_account, role: :agent) }
+
+  before do
+    allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
+    allow(Shopify::FeatureGate).to receive(:enabled?).with(account: shopify_account).and_return(true)
+  end
+
+  describe 'GET /enterprise/api/v1/accounts/{account.id}/billing_summary' do
+    it 'returns a normalized Stripe summary without changing the existing subscription' do
+      get "/enterprise/api/v1/accounts/#{stripe_account.id}/billing_summary",
+          headers: stripe_admin.create_new_auth_token,
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'provider' => 'stripe',
+        'state' => 'active',
+        'plan' => { 'name' => 'Business' },
+        'amount' => nil,
+        'currency' => 'USD',
+        'billing_period' => nil,
+        'trial_ends_at' => nil,
+        'current_period_end' => '2026-08-29T10:00:00Z',
+        'allowed_actions' => {
+          'start_subscription' => false,
+          'manage_subscription' => true,
+          'select_billing_currency' => false,
+          'purchase_credits' => true
+        },
+        'last_verified_at' => nil
+      )
+    end
+
+    it 'returns the resolved Stripe currency when no currency attribute is stored' do
+      stripe_account.update!(
+        custom_attributes: stripe_account.custom_attributes.except('billing_currency')
+      )
+
+      get "/enterprise/api/v1/accounts/#{stripe_account.id}/billing_summary",
+          headers: stripe_admin.create_new_auth_token,
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['currency']).to eq('USD')
+    end
+
+    it 'returns a normalized Shopify summary from the last verified snapshot' do
+      get "/enterprise/api/v1/accounts/#{shopify_account.id}/billing_summary",
+          headers: shopify_admin.create_new_auth_token,
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'provider' => 'shopify',
+        'state' => 'trialing',
+        'plan' => { 'name' => 'Shopify Basic', 'handle' => 'shopify-basic' },
+        'amount' => '29.00',
+        'currency' => 'USD',
+        'billing_period' => 'ANNUAL',
+        'trial_ends_at' => '2026-08-05T10:00:00Z',
+        'current_period_end' => '2026-08-29T10:00:00Z',
+        'allowed_actions' => {
+          'start_subscription' => false,
+          'manage_subscription' => true,
+          'select_billing_currency' => false,
+          'purchase_credits' => false
+        },
+        'last_verified_at' => '2026-07-29T10:00:00Z'
+      )
+    end
+
+    it 'forces Shopify verification when requested' do
+      refreshed_snapshot = Shopify::SubscriptionSnapshot.from_h(
+        shopify_snapshot.merge(
+          'state' => 'active',
+          'trial_ends_at' => nil,
+          'verified_at' => '2026-07-29T11:00:00Z'
+        )
+      )
+      sync_service = instance_double(Enterprise::Billing::ShopifySubscriptionSyncService)
+      allow(Enterprise::Billing::ShopifySubscriptionSyncService).to receive(:new).with(account: shopify_account).and_return(sync_service)
+      allow(sync_service).to receive(:perform) do
+        shopify_account.update!(
+          custom_attributes: shopify_account.custom_attributes.merge(
+            'shopify_subscription_snapshot' => refreshed_snapshot.to_h,
+            'subscription_status' => refreshed_snapshot.state
+          )
+        )
+        refreshed_snapshot
+      end
+
+      get "/enterprise/api/v1/accounts/#{shopify_account.id}/billing_summary",
+          headers: shopify_admin.create_new_auth_token,
+          params: { refresh: true },
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        'provider' => 'shopify',
+        'state' => 'active',
+        'last_verified_at' => '2026-07-29T11:00:00Z'
+      )
+      expect(sync_service).to have_received(:perform)
+    end
+
+    it 'returns the newest persisted snapshot when concurrent refreshes overlap' do
+      refreshed_snapshot = Shopify::SubscriptionSnapshot.from_h(
+        shopify_snapshot.merge(
+          'state' => 'active',
+          'verified_at' => '2026-07-29T11:00:00Z'
+        )
+      )
+      newer_snapshot = Shopify::SubscriptionSnapshot.from_h(
+        shopify_snapshot.merge(
+          'state' => 'cancelled',
+          'verified_at' => '2026-07-29T12:00:00Z'
+        )
+      )
+      sync_service = instance_double(Enterprise::Billing::ShopifySubscriptionSyncService)
+      allow(Enterprise::Billing::ShopifySubscriptionSyncService).to receive(:new).with(account: shopify_account).and_return(sync_service)
+      allow(sync_service).to receive(:perform) do
+        shopify_account.update!(
+          custom_attributes: shopify_account.custom_attributes.merge(
+            'shopify_subscription_snapshot' => newer_snapshot.to_h,
+            'subscription_status' => newer_snapshot.state
+          )
+        )
+        refreshed_snapshot
+      end
+
+      get "/enterprise/api/v1/accounts/#{shopify_account.id}/billing_summary",
+          headers: shopify_admin.create_new_auth_token,
+          params: { refresh: true },
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        'state' => 'cancelled',
+        'last_verified_at' => '2026-07-29T12:00:00Z'
+      )
+    end
+
+    it 'returns service unavailable when Shopify verification fails' do
+      sync_service = instance_double(Enterprise::Billing::ShopifySubscriptionSyncService)
+      allow(Enterprise::Billing::ShopifySubscriptionSyncService).to receive(:new).with(account: shopify_account).and_return(sync_service)
+      allow(sync_service).to receive(:perform).and_raise(Shopify::PartnerClient::ProviderError, 'Shopify unavailable')
+
+      get "/enterprise/api/v1/accounts/#{shopify_account.id}/billing_summary",
+          headers: shopify_admin.create_new_auth_token,
+          params: { refresh: true },
+          as: :json
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response.parsed_body['error']).to eq('Shopify billing could not be verified right now')
+    end
+
+    it 'returns not found for a Shopify account when the feature gate is disabled' do
+      allow(Shopify::FeatureGate).to receive(:enabled?).with(account: shopify_account).and_return(false)
+      expect(Enterprise::Billing::ShopifySubscriptionSyncService).not_to receive(:new)
+
+      get "/enterprise/api/v1/accounts/#{shopify_account.id}/billing_summary",
+          headers: shopify_admin.create_new_auth_token,
+          params: { refresh: true },
+          as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'keeps the summary admin-only for Shopify accounts' do
+      get "/enterprise/api/v1/accounts/#{shopify_account.id}/billing_summary",
+          headers: shopify_agent.create_new_auth_token,
+          as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'POST /enterprise/api/v1/accounts/{account.id}/checkout' do
+    before do
+      create(
+        :integrations_hook,
+        :shopify,
+        account: shopify_account,
+        reference_id: 'billing-test-store.myshopify.com'
+      )
+    end
+
+    it 'returns the trusted Shopify App Pricing URL with the existing redirect contract' do
+      allow(GlobalConfigService).to receive(:load).with('SHOPIFY_APP_HANDLE', nil).and_return('chatwoot')
+      expect(Enterprise::Billing::CreateSessionService).not_to receive(:new)
+
+      post "/enterprise/api/v1/accounts/#{shopify_account.id}/checkout",
+           headers: shopify_admin.create_new_auth_token,
+           as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'redirect_url' => 'https://admin.shopify.com/store/billing-test-store/charges/chatwoot/pricing_plans'
+      )
+    end
+
+    it 'uses the retained shop domain to reopen pricing after uninstall' do
+      shopify_account.hooks.find_by!(app_id: 'shopify').update!(status: :disabled, access_token: nil, settings: {})
+      allow(GlobalConfigService).to receive(:load).with('SHOPIFY_APP_HANDLE', nil).and_return('chatwoot')
+
+      post "/enterprise/api/v1/accounts/#{shopify_account.id}/checkout",
+           headers: shopify_admin.create_new_auth_token,
+           as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'redirect_url' => 'https://admin.shopify.com/store/billing-test-store/charges/chatwoot/pricing_plans'
+      )
+    end
+
+    it 'does not fall through to Stripe when the Shopify feature gate is disabled' do
+      allow(Shopify::FeatureGate).to receive(:enabled?).with(account: shopify_account).and_return(false)
+      expect(Enterprise::Billing::CreateSessionService).not_to receive(:new)
+
+      post "/enterprise/api/v1/accounts/#{shopify_account.id}/checkout",
+           headers: shopify_admin.create_new_auth_token,
+           as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns an actionable error when the Shopify app handle is not configured' do
+      allow(GlobalConfigService).to receive(:load).with('SHOPIFY_APP_HANDLE', nil).and_return(nil)
+
+      post "/enterprise/api/v1/accounts/#{shopify_account.id}/checkout",
+           headers: shopify_admin.create_new_auth_token,
+           as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['error']).to eq('Shopify App Pricing is not available right now')
+    end
+
+    it 'keeps checkout admin-only for Shopify accounts' do
+      post "/enterprise/api/v1/accounts/#{shopify_account.id}/checkout",
+           headers: shopify_agent.create_new_auth_token,
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'Stripe-only billing actions' do
+    it 'rejects Shopify attempts to create a Stripe customer, choose currency, or buy credits' do
+      expect(Enterprise::Billing::TopupCheckoutService).not_to receive(:new)
+
+      post "/enterprise/api/v1/accounts/#{shopify_account.id}/subscription",
+           headers: shopify_admin.create_new_auth_token,
+           as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+
+      post "/enterprise/api/v1/accounts/#{shopify_account.id}/select_billing_currency",
+           headers: shopify_admin.create_new_auth_token,
+           params: { currency: 'usd' },
+           as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+
+      post "/enterprise/api/v1/accounts/#{shopify_account.id}/topup_checkout",
+           headers: shopify_admin.create_new_auth_token,
+           params: { credits: 1000 },
+           as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+
+      get "/enterprise/api/v1/accounts/#{shopify_account.id}/topup_options",
+          headers: shopify_admin.create_new_auth_token,
+          as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+
+      expect(response.parsed_body['error']).to eq('This billing action is not available for Shopify-billed accounts')
+      expect(Enterprise::CreateStripeCustomerJob).not_to have_been_enqueued
+    end
+  end
+end

--- a/spec/enterprise/controllers/enterprise/api/v1/accounts_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/api/v1/accounts_controller_spec.rb
@@ -5,6 +5,28 @@ RSpec.describe 'Enterprise Billing APIs', type: :request do
   let!(:admin) { create(:user, account: account, role: :administrator) }
   let!(:agent) { create(:user, account: account, role: :agent) }
 
+  describe 'GET /api/v1/accounts/{account.id}' do
+    it 'exposes Stripe as the default billing provider' do
+      get "/api/v1/accounts/#{account.id}",
+          headers: admin.create_new_auth_token,
+          as: :json
+
+      expect(response.parsed_body['billing_provider']).to eq('stripe')
+    end
+
+    it 'exposes the Shopify billing provider' do
+      shopify_account = create(:account, internal_attributes: { 'billing_provider' => 'shopify', 'signup_source' => 'shopify' })
+      shopify_admin = create(:user, account: shopify_account, role: :administrator)
+
+      get "/api/v1/accounts/#{shopify_account.id}",
+          headers: shopify_admin.create_new_auth_token,
+          as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body['billing_provider']).to eq('shopify')
+    end
+  end
+
   describe 'API token access' do
     before do
       allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(true)
@@ -77,6 +99,57 @@ RSpec.describe 'Enterprise Billing APIs', type: :request do
                  headers: admin.create_new_auth_token,
                  as: :json
           end.not_to have_enqueued_job(Enterprise::CreateStripeCustomerJob).with(account)
+        end
+
+        it 'rejects Stripe setup for a Shopify account before creating customer state' do
+          shopify_account = create(
+            :account,
+            internal_attributes: {
+              'billing_provider' => 'shopify',
+              'signup_source' => 'shopify'
+            }
+          )
+          shopify_admin = create(:user, account: shopify_account, role: :administrator)
+          shopify_account.enable_features!('shopify_integration')
+          allow(GlobalConfigService).to receive(:load)
+            .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+            .and_return(true)
+
+          expect do
+            post "/enterprise/api/v1/accounts/#{shopify_account.id}/subscription",
+                 headers: shopify_admin.create_new_auth_token,
+                 as: :json
+          end.not_to have_enqueued_job(Enterprise::CreateStripeCustomerJob)
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body['error']).to eq(
+            'This billing action is not available for Shopify-billed accounts'
+          )
+          expect(shopify_account.reload.custom_attributes).not_to have_key('is_creating_customer')
+        end
+
+        it 'rejects Stripe checkout for a Shopify account with residual customer metadata' do
+          shopify_account = create(
+            :account,
+            internal_attributes: {
+              'billing_provider' => 'shopify',
+              'signup_source' => 'shopify'
+            },
+            custom_attributes: { 'stripe_customer_id' => 'cus_from_previous_billing' }
+          )
+          shopify_admin = create(:user, account: shopify_account, role: :administrator)
+          shopify_account.enable_features!('shopify_integration')
+          allow(GlobalConfigService).to receive(:load)
+            .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+            .and_return(true)
+
+          expect(Enterprise::Billing::CreateSessionService).not_to receive(:new)
+
+          post "/enterprise/api/v1/accounts/#{shopify_account.id}/checkout",
+               headers: shopify_admin.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
         end
       end
     end
@@ -264,6 +337,39 @@ RSpec.describe 'Enterprise Billing APIs', type: :request do
           }
           expect(response).to have_http_status(:ok)
           expect(JSON.parse(response.body)).to eq(expected_response)
+        end
+      end
+
+      context 'when the account is billed through Shopify' do
+        let(:account) do
+          create(
+            :account,
+            internal_attributes: { 'billing_provider' => 'shopify' },
+            custom_attributes: { 'plan_name' => nil }
+          )
+        end
+
+        it 'uses the Shopify catalog when resolving the provider default plan' do
+          create(
+            :installation_config,
+            name: 'CHATWOOT_SHOPIFY_PLANS',
+            value: [
+              {
+                'name' => 'Shopify Basic',
+                'handle' => 'shopify-basic',
+                'features' => [],
+                'limits' => { 'agents' => 5, 'inboxes' => 10 }
+              }
+            ],
+            locked: true
+          )
+
+          get "/enterprise/api/v1/accounts/#{account.id}/limits",
+              headers: admin.create_new_auth_token,
+              as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body.dig('limits', 'agents', 'allowed')).to eq(0)
         end
       end
     end

--- a/spec/enterprise/controllers/enterprise/super_admin/app_configs_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/super_admin/app_configs_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'Enterprise Super Admin Application Config API', type: :request do
+  let(:super_admin) { create(:super_admin) }
+
+  before do
+    allow(ChatwootHub).to receive(:pricing_plan).and_return('enterprise')
+    sign_in(super_admin, scope: :super_admin)
+  end
+
+  it 'renders the Enterprise-owned Shopify app handle configuration' do
+    get '/super_admin/app_config?config=shopify'
+
+    expect(response).to have_http_status(:success)
+    expect(response.body).to include('Shopify App Handle')
+    expect(response.body).to include('The app handle used in Shopify Admin App Pricing URLs')
+  end
+
+  it 'saves the Enterprise-owned Shopify app handle configuration' do
+    post '/super_admin/app_config?config=shopify',
+         params: { app_config: { SHOPIFY_APP_HANDLE: 'chatwoot' } }
+
+    expect(response).to redirect_to(super_admin_settings_path)
+    expect(GlobalConfig.get('SHOPIFY_APP_HANDLE')['SHOPIFY_APP_HANDLE']).to eq('chatwoot')
+  end
+
+  it 'rejects an invalid Shopify app handle configuration' do
+    expect do
+      post '/super_admin/app_config?config=shopify',
+           params: { app_config: { SHOPIFY_APP_HANDLE: 'Chatwoot App' } }
+    end.not_to(change { InstallationConfig.find_by(name: 'SHOPIFY_APP_HANDLE')&.value })
+
+    expect(response).to redirect_to(super_admin_app_config_path(config: 'shopify'))
+    expect(flash[:alert]).to include('SHOPIFY_APP_HANDLE must contain only lowercase letters, numbers, and hyphens')
+  end
+end

--- a/spec/enterprise/controllers/enterprise/super_admin/app_configs_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/super_admin/app_configs_controller_spec.rb
@@ -16,7 +16,12 @@ RSpec.describe 'Enterprise Super Admin Application Config API', type: :request d
     expect(response.body).to include('The app handle used in Shopify Admin App Pricing URLs')
   end
 
-  it 'saves the Enterprise-owned Shopify app handle configuration' do
+  it 'saves Shopify configuration with an unset or valid app handle' do
+    post '/super_admin/app_config?config=shopify',
+         params: { app_config: { ENABLE_SHOPIFY_INTEGRATION: 'false', SHOPIFY_APP_HANDLE: '' } }
+
+    expect(response).to redirect_to(super_admin_settings_path)
+
     post '/super_admin/app_config?config=shopify',
          params: { app_config: { SHOPIFY_APP_HANDLE: 'chatwoot' } }
 

--- a/spec/enterprise/jobs/enterprise/billing/shopify_subscription_reconciliation_job_spec.rb
+++ b/spec/enterprise/jobs/enterprise/billing/shopify_subscription_reconciliation_job_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe Enterprise::Billing::ShopifySubscriptionReconciliationJob do
+  let(:eligible_account) do
+    create(
+      :account,
+      internal_attributes: {
+        'billing_provider' => 'shopify',
+        'signup_source' => 'shopify'
+      }
+    )
+  end
+  let(:stripe_account) { create(:account) }
+  let(:account_gate_disabled) do
+    create(
+      :account,
+      internal_attributes: {
+        'billing_provider' => 'shopify',
+        'signup_source' => 'shopify'
+      }
+    )
+  end
+
+  before do
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(true)
+
+    eligible_account.enable_features!('shopify_integration')
+    stripe_account.enable_features!('shopify_integration')
+    account_gate_disabled.enable_features!('shopify_integration')
+
+    create(
+      :integrations_hook,
+      :shopify,
+      account: eligible_account,
+      status: :enabled,
+      reference_id: 'eligible.myshopify.com'
+    )
+    create(
+      :integrations_hook,
+      :shopify,
+      account: stripe_account,
+      status: :enabled,
+      reference_id: 'stripe.myshopify.com'
+    )
+    create(
+      :integrations_hook,
+      :shopify,
+      account: account_gate_disabled,
+      status: :enabled,
+      reference_id: 'disabled.myshopify.com'
+    )
+    account_gate_disabled.disable_features!('shopify_integration')
+  end
+
+  it 'enqueues reconciliation only for enabled Shopify-billed accounts' do
+    expect(Enterprise::Billing::ShopifySubscriptionSyncJob).to receive(:perform_later)
+      .with(eligible_account.id)
+      .once
+
+    described_class.perform_now
+  end
+
+  it 'does not enqueue reconciliation when the global gate is disabled' do
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(false)
+    expect(Enterprise::Billing::ShopifySubscriptionSyncJob).not_to receive(:perform_later)
+
+    described_class.perform_now
+  end
+
+  it 'uses the scheduled jobs queue' do
+    expect(described_class.queue_name).to eq('scheduled_jobs')
+  end
+end

--- a/spec/enterprise/jobs/enterprise/billing/shopify_subscription_sync_job_spec.rb
+++ b/spec/enterprise/jobs/enterprise/billing/shopify_subscription_sync_job_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Enterprise::Billing::ShopifySubscriptionSyncJob do
+  let(:account) do
+    create(
+      :account,
+      internal_attributes: {
+        'billing_provider' => 'shopify',
+        'signup_source' => 'shopify'
+      }
+    )
+  end
+  let(:sync_service) { instance_double(Enterprise::Billing::ShopifySubscriptionSyncService, perform: nil) }
+
+  before do
+    account.enable_features!('shopify_integration')
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(true)
+  end
+
+  it 'runs subscription reconciliation for a feature-enabled account' do
+    allow(Enterprise::Billing::ShopifySubscriptionSyncService).to receive(:new)
+      .with(account: account)
+      .and_return(sync_service)
+
+    described_class.perform_now(account.id)
+
+    expect(sync_service).to have_received(:perform)
+  end
+
+  it 'does not run subscription reconciliation when the account gate is disabled' do
+    account.disable_features!('shopify_integration')
+    expect(Enterprise::Billing::ShopifySubscriptionSyncService).not_to receive(:new)
+
+    described_class.perform_now(account.id)
+  end
+
+  it 'uses the scheduled jobs queue' do
+    expect(described_class.queue_name).to eq('scheduled_jobs')
+  end
+end

--- a/spec/enterprise/jobs/enterprise/internal/trigger_hourly_scheduled_items_job_spec.rb
+++ b/spec/enterprise/jobs/enterprise/internal/trigger_hourly_scheduled_items_job_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Internal::TriggerHourlyScheduledItemsJob do
+  before do
+    allow(Channels::Whatsapp::HealthSyncSchedulerJob).to receive(:perform_later)
+    allow(Enterprise::Billing::ShopifySubscriptionReconciliationJob).to receive(:perform_later)
+    allow(GlobalConfigService).to receive(:load).and_call_original
+  end
+
+  it 'enqueues Shopify reconciliation when the global feature gate is enabled' do
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(true)
+
+    described_class.perform_now
+
+    expect(Enterprise::Billing::ShopifySubscriptionReconciliationJob).to have_received(:perform_later)
+  end
+
+  it 'does not enqueue Shopify reconciliation when the global feature gate is disabled' do
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(false)
+
+    described_class.perform_now
+
+    expect(Enterprise::Billing::ShopifySubscriptionReconciliationJob).not_to have_received(:perform_later)
+  end
+end

--- a/spec/enterprise/models/account_spec.rb
+++ b/spec/enterprise/models/account_spec.rb
@@ -30,6 +30,32 @@ RSpec.describe Account, type: :model do
       expect(account).not_to be_feature_assignment_v2
       expect(account).not_to be_feature_advanced_assignment
     end
+
+    it 'uses Shopify plan features when preserving advanced assignment' do
+      create(
+        :installation_config,
+        name: 'CHATWOOT_SHOPIFY_PLANS',
+        value: [
+          {
+            'name' => 'Shopify Pro',
+            'handle' => 'shopify-pro',
+            'features' => %w[advanced_assignment],
+            'limits' => { 'agents' => 10, 'inboxes' => 20 }
+          }
+        ],
+        locked: true
+      )
+      account = build(
+        :account,
+        internal_attributes: { 'billing_provider' => 'shopify' },
+        custom_attributes: { 'plan_name' => 'Shopify Pro' }
+      )
+
+      account.selected_feature_flags = [:feature_assignment_v2]
+
+      expect(account).to be_feature_assignment_v2
+      expect(account).to be_feature_advanced_assignment
+    end
   end
 
   describe '#api_and_webhooks_enabled?' do
@@ -51,6 +77,63 @@ RSpec.describe Account, type: :model do
       account.enable_features!('api_and_webhooks')
 
       expect(account.api_and_webhooks_enabled?).to be true
+    end
+  end
+
+  describe 'billing identity' do
+    it 'defaults existing accounts to Stripe and Chatwoot signup' do
+      account = create(:account)
+
+      expect(account.billing_provider).to eq('stripe')
+      expect(account.signup_source).to eq('chatwoot')
+    end
+
+    it 'stores Shopify identity at account creation' do
+      account = create(
+        :account,
+        internal_attributes: {
+          'billing_provider' => 'shopify',
+          'signup_source' => 'shopify'
+        }
+      )
+
+      expect(account.billing_provider).to eq('shopify')
+      expect(account.signup_source).to eq('shopify')
+    end
+
+    it 'rejects unsupported billing providers and signup sources' do
+      account = build(:account)
+      account.billing_provider = 'unsupported'
+      account.signup_source = 'unsupported'
+
+      expect(account).not_to be_valid
+      expect(account.errors[:billing_provider]).to be_present
+      expect(account.errors[:signup_source]).to be_present
+    end
+
+    it 'does not allow billing identity to change after account creation' do
+      account = create(:account)
+
+      account.billing_provider = 'shopify'
+      account.signup_source = 'shopify'
+
+      expect(account.save).to be(false)
+      expect(account.errors[:billing_provider]).to include('cannot be changed after account creation')
+      expect(account.errors[:signup_source]).to include('cannot be changed after account creation')
+      expect(account.reload.billing_provider).to eq('stripe')
+      expect(account.signup_source).to eq('chatwoot')
+    end
+
+    it 'does not allow billing identity to change through symbol-keyed internal attributes' do
+      account = create(:account)
+
+      account.internal_attributes = account.internal_attributes.merge(billing_provider: 'shopify', signup_source: 'shopify')
+
+      expect(account.save).to be(false)
+      expect(account.errors[:billing_provider]).to include('cannot be changed after account creation')
+      expect(account.errors[:signup_source]).to include('cannot be changed after account creation')
+      expect(account.reload.billing_provider).to eq('stripe')
+      expect(account.signup_source).to eq('chatwoot')
     end
   end
 
@@ -222,6 +305,71 @@ RSpec.describe Account, type: :model do
       InstallationConfig.where(name: 'ACCOUNT_AGENTS_LIMIT').update(value: '')
 
       expect(account.usage_limits[:agents]).to eq(ChatwootApp.max_limit)
+    end
+  end
+
+  context 'with Shopify plan entitlements' do
+    let(:account) do
+      create(
+        :account,
+        internal_attributes: { 'billing_provider' => 'shopify' },
+        custom_attributes: {
+          'plan_name' => 'Shopify Basic',
+          'subscribed_quantity' => 100,
+          'captain_documents_usage' => 5,
+          'captain_responses_usage' => 10
+        }
+      )
+    end
+    let(:shopify_plan) do
+      {
+        'name' => 'Shopify Basic',
+        'handle' => 'shopify-basic',
+        'features' => %w[help_center campaigns],
+        'limits' => {
+          'agents' => 5,
+          'inboxes' => 10,
+          'emails' => 500,
+          'captain_documents' => 25,
+          'captain_responses' => 100
+        }
+      }
+    end
+
+    before do
+      create(:installation_config, name: 'CHATWOOT_SHOPIFY_PLANS', value: [shopify_plan], locked: true)
+    end
+
+    it 'uses fixed Shopify limits instead of Stripe subscription quantity or global limits' do
+      usage_limits = account.usage_limits
+
+      expect(usage_limits[:agents]).to eq(5)
+      expect(usage_limits[:inboxes]).to eq(10)
+      expect(usage_limits.dig(:captain, :documents)).to eq(
+        total_count: 25,
+        current_available: 20,
+        consumed: 5
+      )
+      expect(usage_limits.dig(:captain, :responses)).to eq(
+        total_count: 100,
+        current_available: 90,
+        consumed: 10
+      )
+      expect(account.email_rate_limit).to eq(500)
+    end
+
+    it 'reads subscribed features from the Shopify plan catalog' do
+      expect(account.subscribed_features).to eq(%w[help_center campaigns])
+      expect(account.email_transcript_enabled?).to be(true)
+    end
+
+    it 'fails closed when the stored Shopify plan is unknown' do
+      account.update!(custom_attributes: { 'plan_name' => 'Unknown' })
+
+      expect(account.usage_limits[:agents]).to eq(0)
+      expect(account.usage_limits[:inboxes]).to eq(0)
+      expect(account.subscribed_features).to eq([])
+      expect(account.email_transcript_enabled?).to be(false)
     end
   end
 

--- a/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
@@ -168,6 +168,33 @@ describe Enterprise::Billing::HandleStripeEventService do
     end
   end
 
+  context 'when a Stripe customer id belongs to a Shopify-billed account' do
+    let!(:account) do
+      create(
+        :account,
+        internal_attributes: { 'billing_provider' => 'shopify' },
+        custom_attributes: { 'stripe_customer_id' => 'cus_123' }
+      )
+    end
+
+    it 'ignores subscription updates' do
+      allow(subscription).to receive(:[]).with('plan')
+                                         .and_return({ 'id' => 'test', 'product' => 'plan_id_startups', 'name' => 'Startups' })
+      previous_attributes = account.custom_attributes.deep_dup
+
+      stripe_event_service.new.perform(event: event)
+
+      expect(account.reload.custom_attributes).to eq(previous_attributes)
+    end
+
+    it 'ignores subscription deletions' do
+      allow(event).to receive(:type).and_return('customer.subscription.deleted')
+      expect(Enterprise::Billing::CreateStripeCustomerService).not_to receive(:new)
+
+      stripe_event_service.new.perform(event: event)
+    end
+  end
+
   describe 'plan-specific feature management' do
     context 'with default plan (Hacker)' do
       it 'disables all premium features' do

--- a/spec/enterprise/services/enterprise/billing/plan_configuration_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/plan_configuration_spec.rb
@@ -1,0 +1,126 @@
+require 'rails_helper'
+
+RSpec.describe Enterprise::Billing::PlanConfiguration do
+  let(:stripe_plans) do
+    [
+      {
+        'name' => 'Hacker',
+        'product_id' => ['stripe-product'],
+        'price_ids' => ['stripe-price']
+      }
+    ]
+  end
+  let(:shopify_plans) do
+    [
+      {
+        'name' => 'Shopify Basic',
+        'handle' => 'shopify-basic',
+        'features' => %w[help_center campaigns],
+        'limits' => {
+          'agents' => 5,
+          'inboxes' => 10,
+          'emails' => 500,
+          'captain_documents' => 25,
+          'captain_responses' => 100
+        }
+      }
+    ]
+  end
+
+  before do
+    create(:installation_config, name: 'CHATWOOT_CLOUD_PLANS', value: stripe_plans)
+    create(:installation_config, name: 'CHATWOOT_SHOPIFY_PLANS', value: shopify_plans, locked: true)
+  end
+
+  it 'keeps Stripe as the default provider configuration' do
+    expect(described_class.plans).to eq(stripe_plans)
+    expect(described_class.default_plan).to eq(stripe_plans.first)
+  end
+
+  it 'loads plans for the account billing provider' do
+    account = create(:account, internal_attributes: { 'billing_provider' => 'shopify' })
+
+    expect(described_class.plans_for(account)).to eq(shopify_plans)
+  end
+
+  it 'raises when the locked Shopify plan catalog is missing' do
+    InstallationConfig.find_by!(name: 'CHATWOOT_SHOPIFY_PLANS').destroy!
+
+    expect do
+      described_class.plans(provider: 'shopify')
+    end.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it 'raises when the locked Shopify plan catalog is empty' do
+    InstallationConfig.find_by!(name: 'CHATWOOT_SHOPIFY_PLANS').update!(value: [])
+
+    expect do
+      described_class.plans(provider: 'shopify')
+    end.to raise_error(described_class::InvalidConfiguration, 'CHATWOOT_SHOPIFY_PLANS must contain at least one plan')
+  end
+
+  it 'finds the current Shopify plan by its Chatwoot plan name' do
+    account = create(
+      :account,
+      internal_attributes: { 'billing_provider' => 'shopify' },
+      custom_attributes: { 'plan_name' => 'Shopify Basic' }
+    )
+
+    expect(described_class.current_plan(account)).to eq(shopify_plans.first)
+  end
+
+  it 'finds a Shopify plan by its verified handle' do
+    expect(described_class.find_shopify_plan_by_handle('shopify-basic')).to eq(shopify_plans.first)
+    expect(described_class.find_shopify_plan_by_handle('unknown')).to be_nil
+  end
+
+  it 'rejects unsupported providers' do
+    expect do
+      described_class.plans(provider: 'unsupported')
+    end.to raise_error(ArgumentError, 'Unsupported billing provider: unsupported')
+  end
+
+  it 'rejects a non-array Shopify catalog' do
+    InstallationConfig.find_by!(name: 'CHATWOOT_SHOPIFY_PLANS').update!(value: {})
+
+    expect do
+      described_class.plans(provider: 'shopify')
+    end.to raise_error(described_class::InvalidConfiguration, 'CHATWOOT_SHOPIFY_PLANS must be an array')
+  end
+
+  it 'rejects Shopify plans without required limits' do
+    shopify_plans.first['limits'].delete('agents')
+    InstallationConfig.find_by!(name: 'CHATWOOT_SHOPIFY_PLANS').update!(value: shopify_plans)
+
+    expect do
+      described_class.plans(provider: 'shopify')
+    end.to raise_error(described_class::InvalidConfiguration, /limits is missing required limits/)
+  end
+
+  it 'rejects unknown Shopify plan features' do
+    shopify_plans.first['features'] = ['unknown_feature']
+    InstallationConfig.find_by!(name: 'CHATWOOT_SHOPIFY_PLANS').update!(value: shopify_plans)
+
+    expect do
+      described_class.plans(provider: 'shopify')
+    end.to raise_error(described_class::InvalidConfiguration, /features contains unknown features/)
+  end
+
+  it 'keeps the Shopify rollout flag outside plan reconciliation' do
+    shopify_plans.first['features'] = [Shopify::FeatureGate::ACCOUNT_FEATURE]
+    InstallationConfig.find_by!(name: 'CHATWOOT_SHOPIFY_PLANS').update!(value: shopify_plans)
+
+    expect do
+      described_class.plans(provider: 'shopify')
+    end.to raise_error(described_class::InvalidConfiguration, /features cannot manage shopify_integration/)
+  end
+
+  it 'rejects duplicate Shopify handles' do
+    shopify_plans << shopify_plans.first.merge('name' => 'Shopify Pro')
+    InstallationConfig.find_by!(name: 'CHATWOOT_SHOPIFY_PLANS').update!(value: shopify_plans)
+
+    expect do
+      described_class.plans(provider: 'shopify')
+    end.to raise_error(described_class::InvalidConfiguration, /duplicate handle values/)
+  end
+end

--- a/spec/enterprise/services/enterprise/billing/reconcile_plan_features_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/reconcile_plan_features_service_spec.rb
@@ -60,5 +60,149 @@ describe Enterprise::Billing::ReconcilePlanFeaturesService do
         expect(account.reload).to be_feature_enabled('whatsapp_embedded_signup_inbox_creation')
       end
     end
+
+    context 'with a Shopify-billed account' do
+      let(:account) do
+        create(
+          :account,
+          internal_attributes: { 'billing_provider' => 'shopify' },
+          custom_attributes: { 'plan_name' => 'Shopify Basic' }
+        )
+      end
+      let(:shopify_plans) do
+        [
+          {
+            'name' => 'Shopify Basic',
+            'handle' => 'shopify-basic',
+            'features' => %w[audit_logs],
+            'limits' => { 'agents' => 5, 'inboxes' => 10 }
+          },
+          {
+            'name' => 'Shopify Pro',
+            'handle' => 'shopify-pro',
+            'features' => %w[audit_logs saml],
+            'limits' => { 'agents' => 10, 'inboxes' => 20 }
+          }
+        ]
+      end
+      let!(:shopify_config) do
+        create(:installation_config, name: 'CHATWOOT_SHOPIFY_PLANS', value: shopify_plans, locked: true)
+      end
+
+      before do
+        allow(GlobalConfigService).to receive(:load).and_call_original
+        allow(GlobalConfigService).to receive(:load)
+          .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+          .and_return(true)
+        account.enable_features!('shopify_integration')
+      end
+
+      it 'enables features from the Shopify plan catalog without changing the rollout flag' do
+        described_class.new(account: account).perform
+
+        expect(account.reload).to be_feature_enabled('audit_logs')
+        expect(account).not_to be_feature_enabled('saml')
+        expect(account).not_to be_feature_enabled('captain_integration_v2')
+        expect(account).to be_feature_enabled('shopify_integration')
+      end
+
+      it 'clears default plan entitlements omitted from every Shopify plan' do
+        account.enable_features!('api_and_webhooks')
+
+        described_class.new(account: account).perform
+
+        expect(account.reload).not_to be_feature_enabled('api_and_webhooks')
+        expect(account).to be_feature_enabled('audit_logs')
+      end
+
+      it 'clears Captain V2 when it is omitted from every Shopify plan' do
+        account.enable_features!('captain_integration_v2')
+
+        described_class.new(account: account).perform
+
+        expect(account.reload).not_to be_feature_enabled('captain_integration_v2')
+        expect(account).to be_feature_enabled('audit_logs')
+      end
+
+      it 'removes features that are not present after a Shopify plan change' do
+        account.update!(custom_attributes: { 'plan_name' => 'Shopify Pro' })
+        described_class.new(account: account).perform
+        expect(account.reload).to be_feature_enabled('saml')
+
+        account.update!(custom_attributes: { 'plan_name' => 'Shopify Basic' })
+        described_class.new(account: account).perform
+
+        expect(account.reload).not_to be_feature_enabled('saml')
+        expect(account).to be_feature_enabled('audit_logs')
+      end
+
+      it 'removes a feature that was deleted from the Shopify catalog' do
+        account.update!(custom_attributes: { 'plan_name' => 'Shopify Pro' })
+        described_class.new(account: account).perform
+        expect(account.reload).to be_feature_enabled('saml')
+
+        shopify_config.update!(value: [shopify_plans.first])
+        account.update!(custom_attributes: { 'plan_name' => 'Shopify Basic' })
+        described_class.new(account: account).perform
+
+        expect(account.reload).not_to be_feature_enabled('saml')
+        expect(account.internal_attributes['shopify_managed_features']).to contain_exactly('audit_logs')
+      end
+
+      it 'preserves a manually managed feature after it is deleted from the Shopify catalog' do
+        account.update!(custom_attributes: { 'plan_name' => 'Shopify Pro' })
+        Internal::Accounts::InternalAttributesService.new(account).manually_managed_features = ['saml']
+        described_class.new(account: account).perform
+
+        shopify_config.update!(value: [shopify_plans.first])
+        account.update!(custom_attributes: { 'plan_name' => 'Shopify Basic' })
+        described_class.new(account: account).perform
+
+        expect(account.reload).to be_feature_enabled('saml')
+        expect(account.internal_attributes['shopify_managed_features']).to contain_exactly('audit_logs')
+      end
+
+      it 'rejects an unknown Shopify plan instead of guessing entitlements' do
+        account.update!(custom_attributes: { 'plan_name' => 'Unknown' })
+
+        expect do
+          described_class.new(account: account).perform
+        end.to raise_error(Enterprise::Billing::PlanConfiguration::UnknownPlan)
+      end
+
+      it 'preserves entitlements when the global Shopify switch is disabled' do
+        account.enable_features!('saml')
+        allow(GlobalConfigService).to receive(:load)
+          .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+          .and_return(false)
+        expect(Enterprise::Billing::PlanConfiguration).not_to receive(:plans_for)
+
+        described_class.new(account: account).perform
+
+        expect(account.reload).to be_feature_enabled('saml')
+      end
+
+      it 'preserves entitlements when the account Shopify flag is disabled' do
+        account.enable_features!('saml')
+        account.disable_features!('shopify_integration')
+        expect(Enterprise::Billing::PlanConfiguration).not_to receive(:plans_for)
+
+        described_class.new(account: account).perform
+
+        expect(account.reload).to be_feature_enabled('saml')
+      end
+
+      it 'removes managed entitlements during lifecycle cleanup when the account Shopify flag is disabled' do
+        account.enable_features!('audit_logs', 'saml')
+        account.disable_features!('shopify_integration')
+        account.update!(custom_attributes: { 'plan_name' => nil })
+
+        described_class.new(account: account, shopify_lifecycle_cleanup: true).perform
+
+        expect(account.reload).not_to be_feature_enabled('audit_logs')
+        expect(account).not_to be_feature_enabled('saml')
+        expect(account).not_to be_feature_enabled('shopify_integration')
+      end
+    end
   end
 end

--- a/spec/enterprise/services/enterprise/billing/shopify_subscription_sync_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/shopify_subscription_sync_service_spec.rb
@@ -1,0 +1,279 @@
+require 'rails_helper'
+
+RSpec.describe Enterprise::Billing::ShopifySubscriptionSyncService do
+  let(:account) do
+    create(
+      :account,
+      internal_attributes: { 'billing_provider' => 'shopify', 'signup_source' => 'shopify' },
+      custom_attributes: {
+        'plan_name' => 'Shopify Basic',
+        'subscription_status' => 'pending'
+      }
+    )
+  end
+  let(:shopify_plans) do
+    [
+      {
+        'name' => 'Shopify Basic',
+        'handle' => 'shopify-basic',
+        'features' => %w[audit_logs],
+        'limits' => { 'agents' => 5, 'inboxes' => 10 }
+      },
+      {
+        'name' => 'Shopify Pro',
+        'handle' => 'shopify-pro',
+        'features' => %w[audit_logs saml],
+        'limits' => { 'agents' => 10, 'inboxes' => 20 }
+      }
+    ]
+  end
+  let(:fetcher) { instance_double(Shopify::SubscriptionFetcher) }
+  let(:verified_at) { '2026-07-29T10:00:00Z' }
+  let(:active_snapshot) do
+    Shopify::SubscriptionSnapshot.from_h(
+      'state' => 'active',
+      'plan_handles' => ['shopify-pro'],
+      'currency' => 'USD',
+      'verified_at' => verified_at
+    )
+  end
+  let(:inactive_snapshot) do
+    Shopify::SubscriptionSnapshot.from_h(
+      'state' => 'expired',
+      'plan_handles' => [],
+      'currency' => nil,
+      'verified_at' => verified_at
+    )
+  end
+
+  before do
+    plans_config = InstallationConfig.find_or_initialize_by(name: 'CHATWOOT_SHOPIFY_PLANS')
+    plans_config.update!(value: shopify_plans, locked: true)
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(true)
+    account.enable_features!('shopify_integration')
+    allow(Shopify::SubscriptionFetcher).to receive(:new).with(account: account).and_return(fetcher)
+  end
+
+  it 'applies the verified Shopify plan and its entitlements' do
+    allow(fetcher).to receive(:perform).with(force: true).and_return(active_snapshot)
+
+    described_class.new(account: account).perform
+
+    expect(account.reload.custom_attributes).to include(
+      'plan_name' => 'Shopify Pro',
+      'subscription_status' => 'active',
+      'billing_currency' => 'USD',
+      'shopify_subscription_verified_at' => verified_at
+    )
+    expect(account.custom_attributes['shopify_subscription_snapshot']).to eq(active_snapshot.to_h)
+    expect(account).to be_active
+    expect(account).to be_feature_enabled('audit_logs')
+    expect(account).to be_feature_enabled('saml')
+    expect(account).to be_feature_enabled('shopify_integration')
+  end
+
+  it 'applies a verified lifecycle snapshot without calling Shopify again' do
+    expect(fetcher).not_to receive(:perform)
+
+    described_class.new(account: account).perform(snapshot: inactive_snapshot)
+
+    expect(account.reload).to be_suspended
+    expect(account.custom_attributes).to include(
+      'plan_name' => nil,
+      'subscription_status' => 'expired',
+      'shopify_subscription_verified_at' => verified_at
+    )
+  end
+
+  it 'applies an inactive lifecycle snapshot when the Shopify account feature is disabled' do
+    account.enable_features!('audit_logs', 'saml')
+    account.disable_features!('shopify_integration')
+    expect(fetcher).not_to receive(:perform)
+
+    described_class.new(account: account).perform(snapshot: inactive_snapshot)
+
+    expect(account.reload).to be_suspended
+    expect(account.custom_attributes).to include(
+      'plan_name' => nil,
+      'subscription_status' => 'expired',
+      'shopify_subscription_verified_at' => verified_at
+    )
+    expect(account).not_to be_feature_enabled('audit_logs')
+    expect(account).not_to be_feature_enabled('saml')
+    expect(account).not_to be_feature_enabled('shopify_integration')
+  end
+
+  it 'does not apply an entitled snapshot when the Shopify account feature is disabled' do
+    account.disable_features!('shopify_integration')
+    expect(fetcher).not_to receive(:perform)
+    previous_attributes = account.custom_attributes.deep_dup
+
+    expect(described_class.new(account: account).perform(snapshot: active_snapshot)).to be_nil
+
+    expect(account.reload.custom_attributes).to eq(previous_attributes)
+    expect(account).to be_active
+  end
+
+  it 'suspends a verified inactive account and removes plan entitlements' do
+    account.enable_features!('audit_logs', 'saml')
+    allow(fetcher).to receive(:perform).with(force: true).and_return(inactive_snapshot)
+
+    described_class.new(account: account).perform
+
+    expect(account.reload).to be_suspended
+    expect(account.custom_attributes).to include(
+      'plan_name' => nil,
+      'subscription_status' => 'expired',
+      'shopify_subscription_verified_at' => verified_at
+    )
+    expect(account.internal_attributes['shopify_billing_suspended']).to eq(account.suspension_history.last['suspended_at'])
+    expect(account.suspension_history.last).to include(
+      'category' => 'non_payment',
+      'reason' => 'Shopify App Pricing subscription is inactive'
+    )
+    expect(account).not_to be_feature_enabled('audit_logs')
+    expect(account).not_to be_feature_enabled('saml')
+    expect(account).to be_feature_enabled('shopify_integration')
+  end
+
+  it 'does not add duplicate suspension events when reconciliation is repeated' do
+    allow(fetcher).to receive(:perform).with(force: true).and_return(inactive_snapshot)
+
+    2.times { described_class.new(account: account).perform }
+
+    expect(account.reload.suspension_history.size).to eq(1)
+  end
+
+  it 'does not let an in-flight active verification restore entitlements after uninstall' do
+    uninstall_snapshot = Shopify::SubscriptionSnapshot.from_h(
+      inactive_snapshot.to_h.merge(
+        'verified_at' => '2026-07-29T10:01:00Z',
+        'latest_event' => {
+          'state' => 'RELATIONSHIP_UNINSTALLED',
+          'occurred_at' => '2026-07-29T10:00:30Z'
+        }
+      )
+    )
+    older_active_snapshot = Shopify::SubscriptionSnapshot.from_h(
+      active_snapshot.to_h.merge('verified_at' => '2026-07-29T10:00:00Z')
+    )
+    expect(fetcher).not_to receive(:perform)
+
+    described_class.new(account: account).perform(snapshot: uninstall_snapshot)
+    result = described_class.new(account: account).perform(snapshot: older_active_snapshot)
+
+    expect(result.to_h).to eq(uninstall_snapshot.to_h)
+    expect(account.reload).to be_suspended
+    expect(account.custom_attributes).to include(
+      'plan_name' => nil,
+      'subscription_status' => 'expired',
+      'shopify_subscription_verified_at' => '2026-07-29T10:01:00Z'
+    )
+    expect(account).not_to be_feature_enabled('saml')
+  end
+
+  it 'restores access after a Shopify-owned billing suspension becomes active' do
+    reactivated_snapshot = Shopify::SubscriptionSnapshot.from_h(
+      active_snapshot.to_h.merge('verified_at' => '2026-07-29T10:01:00Z')
+    )
+    allow(fetcher).to receive(:perform).with(force: true).and_return(inactive_snapshot, reactivated_snapshot)
+
+    described_class.new(account: account).perform
+    described_class.new(account: account).perform
+
+    expect(account.reload).to be_active
+    expect(account.internal_attributes).not_to have_key('shopify_billing_suspended')
+    expect(account.custom_attributes['plan_name']).to eq('Shopify Pro')
+  end
+
+  it 'does not reactivate an account suspended outside Shopify billing' do
+    account.update!(status: :suspended)
+    allow(fetcher).to receive(:perform).with(force: true).and_return(active_snapshot)
+
+    described_class.new(account: account).perform
+
+    expect(account.reload).to be_suspended
+    expect(account.custom_attributes['plan_name']).to eq('Shopify Pro')
+  end
+
+  it 'does not reactivate an account manually suspended after a Shopify billing suspension' do
+    reactivated_snapshot = Shopify::SubscriptionSnapshot.from_h(
+      active_snapshot.to_h.merge('verified_at' => '2026-07-29T10:01:00Z')
+    )
+    allow(fetcher).to receive(:perform).with(force: true).and_return(inactive_snapshot, reactivated_snapshot)
+    described_class.new(account: account).perform
+
+    manual_suspension = {
+      'category' => 'spam',
+      'reason' => 'Manual review',
+      'suspended_at' => 1.minute.from_now.iso8601
+    }
+    account.update!(
+      status: :suspended,
+      internal_attributes: account.internal_attributes.merge('suspensions' => account.suspension_history + [manual_suspension])
+    )
+
+    described_class.new(account: account).perform
+
+    expect(account.reload).to be_suspended
+    expect(account.internal_attributes).not_to have_key('shopify_billing_suspended')
+  end
+
+  it 'preserves the last verified state during a provider outage' do
+    previous_attributes = account.custom_attributes.deep_dup
+    allow(fetcher).to receive(:perform)
+      .with(force: true)
+      .and_raise(Shopify::PartnerClient::ProviderError, 'Shopify Partner API request failed')
+
+    expect do
+      described_class.new(account: account).perform
+    end.to raise_error(Shopify::PartnerClient::ProviderError)
+
+    expect(account.reload.custom_attributes).to eq(previous_attributes)
+    expect(account).to be_active
+  end
+
+  it 'does not call Shopify or mutate the account when the feature gate is disabled' do
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(false)
+    expect(fetcher).not_to receive(:perform)
+    previous_attributes = account.custom_attributes.deep_dup
+
+    expect(described_class.new(account: account).perform).to be_nil
+
+    expect(account.reload.custom_attributes).to eq(previous_attributes)
+  end
+
+  it 'rejects an unknown active plan without changing prior entitlements' do
+    unknown_snapshot = Shopify::SubscriptionSnapshot.from_h(
+      'state' => 'active',
+      'plan_handles' => ['unknown-plan'],
+      'verified_at' => verified_at
+    )
+    allow(fetcher).to receive(:perform).with(force: true).and_return(unknown_snapshot)
+    previous_attributes = account.custom_attributes.deep_dup
+
+    expect do
+      described_class.new(account: account).perform
+    end.to raise_error(described_class::InvalidSubscription, 'Shopify subscription has an unknown plan handle')
+
+    expect(account.reload.custom_attributes).to eq(previous_attributes)
+  end
+
+  it 'rejects multiple active plan handles' do
+    multiple_snapshot = Shopify::SubscriptionSnapshot.from_h(
+      'state' => 'active',
+      'plan_handles' => %w[shopify-basic shopify-pro],
+      'verified_at' => verified_at
+    )
+    allow(fetcher).to receive(:perform).with(force: true).and_return(multiple_snapshot)
+
+    expect do
+      described_class.new(account: account).perform
+    end.to raise_error(described_class::InvalidSubscription, 'Shopify subscription must have exactly one active plan handle')
+  end
+end

--- a/spec/enterprise/services/enterprise/shopify/uninstallation_service_spec.rb
+++ b/spec/enterprise/services/enterprise/shopify/uninstallation_service_spec.rb
@@ -1,0 +1,155 @@
+require 'rails_helper'
+
+RSpec.describe Shopify::UninstallationService do
+  let(:account) do
+    create(
+      :account,
+      internal_attributes: {
+        'billing_provider' => 'shopify',
+        'signup_source' => 'shopify'
+      },
+      custom_attributes: {
+        'plan_name' => 'Shopify Basic',
+        'subscription_status' => 'active',
+        'shopify_subscription_snapshot' => {
+          'state' => 'active',
+          'plan_handles' => ['shopify-basic'],
+          'shop_id' => 'gid://shopify/Shop/5678',
+          'shop_domain' => 'test-store.myshopify.com'
+        }
+      }
+    )
+  end
+  let(:occurred_at) { Time.iso8601('2026-07-29T10:01:00.123456Z') }
+  let(:shopify_plans) do
+    [
+      {
+        'name' => 'Shopify Basic',
+        'handle' => 'shopify-basic',
+        'features' => %w[audit_logs saml],
+        'limits' => { 'agents' => 5, 'inboxes' => 10 }
+      }
+    ]
+  end
+  let(:hook) do
+    create(
+      :integrations_hook,
+      :shopify,
+      account: account,
+      access_token: 'shopify-access-token',
+      settings: {
+        'scope' => 'read_customers,read_orders',
+        'connected_at' => '2026-07-29T09:00:00.000000Z',
+        'installation_id' => SecureRandom.uuid
+      }
+    )
+  end
+  let(:sync_service) { instance_double(Enterprise::Billing::ShopifySubscriptionSyncService) }
+
+  before do
+    account.enable_features!('shopify_integration')
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(true)
+    allow(Enterprise::Billing::ShopifySubscriptionSyncService).to receive(:new)
+      .with(account: account)
+      .and_return(sync_service)
+  end
+
+  it 'expires billing through the sync service and revokes stored credentials' do
+    captured_snapshot = nil
+    allow(sync_service).to receive(:perform) do |snapshot:|
+      captured_snapshot = snapshot
+    end
+
+    described_class.new(hook: hook, occurred_at: occurred_at).perform
+
+    expect(captured_snapshot.to_h).to include(
+      'state' => 'expired',
+      'plan_handles' => [],
+      'shop_id' => 'gid://shopify/Shop/5678',
+      'shop_domain' => 'test-store.myshopify.com',
+      'latest_event' => {
+        'state' => 'RELATIONSHIP_UNINSTALLED',
+        'occurred_at' => occurred_at.iso8601(6)
+      }
+    )
+    expect(hook.reload).to have_attributes(
+      status: 'disabled',
+      access_token: nil,
+      settings: {}
+    )
+  end
+
+  it 'expires billing and deletes a redacted hook when the account feature is disabled' do
+    create(:installation_config, name: 'CHATWOOT_SHOPIFY_PLANS', value: shopify_plans, locked: true)
+    account.enable_features!('audit_logs', 'saml')
+    account.disable_features!('shopify_integration')
+    allow(Enterprise::Billing::ShopifySubscriptionSyncService).to receive(:new)
+      .with(account: account)
+      .and_call_original
+    hook
+
+    expect do
+      described_class.new(hook: hook, occurred_at: occurred_at, delete_hook: true).perform
+    end.to change(Integrations::Hook, :count).by(-1)
+    expect(account.reload).to be_suspended
+    expect(account.custom_attributes).to include(
+      'plan_name' => nil,
+      'subscription_status' => 'expired'
+    )
+    expect(account.custom_attributes['shopify_subscription_snapshot']).not_to include('shop_id', 'shop_domain')
+    expect(account).not_to be_feature_enabled('audit_logs')
+    expect(account).not_to be_feature_enabled('saml')
+    expect(account).not_to be_feature_enabled('shopify_integration')
+  end
+
+  it 'still revokes credentials when billing reconciliation fails' do
+    allow(sync_service).to receive(:perform).and_raise(StandardError, 'sync failed')
+
+    expect do
+      described_class.new(hook: hook, occurred_at: occurred_at).perform
+    end.to raise_error(StandardError, 'sync failed')
+
+    expect(hook.reload).to have_attributes(
+      status: 'disabled',
+      access_token: nil,
+      settings: {}
+    )
+  end
+
+  it 'does not reconcile billing when credential revocation fails' do
+    allow(hook).to receive(:update!).and_raise(ActiveRecord::RecordNotSaved, 'credential revocation failed')
+    expect(sync_service).not_to receive(:perform)
+
+    expect do
+      described_class.new(hook: hook, occurred_at: occurred_at).perform
+    end.to raise_error(ActiveRecord::RecordNotSaved, 'credential revocation failed')
+  end
+
+  it 'expires billing and revokes credentials when the account feature is disabled' do
+    create(:installation_config, name: 'CHATWOOT_SHOPIFY_PLANS', value: shopify_plans, locked: true)
+    account.enable_features!('audit_logs', 'saml')
+    account.disable_features!('shopify_integration')
+    allow(Enterprise::Billing::ShopifySubscriptionSyncService).to receive(:new)
+      .with(account: account)
+      .and_call_original
+
+    described_class.new(hook: hook, occurred_at: occurred_at).perform
+
+    expect(account.reload).to be_suspended
+    expect(account.custom_attributes).to include(
+      'plan_name' => nil,
+      'subscription_status' => 'expired'
+    )
+    expect(account).not_to be_feature_enabled('audit_logs')
+    expect(account).not_to be_feature_enabled('saml')
+    expect(account).not_to be_feature_enabled('shopify_integration')
+    expect(hook.reload).to have_attributes(
+      status: 'disabled',
+      access_token: nil,
+      settings: {}
+    )
+  end
+end

--- a/spec/lib/redis/secure_storage_spec.rb
+++ b/spec/lib/redis/secure_storage_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Redis::SecureStorage do
+  let(:key) { "secure-storage-spec:#{SecureRandom.hex(8)}" }
+  let(:encryption_env) do
+    {
+      'ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY' => 'primary-key',
+      'ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY' => 'deterministic-key',
+      'ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT' => 'key-derivation-salt'
+    }
+  end
+
+  around do |example|
+    with_modified_env(encryption_env) { example.run }
+  end
+
+  after do
+    Redis::Alfred.delete(key)
+  end
+
+  it 'stores encrypted data and decrypts it when read' do
+    described_class.set(key, { access_token: 'secret-access-token' }, 10.minutes)
+
+    raw_value = Redis::Alfred.get(key)
+    expect(raw_value).not_to include('secret-access-token')
+    expect(JSON.parse(described_class.get(key))).to eq('access_token' => 'secret-access-token')
+  end
+
+  it 'returns nil for corrupted encrypted data' do
+    Redis::Alfred.set(key, 'not-encrypted-data')
+
+    expect(described_class.get(key)).to be_nil
+  end
+
+  it 'refuses to write sensitive data without encryption configuration' do
+    with_modified_env(encryption_env.transform_values { nil }) do
+      expect do
+        described_class.set(key, { access_token: 'secret-access-token' }, 10.minutes)
+      end.to raise_error(described_class::EncryptionNotConfigured)
+    end
+  end
+
+  it 'refuses to read sensitive data without encryption configuration' do
+    with_modified_env(encryption_env.transform_values { nil }) do
+      expect { described_class.get(key) }.to raise_error(described_class::EncryptionNotConfigured)
+    end
+  end
+end

--- a/spec/models/integrations/app_spec.rb
+++ b/spec/models/integrations/app_spec.rb
@@ -59,6 +59,33 @@ RSpec.describe Integrations::App do
         )
       end
     end
+
+    context 'when the app is shopify' do
+      let(:app_name) { 'shopify' }
+
+      before do
+        account.enable_features('shopify_integration')
+        allow(GlobalConfigService).to receive(:load)
+          .with('SHOPIFY_APP_STORE_URL', nil)
+          .and_return('https://apps.shopify.com/chatwoot')
+      end
+
+      it 'returns the App Store URL when both feature gates are enabled' do
+        allow(GlobalConfigService).to receive(:load)
+          .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+          .and_return(true)
+
+        expect(app.action).to eq('https://apps.shopify.com/chatwoot')
+      end
+
+      it 'does not return an action when the installation switch is disabled' do
+        allow(GlobalConfigService).to receive(:load)
+          .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+          .and_return(false)
+
+        expect(app.action).to be_nil
+      end
+    end
   end
 
   describe '#active?' do
@@ -75,6 +102,12 @@ RSpec.describe Integrations::App do
     context 'when the app is shopify' do
       let(:app_name) { 'shopify' }
 
+      before do
+        allow(GlobalConfigService).to receive(:load)
+          .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+          .and_return(true)
+      end
+
       it 'returns true if the shopify integration feature is enabled' do
         account.enable_features('shopify_integration')
         allow(GlobalConfigService).to receive(:load).with('SHOPIFY_CLIENT_ID', nil).and_return('client_id')
@@ -89,6 +122,16 @@ RSpec.describe Integrations::App do
       it 'returns false if SHOPIFY_CLIENT_ID is not present, even if feature is enabled' do
         account.enable_features('shopify_integration')
         allow(GlobalConfigService).to receive(:load).with('SHOPIFY_CLIENT_ID', nil).and_return(nil)
+        expect(app.active?(account)).to be false
+      end
+
+      it 'returns false if the installation switch is disabled' do
+        account.enable_features('shopify_integration')
+        allow(GlobalConfigService).to receive(:load)
+          .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+          .and_return(false)
+        allow(GlobalConfigService).to receive(:load).with('SHOPIFY_CLIENT_ID', nil).and_return('client_id')
+
         expect(app.active?(account)).to be false
       end
     end
@@ -141,6 +184,24 @@ RSpec.describe Integrations::App do
       it 'returns true if the account has hooks for the app' do
         create(:integrations_hook, :openai, account: account)
         expect(app.enabled?(account)).to be true
+      end
+    end
+
+    context 'when the app is shopify' do
+      let(:app_name) { 'shopify' }
+
+      before { account.enable_features!('shopify_integration') }
+
+      it 'returns true when the Shopify hook is enabled' do
+        create(:integrations_hook, :shopify, account: account, status: :enabled)
+
+        expect(app.enabled?(account)).to be true
+      end
+
+      it 'returns false when the retained Shopify hook is disabled' do
+        create(:integrations_hook, :shopify, account: account, status: :disabled)
+
+        expect(app.enabled?(account)).to be false
       end
     end
   end

--- a/spec/models/integrations/hook_spec.rb
+++ b/spec/models/integrations/hook_spec.rb
@@ -31,6 +31,46 @@ RSpec.describe Integrations::Hook do
     end
   end
 
+  describe 'Shopify shop identity' do
+    let(:account) { create(:account) }
+
+    before do
+      allow(GlobalConfigService).to receive(:load)
+        .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+        .and_return(true)
+      account.enable_features!('shopify_integration')
+    end
+
+    it 'normalizes the shop domain before validation' do
+      hook = create(:integrations_hook, :shopify, account: account, reference_id: 'My-Store.MyShopify.Com')
+
+      expect(hook.reference_id).to eq('my-store.myshopify.com')
+    end
+
+    it 'rejects invalid shop domains' do
+      hook = build(:integrations_hook, :shopify, account: account, reference_id: 'example.com')
+
+      expect(hook).not_to be_valid
+      expect(hook.errors[:reference_id]).to be_present
+    end
+
+    it 'enforces global case-insensitive shop uniqueness across accounts' do
+      create(:integrations_hook, :shopify, account: account, reference_id: 'my-store.myshopify.com')
+      second_account = create(:account)
+      second_account.enable_features!('shopify_integration')
+
+      duplicate_hook = build(
+        :integrations_hook,
+        :shopify,
+        account: second_account,
+        reference_id: 'MY-STORE.MYSHOPIFY.COM'
+      )
+
+      expect(duplicate_hook).not_to be_valid
+      expect(duplicate_hook.errors[:reference_id]).to include('has already been taken')
+    end
+  end
+
   describe 'scopes' do
     let(:account) { create(:account) }
     let(:inbox) { create(:inbox, account: account) }

--- a/spec/services/shopify/api_context_spec.rb
+++ b/spec/services/shopify/api_context_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Shopify::ApiContext do
+  before do
+    allow(ShopifyAPI::Context).to receive(:setup)
+  end
+
+  it 'initializes Shopify API context from global configuration' do
+    allow(GlobalConfigService).to receive(:load).with('SHOPIFY_CLIENT_ID', nil).and_return('shopify-client-id')
+    allow(GlobalConfigService).to receive(:load).with('SHOPIFY_CLIENT_SECRET', nil).and_return('shopify-client-secret')
+
+    described_class.setup!
+
+    expect(ShopifyAPI::Context).to have_received(:setup).with(
+      api_key: 'shopify-client-id',
+      api_secret_key: 'shopify-client-secret',
+      api_version: ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION,
+      scope: 'read_customers,read_orders,read_fulfillments',
+      is_embedded: true,
+      is_private: false
+    )
+  end
+
+  it 'uses an Admin API version supported by the pinned client' do
+    expect(ShopifyAPI::AdminVersions::SUPPORTED_ADMIN_VERSIONS).to include(described_class::API_VERSION)
+  end
+
+  it 'fails before constructing a client when credentials are unavailable' do
+    allow(GlobalConfigService).to receive(:load).with('SHOPIFY_CLIENT_ID', nil).and_return(nil)
+    allow(GlobalConfigService).to receive(:load).with('SHOPIFY_CLIENT_SECRET', nil).and_return(nil)
+
+    expect do
+      described_class.setup!
+    end.to raise_error(described_class::ConfigurationError, 'Shopify API credentials are unavailable')
+    expect(ShopifyAPI::Context).not_to have_received(:setup)
+  end
+end

--- a/spec/services/shopify/feature_gate_spec.rb
+++ b/spec/services/shopify/feature_gate_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Shopify::FeatureGate do
+  let(:account) { create(:account) }
+
+  around do |example|
+    with_modified_env described_class::GLOBAL_CONFIG => nil do
+      example.run
+    end
+  end
+
+  before do
+    allow(GlobalConfigService).to receive(:load)
+      .with(described_class::GLOBAL_CONFIG, 'false')
+      .and_return(global_config)
+  end
+
+  context 'when the installation switch is disabled' do
+    let(:global_config) { false }
+
+    it 'disables account-less and account-scoped Shopify behavior' do
+      account.enable_features(described_class::ACCOUNT_FEATURE)
+
+      expect(described_class.enabled?).to be false
+      expect(described_class.enabled?(account: account)).to be false
+    end
+  end
+
+  context 'when the installation switch is enabled' do
+    let(:global_config) { true }
+
+    it 'enables account-less Shopify behavior' do
+      expect(described_class.enabled?).to be true
+    end
+
+    it 'requires the account feature for account-scoped behavior' do
+      expect(described_class.enabled?(account: account)).to be false
+
+      account.enable_features(described_class::ACCOUNT_FEATURE)
+
+      expect(described_class.enabled?(account: account)).to be true
+    end
+  end
+
+  context 'when the environment overrides the stored installation switch' do
+    let(:global_config) { false }
+
+    it 'uses a false environment value as a kill switch' do
+      with_modified_env described_class::GLOBAL_CONFIG => 'false' do
+        expect(described_class.enabled?).to be false
+        expect(GlobalConfigService).to have_received(:load)
+          .with(described_class::GLOBAL_CONFIG, 'false')
+      end
+    end
+
+    it 'uses a true environment value to enable the rollout' do
+      with_modified_env described_class::GLOBAL_CONFIG => 'true' do
+        allow(GlobalConfigService).to receive(:load)
+          .with(described_class::GLOBAL_CONFIG, 'false')
+          .and_return('true')
+
+        expect(described_class.enabled?).to be true
+        expect(GlobalConfigService).to have_received(:load)
+          .with(described_class::GLOBAL_CONFIG, 'false')
+      end
+    end
+  end
+end

--- a/spec/services/shopify/partner_client_spec.rb
+++ b/spec/services/shopify/partner_client_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe Shopify::PartnerClient do
+  let(:endpoint) { 'https://partners.shopify.com/123/api/2026-07/graphql.json' }
+  let(:access_token) { 'partner-secret-token' }
+  let(:shop_id) { 'gid://shopify/Shop/5678' }
+  let(:response_body) do
+    {
+      'data' => {
+        'activeSubscription' => {
+          'shop' => {
+            'id' => shop_id,
+            'myshopifyDomain' => 'example.myshopify.com'
+          },
+          'billingPeriod' => 'EVERY_30_DAYS',
+          'cancelAtEndOfCycle' => false,
+          'trialEndsAt' => nil,
+          'currentBillingCycle' => {
+            'startTime' => '2026-07-01T00:00:00Z',
+            'endTime' => '2026-08-01T00:00:00Z'
+          },
+          'items' => [{
+            'handle' => 'shopify-basic',
+            'description' => 'Shopify Basic',
+            'price' => {
+              'active' => true,
+              'currency' => 'USD',
+              'amount' => '29.00'
+            }
+          }]
+        },
+        'events' => { 'edges' => [] }
+      }
+    }
+  end
+
+  before do
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load).with('SHOPIFY_PARTNER_ORGANIZATION_ID', nil).and_return('123')
+    allow(GlobalConfigService).to receive(:load).with('SHOPIFY_PARTNER_APP_ID', nil).and_return('gid://shopify/App/456')
+    allow(GlobalConfigService).to receive(:load).with('SHOPIFY_PARTNER_ACCESS_TOKEN', nil).and_return(access_token)
+    allow(GlobalConfigService).to receive(:load).with('SHOPIFY_PARTNER_API_VERSION', '2026-07').and_return('2026-07')
+  end
+
+  it 'queries the pinned Partner API and returns only normalized subscription data' do
+    request_body = nil
+    request = stub_request(:post, endpoint)
+              .with(headers: { 'X-Shopify-Access-Token' => access_token }) do |provider_request|
+                request_body = provider_request.body
+              end
+              .to_return(status: 200, body: response_body.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    snapshot = described_class.new.subscription_snapshot(shop_id: shop_id)
+
+    expect(snapshot).to have_attributes(state: 'active', plan_handles: ['shopify-basic'])
+    expect(request).to have_been_requested.once
+    body = JSON.parse(request_body)
+    expect(body['query']).to include('orderBy: OCCURRED_AT_DESC')
+    expect(body['variables']).to include(
+      'appId' => 'gid://shopify/App/456',
+      'shopId' => shop_id
+    )
+  end
+
+  it 'keeps GraphQL response details and credentials out of provider errors' do
+    stub_request(:post, endpoint).to_return(
+      status: 200,
+      body: {
+        errors: [{
+          message: "invalid token #{access_token}"
+        }]
+      }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+
+    expect do
+      described_class.new.subscription_snapshot(shop_id: shop_id)
+    end.to raise_error(described_class::ProviderError, 'Shopify Partner API returned GraphQL errors')
+  end
+
+  it 'distinguishes a provider failure from a verified inactive subscription' do
+    stub_request(:post, endpoint).to_timeout
+
+    expect do
+      described_class.new.subscription_snapshot(shop_id: shop_id)
+    end.to raise_error(described_class::ProviderError, /Shopify Partner API request failed/)
+  end
+
+  it 'does not treat an incomplete provider response as a missing subscription' do
+    stub_request(:post, endpoint).to_return(
+      status: 200,
+      body: { data: {} }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+
+    expect do
+      described_class.new.subscription_snapshot(shop_id: shop_id)
+    end.to raise_error(described_class::ProviderError, 'Shopify Partner API returned an invalid response')
+  end
+
+  it 'fails before making a request when Partner credentials are incomplete' do
+    allow(GlobalConfigService).to receive(:load).with('SHOPIFY_PARTNER_ACCESS_TOKEN', nil).and_return(nil)
+    expect(HTTParty).not_to receive(:post)
+
+    expect do
+      described_class.new.subscription_snapshot(shop_id: shop_id)
+    end.to raise_error(described_class::ConfigurationError, 'SHOPIFY_PARTNER_ACCESS_TOKEN is required')
+  end
+end

--- a/spec/services/shopify/partner_configuration_spec.rb
+++ b/spec/services/shopify/partner_configuration_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe Shopify::PartnerConfiguration do
+  let(:valid_values) do
+    {
+      SHOPIFY_PARTNER_ORGANIZATION_ID: '123',
+      SHOPIFY_PARTNER_APP_ID: 'gid://shopify/App/456',
+      SHOPIFY_PARTNER_ACCESS_TOKEN: 'partner-token',
+      SHOPIFY_PARTNER_API_VERSION: '2026-07'
+    }
+  end
+
+  it 'accepts a complete Partner API configuration' do
+    expect { described_class.validate_for_save!(valid_values) }.not_to raise_error
+  end
+
+  it 'allows the optional Partner credentials to remain unconfigured' do
+    expect do
+      described_class.validate_for_save!(SHOPIFY_PARTNER_API_VERSION: '2026-07')
+    end.not_to raise_error
+  end
+
+  it 'rejects an incomplete Partner API configuration' do
+    expect do
+      described_class.validate_for_save!(valid_values.except(:SHOPIFY_PARTNER_ACCESS_TOKEN))
+    end.to raise_error(Shopify::PartnerClient::ConfigurationError, 'SHOPIFY_PARTNER_ACCESS_TOKEN is required')
+  end
+
+  it 'rejects a malformed API version even when credentials are unconfigured' do
+    expect do
+      described_class.validate_for_save!(SHOPIFY_PARTNER_API_VERSION: 'latest')
+    end.to raise_error(Shopify::PartnerClient::ConfigurationError, 'SHOPIFY_PARTNER_API_VERSION must use YYYY-MM format')
+  end
+
+  it 'rejects an API version with an impossible month' do
+    expect do
+      described_class.validate_for_save!(SHOPIFY_PARTNER_API_VERSION: '2026-13')
+    end.to raise_error(Shopify::PartnerClient::ConfigurationError, 'SHOPIFY_PARTNER_API_VERSION must use YYYY-MM format')
+  end
+end

--- a/spec/services/shopify/pending_installation_spec.rb
+++ b/spec/services/shopify/pending_installation_spec.rb
@@ -1,0 +1,246 @@
+require 'rails_helper'
+
+RSpec.describe Shopify::PendingInstallation do
+  let(:access_token) { 'shopify-access-token' }
+  let(:shop) { 'my-store.myshopify.com' }
+  let(:scope) { 'read_customers,read_orders' }
+  let(:encryption_env) do
+    {
+      'ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY' => 'primary-key',
+      'ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY' => 'deterministic-key',
+      'ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT' => 'key-derivation-salt'
+    }
+  end
+  let(:token) { SecureRandom.hex(16) }
+  let(:payload_key) { "shopify_pending_install:#{token}" }
+  let(:claim_key) { "shopify_pending_install_claim:#{token}" }
+  let(:generation_key) { "shopify_pending_install_generation:#{shop}" }
+
+  around do |example|
+    with_modified_env(encryption_env) { example.run }
+  end
+
+  before do
+    Redis::SecureStorage.set(
+      payload_key,
+      { access_token: access_token, shop: shop, scope: scope },
+      10.minutes
+    )
+  end
+
+  after do
+    Redis::Alfred.delete(payload_key)
+    Redis::Alfred.delete(claim_key)
+    Redis::Alfred.delete(generation_key)
+  end
+
+  it 'creates an encrypted pending installation' do
+    created_token = described_class.create(access_token: access_token, shop: shop, scope: scope)
+
+    expect(created_token).to match(described_class::TOKEN_FORMAT)
+  ensure
+    Redis::Alfred.delete("shopify_pending_install:#{created_token}") if created_token
+  end
+
+  it 'claims an encrypted pending installation' do
+    pending_installation = described_class.claim(token: token)
+
+    expect(pending_installation.data).to eq(
+      'access_token' => access_token,
+      'shop' => shop,
+      'scope' => scope
+    )
+  ensure
+    pending_installation&.release!
+  end
+
+  it 'identifies an available pending installation token' do
+    expect(described_class.pending?(token: token)).to be(true)
+    expect(described_class.pending?(token: 'invalid-token')).to be(false)
+  end
+
+  it 'invalidates tokens created before Shopify lifecycle cleanup' do
+    created_token = described_class.create(access_token: access_token, shop: shop, scope: scope)
+
+    described_class.invalidate_shop!(shop: shop)
+
+    expect(described_class.pending?(token: created_token)).to be(false)
+    expect do
+      described_class.claim(token: created_token)
+    end.to raise_error(described_class::InvalidToken, 'Invalid or expired install token')
+  ensure
+    Redis::Alfred.delete("shopify_pending_install:#{created_token}") if created_token
+    Redis::Alfred.delete("shopify_pending_install_claim:#{created_token}") if created_token
+  end
+
+  it 'rejects token creation from an OAuth flow that predates cleanup' do
+    shop_generation = described_class.generation(shop: shop)
+    described_class.invalidate_shop!(shop: shop)
+
+    expect do
+      described_class.create(
+        access_token: access_token,
+        shop: shop,
+        scope: scope,
+        shop_generation: shop_generation
+      )
+    end.to raise_error(described_class::InvalidToken, 'Shopify installation is no longer active')
+  end
+
+  it 'allows a fresh installation after lifecycle cleanup' do
+    described_class.invalidate_shop!(shop: shop)
+    created_token = described_class.create(access_token: access_token, shop: shop, scope: scope)
+    pending_installation = described_class.claim(token: created_token)
+
+    expect(pending_installation.data['generation']).to eq(1)
+  ensure
+    pending_installation&.consume!
+    Redis::Alfred.delete("shopify_pending_install:#{created_token}") if created_token
+  end
+
+  it 'allows only one active claim' do
+    pending_installation = described_class.claim(token: token)
+
+    expect do
+      described_class.claim(token: token)
+    end.to raise_error(described_class::AlreadyClaimed, 'Install token is already being used')
+  ensure
+    pending_installation&.release!
+  end
+
+  it 'allows a retry after the claim is released' do
+    pending_installation = described_class.claim(token: token)
+    pending_installation.release!
+
+    retried_installation = described_class.claim(token: token)
+    expect(retried_installation.data['shop']).to eq(shop)
+  ensure
+    retried_installation&.release!
+  end
+
+  it 'prevents a token bound by a failed attempt from moving to another account' do
+    pending_installation = described_class.claim(token: token, account_id: 1)
+    pending_installation.release!
+
+    expect do
+      described_class.claim(token: token, account_id: 2)
+    end.to raise_error(described_class::InvalidToken, 'Install token cannot be used by this account')
+  end
+
+  it 'removes a new-account binding when signup fails' do
+    pending_installation = described_class.claim(token: token)
+    pending_installation.bind_to_account!(1)
+    pending_installation.release!(unbind: true)
+
+    retried_installation = described_class.claim(token: token)
+
+    expect(retried_installation.data['account_id']).to be_nil
+  ensure
+    retried_installation&.release!
+  end
+
+  it 'prevents replay after the claim is consumed' do
+    pending_installation = described_class.claim(token: token)
+    pending_installation.consume!
+
+    expect(Redis::Alfred.get(payload_key)).to be_nil
+    expect(Redis::Alfred.get(claim_key)).to be_nil
+
+    expect do
+      described_class.claim(token: token)
+    end.to raise_error(described_class::InvalidToken, 'Invalid or expired install token')
+  end
+
+  it 'accepts a lost transaction reply when both keys were consumed' do
+    pending_installation = described_class.claim(token: token)
+    Redis::Alfred.delete(payload_key)
+    Redis::Alfred.delete(claim_key)
+    allow(Redis::Alfred).to receive(:with).and_raise(Redis::CannotConnectError, 'connection lost')
+    allow(pending_installation).to receive(:consume_state).and_return(:consumed)
+
+    expect { pending_installation.consume! }.not_to raise_error
+  end
+
+  it 'classifies a surviving payload as not consumed after the claim expires' do
+    pending_installation = described_class.claim(token: token)
+    Redis::Alfred.delete(claim_key)
+
+    expect(pending_installation.send(:consume_state)).to eq(:not_consumed)
+  end
+
+  it 'does not consume the payload when the claim is no longer owned' do
+    pending_installation = described_class.claim(token: token)
+    Redis::Alfred.set(claim_key, 'newer-claim', ex: described_class::CLAIM_TTL.to_i)
+
+    expect do
+      pending_installation.consume!
+    end.to raise_error(described_class::AlreadyClaimed, 'Install token claim has expired')
+
+    expect(Redis::SecureStorage.get(payload_key)).to be_present
+    expect(Redis::Alfred.get(claim_key)).to eq('newer-claim')
+  end
+
+  it 'rejects malformed tokens before accessing Redis' do
+    expect(Redis::Alfred).not_to receive(:set)
+
+    expect do
+      described_class.claim(token: '../invalid')
+    end.to raise_error(described_class::InvalidToken, 'Invalid or expired install token')
+  end
+
+  it 'releases the claim when the encrypted payload is invalid' do
+    Redis::Alfred.set(payload_key, 'invalid-encrypted-payload')
+
+    expect do
+      described_class.claim(token: token)
+    end.to raise_error(described_class::InvalidToken)
+
+    expect(Redis::Alfred.get(claim_key)).to be_nil
+  end
+
+  it 'requires encryption configuration when creating a pending installation' do
+    with_modified_env(encryption_env.transform_values { nil }) do
+      expect do
+        described_class.create(access_token: access_token, shop: shop, scope: scope)
+      end.to raise_error(Redis::SecureStorage::EncryptionNotConfigured)
+    end
+  end
+
+  it 'normalizes the shop domain before storing it' do
+    created_token = described_class.create(access_token: access_token, shop: 'My-Store.MyShopify.Com', scope: scope)
+    pending_installation = described_class.claim(token: created_token)
+
+    expect(pending_installation.data['shop']).to eq('my-store.myshopify.com')
+  ensure
+    pending_installation&.consume!
+    Redis::Alfred.delete("shopify_pending_install:#{created_token}") if created_token
+  end
+
+  it 'rejects invalid shop domains before storing credentials' do
+    expect(Redis::SecureStorage).not_to receive(:set)
+
+    expect do
+      described_class.create(access_token: access_token, shop: 'example.com', scope: scope)
+    end.to raise_error(described_class::InvalidToken, 'Invalid shop domain')
+  end
+
+  it 'rejects a trailing hyphen in the shop label before storing credentials' do
+    expect(Redis::SecureStorage).not_to receive(:set)
+
+    expect do
+      described_class.create(access_token: access_token, shop: 'bad-.myshopify.com', scope: scope)
+    end.to raise_error(described_class::InvalidToken, 'Invalid shop domain')
+  end
+
+  it 'rejects an encrypted payload with an invalid shop domain' do
+    Redis::SecureStorage.set(
+      payload_key,
+      { access_token: access_token, shop: 'example.com', scope: scope },
+      10.minutes
+    )
+
+    expect do
+      described_class.claim(token: token)
+    end.to raise_error(described_class::InvalidToken, 'Invalid or expired install token')
+  end
+end

--- a/spec/services/shopify/shop_domain_spec.rb
+++ b/spec/services/shopify/shop_domain_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Shopify::ShopDomain do
+  describe '.valid?' do
+    it 'accepts valid Shopify domains' do
+      expect(described_class.valid?('store.myshopify.com')).to be(true)
+      expect(described_class.valid?('my-store.myshopify.io')).to be(true)
+      expect(described_class.valid?('a.myshopify.com')).to be(true)
+    end
+
+    it 'rejects domains with a trailing hyphen in the shop label' do
+      expect(described_class.valid?('bad-.myshopify.com')).to be(false)
+    end
+  end
+end

--- a/spec/services/shopify/shop_identity_spec.rb
+++ b/spec/services/shopify/shop_identity_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe Shopify::ShopIdentity do
+  let(:hook) do
+    create(
+      :integrations_hook,
+      :shopify,
+      reference_id: 'example.myshopify.com',
+      settings: { 'scope' => 'read_orders' }
+    )
+  end
+  let(:client) { instance_double(ShopifyAPI::Clients::Graphql::Admin) }
+  let(:response) do
+    instance_double(
+      ShopifyAPI::Clients::HttpResponse,
+      body: {
+        'data' => {
+          'shop' => {
+            'id' => 'gid://shopify/Shop/5678',
+            'myshopifyDomain' => 'example.myshopify.com'
+          }
+        }
+      }
+    )
+  end
+
+  before do
+    allow(GlobalConfigService).to receive(:load).with('SHOPIFY_CLIENT_ID', nil).and_return('shopify-client-id')
+    allow(GlobalConfigService).to receive(:load).with('SHOPIFY_CLIENT_SECRET', nil).and_return('shopify-client-secret')
+    allow(ShopifyAPI::Context).to receive(:setup)
+    allow(ShopifyAPI::Clients::Graphql::Admin).to receive(:new).and_return(client)
+    allow(client).to receive(:query).and_return(response)
+  end
+
+  it 'resolves the Shopify shop GID from the authenticated shop' do
+    shop_id = described_class.new(hook: hook).shop_id
+
+    expect(shop_id).to eq('gid://shopify/Shop/5678')
+    expect(ShopifyAPI::Context).to have_received(:setup).with(
+      api_key: 'shopify-client-id',
+      api_secret_key: 'shopify-client-secret',
+      api_version: ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION,
+      scope: 'read_customers,read_orders,read_fulfillments',
+      is_embedded: true,
+      is_private: false
+    )
+  end
+
+  it 'does not trust an account-editable shop GID in hook settings' do
+    hook.update!(settings: hook.settings.merge('shop_id' => 'gid://shopify/Shop/9999'))
+
+    expect(client).to receive(:query).and_return(response)
+    expect(described_class.new(hook: hook).shop_id).to eq('gid://shopify/Shop/5678')
+  end
+
+  it 'rejects a shop identity that does not match the installed shop' do
+    allow(response).to receive(:body).and_return(
+      'data' => {
+        'shop' => {
+          'id' => 'gid://shopify/Shop/9999',
+          'myshopifyDomain' => 'other.myshopify.com'
+        }
+      }
+    )
+
+    expect do
+      described_class.new(hook: hook).shop_id
+    end.to raise_error(described_class::ProviderError, 'Shopify Admin API returned a different shop')
+  end
+end

--- a/spec/services/shopify/subscription_fetcher_spec.rb
+++ b/spec/services/shopify/subscription_fetcher_spec.rb
@@ -1,0 +1,146 @@
+require 'rails_helper'
+
+RSpec.describe Shopify::SubscriptionFetcher do
+  let(:account) do
+    create(:account, internal_attributes: { 'billing_provider' => 'shopify', 'signup_source' => 'shopify' })
+  end
+  let(:snapshot) do
+    Shopify::SubscriptionSnapshot.from_h(
+      'state' => 'active',
+      'plan_handles' => ['shopify-basic'],
+      'verified_at' => '2026-07-29T10:00:00Z'
+    )
+  end
+  let(:client) { instance_double(Shopify::PartnerClient) }
+  let(:shop_identity) { instance_double(Shopify::ShopIdentity, shop_id: 'gid://shopify/Shop/5678') }
+
+  let!(:hook) do
+    create(:integrations_hook, :shopify, account: account, settings: { 'shop_id' => 'gid://shopify/Shop/5678' })
+  end
+
+  before do
+    allow(Shopify::FeatureGate).to receive(:enabled?).with(account: account).and_return(true)
+    allow(Shopify::PartnerClient).to receive(:new).and_return(client)
+    allow(Shopify::ShopIdentity).to receive(:new).and_return(shop_identity)
+    allow(client).to receive(:subscription_snapshot).and_return(snapshot)
+    allow(Rails.cache).to receive(:read)
+    allow(Rails.cache).to receive(:write)
+  end
+
+  it 'caches a normalized snapshot for page loads' do
+    verified_at = Time.zone.parse('2026-07-29T10:00:00Z')
+    allow(Time).to receive(:current).and_return(verified_at)
+
+    result = described_class.new(account: account).perform
+
+    expect(result.to_h).to eq(snapshot.to_h)
+    expect(client).to have_received(:subscription_snapshot).with(
+      shop_id: 'gid://shopify/Shop/5678',
+      verified_at: verified_at
+    )
+    expect(Rails.cache).to have_received(:write).with(
+      "shopify:subscription_snapshot:account:#{account.id}",
+      snapshot.to_h,
+      expires_in: 2.minutes
+    )
+  end
+
+  it 'timestamps the verification before provider identity lookup starts' do
+    verified_at = Time.zone.parse('2026-07-29T10:00:00Z')
+    call_order = []
+    allow(Time).to receive(:current) do
+      call_order << :timestamp
+      verified_at
+    end
+    allow(shop_identity).to receive(:shop_id) do
+      call_order << :identity_lookup
+      'gid://shopify/Shop/5678'
+    end
+
+    described_class.new(account: account).perform(force: true)
+
+    expect(call_order).to eq(%i[timestamp identity_lookup])
+    expect(client).to have_received(:subscription_snapshot).with(
+      shop_id: 'gid://shopify/Shop/5678',
+      verified_at: verified_at
+    )
+  end
+
+  it 'serializes provider verification with integration lifecycle changes' do
+    association = account.hooks
+    allow(association).to receive(:find_by!).and_return(hook)
+    allow(hook).to receive(:with_lock).and_call_original
+
+    described_class.new(account: account).perform(force: true)
+
+    expect(hook).to have_received(:with_lock)
+  end
+
+  it 'does not verify a subscription after credentials are revoked while waiting for the hook lock' do
+    association = account.hooks
+    allow(association).to receive(:find_by!).and_return(hook)
+    allow(hook).to receive(:with_lock) do |&block|
+      hook.assign_attributes(status: :disabled, access_token: nil)
+      block.call
+    end
+
+    expect do
+      described_class.new(account: account).perform(force: true)
+    end.to raise_error(ActiveRecord::RecordNotFound, 'Shopify integration credentials are unavailable')
+    expect(client).not_to have_received(:subscription_snapshot)
+  end
+
+  it 'returns a cached normalized snapshot without calling Shopify' do
+    allow(Rails.cache).to receive(:read).and_return(snapshot.to_h)
+
+    result = described_class.new(account: account).perform
+
+    expect(result.to_h).to eq(snapshot.to_h)
+    expect(client).not_to have_received(:subscription_snapshot)
+  end
+
+  it 'bypasses the cache when a fresh verification is required' do
+    allow(Rails.cache).to receive(:read).and_return(snapshot.to_h)
+
+    described_class.new(account: account).perform(force: true)
+
+    expect(Rails.cache).not_to have_received(:read)
+    expect(client).to have_received(:subscription_snapshot).with(
+      shop_id: 'gid://shopify/Shop/5678',
+      verified_at: instance_of(ActiveSupport::TimeWithZone)
+    )
+  end
+
+  it 'serializes provider refreshes on the Shopify hook' do
+    fetcher = described_class.new(account: account)
+    shopify_hook = account.hooks.find_by!(app_id: 'shopify')
+    allow(fetcher).to receive(:hook).and_return(shopify_hook)
+    expect(shopify_hook).to receive(:with_lock).and_yield
+
+    fetcher.perform(force: true)
+
+    expect(Rails.cache).to have_received(:write).with(
+      "shopify:subscription_snapshot:account:#{account.id}",
+      snapshot.to_h,
+      expires_in: 2.minutes
+    )
+  end
+
+  it 'does not call Shopify when the feature gate is disabled' do
+    allow(Shopify::FeatureGate).to receive(:enabled?).with(account: account).and_return(false)
+
+    expect do
+      described_class.new(account: account).perform
+    end.to raise_error(described_class::NotEligible, 'Shopify subscription lookup is disabled')
+    expect(client).not_to have_received(:subscription_snapshot)
+  end
+
+  it 'does not call Shopify for a Stripe-billed account' do
+    account.internal_attributes = account.internal_attributes.merge('billing_provider' => 'stripe')
+
+    expect do
+      described_class.new(account: account).perform
+    end.to raise_error(described_class::NotEligible, 'Account is not billed through Shopify')
+    expect(client).not_to have_received(:subscription_snapshot)
+  end
+end

--- a/spec/services/shopify/subscription_snapshot_spec.rb
+++ b/spec/services/shopify/subscription_snapshot_spec.rb
@@ -1,0 +1,126 @@
+require 'rails_helper'
+
+RSpec.describe Shopify::SubscriptionSnapshot do
+  let(:verified_at) { Time.zone.parse('2026-07-29 10:00:00 UTC') }
+  let(:active_subscription) do
+    {
+      'shop' => {
+        'id' => 'gid://shopify/Shop/5678',
+        'myshopifyDomain' => 'example.myshopify.com'
+      },
+      'billingPeriod' => 'EVERY_30_DAYS',
+      'cancelAtEndOfCycle' => false,
+      'trialEndsAt' => nil,
+      'currentBillingCycle' => {
+        'startTime' => '2026-07-01T00:00:00Z',
+        'endTime' => '2026-08-01T00:00:00Z'
+      },
+      'items' => [{
+        'handle' => 'shopify-basic',
+        'description' => 'Shopify Basic',
+        'price' => {
+          'active' => true,
+          'currency' => 'USD',
+          'amount' => '29.00'
+        }
+      }]
+    }
+  end
+
+  it 'normalizes an active subscription' do
+    snapshot = described_class.from_partner_response(
+      {
+        'activeSubscription' => active_subscription,
+        'events' => { 'edges' => [] }
+      },
+      verified_at: verified_at
+    )
+
+    expect(snapshot).to be_entitled
+    expect(snapshot.to_h).to include(
+      'state' => 'active',
+      'plan_handles' => ['shopify-basic'],
+      'plan_name' => 'Shopify Basic',
+      'amount' => '29.00',
+      'currency' => 'USD',
+      'verified_at' => '2026-07-29T10:00:00.000000Z'
+    )
+  end
+
+  it 'normalizes a trial subscription' do
+    subscription = active_subscription.merge('trialEndsAt' => '2026-08-10T00:00:00Z', 'currentBillingCycle' => nil)
+    snapshot = described_class.from_partner_response(
+      {
+        'activeSubscription' => subscription,
+        'events' => { 'edges' => [] }
+      },
+      verified_at: verified_at
+    )
+
+    expect(snapshot).to have_attributes(state: 'trialing', entitled?: true)
+  end
+
+  it 'normalizes an elapsed trial as active' do
+    subscription = active_subscription.merge('trialEndsAt' => '2026-07-28T00:00:00Z')
+    snapshot = described_class.from_partner_response(
+      {
+        'activeSubscription' => subscription,
+        'events' => { 'edges' => [] }
+      },
+      verified_at: verified_at
+    )
+
+    expect(snapshot).to have_attributes(state: 'active', entitled?: true)
+  end
+
+  it 'prioritizes scheduled cancellation while a trial is active' do
+    subscription = active_subscription.merge(
+      'cancelAtEndOfCycle' => true,
+      'trialEndsAt' => '2026-08-10T00:00:00Z'
+    )
+    snapshot = described_class.from_partner_response(
+      {
+        'activeSubscription' => subscription,
+        'events' => { 'edges' => [] }
+      },
+      verified_at: verified_at
+    )
+
+    expect(snapshot).to have_attributes(state: 'cancelled', entitled?: true)
+  end
+
+  it 'normalizes a completed cancellation as expired' do
+    latest_event = {
+      'state' => 'CANCELED',
+      'cancelEffectiveOn' => '2026-07-28',
+      'occurredAt' => '2026-07-28T00:00:00Z'
+    }
+
+    snapshot = described_class.from_partner_response(
+      {
+        'activeSubscription' => nil,
+        'events' => { 'edges' => [{ 'node' => latest_event }] }
+      },
+      verified_at: verified_at
+    )
+
+    expect(snapshot).to have_attributes(state: 'expired', entitled?: false)
+    expect(snapshot.to_h['latest_event']).to eq(
+      'state' => 'CANCELED',
+      'cancel_effective_on' => '2026-07-28',
+      'occurred_at' => '2026-07-28T00:00:00Z'
+    )
+  end
+
+  it 'normalizes a missing contract separately from an expired contract' do
+    snapshot = described_class.from_partner_response(
+      {
+        'activeSubscription' => nil,
+        'events' => { 'edges' => [] }
+      },
+      verified_at: verified_at
+    )
+
+    expect(snapshot).to have_attributes(state: 'missing', entitled?: false)
+  end
+end

--- a/spec/services/shopify/uninstallation_service_spec.rb
+++ b/spec/services/shopify/uninstallation_service_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe Shopify::UninstallationService do
+  let(:account) { create(:account) }
+  let(:connected_at) { Time.iso8601('2026-07-29T10:01:00.000000Z') }
+  let(:hook) do
+    create(
+      :integrations_hook,
+      :shopify,
+      account: account,
+      access_token: 'shopify-access-token',
+      settings: {
+        'scope' => 'read_customers,read_orders',
+        'connected_at' => connected_at.iso8601(6),
+        'installation_id' => SecureRandom.uuid
+      }
+    )
+  end
+
+  before do
+    account.enable_features!('shopify_integration')
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load)
+      .with('ENABLE_SHOPIFY_INTEGRATION', 'false')
+      .and_return(true)
+  end
+
+  it 'removes the integration for the current installation' do
+    hook
+
+    expect do
+      described_class.new(hook: hook, occurred_at: connected_at + 1.minute).perform
+    end.to change(Integrations::Hook, :count).by(-1)
+
+    expect(account.reload.internal_attributes[Shopify::InstallationGeneration::KEY]).to eq(1)
+  end
+
+  it 'ignores an uninstall event from before the current installation' do
+    result = described_class.new(hook: hook, occurred_at: connected_at - 1.minute).perform
+
+    expect(result).to eq(:stale)
+    expect(hook.reload).to have_attributes(
+      status: 'enabled',
+      access_token: 'shopify-access-token'
+    )
+    expect(account.reload.internal_attributes[Shopify::InstallationGeneration::KEY]).to be_nil
+  end
+
+  it 'reloads the installation generation while holding the hook lock' do
+    replacement_connected_at = connected_at + 2.minutes
+    Integrations::Hook.find(hook.id).update!(
+      settings: hook.settings.merge('connected_at' => replacement_connected_at.iso8601(6))
+    )
+
+    result = described_class.new(hook: hook, occurred_at: connected_at + 1.minute).perform
+
+    expect(result).to eq(:stale)
+    expect(hook.reload).to have_attributes(
+      status: 'enabled',
+      access_token: 'shopify-access-token'
+    )
+  end
+
+  it 'supports lifecycle calls without an occurrence timestamp' do
+    hook
+
+    expect do
+      described_class.new(hook: hook).perform
+    end.to change(Integrations::Hook, :count).by(-1)
+  end
+
+  it 'still cleans up when the account feature is disabled' do
+    hook
+    account.disable_features!('shopify_integration')
+
+    expect do
+      described_class.new(hook: hook, occurred_at: connected_at + 1.minute).perform
+    end.to change(Integrations::Hook, :count).by(-1)
+  end
+end


### PR DESCRIPTION
This is the infrastructure stage of Shopify installation and billing, split from #13550 so it can be reviewed and merged before the shared signup and authentication changes. It adds gated Shopify subscription verification, billing details, plan mapping, and lifecycle cleanup for Shopify-billed accounts.

Existing accounts default to Stripe billing. The new Shopify billing flow requires both `ENABLE_SHOPIFY_INTEGRATION` and the account-level `shopify_integration` feature. The global switch defaults to disabled. This PR is not a rollout of the complete merchant installation journey.

### Related

- Stacked follow-up: #13550, which should merge only after this PR and a final end-to-end sanity check.
- Related: https://linear.app/chatwoot/issue/CW-6500/support-shopify-app-store-install-flow-for-merchant-initiated
- Related: https://linear.app/chatwoot/issue/PLA-170/resolve-shopify-app-store-billing-rejection

### What changed

- Shopify domain validation, feature gates, API clients, secure pending-install storage, and subscription snapshots.
- Shopify billing identity, hosted pricing URLs, billing summary API/UI, plan mapping and fixed plan limits.
- Subscription sync/reconciliation and signed uninstall/privacy cleanup.
- Shopify configuration fields and integration availability checks.

### Things to know

- Shared signup/auth controllers, password reset, resend confirmation, mailers, user/notification callbacks, Google OAuth, MFA, and auth navigation are unchanged from `develop`.
- The minimal shared integration points include account billing identity, account serialization, billing controller/routes/UI, provider-specific plan resolution, Stripe-event protection, hook validation, configuration screens, and the hourly scheduler. These still need review; this PR is not exclusively new files.
- The complete installation/callback/signup wiring remains in #13550. Do not enable this as a standalone merchant rollout.
- No database migration or schema change is included. The duplicate-hook cleanup and unique indexes remain in #13550, along with their database-level tests.
- Captain reservation accounting, IMAP processing changes, notification callback changes, and global configuration-loader changes remain in #13550.
- Uninstall/privacy cleanup intentionally works while the global feature is disabled.
- The existing Stripe plan feature catalog is preserved; Shopify-specific entitlement cleanup has its own feature set.

### How to test

1. With Shopify disabled, verify ordinary signup, login, confirmation resend, password reset, and existing Stripe billing continue working; Shopify should be absent from the integrations list and direct details should be unavailable.
2. In a disposable cloud-mode test instance, configure the Shopify Partner API, app handle, and test plan catalog. Enable the global and account Shopify flags for a pre-provisioned Shopify-origin account with a connected development-store hook.
3. Open Settings → Billing. Verify that it displays the Shopify subscription and that Manage in Shopify opens Shopify-hosted pricing.
4. Select a development-store plan only when Shopify confirms there will be no charge. Return to billing and verify the authoritative plan, state, renewal date, and fixed account limits.
5. Confirm ordinary accounts continue using Stripe checkout and billing. A Shopify account must not enter Stripe subscription or top-up actions.
6. Verify signed uninstall cleanup clears store credentials and removes Shopify entitlements, including while the integration flag is off.

The full first-install, signup, confirmation, and reinstall/reconnect test belongs to #13550 after this infrastructure is merged.
