### PR TITLE
fix(widget): keep SDK-queued conversation attributes when the pre-chat form submits

### DIFF
--- a/app/javascript/widget/views/PreChatForm.vue
+++ b/app/javascript/widget/views/PreChatForm.vue
@@ -59,6 +59,13 @@ export default {
           },
         });
       } else {
+        // Conversation attributes queued through the SDK
+        // (setConversationCustomAttributes) live in pendingCustomAttributes;
+        // clearConversations wipes them, so capture them first and merge them
+        // into the create request. Explicit pre-chat form fields win on
+        // conflicts, matching the sendMessage merge order.
+        const pendingConversationCustomAttributes =
+          this.$store.getters['conversation/getPendingCustomAttributes'];
         this.clearConversations();
         this.clearConversationAttributes();
         this.$store.dispatch('conversation/createConversation', {
@@ -66,7 +73,10 @@ export default {
           emailAddress: emailAddress,
           message: message,
           phoneNumber: phoneNumber,
-          customAttributes: conversationCustomAttributes,
+          customAttributes: {
+            ...pendingConversationCustomAttributes,
+            ...conversationCustomAttributes,
+          },
           contactCustomAttributes: contactCustomAttributes,
         });
       }

--- a/app/javascript/widget/views/specs/PreChatForm.spec.js
+++ b/app/javascript/widget/views/specs/PreChatForm.spec.js
@@ -86,4 +86,82 @@ describe('PreChatForm view', () => {
     expect(createConversation).not.toHaveBeenCalled();
     expect(setCustomAttributes).not.toHaveBeenCalled();
   });
+
+  it('merges SDK-queued pending conversation attributes into the create request', async () => {
+    store = createStore({
+      modules: {
+        conversation: {
+          namespaced: true,
+          actions: { createConversation, clearConversations: vi.fn() },
+          getters: {
+            getPendingCustomAttributes: () => ({ referral_code: 'ABC123' }),
+          },
+        },
+        conversationAttributes: {
+          namespaced: true,
+          actions: { clearConversationAttributes: vi.fn() },
+        },
+        contacts: {
+          namespaced: true,
+          actions: { setCustomAttributes, update: updateContact },
+        },
+      },
+    });
+    const wrapper = mountView();
+    wrapper.vm.onSubmit({
+      fullName: 'John',
+      emailAddress: 'john@example.com',
+      message: 'hey',
+      contactCustomAttributes: {},
+      conversationCustomAttributes: { order_id: '12345' },
+    });
+    await flushPromises();
+
+    expect(createConversation).toHaveBeenCalledWith(expect.anything(), {
+      fullName: 'John',
+      emailAddress: 'john@example.com',
+      message: 'hey',
+      phoneNumber: undefined,
+      customAttributes: { referral_code: 'ABC123', order_id: '12345' },
+      contactCustomAttributes: {},
+    });
+  });
+
+  it('lets explicit pre-chat form fields override SDK-queued values on conflicts', async () => {
+    store = createStore({
+      modules: {
+        conversation: {
+          namespaced: true,
+          actions: { createConversation, clearConversations: vi.fn() },
+          getters: {
+            getPendingCustomAttributes: () => ({ referral_code: 'ABC123' }),
+          },
+        },
+        conversationAttributes: {
+          namespaced: true,
+          actions: { clearConversationAttributes: vi.fn() },
+        },
+        contacts: {
+          namespaced: true,
+          actions: { setCustomAttributes, update: updateContact },
+        },
+      },
+    });
+    const wrapper = mountView();
+    wrapper.vm.onSubmit({
+      fullName: 'John',
+      emailAddress: 'john@example.com',
+      message: 'hey',
+      contactCustomAttributes: {},
+      conversationCustomAttributes: { referral_code: 'FORM99' },
+    });
+    await flushPromises();
+
+    expect(createConversation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        customAttributes: { referral_code: 'FORM99' },
+      })
+    );
+  });
 });


### PR DESCRIPTION
## Problem

With the pre-chat form enabled, any conversation custom attributes queued through the SDK (`setConversationCustomAttributes`) are silently discarded when the visitor submits the form (#15787).

Verified at `master` (`2f1ed80`):

1. `PreChatForm.vue` `onSubmit` calls `clearConversations()` - whose mutation resets `pendingCustomAttributes` (`app/javascript/widget/store/modules/conversation/mutations.js:5-9`) - and then dispatches `conversation/createConversation` carrying only the form's own `conversationCustomAttributes`.
2. The pending map never reaches the create request, so SDK-queued attributes are wiped first and lost either way.
3. The sibling paths do forward it: `sendMessage` (`actions.js:34-42`) and `sendAttachment` both pass `pendingCustomAttributes` through. The create-conversation path is the odd one out.

## Fix

Capture `getPendingCustomAttributes` before the clear and merge it into the create request's `customAttributes`, with explicit pre-chat form fields winning on conflicts (a value the visitor typed beats a stale queued one).

## Verification (labeled evidence)

- **Root cause confirmed at source** at `2f1ed80` (call order in `PreChatForm.vue`, the wiping mutation, the sendMessage/sendAttachment asymmetry).
- **Unit tests (2 new)** in `app/javascript/widget/views/specs/PreChatForm.spec.js`: pending SDK attributes are merged into the create request; explicit form fields override queued values on conflicts.
- **Test status:** run in a minimal vitest harness (vue 3 + vuex + @vue/test-utils; the child `PreChatForm` component, `configMixin`, and the widget event bus are stubbed) - RED on pristine master (merge test fails), GREEN with this patch (all 4 specs pass). The full chatwoot JS suite (yarn install) was not run; the change is one dispatch payload plus its specs.

> Built by breken, your AI support engineer - breken.ai - this one's on us.