### PR TITLE
fix: simplify Captain eligibility checks for paid self-hosted plans

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/captain/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/captain/Index.vue
@@ -86,7 +86,7 @@ const isFeatureAccessible = feature => {
     return (
       isEnterprise &&
       !isOnChatwootCloud.value &&
-      enterprisePlanName !== 'community'
+      ['premium', 'enterprise'].includes(enterprisePlanName)
     );
   }
 

--- a/app/javascript/dashboard/routes/dashboard/settings/captain/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/captain/Index.vue
@@ -82,9 +82,12 @@ const isFeatureAccessible = feature => {
 
   if (feature.enterprise) {
     // plan is shown, but is it accessible?
-    // This ensures that the instance has purchased the enterprise license, and only then we allow
-    // access
-    return isEnterprise && enterprisePlanName === 'enterprise';
+    // Paid self-hosted installations can access these Captain settings.
+    return (
+      isEnterprise &&
+      !isOnChatwootCloud.value &&
+      enterprisePlanName !== 'community'
+    );
   }
 
   return true;

--- a/enterprise/app/jobs/captain/documents/schedule_syncs_job.rb
+++ b/enterprise/app/jobs/captain/documents/schedule_syncs_job.rb
@@ -87,7 +87,7 @@ class Captain::Documents::ScheduleSyncsJob < ApplicationJob
 
   def account_sync_plan(account)
     plan = account.custom_attributes['plan_name']
-    plan = 'enterprise' if plan.blank? && ChatwootApp.self_hosted_enterprise?
+    plan = 'enterprise' if plan.blank? && ChatwootApp.self_hosted_paid?
     plan.to_s.downcase.presence
   end
 

--- a/enterprise/app/models/enterprise/account.rb
+++ b/enterprise/app/models/enterprise/account.rb
@@ -55,7 +55,7 @@ module Enterprise::Account
 
   def captain_document_sync_interval(sync_intervals = Enterprise::Account.captain_document_sync_intervals)
     plan = custom_attributes['plan_name']
-    plan = 'enterprise' if plan.blank? && ChatwootApp.self_hosted_enterprise?
+    plan = 'enterprise' if plan.blank? && ChatwootApp.self_hosted_paid?
     return nil if plan.blank?
 
     interval_hours = sync_intervals[plan.downcase]
@@ -102,7 +102,7 @@ module Enterprise::Account
 
   def enable_default_features
     super
-    enable_features('captain_integration', 'captain_integration_v2') if ChatwootApp.self_hosted_enterprise?
+    enable_features('captain_integration', 'captain_integration_v2') if ChatwootApp.self_hosted_paid?
   end
 
   def sync_assignment_features

--- a/enterprise/lib/enterprise/captain/reply_suggestion_service.rb
+++ b/enterprise/lib/enterprise/captain/reply_suggestion_service.rb
@@ -8,7 +8,7 @@ module Enterprise::Captain::ReplySuggestionService
   private
 
   def use_search_tool?
-    ChatwootApp.chatwoot_cloud? || ChatwootApp.self_hosted_enterprise? || ChatwootHub.pricing_plan == 'premium'
+    ChatwootApp.chatwoot_cloud? || ChatwootApp.self_hosted_paid?
   end
 
   def prompt_variables

--- a/lib/chatwoot_app.rb
+++ b/lib/chatwoot_app.rb
@@ -26,7 +26,7 @@ module ChatwootApp
   end
 
   def self.self_hosted_paid?
-    enterprise? && !chatwoot_cloud? && ChatwootHub.pricing_plan != 'community'
+    enterprise? && !chatwoot_cloud? && %w[premium enterprise].include?(ChatwootHub.pricing_plan)
   end
 
   def self.custom?

--- a/lib/chatwoot_app.rb
+++ b/lib/chatwoot_app.rb
@@ -25,6 +25,10 @@ module ChatwootApp
     enterprise? && !chatwoot_cloud? && GlobalConfig.get_value('INSTALLATION_PRICING_PLAN') == 'enterprise'
   end
 
+  def self.self_hosted_paid?
+    enterprise? && !chatwoot_cloud? && ChatwootHub.pricing_plan != 'community'
+  end
+
   def self.custom?
     @custom ||= root.join('custom').exist?
   end

--- a/lib/llm/feature_router.rb
+++ b/lib/llm/feature_router.rb
@@ -38,7 +38,7 @@ module Llm::FeatureRouter
 
     def installation_model_override(feature_key)
       return unless feature_key == 'conversation_completion'
-      return unless ChatwootApp.self_hosted_enterprise?
+      return unless ChatwootApp.self_hosted_paid?
 
       InstallationConfig.find_by(name: 'CAPTAIN_OPEN_AI_MODEL')&.value.presence
     end

--- a/spec/controllers/super_admin/accounts_controller_spec.rb
+++ b/spec/controllers/super_admin/accounts_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Super Admin accounts API', type: :request do
       end
 
       it 'shows the installation model for internal routing on self-hosted Enterprise', if: ChatwootApp.enterprise? do
-        allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+        allow(ChatwootApp).to receive(:self_hosted_paid?).and_return(true)
         InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'gpt-5.1')
         sign_in(super_admin, scope: :super_admin)
 
