### PR TITLE
feat(conversations): add conversation.viewed event

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ Metrics/ClassLength:
     - 'app/models/message.rb'
     - 'app/models/conversation.rb'
     - 'config/initializers/rack_attack.rb'
+    - 'app/controllers/api/v1/accounts/conversations_controller.rb'
 
 Metrics/MethodLength:
   Max: 19

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -124,6 +124,11 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
     update_last_seen_on_conversation(DateTime.now.utc, assignee?)
   end
 
+  def viewed
+    Conversations::ViewedService.new(conversation: @conversation, user: Current.user).perform
+    head :ok
+  end
+
   def unread
     last_incoming_message = @conversation.messages.incoming.last
     last_seen_at = last_incoming_message.created_at - 1.second if last_incoming_message.present?

--- a/app/javascript/dashboard/api/inbox/conversation.js
+++ b/app/javascript/dashboard/api/inbox/conversation.js
@@ -83,6 +83,10 @@ class ConversationApi extends ApiClient {
     return axios.post(`${this.url}/${id}/update_last_seen`);
   }
 
+  markConversationViewed({ id }) {
+    return axios.post(`${this.url}/${id}/viewed`);
+  }
+
   markMessagesUnread({ id }) {
     return axios.post(`${this.url}/${id}/unread`);
   }

