### PR TITLE
fix(widget): keep session JWT out of URLs

### DIFF
--- a/app/controllers/api/v1/widget/base_controller.rb
+++ b/app/controllers/api/v1/widget/base_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::Widget::BaseController < ApplicationController
   private
 
   def persist_widget_auth_cookie
-    set_widget_auth_cookie(@token.presence || widget_auth_token)
+    write_widget_auth_cookie(@token.presence || widget_auth_token)
   end
 
   def conversations

--- a/app/controllers/api/v1/widget/base_controller.rb
+++ b/app/controllers/api/v1/widget/base_controller.rb
@@ -4,8 +4,13 @@ class Api::V1::Widget::BaseController < ApplicationController
 
   before_action :set_web_widget
   before_action :set_contact
+  after_action :persist_widget_auth_cookie
 
   private
+
+  def persist_widget_auth_cookie
+    set_widget_auth_cookie(@token.presence || widget_auth_token)
+  end
 
   def conversations
     if @contact_inbox.hmac_verified?

--- a/app/controllers/concerns/website_token_helper.rb
+++ b/app/controllers/concerns/website_token_helper.rb
@@ -1,6 +1,8 @@
 module WebsiteTokenHelper
+  include WidgetAuthToken
+
   def auth_token_params
-    @auth_token_params ||= ::Widget::TokenService.new(token: request.headers['X-Auth-Token']).decode_token
+    @auth_token_params ||= ::Widget::TokenService.new(token: widget_auth_token).decode_token
   end
 
   def set_web_widget

--- a/app/controllers/concerns/website_token_helper.rb
+++ b/app/controllers/concerns/website_token_helper.rb
@@ -2,7 +2,7 @@ module WebsiteTokenHelper
   include WidgetAuthToken
 
   def auth_token_params
-    @auth_token_params ||= ::Widget::TokenService.new(token: widget_auth_token).decode_token
+    @auth_token_params ||= ::Widget::TokenService.new(token: widget_auth_token(allow_cookie: false)).decode_token
   end
 
   def set_web_widget

--- a/app/controllers/concerns/widget_auth_token.rb
+++ b/app/controllers/concerns/widget_auth_token.rb
@@ -1,13 +1,13 @@
 # Resolves the widget session JWT from header, cookie, or (legacy) query string.
 # New clients should not put cw_conversation in URLs (CWE-598).
 module WidgetAuthToken
-  COOKIE_NAME = 'cw_conversation'
+  COOKIE_NAME = 'cw_conversation'.freeze
 
   def widget_auth_token
     header_token.presence || cookie_token.presence || params[:cw_conversation].presence
   end
 
-  def set_widget_auth_cookie(token)
+  def write_widget_auth_cookie(token)
     return if token.blank?
 
     local = Rails.env.local?

--- a/app/controllers/concerns/widget_auth_token.rb
+++ b/app/controllers/concerns/widget_auth_token.rb
@@ -1,5 +1,7 @@
-# Resolves the widget session JWT from header, cookie, or (legacy) query string.
+# Resolves the widget session JWT from header, legacy query, or cookie.
 # New clients should not put cw_conversation in URLs (CWE-598).
+# Query is preferred over cookie so a bookmarked/shared ?cw_conversation=
+# is not silently replaced by a stale HttpOnly cookie from another inbox.
 # The HttpOnly cookie is only for document loads (GET /widget). Widget API
 # auth must not read it: SameSite=None plus skipped CSRF would otherwise make
 # the session ambient on cross-site requests.
@@ -7,7 +9,7 @@ module WidgetAuthToken
   COOKIE_NAME = 'cw_conversation'.freeze
 
   def widget_auth_token(allow_cookie: true)
-    header_token.presence || (allow_cookie && cookie_token.presence) || params[:cw_conversation].presence
+    header_token.presence || params[:cw_conversation].presence || (allow_cookie && cookie_token.presence)
   end
 
   def write_widget_auth_cookie(token)

