### PR TITLE
fix: return 404 instead of 500 for unknown portal slugs

### DIFF
--- a/app/controllers/api/v1/accounts/portals_controller.rb
+++ b/app/controllers/api/v1/accounts/portals_controller.rb
@@ -72,7 +72,7 @@ class Api::V1::Accounts::PortalsController < Api::V1::Accounts::BaseController
   private
 
   def fetch_portal
-    @portal = Current.account.portals.find_by(slug: permitted_params[:id])
+    @portal = Current.account.portals.find_by!(slug: permitted_params[:id])
   end
 
   def permitted_params

--- a/spec/controllers/api/v1/accounts/portals_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/portals_controller_spec.rb
@@ -68,6 +68,23 @@ RSpec.describe 'Api::V1::Accounts::Portals', type: :request do
         expect(json_response['meta']['all_articles_count']).to eq 2
         expect(json_response['meta']['mine_articles_count']).to eq 1
       end
+
+      it 'returns not found for a slug that does not exist' do
+        get "/api/v1/accounts/#{account.id}/portals/nonexistent-slug",
+            headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body['error']).to eq 'Resource could not be found'
+      end
+
+      it 'returns not found for a slug that belongs to another account' do
+        other_portal = create(:portal)
+
+        get "/api/v1/accounts/#{account.id}/portals/#{other_portal.slug}",
+            headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #15797 - credit to @Uankur for the precise report and diagnosis (exact citations, repro curls, and the proposed direction); this PR implements the fix they sketched, verified independently against current `develop`. @Uankur - would love your eyes on this.

## Problem

`GET /api/v1/accounts/:account_id/portals/:slug` returns HTTP 500 when the slug does not exist in the account. `fetch_portal` uses `find_by(slug:)`, which returns nil instead of raising, and `show` then calls `@portal.articles` on nil. The blast radius is wider than `show`: `fetch_portal` runs as a `before_action` for every portal action except `index`/`create`, so `update`, `destroy`, `archive`, `logo` and `send_instructions` hit the same nil crash (EE `ssl_status` too).

## Fix

One-token change: `find_by` -> `find_by!`. `ActiveRecord::RecordNotFound` then flows through the existing `handle_with_exception` rescue, which renders the standard 404 `"Resource could not be found"` - the same pattern sibling controllers already use (`labels_controller` uses `find`, and the public portals controllers use `find_by!(slug:)`). The lookup stays scoped to `Current.account.portals`, so a slug belonging to another account also returns 404, matching the reporter's expectation. Pundit authorization is class-level here and unchanged.

## Tests

Two request specs added to `portals_controller_spec.rb`: unknown slug -> 404 with the standard body, and cross-account slug -> 404.

**Test status (honest):** the specs are written but NOT executed - no Ruby toolchain was available in our environment. Verification was static: the nil path, the `handle_with_exception` RecordNotFound -> 404 rescue, and the sibling/public-controller `find_by!` precedent were all confirmed against current `develop` (`2f1ed80f89`). The one-token change mirrors the repo's own usage elsewhere.

> Built by breken, your AI support engineer - breken.ai - this one's on us.