### PR TITLE
fix(widget): rotate session token after sensitive contact writes

### DIFF
--- a/app/controllers/api/v1/widget/configs_controller.rb
+++ b/app/controllers/api/v1/widget/configs_controller.rb
@@ -19,9 +19,7 @@ class Api::V1::Widget::ConfigsController < Api::V1::Widget::BaseController
   end
 
   def set_contact
-    @contact_inbox = @web_widget.inbox.contact_inboxes.find_by(
-      source_id: auth_token_params[:source_id]
-    )
+    @contact_inbox = find_widget_contact_inbox
     @contact = @contact_inbox&.contact
   end
 
@@ -33,8 +31,7 @@ class Api::V1::Widget::ConfigsController < Api::V1::Widget::BaseController
   end
 
   def set_token
-    payload = { source_id: @contact_inbox.source_id, inbox_id: @web_widget.inbox.id }
-    @token = ::Widget::TokenService.new(payload: payload).generate_token
+    @token = ::Widget::TokenService.new(payload: ::Widget::TokenService.payload_for(@contact_inbox)).generate_token
   end
 
   def additional_attributes

--- a/app/controllers/api/v1/widget/contacts_controller.rb
+++ b/app/controllers/api/v1/widget/contacts_controller.rb
@@ -7,25 +7,29 @@ class Api::V1::Widget::ContactsController < Api::V1::Widget::BaseController
   def show; end
 
   def update
-    identify_contact(@contact)
-    rotate_widget_session_if_sensitive
+    return identify_contact(@contact) unless sensitive_contact_write?
+
+    @contact_inbox.with_current_widget_token(auth_token_params) do
+      identify_contact(@contact)
+      @widget_auth_token = @contact_inbox.rotate_widget_token!
+    end
   end
 
   def set_user
-    contact = nil
+    @contact_inbox.with_current_widget_token(auth_token_params) do
+      if a_different_contact?
+        @contact_inbox.invalidate_widget_token!
+        @contact_inbox, @widget_auth_token = build_contact_inbox_with_token(@web_widget)
+        contact = @contact_inbox.contact
+      else
+        contact = @contact
+        @widget_auth_token = @contact_inbox.rotate_widget_token!
+      end
 
-    if a_different_contact?
-      @contact_inbox.invalidate_widget_token!
-      @contact_inbox, @widget_auth_token = build_contact_inbox_with_token(@web_widget)
-      contact = @contact_inbox.contact
-    else
-      contact = @contact
-      @widget_auth_token = @contact_inbox.rotate_widget_token!
+      @contact_inbox.update(hmac_verified: true) if should_verify_hmac?
+
+      identify_contact(contact)
     end
-
-    @contact_inbox.update(hmac_verified: true) if should_verify_hmac?
-
-    identify_contact(contact)
   end
 
   # TODO : clean up this with proper routes delete contacts/custom_attributes
@@ -48,12 +52,6 @@ class Api::V1::Widget::ContactsController < Api::V1::Widget::BaseController
 
   def a_different_contact?
     @contact.identifier.present? && @contact.identifier != permitted_params[:identifier]
-  end
-
-  def rotate_widget_session_if_sensitive
-    return unless sensitive_contact_write?
-
-    @widget_auth_token = @contact_inbox.rotate_widget_token!
   end
 
   def sensitive_contact_write?

--- a/app/controllers/api/v1/widget/contacts_controller.rb
+++ b/app/controllers/api/v1/widget/contacts_controller.rb
@@ -8,16 +8,19 @@ class Api::V1::Widget::ContactsController < Api::V1::Widget::BaseController
 
   def update
     identify_contact(@contact)
+    rotate_widget_session_if_sensitive
   end
 
   def set_user
     contact = nil
 
     if a_different_contact?
+      @contact_inbox.invalidate_widget_token!
       @contact_inbox, @widget_auth_token = build_contact_inbox_with_token(@web_widget)
       contact = @contact_inbox.contact
     else
       contact = @contact
+      @widget_auth_token = @contact_inbox.rotate_widget_token!
     end
 
     @contact_inbox.update(hmac_verified: true) if should_verify_hmac?
@@ -45,6 +48,16 @@ class Api::V1::Widget::ContactsController < Api::V1::Widget::BaseController
 
   def a_different_contact?
     @contact.identifier.present? && @contact.identifier != permitted_params[:identifier]
+  end
+
+  def rotate_widget_session_if_sensitive
+    return unless sensitive_contact_write?
+
+    @widget_auth_token = @contact_inbox.rotate_widget_token!
+  end
+
+  def sensitive_contact_write?
+    %i[email name phone_number identifier].any? { |key| permitted_params[key].present? }
   end
 
   # The plain update endpoint is also used for anonymous prechat updates

