### PR TITLE
fix: prevent duplicate Help Center article creation

### DIFF
--- a/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
+++ b/app/javascript/dashboard/components-next/HelpCenter/Pages/ArticleEditorPage/ArticleEditor.vue
@@ -35,6 +35,7 @@ const emit = defineEmits([
   'setCategory',
   'previewArticle',
   'createArticle',
+  'updateArticleDraft',
 ]);
 
 const { t } = useI18n();
@@ -119,7 +120,13 @@ watch(
 );
 
 const scheduleSave = () => {
-  if (isNewArticle.value) return;
+  if (isNewArticle.value) {
+    emit('updateArticleDraft', {
+      title: localTitle.value,
+      content: localContent.value,
+    });
+    return;
+  }
   debouncedSave();
 };
 

--- a/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesNewPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/helpcenter/pages/PortalsArticlesNewPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue';
+import { ref, computed, onBeforeUnmount } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { useAlert, useTrack } from 'dashboard/composables';
@@ -37,35 +37,96 @@ const isCategoryArticles = computed(
 const article = ref({});
 const isUpdating = ref(false);
 const isSaved = ref(false);
+let draftRevision = 0;
+let persistedRevision = 0;
+let createdArticleId = null;
+let isPageActive = true;
+
+onBeforeUnmount(() => {
+  isPageActive = false;
+});
+
+const updateArticleDraft = ({ title, content }) => {
+  let hasChanges = false;
+
+  if (title !== undefined && article.value.title !== title) {
+    article.value.title = title;
+    hasChanges = true;
+  }
+
+  if (content !== undefined && article.value.content !== content) {
+    article.value.content = content;
+    hasChanges = true;
+  }
+
+  if (hasChanges) draftRevision += 1;
+};
 
 const setAuthorId = authorId => {
+  if (selectedAuthorId.value === authorId) return;
   selectedAuthorId.value = authorId;
+  draftRevision += 1;
 };
 
 const setCategoryId = newCategoryId => {
+  if (selectedCategoryId.value === newCategoryId) return;
   selectedCategoryId.value = newCategoryId;
+  draftRevision += 1;
+};
+
+const currentArticlePayload = () => ({
+  title: article.value.title,
+  content: article.value.content,
+  authorId: selectedAuthorId.value || currentUserId.value,
+  categoryId: selectedCategoryId.value || categoryId.value,
+});
+
+const syncPendingChanges = async articleId => {
+  if (persistedRevision >= draftRevision) return;
+
+  const revision = draftRevision;
+  const {
+    title,
+    content,
+    authorId,
+    categoryId: currentCategoryId,
+  } = currentArticlePayload();
+
+  await store.dispatch('articles/update', {
+    portalSlug,
+    articleId,
+    title,
+    content,
+    author_id: authorId,
+    category_id: currentCategoryId,
+  });
+  persistedRevision = revision;
+  await syncPendingChanges(articleId);
 };
 
 const createNewArticle = async ({ title, content }) => {
-  if (title) article.value.title = title;
-  if (content) article.value.content = content;
+  updateArticleDraft({ title, content });
 
   if (!article.value.title || isUpdating.value) return;
 
   isUpdating.value = true;
   try {
     const { locale } = route.params;
-    const resolvedCategoryId = selectedCategoryId.value || categoryId.value;
-    const articleId = await store.dispatch('articles/create', {
-      portalSlug,
-      content: article.value.content,
-      title: article.value.title,
-      locale: locale,
-      authorId: selectedAuthorId.value || currentUserId.value,
-      categoryId: resolvedCategoryId,
-    });
+    if (!createdArticleId) {
+      const revision = draftRevision;
+      createdArticleId = await store.dispatch('articles/create', {
+        portalSlug,
+        locale,
+        ...currentArticlePayload(),
+      });
+      persistedRevision = revision;
+      useTrack(PORTALS_EVENTS.CREATE_ARTICLE, { locale });
+    }
 
-    useTrack(PORTALS_EVENTS.CREATE_ARTICLE, { locale });
+    await syncPendingChanges(createdArticleId);
+    if (!isPageActive) return;
+
+    const { categoryId: resolvedCategoryId } = currentArticlePayload();
 
     const resolvedSlug = categories.value?.find(
       c => c.id === resolvedCategoryId
@@ -77,7 +138,7 @@ const createNewArticle = async ({ title, content }) => {
         ? 'portals_categories_articles_edit'
         : 'portals_articles_edit',
       params: {
-        articleSlug: articleId,
+        articleSlug: createdArticleId,
         portalSlug,
         locale,
         ...(startedFromCategorySlug
@@ -116,6 +177,7 @@ const goBackToArticles = () => {
     :is-updating="isUpdating"
     :is-saved="isSaved"
     @create-article="createNewArticle"
+    @update-article-draft="updateArticleDraft"
     @go-back="goBackToArticles"
     @set-author="setAuthorId"
     @set-category="setCategoryId"

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -59,12 +59,14 @@ class Article < ApplicationRecord
 
   # Slugs that collide with help center routes (e.g. /hc/:slug/:locale/search)
   RESERVED_SLUGS = %w[search articles categories].freeze
+  SLUG_RANDOM_BYTES = 4
 
   validates :account_id, presence: true
   validates :author_id, presence: true
   validates :title, presence: true
   validates :content, presence: true, if: :published?
   validates :slug, exclusion: { in: RESERVED_SLUGS }
+  validates :slug, uniqueness: true
 
   # ensuring that the position is always set correctly
   before_create :add_position_to_article
@@ -223,7 +225,13 @@ class Article < ApplicationRecord
   end
 
   def ensure_article_slug
-    self.slug ||= "#{Time.now.utc.to_i}-#{title.underscore.parameterize(separator: '-')}" if title.present?
+    return if slug.present? || title.blank?
+
+    timestamp = Time.current.to_i.to_s
+    random_suffix = SecureRandom.hex(SLUG_RANDOM_BYTES)
+    max_title_length = MAX_STRING_COLUMN_LENGTH - timestamp.length - random_suffix.length - 2
+    parameterized_title = title.underscore.parameterize(separator: '-').first(max_title_length)
+    self.slug = "#{timestamp}-#{parameterized_title}-#{random_suffix}"
   end
 end
 Article.include_mod_with('Concerns::Article')


### PR DESCRIPTION
## Description

Creating a Help Center article now keeps title, content, author, and category changes made while the initial draft is being created. Pending changes are saved to that same article before navigation, and retries reuse the created record instead of producing duplicate drafts.

Newly generated article slugs also include a bounded random suffix. This prevents same-title articles created within the same second from colliding with the unique slug index, while existing article URLs remain unchanged.

## Closes

Closes https://github.com/chatwoot/chatwoot/issues/11352

## How to reproduce

1. Open Help Center → Articles → New article.
2. Enter a title, click directly into the editor, and immediately paste content while the create request is still running.
3. Confirm that only one draft article is created and the pasted content is present after navigation.
4. Retry after a failed post-create update and confirm that the existing draft is reused.

## What changed

- Buffer new-article edits without triggering additional create requests.
- Drain pending title, content, author, and category changes before redirecting.
- Retain the created article ID across synchronization failures and avoid redirects after leaving the page.
- Generate readable collision-resistant article slugs and validate their uniqueness.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
