### PR TITLE
chore(deps): bump DOMPurify to 3.4.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "countries-and-timezones": "^3.6.0",
     "date-fns": "2.21.1",
     "date-fns-tz": "^1.3.3",
-    "dompurify": "3.4.13",
+    "dompurify": "3.4.14",
     "flag-icons": "^7.2.3",
     "floating-vue": "^5.2.2",
     "highlight.js": "^11.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: ^1.3.3
         version: 1.3.8(date-fns@2.21.1)
       dompurify:
-        specifier: 3.4.13
-        version: 3.4.13
+        specifier: 3.4.14
+        version: 3.4.14
       flag-icons:
         specifier: ^7.2.3
         version: 7.2.3
@@ -2231,8 +2231,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.13:
-    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
@@ -7078,7 +7078,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.13:
+  dompurify@3.4.14:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -10004,7 +10004,7 @@ snapshots:
 
   vue-dompurify-html@5.3.0(vue@3.5.12(typescript@5.6.2)):
     dependencies:
-      dompurify: 3.4.13
+      dompurify: 3.4.14
       vue: 3.5.12(typescript@5.6.2)
 
   vue-eslint-parser@9.4.3(eslint@8.57.0):


### PR DESCRIPTION
## Description

Fixes #15780

Pins `dompurify` to the current published release **3.4.14** (was 3.4.13) and refreshes `pnpm-lock.yaml`. No sanitizer-config change. Chatwoot already uses the default allow-list.

3.4.14 includes a bypass fix for configurations that allow-list risky tags, plus mixed-document-context hardening. This install does not allow-list extra tags; the bump keeps the pin on the current 3.4.x line.

## Type of change

- [x] Chore / dependency update

## How has this change been tested?

- Lockfile pin and integrity updated to the npm 3.4.14 release

## Checklist

- [x] I have added the relevant tests: n/a (pin only)