--- a/app/controllers/concerns/website_token_helper.rb
+++ b/app/controllers/concerns/website_token_helper.rb
@@ -11,13 +11,20 @@ module WebsiteTokenHelper
   end
 
   def set_contact
-    @contact_inbox = @web_widget.inbox.contact_inboxes.find_by(
-      source_id: auth_token_params[:source_id]
-    )
+    @contact_inbox = find_widget_contact_inbox
     @contact = @contact_inbox&.contact
     raise ActiveRecord::RecordNotFound unless @contact
 
     Current.contact = @contact
+  end
+
+  def find_widget_contact_inbox
+    inbox = @web_widget.inbox.contact_inboxes.find_by(
+      source_id: auth_token_params[:source_id]
+    )
+    return unless inbox&.valid_widget_token?(auth_token_params)
+
+    inbox
   end
 
   def permitted_params

--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -47,8 +47,9 @@ class WidgetsController < ActionController::Base
       inbox_id: @web_widget.inbox.id,
       source_id: @auth_token_params[:source_id]
     )
+    return unless @contact_inbox&.valid_widget_token?(@auth_token_params)
 
-    @contact = @contact_inbox&.contact
+    @contact = @contact_inbox.contact
   end
 
   def build_contact

--- a/app/helpers/widget_helper.rb
+++ b/app/helpers/widget_helper.rb
@@ -1,8 +1,7 @@
 module WidgetHelper
   def build_contact_inbox_with_token(web_widget, additional_attributes = {})
     contact_inbox = web_widget.create_contact_inbox(additional_attributes)
-    payload = { source_id: contact_inbox.source_id, inbox_id: web_widget.inbox.id }
-    token = ::Widget::TokenService.new(payload: payload).generate_token
+    token = ::Widget::TokenService.new(payload: ::Widget::TokenService.payload_for(contact_inbox)).generate_token
 
     [contact_inbox, token]
   end

--- a/app/javascript/shared/helpers/BaseActionCableConnector.js
+++ b/app/javascript/shared/helpers/BaseActionCableConnector.js
@@ -28,6 +28,9 @@ class BaseActionCableConnector {
         },
         received: this.onReceived,
         disconnected: () => {
+          if (this.shuttingDown) {
+            return;
+          }
           BaseActionCableConnector.isDisconnected = true;
           this.onDisconnected();
           this.initReconnectTimer();
@@ -37,13 +40,10 @@ class BaseActionCableConnector {
     this.app = app;
     this.events = {};
     this.reconnectTimer = null;
+    this.presenceTimer = null;
+    this.presenceInterval = presenceInterval;
+    this.shuttingDown = false;
     this.isAValidEvent = () => true;
-    this.triggerPresenceInterval = () => {
-      setTimeout(() => {
-        this.subscription.updatePresence();
-        this.triggerPresenceInterval();
-      }, presenceInterval);
-    };
     this.triggerPresenceInterval();
   }
 
@@ -80,7 +80,28 @@ class BaseActionCableConnector {
   // eslint-disable-next-line class-methods-use-this
   onDisconnected = () => {};
 
+  triggerPresenceInterval = () => {
+    this.clearPresenceTimer();
+    this.presenceTimer = setTimeout(() => {
+      if (this.shuttingDown) {
+        return;
+      }
+      this.subscription.updatePresence();
+      this.triggerPresenceInterval();
+    }, this.presenceInterval);
+  };
+
+  clearPresenceTimer = () => {
+    if (this.presenceTimer) {
+      clearTimeout(this.presenceTimer);
+      this.presenceTimer = null;
+    }
+  };
+
   disconnect() {
+    this.shuttingDown = true;
+    this.clearReconnectTimer();
+    this.clearPresenceTimer();
     this.consumer.disconnect();
   }
 

--- a/app/javascript/widget/helpers/actionCable.js
+++ b/app/javascript/widget/helpers/actionCable.js
@@ -105,6 +105,9 @@ class ActionCableConnector extends BaseActionCableConnector {
     }
 
     if (window.actionCable) {
+      if (typeof window.actionCable.clearTimer === 'function') {
+        window.actionCable.clearTimer();
+      }
       window.actionCable.disconnect();
     }
     window.chatwootPubsubToken = pubsubToken;

--- a/app/javascript/widget/helpers/actionCable.js
+++ b/app/javascript/widget/helpers/actionCable.js
@@ -99,6 +99,23 @@ class ActionCableConnector extends BaseActionCableConnector {
     this.app.$store.dispatch('agent/updatePresence', data.users);
   };
 
+  static refreshConnector(pubsubToken) {
+    if (!pubsubToken) {
+      return;
+    }
+
+    if (window.actionCable) {
+      window.actionCable.disconnect();
+    }
+    window.chatwootPubsubToken = pubsubToken;
+    if (window.WOOT_WIDGET) {
+      window.actionCable = new ActionCableConnector(
+        window.WOOT_WIDGET,
+        pubsubToken
+      );
+    }
+  }
+
   // eslint-disable-next-line class-methods-use-this
   onContactMerge = data => {
     const { pubsub_token: pubsubToken } = data;

--- a/app/javascript/widget/helpers/actionCable.js
+++ b/app/javascript/widget/helpers/actionCable.js
@@ -105,9 +105,6 @@ class ActionCableConnector extends BaseActionCableConnector {
     }
 
     if (window.actionCable) {
-      if (typeof window.actionCable.clearTimer === 'function') {
-        window.actionCable.clearTimer();
-      }
       window.actionCable.disconnect();
     }
     window.chatwootPubsubToken = pubsubToken;

--- a/app/javascript/widget/helpers/specs/actionCable.spec.js
+++ b/app/javascript/widget/helpers/specs/actionCable.spec.js
@@ -50,4 +50,17 @@ describe('Widget ActionCableConnector', () => {
       'conversationAttributes/getAttributes'
     );
   });
+
+  it('replaces the live connector when the pubsub token rotates', () => {
+    const disconnect = vi.fn();
+    window.actionCable = { disconnect };
+    window.WOOT_WIDGET = app;
+
+    ActionCableConnector.refreshConnector('rotated-pubsub');
+
+    expect(disconnect).toHaveBeenCalled();
+    expect(window.chatwootPubsubToken).toBe('rotated-pubsub');
+    expect(window.actionCable).toBeInstanceOf(ActionCableConnector);
+    expect(window.actionCable).not.toBe(connector);
+  });
 });

