### PR TITLE
feat(email): add extended initial IMAP imports

### DIFF
--- a/app/controllers/api/v1/accounts/concerns/email_channel_creation.rb
+++ b/app/controllers/api/v1/accounts/concerns/email_channel_creation.rb
@@ -6,6 +6,7 @@ module Api::V1::Accounts::Concerns::EmailChannelCreation
   def validate_new_email_channel
     return unless params.dig(:channel, :type) == 'email'
 
+    initial_imap_fetch_interval if params.key?(:imap_fetch_interval)
     validate_email_channel(Channel::Email::EDITABLE_ATTRS)
   rescue StandardError => e
     render json: { message: e }, status: :unprocessable_entity
@@ -15,6 +16,15 @@ module Api::V1::Accounts::Concerns::EmailChannelCreation
     return unless @inbox.channel.is_a?(Channel::Email)
     return unless @inbox.channel.imap_fetchable?
 
-    ::Inboxes::FetchImapEmailsJob.perform_later(@inbox.channel)
+    ::Inboxes::FetchImapEmailsJob.perform_later(@inbox.channel, initial_imap_fetch_interval)
+  end
+
+  def initial_imap_fetch_interval
+    return 1 unless params.key?(:imap_fetch_interval)
+
+    interval = params[:imap_fetch_interval]
+    raise ActionController::ParameterMissing, :imap_fetch_interval unless interval.is_a?(Integer) && [1, 7, 30].include?(interval)
+
+    interval
   end
 end

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -526,6 +526,13 @@
             "DESCRIPTION": "Use a forwarding address"
           }
         },
+        "FETCH_EMAILS_FROM": "Fetch emails from",
+        "IMPORT_OPTIONS": {
+          "TITLE": "Initial import",
+          "ONE_DAY": "Last 1 day",
+          "SEVEN_DAYS": "Last 7 days",
+          "THIRTY_DAYS": "Last 30 days"
+        },
         "FINISH_MESSAGE_FORWARDING": "Your email inbox is ready. Set up a forwarding rule in your email provider to start receiving conversations in Chatwoot.",
         "FINISH_MESSAGE_IMAP_SMTP": "Your email inbox is connected. Chatwoot will fetch new emails from your mailbox and use the SMTP settings for replies.",
         "FORWARDING_ADDRESS_LABEL": "Forward emails to this address:",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/emailChannels/ImapSmtpOption.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/emailChannels/ImapSmtpOption.vue