@@ -69,7 +69,7 @@ RSpec.describe 'Super Admin accounts API', type: :request do
   describe 'GET /super_admin/accounts/{account_id}/edit' do
     context 'when it is an authenticated user' do
       it 'renders separate Captain model selectors for customer and internal AI features', if: ChatwootApp.enterprise? do
-        allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+        allow(ChatwootApp).to receive(:self_hosted_paid?).and_return(true)
         InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'gpt-5.1')
         account.update!(captain_models: { 'editor' => 'gpt-4.1' })
         sign_in(super_admin, scope: :super_admin)

--- a/spec/enterprise/lib/captain/conversation_completion_service_spec.rb
+++ b/spec/enterprise/lib/captain/conversation_completion_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Captain::ConversationCompletionService do
       end
 
       it 'uses the internal GPT-4.1 route on Chatwoot Cloud' do
-        allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(false)
+        allow(ChatwootApp).to receive(:self_hosted_paid?).and_return(false)
         InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'gpt-5.1')
         account.enable_features!('captain_integration_v2')
         allow(mock_context).to receive(:chat).with(model: 'gpt-4.1').and_return(mock_chat)
@@ -39,7 +39,7 @@ RSpec.describe Captain::ConversationCompletionService do
       end
 
       it 'uses the installation model on self-hosted Enterprise' do
-        allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+        allow(ChatwootApp).to receive(:self_hosted_paid?).and_return(true)
         InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'gpt-5.1')
         allow(mock_context).to receive(:chat).with(model: 'gpt-5.1').and_return(mock_chat)
 
@@ -47,7 +47,7 @@ RSpec.describe Captain::ConversationCompletionService do
       end
 
       it 'uses the account override ahead of the installation model on self-hosted Enterprise' do
-        allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+        allow(ChatwootApp).to receive(:self_hosted_paid?).and_return(true)
         InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'gpt-5.1')
         account.update!(captain_models: { 'conversation_completion' => 'gpt-5.2' })
         allow(mock_context).to receive(:chat).with(model: 'gpt-5.2').and_return(mock_chat)
@@ -56,7 +56,7 @@ RSpec.describe Captain::ConversationCompletionService do
       end
 
       it 'falls back to the internal GPT-4.1 route when the self-hosted installation model is blank' do
-        allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+        allow(ChatwootApp).to receive(:self_hosted_paid?).and_return(true)
         InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: '')
         allow(mock_context).to receive(:chat).with(model: 'gpt-4.1').and_return(mock_chat)
 

--- a/spec/enterprise/lib/captain/reply_suggestion_service_spec.rb
+++ b/spec/enterprise/lib/captain/reply_suggestion_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Captain::ReplySuggestionService do
 
     before do
       allow(ChatwootApp).to receive(:chatwoot_cloud?).and_return(false)
-      allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(false)
+      allow(ChatwootApp).to receive(:enterprise?).and_return(true)
       allow(ChatwootHub).to receive(:pricing_plan).and_return('premium')
     end
 

--- a/spec/enterprise/models/account_spec.rb
+++ b/spec/enterprise/models/account_spec.rb
@@ -274,8 +274,8 @@ RSpec.describe Account, type: :model do
       )
     end
 
-    it 'enables Captain V2 for new self-hosted enterprise accounts' do
-      allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+    it 'enables Captain V2 for new paid self-hosted accounts' do
+      allow(ChatwootApp).to receive(:self_hosted_paid?).and_return(true)
 
       account = create(:account)
 
@@ -312,8 +312,8 @@ RSpec.describe Account, type: :model do
       expect(account.captain_document_sync_interval).to eq(1.day)
     end
 