--- a/app/javascript/widget/helpers/specs/actionCable.spec.js
+++ b/app/javascript/widget/helpers/specs/actionCable.spec.js
@@ -63,4 +63,10 @@ describe('Widget ActionCableConnector', () => {
     expect(window.actionCable).toBeInstanceOf(ActionCableConnector);
     expect(window.actionCable).not.toBe(connector);
   });
+
+  it('clears presence timers when the connector is disposed', () => {
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+    connector.disconnect();
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/app/javascript/widget/store/modules/contacts.js
+++ b/app/javascript/widget/store/modules/contacts.js
@@ -11,6 +11,7 @@ const parseErrorData = error =>
   error && error.response && error.response.data ? error.response.data : error;
 export const updateWidgetAuthToken = widgetAuthToken => {
   if (widgetAuthToken) {
+    window.authToken = widgetAuthToken;
     setHeader(widgetAuthToken);
     sendMessage({
       event: 'setAuthCookie',
@@ -36,7 +37,8 @@ export const actions = {
   },
   update: async ({ dispatch }, { user }) => {
     try {
-      await ContactsAPI.update(user);
+      const { data } = await ContactsAPI.update(user);
+      updateWidgetAuthToken(data.widget_auth_token);
       dispatch('get');
     } catch (error) {
       // Ignore error

--- a/app/javascript/widget/store/modules/contacts.js
+++ b/app/javascript/widget/store/modules/contacts.js
@@ -1,4 +1,5 @@
 import { sendMessage } from 'widget/helpers/utils';
+import ActionCableConnector from 'widget/helpers/actionCable';
 import ContactsAPI from '../../api/contacts';
 import { SET_USER_ERROR } from '../../constants/errorTypes';
 import { setHeader } from '../../helpers/axios';
@@ -9,7 +10,7 @@ const state = {
 const SET_CURRENT_USER = 'SET_CURRENT_USER';
 const parseErrorData = error =>
   error && error.response && error.response.data ? error.response.data : error;
-export const updateWidgetAuthToken = widgetAuthToken => {
+export const updateWidgetAuthToken = (widgetAuthToken, pubsubToken) => {
   if (widgetAuthToken) {
     window.authToken = widgetAuthToken;
     setHeader(widgetAuthToken);
@@ -17,6 +18,10 @@ export const updateWidgetAuthToken = widgetAuthToken => {
       event: 'setAuthCookie',
       data: { widgetAuthToken },
     });
+  }
+  if (pubsubToken) {
+    window.chatwootPubsubToken = pubsubToken;
+    ActionCableConnector.refreshConnector(pubsubToken);
   }
 };
 
@@ -38,7 +43,7 @@ export const actions = {
   update: async ({ dispatch }, { user }) => {
     try {
       const { data } = await ContactsAPI.update(user);
-      updateWidgetAuthToken(data.widget_auth_token);
+      updateWidgetAuthToken(data.widget_auth_token, data.pubsub_token);
       dispatch('get');
     } catch (error) {
       // Ignore error
@@ -75,9 +80,9 @@ export const actions = {
         custom_attributes,
       };
       const {
-        data: { widget_auth_token: widgetAuthToken },
+        data: { widget_auth_token: widgetAuthToken, pubsub_token: pubsubToken },
       } = await ContactsAPI.setUser(identifier, user);
-      updateWidgetAuthToken(widgetAuthToken);
+      updateWidgetAuthToken(widgetAuthToken, pubsubToken);
       dispatch('get');
       if (identifierHash || widgetAuthToken) {
         dispatch('conversation/clearConversations', {}, { root: true });

--- a/app/javascript/widget/store/modules/specs/contact/actions.spec.js
+++ b/app/javascript/widget/store/modules/specs/contact/actions.spec.js
@@ -1,5 +1,6 @@
 import { API } from 'widget/helpers/axios';
 import { sendMessage } from 'widget/helpers/utils';
+import ActionCableConnector from 'widget/helpers/actionCable';
 import { actions } from '../../contacts';
 
 const commit = vi.fn();
@@ -8,6 +9,9 @@ const dispatch = vi.fn();
 vi.mock('widget/helpers/axios');
 vi.mock('widget/helpers/utils', () => ({
   sendMessage: vi.fn(),
+}));
+vi.mock('widget/helpers/actionCable', () => ({
+  default: { refreshConnector: vi.fn() },
 }));
 
 describe('#actions', () => {
@@ -98,7 +102,26 @@ describe('#actions', () => {
           },
         ],
       ]);
+      expect(ActionCableConnector.refreshConnector).not.toHaveBeenCalled();
       expect(dispatch.mock.calls).toEqual([['get']]);
+    });
+
+    it('reconnects Action Cable when the pubsub token rotates', async () => {
+      const user = {
+        email: 'thoma@sphadikam.com',
+        name: 'Adu Thoma',
+      };
+      API.patch.mockResolvedValue({
+        data: {
+          id: 1,
+          widget_auth_token: 'rotated-token',
+          pubsub_token: 'new-pubsub',
+        },
+      });
+      await actions.update({ commit, dispatch }, { user });
+      expect(ActionCableConnector.refreshConnector).toHaveBeenCalledWith(
+        'new-pubsub'
+      );
     });
   });
 });

--- a/app/javascript/widget/store/modules/specs/contact/actions.spec.js
+++ b/app/javascript/widget/store/modules/specs/contact/actions.spec.js
@@ -91,7 +91,12 @@ describe('#actions', () => {
       });
       await actions.update({ commit, dispatch }, { user });
       expect(sendMessage.mock.calls).toEqual([
-        [{ data: { widgetAuthToken: 'rotated-token' }, event: 'setAuthCookie' }],
+        [
+          {
+            data: { widgetAuthToken: 'rotated-token' },
+            event: 'setAuthCookie',
+          },
+        ],
       ]);
       expect(dispatch.mock.calls).toEqual([['get']]);
     });

--- a/app/javascript/widget/store/modules/specs/contact/actions.spec.js
+++ b/app/javascript/widget/store/modules/specs/contact/actions.spec.js
@@ -80,5 +80,20 @@ describe('#actions', () => {
       expect(commit.mock.calls).toEqual([]);
       expect(dispatch.mock.calls).toEqual([['get']]);
     });
+
+    it('stores a rotated widget auth token', async () => {
+      const user = {
+        email: 'thoma@sphadikam.com',
+        name: 'Adu Thoma',
+      };
+      API.patch.mockResolvedValue({
+        data: { id: 1, widget_auth_token: 'rotated-token' },
+      });
+      await actions.update({ commit, dispatch }, { user });
+      expect(sendMessage.mock.calls).toEqual([
+        [{ data: { widgetAuthToken: 'rotated-token' }, event: 'setAuthCookie' }],
+      ]);
+      expect(dispatch.mock.calls).toEqual([['get']]);
+    });
   });
 });

--- a/app/models/contact_inbox.rb
+++ b/app/models/contact_inbox.rb
@@ -77,18 +77,25 @@ class ContactInbox < ApplicationRecord
 
   def rotate_widget_token!
     with_lock do
-      update!(widget_token_version: widget_token_version + 1)
+      rotate_widget_session_secrets!
       Widget::TokenService.new(payload: Widget::TokenService.payload_for(self)).generate_token
     end
   end
 
   def invalidate_widget_token!
     with_lock do
-      update!(widget_token_version: widget_token_version + 1)
+      rotate_widget_session_secrets!
     end
   end
 
   private
+
+  def rotate_widget_session_secrets!
+    update!(
+      widget_token_version: widget_token_version + 1,
+      pubsub_token: self.class.generate_unique_secure_token
+    )
+  end
 
   def validate_twilio_source_id
     # https://www.twilio.com/docs/glossary/what-e164#regex-matching-for-e164

--- a/app/models/contact_inbox.rb
+++ b/app/models/contact_inbox.rb
@@ -65,6 +65,16 @@ class ContactInbox < ApplicationRecord
     claimed_version == widget_token_version.to_i
   end
 
+  # Re-checks the presented JWT under a row lock so a concurrent request that
+  # already rotated cannot write PII and receive a fresh token.
+  def with_current_widget_token(decoded)
+    with_lock do
+      raise ActiveRecord::RecordNotFound unless valid_widget_token?(decoded)
+
+      yield
+    end
+  end
+
   def rotate_widget_token!
     with_lock do
       update!(widget_token_version: widget_token_version + 1)

--- a/app/models/contact_inbox.rb
+++ b/app/models/contact_inbox.rb
@@ -5,6 +5,7 @@
 #  id            :bigint           not null, primary key
 #  hmac_verified :boolean          default(FALSE)
 #  pubsub_token  :string
+#  widget_token_version :integer          default(0), not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  contact_id    :bigint
@@ -53,6 +54,24 @@ class ContactInbox < ApplicationRecord
 
   def current_conversation
     conversations.last
+  end
+
+  # Legacy JWTs omit token_version and are treated as version 0.
+  def valid_widget_token?(decoded)
+    return false if decoded.blank?
+
+    claimed = decoded[:token_version]
+    claimed_version = claimed.nil? ? 0 : claimed.to_i
+    claimed_version == widget_token_version.to_i
+  end
+
+  def rotate_widget_token!
+    increment!(:widget_token_version)
+    Widget::TokenService.new(payload: Widget::TokenService.payload_for(self)).generate_token
+  end
+
+  def invalidate_widget_token!
+    increment!(:widget_token_version)
   end
 
   private

--- a/app/models/contact_inbox.rb
+++ b/app/models/contact_inbox.rb
@@ -66,12 +66,16 @@ class ContactInbox < ApplicationRecord
   end
 
   def rotate_widget_token!
-    increment!(:widget_token_version)
-    Widget::TokenService.new(payload: Widget::TokenService.payload_for(self)).generate_token
+    with_lock do
+      update!(widget_token_version: widget_token_version + 1)
+      Widget::TokenService.new(payload: Widget::TokenService.payload_for(self)).generate_token
+    end
   end
 
   def invalidate_widget_token!
-    increment!(:widget_token_version)
+    with_lock do
+      update!(widget_token_version: widget_token_version + 1)
+    end
   end
 
   private

--- a/app/services/widget/token_service.rb
+++ b/app/services/widget/token_service.rb
@@ -1,6 +1,14 @@
 class Widget::TokenService < BaseTokenService
   DEFAULT_EXPIRY_DAYS = 180
 
+  def self.payload_for(contact_inbox)
+    {
+      source_id: contact_inbox.source_id,
+      inbox_id: contact_inbox.inbox_id,
+      token_version: contact_inbox.widget_token_version.to_i
+    }
+  end
+
   def generate_token
     JWT.encode(token_payload, secret_key, algorithm)
   end

--- a/app/views/api/v1/widget/contacts/set_user.json.jbuilder
+++ b/app/views/api/v1/widget/contacts/set_user.json.jbuilder
@@ -2,4 +2,7 @@ json.id @contact.id
 json.has_email @contact.email.present?
 json.has_name @contact.name.present?
 json.has_phone_number @contact.phone_number.present?
-json.widget_auth_token @widget_auth_token if @widget_auth_token.present?
+if @widget_auth_token.present?
+  json.widget_auth_token @widget_auth_token
+  json.pubsub_token @contact_inbox.pubsub_token
+end

--- a/app/views/api/v1/widget/contacts/update.json.jbuilder
+++ b/app/views/api/v1/widget/contacts/update.json.jbuilder
@@ -2,3 +2,4 @@ json.id @contact.id
 json.has_email @contact.email.present?
 json.has_name @contact.name.present?
 json.has_phone_number @contact.phone_number.present?
+json.widget_auth_token @widget_auth_token if @widget_auth_token.present?

--- a/app/views/api/v1/widget/contacts/update.json.jbuilder
+++ b/app/views/api/v1/widget/contacts/update.json.jbuilder
@@ -2,4 +2,7 @@ json.id @contact.id
 json.has_email @contact.email.present?
 json.has_name @contact.name.present?
 json.has_phone_number @contact.phone_number.present?
-json.widget_auth_token @widget_auth_token if @widget_auth_token.present?
+if @widget_auth_token.present?
+  json.widget_auth_token @widget_auth_token
+  json.pubsub_token @contact_inbox.pubsub_token
+end

--- a/db/migrate/20260911000000_add_widget_token_version_to_contact_inboxes.rb
+++ b/db/migrate/20260911000000_add_widget_token_version_to_contact_inboxes.rb
@@ -1,0 +1,5 @@
+class AddWidgetTokenVersionToContactInboxes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :contact_inboxes, :widget_token_version, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_31_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_09_11_000000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -777,6 +777,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_31_000000) do
     t.datetime "updated_at", null: false
     t.boolean "hmac_verified", default: false
     t.string "pubsub_token"
+    t.integer "widget_token_version", default: 0, null: false
     t.index ["contact_id"], name: "index_contact_inboxes_on_contact_id"
     t.index ["inbox_id", "source_id"], name: "index_contact_inboxes_on_inbox_id_and_source_id", unique: true
     t.index ["inbox_id"], name: "index_contact_inboxes_on_inbox_id"

--- a/spec/controllers/api/v1/widget/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/contacts_controller_spec.rb
@@ -139,6 +139,18 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
         expect(response).to have_http_status(:success)
       end
 
+      it 'does not change contact PII when the token version is already consumed' do
+        contact_inbox.update!(widget_token_version: 1)
+
+        patch '/api/v1/widget/contact',
+              params: params.merge({ email: 'stolen@test.com' }),
+              headers: { 'X-Auth-Token' => token },
+              as: :json
+
+        expect(response).to have_http_status(:not_found)
+        expect(contact.reload.email).to eq('test@test.com')
+      end
+
       it 'does not rotate the token for custom_attributes-only updates' do
         patch '/api/v1/widget/contact',
               params: params.merge({ custom_attributes: { plan: 'pro' } }),

--- a/spec/controllers/api/v1/widget/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/contacts_controller_spec.rb
@@ -115,7 +115,6 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
       end
 
       it 'rotates the widget session token after a sensitive update' do