@@ -47,6 +47,7 @@ const state = reactive({
   imapPassword: '',
   imapEnableSSL: true,
   imapAuthentication: 'plain',
+  imapFetchInterval: 1,
   smtpAddress: '',
   smtpPort: 587,
   smtpLogin: '',
@@ -59,6 +60,21 @@ const state = reactive({
 
 const selectOptions = options =>
   options.map(value => ({ label: value, value }));
+
+const importWindowOptions = computed(() => [
+  {
+    value: 1,
+    label: t('INBOX_MGMT.ADD.EMAIL_CHANNEL.IMPORT_OPTIONS.ONE_DAY'),
+  },
+  {
+    value: 7,
+    label: t('INBOX_MGMT.ADD.EMAIL_CHANNEL.IMPORT_OPTIONS.SEVEN_DAYS'),
+  },
+  {
+    value: 30,
+    label: t('INBOX_MGMT.ADD.EMAIL_CHANNEL.IMPORT_OPTIONS.THIRTY_DAYS'),
+  },
+]);
 
 const isSMTPConfigured = computed(() =>
   [
@@ -126,6 +142,7 @@ async function createChannel() {
   try {
     const emailChannel = await store.dispatch('inboxes/createChannel', {
       name: state.channelName.trim(),
+      imap_fetch_interval: state.imapFetchInterval,
       channel: buildChannelPayload(),
     });
 
@@ -230,6 +247,15 @@ async function createChannel() {
             <Select
               v-model="state.imapAuthentication"
               :options="selectOptions(IMAP_AUTH_OPTIONS)"
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="text-heading-3 text-n-slate-12">
+              {{ t('INBOX_MGMT.ADD.EMAIL_CHANNEL.FETCH_EMAILS_FROM') }}
+            </span>
+            <Select
+              v-model="state.imapFetchInterval"
+              :options="importWindowOptions"
             />
           </label>
         </div>

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -586,37 +586,54 @@ RSpec.describe 'Inboxes API', type: :request do
         expect(response.body).to include('test@test.com')
       end
 
-      it 'creates an IMAP inbox and queues the default fetch' do
-        imap_connection = instance_double(Net::IMAP, disconnected?: false)
+      [1, 7, 30].each do |import_window|
+        it "creates an IMAP inbox with import window #{import_window.inspect}" do
+          imap_connection = instance_double(Net::IMAP, disconnected?: false)
 
-        allow(Net::IMAP).to receive(:new).and_return(imap_connection)
-        allow(imap_connection).to receive(:login)
-        allow(imap_connection).to receive(:disconnect)
+          allow(Net::IMAP).to receive(:new).and_return(imap_connection)
+          allow(imap_connection).to receive(:login)
+          allow(imap_connection).to receive(:disconnect)
 
-        expect do
-          post "/api/v1/accounts/#{account.id}/inboxes",
-               headers: admin.create_new_auth_token,
-               params: {
-                 name: 'Support',
-                 channel: {
-                   type: 'email',
-                   email: 'support@example.com',
-                   imap_enabled: true,
-                   imap_address: 'imap.example.com',
-                   imap_port: 993,
-                   imap_login: 'support@example.com',
-                   imap_password: 'imap-password',
-                   imap_enable_ssl: true,
-                   imap_authentication: 'login'
-                 }
-               },
-               as: :json
-        end.to have_enqueued_job(Inboxes::FetchImapEmailsJob).with(a_kind_of(Channel::Email))
+          expect do
+            post "/api/v1/accounts/#{account.id}/inboxes",
+                 headers: admin.create_new_auth_token,
+                 params: {
+                   name: 'Support',
+                   imap_fetch_interval: import_window,
+                   channel: {
+                     type: 'email',
+                     email: 'support@example.com',
+                     imap_enabled: true,
+                     imap_address: 'imap.example.com',
+                     imap_port: 993,
+                     imap_login: 'support@example.com',
+                     imap_password: 'imap-password',
+                     imap_enable_ssl: true,
+                     imap_authentication: 'login'
+                   }
+                 },
+                 as: :json
+          end.to have_enqueued_job(Inboxes::FetchImapEmailsJob).with(a_kind_of(Channel::Email), import_window)
 
-        expect(response).to have_http_status(:success)
-        channel = Channel::Email.find_by!(email: 'support@example.com')
-        expect(channel.imap_enabled).to be true
-        expect(channel.smtp_enabled).to be false
+          expect(response).to have_http_status(:success)
+          channel = Channel::Email.find_by!(email: 'support@example.com')
+          expect(channel.imap_enabled).to be true
+          expect(channel.smtp_enabled).to be false
+        end
+      end
+
+      [nil, 90, '7days', '7', 30.5, [], {}].each do |import_window|
+        it "rejects invalid import window #{import_window.inspect} before creating the inbox" do
+          expect do
+            post "/api/v1/accounts/#{account.id}/inboxes",
+                 headers: admin.create_new_auth_token,
+                 params: { name: 'Support', imap_fetch_interval: import_window,
+                           channel: { type: 'email', email: 'support@example.com' } }, as: :json
+          end.not_to change(Inbox, :count)
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(Inboxes::FetchImapEmailsJob).not_to have_been_enqueued
+        end
       end
 
       it 'does not create an inbox or enqueue an import when the IMAP connection fails' do
@@ -649,7 +666,7 @@ RSpec.describe 'Inboxes API', type: :request do
           post "/api/v1/accounts/#{account.id}/inboxes",
                headers: admin.create_new_auth_token,
                params: {
-                 name: 'Support',
+                 name: 'Support', imap_fetch_interval: 30,
                  channel: {
                    type: 'email', email: 'support@example.com', imap_enabled: true,
                    imap_address: 'imap.example.com', imap_port: 993,
@@ -797,13 +814,13 @@ RSpec.describe 'Inboxes API', type: :request do
         expect(twitter_channel.reload.tweets_enabled).to be(false)
       end
 
-      it 'updates email inbox when administrator' do
+      it 'updates email inbox without persisting the creation-only import window' do
         email_channel = create(:channel_email, account: account)
         email_inbox = create(:inbox, channel: email_channel, account: account)
 
         patch "/api/v1/accounts/#{account.id}/inboxes/#{email_inbox.id}",
               headers: admin.create_new_auth_token,
-              params: { enable_auto_assignment: false, channel: { email: 'emailtest@email.test' } },
+              params: { enable_auto_assignment: false, imap_fetch_interval: 30, channel: { email: 'emailtest@email.test' } },
               as: :json
 
         expect(response).to have_http_status(:success)


### PR DESCRIPTION
Adds a choice of 1, 7, or 30 days of existing email when connecting an IMAP inbox.

## Dependency

Stacked on #14597. Merge the parent first, then retarget this PR to develop.

Related to #3891.

## Why

Teams connecting an existing mailbox need recent history, not only new incoming messages.

## What this change does

- Moves the initial-import selector and strict request validation out of #14597.
- Keeps the setup-only parent on its existing one-day fetch.

## Remaining before ready for review

This is a draft: implement bounded continuation beyond the 500-message per-sync cap, preserving the selected date range across batches. Verify large mailboxes, duplicates, failed messages, and interruption recovery before marking ready.

## Validation

After batching is implemented, connect test mailboxes with more than 500 messages across the selected window and verify all eligible history is imported without duplicates. Confirm ordinary recurring fetches remain unchanged.