### PR TITLE
fix(voice): answer WhatsApp calls from the conversation when the call is not in the store

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/VoiceCall.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/VoiceCall.vue
@@ -243,6 +243,16 @@ const handleJoinCall = async () => {
     });
   }
 
+  // The store skips calls that rang while the agent was away or were dismissed; register it so joinCall picks the right provider.
+  callsStore.addCall({
+    callSid: callSid.value,
+    callId: call.value?.id,
+    provider: call.value?.provider,
+    conversationId: conversationId.value,
+    inboxId: inboxId.value,
+    callDirection: VOICE_CALL_DIRECTION.INBOUND,
+  });
+
   await joinCall({
     conversationId: conversationId.value,
     inboxId: inboxId.value,

--- a/enterprise/app/controllers/api/v1/accounts/conference_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/conference_controller.rb
@@ -50,7 +50,7 @@ class Api::V1::Accounts::ConferenceController < Api::V1::Accounts::BaseControlle
   end
 
   def set_voice_inbox_for_conference
-    @voice_inbox = Current.account.inboxes.find(params[:inbox_id])
+    @voice_inbox = Current.account.inboxes.where(channel_type: 'Channel::TwilioSms').find(params[:inbox_id])
     authorize @voice_inbox, :show?
   end
 


### PR DESCRIPTION
Answering an incoming WhatsApp call from the call bubble in the conversation could show "Internal Server Error", and the caller then saw the call as missed. This happened when the call wasn't in the agent's calls store: it rang while the agent wasn't online, or it was dismissed earlier. In that case the dashboard fell back to the Twilio flow and requested a Twilio token for the WhatsApp inbox.

## Closes

- https://linear.app/chatwoot/issue/CW-8174

## How to reproduce

1. Set your availability to Busy or Offline and receive a WhatsApp call on an inbox with calling enabled.
2. Open the conversation and click Answer on the ringing call bubble.
3. Before: "Internal Server Error" and the call ends as missed. After: the call connects.

## What changed

- The call bubble adds the call to the calls store from its own message data before joining, so the WhatsApp answer path is used.
- `ConferenceController` only resolves Twilio inboxes, so the Twilio token and conference endpoints return 404 for other inboxes instead of 500.