-        old_pubsub = contact_inbox.pubsub_token
         patch '/api/v1/widget/contact',
               params: params.merge({ email: 'rotated@test.com' }),
               headers: { 'X-Auth-Token' => token },
@@ -125,9 +124,7 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
         new_token = response.parsed_body['widget_auth_token']
         expect(new_token).to be_present
         expect(new_token).not_to eq(token)
-        expect(response.parsed_body['pubsub_token']).to eq(contact_inbox.reload.pubsub_token)
-        expect(contact_inbox.pubsub_token).not_to eq(old_pubsub)
-        expect(contact_inbox.widget_token_version).to eq(1)
+        expect(contact_inbox.reload.widget_token_version).to eq(1)
 
         get '/api/v1/widget/contact',
             params: { website_token: web_widget.website_token },
@@ -140,6 +137,17 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
             headers: { 'X-Auth-Token' => new_token },
             as: :json
         expect(response).to have_http_status(:success)
+      end
+
+      it 'returns a new Action Cable token after a sensitive update' do
+        old_pubsub = contact_inbox.pubsub_token
+        patch '/api/v1/widget/contact',
+              params: params.merge({ email: 'rotated-pubsub@test.com' }),
+              headers: { 'X-Auth-Token' => token },
+              as: :json
+
+        expect(response.parsed_body['pubsub_token']).to eq(contact_inbox.reload.pubsub_token)
+        expect(contact_inbox.pubsub_token).not_to eq(old_pubsub)
       end
 
       it 'does not change contact PII when the token version is already consumed' do

