### PR TITLE
fix(conversations): make auto-resolution retry-safe

### DIFF
--- a/app/jobs/conversations/resolution_job.rb
+++ b/app/jobs/conversations/resolution_job.rb
@@ -5,11 +5,13 @@ class Conversations::ResolutionJob < ApplicationJob
     # limiting the number of conversations to be resolved to avoid any performance issues
     resolvable_conversations = conversation_scope(account).limit(Limits::BULK_ACTIONS_LIMIT)
     resolvable_conversations.each do |conversation|
-      # send message from bot that conversation has been resolved
-      # do this is account.auto_resolve_message is set
-      ::MessageTemplates::Template::AutoResolve.new(conversation: conversation).perform if account.auto_resolve_message.present?
-      conversation.add_labels(account.auto_resolve_label) if account.auto_resolve_label.present?
-      conversation.toggle_status
+      ActiveRecord::Base.transaction do
+        # send message from bot that conversation has been resolved
+        # do this is account.auto_resolve_message is set
+        ::MessageTemplates::Template::AutoResolve.new(conversation: conversation).perform if account.auto_resolve_message.present?
+        conversation.add_labels(account.auto_resolve_label) if account.auto_resolve_label.present?
+        conversation.toggle_status
+      end
     end
   end
 

--- a/spec/jobs/conversations/resolution_job_spec.rb
+++ b/spec/jobs/conversations/resolution_job_spec.rb
@@ -73,6 +73,36 @@ RSpec.describe Conversations::ResolutionJob do
     expect(conversation.reload.label_list).to include('auto-resolved')
   end
 
+  it 'rolls back side effects before retrying a failed resolution' do
+    account.update(
+      auto_resolve_after: 14_400,
+      auto_resolve_label: 'auto-resolved',
+      auto_resolve_message: 'This conversation was auto-resolved.'
+    )
+    conversation.update(last_activity_at: 13.days.ago)
+    attempts = 0
+
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Conversation).to receive(:toggle_status).and_wrap_original do |method, *args|
+      attempts += 1
+      raise ActiveRecord::StatementInvalid, 'transient failure' if attempts == 1
+
+      method.call(*args)
+    end
+    # rubocop:enable RSpec/AnyInstance
+
+    expect { described_class.perform_now(account: account) }.to raise_error(ActiveRecord::StatementInvalid, 'transient failure')
+    expect(conversation.reload.status).to eq('open')
+    expect(conversation.label_list).not_to include('auto-resolved')
+    expect(conversation.messages.where(content: account.auto_resolve_message)).to be_empty
+
+    described_class.perform_now(account: account)
+
+    expect(conversation.reload.status).to eq('resolved')
+    expect(conversation.label_list).to include('auto-resolved')
+    expect(conversation.messages.where(content: account.auto_resolve_message).count).to eq(1)
+  end
+
   it 'resolves only a limited number of conversations in a single execution' do
     stub_const('Limits::BULK_ACTIONS_LIMIT', 2)
     account.update(auto_resolve_after: 14_400, auto_resolve_ignore_waiting: false) # 10 days in minutes


### PR DESCRIPTION
## Summary
- wrap each conversation's auto-resolution message, label, and status update in one database transaction
- preserve the existing operation order and Sidekiq retry behavior
- add regression coverage for a transient status-update failure followed by a successful retry

Fixes #15451

## Why
If `toggle_status` fails after the auto-resolve template message or label has already been persisted, Sidekiq retries while the conversation is still open and can create duplicate customer-facing resolution messages. Rolling those writes back together lets the retry start from a clean state.

## Testing
- Added a focused `Conversations::ResolutionJob` regression spec covering rollback on the first attempt and exactly one auto-resolve message after retry.
- On head `7776a73b0f2467a005fa75e48aac4b76be318d00`, CircleCI frontend-tests, backend-tests, and coverage are passing; Qlty and Snyk are also green.
- CircleCI's `lint` job is red only at the `Bundle audit` step (`bundle exec bundle audit update && bundle exec bundle audit check -v`). This PR changes only the resolution job and its spec and does not modify `Gemfile`/`Gemfile.lock`, so that dependency-audit failure is unrelated to this patch.