-    it 'uses the enterprise cadence for self-hosted enterprise installs without a plan_name' do
-      allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+    it 'uses the enterprise cadence for paid self-hosted installs without a plan_name' do
+      allow(ChatwootApp).to receive(:self_hosted_paid?).and_return(true)
       create(:installation_config, name: 'CAPTAIN_DOCUMENT_AUTO_SYNC_INTERVALS', value: { enterprise: 6 }.to_json)
       account.update!(custom_attributes: {})
 

--- a/spec/lib/chatwoot_app_spec.rb
+++ b/spec/lib/chatwoot_app_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe ChatwootApp do
+  describe '.self_hosted_paid?' do
+    before do
+      allow(described_class).to receive(:enterprise?).and_return(true)
+      allow(described_class).to receive(:chatwoot_cloud?).and_return(false)
+    end
+
+    %w[premium enterprise].each do |plan|
+      it "allows self-hosted #{plan}" do
+        allow(ChatwootHub).to receive(:pricing_plan).and_return(plan)
+
+        expect(described_class.self_hosted_paid?).to be(true)
+      end
+    end
+
+    ['community', '', nil, 'unexpected'].each do |plan|
+      it "rejects #{plan.inspect}" do
+        allow(ChatwootHub).to receive(:pricing_plan).and_return(plan)
+
+        expect(described_class.self_hosted_paid?).to be(false)
+      end
+    end
+
+    it 'excludes Cloud' do
+      allow(described_class).to receive(:chatwoot_cloud?).and_return(true)
+      allow(ChatwootHub).to receive(:pricing_plan).and_return('enterprise')
+
+      expect(described_class.self_hosted_paid?).to be(false)
+    end
+
+    it 'requires enterprise code' do
+      allow(described_class).to receive(:enterprise?).and_return(false)
+      allow(ChatwootHub).to receive(:pricing_plan).and_return('premium')
+
+      expect(described_class.self_hosted_paid?).to be(false)
+    end
+  end
+end

--- a/spec/lib/llm/feature_router_spec.rb
+++ b/spec/lib/llm/feature_router_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Llm::FeatureRouter do
 
   describe '.resolve' do
     before do
-      allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(false)
+      allow(ChatwootApp).to receive(:self_hosted_paid?).and_return(false)
     end
 
     it 'returns the feature default without an account' do
@@ -47,8 +47,8 @@ RSpec.describe Llm::FeatureRouter do
       )
     end
 
-    it 'uses the installation model for conversation completion on self-hosted Enterprise' do
-      allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+    it 'uses the installation model for conversation completion on paid self-hosted installations' do
+      allow(ChatwootApp).to receive(:self_hosted_paid?).and_return(true)
       InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'gpt-5.1')
 
       resolved = described_class.resolve(feature: 'conversation_completion', account: account)
@@ -62,7 +62,7 @@ RSpec.describe Llm::FeatureRouter do
     end
 
     it 'keeps the OpenAI provider for a custom installation model' do
-      allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+      allow(ChatwootApp).to receive(:self_hosted_paid?).and_return(true)
       InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'custom-openai-model')
 
       resolved = described_class.resolve(feature: 'conversation_completion', account: account)
@@ -75,7 +75,7 @@ RSpec.describe Llm::FeatureRouter do
     end
 
     it 'keeps account overrides ahead of the installation model' do
-      allow(ChatwootApp).to receive(:self_hosted_enterprise?).and_return(true)
+      allow(ChatwootApp).to receive(:self_hosted_paid?).and_return(true)
       InstallationConfig.find_or_initialize_by(name: 'CAPTAIN_OPEN_AI_MODEL').update!(value: 'gpt-5.1')
       account.update!(captain_models: { 'conversation_completion' => 'gpt-5.2' })
 


### PR DESCRIPTION
While looking through #13340 and the recent Premium fix in #15727, I noticed we’re handling Enterprise and Premium as separate cases where the intent is simply “paid self-hosted.”

This adds `ChatwootApp.self_hosted_paid?` and uses it consistently across Captain reply search, model overrides, settings access, new-account defaults, and document sync eligibility.

The existing sync configuration and `enterprise` fallback stay unchanged. No new self-hosted configuration or intervals are introduced. Cloud behavior and Premium seat limits remain unchanged.

## How to test

- Verify the affected Captain features are accessible on Premium and Enterprise, but not Community.
- Confirm the installation model override and new-account Captain defaults work on both paid plans.
- Confirm document sync still uses the existing configuration.