--- a/spec/controllers/api/v1/widget/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/contacts_controller_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
       end
 
       it 'rotates the widget session token after a sensitive update' do
+        old_pubsub = contact_inbox.pubsub_token
         patch '/api/v1/widget/contact',
               params: params.merge({ email: 'rotated@test.com' }),
               headers: { 'X-Auth-Token' => token },
@@ -124,7 +125,9 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
         new_token = response.parsed_body['widget_auth_token']
         expect(new_token).to be_present
         expect(new_token).not_to eq(token)
-        expect(contact_inbox.reload.widget_token_version).to eq(1)
+        expect(response.parsed_body['pubsub_token']).to eq(contact_inbox.reload.pubsub_token)
+        expect(contact_inbox.pubsub_token).not_to eq(old_pubsub)
+        expect(contact_inbox.widget_token_version).to eq(1)
 
         get '/api/v1/widget/contact',
             params: { website_token: web_widget.website_token },
@@ -276,6 +279,7 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
       let(:web_widget) { create(:channel_widget, account: account) }
 
       it 'rotates the existing session token' do
+        old_pubsub = contact_inbox.pubsub_token
         patch '/api/v1/widget/contact/set_user',
               params: params,
               headers: { 'X-Auth-Token' => token },
@@ -285,6 +289,8 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
         new_token = response.parsed_body['widget_auth_token']
         expect(new_token).to be_present
         expect(new_token).not_to eq(token)
