### PR TITLE
fix(whatsapp): show backend errors when calls fail

### DIFF
--- a/app/javascript/dashboard/components-next/Contacts/VoiceCallButton.vue
+++ b/app/javascript/dashboard/components-next/Contacts/VoiceCallButton.vue
@@ -146,7 +146,11 @@ const startCall = async (inboxId, conversationIdHint = null) => {
     try {
       await startWhatsappCall(inboxId, conversationIdHint);
     } catch (error) {
-      useAlert(error?.message || t('CONTACT_PANEL.CALL_FAILED'));
+      useAlert(
+        error?.response?.data?.error ||
+          error?.message ||
+          t('CONTACT_PANEL.CALL_FAILED')
+      );
     }
     return;
   }


### PR DESCRIPTION
When a WhatsApp call fails, the call button now displays the backend's error message instead of the generic “Request failed with status code 422” toast. This lets agents understand failures such as unavailable business-initiated calling.

The existing error-message fallbacks remain available when the response has no explanation. This changes only error presentation; calling eligibility and consent handling remain unchanged.

### How to reproduce

1. Open a contact with a WhatsApp inbox that cannot initiate business calls.
2. Click Call and select the inbox if prompted.
3. Previously, the toast showed only the HTTP 422 error even though the response contained the reason.

### How to test

Attempt a WhatsApp call that returns a backend error. Confirm that the toast shows the response's error message. If no backend message is provided, confirm that the existing error fallback is still shown.