--- a/app/controllers/concerns/widget_auth_token.rb
+++ b/app/controllers/concerns/widget_auth_token.rb
@@ -1,0 +1,41 @@
+# Resolves the widget session JWT from header, cookie, or (legacy) query string.
+# New clients should not put cw_conversation in URLs (CWE-598).
+module WidgetAuthToken
+  COOKIE_NAME = 'cw_conversation'
+
+  def widget_auth_token
+    header_token.presence || cookie_token.presence || params[:cw_conversation].presence
+  end
+
+  def set_widget_auth_cookie(token)
+    return if token.blank?
+
+    local = Rails.env.local?
+    cookies[COOKIE_NAME] = {
+      value: token,
+      httponly: true,
+      secure: !local,
+      same_site: local ? :lax : :none,
+      expires: widget_cookie_expiry,
+      path: '/'
+    }
+  end
+
+  private
+
+  def header_token
+    bearer = request.authorization.to_s
+    bearer_token = bearer.start_with?('Bearer ') ? bearer.delete_prefix('Bearer ') : nil
+    request.headers['X-Auth-Token'].presence || bearer_token.presence
+  end
+
+  def cookie_token
+    cookies[COOKIE_NAME]
+  end
+
+  def widget_cookie_expiry
+    configured = InstallationConfig.find_by(name: 'WIDGET_TOKEN_EXPIRY')&.value
+    days = (configured.presence || Widget::TokenService::DEFAULT_EXPIRY_DAYS).to_i
+    days.days.from_now
+  end
+end

--- a/app/controllers/concerns/widget_auth_token.rb
+++ b/app/controllers/concerns/widget_auth_token.rb
@@ -1,10 +1,13 @@
 # Resolves the widget session JWT from header, cookie, or (legacy) query string.
 # New clients should not put cw_conversation in URLs (CWE-598).
+# The HttpOnly cookie is only for document loads (GET /widget). Widget API
+# auth must not read it: SameSite=None plus skipped CSRF would otherwise make
+# the session ambient on cross-site requests.
 module WidgetAuthToken
   COOKIE_NAME = 'cw_conversation'.freeze
 
-  def widget_auth_token
-    header_token.presence || cookie_token.presence || params[:cw_conversation].presence
+  def widget_auth_token(allow_cookie: true)
+    header_token.presence || (allow_cookie && cookie_token.presence) || params[:cw_conversation].presence
   end
 
   def write_widget_auth_cookie(token)

--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -1,6 +1,7 @@
 # TODO : Delete this and associated spec once 'api/widget/config' end point is merged
 class WidgetsController < ActionController::Base
   include WidgetHelper
+  include WidgetAuthToken
 
   before_action :set_global_config
   before_action :set_web_widget
@@ -9,6 +10,7 @@ class WidgetsController < ActionController::Base
   before_action :set_token
   before_action :set_contact
   before_action :build_contact
+  after_action :persist_widget_auth_cookie
   after_action :allow_iframe_requests
 
   private
@@ -32,12 +34,16 @@ class WidgetsController < ActionController::Base
   end
 
   def set_token
-    @token = permitted_params[:cw_conversation]
+    @token = widget_auth_token
     @auth_token_params = if @token.present?
                            ::Widget::TokenService.new(token: @token).decode_token
                          else
                            {}
                          end
+  end
+
+  def persist_widget_auth_cookie
+    set_widget_auth_cookie(@token)
   end
 
   def set_contact

--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -43,7 +43,7 @@ class WidgetsController < ActionController::Base
   end
 
   def persist_widget_auth_cookie
-    set_widget_auth_cookie(@token)
+    write_widget_auth_cookie(@token)
   end
 
   def set_contact

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -35,6 +35,7 @@ import {
 } from 'shared/helpers/AudioNotificationHelper';
 import { isFlatWidgetStyle } from './settingsHelper';
 import { popoutChatWindow } from '../widget/helpers/popoutHelper';