+        expect(response.parsed_body['pubsub_token']).to eq(contact_inbox.reload.pubsub_token)
+        expect(contact_inbox.pubsub_token).not_to eq(old_pubsub)
 
         get '/api/v1/widget/contact',
             params: { website_token: web_widget.website_token },

--- a/spec/controllers/api/v1/widget/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/contacts_controller_spec.rb
@@ -113,6 +113,48 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
         expect(contact.email).to eq('test-1@test.com')
         expect(response).to have_http_status(:success)
       end
+
+      it 'rotates the widget session token after a sensitive update' do
+        patch '/api/v1/widget/contact',
+              params: params.merge({ email: 'rotated@test.com' }),
+              headers: { 'X-Auth-Token' => token },
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        new_token = response.parsed_body['widget_auth_token']
+        expect(new_token).to be_present
+        expect(new_token).not_to eq(token)
+        expect(contact_inbox.reload.widget_token_version).to eq(1)
+
+        get '/api/v1/widget/contact',
+            params: { website_token: web_widget.website_token },
+            headers: { 'X-Auth-Token' => token },
+            as: :json
+        expect(response).to have_http_status(:not_found)
+
+        get '/api/v1/widget/contact',
+            params: { website_token: web_widget.website_token },
+            headers: { 'X-Auth-Token' => new_token },
+            as: :json
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'does not rotate the token for custom_attributes-only updates' do
+        patch '/api/v1/widget/contact',
+              params: params.merge({ custom_attributes: { plan: 'pro' } }),
+              headers: { 'X-Auth-Token' => token },
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['widget_auth_token']).to be_nil
+        expect(contact_inbox.reload.widget_token_version).to eq(0)
+
+        get '/api/v1/widget/contact',
+            params: { website_token: web_widget.website_token },
+            headers: { 'X-Auth-Token' => token },
+            as: :json
+        expect(response).to have_http_status(:success)
+      end
     end
   end
 
@@ -209,6 +251,34 @@ RSpec.describe '/api/v1/widget/contacts', type: :request do
         expect(body['id']).not_to eq(contact.id)
         expect(body['widget_auth_token']).not_to be_nil
         expect(Contact.find(body['id']).contact_inboxes.first.hmac_verified?).to be(true)
+
+        get '/api/v1/widget/contact',
+            params: { website_token: web_widget.website_token },
+            headers: { 'X-Auth-Token' => token },
+            as: :json
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when the current contact stays the same' do
+      let(:web_widget) { create(:channel_widget, account: account) }
+
+      it 'rotates the existing session token' do
+        patch '/api/v1/widget/contact/set_user',
+              params: params,
+              headers: { 'X-Auth-Token' => token },
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        new_token = response.parsed_body['widget_auth_token']
+        expect(new_token).to be_present
+        expect(new_token).not_to eq(token)
+
+        get '/api/v1/widget/contact',
+            params: { website_token: web_widget.website_token },
+            headers: { 'X-Auth-Token' => token },
+            as: :json
+        expect(response).to have_http_status(:not_found)
       end
     end
 

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -21,6 +21,13 @@ describe '/widget', type: :request do
       expect(response.body).to include(token)
     end
 
+    it 'does not restore the session when the token version is stale' do
+      contact_inbox.increment!(:widget_token_version)
+      get widget_url(website_token: web_widget.website_token, cw_conversation: token)
+      expect(response).to be_successful
+      expect(response.body).not_to include(token)
+    end
+
     it 'returns 404 when called with out website_token' do
       get widget_url
       expect(response).to have_http_status(:not_found)

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -22,7 +22,7 @@ describe '/widget', type: :request do
     end
 
     it 'does not restore the session when the token version is stale' do
-      contact_inbox.increment!(:widget_token_version)
+      contact_inbox.update!(widget_token_version: 1)
       get widget_url(website_token: web_widget.website_token, cw_conversation: token)
       expect(response).to be_successful
       expect(response.body).not_to include(token)

--- a/spec/models/contact_inbox_spec.rb
+++ b/spec/models/contact_inbox_spec.rb
@@ -37,6 +37,26 @@ RSpec.describe ContactInbox do
     end
   end
 
