### PR TITLE
fix(inbox): allow SMTP configuration without IMAP

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -1441,7 +1441,7 @@
     "IMAP": {
       "TITLE": "IMAP",
       "SUBTITLE": "Set your IMAP details",
-      "NOTE_TEXT": "To enable SMTP, please configure IMAP.",
+      "NOTE_TEXT": "Configure IMAP to receive emails directly from your mailbox. Leave it disabled if you use email forwarding.",
       "UPDATE": "Update IMAP settings",
       "TOGGLE_AVAILABILITY": "Enable IMAP configuration for this inbox",
       "TOGGLE_HELP": "Enabling IMAP will help the user to receive email",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/ImapSettings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/ImapSettings.vue
@@ -77,7 +77,7 @@ export default {
     async updateInbox() {
       try {
         this.loading = true;
-        let payload = {
+        const payload = {
           id: this.inbox.id,
           formData: false,
           channel: {
@@ -90,10 +90,6 @@ export default {
             imap_authentication: this.authMechanism,
           },
         };
-
-        if (!this.isIMAPEnabled) {
-          payload.channel.smtp_enabled = false;
-        }
 
         await this.$store.dispatch('inboxes/updateInboxIMAP', payload);
         useAlert(this.$t('INBOX_MGMT.IMAP.EDIT.SUCCESS_MESSAGE'));

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
@@ -381,7 +381,7 @@ export default {
       </SettingsFieldSection>
     </div>
     <ImapSettings :inbox="inbox" />
-    <SmtpSettings v-if="inbox.imap_enabled" :inbox="inbox" />
+    <SmtpSettings :inbox="inbox" />
   </div>
   <div v-else-if="isAWhatsAppChannel && !isATwilioChannel">
     <div v-if="inbox.provider_config">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/specs/ConfigurationPage.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/specs/ConfigurationPage.spec.js
@@ -1,6 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import { createStore } from 'vuex';
 import ConfigurationPage from '../ConfigurationPage.vue';
+import SmtpSettings from '../../SmtpSettings.vue';
 
 vi.mock('dashboard/composables', () => ({
   useAlert: vi.fn(),
@@ -41,6 +42,20 @@ const mountComponent = inbox =>
   });
 
 describe('ConfigurationPage', () => {
+  it.each([false, true])(
+    'shows SMTP settings for email inboxes when IMAP is %s',
+    imapEnabled => {
+      const inbox = {
+        channel_type: 'Channel::Email',
+        imap_enabled: imapEnabled,
+      };
+      const wrapper = mountComponent(inbox);
+
+      expect(wrapper.findComponent(SmtpSettings).exists()).toBe(true);
+      expect(wrapper.findComponent(SmtpSettings).props('inbox')).toEqual(inbox);
+    }
+  );
+
   it('shows the WhatsApp reconfigure option for embedded signup inboxes without checking account feature flags', () => {
     const wrapper = mountComponent({
       channel_type: 'Channel::Whatsapp',

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/specs/ImapSettings.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/specs/ImapSettings.spec.js
@@ -1,0 +1,67 @@
+import { nextTick } from 'vue';
+import { shallowMount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import ImapSettings from '../ImapSettings.vue';
+
+vi.mock('dashboard/composables', () => ({
+  useAlert: vi.fn(),
+}));
+
+describe('ImapSettings', () => {
+  it('disables IMAP without changing the SMTP configuration', async () => {
+    const updateInboxIMAP = vi.fn();
+    const wrapper = shallowMount(ImapSettings, {
+      props: {
+        inbox: {
+          id: 1,
+          imap_enabled: true,
+          smtp_enabled: true,
+          imap_address: 'imap.example.com',
+          imap_port: 993,
+          imap_login: 'support@example.com',
+          imap_password: 'password',
+          imap_enable_ssl: true,
+          imap_authentication: 'plain',
+        },
+      },
+      global: {
+        plugins: [
+          createStore({
+            getters: {
+              'inboxes/getUIFlags': () => ({ isUpdatingIMAP: false }),
+            },
+            actions: {
+              'inboxes/updateInboxIMAP': updateInboxIMAP,
+            },
+          }),
+        ],
+        mocks: { $t: key => key },
+        stubs: {
+          SettingsFieldSection: {
+            template: '<section><slot /></section>',
+          },
+          'woot-input': true,
+        },
+      },
+    });
+
+    await nextTick();
+    await wrapper.find('input[name="toggle-imap-enable"]').setValue(false);
+    await wrapper.find('form').trigger('submit');
+
+    expect(updateInboxIMAP).toHaveBeenCalledOnce();
+    expect(updateInboxIMAP.mock.calls[0][1]).toEqual({
+      id: 1,
+      formData: false,
+      channel: {
+        imap_enabled: false,
+        imap_address: 'imap.example.com',
+        imap_port: 993,
+        imap_login: 'support@example.com',
+        imap_password: 'password',
+        imap_enable_ssl: true,
+        imap_authentication: 'plain',
+      },
+    });
+  });
+});


### PR DESCRIPTION
Email inboxes can now configure custom SMTP while using forwarding for incoming mail. Disabling IMAP also preserves the existing SMTP configuration, so changing the inbound method does not disable outbound delivery.

## What changed

- Show SMTP settings for email inboxes independently of IMAP.
- Keep SMTP settings untouched when saving IMAP configuration.
- Replace the IMAP prerequisite message with guidance about receiving mail through IMAP or forwarding.
- Add regression coverage for SMTP visibility and preserving SMTP when disabling IMAP.

## How to test

1. Open an email inbox that receives mail through forwarding, with IMAP disabled.
2. Open Configuration and confirm SMTP settings are available.
3. Configure a valid SMTP provider, save, and reload. Confirm IMAP stays disabled and SMTP stays enabled.
4. Send a reply and confirm delivery through the configured SMTP provider.
5. In an inbox with both IMAP and SMTP enabled, disable IMAP and save. Reload and confirm SMTP remains enabled.
