### PR TITLE
fix: load ChatwootHub before stubbing edition in specs

### DIFF
--- a/spec/lib/chatwoot_app_spec.rb
+++ b/spec/lib/chatwoot_app_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'chatwoot_hub'
 
 RSpec.describe ChatwootApp do
   describe '.self_hosted_paid?' do


### PR DESCRIPTION
Fixes the backend FOSS CI failures caused by the paid self-hosted plan specs added in #15760. PRs containing those specs can fail before the plan checks even run.

The FOSS job removes Enterprise code. These tests then pretend Enterprise is installed, and loading `ChatwootHub` for the first time tries to load the missing Enterprise extension. That crashes with `undefined method 'const_defined?' for false`.

The fix explicitly loads `ChatwootHub` before the tests override the edition checks. This lets it load using the actual installation state, then allows each test to simulate its plan as intended.
