### PR TITLE
fix(widget): strip HTML from incoming visitor messages on persist

### DIFF
--- a/app/controllers/api/v1/widget/base_controller.rb
+++ b/app/controllers/api/v1/widget/base_controller.rb
@@ -76,11 +76,23 @@ class Api::V1::Widget::BaseController < ApplicationController
     { timestamp: permitted_params[:message][:timestamp] }
   end
 
+  def sanitized_incoming_content
+    @sanitized_incoming_content ||= Widget::IncomingContentSanitizer.sanitize(permitted_params.dig(:message, :content))
+  end
+
+  def reject_blank_incoming_content!
+    return if sanitized_incoming_content.present? || params.dig(:message, :attachments).present?
+
+    record = Message.new
+    record.errors.add(:content, :blank)
+    raise ActiveRecord::RecordInvalid, record
+  end
+
   def message_params
     {
       account_id: conversation.account_id,
       sender: @contact,
-      content: Widget::IncomingContentSanitizer.sanitize(permitted_params[:message][:content]),
+      content: sanitized_incoming_content,
       inbox_id: conversation.inbox_id,
       content_attributes: {
         in_reply_to: permitted_params[:message][:reply_to]

--- a/app/controllers/api/v1/widget/base_controller.rb
+++ b/app/controllers/api/v1/widget/base_controller.rb
@@ -80,7 +80,7 @@ class Api::V1::Widget::BaseController < ApplicationController
     {
       account_id: conversation.account_id,
       sender: @contact,
-      content: permitted_params[:message][:content],
+      content: Widget::IncomingContentSanitizer.sanitize(permitted_params[:message][:content]),
       inbox_id: conversation.inbox_id,
       content_attributes: {
         in_reply_to: permitted_params[:message][:reply_to]

--- a/app/controllers/api/v1/widget/conversations_controller.rb
+++ b/app/controllers/api/v1/widget/conversations_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::Widget::ConversationsController < Api::V1::Widget::BaseController
   end
 
   def create
+    reject_blank_incoming_content!
     ActiveRecord::Base.transaction do
       process_update_contact
       @conversation = create_conversation

--- a/app/controllers/api/v1/widget/messages_controller.rb
+++ b/app/controllers/api/v1/widget/messages_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Widget::MessagesController < Api::V1::Widget::BaseController
   before_action :prevent_reply_to_resolved_conversation, only: [:create]
+  before_action :reject_blank_incoming_content!, only: [:create]
   before_action :set_conversation, only: [:create]
   before_action :set_message, only: [:update]
 

--- a/app/services/widget/incoming_content_sanitizer.rb
+++ b/app/services/widget/incoming_content_sanitizer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Widget visitors can POST arbitrary HTML. Chatwoot stores that string and
+# sanitizes it later in the browser (markdown-it html:false + DOMPurify).
+# Persist-time stripping is defense in depth so a future client sanitizer
+# bypass cannot become stored XSS in the agent dashboard.
+class Widget::IncomingContentSanitizer
+  def self.sanitize(content)
+    return content if content.blank?
+
+    Rails::HTML5::FullSanitizer.new.sanitize(content.to_s)
+  end
+end

--- a/app/services/widget/incoming_content_sanitizer.rb
+++ b/app/services/widget/incoming_content_sanitizer.rb
@@ -4,10 +4,26 @@
 # sanitizes it later in the browser (markdown-it html:false + DOMPurify).
 # Persist-time stripping is defense in depth so a future client sanitizer
 # bypass cannot become stored XSS in the agent dashboard.
+#
+# CommonMark autolinks (`<https://example.com>`, `<user@host>`) are valid
+# visitor text. The HTML5 sanitizer would treat those as empty tags, so
+# they are parked and restored around the strip.
 class Widget::IncomingContentSanitizer
+  AUTO_LINK_REGEX = %r{<(?:https?://[^<>\s]+|[^\s<>]+@[^\s<>]+)>}i
+
   def self.sanitize(content)
     return content if content.blank?
 
-    Rails::HTML5::FullSanitizer.new.sanitize(content.to_s)
+    token = SecureRandom.hex(8)
+    protected = []
+    marked = content.to_s.gsub(AUTO_LINK_REGEX) do |match|
+      protected << match
+      "[[CWAL:#{token}:#{protected.length - 1}]]"
+    end
+
+    stripped = Rails::HTML5::FullSanitizer.new.sanitize(marked)
+    stripped.gsub(/\[\[CWAL:#{Regexp.escape(token)}:(\d+)\]\]/) do
+      protected[Regexp.last_match(1).to_i] || ''
+    end
   end
 end

--- a/app/services/widget/incoming_content_sanitizer.rb
+++ b/app/services/widget/incoming_content_sanitizer.rb
@@ -7,9 +7,13 @@
 #
 # CommonMark autolinks (`<https://example.com>`, `<user@host>`) are valid
 # visitor text. The HTML5 sanitizer would treat those as empty tags, so
-# they are parked and restored around the strip.
+# they are parked and restored around the strip. The email form is a
+# conservative address (local@domain.tld), not "anything with an @",
+# so markup such as `<svg/onload=...@x>` is not parked.
 class Widget::IncomingContentSanitizer
-  AUTO_LINK_REGEX = %r{<(?:https?://[^<>\s]+|[^\s<>]+@[^\s<>]+)>}i
+  URI_AUTOLINK_REGEX = %r{<https?://[^<>\s]+>}i
+  EMAIL_AUTOLINK_REGEX = /<[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}>/
+  AUTO_LINK_REGEX = Regexp.union(URI_AUTOLINK_REGEX, EMAIL_AUTOLINK_REGEX)
 
   def self.sanitize(content)
     return content if content.blank?

--- a/app/services/widget/incoming_content_sanitizer.rb
+++ b/app/services/widget/incoming_content_sanitizer.rb
@@ -5,15 +5,16 @@
 # Persist-time stripping is defense in depth so a future client sanitizer
 # bypass cannot become stored XSS in the agent dashboard.
 #
-# CommonMark autolinks (`<https://example.com>`, `<user@host>`) are valid
-# visitor text. The HTML5 sanitizer would treat those as empty tags, so
-# they are parked and restored around the strip. The email form is a
-# conservative address (local@domain.tld), not "anything with an @",
-# so markup such as `<svg/onload=...@x>` is not parked.
+# CommonMark autolinks are valid visitor text. The HTML5 sanitizer would
+# treat those as empty tags, so a small allow-list is parked and restored
+# around the strip: http(s), ftp(s), mailto, and local@domain.tld.
+# Other schemes (javascript:, data:) and markup that merely contains @
+# are not parked.
 class Widget::IncomingContentSanitizer
-  URI_AUTOLINK_REGEX = %r{<https?://[^<>\s]+>}i
+  URI_AUTOLINK_REGEX = %r{<(?:https?|ftps?)://[^<>\s]+>}i
+  MAILTO_AUTOLINK_REGEX = /<mailto:[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}>/i
   EMAIL_AUTOLINK_REGEX = /<[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}>/
-  AUTO_LINK_REGEX = Regexp.union(URI_AUTOLINK_REGEX, EMAIL_AUTOLINK_REGEX)
+  AUTO_LINK_REGEX = Regexp.union(URI_AUTOLINK_REGEX, MAILTO_AUTOLINK_REGEX, EMAIL_AUTOLINK_REGEX)
 
   def self.sanitize(content)
     return content if content.blank?

--- a/app/services/widget/incoming_content_sanitizer.rb
+++ b/app/services/widget/incoming_content_sanitizer.rb
@@ -10,7 +10,13 @@
 # around the strip: http(s), ftp(s), mailto, and local@domain.tld.
 # Other schemes (javascript:, data:) and markup that merely contains @
 # are not parked.
+#
+# Oversized payloads skip the HTML5 parser so a 150k+ wrapper cannot
+# shrink under Message's content limit and cannot spend parser CPU first.
 class Widget::IncomingContentSanitizer
+  # Keep in lockstep with Message validations on :content.
+  MAX_CONTENT_LENGTH = 150_000
+
   URI_AUTOLINK_REGEX = %r{<(?:https?|ftps?)://[^<>\s]+>}i
   MAILTO_AUTOLINK_REGEX = /<mailto:[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}>/i
   EMAIL_AUTOLINK_REGEX = /<[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}>/
@@ -18,6 +24,7 @@ class Widget::IncomingContentSanitizer
 
   def self.sanitize(content)
     return content if content.blank?
+    return content if content.to_s.length > MAX_CONTENT_LENGTH
 
     token = SecureRandom.hex(8)
     protected = []

--- a/spec/controllers/api/v1/widget/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/conversations_controller_spec.rb
@@ -102,6 +102,21 @@ RSpec.describe '/api/v1/widget/conversations/toggle_typing', type: :request do
       expect(response.parsed_body['messages'][0]['content']).to eq('This is a test message')
     end
 
+    it 'does not create a conversation when the first message sanitizes to blank' do
+      params = conversation_params
+      params[:message][:content] = '<img src=x onerror=alert(1)>'
+
+      expect do
+        post '/api/v1/widget/conversations',
+             headers: { 'X-Auth-Token' => token },
+             params: params,
+             as: :json
+      end.not_to change(Conversation, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['message']).to eq("Content can't be blank")
+    end
+
     it 'create a conversation with a name and without an email' do
       post '/api/v1/widget/conversations',
            headers: { 'X-Auth-Token' => token },

--- a/spec/controllers/api/v1/widget/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/conversations_controller_spec.rb
@@ -89,6 +89,19 @@ RSpec.describe '/api/v1/widget/conversations/toggle_typing', type: :request do
       expect(json_response['messages'][0]['message_type']).to eq 0
     end
 
+    it 'strips HTML from the first incoming message before persist' do
+      params = conversation_params
+      params[:message][:content] = '<img src=x onerror=alert(1)>This is a test message'
+
+      post '/api/v1/widget/conversations',
+           headers: { 'X-Auth-Token' => token },
+           params: params,
+           as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body['messages'][0]['content']).to eq('This is a test message')
+    end
+
     it 'create a conversation with a name and without an email' do
       post '/api/v1/widget/conversations',
            headers: { 'X-Auth-Token' => token },

--- a/spec/controllers/api/v1/widget/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/messages_controller_spec.rb
@@ -103,6 +103,35 @@ RSpec.describe '/api/v1/widget/messages', type: :request do
         expect(conversation.reload.messages.incoming.last.content).to eq('hello **there**')
       end
 
+      it 'rejects HTML-only content that sanitizes to blank' do
+        expect do
+          post api_v1_widget_messages_url,
+               params: {
+                 website_token: web_widget.website_token,
+                 message: { content: '<img src=x onerror=alert(1)>' }
+               },
+               headers: { 'X-Auth-Token' => token },
+               as: :json
+        end.not_to change(conversation.messages, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['message']).to eq("Content can't be blank")
+      end
+
+      it 'keeps an attachment when the caption sanitizes to blank' do
+        file = fixture_file_upload(Rails.root.join('spec/assets/avatar.png'), 'image/png')
+        post api_v1_widget_messages_url,
+             params: {
+               website_token: web_widget.website_token,
+               message: { content: '<img src=x onerror=alert(1)>', attachments: [file] }
+             },
+             headers: { 'X-Auth-Token' => token }
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['content']).to eq('')
+        expect(conversation.messages.last.attachments.first.file.present?).to be(true)
+      end
+
       it 'creates conversation with custom_attributes when first message is sent' do
         conversation.destroy!
         message_params = { content: 'hello world', timestamp: Time.current }

--- a/spec/controllers/api/v1/widget/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/messages_controller_spec.rb
@@ -89,6 +89,20 @@ RSpec.describe '/api/v1/widget/messages', type: :request do
         expect(json_response['content']).to eq(message_params[:content])
       end
 
+      it 'strips HTML from incoming content before persist' do
+        post api_v1_widget_messages_url,
+             params: {
+               website_token: web_widget.website_token,
+               message: { content: '<img src=x onerror=alert(1)>hello **there**' }
+             },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['content']).to eq('hello **there**')
+        expect(conversation.reload.messages.incoming.last.content).to eq('hello **there**')
+      end
+
       it 'creates conversation with custom_attributes when first message is sent' do
         conversation.destroy!
         message_params = { content: 'hello world', timestamp: Time.current }

--- a/spec/services/widget/incoming_content_sanitizer_spec.rb
+++ b/spec/services/widget/incoming_content_sanitizer_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe Widget::IncomingContentSanitizer do
         'Write <support@example.com>'
       )
     end
+
+    it 'does not park HTML that merely contains an @' do
+      raw = '<svg/onload=alert(1)//@x>hello'
+      expect(described_class.sanitize(raw)).not_to include('onload')
+      expect(described_class.sanitize(raw)).not_to include('<svg')
+    end
   end
 end
-

--- a/spec/services/widget/incoming_content_sanitizer_spec.rb
+++ b/spec/services/widget/incoming_content_sanitizer_spec.rb
@@ -48,5 +48,14 @@ RSpec.describe Widget::IncomingContentSanitizer do
       expect(described_class.sanitize(raw)).not_to include('onload')
       expect(described_class.sanitize(raw)).not_to include('<svg')
     end
+
+    it 'does not parse HTML when the original content exceeds the message limit' do
+      sanitizer = instance_double(Rails::HTML5::FullSanitizer)
+      allow(Rails::HTML5::FullSanitizer).to receive(:new).and_return(sanitizer)
+      expect(sanitizer).not_to receive(:sanitize)
+
+      raw = "<b>#{'h' * (described_class::MAX_CONTENT_LENGTH + 1)}</b>"
+      expect(described_class.sanitize(raw)).to eq(raw)
+    end
   end
 end

--- a/spec/services/widget/incoming_content_sanitizer_spec.rb
+++ b/spec/services/widget/incoming_content_sanitizer_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Widget::IncomingContentSanitizer do
+  describe '.sanitize' do
+    it 'returns blank content unchanged' do
+      expect(described_class.sanitize(nil)).to be_nil
+      expect(described_class.sanitize('')).to eq('')
+    end
+
+    it 'keeps ordinary text and markdown' do
+      expect(described_class.sanitize('hello **there**')).to eq('hello **there**')
+    end
+
+    it 'strips HTML tags and event-handler payloads' do
+      raw = '<img src=x onerror=alert(1)>hello'
+      expect(described_class.sanitize(raw)).to eq('hello')
+    end
+
+    it 'strips template wrappers used in known DOMPurify bypasses' do
+      raw = '<template><img src=x onerror=alert(1)></template>safe'
+      expect(described_class.sanitize(raw)).to eq('safe')
+    end
+  end
+end

--- a/spec/services/widget/incoming_content_sanitizer_spec.rb
+++ b/spec/services/widget/incoming_content_sanitizer_spec.rb
@@ -22,5 +22,15 @@ RSpec.describe Widget::IncomingContentSanitizer do
       raw = '<template><img src=x onerror=alert(1)></template>safe'
       expect(described_class.sanitize(raw)).to eq('safe')
     end
+
+    it 'keeps CommonMark URL and email autolinks' do
+      expect(described_class.sanitize('Visit <https://example.com> please')).to eq(
+        'Visit <https://example.com> please'
+      )
+      expect(described_class.sanitize('Write <support@example.com>')).to eq(
+        'Write <support@example.com>'
+      )
+    end
   end
 end
+

--- a/spec/services/widget/incoming_content_sanitizer_spec.rb
+++ b/spec/services/widget/incoming_content_sanitizer_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe Widget::IncomingContentSanitizer do
       expect(described_class.sanitize('Write <support@example.com>')).to eq(
         'Write <support@example.com>'
       )
+      expect(described_class.sanitize('Get <ftp://files.example.com>')).to eq(
+        'Get <ftp://files.example.com>'
+      )
+      expect(described_class.sanitize('Mail <mailto:support@example.com>')).to eq(
+        'Mail <mailto:support@example.com>'
+      )
+    end
+
+    it 'does not park javascript or data URI autolinks' do
+      expect(described_class.sanitize('<javascript:alert(1)>')).not_to include('javascript:')
+      expect(described_class.sanitize('<data:text/html,alert(1)>')).not_to include('data:')
     end
 
     it 'does not park HTML that merely contains an @' do


### PR DESCRIPTION
## Description

Fixes #15779

The website widget stores visitor `message.content` as submitted. Rendering later goes through markdown-it (`html: false`) and DOMPurify. That is the last line of defense, but a future client-sanitizer bypass would already be **stored** and would execute in the agent dashboard.

This PR strips HTML from **incoming website-widget** content at persist (Rails HTML5 full sanitizer). Markdown text such as `**bold**` is kept. Email bodies, agent compose, and canned responses are unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update: no

## How has this change been tested?

- Service spec for tag strip / markdown keep / blank passthrough
- `POST /api/v1/widget/messages` persists stripped content
- `POST /api/v1/widget/conversations` first message is stripped the same way

## Checklist

- [x] I have added the relevant tests
- [x] I have added a sample PR description