--- a/app/javascript/dashboard/api/specs/inbox/conversation.spec.js
+++ b/app/javascript/dashboard/api/specs/inbox/conversation.spec.js
@@ -12,6 +12,7 @@ describe('#ConversationAPI', () => {
     expect(conversationAPI).toHaveProperty('toggleStatus');
     expect(conversationAPI).toHaveProperty('assignAgent');
     expect(conversationAPI).toHaveProperty('assignTeam');
+    expect(conversationAPI).toHaveProperty('markConversationViewed');
     expect(conversationAPI).toHaveProperty('markMessageRead');
     expect(conversationAPI).toHaveProperty('toggleTyping');
     expect(conversationAPI).toHaveProperty('mute');
@@ -118,6 +119,13 @@ describe('#ConversationAPI', () => {
       conversationAPI.markMessageRead({ id: 12 });
       expect(axiosMock.post).toHaveBeenCalledWith(
         `/api/v1/conversations/12/update_last_seen`
+      );
+    });
+
+    it('#markConversationViewed', () => {
+      conversationAPI.markConversationViewed({ id: 12 });
+      expect(axiosMock.post).toHaveBeenCalledWith(
+        '/api/v1/conversations/12/viewed'
       );
     });
 

--- a/app/javascript/dashboard/composables/spec/useAutomation.spec.js
+++ b/app/javascript/dashboard/composables/spec/useAutomation.spec.js
@@ -206,6 +206,7 @@ describe('useAutomation', () => {
     automationTypes.conversation_updated = { conditions: [] };
     automationTypes.conversation_opened = { conditions: [] };
     automationTypes.conversation_resolved = { conditions: [] };
+    automationTypes.conversation_viewed = { conditions: [] };
 
     automationHelper.generateCustomAttributeTypes.mockReturnValue([]);
     automationHelper.generateCustomAttributes.mockReturnValue([]);

--- a/app/javascript/dashboard/composables/useAutomation.js
+++ b/app/javascript/dashboard/composables/useAutomation.js
@@ -170,6 +170,7 @@ export function useAutomation(startValue = null) {
       'conversation_created',
       'conversation_updated',
       'conversation_opened',
+      'conversation_viewed',
     ].forEach(eventToUpdate => {
       const standardConditions = automationTypes[
         eventToUpdate

--- a/app/javascript/dashboard/i18n/locale/en/automation.json
+++ b/app/javascript/dashboard/i18n/locale/en/automation.json
@@ -181,7 +181,8 @@
       "CONVERSATION_UPDATED": "Conversation Updated",
       "MESSAGE_CREATED": "Message Created",
       "CONVERSATION_RESOLVED": "Conversation Resolved",
-      "CONVERSATION_OPENED": "Conversation Opened"
+      "CONVERSATION_OPENED": "Conversation Opened",
+      "CONVERSATION_VIEWED": "Conversation Viewed"
     },
     "ACTIONS": {
       "ASSIGN_AGENT": "Assign to Agent",

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -63,6 +63,7 @@
             "CONVERSATION_CREATED": "Conversation Created",
             "CONVERSATION_STATUS_CHANGED": "Conversation Status Changed",
             "CONVERSATION_UPDATED": "Conversation Updated",
+            "CONVERSATION_VIEWED": "Conversation Viewed",
             "MESSAGE_CREATED": "Message created",
             "MESSAGE_UPDATED": "Message updated",
             "WEBWIDGET_TRIGGERED": "Live chat widget opened by the user",

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
@@ -570,6 +570,144 @@ export const AUTOMATIONS = {
       },
     ],
   },
+  conversation_viewed: {
+    conditions: [
+      {
+        key: 'status',
+        name: 'STATUS',
+        inputType: 'multi_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
+        key: 'browser_language',
+        name: 'BROWSER_LANGUAGE',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
+        key: 'email',
+        name: 'EMAIL',
+        inputType: 'plain_text',
+        filterOperators: OPERATOR_TYPES_2,
+      },
+      {
+        key: 'mail_subject',
+        name: 'MAIL_SUBJECT',
+        inputType: 'plain_text',
+        filterOperators: OPERATOR_TYPES_2,
+      },
+      {
+        key: 'country_code',
+        name: 'COUNTRY_NAME',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
+        key: 'referer',
+        name: 'REFERER_LINK',
+        inputType: 'plain_text',
+        filterOperators: OPERATOR_TYPES_2,
+      },
+      {
+        key: 'assignee_id',
+        name: 'ASSIGNEE_NAME',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_3,
+      },
+      {
+        key: 'phone_number',
+        name: 'PHONE_NUMBER',
+        inputType: 'plain_text',
+        filterOperators: OPERATOR_TYPES_6,
+      },
+      {
+        key: 'company_name',
+        name: 'COMPANY_NAME',
+        inputType: 'plain_text',
+        filterOperators: OPERATOR_TYPES_2,
+      },
+      {
+        key: 'team_id',
+        name: 'TEAM_NAME',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_3,
+      },
+      {
+        key: 'inbox_id',
+        name: 'INBOX',
+        inputType: 'multi_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
+        key: 'conversation_language',
+        name: 'CONVERSATION_LANGUAGE',
+        inputType: 'multi_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
+        key: 'priority',
+        name: 'PRIORITY',
+        inputType: 'multi_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
+        key: 'labels',
+        name: 'LABELS',
+        inputType: 'multi_select',
+        filterOperators: OPERATOR_TYPES_3,
+      },
+    ],
+    actions: [
+      {
+        key: 'assign_agent',
+        name: 'ASSIGN_AGENT',
+      },
+      {
+        key: 'assign_team',
+        name: 'ASSIGN_TEAM',
+      },
+      {
+        key: 'remove_assigned_agent',
+        name: 'REMOVE_ASSIGNED_AGENT',
+      },
+      {
+        key: 'remove_assigned_team',
+        name: 'REMOVE_ASSIGNED_TEAM',
+      },
+      {
+        key: 'send_email_to_team',
+        name: 'SEND_EMAIL_TO_TEAM',
+      },
+      {
+        key: 'send_message',
+        name: 'SEND_MESSAGE',
+      },
+      {
+        key: 'send_email_transcript',
+        name: 'SEND_EMAIL_TRANSCRIPT',
+      },
+      {
+        key: 'mute_conversation',
+        name: 'MUTE_CONVERSATION',
+      },
+      {
+        key: 'snooze_conversation',
+        name: 'SNOOZE_CONVERSATION',
+      },
+      {
+        key: 'pending_conversation',
+        name: 'PENDING_CONVERSATION',
+      },
+      {
+        key: 'send_webhook_event',
+        name: 'SEND_WEBHOOK_EVENT',
+      },
+      {
+        key: 'send_attachment',
+        name: 'SEND_ATTACHMENT',
+      },
+    ],
+  },
   conversation_resolved: {
     conditions: [
       {
@@ -706,6 +844,10 @@ export const AUTOMATION_RULE_EVENTS = [
   {
     key: 'conversation_opened',
     value: 'CONVERSATION_OPENED',
+  },
+  {
+    key: 'conversation_viewed',
+    value: 'CONVERSATION_VIEWED',
   },
 ];
 

--- a/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/integrations/Webhooks/WebhookForm.vue
@@ -14,6 +14,7 @@ const SUPPORTED_WEBHOOK_EVENTS = [
   'conversation_created',
   'conversation_status_changed',
   'conversation_updated',
+  'conversation_viewed',
   'message_created',
   'message_updated',
   'webwidget_triggered',

--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -276,6 +276,7 @@ const actions = {
         // Ignore error
       }
     }
+    dispatch('conversationViewed', { id: data.id });
   },
 
   assignAgent: async (
@@ -643,6 +644,14 @@ const actions = {
       commit(types.SET_INBOX_CAPTAIN_ASSISTANT, response.data);
     } catch (error) {
       // Handle error
+    }
+  },
+
+  conversationViewed: async (_, { id }) => {
+    try {
+      await ConversationApi.markConversationViewed({ id });
+    } catch (error) {
+      // Ignore error
     }
   },
 

--- a/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
@@ -520,6 +520,21 @@ describe('#actions', () => {
     });
   });
 
+  describe('#conversationViewed', () => {
+    it('marks the conversation as viewed', async () => {
+      axios.post.mockResolvedValue({});
+      await actions.conversationViewed({ commit }, { id: 1 });
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/conversations/1/viewed');
+    });
+
+    it('does not throw when the API call fails', async () => {
+      axios.post.mockRejectedValue({ message: 'Incorrect header' });
+      await expect(
+        actions.conversationViewed({ commit }, { id: 1 })
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe('#sendEmailTranscript', () => {
     it('sends correct mutations if api is successful', async () => {
       axios.post.mockResolvedValue({});
@@ -960,7 +975,13 @@ describe('#addMentions', () => {
         [types.SET_CURRENT_CHAT_WINDOW, data],
         [types.CLEAR_ALL_MESSAGES_LOADED, 42],
       ]);
-      expect(localDispatch).not.toHaveBeenCalled();
+      expect(localDispatch).toHaveBeenCalledWith('conversationViewed', {
+        id: 42,
+      });
+      expect(localDispatch).not.toHaveBeenCalledWith(
+        'fetchPreviousMessages',
+        expect.anything()
+      );
     });
 
     it('should commit SET_CHAT_DATA_FETCHED by ID, not mutate the data object directly (race condition fix)', async () => {

--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -15,6 +15,14 @@ class AgentBotListener < BaseListener
     agent_bots_for(inbox, conversation).each { |agent_bot| process_webhook_bot_event(agent_bot, payload) }
   end
 
+  def conversation_viewed(event)
+    conversation = extract_conversation_and_account(event)[0]
+    inbox = conversation.inbox
+    event_name = __method__.to_s
+    payload = conversation.webhook_data.merge(event: event_name)
+    agent_bots_for(inbox, conversation).each { |agent_bot| process_webhook_bot_event(agent_bot, payload) }
+  end
+
   def conversation_status_changed(event)
     conversation = extract_conversation_and_account(event)[0]
     changed_attributes = extract_changed_attributes(event)

--- a/app/listeners/automation_rule_listener.rb
+++ b/app/listeners/automation_rule_listener.rb
@@ -7,6 +7,10 @@ class AutomationRuleListener < BaseListener
     process_conversation_event(event, 'conversation_created')
   end
 
+  def conversation_viewed(event)
+    process_conversation_event(event, 'conversation_viewed')
+  end
+
   def conversation_opened(event)
     process_conversation_event(event, 'conversation_opened')
   end

--- a/app/listeners/webhook_listener.rb
+++ b/app/listeners/webhook_listener.rb
@@ -22,6 +22,14 @@ class WebhookListener < BaseListener
     deliver_webhook_payloads(payload, inbox)
   end
 
+  def conversation_viewed(event)
+    conversation = extract_conversation_and_account(event)[0]
+    inbox = conversation.inbox
+    viewed_by = event.data[:viewed_by]
+    payload = conversation.webhook_data.merge(event: __method__.to_s, viewed_by_agent: viewed_by&.webhook_data)
+    deliver_webhook_payloads(payload, inbox)
+  end
+
   def message_created(event)
     message = extract_message_and_account(event)[0]
     inbox = message.inbox

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -29,7 +29,8 @@ class Webhook < ApplicationRecord
   validate :validate_webhook_subscriptions
   enum webhook_type: { account_type: 0, inbox_type: 1 }
 
-  ALLOWED_WEBHOOK_EVENTS = %w[conversation_status_changed conversation_updated conversation_created contact_created contact_updated
+  ALLOWED_WEBHOOK_EVENTS = %w[conversation_status_changed conversation_updated conversation_created conversation_viewed
+                              contact_created contact_updated
                               message_created message_updated webwidget_triggered inbox_created inbox_updated
                               conversation_typing_on conversation_typing_off].freeze
 

--- a/app/services/conversations/viewed_service.rb
+++ b/app/services/conversations/viewed_service.rb
@@ -11,9 +11,8 @@ class Conversations::ViewedService
   end
 
   def perform
-    return if throttled?
+    return unless claim_throttle_key
 
-    Rails.cache.write(cache_key, true, expires_in: THROTTLE_WINDOW)
     dispatch_event
   end
 
@@ -28,11 +27,11 @@ class Conversations::ViewedService
     )
   end
 
-  def throttled?
-    Rails.cache.read(cache_key).present?
+  def claim_throttle_key
+    Redis::Alfred.set(throttle_key, true, nx: true, ex: THROTTLE_WINDOW.to_i)
   end
 
-  def cache_key
+  def throttle_key
     "conversation_viewed/#{@conversation.id}/#{@user&.id}"
   end
 end

--- a/app/services/conversations/viewed_service.rb
+++ b/app/services/conversations/viewed_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class Conversations::ViewedService
+  include Events::Types
+
+  THROTTLE_WINDOW = 60.seconds
+
+  def initialize(conversation:, user:)
+    @conversation = conversation
+    @user = user
+  end
+
+  def perform
+    return if throttled?
+
+    Rails.cache.write(cache_key, true, expires_in: THROTTLE_WINDOW)
+    dispatch_event
+  end
+
+  private
+
+  def dispatch_event
+    Rails.configuration.dispatcher.dispatch(
+      CONVERSATION_VIEWED,
+      Time.zone.now,
+      conversation: @conversation,
+      viewed_by: @user
+    )
+  end
+
+  def throttled?
+    Rails.cache.read(cache_key).present?
+  end
+
+  def cache_key
+    "conversation_viewed/#{@conversation.id}/#{@user&.id}"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,6 +186,7 @@ Rails.application.routes.draw do
               post :toggle_priority
               post :toggle_typing_status
               post :update_last_seen
+              post :viewed
               post :unread
               post :custom_attributes
               post :destroy_custom_attributes

--- a/lib/events/types.rb
+++ b/lib/events/types.rb
@@ -18,6 +18,7 @@ module Events::Types
   CONVERSATION_UPDATED = 'conversation.updated'
   CONVERSATION_DELETED = 'conversation.deleted'
   CONVERSATION_READ = 'conversation.read'
+  CONVERSATION_VIEWED = 'conversation.viewed'
   CONVERSATION_BOT_HANDOFF = 'conversation.bot_handoff'
   # FIXME: deprecate the opened and resolved events in future in favor of status changed event.
   CONVERSATION_OPENED = 'conversation.opened'

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -1057,6 +1057,41 @@ RSpec.describe 'Conversations API', type: :request do
     end
   end
 
+  describe 'POST /api/v1/accounts/{account.id}/conversations/:id/viewed' do
+    let(:conversation) { create(:conversation, account: account) }
+
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized' do
+        post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/viewed"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an authenticated user' do
+      let(:agent) { create(:user, account: account, role: :agent) }
+
+      before do
+        create(:inbox_member, user: agent, inbox: conversation.inbox)
+      end
+
+      it 'dispatches the conversation.viewed event' do
+        expect(Rails.configuration.dispatcher).to receive(:dispatch).with(
+          Events::Types::CONVERSATION_VIEWED,
+          instance_of(ActiveSupport::TimeWithZone),
+          conversation: conversation,
+          viewed_by: agent
+        )
+
+        post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/viewed",
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
   describe 'POST /api/v1/accounts/{account.id}/conversations/:id/unread' do
     let(:conversation) { create(:conversation, account: account) }
 

--- a/spec/lib/chatwoot_app_spec.rb
+++ b/spec/lib/chatwoot_app_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe ChatwootApp do
   describe '.self_hosted_paid?' do
     before do
+      # Force ChatwootHub to autoload before we stub enterprise?. Otherwise the
+      # autoload runs the enterprise extension injection while enterprise? is
+      # stubbed to true, which raises when the enterprise code is not present.
+      ChatwootHub.singleton_class
       allow(described_class).to receive(:enterprise?).and_return(true)
       allow(described_class).to receive(:chatwoot_cloud?).and_return(false)
     end

--- a/spec/listeners/agent_bot_listener_spec.rb
+++ b/spec/listeners/agent_bot_listener_spec.rb
@@ -158,6 +158,29 @@ describe AgentBotListener do
     end
   end
 
+  describe '#conversation_viewed' do
+    let(:event_name) { 'conversation.viewed' }
+    let!(:event) { Events::Base.new(event_name, Time.zone.now, conversation: conversation, viewed_by: user) }
+
+    context 'when agent bot is not configured' do
+      it 'does not send event to agent bot' do
+        expect(AgentBots::WebhookJob).to receive(:perform_later).exactly(0).times
+        listener.conversation_viewed(event)
+      end
+    end
+
+    context 'when agent bot is configured' do
+      it 'sends the event to the agent bot' do
+        create(:agent_bot_inbox, inbox: inbox, agent_bot: agent_bot)
+        expect(AgentBots::WebhookJob).to receive(:perform_later).with(
+          agent_bot.outgoing_url, conversation.webhook_data.merge(event: 'conversation_viewed'),
+          :agent_bot_webhook, secret: agent_bot.secret, delivery_id: instance_of(String)
+        ).once
+        listener.conversation_viewed(event)
+      end
+    end
+  end
+
   describe '#conversation_resolved' do
     let(:event_name) { 'conversation.resolved' }
     let!(:event) { Events::Base.new(event_name, Time.zone.now, conversation: conversation) }

--- a/spec/listeners/automation_rule_listener_spec.rb
+++ b/spec/listeners/automation_rule_listener_spec.rb
@@ -58,6 +58,27 @@ describe AutomationRuleListener do
     end
   end
 
+  describe 'conversation_viewed' do
+    let!(:automation_rule) { create(:automation_rule, event_name: 'conversation_viewed', account: account) }
+    let(:event) do
+      Events::Base.new('conversation_viewed', Time.zone.now, { conversation: conversation })
+    end
+
+    context 'when matching rules are present' do
+      it 'calls AutomationRules::ActionService if conditions match' do
+        allow(condition_match).to receive(:present?).and_return(true)
+        listener.conversation_viewed(event)
+        expect(AutomationRules::ActionService).to have_received(:new).with(automation_rule, account, conversation)
+      end
+
+      it 'does not call AutomationRules::ActionService if conditions do not match' do
+        allow(condition_match).to receive(:present?).and_return(false)
+        listener.conversation_viewed(event)
+        expect(AutomationRules::ActionService).not_to have_received(:new).with(automation_rule, account, conversation)
+      end
+    end
+  end
+
   describe 'conversation_updated' do
     let!(:automation_rule) { create(:automation_rule, event_name: 'conversation_updated', account: account) }
     let(:event) do

--- a/spec/listeners/webhook_listener_spec.rb
+++ b/spec/listeners/webhook_listener_spec.rb
@@ -198,7 +198,7 @@ describe WebhookListener do
 
     context 'when webhook is configured' do
       it 'triggers webhook with the viewing agent' do
-        webhook = create(:webhook, inbox: inbox, account: account)
+        webhook = create(:webhook, inbox: inbox, account: account, subscriptions: %w[conversation_viewed])
         expect(WebhookJob).to receive(:perform_later).with(
           webhook.url,
           conversation.webhook_data.merge(event: 'conversation_viewed', viewed_by_agent: user.webhook_data),

--- a/spec/listeners/webhook_listener_spec.rb
+++ b/spec/listeners/webhook_listener_spec.rb
@@ -183,6 +183,33 @@ describe WebhookListener do
     end
   end
 
+  describe '#conversation_viewed' do
+    let(:event_name) { :'conversation.viewed' }
+    let!(:conversation_viewed_event) do
+      Events::Base.new(event_name, Time.zone.now, conversation: conversation, viewed_by: user)
+    end
+
+    context 'when webhook is not configured' do
+      it 'does not trigger webhook' do
+        expect(WebhookJob).to receive(:perform_later).exactly(0).times
+        listener.conversation_viewed(conversation_viewed_event)
+      end
+    end
+
+    context 'when webhook is configured' do
+      it 'triggers webhook with the viewing agent' do
+        webhook = create(:webhook, inbox: inbox, account: account)
+        expect(WebhookJob).to receive(:perform_later).with(
+          webhook.url,
+          conversation.webhook_data.merge(event: 'conversation_viewed', viewed_by_agent: user.webhook_data),
+          :account_webhook,
+          secret: webhook.secret, delivery_id: instance_of(String)
+        ).once
+        listener.conversation_viewed(conversation_viewed_event)
+      end
+    end
+  end
+
   describe '#conversation_updated' do
     let(:custom_attributes) { { test: nil } }
     let!(:conversation_updated_event) do

--- a/spec/services/conversations/viewed_service_spec.rb
+++ b/spec/services/conversations/viewed_service_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Conversations::ViewedService do
+  let(:account) { create(:account) }
+  let(:inbox) { create(:inbox, account: account) }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox) }
+  let(:user) { create(:user, account: account) }
+
+  describe '#perform' do
+    context 'when the conversation was not viewed within the throttle window' do
+      before do
+        allow(Rails.cache).to receive(:read).and_return(nil)
+        allow(Rails.cache).to receive(:write)
+      end
+
+      it 'dispatches the conversation.viewed event' do
+        expect(Rails.configuration.dispatcher).to receive(:dispatch).with(
+          Events::Types::CONVERSATION_VIEWED,
+          instance_of(ActiveSupport::TimeWithZone),
+          conversation: conversation,
+          viewed_by: user
+        )
+
+        described_class.new(conversation: conversation, user: user).perform
+      end
+
+      it 'stores the throttle key' do
+        allow(Rails.configuration.dispatcher).to receive(:dispatch)
+
+        expect(Rails.cache).to receive(:write).with(
+          "conversation_viewed/#{conversation.id}/#{user.id}", true, expires_in: 60.seconds
+        )
+
+        described_class.new(conversation: conversation, user: user).perform
+      end
+    end
+
+    context 'when the conversation was viewed within the throttle window' do
+      before do
+        allow(Rails.cache).to receive(:read).and_return(true)
+      end
+
+      it 'does not dispatch the event' do
+        expect(Rails.configuration.dispatcher).not_to receive(:dispatch)
+
+        described_class.new(conversation: conversation, user: user).perform
+      end
+    end
+  end
+end

--- a/spec/services/conversations/viewed_service_spec.rb
+++ b/spec/services/conversations/viewed_service_spec.rb
@@ -7,10 +7,9 @@ RSpec.describe Conversations::ViewedService do
   let!(:user) { create(:user, account: account) }
 
   describe '#perform' do
-    context 'when the conversation was not viewed within the throttle window' do
+    context 'when the throttle key can be claimed' do
       before do
-        allow(Rails.cache).to receive(:read).and_return(nil)
-        allow(Rails.cache).to receive(:write)
+        allow(Redis::Alfred).to receive(:set).and_return('OK')
       end
 
       it 'dispatches the conversation.viewed event' do
@@ -24,20 +23,20 @@ RSpec.describe Conversations::ViewedService do
         described_class.new(conversation: conversation, user: user).perform
       end
 
-      it 'stores the throttle key' do
+      it 'claims the throttle key atomically' do
         allow(Rails.configuration.dispatcher).to receive(:dispatch)
 
-        expect(Rails.cache).to receive(:write).with(
-          "conversation_viewed/#{conversation.id}/#{user.id}", true, expires_in: 60.seconds
+        expect(Redis::Alfred).to receive(:set).with(
+          "conversation_viewed/#{conversation.id}/#{user.id}", true, nx: true, ex: 60
         )
 
         described_class.new(conversation: conversation, user: user).perform
       end
     end
 
-    context 'when the conversation was viewed within the throttle window' do
+    context 'when the throttle key is already claimed' do
       before do
-        allow(Rails.cache).to receive(:read).and_return(true)
+        allow(Redis::Alfred).to receive(:set).and_return(nil)
       end
 
       it 'does not dispatch the event' do

--- a/spec/services/conversations/viewed_service_spec.rb
+++ b/spec/services/conversations/viewed_service_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Conversations::ViewedService do
-  let(:account) { create(:account) }
-  let(:inbox) { create(:inbox, account: account) }
-  let(:conversation) { create(:conversation, account: account, inbox: inbox) }
-  let(:user) { create(:user, account: account) }
+  let!(:account) { create(:account) }
+  let!(:inbox) { create(:inbox, account: account) }
+  let!(:conversation) { create(:conversation, account: account, inbox: inbox) }
+  let!(:user) { create(:user, account: account) }
 
   describe '#perform' do
     context 'when the conversation was not viewed within the throttle window' do

--- a/swagger/definitions/request/webhooks/create_update_payload.yml
+++ b/swagger/definitions/request/webhooks/create_update_payload.yml
@@ -14,6 +14,7 @@ properties:
       enum:
         [
           'conversation_created',
+          'conversation_viewed',
           'conversation_status_changed',
           'conversation_updated',
           'message_created',

--- a/swagger/definitions/resource/webhook.yml
+++ b/swagger/definitions/resource/webhook.yml
@@ -15,6 +15,7 @@ properties:
       type: string
       enum: [
         "conversation_created",
+        "conversation_viewed",
         "conversation_status_changed",
         "conversation_updated",
         "contact_created",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -11509,6 +11509,7 @@
               "type": "string",
               "enum": [
                 "conversation_created",
+                "conversation_viewed",
                 "conversation_status_changed",
                 "conversation_updated",
                 "contact_created",
@@ -14462,6 +14463,7 @@
               "type": "string",
               "enum": [
                 "conversation_created",
+                "conversation_viewed",
                 "conversation_status_changed",
                 "conversation_updated",
                 "message_created",

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -10016,6 +10016,7 @@
               "type": "string",
               "enum": [
                 "conversation_created",
+                "conversation_viewed",
                 "conversation_status_changed",
                 "conversation_updated",
                 "contact_created",
@@ -12959,6 +12960,7 @@
               "type": "string",
               "enum": [
                 "conversation_created",
+                "conversation_viewed",
                 "conversation_status_changed",
                 "conversation_updated",
                 "message_created",

--- a/swagger/tag_groups/client_swagger.json
+++ b/swagger/tag_groups/client_swagger.json
@@ -2183,6 +2183,7 @@
               "type": "string",
               "enum": [
                 "conversation_created",
+                "conversation_viewed",
                 "conversation_status_changed",
                 "conversation_updated",
                 "contact_created",
@@ -5126,6 +5127,7 @@
               "type": "string",
               "enum": [
                 "conversation_created",
+                "conversation_viewed",
                 "conversation_status_changed",
                 "conversation_updated",
                 "message_created",

--- a/swagger/tag_groups/other_swagger.json
+++ b/swagger/tag_groups/other_swagger.json
@@ -1598,6 +1598,7 @@
               "type": "string",
               "enum": [
                 "conversation_created",
+                "conversation_viewed",
                 "conversation_status_changed",
                 "conversation_updated",
                 "contact_created",
@@ -4541,6 +4542,7 @@
               "type": "string",
               "enum": [
                 "conversation_created",
+                "conversation_viewed",
                 "conversation_status_changed",
                 "conversation_updated",
                 "message_created",

--- a/swagger/tag_groups/platform_swagger.json
+++ b/swagger/tag_groups/platform_swagger.json
@@ -2359,6 +2359,7 @@
               "type": "string",
               "enum": [
                 "conversation_created",
+                "conversation_viewed",
                 "conversation_status_changed",
                 "conversation_updated",
                 "contact_created",
@@ -5302,6 +5303,7 @@
               "type": "string",
               "enum": [
                 "conversation_created",
+                "conversation_viewed",
                 "conversation_status_changed",
                 "conversation_updated",
                 "message_created",


### PR DESCRIPTION
## Description

Fires a `conversation.viewed` event when an agent opens a conversation,
exposing it to webhooks, agent bots and automation rules. Views are
throttled to once per 60 seconds per agent and conversation.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Open a conversation as an agent -> the `conversation.viewed` event is dispatched.
- Subscribe a webhook to `conversation_viewed` -> the payload includes `viewed_by_agent`.
- Create an automation rule on "Conversation Viewed" -> it runs on view.
- Added request, service, listener and frontend specs.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works