+  describe 'widget token version' do
+    let(:contact_inbox) { create(:contact_inbox) }
+
+    it 'accepts legacy tokens that omit token_version while version is 0' do
+      decoded = { source_id: contact_inbox.source_id, inbox_id: contact_inbox.inbox_id }
+      expect(contact_inbox.valid_widget_token?(decoded)).to be(true)
+    end
+
+    it 'rejects a stale token after rotation' do
+      stale = { source_id: contact_inbox.source_id, inbox_id: contact_inbox.inbox_id, token_version: 0 }
+      new_token = contact_inbox.rotate_widget_token!
+
+      expect(contact_inbox.widget_token_version).to eq(1)
+      expect(contact_inbox.valid_widget_token?(stale)).to be(false)
+      expect(new_token).to be_present
+      decoded = Widget::TokenService.new(token: new_token).decode_token
+      expect(contact_inbox.valid_widget_token?(decoded)).to be(true)
+    end
+  end
+
   describe 'validations' do
     context 'when source_id' do
       it 'allows source_id longer than 255 characters for channels without format restrictions' do

--- a/spec/models/contact_inbox_spec.rb
+++ b/spec/models/contact_inbox_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe ContactInbox do
       decoded = Widget::TokenService.new(token: new_token).decode_token
       expect(contact_inbox.valid_widget_token?(decoded)).to be(true)
     end
+
+    it 'rotates the Action Cable pubsub token with the JWT' do
+      old_pubsub = contact_inbox.pubsub_token
+      contact_inbox.rotate_widget_token!
+
+      expect(contact_inbox.reload.pubsub_token).to be_present
+      expect(contact_inbox.pubsub_token).not_to eq(old_pubsub)
+    end
   end
 
   describe 'validations' do

--- a/spec/models/contact_inbox_spec.rb
+++ b/spec/models/contact_inbox_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe ContactInbox do
       expect(contact_inbox.valid_widget_token?(decoded)).to be(true)
     end
 
+    it 'does not yield when the presented version was already consumed' do
+      decoded = { source_id: contact_inbox.source_id, inbox_id: contact_inbox.inbox_id, token_version: 0 }
+      contact_inbox.update!(widget_token_version: 1)
+      yielded = false
+
+      expect do
+        contact_inbox.with_current_widget_token(decoded) { yielded = true }
+      end.to raise_error(ActiveRecord::RecordNotFound)
+      expect(yielded).to be(false)
+    end
+
     it 'rejects a stale token after rotation' do
       stale = { source_id: contact_inbox.source_id, inbox_id: contact_inbox.inbox_id, token_version: 0 }
       new_token = contact_inbox.rotate_widget_token!

--- a/spec/services/widget/token_service_spec.rb
+++ b/spec/services/widget/token_service_spec.rb
@@ -25,6 +25,17 @@ describe Widget::TokenService do
     end
   end
 
+  describe '.payload_for' do
+    it 'includes source_id, inbox_id, and the current token_version' do
+      contact_inbox = create(:contact_inbox)
+      payload = described_class.payload_for(contact_inbox)
+
+      expect(payload[:source_id]).to eq(contact_inbox.source_id)
+      expect(payload[:inbox_id]).to eq(contact_inbox.inbox_id)
+      expect(payload[:token_version]).to eq(0)
+    end
+  end
+
   describe '#decode_token' do
     let(:token) { token_service.generate_token }
     let(:decoder_service) { described_class.new(token: token) }


### PR DESCRIPTION
## Description

Fixes #15776

The widget session JWT is long-lived and was not rotated when a visitor (or anyone holding that JWT) updated contact PII. A captured token stayed valid for the rest of its lifetime.

Minting a new JWT with the same `source_id` / `inbox_id` is not enough — both tokens would still decode. This PR adds `contact_inboxes.widget_token_version`, embeds it in new JWTs, and rejects a token whose version no longer matches.

After a sensitive write the client receives `widget_auth_token`, updates `X-Auth-Token` / `window.authToken`, and overwrites the parent `cw_conversation` cookie via the existing `setAuthCookie` path.

Sensitive writes:

- `PATCH /api/v1/widget/contact` when `email`, `name`, `phone_number`, or `identifier` is present
- `PATCH /api/v1/widget/contact/set_user` (always; also invalidates the previous inbox when the identifier changes)

Custom-attribute-only updates do not rotate.

Legacy tokens that omit `token_version` are treated as version `0`, so existing embeds keep working until the first rotation.

Independent of #15775 / JWT-in-URL.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Request specs: sensitive `PATCH` returns a new token; the old token is `404` on a later contact read; custom-attribute updates do not rotate; `set_user` invalidates the previous session
- Model spec: legacy (no version) tokens remain valid at version 0; rotation bumps the version
- Widget `GET /widget` does not restore a stale-version session
- JS: contact `update` applies `widget_auth_token` via `setAuthCookie`

I could not run the full Chatwoot suite in this environment (no Ruby gems / `node_modules` on the contributor machine). CI on this PR should run them.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
