### PR TITLE
fix: process WhatsApp Cloud API message edit webhooks

### DIFF
--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -30,6 +30,7 @@ class Whatsapp::IncomingMessageBaseService
     # We don't support reactions & ephemeral message now, we need to skip processing the message
     # if the webhook event is a reaction or an ephermal message or an unsupported message.
     return if unprocessable_message_type?(message_type)
+    return process_message_edit if message_type == 'edit'
 
     # Multiple webhook events can be received for the same message due to
     # misconfigurations in the Meta business manager account.
@@ -46,6 +47,29 @@ class Whatsapp::IncomingMessageBaseService
       set_conversation
       create_messages
     end
+  end
+
+  # Meta delivers message edits (currently a coexistence feature) as a webhook message
+  # with type: edit - the original wamid is under edit.original_message_id and the
+  # updated payload under edit.message. The create pipeline below can't handle that
+  # shape: the dedupe lookup runs against the edit event's own fresh id, and content
+  # is read from the top level, so edits were silently dropped. Mirror
+  # Telegram::UpdateMessageService instead: find the original message and update
+  # its content (text body or media caption).
+  def process_message_edit
+    edit = messages_data.first[:edit]
+    return if edit.blank?
+
+    original_message = inbox.messages.find_by(source_id: edit[:original_message_id])
+    return if original_message.blank?
+
+    edited_message = edit[:message] || {}
+    new_content = message_content(edited_message)
+    edited_type = edited_message[:type]
+    new_content ||= edited_message[edited_type.to_sym].try(:[], :caption) if edited_type.present?
+    return if new_content.blank?
+
+    original_message.update!(content: new_content)
   end
 
   def process_statuses

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -1049,4 +1049,77 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
   def contact_from_number
     Contact.find_by(phone_number: contact_phone_number)
   end
+  context 'when a message edit webhook arrives' do
+    let(:contact_inbox) { create(:contact_inbox, inbox: whatsapp_channel.inbox, source_id: sender_number) }
+    let(:conversation) { create(:conversation, inbox: whatsapp_channel.inbox, contact_inbox: contact_inbox) }
+    let!(:original_message) do
+      create(:message, conversation: conversation, source_id: 'wamid.ORIGINAL', content: 'before edit')
+    end
+    let(:edit_params) do
+      {
+        phone_number: whatsapp_channel.phone_number,
+        object: 'whatsapp_business_account',
+        entry: [{
+          changes: [{
+            value: {
+              contacts: [{ profile: { name: 'Sojan Jose' }, wa_id: sender_number }],
+              messages: [{
+                id: 'wamid.EDIT_EVENT',
+                from: sender_number,
+                timestamp: '1664799905',
+                type: 'edit',
+                edit: edit_payload
+              }]
+            }
+          }]
+        }]
+      }.with_indifferent_access
+    end
+
+    context 'with a text edit' do
+      let(:edit_payload) do
+        {
+          original_message_id: 'wamid.ORIGINAL',
+          message: { type: 'text', text: { body: 'after edit' } }
+        }
+      end
+
+      it 'updates the original message content and creates no new message' do
+        expect do
+          described_class.new(inbox: whatsapp_channel.inbox, params: edit_params).perform
+        end.not_to change { whatsapp_channel.inbox.messages.count }
+        expect(original_message.reload.content).to eq('after edit')
+      end
+    end
+
+    context 'with a media caption edit' do
+      let(:edit_payload) do
+        {
+          original_message_id: 'wamid.ORIGINAL',
+          message: { type: 'image', image: { id: 'media-1', caption: 'updated caption' } }
+        }
+      end
+
+      it 'updates the original message content to the new caption without downloading media' do
+        described_class.new(inbox: whatsapp_channel.inbox, params: edit_params).perform
+        expect(original_message.reload.content).to eq('updated caption')
+      end
+    end
+
+    context 'when the original message is unknown' do
+      let(:edit_payload) do
+        {
+          original_message_id: 'wamid.DOES_NOT_EXIST',
+          message: { type: 'text', text: { body: 'after edit' } }
+        }
+      end
+
+      it 'does not create a new message' do
+        expect do
+          described_class.new(inbox: whatsapp_channel.inbox, params: edit_params).perform
+        end.not_to change { whatsapp_channel.inbox.messages.count }
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Fixes #15770

## Problem

Meta delivers message edits (currently a coexistence feature) as webhook messages with `type: "edit"`: the original wamid is under `edit.original_message_id` and the updated payload under `edit.message`. `Whatsapp::IncomingMessageBaseService` silently dropped them three ways:

1. `unprocessable_message_type?` doesn't exempt `edit`, so the edit entered the regular **create** pipeline;
2. dedupe looks up the edit event's own fresh wamid, never `original_message_id`;
3. `create_regular_message` reads content from the top level (`nil` for edits) and `attach_files` treats the `edit` hash as media.

The original message was never updated and nothing rendered. The same path mishandles `smb_message_echoes` edits. There was zero edit handling in any whatsapp service.

## Fix

Route `type == 'edit'` to a new `process_message_edit`, mirroring the repo's own `Telegram::UpdateMessageService` pattern:

- find the original message by `source_id: edit.original_message_id`;
- update its content from the edited text body, or the media caption for media edits;
- no-op when the original is unknown (edit arrived before the original);
- never create a duplicate message.

`MESSAGE_UPDATED` dispatch on update means the UI refreshes for free. Deliberately minimal: no "edited" marker, since no repo convention exists for one yet.

## Tests

Three specs on `IncomingMessageWhatsappCloudService`: text edit updates the original without creating a message, media caption edit updates content without downloading media, unknown original no-ops.

## Disclosures

- The payload shape follows Meta's webhook documentation for the message-edit field.
- Patch and specs are **unrun** (no Ruby runtime in this environment); correctness was verified by a logic-level port of the exact HEAD methods (pre-change: an edit walks into `attach_files` with nil media; post-change: original updated, no duplicate) plus `git apply --check` against pristine `develop` (bacb65d), and by mirroring the existing `Telegram::UpdateMessageService` control flow.

> Built by breken, your AI support engineer - breken.ai - this one's on us.