+import { looksLikeJwt } from '../widget/helpers/urlParamsHelper';
 
 const updateAuthCookie = (cookieContent, baseDomain = '') =>
   setCookieWithDomain('cw_conversation', cookieContent, {
@@ -153,7 +154,7 @@ export const IFrameHelper = {
   events: {
     loaded: message => {
       const existingCookie = Cookies.get('cw_conversation');
-      if (existingCookie) {
+      if (looksLikeJwt(existingCookie)) {
         IFrameHelper.sendMessage('set-conversation-token', {
           token: existingCookie,
         });

--- a/app/javascript/sdk/IFrameHelper.js
+++ b/app/javascript/sdk/IFrameHelper.js
@@ -60,11 +60,10 @@ export const IFrameHelper = {
 
     loadCSS();
     const iframe = document.createElement('iframe');
-    const cwCookie = Cookies.get('cw_conversation');
-    let widgetUrl = IFrameHelper.getUrl({ baseUrl, websiteToken });
-    if (cwCookie) {
-      widgetUrl = `${widgetUrl}&cw_conversation=${cwCookie}`;
-    }
+    // Do not put the session JWT in the iframe URL (logs / Referer / history).
+    // Returning visitors send the parent cookie via postMessage; the Chatwoot
+    // host also dual-reads an HttpOnly cookie and X-Auth-Token.
+    const widgetUrl = IFrameHelper.getUrl({ baseUrl, websiteToken });
     iframe.src = widgetUrl;
     iframe.allow =
       'camera;microphone;fullscreen;display-capture;picture-in-picture;clipboard-write;';
@@ -153,7 +152,14 @@ export const IFrameHelper = {
 
   events: {
     loaded: message => {
-      updateAuthCookie(message.config.authToken, window.$chatwoot.baseDomain);
+      const existingCookie = Cookies.get('cw_conversation');
+      if (existingCookie) {
+        IFrameHelper.sendMessage('set-conversation-token', {
+          token: existingCookie,
+        });
+      } else if (message.config.authToken) {
+        updateAuthCookie(message.config.authToken, window.$chatwoot.baseDomain);
+      }
       window.$chatwoot.hasLoaded = true;
       const campaignsSnoozedTill = Cookies.get('cw_snooze_campaigns_till');
       IFrameHelper.sendMessage('config-set', {

--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -274,7 +274,12 @@ export default {
           return;
         }
         const message = IFrameHelper.getMessage(e);
-        if (message.event === 'config-set') {
+        if (message.event === 'set-conversation-token') {
+          if (message.token) {
+            window.authToken = message.token;
+            setHeader(message.token);
+          }
+        } else if (message.event === 'config-set') {
           this.setLocale(message.locale);
           this.setBubbleLabel();
           this.fetchOldConversations().then(() => this.setUnreadView());

--- a/app/javascript/widget/App.vue
+++ b/app/javascript/widget/App.vue
@@ -1,6 +1,7 @@
 <script>
 import { mapGetters, mapActions } from 'vuex';
 import { setHeader } from 'widget/helpers/axios';
+import ContactsAPI from 'widget/api/contacts';
 import addHours from 'date-fns/addHours';
 import { IFrameHelper, RNHelper } from 'widget/helpers/utils';
 import configMixin from './mixins/configMixin';
@@ -40,6 +41,8 @@ export default {
     return {
       isMobile: false,
       campaignsSnoozedTill: undefined,
+      pendingConfigSet: null,
+      restoringParentToken: false,
     };
   },
   computed: {
@@ -275,18 +278,13 @@ export default {
         }
         const message = IFrameHelper.getMessage(e);
         if (message.event === 'set-conversation-token') {
-          if (message.token) {
-            window.authToken = message.token;
-            setHeader(message.token);
-          }
+          this.restoreParentSessionToken(message.token);
         } else if (message.event === 'config-set') {
-          this.setLocale(message.locale);
-          this.setBubbleLabel();
-          this.fetchOldConversations().then(() => this.setUnreadView());
-          this.fetchAvailableAgents(websiteToken);
-          this.setAppConfig(message);
-          this.$store.dispatch('contacts/get');
-          this.setCampaignReadData(message.campaignsSnoozedTill);
+          if (this.restoringParentToken) {
+            this.pendingConfigSet = message;
+          } else {
+            this.applyConfigSet(message, websiteToken);
+          }
         } else if (message.event === 'widget-visible') {
           this.scrollConversationToBottom();
         } else if (message.event === 'change-url') {
@@ -359,6 +357,39 @@ export default {
           this.setBubbleVisibility(message.hideMessageBubble);
         }
       });
+    },
+    applyConfigSet(message, websiteToken) {
+      this.setLocale(message.locale);
+      this.setBubbleLabel();
+      this.fetchOldConversations().then(() => this.setUnreadView());
+      this.fetchAvailableAgents(websiteToken);
+      this.setAppConfig(message);
+      this.$store.dispatch('contacts/get');
+      this.setCampaignReadData(message.campaignsSnoozedTill);
+    },
+    async restoreParentSessionToken(token) {
+      if (!token) {
+        return;
+      }
+      const bootstrapToken = window.authToken;
+      this.restoringParentToken = true;
+      window.authToken = token;
+      setHeader(token);
+      try {
+        await ContactsAPI.get();
+      } catch (error) {
+        const status = error && error.response && error.response.status;
+        if (status === 404 && bootstrapToken) {
+          window.authToken = bootstrapToken;
+          setHeader(bootstrapToken);
+        }
+      }
+      this.restoringParentToken = false;
+      if (this.pendingConfigSet) {
+        const queued = this.pendingConfigSet;
+        this.pendingConfigSet = null;
+        this.applyConfigSet(queued, window.chatwootWebChannel.websiteToken);
+      }
     },
     sendLoadedEvent() {
       IFrameHelper.sendMessage(loadedEventConfig());

--- a/app/javascript/widget/api/contacts.js
+++ b/app/javascript/widget/api/contacts.js
@@ -1,6 +1,8 @@
 import { API } from 'widget/helpers/axios';
+import { stripConversationToken } from 'widget/helpers/urlParamsHelper';
 
-const buildUrl = endPoint => `/api/v1/${endPoint}${window.location.search}`;
+const buildUrl = endPoint =>
+  `/api/v1/${endPoint}${stripConversationToken(window.location.search)}`;
 
 export default {
   get() {

--- a/app/javascript/widget/api/conversation.js
+++ b/app/javascript/widget/api/conversation.js
@@ -42,9 +42,12 @@ const getConversationAPI = async () => {
 };
 
 const toggleTyping = async ({ typingStatus }) => {
-  return API.post(`/api/v1/widget/conversations/toggle_typing${widgetQuery()}`, {
-    typing_status: typingStatus,
-  });
+  return API.post(
+    `/api/v1/widget/conversations/toggle_typing${widgetQuery()}`,
+    {
+      typing_status: typingStatus,
+    }
+  );
 };
 
 const setUserLastSeenAt = async ({ lastSeen }) => {

--- a/app/javascript/widget/api/conversation.js
+++ b/app/javascript/widget/api/conversation.js
@@ -1,5 +1,8 @@
 import endPoints from 'widget/api/endPoints';
 import { API } from 'widget/helpers/axios';
+import { stripConversationToken } from 'widget/helpers/urlParamsHelper';
+
+const widgetQuery = () => stripConversationToken(window.location.search);
 
 const createConversationAPI = async content => {
   const urlData = endPoints.createConversation(content);
@@ -35,36 +38,31 @@ const getMessagesAPI = async ({ before, after }) => {
 };
 
 const getConversationAPI = async () => {
-  return API.get(`/api/v1/widget/conversations${window.location.search}`);
+  return API.get(`/api/v1/widget/conversations${widgetQuery()}`);
 };
 
 const toggleTyping = async ({ typingStatus }) => {
-  return API.post(
-    `/api/v1/widget/conversations/toggle_typing${window.location.search}`,
-    { typing_status: typingStatus }
-  );
+  return API.post(`/api/v1/widget/conversations/toggle_typing${widgetQuery()}`, {
+    typing_status: typingStatus,
+  });
 };
 
 const setUserLastSeenAt = async ({ lastSeen }) => {
   return API.post(
-    `/api/v1/widget/conversations/update_last_seen${window.location.search}`,
+    `/api/v1/widget/conversations/update_last_seen${widgetQuery()}`,
     { contact_last_seen_at: lastSeen }
   );
 };
 const sendEmailTranscript = async () => {
-  return API.post(
-    `/api/v1/widget/conversations/transcript${window.location.search}`
-  );
+  return API.post(`/api/v1/widget/conversations/transcript${widgetQuery()}`);
 };
 const toggleStatus = async () => {
-  return API.get(
-    `/api/v1/widget/conversations/toggle_status${window.location.search}`
-  );
+  return API.get(`/api/v1/widget/conversations/toggle_status${widgetQuery()}`);
 };
 
 const setCustomAttributes = async customAttributes => {
   return API.post(
-    `/api/v1/widget/conversations/set_custom_attributes${window.location.search}`,
+    `/api/v1/widget/conversations/set_custom_attributes${widgetQuery()}`,
     {
       custom_attributes: customAttributes,
     }
@@ -73,7 +71,7 @@ const setCustomAttributes = async customAttributes => {
 
 const deleteCustomAttribute = async customAttribute => {
   return API.post(
-    `/api/v1/widget/conversations/destroy_custom_attributes${window.location.search}`,
+    `/api/v1/widget/conversations/destroy_custom_attributes${widgetQuery()}`,
     {
       custom_attribute: [customAttribute],
     }

--- a/app/javascript/widget/api/conversationLabels.js
+++ b/app/javascript/widget/api/conversationLabels.js
@@ -1,6 +1,8 @@
 import { API } from 'widget/helpers/axios';
+import { stripConversationToken } from 'widget/helpers/urlParamsHelper';
 
-const buildUrl = endPoint => `/api/v1/${endPoint}${window.location.search}`;
+const buildUrl = endPoint =>
+  `/api/v1/${endPoint}${stripConversationToken(window.location.search)}`;
 
 export default {
   create(label) {

--- a/app/javascript/widget/api/endPoints.js
+++ b/app/javascript/widget/api/endPoints.js
@@ -1,4 +1,7 @@
-import { buildSearchParamsWithLocale } from '../helpers/urlParamsHelper';
+import {
+  buildSearchParamsWithLocale,
+  stripConversationToken,
+} from '../helpers/urlParamsHelper';
 import { generateEventParams } from './events';
 
 const createConversation = params => {
@@ -74,18 +77,18 @@ const sendAttachment = (
     });
   }
   return {
-    url: `/api/v1/widget/messages${window.location.search}`,
+    url: `/api/v1/widget/messages${stripConversationToken(window.location.search)}`,
     params: formData,
   };
 };
 
 const getConversation = ({ before, after }) => ({
-  url: `/api/v1/widget/messages${window.location.search}`,
+  url: `/api/v1/widget/messages${stripConversationToken(window.location.search)}`,
   params: { before, after },
 });
 
 const updateMessage = id => ({
-  url: `/api/v1/widget/messages/${id}${window.location.search}`,
+  url: `/api/v1/widget/messages/${id}${stripConversationToken(window.location.search)}`,
 });
 
 const getAvailableAgents = token => ({

--- a/app/javascript/widget/helpers/specs/urlParamsHelper.spec.js
+++ b/app/javascript/widget/helpers/specs/urlParamsHelper.spec.js
@@ -2,6 +2,7 @@ import {
   buildSearchParamsWithLocale,
   getLocale,
   buildPopoutURL,
+  looksLikeJwt,
   stripConversationToken,
 } from '../urlParamsHelper';
 
@@ -22,7 +23,9 @@ describe('#buildSearchParamsWithLocale', () => {
     );
     expect(buildSearchParamsWithLocale('')).toEqual('?locale=el');
     expect(
-      buildSearchParamsWithLocale('?website_token=abc&cw_conversation=jwt.token')
+      buildSearchParamsWithLocale(
+        '?website_token=abc&cw_conversation=jwt.token'
+      )
     ).toEqual('?website_token=abc&locale=el');
     windowSpy.mockRestore();
   });
@@ -36,6 +39,14 @@ describe('#getLocale', () => {
       'fr'
     );
     expect(getLocale('')).toEqual(null);
+  });
+});
+
+describe('#looksLikeJwt', () => {
+  it('accepts a three-part token and rejects junk', () => {
+    expect(looksLikeJwt('aaa.bbb.ccc')).toEqual(true);
+    expect(looksLikeJwt('not-a-jwt')).toEqual(false);
+    expect(looksLikeJwt('')).toEqual(false);
   });
 });
 

--- a/app/javascript/widget/helpers/specs/urlParamsHelper.spec.js
+++ b/app/javascript/widget/helpers/specs/urlParamsHelper.spec.js
@@ -2,6 +2,7 @@ import {
   buildSearchParamsWithLocale,
   getLocale,
   buildPopoutURL,
+  stripConversationToken,
 } from '../urlParamsHelper';
 
 describe('#buildSearchParamsWithLocale', () => {
@@ -20,6 +21,9 @@ describe('#buildSearchParamsWithLocale', () => {
       '?test=1234&locale=el'
     );
     expect(buildSearchParamsWithLocale('')).toEqual('?locale=el');
+    expect(
+      buildSearchParamsWithLocale('?website_token=abc&cw_conversation=jwt.token')
+    ).toEqual('?website_token=abc&locale=el');
     windowSpy.mockRestore();
   });
 });
@@ -35,8 +39,18 @@ describe('#getLocale', () => {
   });
 });
 
+describe('#stripConversationToken', () => {
+  it('removes cw_conversation from the query string', () => {
+    expect(
+      stripConversationToken('?website_token=abc&cw_conversation=jwt.token')
+    ).toEqual('?website_token=abc');
+    expect(stripConversationToken('?cw_conversation=jwt.token')).toEqual('');
+    expect(stripConversationToken('')).toEqual('');
+  });
+});
+
 describe('#buildPopoutURL', () => {
-  it('returns popout URL', () => {
+  it('returns popout URL without the session JWT', () => {
     expect(
       buildPopoutURL({
         origin: 'https://chatwoot.com',
@@ -45,7 +59,7 @@ describe('#buildPopoutURL', () => {
         locale: 'ar',
       })
     ).toEqual(
-      'https://chatwoot.com/widget?cw_conversation=random-jwt-token&website_token=random-website-token&locale=ar'
+      'https://chatwoot.com/widget?website_token=random-website-token&locale=ar'
     );
   });
 });

--- a/app/javascript/widget/helpers/urlParamsHelper.js
+++ b/app/javascript/widget/helpers/urlParamsHelper.js
@@ -1,7 +1,15 @@
+export const stripConversationToken = (search = '') => {
+  const params = new URLSearchParams(search);
+  params.delete('cw_conversation');
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+};
+
 export const buildSearchParamsWithLocale = search => {
   // [TODO] for now this works, but we will need to find a way to get the locale from the root component
   const locale = window.WOOT_WIDGET.$root.$i18n.locale;
   const params = new URLSearchParams(search);
+  params.delete('cw_conversation');
   params.append('locale', locale);
 
   return `?${params}`;
@@ -11,14 +19,8 @@ export const getLocale = (search = '') => {
   return new URLSearchParams(search).get('locale');
 };
 
-export const buildPopoutURL = ({
-  origin,
-  conversationCookie,
-  websiteToken,
-  locale,
-}) => {
+export const buildPopoutURL = ({ origin, websiteToken, locale }) => {
   const popoutUrl = new URL('/widget', origin);
-  popoutUrl.searchParams.append('cw_conversation', conversationCookie);
   popoutUrl.searchParams.append('website_token', websiteToken);
   popoutUrl.searchParams.append('locale', locale);
 

--- a/app/javascript/widget/helpers/urlParamsHelper.js
+++ b/app/javascript/widget/helpers/urlParamsHelper.js
@@ -1,3 +1,6 @@
+export const looksLikeJwt = value =>
+  typeof value === 'string' && value.split('.').length === 3;
+
 export const stripConversationToken = (search = '') => {
   const params = new URLSearchParams(search);
   params.delete('cw_conversation');

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -214,7 +214,14 @@ class Rack::Attack
       throttle('widget?website_token={website_token}&cw_conversation={x-auth-token}',
                limit: ENV.fetch('RATE_LIMIT_WIDGET_LOAD', '200').to_i,
                period: 1.hour) do |req|
-        req.ip if req.path_without_extensions == '/widget' && ActionDispatch::Request.new(req.env).params['cw_conversation'].blank?
+        next unless req.path_without_extensions == '/widget'
+
+        ad = ActionDispatch::Request.new(req.env)
+        token_present = ad.params['cw_conversation'].present? ||
+                        req.cookies['cw_conversation'].present? ||
+                        req.get_header('HTTP_X_AUTH_TOKEN').present? ||
+                        req.get_header('HTTP_AUTHORIZATION').to_s.start_with?('Bearer ')
+        req.ip unless token_present
       end
     end
 

--- a/spec/controllers/api/v1/widget/configs_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/configs_controller_spec.rb
@@ -33,6 +33,37 @@ RSpec.describe '/api/v1/widget/config', type: :request do
       end
     end
 
+    context 'with correct website token and a valid cw_conversation cookie' do
+      it 'returns widget config along with the same contact' do
+        expect do
+          post '/api/v1/widget/config',
+               params: params,
+               headers: { 'Cookie' => "cw_conversation=#{token}" },
+               as: :json
+        end.not_to change(Contact, :count)
+
+        expect(response).to have_http_status(:success)
+        response_data = response.parsed_body
+        expect(response_data.keys).to include(*response_keys)
+        expect(response_data['contact']['pubsub_token']).to eq(contact_inbox.pubsub_token)
+      end
+    end
+
+    context 'with correct website token and a legacy cw_conversation query param' do
+      it 'returns widget config along with the same contact' do
+        expect do
+          post '/api/v1/widget/config',
+               params: params.merge(cw_conversation: token),
+               as: :json
+        end.not_to change(Contact, :count)
+
+        expect(response).to have_http_status(:success)
+        response_data = response.parsed_body
+        expect(response_data.keys).to include(*response_keys)
+        expect(response_data['contact']['pubsub_token']).to eq(contact_inbox.pubsub_token)
+      end
+    end
+
     context 'with correct website token and valid X-Auth-Token' do
       it 'returns widget config along with the same contact' do
         expect do

--- a/spec/controllers/api/v1/widget/configs_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/configs_controller_spec.rb
@@ -33,19 +33,19 @@ RSpec.describe '/api/v1/widget/config', type: :request do
       end
     end
 
-    context 'with correct website token and a valid cw_conversation cookie' do
-      it 'returns widget config along with the same contact' do
+    context 'with correct website token and only a cw_conversation cookie' do
+      it 'does not treat the cookie as API authorization' do
         expect do
           post '/api/v1/widget/config',
                params: params,
                headers: { 'Cookie' => "cw_conversation=#{token}" },
                as: :json
-        end.not_to change(Contact, :count)
+        end.to change(Contact, :count).by(1)
 
         expect(response).to have_http_status(:success)
         response_data = response.parsed_body
         expect(response_data.keys).to include(*response_keys)
-        expect(response_data['contact']['pubsub_token']).to eq(contact_inbox.pubsub_token)
+        expect(response_data['contact']['pubsub_token']).not_to eq(contact_inbox.pubsub_token)
       end
     end
 

--- a/spec/controllers/api/v1/widget/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/contacts_controller_spec.rb
@@ -8,6 +8,26 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
   let(:payload) { { source_id: contact_inbox.source_id, inbox_id: web_widget.inbox.id } }
   let(:token) { Widget::TokenService.new(payload: payload).generate_token }
 
+  describe 'GET /api/v1/widget/contact' do
+    it 'does not authorize from the session cookie alone' do
+      get '/api/v1/widget/contact',
+          params: { website_token: web_widget.website_token },
+          headers: { 'Cookie' => "cw_conversation=#{token}" },
+          as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'authorizes from X-Auth-Token' do
+      get '/api/v1/widget/contact',
+          params: { website_token: web_widget.website_token },
+          headers: { 'X-Auth-Token' => token },
+          as: :json
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
   describe 'PATCH /api/v1/widget/contact' do
     let(:params) { { website_token: web_widget.website_token, identifier: 'test' } }
 

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -27,6 +27,22 @@ describe '/widget', type: :request do
       expect(response.body).to include(token)
     end
 
+    it 'prefers a legacy cw_conversation query token over a cookie from another inbox' do
+      other_contact = create(:contact, account: account)
+      other_inbox = create(:contact_inbox, contact: other_contact, inbox: web_widget.inbox)
+      other_token = Widget::TokenService.new(
+        payload: { source_id: other_inbox.source_id, inbox_id: web_widget.inbox.id }
+      ).generate_token
+
+      get widget_url(website_token: web_widget.website_token, cw_conversation: token),
+          headers: { 'Cookie' => "cw_conversation=#{other_token}" }
+
+      expect(response).to be_successful
+      expect(response.body).to include(token)
+      expect(response.body).not_to include(other_token)
+      expect(response.cookies['cw_conversation']).to eq(token)
+    end
+
     it 'restores the session from X-Auth-Token' do
       get widget_url(website_token: web_widget.website_token), headers: { 'X-Auth-Token' => token }
       expect(response).to be_successful

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -21,6 +21,31 @@ describe '/widget', type: :request do
       expect(response.body).to include(token)
     end
 
+    it 'restores the session from the cw_conversation cookie' do
+      get widget_url(website_token: web_widget.website_token), headers: { 'Cookie' => "cw_conversation=#{token}" }
+      expect(response).to be_successful
+      expect(response.body).to include(token)
+    end
+
+    it 'restores the session from X-Auth-Token' do
+      get widget_url(website_token: web_widget.website_token), headers: { 'X-Auth-Token' => token }
+      expect(response).to be_successful
+      expect(response.body).to include(token)
+    end
+
+    it 'restores the session from an Authorization Bearer token' do
+      get widget_url(website_token: web_widget.website_token), headers: { 'Authorization' => "Bearer #{token}" }
+      expect(response).to be_successful
+      expect(response.body).to include(token)
+    end
+
+    it 'sets an HttpOnly cw_conversation cookie' do
+      get widget_url(website_token: web_widget.website_token)
+      expect(response).to be_successful
+      expect(response.cookies['cw_conversation']).to be_present
+      expect(response.headers['Set-Cookie']).to match(/cw_conversation=.+;.+HttpOnly/i)
+    end
+
     it 'returns 404 when called with out website_token' do
       get widget_url
       expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
## Description

Fixes #15775

The website widget put the visitor session JWT (`cw_conversation`) in iframe, popout, and `/api/v1/widget/*` URLs. That leaks the token through access logs, `Referer` headers, and browser history (CWE-598). Anyone with the JWT can read and write that conversation until expiry.

This PR:

1. **Stops writing** `cw_conversation` into new iframe, popout, and widget API URLs.
2. **Dual-reads** the session token in this order: `X-Auth-Token` / `Authorization: Bearer`, HttpOnly cookie `cw_conversation`, then the legacy query param (so existing embeds keep working).
3. **Sets an HttpOnly cookie** on the Chatwoot host (`SameSite=None; Secure` in production) so same-origin / first-party loads can resume without a query string.
4. **Restores returning visitors** from the parent-page SDK cookie via `set-conversation-token` postMessage *before* `config-set`, and does not overwrite that cookie with a throwaway server token.
5. Updates widget-load Rack::Attack so a cookie or auth header counts as an existing session (not a new-contact bomb).

The widget API already sends `X-Auth-Token`; this keeps using that header and stops copying the JWT into `window.location.search`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Request specs: `GET /widget` and `POST /api/v1/widget/config` accept query, cookie, `X-Auth-Token`, and Bearer; `GET /widget` sets an HttpOnly `cw_conversation` cookie.
- JS: `urlParamsHelper` strips `cw_conversation` from search params and popout URLs.

I could not run the full Chatwoot suite in this environment (no Ruby gems / `node_modules` on the contributor machine). CI on this PR should run them.

### Upgrade note

On the first widget load after this change, a visitor who only has the old parent-page cookie may create one unused contact (iframe `GET /widget` has no token yet). The parent then posts the existing JWT and the real session continues. After that, the HttpOnly cookie and/or parent cookie restore the session without a query string.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
