### PR TITLE
fix(widget): preserve pending conversation custom attributes on pre-chat form submit

### DIFF
--- a/app/javascript/widget/views/PreChatForm.vue
+++ b/app/javascript/widget/views/PreChatForm.vue
@@ -59,6 +59,7 @@ export default {
           },
         });
       } else {
+        const { pendingCustomAttributes } = this.$store.state.conversation;
         this.clearConversations();
         this.clearConversationAttributes();
         this.$store.dispatch('conversation/createConversation', {
@@ -66,7 +67,10 @@ export default {
           emailAddress: emailAddress,
           message: message,
           phoneNumber: phoneNumber,
-          customAttributes: conversationCustomAttributes,
+          customAttributes: {
+            ...pendingCustomAttributes,
+            ...conversationCustomAttributes,
+          },
           contactCustomAttributes: contactCustomAttributes,
         });
       }

--- a/app/javascript/widget/views/specs/PreChatForm.spec.js
+++ b/app/javascript/widget/views/specs/PreChatForm.spec.js
@@ -21,6 +21,7 @@ describe('PreChatForm view', () => {
       modules: {
         conversation: {
           namespaced: true,
+          state: { pendingCustomAttributes: {} },
           actions: { createConversation, clearConversations: vi.fn() },
         },
         conversationAttributes: {
@@ -61,6 +62,44 @@ describe('PreChatForm view', () => {
     // would race the contact merge on the server and write to a destroyed
     // contact
     expect(setCustomAttributes).not.toHaveBeenCalled();
+  });
+
+  it('merges pending conversation custom attributes set via the SDK before the conversation existed', async () => {
+    store = createStore({
+      modules: {
+        conversation: {
+          namespaced: true,
+          state: { pendingCustomAttributes: { referral_code: 'ABC123' } },
+          actions: { createConversation, clearConversations: vi.fn() },
+        },
+        conversationAttributes: {
+          namespaced: true,
+          actions: { clearConversationAttributes: vi.fn() },
+        },
+        contacts: {
+          namespaced: true,
+          actions: { setCustomAttributes, update: updateContact },
+        },
+      },
+    });
+    const wrapper = mountView();
+    wrapper.vm.onSubmit({
+      fullName: 'John',
+      emailAddress: 'john@example.com',
+      message: 'hey',
+      contactCustomAttributes: {},
+      conversationCustomAttributes: { order_id: '12345' },
+    });
+    await flushPromises();
+
+    expect(createConversation).toHaveBeenCalledWith(expect.anything(), {
+      fullName: 'John',
+      emailAddress: 'john@example.com',
+      message: 'hey',
+      phoneNumber: undefined,
+      customAttributes: { referral_code: 'ABC123', order_id: '12345' },
+      contactCustomAttributes: {},
+    });
   });
 
   it('sends contact custom attributes along with the contact update for campaigns', async () => {


### PR DESCRIPTION
## Description

Fixes #15787

`PreChatForm.vue`'s `onSubmit` calls `clearConversations()` (which resets `conversation/pendingCustomAttributes` to `{}`) before dispatching `conversation/createConversation`. The `createConversation` action only forwards whatever `customAttributes` the pre-chat form itself provided — it never reads `pendingCustomAttributes` from state, unlike `sendMessage`/`sendMessageWithData` and `sendAttachment`, which do merge it in for every message after the first one.

So any conversation custom attribute queued via `window.$chatwoot.setConversationCustomAttributes()` before the conversation exists survives fine on inboxes without a pre-chat form (the first message goes through the plain `sendMessage` path once the conversation already exists client-side), but is silently dropped whenever a pre-chat form is enabled — the default/common setup.

Fix: read `pendingCustomAttributes` out of state before `clearConversations()` runs, and merge it into the `customAttributes` sent with the create-conversation request (explicit pre-chat form fields still win on key conflicts).

Note: #15788 independently proposes an equivalent fix (same file/line, same merge order), reading the pending value through the `conversation/getPendingCustomAttributes` getter instead of `state` directly , either approach works. This PR additionally includes end-to-end verification against a real running instance (see below), not just unit tests against a mocked store.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Unit: added a spec to `PreChatForm.spec.js` asserting `pendingCustomAttributes` from the conversation module's state gets merged into the `createConversation` dispatch payload, with existing specs (contact attributes, campaign path) still passing.
2. End-to-end, against a real instance: built this branch into a Docker image (`docker/Dockerfile`) and ran it as a self-hosted Chatwoot install (Postgres + Redis + Rails + Sidekiq) with a Website inbox, pre-chat form enabled, and a `Conversation`-scoped custom attribute registered. Used a headless-browser script to load the widget, call `window.$chatwoot.setConversationCustomAttributes({...})` on `chatwoot:ready` (before any conversation exists), open the widget, submit the pre-chat form, and send the first message. Confirmed via the `/api/v1/accounts/:id/conversations` API that the created conversation persisted the custom attribute, reproducing the bug on unpatched `develop` and confirming the fix on this branch.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes